### PR TITLE
Build only with required adapters

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,11 +49,10 @@ gulp.task('webpack', function() {
         webpackConfig.output.filename = 'prebid.' + argv.tag + '.js';
     }
 
-    return gulp.src('src/**/*.js')
+    return gulp.src('src/*.js')
         .pipe(webpack(webpackConfig))
         .pipe(header(banner, {pkg: pkg}))
         .pipe(gulp.dest('build/dev'))
-        .pipe(gulp.dest('test/app'))
         .pipe(uglify())
         .pipe(gulp.dest('build/dist'))
         .pipe(connect.reload());

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@
 var webpackConfig = require('./webpack.conf');
 webpackConfig.module.postLoaders = [{
     test: /\.js$/,
-    exclude: /(mediation-script)|(node_modules)|(test)|(polyfill)|(visibly)/,
+    exclude: /(node_modules)|(test)|(integrationExamples)|(build)/,
     loader: 'istanbul-instrumenter'
 }];
 
@@ -31,7 +31,7 @@ module.exports = function(config) {
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
             'test/**/*_spec.js': ['webpack'],
-            'src/**/*.js': ['coverage']
+            'src/*.js': ['coverage']
         },
 
         // WebPack Related

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -4,7 +4,7 @@ module.exports = {
         filename: 'prebid.js'
     },
     resolve: {
-        modulesDirectories: ['', 'node_modules', 'src', 'adapters']
+        modulesDirectories: ['', 'node_modules', 'src']
     },
     resolveLoader: {
         modulesDirectories: ['loaders', 'node_modules']


### PR DESCRIPTION
This commit allows limiting the number of adapters included in a build by modifying lines [here](https://github.com/prebid/Prebid.js/blob/build-with-required-adapters/src/adaptermanager.js#L3) to require only the adapters needed and [here](https://github.com/prebid/Prebid.js/blob/build-with-required-adapters/src/adaptermanager.js#L92) to register those adapters. This will have an impact on the file size of prebid.js build files.