### PR TITLE
added info-level log message to setPriceGranularity()

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -993,6 +993,7 @@ pbjs.aliasBidder = function (bidderCode, alias) {
 };
 
 pbjs.setPriceGranularity = function (granularity) {
+  utils.logInfo('Invoking pbjs.setPriceGranularity', arguments);
   if (!granularity) {
     utils.logError('Prebid Error: no value passed to `setPriceGranularity()`');
   } else {


### PR DESCRIPTION
I realize this is a nit-pick, but this was helpful to me when I was debugging my use of setPriceGranularity() so I thought it might be of value to others.