### PR TITLE
fix(yieldbot): slot name is case sensitive

### DIFF
--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -35,7 +35,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
         buildCreative: function(slot, size) {
             return '<script type="text/javascript" src="//cdn.yldbt.com/js/yieldbot.intent.js"></script>' +
                 '<script type="text/javascript">var ybotq = ybotq || [];' +
-                'ybotq.push(function () {yieldbot.renderAd(\'' + slot.toLowerCase() + ':' + size + '\');});</script>';
+                'ybotq.push(function () {yieldbot.renderAd(\'' + slot + ':' + size + '\');});</script>';
         },
         /**
          * Bid response builder.


### PR DESCRIPTION
The Yieldbot `yieldbot.renderAd(<slotName>:<size>)` function assumes a case sensitive slot name.

Requests to render a slot **_where the name has a case mismatch_**, compared to the Yieldbot backend slot name, will result in no ad available for rendering; despite there being a bid indicating an ad being available.

Erroneously, the slot name had case set with `.toLowerCase()`.

Use `slot` name as provided.