### PR TITLE
bug 270 cont: defineSlot was picking up object globals

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -220,11 +220,15 @@ var RubiconAdapter = function RubiconAdapter() {
     }
 
     for (var key in visitor) {
-      slot.addFPV(key, visitor[key]);
+      if (visitor.hasOwnProperty(key)) {
+        slot.addFPV(key, visitor[key]);
+      }
     }
 
     for (var key in inventory) {
-      slot.addFPI(key, inventory[key]);
+      if (inventory.hasOwnProperty(key)) {
+        slot.addFPI(key, inventory[key]);
+      }
     }
 
     slot.addKW(keywords);


### PR DESCRIPTION
fixing an issue we just found relating to issue 270 -- global attributes were showing up in the ad requests. e.g.
`Object.prototype.newAttr = "test123";`
resulted in ad calls containing this attribute:
`[...]&tg_v.newAttr=test123&tg_i.newAttr=test123&[...]`



