### PR TITLE
Sovrn - allow same tagId for multiple slots

### DIFF
--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -15,26 +15,7 @@ var SovrnAdapter = function SovrnAdapter() {
   function _callBids(params) {
     var sovrnBids = params.bids || [];
 
-    // De-dupe by tagid then issue single bid request for all bids
-    _requestBids(_getUniqueTagids(sovrnBids));
-  }
-
-  // filter bids to de-dupe them?
-  function _getUniqueTagids(bids) {
-    var key;
-    var map = {};
-    var Tagids = [];
-    bids.forEach(function (bid) {
-      map[utils.getBidIdParamater('tagid', bid.params)] = bid;
-    });
-
-    for (key in map) {
-      if (map.hasOwnProperty(key)) {
-        Tagids.push(map[key]);
-      }
-    }
-
-    return Tagids;
+    _requestBids(sovrnBids);
   }
 
   function _requestBids(bidReqs) {

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -124,7 +124,7 @@ var SovrnAdapter = function SovrnAdapter() {
               //store bid response
               //bid status is good (indicating 1)
               bid = bidfactory.createBid(1);
-              bid.creative_id = sovrnBid.Id;
+              bid.creative_id = sovrnBid.id;
               bid.bidderCode = 'sovrn';
               bid.cpm = responseCPM;
 


### PR DESCRIPTION
Incorporating change from "Sovrn adapter - Allow using the same tagId for multiple slots #189".
Fixing a typo to get the creative_id for the bid response.