### PR TITLE
Same ad slot will populate multiple divs

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -461,9 +461,9 @@ pbjs.setTargetingForAdUnitsGPTAsync = function(codeArr) {
 			//get all the slots from google tag
 			var slots = window.googletag.pubads().getSlots();
 			for (var k = 0; k < slots.length; k++) {
-				if (slots[k].getAdUnitPath() === code) {
+				if (slots[k].getSlotElementId() === code) {
 					placementBids = getBidResponsesByAdUnit(code);
-					setGPTAsyncTargeting(code, slots[k], placementBids);
+					setGPTAsyncTargeting(slots[k].getAdUnitPath(), slots[k], placementBids);
 				}
 			}
 		}
@@ -471,10 +471,10 @@ pbjs.setTargetingForAdUnitsGPTAsync = function(codeArr) {
 		//get all the slots from google tag
 		var slots = window.googletag.pubads().getSlots();
 		for (i = 0; i < slots.length; i++) {
-			var adUnitCode = slots[i].getAdUnitPath();
+			var adUnitCode = slots[i].getSlotElementId();
 			if (adUnitCode) {
 				placementBids = getBidResponsesByAdUnit(adUnitCode);
-				setGPTAsyncTargeting(adUnitCode, slots[i], placementBids);
+				setGPTAsyncTargeting(slots[i].getAdUnitPath(), slots[i], placementBids);
 			}
 		}
 	}
@@ -696,7 +696,7 @@ pbjs.registerBidAdapter = function(bidderAdaptor, bidderCode){
 	}
 	catch(e){
 		utils.logError('Error registering bidder adapter : ' + e.message);
-	}	
+	}
 };
 
 /**


### PR DESCRIPTION
From issue https://github.com/prebid/Prebid.js/issues/69

```
var rightSlot = googletag.defineSlot('12345/slot/name', [[300, 250]], 'div1').addService(googletag.pubads());
var topSlot = googletag.defineSlot('12345/slot/name', [[728,90]], 'div2').addService(googletag.pubads());
```

Will now populate two different sized ads.  The prebid `code` param in the adUnits array must be set to `div1` and `div2` for this to work.  I did not change `setGPTAsyncTargeting` and continue to pass the original slot name in so that the targeting behavior does not change.