### PR TITLE
Fix configuration syntax error and style inconsistency

### DIFF
--- a/integrationExamples/gpt/pbjs_example_gpt.html
+++ b/integrationExamples/gpt/pbjs_example_gpt.html
@@ -88,8 +88,7 @@
                     nid: "TO ADD",
                     cookiename: "cto_test"
                 }
-            }
-            {
+            }, {
                 bidder: 'yieldbot',
                 params: {
                     psn: 'TO ADD',


### PR DESCRIPTION
I noticed this syntax error in pbjs_example_gpt.html