### PR TITLE
Don't return empty zones (Criteo adapter)

### DIFF
--- a/src/adapters/criteo.js
+++ b/src/adapters/criteo.js
@@ -53,7 +53,7 @@ var CriteoAdapter = function CriteoAdapter() {
 						adResponse = bidfactory.createBid(1);
 						adResponse.bidderCode = 'criteo';
 
-						adResponse.keys = content.split(';');
+						adResponse.keys = content.replace(/\;$/, '').split(';');
 					} else {
 						// Indicate an ad was not returned
 						adResponse = bidfactory.createBid(2);


### PR DESCRIPTION
Criteo returns something like:

zone1;zone2;zone3;

in their cookie. This results in an array like:

['zone1', 'zone2', 'zone3', '']

We don't want this empty element. To prevent this from happening we remove the trailing semicolon from the cookie string before split().