### PR TITLE
Remove incorrect check for siteID

### DIFF
--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -224,10 +224,6 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
 			return;
 		}
 
-		if (!cygnus_index_args.siteID) {
-			return;
-		}
-
 		cygnus_index_args.slots = [];
 		var bidCount = 0;
 


### PR DESCRIPTION
This is no longer required and is causing issues due to the changes to support the standard config format. Please merge otherwise the indexExchange.js adapter will not function. Thanks!