### PR TITLE
custom namespacing [cleaned up commit]

### DIFF
--- a/src/adapters/adform.js
+++ b/src/adapters/adform.js
@@ -2,6 +2,7 @@ var utils = require('../utils.js');
 var adloader = require('../adloader.js');
 var bidmanager = require('../bidmanager.js');
 var bidfactory = require('../bidfactory.js');
+var CONSTANTS = require('../constants.json');
 
 function AdformAdapter() {
 
@@ -30,8 +31,8 @@ function AdformAdapter() {
       request.unshift('//adx.adform.net/adx/?rp=4');
     }
 
-    pbjs[callbackName] = handleCallback(bids);
-    request.push('callback=pbjs.' + callbackName);
+    window[CONSTANTS.PBJS_GLOBAL_VAR_NAME][callbackName] = handleCallback(bids);
+    request.push('callback='+CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.' + callbackName);
 
     adloader.loadScript(request.join('&'));
   }

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -45,7 +45,7 @@ AppNexusAdapter = function AppNexusAdapter() {
 
     var jptCall = 'http' + (document.location.protocol === 'https:' ? 's://secure.adnxs.com/jpt?' : '://ib.adnxs.com/jpt?');
 
-    jptCall = utils.tryAppendQueryString(jptCall, 'callback', 'pbjs.handleAnCB');
+    jptCall = utils.tryAppendQueryString(jptCall, 'callback', CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.handleAnCB');
     jptCall = utils.tryAppendQueryString(jptCall, 'callback_uid', callbackId);
     jptCall = utils.tryAppendQueryString(jptCall, 'psa', '0');
     jptCall = utils.tryAppendQueryString(jptCall, 'id', placementId);
@@ -140,7 +140,7 @@ AppNexusAdapter = function AppNexusAdapter() {
   }
 
   //expose the callback to the global object:
-  pbjs.handleAnCB = function (jptResponseObj) {
+  window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].handleAnCB = function (jptResponseObj) {
 
     var bidCode;
 

--- a/src/adapters/nginad.js
+++ b/src/adapters/nginad.js
@@ -100,7 +100,7 @@ var NginAdAdapter = function NginAdAdapter() {
       }
     };
 
-    var scriptUrl = window.location.protocol + '//' + rtbServerDomain + '/bid/rtb?callback=window.pbjs.nginadResponse' +
+    var scriptUrl = window.location.protocol + '//' + rtbServerDomain + '/bid/rtb?callback=window.'+CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.nginadResponse' +
       '&br=' + encodeURIComponent(JSON.stringify(nginadBidReq));
 
     adloader.loadScript(scriptUrl, null);
@@ -119,7 +119,7 @@ var NginAdAdapter = function NginAdAdapter() {
   }
 
   //expose the callback to the global object:
-  pbjs.nginadResponse = function(nginadResponseObj) {
+  window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].nginadResponse = function(nginadResponseObj) {
     var bid = {};
     var key;
 

--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -1,6 +1,8 @@
 var utils = require('../utils.js');
 var bidfactory = require('../bidfactory.js');
 var bidmanager = require('../bidmanager.js');
+var CONSTANTS = require('../constants.json');
+
 
 /**
  * Adapter for requesting bids from Pubmatic.
@@ -64,7 +66,7 @@ var PubmaticAdapter = function PubmaticAdapter() {
 
     content += '<scr' + 'ipt src="https://ads.pubmatic.com/AdServer/js/gshowad.js"></scr' + 'ipt>';
     content += '<scr' + 'ipt>';
-    content += 'window.parent.pbjs.handlePubmaticCallback({progKeyValueMap: progKeyValueMap,' +
+    content += 'window.parent.'+CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.handlePubmaticCallback({progKeyValueMap: progKeyValueMap,' +
       ' bidDetailsMap: bidDetailsMap})';
     content += '</scr' + 'ipt>';
     content += '</body></html>';
@@ -73,7 +75,7 @@ var PubmaticAdapter = function PubmaticAdapter() {
     return content;
   }
 
-  pbjs.handlePubmaticCallback = function (response) {
+  window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].handlePubmaticCallback = function (response) {
     var i;
     var adUnit;
     var adUnitInfo;

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -69,7 +69,7 @@ var SovrnAdapter = function SovrnAdapter() {
       }
     };
 
-    var scriptUrl = '//' + sovrnUrl + '?callback=window.pbjs.sovrnResponse' +
+    var scriptUrl = '//' + sovrnUrl + '?callback=window.'+CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.sovrnResponse' +
       '&br=' + encodeURIComponent(JSON.stringify(sovrnBidReq));
     adloader.loadScript(scriptUrl, null);
   }
@@ -90,7 +90,7 @@ var SovrnAdapter = function SovrnAdapter() {
   }
 
   //expose the callback to the global object:
-  pbjs.sovrnResponse = function (sovrnResponseObj) {
+  window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].sovrnResponse = function (sovrnResponseObj) {
     // valid object?
     if (sovrnResponseObj && sovrnResponseObj.id) {
       // valid object w/ bid responses?

--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -1,6 +1,8 @@
 var bidfactory = require('../bidfactory.js');
 var bidmanager = require('../bidmanager.js');
 var adloader = require('../adloader');
+var CONSTANTS = require('../constants.json');
+
 
 var SpringServeAdapter;
 SpringServeAdapter = function SpringServeAdapter() {
@@ -48,7 +50,7 @@ SpringServeAdapter = function SpringServeAdapter() {
 
     spCall += '&domain=';
     spCall += domain;
-    spCall += '&callback=pbjs.handleSpringServeCB';
+    spCall += '&callback='+CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.handleSpringServeCB';
 
     return spCall;
   }
@@ -62,7 +64,7 @@ SpringServeAdapter = function SpringServeAdapter() {
     }
   }
 
-  pbjs.handleSpringServeCB = function (responseObj) {
+  window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].handleSpringServeCB = function (responseObj) {
     if (responseObj && responseObj.seatbid && responseObj.seatbid.length > 0 &&
       responseObj.seatbid[0].bid[0] !== undefined) {
       //look up the request attributs stored in the bidmanager

--- a/src/adapters/triplelift.js
+++ b/src/adapters/triplelift.js
@@ -38,6 +38,7 @@ function buildTLCall(bid, callbackId) {
 	var tlCall = document.location.protocol + tlURI;
 
 	tlCall = utils.tryAppendQueryString(tlCall, 'callback', 'pbjs.TLCB');
+	tlCall = utils.tryAppendQueryString(tlCall, 'callback', CONSTANTS.PBJS_GLOBAL_VAR_NAME+'.TLCB');
 	tlCall = utils.tryAppendQueryString(tlCall, 'lib', 'prebid');
 	tlCall = utils.tryAppendQueryString(tlCall, 'lib', '0.5.0');
 	tlCall = utils.tryAppendQueryString(tlCall, 'callback_id', callbackId);
@@ -52,7 +53,7 @@ function buildTLCall(bid, callbackId) {
 	//append referrer
 	var referrer = utils.getTopWindowUrl();
 	tlCall = utils.tryAppendQueryString(tlCall, 'referrer', referrer);
-	
+
 	//remove the trailing "&"
 	if (tlCall.lastIndexOf('&') === tlCall.length - 1) {
 		tlCall = tlCall.substring(0, tlCall.length - 1);
@@ -71,7 +72,9 @@ function buildTLCall(bid, callbackId) {
 
 
 //expose the callback to the global object:
-pbjs.TLCB = function(tlResponseObj) {
+
+window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].TLCB = function(tlResponseObj) {
+
 	if (tlResponseObj && tlResponseObj.callback_id) {
 		var bidObj = bidmanager.pbCallbackMap[tlResponseObj.callback_id],
 			placementCode = bidObj.placementCode;

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -2,6 +2,8 @@ var CONSTANTS = require('./constants.json');
 var utils = require('./utils.js');
 var events = require('./events');
 
+var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
+
 var objectType_function = 'function';
 var objectType_undefined = 'undefined';
 

--- a/src/constants.json
+++ b/src/constants.json
@@ -1,5 +1,5 @@
 {
-  "PBJS_GLOBAL_VAR_NAME": "DoggieBidder",
+  "PBJS_GLOBAL_VAR_NAME": "pbjs",
   "JSON_MAPPING": {
     "PL_CODE": "code",
     "PL_SIZE": "sizes",

--- a/src/constants.json
+++ b/src/constants.json
@@ -1,4 +1,5 @@
 {
+  "PBJS_GLOBAL_VAR_NAME": "DoggieBidder",
   "JSON_MAPPING": {
     "PL_CODE": "code",
     "PL_SIZE": "sizes",

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,10 +1,12 @@
 /** @module pbjs */
 
-// if pbjs already exists in global dodcument scope, use it, if not, create the object
-window.pbjs = (window.pbjs || {});
-window.pbjs.que = window.pbjs.que || [];
-var pbjs = window.pbjs;
 var CONSTANTS = require('./constants.json');
+
+// if the global var already exists in global dodcument scope, use it, if not, create the object
+window[CONSTANTS.PBJS_GLOBAL_VAR_NAME] = (window[CONSTANTS.PBJS_GLOBAL_VAR_NAME] || {});
+window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].que = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME].que || [];
+var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
+
 var utils = require('./utils.js');
 var bidmanager = require('./bidmanager.js');
 var adaptermanager = require('./adaptermanager');

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,6 +207,7 @@ var errLogFn = (function (hasLogger) {
 }(hasConsoleLogger()));
 
 var debugTurnedOn = function () {
+  var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
   if (pbjs.logging === false && _loggingChecked === false) {
     pbjs.logging = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
     _loggingChecked = true;

--- a/test/helpers/pbjs-test-only.js
+++ b/test/helpers/pbjs-test-only.js
@@ -1,10 +1,15 @@
+var CONSTANTS = require('src/constants.json');
+
+
 export const pbjsTestOnly = {
 
   getAdUnits() {
+    var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
     return pbjs.adUnits;
   },
 
   clearAllAdUnits() {
+    var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
     pbjs.adUnits = [];
   }
 };

--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -1,4 +1,8 @@
 describe('Publisher API _ AdUnits', function () {
+
+  var CONSTANTS = require('src/constants.json');
+
+
   var assert = require('chai').assert;
   var expect = require('chai').expect;
   var pbjsTestOnly = require('../helpers/pbjs-test-only').pbjsTestOnly;
@@ -41,7 +45,9 @@ describe('Publisher API _ AdUnits', function () {
                 }
             ]
     }];
-
+    var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
+    //console.log('pbjs = ');
+    //console.log(pbjs);
     pbjs.addAdUnits(adUnits);
   });
 
@@ -50,7 +56,6 @@ describe('Publisher API _ AdUnits', function () {
   });
 
   describe('addAdUnits', function () {
-
     var adUnits, adUnit1, bids1, adUnit2, bids2;
 
     it('should have two adUnits', function () {
@@ -98,10 +103,10 @@ describe('Publisher API _ AdUnits', function () {
   });
 
   describe('removeAdUnit', function () {
-
     var adUnits, adUnit2, bids2;
 
     it('the first adUnit should be not existed', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       pbjs.removeAdUnit('/1996833/slot-1');
       adUnits = pbjsTestOnly.getAdUnits();
       adUnit2 = adUnits[0];
@@ -110,6 +115,7 @@ describe('Publisher API _ AdUnits', function () {
     });
 
     it('the second adUnit should be still existed', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       assert.strictEqual(adUnit2.code, '/1996833/slot-2', 'adUnit2 code');
       assert.deepEqual(adUnit2.sizes, [[468, 60]], 'adUnit2 sizes');
       assert.strictEqual(bids2[0].bidder, 'rubicon', 'adUnit2 bids1 bidder');

--- a/test/spec/aliasBidder_spec.js
+++ b/test/spec/aliasBidder_spec.js
@@ -6,6 +6,9 @@ describe('Publisher API _ Alias Bidder', function () {
   var should = require('chai').should();
   var prebid = require('../../src/prebid');
 
+  var CONSTANTS = require('../../src/constants.json');
+  var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
+
   before(function () {
 
     var topSlotCode = '/19968336/header-bid-tag1';

--- a/test/spec/api_spec.js
+++ b/test/spec/api_spec.js
@@ -1,6 +1,9 @@
 var assert = require('chai').assert;
 var prebid = require('../../src/prebid');
 
+var CONSTANTS = require('../../src/constants.json');
+var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
+
 describe('Publisher API', function () {
   // var assert = chai.assert;
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3,6 +3,7 @@ var assert = require('chai').assert;
 var prebid = require('src/prebid');
 var utils = require('src/utils');
 var bidmanager = require('src/bidmanager');
+var CONSTANTS = require('src/constants.json');
 
 var bidResponses = require('test/fixtures/bid-responses.json');
 var targetingMap = require('test/fixtures/targeting-map.json');
@@ -60,11 +61,13 @@ after(function () {
 describe('Unit: Prebid API', function () {
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     it('should return targeting info as a string', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getAdserverTargetingForAdUnitCodeStr(config.adUnitCodes[0]);
       assert.equal(result, targetingString, 'returns expected string of ad targeting info');
     });
 
     it('should log message if adunitCode param is falsey', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getAdserverTargetingForAdUnitCodeStr();
       assert.ok(spyLogMessage.calledWith('Need to call getAdserverTargetingForAdUnitCodeStr with adunitCode'), 'expected message was logged');
       assert.equal(result, undefined, 'result is undefined');
@@ -73,11 +76,13 @@ describe('Unit: Prebid API', function () {
 
   describe('getAdserverTargetingForAdUnitCode', function () {
     it('should return targeting info as an object', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getAdserverTargetingForAdUnitCode(config.adUnitCodes[0]);
       assert.deepEqual(result, targetingMap[config.adUnitCodes[0]], 'returns expected targeting info object');
     });
 
     it('should return full targeting map object if adunitCode is falsey', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getAdserverTargetingForAdUnitCode();
       assert.deepEqual(result, targetingMap, 'the complete targeting map object is returned');
     });
@@ -85,6 +90,7 @@ describe('Unit: Prebid API', function () {
 
   describe('getAdServerTargeting', function () {
     it('should call getAdServerTargetingForAdUnitCode', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var spyGetAdServerTargetingForAdUnitCode = sinon.spy(pbjs, 'getAdserverTargetingForAdUnitCode');
       pbjs.getAdserverTargeting();
       assert.ok(spyGetAdServerTargetingForAdUnitCode.calledOnce, 'called the expected function');
@@ -94,6 +100,7 @@ describe('Unit: Prebid API', function () {
 
   describe('getBidResponses', function () {
     it('should return expected bid responses when passed an adunitCode', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getBidResponses(config.adUnitCodes[0]);
       var compare = require('test/fixtures/bid-responses-cloned.json')[config.adUnitCodes[0]];
 
@@ -101,6 +108,7 @@ describe('Unit: Prebid API', function () {
     });
 
     it('should return expected bid responses when not passed an adunitCode', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var result = pbjs.getBidResponses();
       var compare = require('test/fixtures/bid-responses-cloned.json');
 
@@ -110,6 +118,7 @@ describe('Unit: Prebid API', function () {
 
   describe('getBidResponsesForAdUnitCode', function () {
     it('should call getBidResponses with passed in adUnitCode', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var adUnitCode = 'xyz';
       var spyGetBidResponses = sinon.spy(pbjs, 'getBidResponses');
 
@@ -121,6 +130,7 @@ describe('Unit: Prebid API', function () {
 
   describe('setTargetingForGPTAsync', function () {
     it('should log a message when googletag functions not defined', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var pubads = window.googletag.pubads;
 
       window.googletag.pubads = undefined;
@@ -130,6 +140,7 @@ describe('Unit: Prebid API', function () {
     });
 
     it('should set targeting when passed an array of ad unit codes', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
 
@@ -145,6 +156,7 @@ describe('Unit: Prebid API', function () {
     });
 
     it('should set targeting from googletag data', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
 
@@ -162,6 +174,7 @@ describe('Unit: Prebid API', function () {
 
   describe('allBidsAvailable', function () {
     it('should call bidmanager.allBidsBack', function () {
+      var pbjs = window[CONSTANTS.PBJS_GLOBAL_VAR_NAME];
       var spyAllBidsBack = sinon.spy(bidmanager, 'allBidsBack');
 
       pbjs.allBidsAvailable();


### PR DESCRIPTION
This is how I implemented: #115

I am totally open to other ways of implementing this feature. I just want this feature to exist.

This is the "obvious" way of doing namespacing - allow a configurable field in constants.json where the global variable name can be chosen.

Then everywhere pbjs was used needs to lookup what the global var is called.