### PR TITLE
Adding travis-ci to check the project properly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+node_js:
+  - 0.12
+  - 0.11
+
+before_install:
+  - npm install -g gulp
+
+script:
+  - gulp build


### PR DESCRIPTION
Adding CI in charge of building the app everytime someone commits or sends a PR so you know when something go wrong you would need to sign up into travis-ci(free) and add your repo so it can start building the project already tested in my fork works great.

https://travis-ci.org/ialex/Prebid.js/jobs/75503038

If the projects gets tests later on we can run them using travis too.
