### PR TITLE
Bug: ie < 11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,7 @@ var _hgPriceCap = 20.00;
 var t_Arr = 'Array',
     t_Str = 'String',
     t_Fn = 'Function',
+    toString = Object.prototype.toString,
     hasOwnProperty = Object.prototype.hasOwnProperty,
     slice = Array.prototype.slice;
 


### PR DESCRIPTION
toString wasn't taken off of `Object.prototype`, so was assumed from window, which causes problem in ie < 11 (invalid call)