### PR TITLE
Yieldbot making multiple request to yieldbot.intent.js

### DIFF
--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -107,7 +107,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
         ybotlib.handleUpdateState();
       });
 
-      adloader.loadScript('//cdn.yldbt.com/js/yieldbot.intent.js');
+      adloader.loadScript('//cdn.yldbt.com/js/yieldbot.intent.js', function() {}, true);
     },
     /**
      * Yieldbot bid request callback handler.

--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -33,7 +33,8 @@ var YieldbotAdapter = function YieldbotAdapter() {
      * @private
      */
     buildCreative: function (slot, size) {
-      return '<script type="text/javascript">var ybotq = ybotq || [];' +
+      return '<script type="text/javascript" src="//cdn.yldbt.com/js/yieldbot.intent.js"></script>' +
+        '<script type="text/javascript">var ybotq = ybotq || [];' +
         'ybotq.push(function () {yieldbot.renderAd(\'' + slot + ':' + size + '\');});</script>';
     },
     /**

--- a/src/adapters/yieldbot.js
+++ b/src/adapters/yieldbot.js
@@ -33,8 +33,7 @@ var YieldbotAdapter = function YieldbotAdapter() {
      * @private
      */
     buildCreative: function (slot, size) {
-      return '<script type="text/javascript" src="//cdn.yldbt.com/js/yieldbot.intent.js"></script>' +
-        '<script type="text/javascript">var ybotq = ybotq || [];' +
+      return '<script type="text/javascript">var ybotq = ybotq || [];' +
         'ybotq.push(function () {yieldbot.renderAd(\'' + slot + ':' + size + '\');});</script>';
     },
     /**


### PR DESCRIPTION
We're finally making the transition of moving Yieldbot into Prebid for our setup, but I noticed Yieldbot makes multiple request to yieldbot.intent.js. In fact, since we're running refreshes for all of our lazy loaded ads - we have 4+ requests for this script.

I've enabled caching on the intent.js script and removed the duplicate call to it in the creative rendering.