### PR TITLE
Prebid Auctions

### DIFF
--- a/src/adapters/adequant.js
+++ b/src/adapters/adequant.js
@@ -4,7 +4,7 @@ var adloader = require('../adloader.js');
 
 module.exports = function() {
   var req_url_base = 'https://rex.adequant.com/rex/c2s_prebid?';
-  
+
   function _callBids(params) {
     var req_url = [];
     var publisher_id = null;
@@ -12,13 +12,13 @@ module.exports = function() {
     var cats = null;
     var replies = [];
     var placements = {};
-    
+
     var bids = params.bids || [];
     for (var i = 0; i < bids.length; i++) {
       var bid_request = bids[i];
       var br_params = bid_request.params || {};
       placements[bid_request.placementCode] = true;
-      
+
       publisher_id = br_params.publisher_id.toString()    || publisher_id;
       var bidfloor = br_params.bidfloor                   || 0.01;
       cats         = br_params.cats                       || cats;
@@ -33,18 +33,18 @@ module.exports = function() {
     if (cats)         { req_url.push('c='+cats.join('+')); }
     if (sizes)        { req_url.push('s='+sizes.join('+')); }
     
-    adloader.loadScript(req_url_base+req_url.join('&'), function() { process_bids(replies, placements); });
+    adloader.loadScript(req_url_base+req_url.join('&'), function() { process_bids(replies, placements, bids); });
   }
-  
-  function process_bids(replies, placements) {
+
+  function process_bids(replies, placements, bids) {
     var placement_code, bid, adequant_creatives = window.adequant_creatives;
     if (adequant_creatives && adequant_creatives.seatbid) {
       for (var i=0; i<adequant_creatives.seatbid.length; i++) {
         var bid_response = adequant_creatives.seatbid[i].bid[0];
         placement_code = replies[parseInt(bid_response.impid,10)-1];
         if (!placement_code || !placements[placement_code]) { continue; }
-        
-        bid = bidfactory.createBid(1);
+        const bidRequestId = bids.find(bid => bid.placementCode === placement_code).bidId;
+        bid = bidfactory.createBid(1, bidRequestId);
         bid.bidderCode = 'adequant';
         bid.cpm = bid_response.price;
         bid.ad = bid_response.adm;
@@ -55,8 +55,9 @@ module.exports = function() {
       }
     }
     for (placement_code in placements) {
+      const bidRequestId = bids.find(bid => bid.placementCode === placement_code).bidId;
       if (placements[placement_code]) {
-        bid = bidfactory.createBid(2);
+        bid = bidfactory.createBid(2, bidRequestId);
         bid.bidderCode = 'adequant';
         bidmanager.addBidResponse(placement_code, bid);
       }

--- a/src/adapters/adform.js
+++ b/src/adapters/adform.js
@@ -67,7 +67,7 @@ function AdformAdapter() {
         if (adItem && adItem.response === 'banner' &&
             verifySize(adItem, bid.sizes)) {
 
-          bidObject = bidfactory.createBid(1);
+          bidObject = bidfactory.createBid(1, bid.bidId);
           bidObject.bidderCode = bidder;
           bidObject.cpm = adItem.win_bid;
           bidObject.cur = adItem.win_cur;
@@ -76,7 +76,7 @@ function AdformAdapter() {
           bidObject.height = adItem.height;
           bidmanager.addBidResponse(bid.placementCode, bidObject);
         } else {
-          bidObject = bidfactory.createBid(2);
+          bidObject = bidfactory.createBid(2, bid.bidId);
           bidObject.bidderCode = bidder;
           bidmanager.addBidResponse(bid.placementCode, bidObject);
         }

--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -73,7 +73,7 @@ var AolAdapter = function AolAdapter() {
     // clean up--we no longer need to store the bid
     delete bidsMap[context.alias];
 
-    var bidResponse = bidfactory.createBid(1);
+    var bidResponse = bidfactory.createBid(1, bid.bidId);
     var ad = response.getCreative();
     if (typeof response.getPixels() !== 'undefined') {
       ad += response.getPixels();
@@ -105,7 +105,7 @@ var AolAdapter = function AolAdapter() {
     // clean up--we no longer need to store the bid
     delete bidsMap[context.alias];
 
-    var bidResponse = bidfactory.createBid(2);
+    var bidResponse = bidfactory.createBid(2, bid.bidId);
     bidResponse.bidderCode = ADTECH_BIDDER_NAME;
     bidResponse.reason = response.getNbr();
     bidResponse.raw = response.getResponse();

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -1,4 +1,4 @@
-import { getBidRequest } from '../utils.js';
+import { findBidRequest } from '../utils.js';
 
 var CONSTANTS = require('../constants.json');
 var utils = require('../utils.js');
@@ -12,23 +12,10 @@ AppNexusAdapter = function AppNexusAdapter() {
   var baseAdapter = Adapter.createNew('appnexus');
 
   baseAdapter.callBids = function (params) {
-    //var bidCode = baseAdapter.getBidderCode();
-
-    var anArr = params.bids;
-
-    //var bidsCount = anArr.length;
-
-    //set expected bids count for callback execution
-    //bidmanager.setExpectedBidsCount(bidCode, bidsCount);
-
-    for (var i = 0; i < anArr.length; i++) {
-      var bidRequest = anArr[i];
-      var callbackId = bidRequest.bidId;
-      adloader.loadScript(buildJPTCall(bidRequest, callbackId));
-
-      //store a reference to the bidRequest from the callback id
-      //bidmanager.pbCallbackMap[callbackId] = bidRequest;
-    }
+    params.bids.map(bid => {
+      const callbackId = bid.bidId;
+      adloader.loadScript(buildJPTCall(bid, callbackId));
+    });
   };
 
   function buildJPTCall(bid, callbackId) {
@@ -151,7 +138,8 @@ AppNexusAdapter = function AppNexusAdapter() {
       var responseCPM;
       var id = jptResponseObj.callback_uid;
       var placementCode = '';
-      var bidObj = getBidRequest(id);
+      var bidObj = findBidRequest({ bidId: id });
+
       if (bidObj) {
 
         bidCode = bidObj.bidder;
@@ -178,7 +166,7 @@ AppNexusAdapter = function AppNexusAdapter() {
         //store bid response
         //bid status is good (indicating 1)
         var adId = jptResponseObj.result.creative_id;
-        bid = bidfactory.createBid(1);
+        bid = bidfactory.createBid(1, id);
         bid.creative_id = adId;
         bid.bidderCode = bidCode;
         bid.cpm = responseCPM;
@@ -196,7 +184,7 @@ AppNexusAdapter = function AppNexusAdapter() {
 
         // @endif
         //indicate that there is no bid for this placement
-        bid = bidfactory.createBid(2);
+        bid = bidfactory.createBid(2, id);
         bid.bidderCode = bidCode;
         bidmanager.addBidResponse(placementCode, bid);
       }

--- a/src/adapters/nginad.js
+++ b/src/adapters/nginad.js
@@ -1,3 +1,5 @@
+import { findBidderRequestByBidId } from '../utils';
+
 var CONSTANTS = require('../constants.json');
 var utils = require('../utils.js');
 var bidfactory = require('../bidfactory.js');
@@ -142,8 +144,7 @@ var NginAdAdapter = function NginAdAdapter() {
       var id = nginadBid.impid;
 
       // try to fetch the bid request we sent NginAd
-      var bidObj = pbjs._bidsRequested.find(bidSet => bidSet.bidderCode === 'nginad').bids
-        .find(bid => bid.bidId === id);
+      var bidObj = findBidderRequestByBidId({ adId: id });
       if (!bidObj) {
         return handleErrorResponse(nginadBid, defaultPlacementForBadBid);
       }

--- a/src/adapters/pulsepoint.js
+++ b/src/adapters/pulsepoint.js
@@ -43,7 +43,7 @@ var PulsePointAdapter = function PulsePointAdapter() {
   function bidResponseAvailable(bidRequest, bidResponse) {
     if (bidResponse) {
       var adSize = bidRequest.params.cf.toUpperCase().split('X');
-      var bid = bidfactory.createBid(1);
+      var bid = bidfactory.createBid(1, bidRequest.bidId);
       bid.bidderCode = bidRequest.bidder;
       bid.cpm = bidResponse.bidCpm;
       bid.ad = bidResponse.html;
@@ -51,7 +51,7 @@ var PulsePointAdapter = function PulsePointAdapter() {
       bid.height = adSize[1];
       bidmanager.addBidResponse(bidRequest.placementCode, bid);
     } else {
-      var passback = bidfactory.createBid(2);
+      var passback = bidfactory.createBid(2, bidRequest.bidId);
       passback.bidderCode = bidRequest.bidder;
       bidmanager.addBidResponse(bidRequest.placementCode, passback);
     }

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -1,3 +1,5 @@
+import { findBidRequest } from '../utils';
+
 var CONSTANTS = require('../constants.json');
 var utils = require('../utils.js');
 var bidfactory = require('../bidfactory.js');
@@ -55,7 +57,6 @@ var SovrnAdapter = function SovrnAdapter() {
         bidfloor: bidFloor
       };
       sovrnImps.push(imp);
-      //bidmanager.pbCallbackMap[imp.id] = bid;
       allPlacementCodes.push(bid.placementCode);
     });
 
@@ -105,8 +106,7 @@ var SovrnAdapter = function SovrnAdapter() {
           var bid = {};
 
           // try to fetch the bid request we sent Sovrn
-          var bidObj = pbjs._bidsRequested.find(bidSet => bidSet.bidderCode === 'sovrn').bids
-          .find(bid => bid.bidId === id);
+          var bidObj = findBidRequest({ bidId: id });
 
           if (bidObj) {
             placementCode = bidObj.placementCode;

--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -57,48 +57,42 @@ SpringServeAdapter = function SpringServeAdapter() {
     var bids = params.bids || [];
     for (var i = 0; i < bids.length; i++) {
       var bid = bids[i];
-      //bidmanager.pbCallbackMap[bid.params.impId] = params;
+      pbjs.handleSpringServeCB = _createCallback(bid);
       adloader.loadScript(buildSpringServeCall(bid));
     }
   }
 
-  pbjs.handleSpringServeCB = function (responseObj) {
-    if (responseObj && responseObj.seatbid && responseObj.seatbid.length > 0 &&
-      responseObj.seatbid[0].bid[0] !== undefined) {
-      //look up the request attributs stored in the bidmanager
-      var responseBid = responseObj.seatbid[0].bid[0];
-      //var requestObj = bidmanager.getPlacementIdByCBIdentifer(responseBid.impid);
-      var requestBids = pbjs._bidsRequested.find(bidSet => bidSet.bidderCode === 'springserve').bids
-        .filter(bid => bid.params && bid.params.impId === +responseBid.impid);
-      var bid = bidfactory.createBid(1);
-      var placementCode;
+  function _createCallback(bidRequest) {
+    return function _handleSpringServeCB(responseObj) {
+      if (responseObj && responseObj.seatbid && responseObj.seatbid.length > 0 &&
+        responseObj.seatbid[0].bid[0] !== undefined) {
 
-      //assign properties from the original request to the bid object
-      for (var i = 0; i < requestBids.length; i++) {
-        var bidRequest = requestBids[i];
-        if (bidRequest.bidder === 'springserve') {
-          placementCode = bidRequest.placementCode;
-          var size = bidRequest.sizes[0];
-          bid.width = size[0];
-          bid.height = size[1];
+        var responseBid = responseObj.seatbid[0].bid[0];
+        var bid = bidfactory.createBid(1, bidRequest.bidId);
+        var placementCode;
+
+        //assign properties from the original request to the bid object
+        placementCode = bidRequest.placementCode;
+        var size = bidRequest.sizes[0];
+        bid.width = size[0];
+        bid.height = size[1];
+
+        bid.bidderCode = bidRequest.bidder;
+
+        if (responseBid.hasOwnProperty('price') && responseBid.hasOwnProperty('adm')) {
+          //assign properties from the response to the bid object
+          bid.cpm = responseBid.price;
+          bid.ad = responseBid.adm;
+        } else {
+          //make object for invalid bid response
+          bid = bidfactory.createBid(2, bidRequest.bidId);
+          bid.bidderCode = 'springserve';
         }
+
+        bidmanager.addBidResponse(placementCode, bid);
       }
-
-      bid.bidderCode = requestBids[0].bidder;
-
-      if (responseBid.hasOwnProperty('price') && responseBid.hasOwnProperty('adm')) {
-        //assign properties from the response to the bid object
-        bid.cpm = responseBid.price;
-        bid.ad = responseBid.adm;
-      } else {
-        //make object for invalid bid response
-        bid = bidfactory.createBid(2);
-        bid.bidderCode = 'springserve';
-      }
-
-      bidmanager.addBidResponse(placementCode, bid);
-    }
-  };
+    };
+  }
 
   // Export the callBids function, so that prebid.js can execute this function
   // when the page asks to send out bid requests.

--- a/src/adapters/triplelift.js
+++ b/src/adapters/triplelift.js
@@ -1,3 +1,5 @@
+import { findBidderRequestByBidId } from '../utils';
+
 var utils = require('../utils.js');
 var adloader = require('../adloader.js');
 var bidmanager = require('../bidmanager.js');
@@ -7,26 +9,18 @@ var bidfactory = require('../bidfactory.js');
 *  Use to create a TripleLiftAdapter object
 */
 
-
 var TripleLiftAdapter = function TripleLiftAdapter() {
 
   function _callBids(params) {
     var tlReq = params.bids;
     var bidsCount = tlReq.length;
 
-    //set expected bids count for callback execution
-    //bidmanager.setExpectedBidsCount('triplelift',bidsCount);
-
     for (var i = 0; i < bidsCount; i++) {
       var bidRequest = tlReq[i];
       var callbackId = bidRequest.bidderRequestId;
       adloader.loadScript(buildTLCall(bidRequest, callbackId));
-      //store a reference to the bidRequest from the callback id
-      //bidmanager.pbCallbackMap[callbackId] = bidRequest;
     }
-
   }
-
 
   function buildTLCall(bid, callbackId) {
     //determine tag params
@@ -68,12 +62,10 @@ var TripleLiftAdapter = function TripleLiftAdapter() {
 
   }
 
-
   //expose the callback to the global object:
   pbjs.TLCB = function(tlResponseObj) {
     if (tlResponseObj && tlResponseObj.callback_id) {
-      //var bidObj = bidmanager.pbCallbackMap[tlResponseObj.callback_id],
-      var bidObj = pbjs._bidsRequested.find(bidSet => bidSet.bidderRequestId === tlResponseObj.callback_id).bids.reduce((a, b) => b);
+      var bidObj = findBidderRequestByBidId({ adId: tlResponseObj.callback_id });
       var placementCode = bidObj.placementCode;
 
       // @if NODE_ENV='debug'

--- a/src/auctionmanager.js
+++ b/src/auctionmanager.js
@@ -1,0 +1,96 @@
+const adaptermanager = require('./adaptermanager');
+const utils = require('./utils');
+
+export const auctionManager = (function() {
+  var _auctions = [];
+
+  function _createAuction() {
+    const auction = new Auction();
+    _addAuction(auction);
+    return auction;
+  }
+
+  function _getAuction(auctionId) {
+    _auctions.find(auction => auction.auctionId === auctionId);
+  }
+
+  function _addAuction(auction) {
+    _auctions.push(auction);
+  }
+
+  function _removeAuction(auction) {
+    _auctions.splice(_auctions.indexOf(auction), 1);
+  }
+
+  function _findAuctionsByBidderCode(bidderCode) {
+    var _bidderCode = bidderCode;
+    return _auctions.filter(_auction => _auction.getBidderRequests()
+      .filter(bidderRequest => bidderRequest.bidderCode === _bidderCode));
+  }
+
+  function Auction() {
+    var _id = utils.getUniqueIdentifierStr();
+    var _adUnits = [];
+    var _targeting = [];
+    var _bidderRequests = [];
+    var _bidsReceived = [];
+
+    this.setAdUnits = (adUnits) => _adUnits = adUnits;
+    this.setTargeting = (targeting) => _targeting = targeting;
+    this.setBidderRequests = (bidderRequests) => _bidderRequests = bidderRequests;
+    this.setBidsReceived = (bidsReceived) =>_bidsReceived = _bidsReceived.concat(bidsReceived);
+
+    this.getId = () => _id;
+    this.getAdUnits = () => _adUnits;
+    this.getBidderRequests = () => _bidderRequests;
+    this.getBidsReceived = () => _bidsReceived;
+    this.getTargeting = () => _targeting;
+
+    this.callBids = function callBids() {
+      adaptermanager.callBids(this);
+    };
+  }
+
+  return {
+    createAuction() {
+      return _createAuction();
+    },
+
+    getAuction() {
+      return _getAuction(...arguments);
+    },
+
+    getSingleAuction() {
+      return _auctions[0] || _createAuction();
+    },
+
+    findAuctionByBidderCode() {
+      return _findAuctionsByBidderCode(...arguments);
+    },
+
+    findBidderRequestByBidId({ bidId }) {
+      return _auctions.map(auction => auction.getBidderRequests()
+      .find(request => request.bids
+        .find(bid => bid.bidId === bidId)))[0] || { start: null };
+    },
+
+    findBidderRequestByBidParamImpId({ impId }) {
+      return _auctions.map(auction => auction.getBidderRequests()
+        .find(request => request.bids
+          .find(bid => bid.params && bid.params.impId === impId)));
+    },
+
+    findAuctionByBidId(bidId) {
+      return _auctions.find(auction => auction.getBidderRequests()
+        .find(request => request.bids
+          .find(bid => bid.bidId === bidId)));
+    },
+
+    findBidRequest({ bidId }) {
+      return _auctions.map(auction => auction.getBidderRequests()
+        .map(request => request.bids
+          .find(bid => bid.bidId === bidId)))[0]
+        .filter(bid => bid !== undefined)[0];
+    }
+  };
+}());

--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -14,15 +14,14 @@ var utils = require('./utils.js');
  dealId,
  priceKeyString;
  */
-function Bid(statusCode) {
-  var _bidId = utils.getUniqueIdentifierStr();
+function Bid(statusCode, bidId) {
   var _statusCode = statusCode || 0;
 
   this.bidderCode = '';
   this.width = 0;
   this.height = 0;
   this.statusMessage = _getStatus();
-  this.adId = _bidId;
+  this.bidId = bidId || utils.getUniqueIdentifierStr();
 
   function _getStatus() {
     switch (_statusCode) {
@@ -49,6 +48,6 @@ function Bid(statusCode) {
 }
 
 // Bid factory function.
-exports.createBid = function (statusCode) {
-  return new Bid(statusCode);
+exports.createBid = function (statusCode, adId) {
+  return new Bid(statusCode, adId);
 };

--- a/src/events.js
+++ b/src/events.js
@@ -8,9 +8,7 @@ var push = Array.prototype.push;
 
 //define entire events
 //var allEvents = ['bidRequested','bidResponse','bidWon','bidTimeout'];
-var allEvents = utils._map(CONSTANTS.EVENTS, function (v) {
-  return v;
-});
+var allEvents = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
 
 var idPaths = CONSTANTS.EVENT_ID_PATHS;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -464,10 +464,6 @@ export function flatten(a, b) {
   return a.concat(b);
 }
 
-export function getBidRequest(id) {
-  return pbjs._bidsRequested.map(bidSet => bidSet.bids.find(bid => bid.bidId === id)).find(bid => bid);
-}
-
 export function getKeys(obj) {
   return Object.keys(obj);
 }
@@ -492,5 +488,22 @@ export function getHighestCpm(previous, current) {
   if (previous.cpm === current.cpm) {
     return previous.timeToRespond > current.timeToRespond ? current : previous;
   }
+
   return previous.cpm < current.cpm ? current : previous;
+}
+
+export function getUniqueIdentifierStr() {
+  exports.getUniqueIdentifierStr();
+}
+
+export function findBidderRequestByBidId() {
+  return pbjs.auctionManager.findBidderRequestByBidId(...arguments);
+}
+
+export function findAuctionByBidderCode() {
+  return pbjs.auctionManager.findAuctionByBidderCode(...arguments);
+}
+
+export function findBidRequest() {
+  return pbjs.auctionManager.findBidRequest(...arguments);
 }

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -1135,7 +1135,7 @@ export function getTargetingKeys() {
   ];
 }
 
-// Key/values used to set ad server targeting when bid landscape 
+// Key/values used to set ad server targeting when bid landscape
 // targeting is on.
 export function getTargetingKeysBidLandscape() {
   return [

--- a/test/spec/aliasBidder_spec.js
+++ b/test/spec/aliasBidder_spec.js
@@ -1,5 +1,8 @@
 import { pbjsTestOnly } from 'test/helpers/pbjs-test-only';
 
+window.pbjs = (window.pbjs || {});
+var pbjs = window.pbjs;
+
 describe('Publisher API _ Alias Bidder', function () {
   var assert = require('chai').assert;
   var expect = require('chai').expect;

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -56,7 +56,7 @@ describe('bidmanager.js', function () {
         return this.height + 'x' + this.width;
       };
       bid.bidderCode = bidderCode;
-      bid.adId = adId;
+      bid.bidId = adId;
 
     });
 
@@ -365,29 +365,29 @@ describe('bidmanager.js', function () {
       bid.cpm = '1.99';
       let expectedIncrement = '1.99';
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      // pop this bid because another test relies on global pbjs._bidsReceived
-      let registeredBid = pbjs._bidsReceived.pop();
+      // pop this bid because another test relies on global auction.getBidsReceived()
+      let registeredBid = auction.getBidsReceived().pop();
       assert.equal(registeredBid.pbDg, expectedIncrement, '0 - 3 hits at to 1 cent increment');
 
       // 3 - 8 dollars
       bid.cpm = '4.39';
       expectedIncrement = '4.35';
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      registeredBid = pbjs._bidsReceived.pop();
+      registeredBid = auction.getBidsReceived().pop();
       assert.equal(registeredBid.pbDg, expectedIncrement, '3 - 8 hits at 5 cent increment');
 
       // 8 - 20 dollars
       bid.cpm = '19.99';
       expectedIncrement = '19.50';
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      registeredBid = pbjs._bidsReceived.pop();
+      registeredBid = auction.getBidsReceived().pop();
       assert.equal(registeredBid.pbDg, expectedIncrement, '8 - 20 hits at 50 cent increment');
 
       // 20+ dollars
       bid.cpm = '73.07';
       expectedIncrement = '20.00';
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      registeredBid = pbjs._bidsReceived.pop();
+      registeredBid = auction.getBidsReceived().pop();
       assert.equal(registeredBid.pbDg, expectedIncrement, '20+ caps at 20.00');
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -17,13 +17,15 @@ var events = require('src/events');
 var ga = require('src/ga');
 var CONSTANTS = require('src/constants.json');
 
-var bidResponses = require('test/fixtures/bid-responses.json');
-var targetingMap = require('test/fixtures/targeting-map.json');
+//var bidResponses = require('test/fixtures/bid-responses.json');
+//var targetingMap = require('test/fixtures/targeting-map.json');
 var config = require('test/fixtures/config.json');
 
 pbjs = pbjs || {};
-pbjs._bidsRequested = getBidRequests();
-pbjs._bidsReceived = getBidResponses();
+
+//var auction = getAuction();
+//auction.getBidderRequests = getBidRequests();
+//auction.getBidsReceived = getBidResponses();
 
 function resetAuction() {
   pbjs._sendAllBids = false;
@@ -207,7 +209,7 @@ describe('Unit: Prebid Module', function () {
     it('should return expected bid responses when not passed an adunitCode', function () {
       var result = pbjs.getBidResponses();
       var compare = getBidResponses().map(bid => bid.adUnitCode)
-        .filter((v, i, a) => a.indexOf(v) === i).map(adUnitCode => pbjs._bidsReceived
+        .filter((v, i, a) => a.indexOf(v) === i).map(adUnitCode => auction.getBidsReceived()
           .filter(bid => bid.adUnitCode === adUnitCode))
         .map(bids => {
           return {
@@ -369,14 +371,14 @@ describe('Unit: Prebid Module', function () {
         "width": 300,
         "height": 250,
       };
-      pbjs._bidsReceived.push(adResponse);
+      auction.getBidsReceived().push(adResponse);
 
       spyLogError = sinon.spy(utils, 'logError');
       spyLogMessage = sinon.spy(utils, 'logMessage');
     });
 
     afterEach(function () {
-      pbjs._bidsReceived.splice(pbjs._bidsReceived.indexOf(adResponse), 1);
+      auction.getBidsReceived().splice(auction.getBidsReceived().indexOf(adResponse), 1);
       utils.logError.restore();
       utils.logMessage.restore();
     });
@@ -582,7 +584,7 @@ describe('Unit: Prebid Module', function () {
       const bidderCode = 'appnexus';
       pbjs.bidsAvailableForAdapter(bidderCode);
 
-      const requestedBids = pbjs._bidsRequested.find(bid => bid.bidderCode === bidderCode);
+      const requestedBids = auction.getBidderRequests().find(bid => bid.bidderCode === bidderCode);
       requestedBids.bids.forEach(bid => {
         assert.equal(bid.bidderCode, bidderCode, 'bidderCode was set');
         assert.equal(bid.statusMessage, 'Bid available', 'bid set as available');


### PR DESCRIPTION
Prebid Auctions are implemented which enables instances of Prebid requests, responses and ad renders. This PR also includes the API changes needed to make concurrent requests for multiple placements, to queue up the next set of placements (for example, in an image carousel app) and to connect bid requests with bid responses across auction instances for greater level of analytics details.