### PR TITLE
Add UnderdogMedia Adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -21,6 +21,7 @@
     "brightcom",
     "wideorbit",
     "jcm",
+    "underdogmedia",
     {
       "appnexus": {
         "alias": "brealtime"

--- a/src/adapters/underdogmedia.js
+++ b/src/adapters/underdogmedia.js
@@ -1,0 +1,75 @@
+var bidfactory = require('../bidfactory.js');
+var bidmanager = require('../bidmanager.js');
+var adloader = require('../adloader.js');
+var utils = require('../utils.js');
+
+var UnderdogMediaAdapter = function UnderdogMediaAdapter() {
+
+  var getJsStaticUrl = window.location.protocol + '//rtb.udmserve.net/udm_header_lib.js';
+
+  function _callBids(params) {
+    if (typeof window.udm_header_lib === 'undefined') {
+      adloader.loadScript(getJsStaticUrl, function () { bid(params); });
+    } else {
+      bid(params);
+    }
+  }
+
+  function bid(params) {
+    var bids = params.bids;
+    for (var i = 0; i < bids.length; i++) {
+      var bidRequest = bids[i];
+      var callback = bidResponseCallback(bidRequest);
+      var udmBidRequest = new window.udm_header_lib.BidRequest({
+        sizes: bidRequest.sizes,
+        siteId: bidRequest.params.siteId,
+        bidfloor: bidRequest.params.bidfloor,
+        placementCode: bidRequest.placementCode,
+        callback: callback
+      });
+      udmBidRequest.send();
+    }
+  }
+
+  function bidResponseCallback(bid) {
+    return function (bidResponse) {
+      bidResponseAvailable(bid, bidResponse);
+    };
+  }
+
+  function bidResponseAvailable(bidRequest, bidResponse) {
+    if(bidResponse.bids.length > 0){
+      for(var i = 0; i < bidResponse.bids.length; i++){
+        var udm_bid = bidResponse.bids[i];
+        var bid = bidfactory.createBid(1);
+        bid.bidderCode = bidRequest.bidder;
+        bid.cpm = udm_bid.cpm;
+        bid.width = udm_bid.width;
+        bid.height = udm_bid.height;
+
+        if(udm_bid.ad_url !== undefined){
+          bid.adUrl = udm_bid.ad_url;
+        }
+        else if(udm_bid.ad_html !== undefined){
+          bid.ad = udm_bid.ad_html;
+        }else{
+          utils.logMessage('Underdogmedia bid is lacking both ad_url and ad_html, skipping bid');
+          continue;
+        }
+
+        bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      }
+    }else{
+      var nobid = bidfactory.createBid(2);
+      nobid.bidderCode = bidRequest.bidder;
+      bidmanager.addBidResponse(bidRequest.placementCode, nobid);
+    }
+  }
+
+  return {
+    callBids: _callBids
+  };
+
+};
+
+module.exports = UnderdogMediaAdapter;

--- a/test/spec/adapters/underdogmedia_spec.js
+++ b/test/spec/adapters/underdogmedia_spec.js
@@ -1,0 +1,138 @@
+/* jshint -W030 */
+
+import Adapter from '../../../src/adapters/underdogmedia';
+import bidManager from '../../../src/bidmanager';
+import {parse as parseURL} from 'url';
+import {parse as parseQuery} from 'qs';
+import {expect} from 'chai';
+
+describe('underdog media adapter test', () => {
+
+  let adapter;
+  let server;
+
+  // Minimal stub implementation of underdog media header bid API
+  // This will prevent the need to load underdog's static library, and to make requests to underdog's server
+  window.udm_header_lib = {
+
+    BidRequest: function(options){
+      return {
+        send: function(){
+            var siteId = options.siteId;
+            if(siteId == 10272){
+              // Only bid on this particular site id
+              var bids = [];
+              for(var i = 0; i < options.sizes.length; i++){
+                var size = options.sizes[i];
+                bids.push({
+                  cpm: 3.14,
+                  ad_html: `Ad HTML for site ID ${siteId} size ${size[0]}x${size[1]}`,
+                  width:   size[0],
+                  height:  size[1]
+                });
+              }
+              options.callback({
+                bids: bids
+              });
+            } else {
+              options.callback({
+                bids: []
+              });
+            }
+
+        }
+      };
+    }
+
+  };
+
+  // The third bid here is an invalid site id and should return a 'no-bid'.
+  function request() {
+    adapter.callBids({
+      bidderCode: 'underdogmedia',
+      bids: [
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'foo',
+          sizes: [[728, 90]],
+          params: {
+            siteId: '10272'
+          }
+        },
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'bar',
+          sizes: [[300, 250]],
+          params: {
+            siteId: '10272'
+          }
+        },
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'nothing',
+          sizes: [[160, 600]],
+          params: {
+            siteId: '31337'
+          }
+        }
+      ]
+    });
+  }
+
+  beforeEach(() => {
+    adapter = new Adapter();
+  });
+
+  afterEach(() => {
+  });
+
+  describe('adding bids to the manager', () => {
+
+    let firstBid;
+    let secondBid;
+    let thirdBid;
+
+    beforeEach(() => {
+      sinon.stub(bidManager, 'addBidResponse');
+      request();
+      firstBid = bidManager.addBidResponse.firstCall.args[1];
+      secondBid = bidManager.addBidResponse.secondCall.args[1];
+      thirdBid = bidManager.addBidResponse.thirdCall.args[1];
+    });
+
+    afterEach(() => {
+      bidManager.addBidResponse.restore();
+    });
+
+    it('will add a bid object for each bid', () => {
+      sinon.assert.calledThrice(bidManager.addBidResponse);
+    });
+
+    it('will add the ad html to the bid object', () => {
+      expect(firstBid).to.have.property('ad', 'Ad HTML for site ID 10272 size 728x90');
+      expect(secondBid).to.have.property('ad', 'Ad HTML for site ID 10272 size 300x250');
+      expect(thirdBid).to.not.have.property('ad');
+    });
+
+    it('will have the right size attached', () => {
+      expect(firstBid).to.have.property('width', 728);
+      expect(firstBid).to.have.property('height', 90);
+      expect(secondBid).to.have.property('width', 300);
+      expect(secondBid).to.have.property('height', 250);
+    });
+
+    it('will add the CPM to the bid object', () => {
+      expect(firstBid).to.have.property('cpm', 3.14);
+      expect(secondBid).to.have.property('cpm', 3.14);
+      expect(thirdBid).to.not.have.property('cpm');
+    });
+
+    it('will add the bidder code to the bid object', () => {
+      expect(firstBid).to.have.property('bidderCode', 'underdogmedia');
+      expect(secondBid).to.have.property('bidderCode', 'underdogmedia');
+      expect(thirdBid).to.have.property('bidderCode', 'underdogmedia');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Hello,

We would like to add an adapter to support our Bidding API. The tests included use a mocked implementation of our Bidding API, therefore no contact with our server is needed to run the tests.

Here are the parameters our adapter supports:

- bidfloor (optional)
- siteId (required)

Here are some parameters than anyone is free to use to test our adapter:

```
{
    bidder: 'underdogmedia',
    params: {
       siteId: '10272'
    }
}

```

It should consistently return test bids for at least the 728x90, 300x250, 160x600 ad sizes.

If anyone has issues with this adapter please contact us at: prebid@underdogmedia.com

Thanks,
Underdog Media

