### PR TITLE
Handle pbBidResponseByPlacement attributes as empty objects

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -168,7 +168,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
     }
 
     //store by placement ID
-    if (adUnitCode && pbBidResponseByPlacement[adUnitCode]) {
+    if (adUnitCode && pbBidResponseByPlacement[adUnitCode] && !utils.isEmpty(pbBidResponseByPlacement[adUnitCode])) {
       //update bid response object
       bidResponseObj = pbBidResponseByPlacement[adUnitCode];
 


### PR DESCRIPTION
pbBidResponseByPlacement[adUnitCode] is sometimes an empty object.
When this occurs, the call to .bids.push() fails as bids is undefined.