### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pbjs.que.push(function(){
     }];
 	//add the adUnits
     pbjs.addAdUnits(adUnits);
-    }];
+});
 ```
 
 **Request Bids**


### PR DESCRIPTION
The example has a `]` where a `)` is needed.