### PR TITLE
IndexExchange Secondary Request support (rotating ads, slideshows, etc)

### DIFF
--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -314,7 +314,13 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
 
 		window.cygnus_index_ready_state = function() {
 			try {
+                bidmanager.setExpectedBidsCount(ADAPTER_CODE, 0);
 				var indexObj = _IndexRequestData.targetIDToBid;
+                var counter = 0;
+                for(var key in indexObj){
+                    counter++;
+                }
+                bidmanager.setExpectedBidsCount(ADAPTER_CODE, counter);
 				var lookupObj = cygnus_index_args;
 
 				if (utils.isEmpty(indexObj)) {


### PR DESCRIPTION
*UPDATE*
Pull request now also includes a fix to prevent IX from hitting the PBJS global timeout every time. See the comment below for details.

Updated the Index Exchange bidder adapter so that it supports multiple requests per page load (eg. slideshows, rotating ads, etc).

Previous functionality was to ignore request besides the initial one (on a single page load).
New functionality allows a new request to be sent to the Index Exchange ad server network without reloading the page.