### PR TITLE
Multiple adserver targeting

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -158,10 +158,12 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
 	if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode]) {
 		//
 		setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
+		custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
 	}
 	//next try with defaultBidderSettings
 	else if (defaultBidderSettingsMap[bidderCode]) {
 		setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
+		custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
 	}
 	//now try with "generic" settings
 	else if (custBidObj && bidder_settings) {
@@ -191,8 +193,6 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
 				}]
 			};
 		}
-
-		custBidObj.usesGenericKeys = true;
 		setKeys(keyValues, bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD], custBidObj);
 	}
 
@@ -255,7 +255,7 @@ exports.executeCallback = function() {
 		processCallbacks(externalOneTimeCallback);
 		externalOneTimeCallback = null;
 	}
-	
+
 };
 
 exports.allBidsBack = function() {
@@ -278,7 +278,7 @@ function processCallbacks(callbackQueue, params){
 		}
 		else{
 			callFunction(callbackQueue, params);
-		}		
+		}
 }
 
 function callFunction(func, args){
@@ -290,7 +290,7 @@ function callFunction(func, args){
 		catch(e){
 			utils.logError('Error executing callback function: ' + e.message);
 		}
-	}	
+	}
 }
 
 function checkBidsBackByAdUnit(adUnitCode){
@@ -301,7 +301,7 @@ function checkBidsBackByAdUnit(adUnitCode){
 			//all bids back for ad unit
 			if(bidsBack === adUnit.bids.length){
 				triggerAdUnitCallbacks(adUnitCode);
-				
+
 			}
 		}
 	}
@@ -323,12 +323,12 @@ exports.checkIfAllBidsAreIn = function(adUnitCode) {
 
 	//check by ad units
 	checkBidsBackByAdUnit(adUnitCode);
-	
+
 
 	if (_allBidsAvailable) {
 		//execute our calback method if it exists && pbjs.initAdserverSet !== true
 		this.executeCallback();
-		
+
 	}
 };
 
@@ -349,5 +349,5 @@ exports.addCallback = function(id, callback, cbEvent){
 		externalCallbackByAdUnitArr.push(callback);
 	}
 
-	
+
 };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -340,7 +340,18 @@ function requestAllBids(tmout){
 //		Start Public APIs		//
 // 								//
 //////////////////////////////////
+/**
+ * This function returns the query string targeting parameters available at this moment for a given ad unit. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
+ * @param  {string} [adunitCode] adUnitCode to get the bid responses for
+ * @alias module:pbjs.getAdserverTargetingForAdUnitCodeStr
+ * @return {array}	returnObj return bids array
+ */
+pbjs.getAdserverTargetingForAdUnitCodeStr = function(adunitCode) {
+	// call to retrieve bids array
+	var res = pbjs.getAdserverTargetingForAdUnitCode(adunitCode);
+	return utils.transformAdServerTargetingObj(res);
 
+};
 /**
  * This function returns the query string targeting parameters available at this moment for a given ad unit. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
  * @param  {string} [adunitCode] adUnitCode to get the bid responses for

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -199,12 +199,14 @@ function setGPTAsyncTargeting(code, slot, adUnitBids) {
 		for (var i = 0; i < adUnitBids.bids.length; i++) {
 			var bid = adUnitBids.bids[i];
 			//if use the generic key push into array with CPM for sorting
-			if (bid.alwaysUseBid) {
+			if (!bid.alwaysUseBid) {
 				bidArrayTargeting.push({
 					cpm: bid.cpm,
 					bid: bid
 				});
-			} else {
+			}
+			// alwaysUseBid = true - send the bid anyway
+			else {
 				var keyStrings = adUnitBids.bids[i].adserverTargeting;
 				for (var key in keyStrings) {
 					if (keyStrings.hasOwnProperty(key)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,22 @@ exports.parseQueryStringParameters = function(queryObj) {
 	return result;
 };
 
+
+//transform an array of AdServer targeting bids into a query string to send to the adserver
+//bid params should be an object such as {key: "value", key1 : "value1"}
+exports.transformAdServerTargetingObj = function(adServerTargetingAr) {
+	var result = "";
+	if (!adServerTargetingAr)
+		return "";
+	for (var i = 0; i < adServerTargetingAr.length; ++i){
+		AdserverTargetingObj = adServerTargetingAr[i];
+		for (var k in AdserverTargetingObj)
+			if (AdserverTargetingObj.hasOwnProperty(k))
+				result += k + "=" + encodeURIComponent(AdserverTargetingObj[k]) + "&";
+	}
+	return result;
+};
+
 //parse a GPT-Style General Size Array or a string like "300x250" into a format
 //suitable for passing to a GPT tag, may include size and/or promo sizes
 exports.parseSizesInput = function(sizeObj) {


### PR DESCRIPTION
fixed the logic to select the bids to send to the ad server.
Now, below bids will be send to the adserver:
  - if the bid belongs to a bidder in which bidderSettings object has the alwaysUseBid: true property
  - if the bid has the highest cpm among all remaining bids (bid without alwaysUseBid: true)

now getAdserverTargetingForAdUnit returns an array

Also added a getAdserverTargetingForAdUnitStr which returns the winning bids parameters as query string for confort.