### PR TITLE
iterate over adUnits backwards to prevent errors with in-place mutation

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -459,7 +459,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
 $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.removeAdUnit', arguments);
   if (adUnitCode) {
-    for (var i = 0; i < $$PREBID_GLOBAL$$.adUnits.length; i++) {
+    for (var i = $$PREBID_GLOBAL$$.adUnits.length - 1; i >= 0; i--) {
       if ($$PREBID_GLOBAL$$.adUnits[i].code === adUnitCode) {
         $$PREBID_GLOBAL$$.adUnits.splice(i, 1);
       }


### PR DESCRIPTION
Let me know if you want me to add a `break;`.  I don't want to modify the results of those that may have depended on it removing multiples in the past.