### PR TITLE
Fix bugs in ga.js for analytics reporting

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -134,6 +134,11 @@ exports.addBidResponse = function (adUnitCode, bid) {
       bid.cpm = 0;
     }
 
+    // alias the bidderCode to bidder;
+    // NOTE: this is to match documentation
+    // on custom k-v targeting
+    bid.bidder = bid.bidderCode;
+
     //emit the bidAdjustment event before bidResponse, so bid response has the adjusted bid value
     events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
 
@@ -149,11 +154,6 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
     //put adUnitCode into bid
     bid.adUnitCode = adUnitCode;
-
-    // alias the bidderCode to bidder;
-    // NOTE: this is to match documentation
-    // on custom k-v targeting
-    bid.bidder = bid.bidderCode;
 
     //if there is any key value pairs to map do here
     var keyValues = {};

--- a/src/ga.js
+++ b/src/ga.js
@@ -49,18 +49,17 @@ exports.enableAnalytics = function (gaOptions) {
     }
 
     if (eventObj.eventType === BID_REQUESTED) {
-      //bid is 1st args
-      bid = args[0];
+      bid = args;
       sendBidRequestToGa(bid);
     } else if (eventObj.eventType === BID_RESPONSE) {
       //bid is 2nd args
-      bid = args[1];
+      bid = args;
       sendBidResponseToGa(bid);
 
     } else if (eventObj.eventType === BID_TIMEOUT) {
-      _timedOutBidders = args[0];
+      _timedOutBidders = args.bidderCode;
     } else if (eventObj.eventType === BID_WON) {
-      bid = args[0];
+      bid = args;
       sendBidWonToGa(bid);
     }
   });


### PR DESCRIPTION
fix to set `bid` to `args` object instead of array element of `args`
set `bidder` property before emitting events

fixes #269 and #272 

cc: @dmitriyshashkin
