### PR TITLE
adapter loader refactor

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var uglify = require('gulp-uglify');
 var jshint = require('gulp-jshint');
 var clean = require('gulp-clean');
 var karma = require('gulp-karma');
+var mocha = require('gulp-mocha');
 var opens = require('open');
 var webpackConfig = require('./webpack.conf.js');
 var helpers = require('./gulpHelpers');
@@ -32,7 +33,7 @@ gulp.task('default', ['clean', 'quality', 'webpack']);
 
 gulp.task('serve', ['clean', 'quality', 'devpack', 'webpack', 'watch', 'test']);
 
-gulp.task('run-tests', ['clean', 'quality', 'webpack', 'test']);
+gulp.task('run-tests', ['clean', 'quality', 'webpack', 'test', 'mocha']);
 
 gulp.task('build', ['clean', 'quality', 'webpack', 'devpack', 'zip']);
 
@@ -129,6 +130,17 @@ gulp.task('test', function () {
     }));
 });
 
+gulp.task('mocha', function() {
+    return gulp.src(['test/spec/loaders/**/*.js'], { read: false })
+        .pipe(mocha({
+          reporter: 'spec',
+          globals: {
+            expect: require('chai').expect
+          }
+        }))
+        .on('error', gutil.log);
+});
+
 // Small task to load coverage reports in the browser
 gulp.task('coverage', function (done) {
   var coveragePort = 1999;
@@ -145,9 +157,16 @@ gulp.task('coverage', function (done) {
 // Watch Task with Live Reload
 gulp.task('watch', function () {
 
-  gulp.watch(['test/spec/**/*.js'], ['quality', 'webpack', 'devpack', 'test']);
+  gulp.watch([
+    'src/**/*.js',
+    'test/spec/**/*.js',
+    '!test/spec/loaders/**/*.js'
+  ], ['quality', 'webpack', 'devpack', 'test']);
+  gulp.watch([
+    'loaders/**/*.js',
+    'test/spec/loaders/**/*.js'
+  ], ['quality', 'mocha']);
   gulp.watch(['integrationExamples/gpt/*.html'], ['test']);
-  gulp.watch(['src/**/*.js'], ['quality', 'webpack', 'devpack', 'test']);
   connect.server({
     port: 9999,
     root: './',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -233,7 +233,9 @@ module.exports = function (config) {
     ],
 
     // list of files to exclude
-    exclude: [],
+    exclude: [
+      'test/spec/loaders/**/*.js'
+    ],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/loaders/adapterLoader.js
+++ b/loaders/adapterLoader.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const blockLoader = require('block-loader');
 const getAdapters = require('./getAdapters');
 
-const adapters = getAdapters('../adapters.json');
+const adapters = getAdapters();
 const files = fs.readdirSync('src/adapters').map((file) => file.replace(/\.[^/.]+$/, ''));
 const adapterNames = adapters.map(getNames).filter(getUniques);
 const aliases = adapters.filter(getAliases);

--- a/loaders/getAdapters.js
+++ b/loaders/getAdapters.js
@@ -4,17 +4,17 @@ const fs = require('fs');
 const path = require('path');
 const argv = require('yargs').argv;
 
-const jsonPath = argv['adapters'] || '';
+const customAdaptersPath = argv['adapters'] || '';
 
 module.exports = function getAdapters(all) {
-  const json = path.resolve(process.cwd(), jsonPath);
+  const json = path.resolve(process.cwd(), customAdaptersPath);
 
   let adapters;
   try {
     fs.statSync(json);
     adapters = require(json);
   } catch (e) {
-    if (jsonPath) {
+    if (customAdaptersPath) {
       console.log(`Prebid Warning: custom adapters config cannot be loaded from ${json}, ` +
         'using default adapters.json');
     }

--- a/loaders/getAdapters.js
+++ b/loaders/getAdapters.js
@@ -4,22 +4,32 @@ const fs = require('fs');
 const path = require('path');
 const argv = require('yargs').argv;
 
-const customAdaptersPath = argv['adapters'] || '';
+const defaultAdapters = 'adapters.json';
 
-module.exports = function getAdapters(all) {
-  const json = path.resolve(process.cwd(), customAdaptersPath);
-
-  let adapters;
+function load(file) {
   try {
-    fs.statSync(json);
-    adapters = require(json);
+    const buffer = fs.readFileSync(file);
+    return JSON.parse(buffer.toString());
   } catch (e) {
-    if (customAdaptersPath) {
-      console.log(`Prebid Warning: custom adapters config cannot be loaded from ${json}, ` +
-        'using default adapters.json');
-    }
-    adapters = require(all);
+    return [];
+  }
+}
+
+module.exports = function getAdapters() {
+  let customAdapters = argv.adapters;
+
+  if (!customAdapters) {
+    return load(defaultAdapters);
   }
 
-  return adapters;
+  customAdapters = path.resolve(process.cwd(), customAdapters);
+
+  try {
+    fs.statSync(customAdapters);
+    return load(customAdapters);
+  } catch (e) {
+    console.log(`Prebid Warning: custom adapters config cannot be loaded from ${customAdapters}, ` +
+      'using default adapters.json');
+    return load(defaultAdapters);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
-    "test": "gulp test",
-    "test-loaders": "mocha test/spec/loaders/ --bail"
+    "test": "gulp test && gulp mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "test-loaders": "mocha test/spec/loaders/ --bail"
   },
   "repository": {
     "type": "git",
@@ -73,8 +74,10 @@
     "localtunnel": "^1.3.0",
     "lodash": "^2.4.1",
     "mocha": "^1.21.4",
+    "mock-fs": "^3.11.0",
     "open": "0.0.5",
     "phantomjs": "^1.9.18",
+    "proxyquire": "^1.7.10",
     "querystringify": "0.0.3",
     "raw-loader": "^0.5.1",
     "redis": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-jsdoc-to-markdown": "^1.2.1",
     "gulp-jshint": "^1.8.4",
     "gulp-karma": "0.0.4",
+    "gulp-mocha": "^2.2.0",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.4.0",
     "gulp-uglify": "^0.3.1",

--- a/test/spec/loaders/getAdapters_spec.js
+++ b/test/spec/loaders/getAdapters_spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const mockfs = require('mock-fs');
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+
+require('../../../loaders/getAdapters');
+
+describe('loaders/getAdapters', () => {
+
+  let defaultAdapters;
+  let customAdapters;
+
+  beforeEach(() => {
+    defaultAdapters = [ 'adapter 1', 'adapter 2', 'adapter 3' ];
+    customAdapters = [ 'adapter 1' ];
+  });
+
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  describe('when custom adapter list is defined', () => {
+
+    describe('and exists', () => {
+
+      it('should return custom adapter list', () => {
+        mockfs({
+          'adapters.json': JSON.stringify(defaultAdapters),
+          'custom-adapters.json': JSON.stringify(customAdapters)
+        });
+        const getAdapters = proxyquire('../../../loaders/getAdapters', {
+          yargs: { argv: { adapters: 'custom-adapters.json' } }
+        });
+        expect(getAdapters()).to.deep.equal(customAdapters);
+      });
+
+    });
+
+    describe('and does not exist', () => {
+
+      it('should return default adapter list and show warning', () => {
+        let log;
+        const consoleLog = console.log.bind(console);
+        console.log = (message) => {
+          log = message;
+        };
+        mockfs({
+          'adapters.json': JSON.stringify(defaultAdapters)
+        });
+        const getAdapters = proxyquire('../../../loaders/getAdapters', {
+          yargs: { argv: { adapters: 'non-existent-adapters.json' } }
+        });
+        expect(getAdapters()).to.deep.equal(defaultAdapters);
+        expect(log).to.match(/non-existent-adapters.json/);
+        console.log = consoleLog;
+      });
+
+    });
+
+  });
+
+  describe('when custom adapter list is not defined', () => {
+
+    it('should return default adapter list', () => {
+      mockfs({
+        'adapters.json': JSON.stringify(defaultAdapters)
+      });
+      const getAdapters = proxyquire('../../../loaders/getAdapters', {
+        yargs: { argv: {} }
+      });
+      expect(getAdapters()).to.deep.equal(defaultAdapters);
+    });
+
+  });
+
+  describe('when default adapter list cannot be found', () => {
+
+    it('should return empty array', () => {
+      mockfs({
+        'adapters.json': mockfs.file({ mode: 0x000 })
+      });
+      const getAdapters = proxyquire('../../../loaders/getAdapters', {
+        yargs: { argv: {} }
+      });
+      expect(getAdapters()).to.deep.equal([]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
I've refactored `loader/getAdapter.js` which I added in #424 to be able to add test coverage for it

`proxyquire` and `mock-fs` npm packages were necessary to be added to mock out internal dependencies in the `getAdapter` module

`getAdapter` is now completely self-contained and just needs to be called from `loaders/adapterLoader.js` module without parameters, the default `adapters.json` file is referenced inside `getAdapter`

as `getAdapter` is a Node module, `mocha` has been used to run tests against it

I've used `chai/expect` but if required I'm happy to convert the assertions to `chai/assert` instead

there's a new npm script `test-loaders` added to `package.json` to run the tests against the loader modules