### PR TITLE
Set repo source constant

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "requirejs": "^2.1.20",
     "run-sequence": "^1.1.4",
     "sinon": "^1.12.1",
+    "string-replace-webpack-plugin": "0.0.3",
     "uglify-js": "^2.4.15",
     "webpack": "^1.12.3",
     "webpack-stream": "^3.1.0",

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -70,17 +70,9 @@ var SovrnAdapter = function SovrnAdapter() {
     };
 
     var scriptUrl = '//' + sovrnUrl + '?callback=window.pbjs.sovrnResponse' +
-      '&src=' + _getSource() +
+      '&src=' + CONSTANTS.REPO_AND_VERSION +
       '&br=' + encodeURIComponent(JSON.stringify(sovrnBidReq));
     adloader.loadScript(scriptUrl, null);
-  }
-
-  function _getSource() {
-    var packageJson = require('../../package.json');
-    var repositoryUrlParts = packageJson.repository.url.split('/');
-    var source = repositoryUrlParts.length > 3 && repositoryUrlParts[3] === 'sovrn' ? 'sovrn': 'oss'; // github account
-
-    return source + '_prebid_' + packageJson.version;
   }
 
   function addBlankBidResponsesForAllPlacementsExceptThese(placementsWithBidsBack) {

--- a/src/constants.json
+++ b/src/constants.json
@@ -9,6 +9,7 @@
     "ADSERVER_TARGETING": "adserverTargeting",
     "BD_SETTING_STANDARD": "standard"
   },
+  "REPO_AND_VERSION": "%%REPO_AND_VERSION%%",
   "DEBUG_MODE": "pbjs_debug",
   "STATUS": {
     "GOOD": 1,

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,3 +1,6 @@
+var prebid = require('./package.json');
+var StringReplacePlugin = require('string-replace-webpack-plugin');
+
 module.exports = {
   output: {
     filename: 'prebid.js'
@@ -27,7 +30,24 @@ module.exports = {
         test: /adaptermanager.js/,
         include: /(src)/,
         loader: 'adapterLoader'
+      },
+      {
+        test: /constants.json$/,
+        include: /(src)/,
+        loader: StringReplacePlugin.replace({
+          replacements: [
+            {
+              pattern: /%%REPO_AND_VERSION%%/g,
+              replacement: function (match, p1, offset, string) {
+                return `${prebid.repository.url.split('/')[3]}_prebid_${prebid.version}`;
+              }
+            }
+          ]
+        })
       }
     ]
-  }
+  },
+  plugins: [
+    new StringReplacePlugin()
+  ]
 };


### PR DESCRIPTION
Set a REPO_AND_VERSION constant during webpack that can be used to determine which Github repo the code was cloned from and the current version of Prebid.

/ht to @ojotoxy for the String Replace Webpack Plugin used in #293.

This PR requires an `npm install` to pick up the plugin.