### PR TITLE
Add bidfloor parameter to AOL adapter

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -140,7 +140,8 @@ var AolAdapter = function AolAdapter() {
       },
       params: {
         cors: 'yes',
-        cmd: 'bid'
+        cmd: 'bid',
+        bidfloor: (typeof bid.params.bidFloor !== "undefined") ? bid.params.bidFloor.toString() : '',
       },
       pubApiConfig: ADTECH_PUBAPI_CONFIG,
       placementCode: bid.placementCode

--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -141,7 +141,7 @@ var AolAdapter = function AolAdapter() {
       params: {
         cors: 'yes',
         cmd: 'bid',
-        bidfloor: (typeof bid.params.bidFloor !== "undefined") ? bid.params.bidFloor.toString() : '',
+        bidfloor: (typeof bid.params.bidFloor !== "undefined") ? bid.params.bidFloor.toString() : ''
       },
       pubApiConfig: ADTECH_PUBAPI_CONFIG,
       placementCode: bid.placementCode


### PR DESCRIPTION
We set the bidfloor parameter of the bid request object to a numeric string representing decimal CPM. If the bidfloor is not set, we pass the empty string which excludes the parameter from the resulting bid request call.