### PR TITLE
Update sovrn adapter to add empty bids for any request where no bid is returned.

### DIFF
--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -4,8 +4,6 @@ var bidfactory = require('../bidfactory.js');
 var bidmanager = require('../bidmanager.js');
 var adloader = require('../adloader');
 
-var allPlacementCodes;
-
 /**
  * Adapter for requesting bids from Sovrn
  */
@@ -24,7 +22,6 @@ var SovrnAdapter = function SovrnAdapter() {
     var page = window.location.pathname + location.search + location.hash;
 
     var sovrnImps = [];
-    allPlacementCodes = [];
 
     //build impression array for sovrn
     utils._each(bidReqs, function (bid) {
@@ -55,8 +52,6 @@ var SovrnAdapter = function SovrnAdapter() {
         bidfloor: bidFloor
       };
       sovrnImps.push(imp);
-      //bidmanager.pbCallbackMap[imp.id] = bid;
-      allPlacementCodes.push(bid.placementCode);
     });
 
     // build bid request with impressions
@@ -75,18 +70,16 @@ var SovrnAdapter = function SovrnAdapter() {
     adloader.loadScript(scriptUrl, null);
   }
 
-  function addBlankBidResponsesForAllPlacementsExceptThese(placementsWithBidsBack) {
-    utils._each(allPlacementCodes, function (placementCode) {
-      if (utils.contains(placementsWithBidsBack, placementCode)) {
-        // A bid was returned for this placement already
-        return null;
-      } else {
-        // Add a no-bid response for this placement.
-        var bid = {};
-        bid = bidfactory.createBid(2);
-        bid.bidderCode = 'sovrn';
-        bidmanager.addBidResponse(placementCode, bid);
-      }
+  function addBlankBidResponses(impidsWithBidBack) {
+    var missing = pbjs._bidsRequested.find(bidSet => bidSet.bidderCode === 'sovrn').bids
+      .filter(bid => impidsWithBidBack.indexOf(bid.bidId) < 0);
+
+    missing.forEach(function (bidRequest) {
+      // Add a no-bid response for this bid request.
+      var bid = {};
+      bid = bidfactory.createBid(2);
+      bid.bidderCode = 'sovrn';
+      bidmanager.addBidResponse(bidRequest.placementCode, bid);
     });
   }
 
@@ -96,7 +89,7 @@ var SovrnAdapter = function SovrnAdapter() {
     if (sovrnResponseObj && sovrnResponseObj.id) {
       // valid object w/ bid responses?
       if (sovrnResponseObj.seatbid && sovrnResponseObj.seatbid.length !== 0 && sovrnResponseObj.seatbid[0].bid && sovrnResponseObj.seatbid[0].bid.length !== 0) {
-        var placementsWithBidsBack = [];
+        var impidsWithBidBack = [];
         sovrnResponseObj.seatbid[0].bid.forEach(function (sovrnBid) {
 
           var responseCPM;
@@ -110,7 +103,6 @@ var SovrnAdapter = function SovrnAdapter() {
 
           if (bidObj) {
             placementCode = bidObj.placementCode;
-            placementsWithBidsBack.push(placementCode);
             bidObj.status = CONSTANTS.STATUS.GOOD;
 
             //place ad response on bidmanager._adResponsesByBidderId
@@ -140,31 +132,19 @@ var SovrnAdapter = function SovrnAdapter() {
               bid.height = parseInt(sovrnBid.h);
 
               bidmanager.addBidResponse(placementCode, bid);
-
-            } else {
-              //0 price bid
-              //indicate that there is no bid for this placement
-              bid = bidfactory.createBid(2);
-              bid.bidderCode = 'sovrn';
-              bidmanager.addBidResponse(placementCode, bid);
-
+              impidsWithBidBack.push(id);
             }
-          } else { // bid not found, we never asked for this?
-            //no response data
-            bid = bidfactory.createBid(2);
-            bid.bidderCode = 'sovrn';
-            bidmanager.addBidResponse(placementCode, bid);
           }
         });
 
-        addBlankBidResponsesForAllPlacementsExceptThese(placementsWithBidsBack);
+        addBlankBidResponses(impidsWithBidBack);
       } else {
-        //no response data for any placements
-        addBlankBidResponsesForAllPlacementsExceptThese([]);
+        //no response data for all requests
+        addBlankBidResponses([]);
       }
     } else {
-      //no response data for any placements
-      addBlankBidResponsesForAllPlacementsExceptThese([]);
+      //no response data for all requests
+      addBlankBidResponses([]);
     }
 
   }; // sovrnResponse

--- a/test/spec/adapters/sovrn_spec.js
+++ b/test/spec/adapters/sovrn_spec.js
@@ -1,0 +1,173 @@
+describe('sovrn adapter tests', function () {
+  const expect = require('chai').expect;
+  const adapter = require('src/adapters/sovrn');
+  const bidmanager = require('src/bidmanager');
+
+  describe('sovrnResponse', function () {
+
+    it('should exist and be a function', function () {
+      expect(pbjs.sovrnResponse).to.exist.and.to.be.a('function');
+    });
+
+    it('should add empty bid responses if no bids returned', function () {
+      var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+      var bidderRequest = {
+        bidderCode: 'sovrn',
+        bids: [
+          {
+            bidId: 'bidId1',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315045'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-1'
+          },
+          {
+            bidId: 'bidId2',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315046'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-2'
+          },
+          {
+            bidId: 'bidId3',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315047'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-2'
+          },
+        ]
+      };
+
+      // no bids returned in the response.
+      var response = {
+        "id": "54321",
+        "seatbid": []
+      };
+
+      pbjs._bidsRequested.push(bidderRequest);
+      // adapter needs to be called, in order for the stub to register.
+      adapter()
+
+      pbjs.sovrnResponse(response);
+
+      var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+      var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+      var bidPlacementCode2 = stubAddBidResponse.getCall(1).args[0];
+      var bidObject2 = stubAddBidResponse.getCall(1).args[1];
+      var bidPlacementCode3 = stubAddBidResponse.getCall(2).args[0];
+      var bidObject3 = stubAddBidResponse.getCall(2).args[1];
+
+      expect(bidPlacementCode1).to.equal('div-gpt-ad-12345-1');
+      expect(bidObject1.getStatusCode()).to.equal(2);
+      expect(bidObject1.bidderCode).to.equal('sovrn');
+
+      expect(bidPlacementCode2).to.equal('div-gpt-ad-12345-2');
+      expect(bidObject2.getStatusCode()).to.equal(2);
+      expect(bidObject2.bidderCode).to.equal('sovrn');
+
+      expect(bidPlacementCode3).to.equal('div-gpt-ad-12345-2');
+      expect(bidObject3.getStatusCode()).to.equal(2);
+      expect(bidObject3.bidderCode).to.equal('sovrn');
+
+      stubAddBidResponse.calledThrice;
+
+      stubAddBidResponse.restore();
+    });
+
+    it('should add a bid response for bids returned and empty bid responses for the rest', function () {
+      var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+      var bidderRequest = {
+        bidderCode: 'sovrn',
+        bids: [
+          {
+            bidId: 'bidId1',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315045'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-1'
+          },
+          {
+            bidId: 'bidId2',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315046'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-2'
+          },
+          {
+            bidId: 'bidId3',
+            bidder: 'sovrn',
+            params: {
+              tagid: '315047'
+            },
+            sizes: [[320, 50]],
+            placementCode: 'div-gpt-ad-12345-2'
+          },
+        ]
+      };
+
+      // Returning a single bid in the response.
+      var response = {
+        "id": "54321111",
+        "seatbid": [ {
+          "bid" : [ {
+            "id" : "1111111",
+            "impid" : "bidId2",
+            "price" : 0.09,
+            "nurl" : "http://url",
+            "adm" : "ad-code",
+            "h" : 250,
+            "w" : 300,
+            "ext" : { }
+          } ]
+        } ]
+      };
+
+      pbjs._bidsRequested.push(bidderRequest);
+      // adapter needs to be called, in order for the stub to register.
+      adapter()
+
+      pbjs.sovrnResponse(response);
+
+      var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+      var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+      var bidPlacementCode2 = stubAddBidResponse.getCall(1).args[0];
+      var bidObject2 = stubAddBidResponse.getCall(1).args[1];
+      var bidPlacementCode3 = stubAddBidResponse.getCall(2).args[0];
+      var bidObject3 = stubAddBidResponse.getCall(2).args[1];
+
+      expect(bidPlacementCode1).to.equal('div-gpt-ad-12345-2');
+      expect(bidObject1.getStatusCode()).to.equal(1);
+      expect(bidObject1.bidderCode).to.equal('sovrn');
+      expect(bidObject1.creativeId).to.equal('1111111');
+      expect(bidObject1.cpm).to.equal(0.09);
+      expect(bidObject1.height).to.equal(250);
+      expect(bidObject1.width).to.equal(300);
+      expect(bidObject1.ad).to.equal('ad-code<img src="http://url">');
+
+      expect(bidPlacementCode2).to.equal('div-gpt-ad-12345-1');
+      expect(bidObject2.getStatusCode()).to.equal(2);
+      expect(bidObject2.bidderCode).to.equal('sovrn');
+
+      expect(bidPlacementCode3).to.equal('div-gpt-ad-12345-2');
+      expect(bidObject3.getStatusCode()).to.equal(2);
+      expect(bidObject3.bidderCode).to.equal('sovrn');
+
+      stubAddBidResponse.calledThrice;
+
+      stubAddBidResponse.restore();
+    });
+  });
+});
+

--- a/test/spec/adapters/sovrn_spec.js
+++ b/test/spec/adapters/sovrn_spec.js
@@ -150,7 +150,7 @@ describe('sovrn adapter tests', function () {
       expect(bidPlacementCode1).to.equal('div-gpt-ad-12345-2');
       expect(bidObject1.getStatusCode()).to.equal(1);
       expect(bidObject1.bidderCode).to.equal('sovrn');
-      expect(bidObject1.creativeId).to.equal('1111111');
+      expect(bidObject1.creative_id).to.equal('1111111');
       expect(bidObject1.cpm).to.equal(0.09);
       expect(bidObject1.height).to.equal(250);
       expect(bidObject1.width).to.equal(300);


### PR DESCRIPTION
If Sovrn is configured for multiple bids per placement code, and Sovrn does not return a bid for each one, then pbjs.allBidsAvailable() will always return `false` even though the Sovrn response has been received. This causes Prebid to wait for the timeout before calling the bidsBackHandler even though all responses are back. The existing code assumes one bid request per placement code.

This PR updates the logic to ensure empty bids exist for each bid requested that did not get a response back. Also adds tests.