### PR TITLE
Fix for #196

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -208,20 +208,8 @@ exports.getKeyValueTargetingPairs = function (bidderCode, custBidObj) {
   var keyValues = {};
   var bidder_settings = pbjs.bidderSettings || {};
 
-  //1) set keys from specific bidder setting if they exist
-  if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode] && bidder_settings[bidderCode][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
-    setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
-    custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
-  }
-
-  //2) set keys from standard setting. NOTE: this API doesn't seeem to be in use by any Adapter currently
-  else if (defaultBidderSettingsMap[bidderCode]) {
-    setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
-    custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
-  }
-
-  //3) set the keys from "standard" setting or from prebid defaults
-  else if (custBidObj && bidder_settings) {
+  //1) set the keys from "standard" setting or from prebid defaults
+  if (custBidObj && bidder_settings) {
     if (!bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD]) {
       bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD] = {
         adserverTargeting: [
@@ -254,6 +242,18 @@ exports.getKeyValueTargetingPairs = function (bidderCode, custBidObj) {
     setKeys(keyValues, bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD], custBidObj);
   }
 
+  //2) set keys from specific bidder setting override if they exist
+  if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode] && bidder_settings[bidderCode][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
+    setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
+    custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
+  }
+
+  //2) set keys from standard setting. NOTE: this API doesn't seeem to be in use by any Adapter currently
+  else if (defaultBidderSettingsMap[bidderCode]) {
+    setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
+    custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
+  }
+
   return keyValues;
 };
 
@@ -264,6 +264,10 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
   utils._each(targeting, function (kvPair) {
     var key = kvPair.key;
     var value = kvPair.val;
+
+    if (keyValues[key]) {
+      utils.logWarn('The key: ' + key + ' is getting ovewritten');
+    }
 
     if (utils.isFn(value)) {
       try {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -277,7 +277,7 @@ function buildBidResponse(bidArray) {
       if (bid.alwaysUseBid && bidClone.adserverTargeting) { // add the bid if alwaysUse and bid has returned
         // push key into targeting
         pb_targetingMap[bidClone.adUnitCode] = utils.extend(pb_targetingMap[bidClone.adUnitCode], bidClone.adserverTargeting);
-      } else if (bid.cpm && bid.cpm > 0) {
+      } if (bid.cpm && bid.cpm > 0) {
         //else put into auction array if cpm > 0
         bidArrayTargeting.push({
           cpm: bid.cpm,

--- a/src/utils.js
+++ b/src/utils.js
@@ -177,6 +177,12 @@ exports.getTopWindowUrl = function () {
   }
 };
 
+exports.logWarn = function (msg) {
+  if (debugTurnedOn() && console.warn) {
+    console.warn('WARNING: ' + msg);
+  }
+};
+
 exports.logInfo = function(msg, args) {
   if (debugTurnedOn() && hasConsoleLogger()) {
     if (infoLogger) {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -210,7 +210,7 @@ var bidmanager = require('../../src/bidmanager');
 
             });
 
-            it('Custom bidCpmAdjustment AND custom configuration for one bidder and do NOT inherit standard', function() {
+            it('Custom bidCpmAdjustment AND custom configuration for one bidder and inherit standard settings', function() {
                 pbjs.bidderSettings =
                     {
                         appnexus: {
@@ -264,7 +264,38 @@ var bidmanager = require('../../src/bidmanager');
                         }
                 };
 
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 15.0 };
+                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 15.0, "hb_size":"300x250" };
+                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+                assert.deepEqual(response, expected);
+
+            });
+
+
+            it('alwaysUseBid=true and inherit custom', function() {
+                pbjs.bidderSettings =
+                    {
+                        appnexus: {
+                            alwaysUseBid : true,
+                            adserverTargeting: [{
+                                key: "hb_bidder",
+                                val: function(bidResponse) {
+                                    return bidResponse.bidderCode;
+                                }
+                            }, {
+                                key: "hb_adid",
+                                val: function(bidResponse) {
+                                    return bidResponse.adId;
+                                }
+                            }, {
+                                key: "hb_pb",
+                                val: function(bidResponse) {
+                                  return bidResponse.pbHg;
+                                }
+                            }]
+                        }
+                };
+
+                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 5.57, "hb_size":"300x250" };
                 var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
                 assert.deepEqual(response, expected);
 


### PR DESCRIPTION
Bidders will always get key value pairs that are set in the `default` (i.e. `hb_pb`, `hb_bidder`, `hb_adid`, `hb_size`) even if using `alwaysUseBid=true`. If they choice to use the same key as the default keys, the value will be overwritten. 