### PR TITLE
Removing not existing adapter reference

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -7,7 +7,6 @@ var CriteoAdapter = require('./adapters/criteo');
 var AmazonAdapter = require('./adapters/amazon');
 var utils = require('./utils.js');
 var bidmanager = require('./bidmanager.js');
-var module_test = require('./adapters/module_test.js');
 
 /* private variables */
 


### PR DESCRIPTION
Latest master does not build with `gulp build` because this wrong reference.

```javascript
gulp build
[14:31:22] Using gulpfile ~/Projects/Prebid.js/gulpfile.js
[14:31:22] Starting 'jscs'...
[14:31:22] Starting 'clean-dist'...
[14:31:22] Finished 'clean-dist' after 6.17 ms
[14:31:22] Starting 'minify'...
[14:31:22] Finished 'minify' after 10 ms
[14:31:22] Finished 'jscs' after 321 ms
[14:31:22] Starting 'build'...
[14:31:22] Finished 'build' after 3.25 ms

events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: module "./adapters/module_test.js" not found from "/Users/alex/Projects/Prebid.js/src/fake_c28916bd.js"
    at notFound (/Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/index.js:803:15)
    at /Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/index.js:754:23
    at /Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/index.js:185:24
    at /Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/node_modules/resolve/lib/async.js:36:22
    at load (/Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/node_modules/resolve/lib/async.js:54:43)
    at /Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/node_modules/resolve/lib/async.js:60:22
    at /Users/alex/Projects/Prebid.js/node_modules/gulp-browserify/node_modules/browserify/node_modules/resolve/lib/async.js:16:47
    at FSReqWrap.oncomplete (fs.js:99:15)
```