### PR TITLE
Provide deterministic behavior for sort function.

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -141,6 +141,9 @@ function getWinningBidTargeting() {
   return winners;
 
   function getHighestCpm(previous, current) {
+    if (previous.cpm == current.cpm) {
+      return previous.timeToRespond > current.timeToRespond ? current : previous;
+    }
     return previous.cpm < current.cpm ? current : previous;
   }
 }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -141,7 +141,7 @@ function getWinningBidTargeting() {
   return winners;
 
   function getHighestCpm(previous, current) {
-    if (previous.cpm == current.cpm) {
+    if (previous.cpm === current.cpm) {
       return previous.timeToRespond > current.timeToRespond ? current : previous;
     }
     return previous.cpm < current.cpm ? current : previous;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -100,6 +100,13 @@ function checkDefinedPlacement(id) {
   return true;
 }
 
+var getHighestCpm = exports.getHighestCpm = function (previous, current) {
+  if (previous.cpm === current.cpm) {
+    return previous.timeToRespond > current.timeToRespond ? current : previous;
+  }
+  return previous.cpm < current.cpm ? current : previous;
+};
+
 function getWinningBidTargeting() {
   let presets;
   if (isGptPubadsDefined()) {
@@ -139,13 +146,6 @@ function getWinningBidTargeting() {
   }
 
   return winners;
-
-  function getHighestCpm(previous, current) {
-    if (previous.cpm === current.cpm) {
-      return previous.timeToRespond > current.timeToRespond ? current : previous;
-    }
-    return previous.cpm < current.cpm ? current : previous;
-  }
 }
 
 function getBidLandscapeTargeting() {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -70,6 +70,44 @@ window.googletag = {
 
 describe('Unit: Prebid Module', function () {
 
+  describe('getHighestCpm', function () {
+    it('should pick the existing highest cpm', function () {
+      var previous = {
+        cpm: 2,
+        timeToRespond: 100
+      };
+      var current = {
+        cpm: 1,
+        timeToRespond: 100
+      };
+      assert.equal(prebid.getHighestCpm(previous, current), previous);
+    });
+
+    it('should pick the new highest cpm', function () {
+      var previous = {
+        cpm: 1,
+        timeToRespond: 100
+      };
+      var current = {
+        cpm: 2,
+        timeToRespond: 100
+      };
+      assert.equal(prebid.getHighestCpm(previous, current), current);
+    });
+
+    it('should pick the fastest cpm in case of tie', function () {
+      var previous = {
+        cpm: 1,
+        timeToRespond: 100
+      };
+      var current = {
+        cpm: 1,
+        timeToRespond: 50
+      };
+      assert.equal(prebid.getHighestCpm(previous, current), current);
+    });
+  });
+
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     it('should return targeting info as a string', function () {
       const adUnitCode = config.adUnitCodes[0];


### PR DESCRIPTION
@mkendall07 

The current behavior for sorting the bids (not actually sorting, just picking the highest) does not handle the case in which bids are equal/tied.   This leads to non-deterministic behavior in picking the highest bid.

The addition provided in this PR has two goals.  1) Make the behavior of the sort function deterministic so an identical algorithm implemented elsewhere using the raw bid data will return the same results.  2) Use the existing `timeToRespond` as a secondary sorting key which has the added benefit of slightly incentivizing faster bids while still being simple to implement.

For our project we have been noticing a sizable amount of equal bids, so this issue actually occurs quite frequently.  This would help publishers doing their own logging to better match Prebid (since the algorithm will now be deterministic) and it will enable bidders to get a better read on why a bid won/lost at a certain price.

.cc @mmilleruva 