### PR TITLE
Added rp_fastlane=true parameter

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -71,6 +71,7 @@ var RubiconAdapter = function RubiconAdapter() {
 			'window.rp_adtype   = "jsonp";' +
 			'window.rp_inventory = %%RP_INVENTORY%% ;' +
 			'window.rp_floor=%%RP_FLOOR%%;' +
+			'window.rp_fastlane = true;' +
 			'window.rp_callback = ' + callback + ';';
 
 


### PR DESCRIPTION
The rp_fastlane parameter allows Rubicon to distinguish between header bidding activation and standard tag based activation.