### PR TITLE
Build prebid.js with specified adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# HEY DEVELOPERS!
-### `rm -rf ./node_modules && npm cache clean && npm install`
-With [this commit](http://bit.ly/1Ran76T) we have changed the build system to use Webpack, Karma and Istanbul. This change was made to   support improved unit test coverage and reporting. Reinstalling Prebid.js is necessary as many node modules changed, and you are likely   to experience errors otherwise. After pulling down latest master please `rm -rf ./node_modules && npm cache clean && npm install`.
-### Build path change
-The `./dist` and `./dev` directories have been moved to a `./build` directory -- please update your own dev and example paths to `prebid.js` accordingly. You will also find code coverage reports in the `./build/coverage` directory.
 Prebid.js
 ========
 
@@ -38,7 +33,7 @@ Download the integration example [here](https://github.com/prebid/Prebid.js/blob
 
 ### Example code ###
 
-**Include the prebid.js libraray**
+**Include the prebid.js library**
 Note that you need to host `prebid.js` locally or on a CDN and update the reference in the code snippet below for `cdn.host.com/prebid.min.js
 ```javascript
 (function() {
@@ -82,7 +77,8 @@ pbjs.que.push(function(){
 ```
 
 **See Console Debug Errors during testing**
-By default console errors are supressed. To enabled add `?pbjs_debug=true` to the end of the URL for testing. 
+By default console errors are suppressed. To enabled add `?pbjs_debug=true` to the end of the URL
+ for testing.
 
 API
 ----------
@@ -93,29 +89,103 @@ Full Developer API reference:
 Contribute
 ----------
 
-### Add an Bidder Adapter ###
+### Add a Bidder Adapter ###
 Follow the [guide outlined here](http://prebid.org/dev-docs/bidder-adaptor.html) to add an adapter. 
 
-### install ###
-    $ sudo npm install
+### Install ###
+    $ npm install
+
+If you experience errors, after a version update, try a fresh install:
+
+    $ rm -rf ./node_modules && npm cache clean && npm install
 
 ### Build ###
     $ gulp build
 
-### Configure ###
-Edit `./integrationExamples/gpt/pbjs_example_gpt.html`
+Runs code quality checks, generates prebid.js files and creates zip archive distributable:
 
-Change `{id}` values appropriately 
-    
+   `./build/dev/prebid.js` Full source code for dev and debug
+    `./build/dev/prebid.js.map` Source map for dev and debug
+    `./build/dist/prebid.js` Minified production code
+    `./prebid.js_<version>.zip` Distributable
+
+Code quality is defined by `./.jscs` and `./.jshint` files and errors are reported in the
+terminal. The build will continue with quality errors, however. If you are contributing code
+you can configure your editor with the provided .jscs and .jshint settings.
+
+### Configure ###
+Edit example file `./integrationExamples/gpt/pbjs_example_gpt.html`:
+
+1. Change `{id}` values appropriately to set up ad units and bidders.
+
+1. Set path for prebid.js in your example file:
+   #####Development `pbs.src = './build/dev/prebid.js';` #####
+    ```javascript
+    (function() {
+            var d = document, pbs = d.createElement('script'), pro = d.location.protocol;
+            pbs.type = 'text/javascript';
+            pbs.src = ((pro === 'https:') ? 'https' : 'http') + ':./build/dev/prebid.js';
+            var target = document.getElementsByTagName('head')[0];
+            target.insertBefore(pbs, target.firstChild);
+    })();
+    ```
+   #####Test/Deploy (default) `pbs.src = './build/dist/prebid.js';`#####
+    ```javascript
+    (function() {
+            var d = document, pbs = d.createElement('script'), pro = d.location.protocol;
+            pbs.type = 'text/javascript';
+            pbs.src = ((pro === 'https:') ? 'https' : 'http') + './build/dist/prebid.js';
+            var target = document.getElementsByTagName('head')[0];
+            target.insertBefore(pbs, target.firstChild);
+    })();
+    ```
+1. (optional optimization) Edit `./package.json` to set the adapters you want to build with:
+
+    ```json
+        "adapters": [
+            "adform",
+            "aol",
+            "appnexus",
+            "indexExchange",
+            "openx",
+            "pubmatic",
+            "pulsepoint",
+            "rubicon",
+            "rubiconLegacy",
+            "sovrn",
+            "springserve",
+            "yieldbot"
+  ]
+    ```
+
 ### Run ###
 
     $ gulp serve
 
-Navigate to http://localhost:9999/integrationExamples/gpt/pbjs_example_gpt.html to run the example file
+This runs code quality checks, generates prebid files and starts a webserver at
+`http://localhost:9999` serving from project root. Navigate to your example implementation to test,
+and if your prebid.js file is sourced from the `./build/dev` directory you will have sourcemaps
+available in browser developer tools.
+
+Navigate to `http://localhost:9999/integrationExamples/gpt/pbjs_example_gpt.html` to run the
+example file.
+
+Navigate to `http://localhost:9999/build/coverage/karma_html/report` to view a test coverage report.
+
+A watch is also in place that will run continuous tests in the terminal as you edit code and
+tests.
 
 ### Unit Test In the Browser ###
+    $ gulp test --watch
 
-Navigate to http://localhost:9999/build/coverage/karma_html/report to view test results.
+This will run tests and keep the Karma test browser open. If your prebid.js file is sourced from
+the build/dev directory you will also have sourcemaps available when viewing browser developer
+tools. Access the Karma debug page at:
+`http://localhost:9876/debug.html`
+View console for test results and developer tools to set breakpoints in source code.
+
+Detailed code coverage reporting can be generated explicitly with `$ gulp test --coverage` and
+results found in `./build/coverage`.
 
 ### Supported Browsers ###
 Prebid.js is supported on IE9+ and modern browsers.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var argv = require('yargs').argv;
 var gulp = require('gulp');
 var gutil = require('gulp-util');
@@ -18,20 +20,20 @@ var header = require('gulp-header');
 var zip = require('gulp-zip');
 
 var CI_MODE = process.env.NODE_ENV === 'ci';
-var pkg = require('./package.json');
+var prebid = require('./package.json');
 var dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
-var packageNameVersion = pkg.name + '_' + pkg.version;
-var banner = '/* <%= pkg.name %> v<%= pkg.version %> \n' + dateString + ' */\n';
+var packageNameVersion = prebid.name + '_' + prebid.version;
+var banner = '/* <%= prebid.name %> v<%= prebid.version %> \n' + dateString + ' */\n';
 
 // Tasks
 gulp.task('default', ['clean', 'quality', 'webpack']);
 
 gulp.task('serve', ['clean', 'quality', 'devpack', 'webpack', 'watch', 'test']);
 
-gulp.task('build', ['clean', 'quality', 'webpack', 'zip']);
+gulp.task('build', ['clean', 'quality', 'webpack', 'devpack', 'zip']);
 
 gulp.task('clean', function () {
-  return gulp.src(['build', 'test/app/**/*.js', 'test/app/index.html'], {
+  return gulp.src(['build'], {
       read: false
     })
     .pipe(clean());
@@ -39,7 +41,7 @@ gulp.task('clean', function () {
 
 gulp.task('devpack', function () {
   webpackConfig.devtool = 'source-map';
-  return gulp.src('src/**/*.js')
+  return gulp.src('src/*.js')
     .pipe(webpack(webpackConfig))
     .pipe(gulp.dest('build/dev'))
     .pipe(connect.reload());
@@ -54,10 +56,10 @@ gulp.task('webpack', function () {
 
   webpackConfig.devtool = null;
 
-  return gulp.src('src/**/*.js')
-    .pipe(header(banner, { pkg: pkg }))
+  return gulp.src('src/*.js')
     .pipe(webpack(webpackConfig))
     .pipe(uglify())
+    .pipe(header(banner, { prebid: prebid }))
     .pipe(gulp.dest('build/dist'))
     .pipe(connect.reload());
 });
@@ -100,9 +102,9 @@ gulp.task('coverage', function (done) {
 // Watch Task with Live Reload
 gulp.task('watch', function () {
 
-  gulp.watch(['test/spec/**/*.js'], ['webpack', 'test']);
+  gulp.watch(['test/spec/**/*.js'], ['quality', 'webpack', 'devpack', 'test']);
   gulp.watch(['integrationExamples/gpt/*.html'], ['test']);
-  gulp.watch(['src/**/*.js'], ['webpack', 'test']);
+  gulp.watch(['src/**/*.js'], ['quality', 'webpack', 'devpack', 'test']);
   connect.server({
     port: 9999,
     root: './',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,6 +38,9 @@ module.exports = function (config) {
 
     // WebPack Related
     webpack: webpackConfig,
+    webpackMiddleware: {
+      noInfo: true
+    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/loaders/adapterLoader.js
+++ b/loaders/adapterLoader.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const fs = require('fs');
+const blockLoader = require('block-loader');
+let adapters = require('../package.json').adapters;
+
+var options = {
+  start: '/** INSERT ADAPTERS - DO NOT EDIT OR REMOVE */',
+  end: '/** END INSERT ADAPTERS */',
+  process: function insertAdapters() {
+    const files = fs.readdirSync('src/adapters').map((file) => file.replace(/\.[^/.]+$/, ''));
+
+    if (!adapters || !adapters.length) {
+      console.log('Prebid Warning: adapters config not found in package.json, building with all' +
+        ' adapters');
+      adapters = files;
+    }
+
+    let inserts = adapters.filter((adapter) => {
+      if (files.includes(adapter)) {
+        return adapter;
+      } else {
+        console.log(`Prebid Warning: no adapter found for ${adapter}, continuing.`);
+      }
+    });
+
+    if (!inserts.length) {
+      console.log('Prebid Warning: no matching adapters found for config, building with all' +
+        ' adapters.');
+    }
+
+    inserts = inserts.length ? inserts : files;
+    return inserts.map((adapter) => {
+      return `var ${adapterName(adapter)} = require('./adapters/${adapter}.js');\n` +
+        `exports.registerBidAdapter(new ${adapterName(adapter)}` +
+        `${useCreateNew(adapter)}(), '${adapter}');\n`;
+    }).join('');
+  }
+};
+
+function adapterName(adapter) {
+  let result = adapter.split('');
+  return result[0].toUpperCase() + result.join('').substr(1) + 'Adapter';
+}
+
+// some adapters export an object with a `createNew` constructor so accommodate this pattern
+function useCreateNew(adapter) {
+  return adapter === 'appnexus' ? '.createNew' : '';
+}
+
+module.exports = blockLoader(options);

--- a/package.json
+++ b/package.json
@@ -6,12 +6,27 @@
   "scripts": {
     "test": "gulp test"
   },
+  "adapters": [
+    "adform",
+    "aol",
+    "appnexus",
+    "indexExchange",
+    "openx",
+    "pubmatic",
+    "pulsepoint",
+    "rubicon",
+    "rubiconLegacy",
+    "sovrn",
+    "springserve",
+    "yieldbot"
+  ],
   "author": [],
   "license": "Apache-2.0",
   "devDependencies": {
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.3",
     "babel-preset-es2015": "^6.5.0",
+    "block-loader": "^2.1.0",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
     "clone": "^0.1.17",

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,16 +1,5 @@
 /** @module adaptermanger */
 
-var RubiconAdapter = require('./adapters/rubicon.js');
-var AppNexusAdapter = require('./adapters/appnexus.js');
-var AolAdapter = require('./adapters/aol');
-var OpenxAdapter = require('./adapters/openx');
-var PubmaticAdapter = require('./adapters/pubmatic.js');
-var YieldbotAdapter = require('./adapters/yieldbot');
-var IndexExchange = require('./adapters/indexExchange');
-var Sovrn = require('./adapters/sovrn');
-var PulsePointAdapter = require('./adapters/pulsepoint.js');
-var SpringServeAdapter = require('./adapters/springserve.js');
-var AdformAdapter = require('./adapters/adform');
 var bidmanager = require('./bidmanager.js');
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -86,18 +75,9 @@ exports.aliasBidAdapter = function (bidderCode, alias) {
   }
 };
 
-// Register the bid adaptors here
-exports.registerBidAdapter(new RubiconAdapter(), 'rubicon');
-exports.registerBidAdapter(new AppNexusAdapter.createNew(), 'appnexus');
-exports.registerBidAdapter(new OpenxAdapter(), 'openx');
-exports.registerBidAdapter(new PubmaticAdapter(), 'pubmatic');
-exports.registerBidAdapter(new YieldbotAdapter(), 'yieldbot');
-exports.registerBidAdapter(new IndexExchange(), 'indexExchange');
-exports.registerBidAdapter(new SpringServeAdapter(), 'springserve');
-exports.registerBidAdapter(new Sovrn(), 'sovrn');
-exports.registerBidAdapter(new AolAdapter(), 'aol');
-exports.registerBidAdapter(new PulsePointAdapter(), 'pulsepoint');
+/** INSERT ADAPTERS - DO NOT EDIT OR REMOVE */
+// here be adapters
+/** END INSERT ADAPTERS */
 
 //default bidder alias
 exports.aliasBidAdapter('appnexus', 'brealtime');
-exports.registerBidAdapter(new AdformAdapter(), 'adform');

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -7,7 +7,7 @@ module.exports = {
     modulesDirectories: ['', 'node_modules', 'src']
   },
   resolveLoader: {
-    modulesDirectories: ['node_modules']
+    modulesDirectories: ['loaders', 'node_modules']
   },
   module: {
     loaders: [
@@ -22,6 +22,11 @@ module.exports = {
       {
         test: /\.json$/,
         loader: 'json'
+      },
+      {
+        test: /adaptermanager.js/,
+        include: /(src)/,
+        loader: 'adapterLoader'
       }
     ]
   }


### PR DESCRIPTION
An `adapters` section in package.json allows for specifying which adapters to build with. This makes it easy to optimize the prebid file size by only including adapters that you need. Adapter names can be added and removed from the `adapters` array and only those adapter code files will be included in the build. If no adapters are found or no `adapters` section exists, then all adapters will be included. Adapter names must match the adapter file names.

review notes

* renamed file -> `adapterLoader.js`
* move version header task after uglify

updates

* split strings to array in favor of spread operator
* update README, add devpack task to watch and build