### PR TITLE
Include bidder code in iframe html properties.

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -573,7 +573,14 @@ pbjs.renderAd = function (doc, id) {
         //doc.body.style.width = width;
         //doc.body.style.height = height;
         else if (url) {
-          doc.write('<IFRAME SRC="' + url + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true" WIDTH="' + width + '" HEIGHT="' + height + '"></IFRAME>');
+          doc.write('<IFRAME ' +
+            'SRC="' + url + '" ' +
+            'WIDTH="' + width + '" ' +
+            'HEIGHT="' + height + '" ' +
+            'DATA-BIDDER="' + adObject.bidderCode + '" ' +
+            'FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true"' +
+            '></IFRAME>'
+          );
           doc.close();
 
           if (doc.defaultView && doc.defaultView.frameElement) {


### PR DESCRIPTION
Currently, it is not possible to post-ad-load determine the winning bidder based on the HTML.  Inspecting the iFrame isn't really an option either, since it is blocked by cross-domain security policy.  With this PR, just inspecting the data elements of the iFrame should be enough.

There is also https://github.com/prebid/Prebid.js/releases which includes a `bidWon` event, but this is only possible if you are in prebid or accessing it already.