### PR TITLE
Fix the handling of AOL nbr

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -100,7 +100,7 @@ var AolAdapter = function AolAdapter() {
    * @param {ADTECHContext} context the context passed from aol
    */
   function _addErrorBid(response, context) {
-    var bid = bidsMap[context.alias || context.placement];
+    var bid = bidsMap[context.placement];
 
     if (!bid) {
       utils.logError('mismatched bid: ' + context.placement, ADTECH_BIDDER_NAME, context);


### PR DESCRIPTION
When AOL does not have a bid for an ad slot, they will send a 'nbr' or
'no bid response'. Previously the aol adapter would cause an error
whenever it encountered one of these nbr's, and cause none of our GPT
targeting to be set.

The issue was caused by the bidsMap array in the Aol adapter. This
array is built with _mapUnit() and uses the placement ids as array keys.

_addBid() uses bidsMap to look up the bids using the placement id as
the array key. _addErrorBid() also uses bidsMap to look up the bid,
however it tries to use the bid alias first, rather than the placement
id. This is where the error occurs, when _addErrorBid() tries to lookup
the bid using the alias as the array key. The array key could never be
the alias, so I have removed that check. Now the placement id will be
used to find the bid in the bidsMap in all cases. Placement id is
required for AOL, unlike the alias, so this should not fail anymore.