### PR TITLE
bug 270: callBid loop

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -274,8 +274,8 @@ var RubiconAdapter = function RubiconAdapter() {
       var slots = [];
       var bids  = params.bids;
 
-      for (var key in bids) {
-        slots.push(_defineSlot(bids[key]));
+      for (var i=0, ln=bids.length; i < ln; i++) {
+        slots.push(_defineSlot(bids[i]));
       }
 
       var parameters = { slots: slots };


### PR DESCRIPTION
Tested by adding a row to a local test file
`Object.prototype.newAttr = "test123";`
Verified that before the fix the original loop would see 'newAttr', but after the fix the loop only ran through the array elements.

Also had an engineer review the minor change.