### PR TITLE
Taking into account the NaN values returned by DAC.js

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -38,7 +38,7 @@ var AolAdapter = function AolAdapter() {
     }
 
     cpm = response.getCPM();
-    if (cpm == null) {
+    if (cpm == null || isNaN(cpm)) {
       return _addErrorBid(response, context);
     }
 


### PR DESCRIPTION
Fixing the bug where valid bids are created from responses (returned by DAC.js) where cpm is NaN.

@mkendall07 is there any reason why the AOL adapter has been removed (and not included in the release) ?