### PR TITLE
`pbjs.enableSendAllBids` API method

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -42,5 +42,11 @@
     "MEDIUM": "medium",
     "HIGH": "high",
     "AUTO": "auto"
-  }
+  },
+  "TARGETING_KEYS": [
+    "hb_bidder",
+    "hb_adid",
+    "hb_pb",
+    "hb_size"
+  ]
 }

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -57,7 +57,7 @@ after(function () {
   utils.logMessage.restore();
 });
 
-describe('Unit: Prebid API', function () {
+describe('Unit: Prebid Module', function () {
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     it('should return targeting info as a string', function () {
       var result = pbjs.getAdserverTargetingForAdUnitCodeStr(config.adUnitCodes[0]);
@@ -157,6 +157,30 @@ describe('Unit: Prebid API', function () {
       assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_adid', '148018fe5e'), 'sets hb_adid param');
       assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_pb', '10.00'), 'sets hb_pb param');
       assert.ok(slots[0].spySetTargeting.calledWithExactly('foobar', '300x250'), 'sets foobar param');
+    });
+
+    it('Calling enableSendAllBids should set targeting to include standard keys with bidder' +
+      ' append to key name', function() {
+      var slots = createSlotArray();
+      window.googletag.pubads().setSlots(slots);
+
+      pbjs.enableSendAllBids();
+      pbjs.setTargetingForGPTAsync();
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_bidder', ''), 'clears hb_bidder param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_adid', ''), 'clears hb_adid param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_pb', ''), 'clears hb_pb param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('foobar', ''), 'clears foobar param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_bidder', 'rubicon'), 'sets hb_bidder param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_adid', '148018fe5e'), 'sets hb_adid param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('hb_pb', '10.00'), 'sets hb_pb param');
+      assert.ok(slots[0].spySetTargeting.calledWithExactly('foobar', '300x250'), 'sets foobar param');
+      assert.ok(slots[0].spySetTargeting.calledWith('hb_bidder_rubicon', ''), 'sets' +
+        ' hb_bidder_rubicon param');
+      assert.ok(slots[0].spySetTargeting.calledWith('hb_adid_rubicon', ''), 'sets hb_adid_rubicon param');
+      assert.ok(slots[0].spySetTargeting.calledWith('hb_pb_rubicon', ''), 'sets hb_pb_rubicon' +
+        ' param');
+      assert.ok(!slots[0].spySetTargeting.calledWithExactly('foobar_rubicon', ''), 'does' +
+        ' not set custom keys with bidder in key name for foobar_rubicon param');
     });
   });
 


### PR DESCRIPTION
`pbjs.enableSendAllBids()` can be called from the implementation page which will set Prebid to include targeting information for each bidder returned in a call to `requestBids()` when making an ad server request. This call needs to be made before the call to `pbjs.setTargetingForGPTAsync()`.

Targeting key/pairs would then look like this:
```
{
  "hb_bidder": "appnexus",
  "hb_adid": "191f4aca0c0be8",
  "hb_pb": "10.00",
  "hb_size": "300x250",
  "foobar": "300x250",
  "hb_bidder_springserve": "springserve",
  "hb_adid_springserve": "129a7ed7a6fb40e",
  "hb_pb_springserve": "10.00",
  "hb_size_springserve": "300x250",
  "foobar_springserve": "300x250",
  "hb_bidder_triplelift": "triplelift",
  "hb_adid_triplelift": "1663076dadb443d",
  "hb_pb_triplelift": "10.00",
  "hb_size_triplelift": "0x0",
  "foobar_triplelift": "0x0",
  "hb_bidder_appnexus": "appnexus",
  "hb_adid_appnexus": "191f4aca0c0be8",
  "hb_pb_appnexus": "10.00",
  "hb_size_appnexus": "300x250",
  "foobar_appnexus": "300x250",
  "hb_bidder_pagescience": "pagescience",
  "hb_adid_pagescience": "2024c6abebaa183",
  "hb_pb_pagescience": "10.00",
  "hb_size_pagescience": "300x250",
  "foobar_pagescience": "300x250"
}
```
any custom targeting will continue to take precedence over defaults.