### PR TITLE
Fix price bucket string; high granularity was using low price cap.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -242,8 +242,8 @@ exports.getPriceBucketString = function(cpm) {
 			}
 
 			//round to closet .01
-			if (cpmFloat > _lgPriceCap) {
-				returnObj.high = _lgPriceCap.toFixed(2);
+			if (cpmFloat > _hgPriceCap) {
+				returnObj.high = _hgPriceCap.toFixed(2);
 			} else {
 				returnObj.high = (Math.floor(cpm * 100) / 100).toFixed(2);
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ var objectType_number = 'number';
 var _loggingChecked = false;
 
 var _lgPriceCap = 5.00;
-var _mgPriceCap = 10.00;
+var _mgPriceCap = 20.00;
 var _hgPriceCap = 20.00;
 
 var t_Arr = 'Array',


### PR DESCRIPTION
Copy 'n' paste typo in `utils.js` it seems. The check for high granularity bid price was using the low granularity cap.

@mkendall07 wrt price caps, the doc is inconsistent with [utils.js#L10..L12](https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L10..L12) e.g.
- [Available bidResponse Values](http://prebid.org/publisher-api.html#available-bidresponse-values)
- [Price Bucket Definition](http://prebid.org/adops.html#price-bucket-definition)

Happy to grep https://github.com/prebid/prebid.github.io and submit a PR. I mention it here b/c you may have intended to have the [bucket caps](https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L10..L12) per the doc, but the cap values specified in the code seem reasonable.