### PR TITLE
Feature sovrn handles custom sizes

### DIFF
--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -35,13 +35,14 @@ var SovrnAdapter = function SovrnAdapter() {
 
       //sovrn supports only one size per tagid, so we just take the first size if there are more
       //if we are a 2 item array of 2 numbers, we must be a SingleSize array
-      var sizeArrayLength = bid.sizes.length;
-      if (sizeArrayLength === 2 && typeof bid.sizes[0] === 'number' && typeof bid.sizes[1] === 'number') {
-        adW = bid.sizes[0];
-        adH = bid.sizes[1];
+      var bidSizes = bid.params.sizes || bid.sizes;
+      var sizeArrayLength = bidSizes.length;
+      if (sizeArrayLength === 2 && typeof bidSizes[0] === 'number' && typeof bidSizes[1] === 'number') {
+        adW = bidSizes[0];
+        adH = bidSizes[1];
       } else {
-        adW = bid.sizes[0][0];
-        adH = bid.sizes[0][1];
+        adW = bidSizes[0][0];
+        adH = bidSizes[0][1];
       }
 
       var imp =

--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -35,7 +35,7 @@ var SovrnAdapter = function SovrnAdapter() {
 
       //sovrn supports only one size per tagid, so we just take the first size if there are more
       //if we are a 2 item array of 2 numbers, we must be a SingleSize array
-      var bidSizes = bid.params.sizes || bid.sizes;
+      var bidSizes = Array.isArray(bid.params.sizes) ? bid.params.sizes : bid.sizes;
       var sizeArrayLength = bidSizes.length;
       if (sizeArrayLength === 2 && typeof bidSizes[0] === 'number' && typeof bidSizes[1] === 'number') {
         adW = bidSizes[0];


### PR DESCRIPTION
Sovrn allows publishers to create additional tags for specific sizes.  For example, we have an ad unit that can be either 300x250 _or_ 300x600 depending on the Sovrn tag.

This PR allows publishers to send the appropriate sizes to the appropriate Sovrn tag which will take the place of the `bid.sizes` property which is passed to the adapter.  It does not change how sizes work for any other Prebid adapters nor does it change the way publishers implement the Sovrn adapter.  If the sizes parameter isn't passed, there is no change to current behavior.  It only provides additional functionality in the case where users want to have additional sets of tags that correspond to certain sizes. 

.cc @mmilleruva 