### PR TITLE
Remove gulp as a dependency to have a cleaner interface to the tools

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,13 @@
 // Karma configuration
 // Generated on Thu Aug 07 2014 09:45:28 GMT-0700 (PDT)
 var webpackConfig = require('./webpack.conf');
+var helpers = require('./gulpHelpers');
+var argv = require('yargs').argv;
+// Pass your browsers by using --browsers=chrome,firefox,ie9
+// Run CI by passing --watch
+var defaultBrowsers = CI_MODE ? ['PhantomJS'] : ['Chrome']
+var browserArgs = helpers.parseBrowserArgs(argv).map(helpers.toCapitalCase);
+
 webpackConfig.module.postLoaders = [
   {
     test: /\.js$/,
@@ -38,9 +45,6 @@ module.exports = function (config) {
 
     // WebPack Related
     webpack: webpackConfig,
-    webpackMiddleware: {
-      noInfo: true
-    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
@@ -78,16 +82,15 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: (argv.watch) ? true : false,
 
     // start these browsers
-    // NOTE: these get defined again in gulpfile.js for the gulp tasks
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome', 'Firefox'],
+    browsers: (browserArgs.length > 0) ? browserArgs : defaultBrowsers,
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    singleRun: (argv.watch) ? false : true,
 
     plugins: [
       'karma-phantomjs-launcher',

--- a/package.json
+++ b/package.json
@@ -4,11 +4,22 @@
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
-    "test": "gulp test"
+    "test": "karma start karma.conf.js",
+    "clean": "rm -r ./build || :",
+    "hint": "jshint src/**/*.js",
+    "jscs": "jscs src/**/*.js",
+    "quality": "npm run hint && npm run jscs",
+    "webpack": "webpack -p --config webpack.conf.js --devtool null",
+    "compress": "zip ${VISUAL}${LOGNAME}.zip build/dist/* integrationExamples/gpt/*",
+    "zip": "npm run jscs && npm run clean && npm run webpack && npm run compress",
+    "default": "npm run clean && npm run quality && npm run webpack",
+    "build": "npm run clean && npm run quality && npm run webpack && npm run compress",
+    "clean-docs": "rm -r docs",
+    "jsdoc2md": "jsdoc2md src/prebid.js > docs/docs.md"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/prebid/Prebid.js.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prebid/Prebid.js.git"
   },
   "adapters": [
     "adform",
@@ -58,8 +69,10 @@
     "istanbul": "^0.3.2",
     "istanbul-instrumenter-loader": "^0.1.2",
     "jquery": "1.11.1",
+    "jscs": "^2.11.0",
+    "jshint": "^2.9.1",
     "json-loader": "^0.5.1",
-    "karma": "^0.13.2",
+    "karma": "^0.13.21",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.0",
@@ -91,7 +104,7 @@
     "run-sequence": "^1.1.4",
     "sinon": "^1.12.1",
     "uglify-js": "^2.4.15",
-    "webpack": "^1.12.3",
+    "webpack": "^1.12.14",
     "webpack-stream": "^3.1.0",
     "yargs": "^1.3.1"
   },

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,13 +1,19 @@
+var argv = require('yargs').argv;
+
 module.exports = {
+  entry: [
+    'src/prebid.js'
+  ],
   output: {
+    path: 'build/dist/',
     filename: 'prebid.js'
   },
-  devtool: 'source-map',
+  devtool: argv.devtool && argv.devtool.length ?  argv.devtool : 'source-maps',
   resolve: {
     modulesDirectories: ['', 'node_modules', 'src']
   },
   resolveLoader: {
-    modulesDirectories: ['loaders', 'node_modules']
+    modulesDirectories: ['node_modules']
   },
   module: {
     loaders: [
@@ -22,11 +28,6 @@ module.exports = {
       {
         test: /\.json$/,
         loader: 'json'
-      },
-      {
-        test: /adaptermanager.js/,
-        include: /(src)/,
-        loader: 'adapterLoader'
       }
     ]
   }


### PR DESCRIPTION
THIS IS A WORK IN PROGRESS

I have been adding my own set of analytics and have been chasing errors gulp plugins show it is cleaner to use directly the cli tools. i have ported almost all basic functions to npm scripts, the equivalent commands are shorter.

You can give them a try npm install --save-dev jscs webpack jshint karma
npm run default
npm run build
npm run test
npm run quality

let me know your thougths on this to complete porting missing gulp commands.

