### PR TITLE
fix: wrong entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prebid.js",
   "version": "0.6.0",
   "description": "Header Bidding Management Library",
-  "main": "prebid.js",
+  "main": "src/prebid.js",
   "scripts": {
     "test": "gulp test"
   },


### PR DESCRIPTION
It was impossible to require the module as a npm package. For example:
```
var pbjs = require('prebid.js');
```
caused the error: Cannot find module 'prebid.js'
So it was impossible to use with Browserify/Webpack.