### PR TITLE
Fix potential timing issue on bid responses

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -27,6 +27,13 @@ exports.callBids = function(bidderArr) {
 			//emit 'bidRequested' event
 			events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidder);
 			currentBidder.callBids(bidder);
+
+			// if the bidder didn't explicitly set the number of bids
+			// expected, default to the number of bids passed into the bidder
+			if (bidmanager.getExpectedBidsCount(bidder.bidderCode) === undefined) {
+				bidmanager.setExpectedBidsCount(bidder.bidderCode, bidder.bids.length);
+			}
+
 			var currentTime = new Date().getTime();
 			bidmanager.registerBidRequestTime(bidder.bidderCode, currentTime);
 

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -111,6 +111,7 @@ exports.setExpectedBidsCount = function(bidderCode,count){
 function getExpectedBidsCount(bidderCode){
 	return expectedBidsCount[bidderCode];
 }
+exports.getExpectedBidsCount = getExpectedBidsCount;
 
 
 /*
@@ -395,17 +396,13 @@ exports.checkIfAllBidsAreIn = function(adUnitCode) {
 // check all bids response received by bidder
 function checkAllBidsResponseReceived(){
 	var available = true;
-	
-	utils._each(bidResponseReceivedCount,function(count,bidderCode){
 
-		//expected bids count check for appnexus
-		if(bidderCode === 'appnexus'){
-			var expectedCount = getExpectedBidsCount(bidderCode);
+	utils._each(bidResponseReceivedCount, function(count, bidderCode){
+		var expectedCount = getExpectedBidsCount(bidderCode);
 
-			if(typeof expectedCount === objectType_undefined || count < expectedCount){
-				available = false;
-			}
-		}else if(count<1){
+		// expectedCount should be set in the adapter, or it will be set
+		// after we call adapter.callBids()
+		if ((typeof expectedCount === objectType_undefined) || (count < expectedCount)) {
 			available = false;
 		}
 	});


### PR DESCRIPTION
* conditional check for appnexus meant that other adapters with multiple responses/resource requests (e.g., AOL, rubicon) might return bids after `checkAllBidResponseReceived() === true`; code preferred appnexus bidder
* by letting all adapters specify number of expected bids with `setExpectedBidsCount` we let number of returned bids differ from number of bids passed in, e.g. in cases where each size is represented as a separate bid