### PR TITLE
add `setPriceGranularity` API method

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -24,11 +24,9 @@ var bidResponseReceivedCount = {};
 exports.bidResponseReceivedCount = bidResponseReceivedCount;
 
 var expectedBidsCount = {};
-
 var _allBidsAvailable = false;
-
 var _callbackExecuted = false;
-
+var _granularity = CONSTANTS.GRANULARITY_OPTIONS.MEDIUM;
 var defaultBidderSettingsMap = {};
 var bidderStartTimes = {};
 
@@ -151,6 +149,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
     bid.pbLg = priceStringsObj.low;
     bid.pbMg = priceStringsObj.med;
     bid.pbHg = priceStringsObj.high;
+    bid.pbAg = priceStringsObj.auto;
 
     //put adUnitCode into bid
     bid.adUnitCode = adUnitCode;
@@ -226,7 +225,15 @@ exports.getKeyValueTargetingPairs = function (bidderCode, custBidObj) {
           }, {
             key: 'hb_pb',
             val: function (bidResponse) {
-              return bidResponse.pbMg;
+              if (_granularity === CONSTANTS.GRANULARITY_OPTIONS.AUTO) {
+                return bidResponse.pbAg;
+              } else if (_granularity === CONSTANTS.GRANULARITY_OPTIONS.LOW) {
+                return bidResponse.pbLg;
+              } else if (_granularity === CONSTANTS.GRANULARITY_OPTIONS.MEDIUM) {
+                return bidResponse.pbMg;
+              } else if (_granularity === CONSTANTS.GRANULARITY_OPTIONS.HIGH) {
+                return bidResponse.pbHg;
+              }
             }
           }, {
             key: 'hb_size',
@@ -282,6 +289,17 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
 
   return keyValues;
 }
+
+exports.setPriceGranularity = function setPriceGranularity(granularity) {
+  var granularityOptions = CONSTANTS.GRANULARITY_OPTIONS;
+  if (Object.keys(granularityOptions).filter(option => granularity === granularityOptions[option])) {
+    _granularity = granularity;
+  } else {
+    utils.logWarn('Prebid Warning: setPriceGranularity was called with invalid setting, using' +
+      ' `medium` as default.');
+    _granularity = CONSTANTS.GRANULARITY_OPTIONS.MEDIUM;
+  }
+};
 
 exports.registerDefaultBidderSetting = function (bidderCode, defaultSetting) {
   defaultBidderSettingsMap[bidderCode] = defaultSetting;

--- a/src/constants.json
+++ b/src/constants.json
@@ -36,5 +36,11 @@
   },
   "EVENT_ID_PATHS": {
     "bidWon": "adUnitCode"
+  },
+  "GRANULARITY_OPTIONS": {
+    "LOW": "low",
+    "MEDIUM": "medium",
+    "HIGH": "high",
+    "AUTO": "auto"
   }
 }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -959,4 +959,12 @@ pbjs.aliasBidder = function (bidderCode, alias) {
   }
 };
 
+pbjs.setPriceGranularity = function (granularity) {
+  if (!granularity) {
+    utils.logError('Prebid Error: no value passed to `setPriceGranularity()`');
+  } else {
+    bidmanager.setPriceGranularity(granularity);
+  }
+};
+
 processQue();

--- a/src/utils.js
+++ b/src/utils.js
@@ -267,34 +267,52 @@ exports.getPriceBucketString = function (cpm) {
   var low = '';
   var med = '';
   var high = '';
+  var auto = '';
+
   var cpmFloat = 0;
   var returnObj = {
     low: low,
     med: med,
-    high: high
+    high: high,
+    auto: auto
   };
   try {
     cpmFloat = parseFloat(cpm);
     if (cpmFloat) {
-      //round to closet .5
+      //round to closest .5
       if (cpmFloat > _lgPriceCap) {
         returnObj.low = _lgPriceCap.toFixed(2);
       } else {
         returnObj.low = (Math.floor(cpm * 2) / 2).toFixed(2);
       }
 
-      //round to closet .1
+      //round to closest .1
       if (cpmFloat > _mgPriceCap) {
         returnObj.med = _mgPriceCap.toFixed(2);
       } else {
         returnObj.med = (Math.floor(cpm * 10) / 10).toFixed(2);
       }
 
-      //round to closet .01
+      //round to closest .01
       if (cpmFloat > _hgPriceCap) {
         returnObj.high = _hgPriceCap.toFixed(2);
       } else {
         returnObj.high = (Math.floor(cpm * 100) / 100).toFixed(2);
+      }
+
+      // round auto default sliding scale
+      if (cpmFloat <= 5) {
+        // round to closest .05
+        returnObj.auto = (Math.floor(cpm * 20) / 20).toFixed(2);
+      } else if (cpmFloat <= 10) {
+        // round to closest .10
+        returnObj.auto = (Math.floor(cpm * 10) / 10).toFixed(2);
+      } else if (cpmFloat <= 20) {
+        // round to closest .50
+        returnObj.auto = (Math.floor(cpm * 2) / 2).toFixed(2);
+      } else {
+        // cap at 20.00
+        returnObj.auto = '20.00';
       }
     }
   } catch (e) {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -6,300 +6,345 @@ var assert = require("assert");
 var utils = require('../../src/utils');
 var bidmanager = require('../../src/bidmanager');
 
-    describe('replaceTokenInString', function(){
+describe('replaceTokenInString', function () {
 
-        it('should replace all given tokens in a String', function() {
-            var tokensToReplace = {
-                'foo': 'bar',
-                'zap': 'quux'
-            };
+  it('should replace all given tokens in a String', function () {
+    var tokensToReplace = {
+      'foo': 'bar',
+      'zap': 'quux'
+    };
 
-            var output = utils.replaceTokenInString("hello %FOO%, I am %ZAP%", tokensToReplace, "%");
-            assert.equal(output, "hello bar, I am quux");
-        });
+    var output = utils.replaceTokenInString("hello %FOO%, I am %ZAP%", tokensToReplace, "%");
+    assert.equal(output, "hello bar, I am quux");
+  });
 
-        it('should ignore tokens it does not see', function() {
-            var output = utils.replaceTokenInString("hello %FOO%", {}, "%");
+  it('should ignore tokens it does not see', function () {
+    var output = utils.replaceTokenInString("hello %FOO%", {}, "%");
 
-            assert.equal(output, "hello %FOO%");
-        });
+    assert.equal(output, "hello %FOO%");
+  });
+});
+
+describe('bidmanager.js', function () {
+
+  describe('getKeyValueTargetingPairs', function () {
+    var bid = {};
+    var bidPriceCpm = 5.578;
+    var bidPbLg = 5.50;
+    var bidPbMg = 5.50;
+    var bidPbHg = 5.57;
+    var bidPbAg = 5.50;
+
+    var adUnitCode = '12345';
+    var bidderCode = 'appnexus';
+    var size = '300x250';
+    var adId = '1adId';
+
+    before(function () {
+      bid.cpm = bidPriceCpm;
+      bid.pbLg = bidPbLg;
+      bid.pbMg = bidPbMg;
+      bid.pbHg = bidPbHg;
+      bid.pbAg = bidPbAg;
+
+      bid.height = 300;
+      bid.width = 250;
+      bid.adUnitCode = adUnitCode;
+      bid.getSize = function () {
+        return this.height + 'x' + this.width;
+      };
+      bid.bidderCode = bidderCode;
+      bid.adId = adId;
+
     });
 
+    it('No bidder level configuration defined - default', function () {
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": bidPbMg,
+        "hb_size": size
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
 
-    describe('bidmanager.js', function(){
-
-        describe('getKeyValueTargetingPairs', function(){
-            var bid = {};
-            var bidPriceCpm = 5.578;
-            var bidPbLg = 5.50;
-            var bidPbMg = 5.50;
-            var bidPbHg = 5.57;
-            var adUnitCode = '12345';
-            var bidderCode = 'appnexus';
-            var size = '300x250';
-            var adId = '1adId';
-
-            before(function() {
-                bid.cpm = bidPriceCpm;
-                bid.pbLg = bidPbLg;
-                bid.pbMg = bidPbMg;
-                bid.pbHg = bidPbHg;
-                bid.height = 300;
-                bid.width = 250;
-                bid.adUnitCode = adUnitCode;
-                bid.getSize = function(){
-                    return this.height + 'x' + this.width;
-                };
-                bid.bidderCode = bidderCode;
-                bid.adId = adId;
-
-            });
-
-
-            it('No bidder level configuration defined - default', function() {
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": bidPbMg,"hb_size": size};
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-             it('Custom configuration for all bidders', function() {
-                pbjs.bidderSettings =
-                    {
-                        standard: {
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return bidResponse.pbHg;
-                                }
-                            }, {
-                                key: "hb_size",
-                                val: function(bidResponse) {
-                                    return bidResponse.size;
-
-                                }
-                            }]
-
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": bidPbHg,"hb_size": size};
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-            it('Custom configuration for one bidder', function() {
-                pbjs.bidderSettings =
-                    {
-                        appnexus: {
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return bidResponse.pbHg;
-                                }
-                            }, {
-                                key: "hb_size",
-                                val: function(bidResponse) {
-                                    return bidResponse.size;
-
-                                }
-                            }]
-
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": bidPbHg,"hb_size": size};
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-            it('Custom configuration for one bidder - not matched', function() {
-                pbjs.bidderSettings =
-                    {
-                        nonExistentBidder: {
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return bidResponse.pbHg;
-                                }
-                            }, {
-                                key: "hb_size",
-                                val: function(bidResponse) {
-                                    return bidResponse.size;
-
-                                }
-                            }]
-
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": bidPbMg,"hb_size": size};
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-            it('Custom bidCpmAdjustment for one bidder and inherit standard', function() {
-                pbjs.bidderSettings =
-                    {
-                        appnexus: {
-                            bidCpmAdjustment : function(bidCpm){
-                                return bidCpm * 0.7;
-                            },
-                        },
-                        standard: {
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return 10.00;
-                                }
-                            }]
-
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 10.0 };
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-            it('Custom bidCpmAdjustment AND custom configuration for one bidder and inherit standard settings', function() {
-                pbjs.bidderSettings =
-                    {
-                        appnexus: {
-                            bidCpmAdjustment : function(bidCpm){
-                                return bidCpm * 0.7;
-                            },
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return 15.00;
-                                }
-                            }]
-                        },
-                        standard: {
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                    //change default here
-                                    return 10.00;
-                                },
-                            },
-                            {
-                                key: "hb_size",
-                                val: function(bidResponse) {
-                                    return bidResponse.size;
-
-                                }
-                            }]
-
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 15.0, "hb_size":"300x250" };
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-
-            it('alwaysUseBid=true and inherit custom', function() {
-                pbjs.bidderSettings =
-                    {
-                        appnexus: {
-                            alwaysUseBid : true,
-                            adserverTargeting: [{
-                                key: "hb_bidder",
-                                val: function(bidResponse) {
-                                    return bidResponse.bidderCode;
-                                }
-                            }, {
-                                key: "hb_adid",
-                                val: function(bidResponse) {
-                                    return bidResponse.adId;
-                                }
-                            }, {
-                                key: "hb_pb",
-                                val: function(bidResponse) {
-                                  return bidResponse.pbHg;
-                                }
-                            }]
-                        }
-                };
-
-                var expected = {"hb_bidder":  bidderCode, "hb_adid": adId,"hb_pb": 5.57, "hb_size":"300x250" };
-                var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-                assert.deepEqual(response, expected);
-
-            });
-
-        });
     });
+
+    it('Custom configuration for all bidders', function () {
+      pbjs.bidderSettings =
+      {
+        standard: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return bidResponse.pbHg;
+              }
+            }, {
+              key: "hb_size",
+              val: function (bidResponse) {
+                return bidResponse.size;
+
+              }
+            }
+          ]
+
+        }
+      };
+
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": bidPbHg,
+        "hb_size": size
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+    it('Custom configuration for one bidder', function () {
+      pbjs.bidderSettings =
+      {
+        appnexus: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return bidResponse.pbHg;
+              }
+            }, {
+              key: "hb_size",
+              val: function (bidResponse) {
+                return bidResponse.size;
+
+              }
+            }
+          ]
+
+        }
+      };
+
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": bidPbHg,
+        "hb_size": size
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+    it('Custom configuration for one bidder - not matched', function () {
+      pbjs.bidderSettings =
+      {
+        nonExistentBidder: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return bidResponse.pbHg;
+              }
+            }, {
+              key: "hb_size",
+              val: function (bidResponse) {
+                return bidResponse.size;
+
+              }
+            }
+          ]
+
+        }
+      };
+
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": bidPbMg,
+        "hb_size": size
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+    it('Custom bidCpmAdjustment for one bidder and inherit standard', function () {
+      pbjs.bidderSettings =
+      {
+        appnexus: {
+          bidCpmAdjustment: function (bidCpm) {
+            return bidCpm * 0.7;
+          },
+        },
+        standard: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return 10.00;
+              }
+            }
+          ]
+
+        }
+      };
+
+      var expected = { "hb_bidder": bidderCode, "hb_adid": adId, "hb_pb": 10.0 };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+    it('Custom bidCpmAdjustment AND custom configuration for one bidder and inherit standard settings', function () {
+      pbjs.bidderSettings =
+      {
+        appnexus: {
+          bidCpmAdjustment: function (bidCpm) {
+            return bidCpm * 0.7;
+          },
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return 15.00;
+              }
+            }
+          ]
+        },
+        standard: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                //change default here
+                return 10.00;
+              },
+            },
+            {
+              key: "hb_size",
+              val: function (bidResponse) {
+                return bidResponse.size;
+
+              }
+            }
+          ]
+
+        }
+      };
+
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": 15.0,
+        "hb_size": "300x250"
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+    it('alwaysUseBid=true and inherit custom', function () {
+      pbjs.bidderSettings =
+      {
+        appnexus: {
+          alwaysUseBid: true,
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                return bidResponse.pbHg;
+              }
+            }
+          ]
+        }
+      };
+
+      var expected = {
+        "hb_bidder": bidderCode,
+        "hb_adid": adId,
+        "hb_pb": 5.57,
+        "hb_size": "300x250"
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
+
+  });
+});


### PR DESCRIPTION
Provides a `pbjs.setPriceGranularity` API method to configure which price bucket is used for "hb_pb". The accepted values are, "low", "medium", "high" and "auto", with "auto" being the default. Also introduces the "auto" price bucket which applies a sliding scale to determine granularity as:

| cpm | granularity |
|---|---|
| cpm < 5 | .05 increments |
| cpm > 5 and < 10 | .10 increments |
| cpm > 10 and < 20 | .50 increments | 
| cpm > 20 | pb capped at 20 |

If no setting is supplied the "medium" price bucket granularity is used.