### PR TITLE
AOL adapter - store bid data in the bidmanager

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -6,7 +6,6 @@ var adloader = require('../adloader');
 var AolAdapter = function AolAdapter() {
 
   // constants
-  var ADTECH_PLACEMENT_RXP = /\W/g;
   var ADTECH_URI = (window.location.protocol) + '//aka-cdn.adtechus.com/dt/common/DAC.js';
   var ADTECH_BIDDER_NAME = 'aol';
   var ADTECH_PUBAPI_CONFIG = {
@@ -31,18 +30,7 @@ var AolAdapter = function AolAdapter() {
   var bidsMap = {};
   var d = window.document;
   var h = d.getElementsByTagName('HEAD')[0];
-  var aliasCount = 0;
   var dummyUnitIdCount = 0;
-
-  /**
-   * @private Given a placementCode slot path/div id
-   * for a unit, return a unique alias
-   * @param {String} placementCode
-   * @return {String} alias
-   */
-  function _generateAlias(placementCode) {
-    return (placementCode || 'alias').replace(ADTECH_PLACEMENT_RXP, '') + (++aliasCount);
-  }
 
   /**
    * @private create a div that we'll use as the
@@ -69,7 +57,7 @@ var AolAdapter = function AolAdapter() {
    * @param {ADTECHContext} context the context passed from aol
    */
   function _addBid(response, context) {
-    var bid = bidsMap[context.placement];
+    var bid = bidsMap[context.alias];
     var cpm;
 
     if (!bid) {
@@ -81,6 +69,9 @@ var AolAdapter = function AolAdapter() {
     if (cpm === null || isNaN(cpm)) {
       return _addErrorBid(response, context);
     }
+
+    // clean up--we no longer need to store the bid
+    delete bidsMap[context.alias];
 
     var bidResponse = bidfactory.createBid(1);
     bidResponse.bidderCode = ADTECH_BIDDER_NAME;
@@ -100,12 +91,15 @@ var AolAdapter = function AolAdapter() {
    * @param {ADTECHContext} context the context passed from aol
    */
   function _addErrorBid(response, context) {
-    var bid = bidsMap[context.placement];
+    var bid = bidsMap[context.alias];
 
     if (!bid) {
       utils.logError('mismatched bid: ' + context.placement, ADTECH_BIDDER_NAME, context);
       return;
     }
+
+    // clean up--we no longer need to store the bid
+    delete bidsMap[context.alias];
 
     var bidResponse = bidfactory.createBid(2);
     bidResponse.bidderCode = ADTECH_BIDDER_NAME;
@@ -120,8 +114,10 @@ var AolAdapter = function AolAdapter() {
    * @return {Object} the bid request, formatted for the ADTECH/DAC api
    */
   function _mapUnit(bid) {
+    var alias = bid.params.alias || utils.getUniqueIdentifierStr();
+
     // save the bid
-    bidsMap[bid.params.placement] = bid;
+    bidsMap[alias] = bid;
 
     return {
       adContainerId: _dummyUnit(bid.params.adContainerId),
@@ -131,7 +127,7 @@ var AolAdapter = function AolAdapter() {
       secure: false,
       serviceType: 'pubapi',
       performScreenDetection: false,
-      alias: bid.params.alias || _generateAlias(bid.placementCode),
+      alias: alias,
       network: bid.params.network,
       placement: parseInt(bid.params.placement),
       gpt: {


### PR DESCRIPTION
Unlike the appnexus adapter, the aol adapter was storing its bid object
in a local object using the placement as key. This limits the bid
requests to only load ads for unique placements. For example, let's say
I have three 300x250 ads and I want to use the same placement id for
each 300x250 ad instance. Storing bid data with the placement as key
will only allow one of the three to be displayed because using the
placement key will result in bid data being overwritten. This commit
updates the aol adapter to work in a similar fashion to the appnexus
adapter, using the bidmanager to store bid data.

fixes #227 