### PR TITLE
Replace preset targeting after setting winning bid targeting

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -170,7 +170,7 @@ function getWinningBidTargeting() {
   });
 
   if (presetTargeting) {
-    winners.concat(presetTargeting);
+    winners = winners.concat(presetTargeting);
   }
 
   return winners;

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -1129,13 +1129,17 @@ export function getTargetingKeys() {
       "300x250"
     ],
     [
+      "testKey",
+      "a test targeting value"
+    ],
+    [
       "foobar",
       "300x250"
     ]
   ];
 }
 
-// Key/values used to set ad server targeting when bid landscape 
+// Key/values used to set ad server targeting when bid landscape
 // targeting is on.
 export function getTargetingKeysBidLandscape() {
   return [
@@ -1158,6 +1162,10 @@ export function getTargetingKeysBidLandscape() {
     [
       "foobar",
       "300x250"
+    ],
+    [
+      "testKey",
+      "a test targeting value"
     ],
     [
       "foobar",

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -46,7 +46,7 @@ var Slot = function Slot(elementId, pathId) {
     },
 
     getTargeting: function getTargeting() {
-      return [{ testKey: ['a test targeting value'] }];
+      return {testKey: ['a test targeting value']}['testKey'];
     },
 
     getTargetingKeys: function getTargetingKeys() {
@@ -310,6 +310,10 @@ describe('Unit: Prebid Module', function () {
         [
           "foobar",
           "300x250"
+        ],
+        [
+          "testKey",
+          "a test targeting value"
         ],
         [
           "always_use_me",


### PR DESCRIPTION
presetTargeting was being concated onto winning bid targeting, but not stored back into that variable. Possibly fixes #391