### PR TITLE
Use cross-browser parseInt function

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -30,7 +30,7 @@ function AppnexusAstAdapter() {
         tag.sizes = getSizes(bid.sizes);
         tag.primary_size = tag.sizes[0];
         tag.uuid = bid.bidId;
-        tag.id = Number.parseInt(bid.params.placementId);
+        tag.id = parseInt(bid.params.placementId, 10);
         tag.allow_smaller_sizes = bid.params.allowSmallerSizes || false;
         tag.prebid = true;
         tag.disable_psa = true;


### PR DESCRIPTION
Changed `Number.parseInt` to cross-browser `parseInt` and added radix. Tested and passing on:
* Safari 7.1.8 (Mac OS X 10.9.5)
* IE 11.0.0 (Windows 10 0.0.0)
* IE 11.0.0 (Windows 7 0.0.0)