### PR TITLE
prevent externalOneTimeCallback from being called more than once

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -244,8 +244,12 @@ exports.executeCallback = function () {
 
   //execute one time callback
   if (externalOneTimeCallback) {
-    processCallbacks([externalOneTimeCallback]);
-    externalOneTimeCallback = null;
+    try {
+      processCallbacks([externalOneTimeCallback]);
+    }
+    finally {
+      externalOneTimeCallback = null;
+    }
   }
 
   $$PREBID_GLOBAL$$.clearAuction();


### PR DESCRIPTION
Currently if there is an error somewhere inside the handler provided to bidsBackHandler the handler will be called twice: once when all the auction results are in and again when the auction timeout is hit.

This makes sure the proper cleanup happens even in the case of error.