### PR TITLE
Feature powerful adjust

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -333,6 +333,10 @@ function adjustBids(bid) {
   }
 }
 
+exports.adjustBids = function() {
+  return adjustBids(...arguments);
+};
+
 function getPriceBucketString(cpm) {
   var cpmFloat = 0;
   var returnObj = {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -320,7 +320,7 @@ function adjustBids(bid) {
   if (code && $$PREBID_GLOBAL$$.bidderSettings && $$PREBID_GLOBAL$$.bidderSettings[code]) {
     if (typeof $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment === objectType_function) {
       try {
-        bidPriceAdjusted = $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm, bid);
+        bidPriceAdjusted = $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm, utils.extend({}, bid));
       }
       catch (e) {
         utils.logError('Error during bid adjustment', 'bidmanager.js', e);

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -314,7 +314,7 @@ function adjustBids(bid) {
   if (code && pbjs.bidderSettings && pbjs.bidderSettings[code]) {
     if (typeof pbjs.bidderSettings[code].bidCpmAdjustment === objectType_function) {
       try {
-        bidPriceAdjusted = pbjs.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm);
+        bidPriceAdjusted = pbjs.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm, bid);
       }
       catch (e) {
         utils.logError('Error during bid adjustment', 'bidmanager.js', e);

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -350,6 +350,35 @@ describe('bidmanager.js', function () {
 
   });
 
+  describe('adjustBids', () => {
+    it('should adjust bids and pass copy of bid object', () => {
+      const bid = Object.assign({},
+        bidfactory.createBid(2),
+        fixtures.getBidResponses()[5]
+      );
+
+      assert.equal(bid.cpm, .5);
+
+      $$PREBID_GLOBAL$$.bidderSettings =
+      {
+        brealtime: {
+          bidCpmAdjustment: function (bidCpm, bidObj) {
+            assert.deepEqual(bidObj, bid);
+            return bidCpm * 0.5;
+          },
+        },
+        standard: {
+          adserverTargeting: [
+          ]
+        }
+      };
+
+      bidmanager.adjustBids(bid)
+      assert.equal(bid.cpm, .25);
+
+    });
+  });
+
   describe('addBidResponse', () => {
     before(() => {
       $$PREBID_GLOBAL$$.adUnits = fixtures.getAdUnits();


### PR DESCRIPTION
@mkendall07 

If we pass the whole bid object, Prebid publishers have some extremely cool new abilities.  Using the very same `bidCpmAdjustment` function (which btw will still be backwards compatible) users can do things like enhance their analytics with the additional data, track creatives across partners, decrease bids from slow bidders, etc.!  

.cc @nanek