### PR TITLE
Fix reentrancy allow requestBid for multiple ad units at same time

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "adform",
     "aol",
     "appnexus",
+    "criteo",
     "indexExchange",
     "openx",
     "pubmatic",

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -10,7 +10,7 @@ import { BaseAdapter } from './adapters/baseAdapter';
 var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;
 
-exports.callBids = function (bidderArr) {
+exports.callBids = function (bidRequest, bidderArr) {
   for (var i = 0; i < bidderArr.length; i++) {
     //use the bidder code to identify which function to call
     var bidder = bidderArr[i];
@@ -20,12 +20,12 @@ exports.callBids = function (bidderArr) {
 
       //emit 'bidRequested' event
       events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidder);
-      currentBidder.callBids(bidder);
+      currentBidder.callBids(bidder, bidRequest);
 
       // if the bidder didn't explicitly set the number of bids
       // expected, default to the number of bids passed into the bidder
-      if (bidmanager.getExpectedBidsCount(bidder.bidderCode) === undefined) {
-        bidmanager.setExpectedBidsCount(bidder.bidderCode, bidder.bids.length);
+      if (bidmanager.getExpectedBidsCount(bidRequest.bidResponses, bidder.bidderCode) === undefined) {
+        bidmanager.setExpectedBidsCount(bidRequest.bidResponses, bidder.bidderCode, bidder.bids.length);
       }
 
       var currentTime = new Date().getTime();

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -10,7 +10,7 @@ import { BaseAdapter } from './adapters/baseAdapter';
 var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;
 
-exports.callBids = function (bidRequest, bidderArr) {
+exports.callBids = function (bidResponses, bidderArr) {
   for (var i = 0; i < bidderArr.length; i++) {
     //use the bidder code to identify which function to call
     var bidder = bidderArr[i];
@@ -20,12 +20,12 @@ exports.callBids = function (bidRequest, bidderArr) {
 
       //emit 'bidRequested' event
       events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidder);
-      currentBidder.callBids(bidder, bidRequest);
+      currentBidder.callBids(bidder, bidResponses);
 
       // if the bidder didn't explicitly set the number of bids
       // expected, default to the number of bids passed into the bidder
-      if (bidmanager.getExpectedBidsCount(bidRequest.bidResponses, bidder.bidderCode) === undefined) {
-        bidmanager.setExpectedBidsCount(bidRequest.bidResponses, bidder.bidderCode, bidder.bids.length);
+      if (bidmanager.getExpectedBidsCount(bidResponses, bidder.bidderCode) === undefined) {
+        bidmanager.setExpectedBidsCount(bidResponses, bidder.bidderCode, bidder.bids.length);
       }
 
       var currentTime = new Date().getTime();

--- a/src/adapters/adform.js
+++ b/src/adapters/adform.js
@@ -9,7 +9,7 @@ function AdformAdapter() {
     callBids: _callBids
   };
 
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
     var callbackName = '_adf_' + utils.getUniqueIdentifierStr();
     var bid;
     var noDomain = true;
@@ -30,7 +30,7 @@ function AdformAdapter() {
       request.unshift('//adx.adform.net/adx/?rp=4');
     }
 
-    pbjs[callbackName] = handleCallback(bids);
+    pbjs[callbackName] = handleCallback(bids, requestContext);
     request.push('callback=pbjs.' + callbackName);
 
     adloader.loadScript(request.join('&'));
@@ -54,7 +54,7 @@ function AdformAdapter() {
     return encode64(url.join(''));
   }
 
-  function handleCallback(bids) {
+  function handleCallback(bids, requestContext) {
     return function handleResponse(adItems) {
       var bidObject;
       var bidder = 'adform';
@@ -73,11 +73,11 @@ function AdformAdapter() {
           bidObject.ad = adItem.banner;
           bidObject.width = adItem.width;
           bidObject.height = adItem.height;
-          bidmanager.addBidResponse(bid.placementCode, bidObject);
+          bidmanager.addBidResponse(requestContext, bid.placementCode, bidObject);
         } else {
           bidObject = bidfactory.createBid(2);
           bidObject.bidderCode = bidder;
-          bidmanager.addBidResponse(bid.placementCode, bidObject);
+          bidmanager.addBidResponse(requestContext, bid.placementCode, bidObject);
         }
       }
     };

--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -26,7 +26,6 @@ var AolAdapter = function AolAdapter() {
     pubApiER: _addErrorBid
   };
 
-  var bids;
   var bidsMap = {};
   var d = window.document;
   var h = d.getElementsByTagName('HEAD')[0];
@@ -86,7 +85,7 @@ var AolAdapter = function AolAdapter() {
     bidResponse.creativeId = response.getCreativeId();
 
     // add it to the bid manager
-    bidmanager.addBidResponse(bid.placementCode, bidResponse);
+    bidmanager.addBidResponse(bid.context, bid.placementCode, bidResponse);
   }
 
   /**
@@ -109,7 +108,7 @@ var AolAdapter = function AolAdapter() {
     bidResponse.bidderCode = ADTECH_BIDDER_NAME;
     bidResponse.reason = response.getNbr();
     bidResponse.raw = response.getResponse();
-    bidmanager.addBidResponse(bid.placementCode, bidResponse);
+    bidmanager.addBidResponse(bid.context, bid.placementCode, bidResponse);
   }
 
   /**
@@ -151,7 +150,7 @@ var AolAdapter = function AolAdapter() {
    * @private once ADTECH is loaded, request bids by
    * calling ADTECH.loadAd
    */
-  function _reqBids() {
+  function _reqBids(bids, requestContext) {
     if (!window.ADTECH) {
       utils.logError('window.ADTECH is not present!', ADTECH_BIDDER_NAME);
       return;
@@ -159,6 +158,7 @@ var AolAdapter = function AolAdapter() {
 
     // get the bids
     utils._each(bids, function (bid) {
+      bid.context = requestContext;
       var bidreq = _mapUnit(bid);
       window.ADTECH.loadAd(bidreq);
     });
@@ -171,10 +171,10 @@ var AolAdapter = function AolAdapter() {
    * @param {Object} params
    * @param {Array} params.bids the bids to be requested
    */
-  function _callBids(params) {
-    bids = params.bids;
+  function _callBids(params, requestContext) {
+    var bids = params.bids;
     if (!bids || !bids.length) return;
-    adloader.loadScript(ADTECH_URI, _reqBids);
+    adloader.loadScript(ADTECH_URI, _reqBids(bids, requestContext));
   }
 
   return {

--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -174,7 +174,7 @@ var AolAdapter = function AolAdapter() {
   function _callBids(params, requestContext) {
     var bids = params.bids;
     if (!bids || !bids.length) return;
-    adloader.loadScript(ADTECH_URI, _reqBids(bids, requestContext));
+    adloader.loadScript(ADTECH_URI, function(){_reqBids(bids, requestContext);});
   }
 
   return {

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -9,17 +9,18 @@ var AppNexusAdapter;
 AppNexusAdapter = function AppNexusAdapter() {
   var baseAdapter = Adapter.createNew('appnexus');
 
-  baseAdapter.callBids = function (params) {
+  baseAdapter.callBids = function (params, requestContext) {
     var bidCode = baseAdapter.getBidderCode();
 
     var anArr = params.bids;
     var bidsCount = anArr.length;
 
     //set expected bids count for callback execution
-    bidmanager.setExpectedBidsCount(bidCode, bidsCount);
+    bidmanager.setExpectedBidsCount(requestContext.bidResponses, bidCode, bidsCount);
 
     for (var i = 0; i < bidsCount; i++) {
       var bidRequest = anArr[i];
+      bidRequest.context = requestContext;
       var callbackId = utils.getUniqueIdentifierStr();
       adloader.loadScript(buildJPTCall(bidRequest, callbackId));
 
@@ -185,7 +186,7 @@ AppNexusAdapter = function AppNexusAdapter() {
         bid.height = jptResponseObj.result.height;
         bid.dealId = jptResponseObj.result.deal_id;
 
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 
       } else {
         //no response data
@@ -196,7 +197,7 @@ AppNexusAdapter = function AppNexusAdapter() {
         //indicate that there is no bid for this placement
         bid = bidfactory.createBid(2);
         bid.bidderCode = bidCode;
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse(bidObj.context, placementCode, bid);
       }
 
     } else {

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -16,7 +16,7 @@ AppNexusAdapter = function AppNexusAdapter() {
     var bidsCount = anArr.length;
 
     //set expected bids count for callback execution
-    bidmanager.setExpectedBidsCount(requestContext.bidResponses, bidCode, bidsCount);
+    bidmanager.setExpectedBidsCount(requestContext, bidCode, bidsCount);
 
     for (var i = 0; i < bidsCount; i++) {
       var bidRequest = anArr[i];

--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -10,26 +10,25 @@ const AST_URL = 'https://acdn.adnxs.com/ast/alpha/ast.js';
 export class AppnexusAst extends BaseAdapter {
   constructor(code) {
     super(code);
-    this._bidRequests = null;
   }
 
-  callBids(params) {
+  callBids(params, requestContext) {
     window.apntag = window.apntag || {};
     window.apntag.anq = window.apntag.anq || [];
-    this._bidRequests = params.bids;
+    var bidRequests = params.bids;
     adloader.loadScript(AST_URL, () => {
-      this._requestAds(this.code);
+      this._requestAds(this.code, bidRequests, requestContext);
     }, true);
   }
 
-  _requestAds(code) {
+  _requestAds(code, bidRequests, requestContext) {
     if (utils.debugTurnedOn()) {
       window.apntag.debug = true;
     }
 
     window.apntag.clearRequest();
 
-    for (let bidRequest of this._bidRequests) {
+    for (let bidRequest of bidRequests) {
       const astTag = this._buildTag(bidRequest);
       const requestTag = window.apntag.defineTag(astTag);
       const placementCode = bidRequest.placementCode;
@@ -53,7 +52,7 @@ export class AppnexusAst extends BaseAdapter {
 
         bid.width = ad.banner.width;
         bid.height = ad.banner.height;
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse(requestContext, placementCode, bid);
       });
 
       //no bid
@@ -61,7 +60,7 @@ export class AppnexusAst extends BaseAdapter {
         const bid = bidfactory.createBid(CONSTANTS.STATUS.NO_BID);
         bid.code = code;
         bid.bidderCode = code;
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse(requestContext, placementCode, bid);
       });
     }
 

--- a/src/adapters/criteo.js
+++ b/src/adapters/criteo.js
@@ -17,7 +17,7 @@ var CriteoAdapter = function CriteoAdapter() {
 
 		// Only make one request per "nid"
 		_getUniqueNids(bids).forEach(function(bid){
-            _requestBid(bid, requestContext);
+            _requestBid(bids, bid, requestContext);
         });
 	}
 
@@ -36,7 +36,7 @@ var CriteoAdapter = function CriteoAdapter() {
 		return nids;
 	}
 
-	function _requestBid(bid, requestContext) {
+	function _requestBid(bids, bid, requestContext) {
 		var varname = bid.params.varname;
 		var scriptUrl = '//rtax.criteo.com/delivery/rta/rta.js?netId=' + encodeURI(bid.params.nid) +
 			'&cookieName=' + encodeURI(bid.params.cookiename) +

--- a/src/adapters/criteo.js
+++ b/src/adapters/criteo.js
@@ -1,0 +1,75 @@
+var CONSTANTS = require('../constants.json');
+var utils = require('../utils.js');
+var bidfactory = require('../bidfactory.js');
+var bidmanager = require('../bidmanager.js');
+var adloader = require('../adloader');
+
+/**
+ * Adapter for requesting bids from Criteo.
+ *
+ * @returns {{callBids: _callBids}}
+ * @constructor
+ */
+var CriteoAdapter = function CriteoAdapter() {
+
+	function _callBids(params, requestContext) {
+		var bids = params.bids || [];
+
+		// Only make one request per "nid"
+		_getUniqueNids(bids).forEach(function(bid){
+            _requestBid(bid, requestContext);
+        });
+	}
+
+	function _getUniqueNids(bids) {
+		var key;
+		var map = {};
+		var nids = [];
+		bids.forEach(function(bid) {
+			map[bid.params.nid] = bid;
+		});
+		for (key in map) {
+			if (map.hasOwnProperty(key)) {
+				nids.push(map[key]);
+			}
+		}
+		return nids;
+	}
+
+	function _requestBid(bid, requestContext) {
+		var varname = bid.params.varname;
+		var scriptUrl = '//rtax.criteo.com/delivery/rta/rta.js?netId=' + encodeURI(bid.params.nid) +
+			'&cookieName=' + encodeURI(bid.params.cookiename) +
+			'&rnd=' + Math.floor(Math.random() * 99999999999) +
+			'&varName=' + encodeURI(varname);
+
+		adloader.loadScript(scriptUrl, function(response) {
+			var adResponse;
+			var content = window[varname];
+
+			// Add a response for each bid matching the "nid"
+			bids.forEach(function(existingBid) {
+				if (existingBid.params.nid === bid.params.nid) {
+					if (content) {
+						adResponse = bidfactory.createBid(1);
+						adResponse.bidderCode = 'criteo';
+
+						adResponse.keys = content.replace(/\;$/, '').split(';');
+					} else {
+						// Indicate an ad was not returned
+						adResponse = bidfactory.createBid(2);
+						adResponse.bidderCode = 'criteo';
+					}
+
+					bidmanager.addBidResponse(requestContext, existingBid.placementCode, adResponse);
+				}
+			});
+		});
+	}
+
+	return {
+		callBids: _callBids
+	};
+};
+
+module.exports = CriteoAdapter;

--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -14,7 +14,10 @@ var cygnus_index_parse_res = function () {
 
 window.cygnus_index_args = {};
 
-var _IndexRequestData = {};
+var _IndexRequestData = {
+    impIDToSlotID: {},
+    reqOptions: {}
+};
 
 var cygnus_index_adunits =  [[728, 90], [120, 600], [300, 250], [160, 600], [336, 280], [234, 60], [300, 600], [300, 50], [320, 50], [970, 250], [300, 1050], [970, 90], [180, 150]]; // jshint ignore:line
 
@@ -260,6 +263,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
       return;
     }
 
+    cygnus_index_primary_request = true;
     cygnus_index_args.slots = [];
     var bidCount = 0;
 

--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -337,7 +337,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
         }
       }
 
-      bidmanager.setExpectedBidsCount(requestContext.bidResponses, ADAPTER_CODE, bidCount);
+      bidmanager.setExpectedBidsCount(requestContext, ADAPTER_CODE, bidCount);
     }
 
     cygnus_index_primary_request = false;
@@ -375,7 +375,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
               bid.height = slotObj.height;
               bid.siteID = slotObj.siteID;
 
-              bidmanager.addBidResponse(requestContext.bidResponses, adUnitCode, bid);
+              bidmanager.addBidResponse(requestContext, adUnitCode, bid);
             }
           });
         });
@@ -404,7 +404,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
     bid.bidderCode = ADAPTER_CODE;
 
     //log error to first add unit
-    bidmanager.addBidResponse(requestContext.bidResponses, firstAdUnitCode, bid);
+    bidmanager.addBidResponse(requestContext, firstAdUnitCode, bid);
   }
 
   return {

--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -14,6 +14,8 @@ var cygnus_index_parse_res = function () {
 
 window.cygnus_index_args = {};
 
+var _IndexRequestData = {};
+
 var cygnus_index_adunits =  [[728, 90], [120, 600], [300, 250], [160, 600], [336, 280], [234, 60], [300, 600], [300, 50], [320, 50], [970, 250], [300, 1050], [970, 90], [180, 150]]; // jshint ignore:line
 
 var cygnus_index_start = function () {
@@ -237,6 +239,7 @@ var cygnus_index_start = function () {
 
     return req.buildRequest();
   } catch (e) {
+      utils.logError('Error calling index adapter', ADAPTER_NAME, e);
   }
 };
 
@@ -250,7 +253,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
   ];
   var firstAdUnitCode = '';
 
-  function _callBids(request) {
+  function _callBids(request, requestContext) {
     var bidArr = request.bids;
 
     if (!utils.hasValidBidRequest(bidArr[0].params, requiredParams, ADAPTER_NAME)) {
@@ -330,7 +333,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
         }
       }
 
-      bidmanager.setExpectedBidsCount(ADAPTER_CODE, bidCount);
+      bidmanager.setExpectedBidsCount(requestContext.bidResponses, ADAPTER_CODE, bidCount);
     }
 
     cygnus_index_primary_request = false;
@@ -345,7 +348,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
         if (utils.isEmpty(indexObj)) {
           var bid = bidfactory.createBid(2);
           bid.bidderCode = ADAPTER_CODE;
-          logErrorBidResponse();
+          logErrorBidResponse(requestContext);
           return;
         }
 
@@ -368,13 +371,13 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
               bid.height = slotObj.height;
               bid.siteID = slotObj.siteID;
 
-              bidmanager.addBidResponse(adUnitCode, bid);
+              bidmanager.addBidResponse(requestContext.bidResponses, adUnitCode, bid);
             }
           });
         });
       } catch (e) {
         utils.logError('Error calling index adapter', ADAPTER_NAME, e);
-        logErrorBidResponse();
+        logErrorBidResponse(requestContext);
       }
     };
   }
@@ -391,13 +394,13 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
     return returnObj;
   }
 
-  function logErrorBidResponse() {
+  function logErrorBidResponse(requestContext) {
     //no bid response
     var bid = bidfactory.createBid(2);
     bid.bidderCode = ADAPTER_CODE;
 
     //log error to first add unit
-    bidmanager.addBidResponse(firstAdUnitCode, bid);
+    bidmanager.addBidResponse(requestContext.bidResponses, firstAdUnitCode, bid);
   }
 
   return {

--- a/src/adapters/nginad.js
+++ b/src/adapters/nginad.js
@@ -13,11 +13,11 @@ var NginAdAdapter = function NginAdAdapter() {
 
   var rtbServerDomain = 'placeholder.for.nginad.server.com';
 
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
     var nginadBids = params.bids || [];
 
     // De-dupe by tagid then issue single bid request for all bids
-    _requestBids(_getUniqueTagids(nginadBids));
+    _requestBids(_getUniqueTagids(nginadBids), requestContext);
   }
 
   // filter bids to de-dupe them?
@@ -56,7 +56,7 @@ var NginAdAdapter = function NginAdAdapter() {
     return [adW, adH];
   }
 
-  function _requestBids(bidReqs) {
+  function _requestBids(bidReqs, requestContext) {
     // build bid request object
     var domain = window.location.host;
     var page = window.location.pathname + location.search + location.hash;
@@ -84,6 +84,7 @@ var NginAdAdapter = function NginAdAdapter() {
       };
 
       nginadImps.push(imp);
+      bid.context = requestContext;
       bidmanager.pbCallbackMap[imp.id] = bid;
 
       rtbServerDomain = bid.params.nginadDomain;
@@ -115,7 +116,7 @@ var NginAdAdapter = function NginAdAdapter() {
 
     var bid = bidfactory.createBid(2);
     bid.bidderCode = 'nginad';
-    bidmanager.addBidResponse(defaultPlacementForBadBid, bid);
+    bidmanager.addBidResponse({/*request context?*/}, defaultPlacementForBadBid, bid);
   }
 
   //expose the callback to the global object:
@@ -174,7 +175,7 @@ var NginAdAdapter = function NginAdAdapter() {
       bid.width = whArr[0];
       bid.height = whArr[1];
 
-      bidmanager.addBidResponse(placementCode, bid);
+      bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 
     }
 

--- a/src/adapters/openx.js
+++ b/src/adapters/openx.js
@@ -17,10 +17,9 @@ var OpenxAdapter = function OpenxAdapter(options) {
 
   var opts = options || {};
   var scriptUrl;
-  var bids;
 
-  function _callBids(params) {
-    bids = params.bids || [];
+  function _callBids(params, requestContext) {
+    var bids = params.bids || [];
     for (var i = 0; i < bids.length; i++) {
       var bid = bids[i];
 
@@ -42,10 +41,10 @@ var OpenxAdapter = function OpenxAdapter(options) {
       }
     }
 
-    _requestBids();
+    _requestBids(bids, requestContext);
   }
 
-  function _requestBids() {
+  function _requestBids(bids, requestContext) {
 
     if (scriptUrl) {
       adloader.loadScript(scriptUrl, function () {
@@ -96,12 +95,12 @@ var OpenxAdapter = function OpenxAdapter(options) {
               adResponse.width = adUnit.get('width');
               adResponse.height = adUnit.get('height');
 
-              bidmanager.addBidResponse(bid.placementCode, adResponse);
+              bidmanager.addBidResponse(requestContext.bidResponses, bid.placementCode, adResponse);
             } else {
               // Indicate an ad was not returned
               adResponse = bidfactory.createBid(2);
               adResponse.bidderCode = 'openx';
-              bidmanager.addBidResponse(bid.placementCode, adResponse);
+              bidmanager.addBidResponse(requestContext.bidResponses, bid.placementCode, adResponse);
             }
           }
         }, OX.Hooks.ON_AD_RESPONSE);

--- a/src/adapters/openx.js
+++ b/src/adapters/openx.js
@@ -95,12 +95,12 @@ var OpenxAdapter = function OpenxAdapter(options) {
               adResponse.width = adUnit.get('width');
               adResponse.height = adUnit.get('height');
 
-              bidmanager.addBidResponse(requestContext.bidResponses, bid.placementCode, adResponse);
+              bidmanager.addBidResponse(requestContext, bid.placementCode, adResponse);
             } else {
               // Indicate an ad was not returned
               adResponse = bidfactory.createBid(2);
               adResponse.bidderCode = 'openx';
-              bidmanager.addBidResponse(requestContext.bidResponses, bid.placementCode, adResponse);
+              bidmanager.addBidResponse(requestContext, bid.placementCode, adResponse);
             }
           }
         }, OX.Hooks.ON_AD_RESPONSE);

--- a/src/adapters/pulsepoint.js
+++ b/src/adapters/pulsepoint.js
@@ -7,18 +7,19 @@ var PulsePointAdapter = function PulsePointAdapter() {
   var getJsStaticUrl = window.location.protocol + '//tag.contextweb.com/getjs.static.js';
   var bidUrl = window.location.protocol + '//bid.contextweb.com/header/tag';
 
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
     if (typeof window.pp === 'undefined') {
-      adloader.loadScript(getJsStaticUrl, function () { bid(params); });
+      adloader.loadScript(getJsStaticUrl, function () { bid(params, requestContext); });
     } else {
-      bid(params);
+      bid(params, requestContext);
     }
   }
 
-  function bid(params) {
+  function bid(params, requestContext) {
     var bids = params.bids;
     for (var i = 0; i < bids.length; i++) {
       var bidRequest = bids[i];
+      bidRequest.context = requestContext;
       var callback = bidResponseCallback(bidRequest);
       var ppBidRequest = new window.pp.Ad({
         cf: bidRequest.params.cf,
@@ -49,11 +50,11 @@ var PulsePointAdapter = function PulsePointAdapter() {
       bid.ad = bidResponse.html;
       bid.width = adSize[0];
       bid.height = adSize[1];
-      bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      bidmanager.addBidResponse(bidRequest.context, bidRequest.placementCode, bid);
     } else {
       var passback = bidfactory.createBid(2);
       passback.bidderCode = bidRequest.bidder;
-      bidmanager.addBidResponse(bidRequest.placementCode, passback);
+      bidmanager.addBidResponse(bidRequest.context, bidRequest.placementCode, passback);
     }
   }
 

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -124,7 +124,7 @@ var RubiconAdapter = function RubiconAdapter() {
    * on the response from rubicon
    * @param {Object} response -- AJAX response from fastlane
    */
-  function _addBid(response, ads) {
+  function _addBid(response, ads, requestContext) {
     // get the bid for the placement code
     var bid;
     if (!ads || ads.length === 0) {
@@ -133,7 +133,7 @@ var RubiconAdapter = function RubiconAdapter() {
       bid = _makeBid(response, ads);
     }
 
-    bidmanager.addBidResponse(response.getElementId(), bid);
+    bidmanager.addBidResponse(requestContext, response.getElementId(), bid);
   }
 
   /**
@@ -236,14 +236,14 @@ var RubiconAdapter = function RubiconAdapter() {
    * Handle the bids received (from rubicon)
    * @param {array} slots
    */
-  function _bidsReady(slots) {
+  function _bidsReady(slots, requestContext) {
     // NOTE: we don't really need to do anything,
     // because right now we're shimming XMLHttpRequest.open,
     // but in the future we'll get data from rubicontag here
     utils.logMessage('Rubicon Project bidding complete: ' + ((new Date).getTime() - _bidStart));
 
     utils._each(slots, function (slot) {
-      _addBid(slot, slot.getRawResponses());
+      _addBid(slot, slot.getRawResponses(), requestContext);
     });
   }
 
@@ -253,7 +253,7 @@ var RubiconAdapter = function RubiconAdapter() {
    * @param {Object} params the bidder-level params (from prebid)
    * @param {Array} params.bids the bids requested
    */
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
 
     // start the timer; want to measure from
     // even just loading the SDK
@@ -280,7 +280,7 @@ var RubiconAdapter = function RubiconAdapter() {
 
       var parameters = {slots : slots};
       var callback   = function (){
-        _bidsReady(slots);
+        _bidsReady(slots, requestContext);
       };
 
       window.rubicontag.run(callback, parameters);

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -12,13 +12,13 @@ var allPlacementCodes;
 var SovrnAdapter = function SovrnAdapter() {
   var sovrnUrl = 'ap.lijit.com/rtb/bid';
 
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
     var sovrnBids = params.bids || [];
 
-    _requestBids(sovrnBids);
+    _requestBids(sovrnBids, requestContext);
   }
 
-  function _requestBids(bidReqs) {
+  function _requestBids(bidReqs, requestContext) {
     // build bid request object
     var domain = window.location.host;
     var page = window.location.pathname + location.search + location.hash;
@@ -55,6 +55,7 @@ var SovrnAdapter = function SovrnAdapter() {
         bidfloor: bidFloor
       };
       sovrnImps.push(imp);
+      bid.context = requestContext;
       bidmanager.pbCallbackMap[imp.id] = bid;
       allPlacementCodes.push(bid.placementCode);
     });
@@ -84,7 +85,7 @@ var SovrnAdapter = function SovrnAdapter() {
         var bid = {};
         bid = bidfactory.createBid(2);
         bid.bidderCode = 'sovrn';
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse({/*no context?*/}, placementCode, bid);
       }
     });
   }
@@ -136,21 +137,21 @@ var SovrnAdapter = function SovrnAdapter() {
               bid.width = parseInt(sovrnBid.w);
               bid.height = parseInt(sovrnBid.h);
 
-              bidmanager.addBidResponse(placementCode, bid);
+              bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 
             } else {
               //0 price bid
               //indicate that there is no bid for this placement
               bid = bidfactory.createBid(2);
               bid.bidderCode = 'sovrn';
-              bidmanager.addBidResponse(placementCode, bid);
+              bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 
             }
           } else { // bid not found, we never asked for this?
             //no response data
             bid = bidfactory.createBid(2);
             bid.bidderCode = 'sovrn';
-            bidmanager.addBidResponse(placementCode, bid);
+            bidmanager.addBidResponse({/*no context?*/}, placementCode, bid);
           }
         });
 

--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -53,10 +53,11 @@ SpringServeAdapter = function SpringServeAdapter() {
     return spCall;
   }
 
-  function _callBids(params) {
+  function _callBids(params, requestContext) {
     var bids = params.bids || [];
     for (var i = 0; i < bids.length; i++) {
       var bid = bids[i];
+      params.context = requestContext;
       bidmanager.pbCallbackMap[bid.params.impId] = params;
       adloader.loadScript(buildSpringServeCall(bid));
     }
@@ -94,7 +95,7 @@ SpringServeAdapter = function SpringServeAdapter() {
         bid.bidderCode = 'springserve';
       }
 
-      bidmanager.addBidResponse(placementCode, bid);
+      bidmanager.addBidResponse(requestObj.context, placementCode, bid);
     }
   };
 

--- a/src/adapters/triplelift.js
+++ b/src/adapters/triplelift.js
@@ -11,15 +11,16 @@ var bidfactory = require('../bidfactory.js');
 
 var TripleLiftAdapter = function TripleLiftAdapter() {
 
-function _callBids(params) {
+function _callBids(params, requestContext) {
 	var tlReq = params.bids;
 	var bidsCount = tlReq.length;
 
 	//set expected bids count for callback execution
-	bidmanager.setExpectedBidsCount('triplelift',bidsCount);
+	bidmanager.setExpectedBidsCount(requestContext, 'triplelift', bidsCount);
 
 	for (var i = 0; i < bidsCount; i++) {
 		var bidReqeust = tlReq[i];
+        bidReqeust.context = requestContext;
 		var callbackId = utils.getUniqueIdentifierStr();
 		adloader.loadScript(buildTLCall(bidReqeust, callbackId));
 		//store a reference to the bidRequest from the callback id
@@ -90,7 +91,7 @@ pbjs.TLCB = function(tlResponseObj) {
 			bid.width = tlResponseObj.width;
 			bid.height = tlResponseObj.height;
 			bid.dealId = tlResponseObj.deal_id;
-			bidmanager.addBidResponse(placementCode, bid);
+			bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 
 		} else {
 			//no response data
@@ -99,7 +100,7 @@ pbjs.TLCB = function(tlResponseObj) {
 			// @endif
 			bid = bidfactory.createBid(2);
 			bid.bidderCode = 'triplelift';
-			bidmanager.addBidResponse(placementCode, bid);
+			bidmanager.addBidResponse(bidObj.context, placementCode, bid);
 		}
 
 	} else {

--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -96,6 +96,8 @@ var YieldbotAdapter = function YieldbotAdapter() {
           yieldbot.pub(psn);
           yieldbot.defineSlot(slot, { sizes: bid.sizes || [] });
 
+          bid.context = requestContext;
+
           var cbId = utils.getUniqueIdentifierStr();
           bidmanager.pbCallbackMap[cbId] = bid;
           ybotlib.definedSlots.push(cbId);
@@ -106,7 +108,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
       });
 
       ybotq.push(function () {
-        ybotlib.handleUpdateState(requestContext);
+        ybotlib.handleUpdateState();
       });
 
       adloader.loadScript('//cdn.yldbt.com/js/yieldbot.intent.js');
@@ -117,7 +119,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
      * @see {@link YieldbotAdapter~_callBids}
      * @private
      */
-    handleUpdateState: function (requestContext) {
+    handleUpdateState: function () {
       var yieldbot = window.yieldbot;
 
       utils._each(ybotlib.definedSlots, function (v) {
@@ -133,7 +135,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
         placementCode = adapterConfig.placementCode || 'ERROR_YB_NO_PLACEMENT';
         var bid = ybotlib.buildBid(criteria);
 
-        bidmanager.addBidResponse(requestContext, placementCode, bid);
+        bidmanager.addBidResponse(adapterConfig.context, placementCode, bid);
 
       });
     }

--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -78,7 +78,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
      * @param {Object} params - Adapter bid configuration object
      * @private
      */
-    callBids: function (params) {
+    callBids: function (params, requestContext) {
 
       var bids = params.bids || [];
       var ybotq = window.ybotq || [];
@@ -106,7 +106,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
       });
 
       ybotq.push(function () {
-        ybotlib.handleUpdateState();
+        ybotlib.handleUpdateState(requestContext);
       });
 
       adloader.loadScript('//cdn.yldbt.com/js/yieldbot.intent.js');
@@ -117,7 +117,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
      * @see {@link YieldbotAdapter~_callBids}
      * @private
      */
-    handleUpdateState: function () {
+    handleUpdateState: function (requestContext) {
       var yieldbot = window.yieldbot;
 
       utils._each(ybotlib.definedSlots, function (v) {
@@ -133,7 +133,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
         placementCode = adapterConfig.placementCode || 'ERROR_YB_NO_PLACEMENT';
         var bid = ybotlib.buildBid(criteria);
 
-        bidmanager.addBidResponse(placementCode, bid);
+        bidmanager.addBidResponse(requestContext, placementCode, bid);
 
       });
     }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -140,7 +140,7 @@ function sortAndCallBids(bidRequest, sortFunc) {
     pbArr.sort(sortFunc);
   }
 
-  adaptermanager.callBids(bidRequest, pbArr);
+  adaptermanager.callBids(bidRequest.bidResponses, pbArr);
 }
 
 function loadPreBidders(bidRequest) {


### PR DESCRIPTION
It changes the API to pass Bids as context and the bidReponses:

FIx for #268 

```
pbjs.que.push(function() {
        pbjs.requestBids({
          timeout: M2_TIMEOUT,
          adUnitCodes: ['/28725708/AdUnitCode_id'],
          bidsBackHandler: function(bidResponses) {
            pbjs.setTargetingForGPTAsync(bidResponses, ['/28725708/AdUnitCode_id']);
            googletag.pubads().refresh([slot2]);
          }
        });
      });
```