### PR TITLE
issues in utilities/refactor of type-checking usage, "bidder" conflict with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Download the integration example [here](https://github.com/prebid/Prebid.js/blob
 (function() {
         var d = document, pbs = d.createElement('script'), pro = d.location.protocal;
         pbs.type = 'text/javascript';
-        pbs.src = (pro ? 'https' : 'http') + '://cdn.host.com/prebid.min.js';
+        pbs.src = ((pro === 'https:') ? 'https' : 'http') + '://cdn.host.com/prebid.min.js';
         var target = document.getElementsByTagName('head')[0];
         target.insertBefore(pbs, target.firstChild);
 })();

--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -11,9 +11,6 @@ function YieldbotAdapter() {
   var toString = Object.prototype.toString,
       hasOwnProperty = Object.prototype.hasOwnProperty,
       ybq = window.ybotq || (window.ybotq = []),
-      t_Arr = 'Array',
-      t_Str = 'String',
-      t_Fn = 'Function',
       bidmap = {};
 
   // constants
@@ -27,18 +24,13 @@ function YieldbotAdapter() {
   var yb = {
 
     /**
-     * basic template: %%MY_VAR_TO_TPL%%
-     */
-    tplRxp: /%%(\w+)%%/g,
-
-    /**
      * Normalize a size; if the user gives us
      * a dim array, produce a wxh string
      * @param {String|Array} size
      * @return {String} WxH string
      */
     formatSize: function (size) {
-      return utils.isA(size, t_Arr) ? size.join('x') : size;
+      return utils.isArray(size) ? size.join('x') : size;
     },
 
     /**
@@ -54,9 +46,7 @@ function YieldbotAdapter() {
         size: yb.formatSize(size),
       };
 
-      return CREATIVE_TEMPLATE.replace(yb.tplRxp, function ($0, $1) {
-        return args[($1 || '').toLowerCase()];
-      });
+      return utils.replaceTokenInString(CREATIVE_TEMPLATE, args, '%%');
     },
 
     /**
@@ -78,6 +68,7 @@ function YieldbotAdapter() {
       bid.cpm = parseInt(params.ybot_cpm) / 100.0;
       bid.ad = yb.creative(slot, params.ybot_size);
       bid.placementCode = placement;
+
       return bid;
     },
 
@@ -120,7 +111,8 @@ function YieldbotAdapter() {
         return addErrorBid(placementCode, yslot, params);
       }
 
-      bidmanager.addBidResponse(placementCode, yb.makeBid(placementCode, yslot, params));
+      var bid = yb.makeBid(placementCode, yslot, params);
+      bidmanager.addBidResponse(placementCode, bid);
     });
   }
 

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -205,7 +205,7 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
       try {
         keyValues[key] = value(custBidObj);
       } catch (e) {
-        utils.logError("invalid function during k/v targeting", "BIDMANAGER");
+        utils.logError("bidmanager", "ERROR", e);
       }
     } else {
 			keyValues[key] = value;
@@ -296,17 +296,6 @@ function checkBidsBackByAdUnit(adUnitCode){
 			}
 		}
 	}
-	/*
-	utils.mapForEach(biddersByPlacementMap, function(value, key){
-		console.log('key: '+ key);
-		console.log(value);
-		if(key === adUnitCode){
-			var val = pbBidResponseByPlacement[adUnitCode];
-			alert('we have a winner: ' + val.bidsReceivedCount );
-		}
-
-	});
-	*/
 }
 
 exports.setBidderMap = function(bidderMap){

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -80,7 +80,6 @@ exports.addBidResponse = function(adUnitCode, bid) {
 		//increment the bid count
 		bidResponseRecievedCount++;
 		//get price settings here
-		
 		if (bid.getStatusCode() === 2) {
 			bid.cpm = 0;
 		}
@@ -93,27 +92,10 @@ exports.addBidResponse = function(adUnitCode, bid) {
 		//put adUnitCode into bid
 		bid.adUnitCode = adUnitCode;
 
-		/*
-		//if we have enough info to create the bid response - create here
-		if (bid.getStatusCode() && placementCode && bid.GetBidderCode()) {
-			bidResponse = {
-				bidderCode: bidderCode,
-				cpm: cpm,
-				adUrl: ad,
-				adId: adId,
-				width: width,
-				height: height,
-				dealId: dealId,
-				isDeal: isDeal,
-				tier: tier,
-				custObj: custObj,
-				status: statusCode,
-				keyLg: priceStringsObj.low,
-				keyMg: priceStringsObj.med,
-				keyHg: priceStringsObj.high
-			};
-		}
-		*/
+    // alias the bidderCode to bidder;
+    // NOTE: this is to match documentation
+    // on custom k-v targeting
+    bid.bidder = bid.bidderCode;
 
 		//if there is any key value pairs to map do here
 		var keyValues = {};
@@ -140,7 +122,6 @@ exports.addBidResponse = function(adUnitCode, bid) {
 			//should never reach this code
 			utils.logError('Internal error in bidmanager.addBidResponse. Params: ' + adUnitCode + ' & ' + bid );
 		}
-
 
 	} else {
 		//create an empty bid bid response object
@@ -203,34 +184,35 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
 					}
 				}]
 			};
-
-			//set default settings 
-
 		}
+
 		custBidObj.usesGenericKeys = true;
 		setKeys(keyValues, bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD], custBidObj);
 	}
 
 	return keyValues;
-
 }
 
 function setKeys(keyValues, bidderSettings, custBidObj) {
 	var targeting = bidderSettings[CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING];
-	custBidObj['size'] = custBidObj.getSize();
-	for (var i = 0; i < targeting.length; i++) {
-		var key = targeting[i].key;
-		var value = targeting[i].val;
-		if (typeof value === objectType_function) {
-			try {
-				keyValues[key] = value(custBidObj);
-			} catch (e) {
-				utils.logError('Exception trying to parse value. Check bidderSettings configuration : ' + e.message);
-			}
-		} else {
+	custBidObj.size = custBidObj.getSize();
+
+  utils._each(targeting, function (kvPair) {
+    var key = kvPair.key,
+        value = kvPair.val;
+
+    if (utils.isFn(value)) {
+      try {
+        keyValues[key] = value(custBidObj);
+      } catch (e) {
+        utils.logError("invalid function during k/v targeting", "BIDMANAGER");
+      }
+    } else {
 			keyValues[key] = value;
-		}
-	}
+    }
+  });
+
+  return keyValues;
 }
 
 exports.registerDefaultBidderSetting = function(bidderCode, defaultSetting) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,18 +26,16 @@ var t_Arr = 'Array',
  *   map['something'] = 'something else';
  *   console.log(replaceTokenInString(str, map, '%%')); => "text it was subbed this text with something else"
  */
-var tokenRxpMap = {},
-    wordMatch = '(\\w+)';
-
-function getRegexpForToken(token) {
-  return (tokenRxpMap[token] ? tokenRxpMap[token] : (tokenRxpMap[token] = new RegExp(token + wordMatch + token, 'g')));
-}
-
 exports.replaceTokenInString = function(str, map, token) {
-  var regex = getRegexpForToken(token);
-  return str.replace(regex, function ($0, $1) {
-    return map[($1 || '').toLowerCase()] || '';
+  this._each(map, function (value, key) {
+    value = (value === undefined) ? '' : value;
+
+    var keyString = token + key.toUpperCase() + token,
+        re = new RegExp(keyString, 'g');
+
+    str = str.replace(re, value);
   });
+  return str
 };
 
 /* utility method to get incremental integer starting from 1 */
@@ -155,14 +153,15 @@ exports.logMessage = function(msg) {
 	}
 };
 
-var hasConsoleLogger = function() {
-	return (window.console && window.console.log);
-};
-exports.hasConsoleLogger = hasConsoleLogger;
-
 function hasConsoleLogger() {
 	return (window.console && window.console.log);
 }
+exports.hasConsoleLogger = hasConsoleLogger;
+
+var errLogFn = (function (hasLogger) {
+  if (!hasLogger) return '';
+  return window.console.error ? 'error' : 'log';
+}(hasConsoleLogger()));
 
 var debugTurnedOn = function() {
 	if (pbjs.logging === false && _loggingChecked === false) {
@@ -178,15 +177,10 @@ var debugTurnedOn = function() {
 };
 exports.debugTurnedOn = debugTurnedOn;
 
-exports.logError = function(msg, code) {
+exports.logError = function(msg, code, exception) {
 	var errCode = code || 'ERROR';
 	if (debugTurnedOn() && hasConsoleLogger()) {
-		if (console.error) {
-			console.error(errCode + ': ' + msg);
-		} else {
-			console.log(errCode + ': ' + msg);
-		}
-
+    console[errLogFn].call(console, errCode + ': ' + msg, exception || '');
 	}
 };
 
@@ -263,20 +257,6 @@ exports.getPriceBucketString = function(cpm) {
 	}
 	return returnObj;
 
-};
-
-exports.mapForEach = function(obj, func) {
-
-  if (!this.isFn(func)) {
-    throw new TypeError();
-  }
-
-  var self = this;
-  function boundFn(value, key) {
-    return func.call(self, value, key);
-  }
-
-  this._each(obj, boundFn);
 };
 
 /**


### PR DESCRIPTION
* move yieldbot templating into utilities
* standardize use of `isA` and helper functions
* bug with `hasOwnProperty` not being defined in utilities
* set `bidder` on bidResponse from `bidderCode` to match docs here -- http://prebid.org/publisher-api.html#configure-ad-server-targeting
* typo in example in readme for script tag
