### PR TITLE
Update triplelift to use the bid.bidId instead of bidderRequestId.

### DIFF
--- a/src/adapters/triplelift.js
+++ b/src/adapters/triplelift.js
@@ -19,7 +19,7 @@ var TripleLiftAdapter = function TripleLiftAdapter() {
 
     for (var i = 0; i < bidsCount; i++) {
       var bidRequest = tlReq[i];
-      var callbackId = bidRequest.bidderRequestId;
+      var callbackId = bidRequest.bidId;
       adloader.loadScript(buildTLCall(bidRequest, callbackId));
       //store a reference to the bidRequest from the callback id
       //bidmanager.pbCallbackMap[callbackId] = bidRequest;
@@ -75,8 +75,7 @@ var TripleLiftAdapter = function TripleLiftAdapter() {
   //expose the callback to the global object:
   $$PREBID_GLOBAL$$.TLCB = function(tlResponseObj) {
     if (tlResponseObj && tlResponseObj.callback_id) {
-      //var bidObj = bidmanager.pbCallbackMap[tlResponseObj.callback_id],
-      var bidObj = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderRequestId === tlResponseObj.callback_id).bids.reduce((a, b) => b);
+      var bidObj = utils.getBidRequest(tlResponseObj.callback_id);
       var placementCode = bidObj.placementCode;
 
       // @if NODE_ENV='debug'


### PR DESCRIPTION
Triplelift currently uses the `bidderRequestId` for a callbackId. This forces the callbackId to be the same for all bids even for different ad placements. When bid response come back, they all are incorrectly associated to just one ad placement. This PR updates the adapter to use the bidId instead.