### PR TITLE
Adding src param to track build source

### DIFF
--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -70,8 +70,17 @@ var SovrnAdapter = function SovrnAdapter() {
     };
 
     var scriptUrl = '//' + sovrnUrl + '?callback=window.pbjs.sovrnResponse' +
+      '&src=' + _getSource() +
       '&br=' + encodeURIComponent(JSON.stringify(sovrnBidReq));
     adloader.loadScript(scriptUrl, null);
+  }
+
+  function _getSource() {
+    var packageJson = require('../../package.json');
+    var repositoryUrlParts = packageJson.repository.url.split('/');
+    var source = repositoryUrlParts.length > 3 && repositoryUrlParts[3] === 'sovrn' ? 'sovrn': 'oss'; // github account
+
+    return source + '_prebid_' + packageJson.version;
   }
 
   function addBlankBidResponsesForAllPlacementsExceptThese(placementsWithBidsBack) {


### PR DESCRIPTION
This change allows sovrn to track calls originating from different build sources. It will help to differentiate requests from internal vs. open source builds and between versions.