### PR TITLE
AOL adapter rendering 'undefined' below creative

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -74,8 +74,12 @@ var AolAdapter = function AolAdapter() {
     delete bidsMap[context.alias];
 
     var bidResponse = bidfactory.createBid(1);
+    var ad = response.getCreative();
+    if (typeof response.getPixels() !== 'undefined') {
+        ad += response.getPixels();
+    }
     bidResponse.bidderCode = ADTECH_BIDDER_NAME;
-    bidResponse.ad = response.getCreative() + response.getPixels();
+    bidResponse.ad = ad;
     bidResponse.cpm = cpm;
     bidResponse.width = response.getAdWidth();
     bidResponse.height = response.getAdHeight();


### PR DESCRIPTION
The response from AOL usually contains the creative code, along with
some code for a tracking pixel.
However, after a user has been synced with ADTECHUS via their tracking
pixel, the subsequent bid responses from AOL will no longer contain
the pixel code.
_addBid() stores the bid response and ad code. Whatever is returned from
response.getCreative() is concatenated with whatever is returned from
response.getPixels() and this is stored as the ad code.
After a user is synced and no longer receiving the tracking pixels,
repsonse.getPixels() will return 'undefined', which is concatenated to
the creative code and rendered to the page.
This pull request changes the AOL adapter to only concatenate the pixel
if it is not 'undefined'.