### PR TITLE
Pass Deal IDs on bids to ad server as targeting data

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -96,6 +96,11 @@ exports.addBidResponse = function (adUnitCode, bid) {
     var keyValues = {};
     if (bid.bidderCode && bid.cpm !== 0) {
       keyValues = getKeyValueTargetingPairs(bid.bidderCode, bid);
+
+      if (bid.dealId) {
+        keyValues[`hb_deal_${bid.bidderCode}`] = bid.dealId;
+      }
+
       bid.adserverTargeting = keyValues;
     }
 

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -390,5 +390,17 @@ describe('bidmanager.js', function () {
       registeredBid = pbjs._bidsReceived.pop();
       assert.equal(registeredBid.pbDg, expectedIncrement, '20+ caps at 20.00');
     });
+
+    it('should place dealIds in adserver targeting', () => {
+      const bid = Object.assign({},
+        bidfactory.createBid(2),
+        fixtures.getBidResponses()[0]
+      );
+
+      bid.dealId = "test deal";
+      bidmanager.addBidResponse(bid.adUnitCode, bid);
+      const addedBid = pbjs._bidsReceived.pop();
+      assert.equal(addedBid.adserverTargeting[`hb_deal_${bid.bidderCode}`], bid.dealId, 'dealId placed in adserverTargeting');
+    });
   });
 });


### PR DESCRIPTION
If a bid response contains a dealId, its ad server targeting will receive a key with the form `hb_deal_<bidderCode>`. Bids with the highest cpm still always win whether they contain a deal or not. If a winning bid does have a dealId, its ad server targeting will also have a key of `hb_deal` with the value of the deal id. Deals are always sent to the server, regardless of whether `enableSendAllBids` is on or off.

* Construct required key/value pairs for bids with deals
* Always attach bids with deals to targeting
* Test addBidResponse places dealIds in adserver targeting