### PR TITLE
getBidderCodes now loops over adUnits object if passed

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -22,6 +22,7 @@
     "brightcom",
     "wideorbit",
     "jcm",
+    "underdogmedia",
     {
       "appnexus": {
         "alias": "brealtime"

--- a/adapters.json
+++ b/adapters.json
@@ -5,6 +5,7 @@
     "admedia",
     "aol",
     "appnexus",
+    "fan",
     "indexExchange",
     "kruxlink",
     "openx",

--- a/integrationExamples/gpt/pbjs_partial_refresh_gpt.html
+++ b/integrationExamples/gpt/pbjs_partial_refresh_gpt.html
@@ -82,6 +82,11 @@
                             publisherId: 'TO ADD',
                             adSlot: 'TO ADD@300x600'
                         }
+                    }, {
+                        bidder: 'fan',
+                        params: {
+                            placementId: 'TO ADD'
+                        }
                     }
                 ]
             }, {

--- a/src/adapters/fan.js
+++ b/src/adapters/fan.js
@@ -1,0 +1,253 @@
+const {ajax} = require('../ajax');
+const bidFactory = require('../bidfactory');
+const bidManager = require('../bidmanager');
+const utils = require('../utils');
+const BASE_URL = 'https://an.facebook.com/v1/placementbid.json';
+const ACCEPTED_FORMATS = ['320x50', '300x250', '728x90'];
+
+function getBidSize({sizes, params}) {
+  let width = 0;
+  let height = 0;
+
+  if (sizes.length === 2 &&
+      typeof sizes[0] === 'number' &&
+      typeof sizes[1] === 'number') {
+    // The array contains 1 size (the items are the values)
+    width = sizes[0];
+    height = sizes[1];
+  } else if (sizes.length >= 1) {
+    // The array contains array of sizes, use the first size
+    width = sizes[0][0];
+    height = sizes[0][1];
+
+    if (sizes.length > 1) {
+      utils.logInfo(
+        `AudienceNetworkAdapter supports only one size per ` +
+        `impression, but ${sizes.length} sizes passed for ` +
+        `placementId ${params.placementId}. Using first only.`
+      );
+    }
+  }
+
+  return {height, width};
+}
+
+function getPlacementWebAdFormat(placement) {
+  if (!placement.params.native) {
+    let {width, height} = getBidSize(placement);
+    let size = `${width}x${height}`;
+    if (ACCEPTED_FORMATS.includes(size)) {
+      return size;
+    }
+  }
+  return 'native';
+}
+
+function buildAd(unit, bid) {
+  return getPlacementWebAdFormat(unit) === 'native' ?
+    `<head>
+      <script>var inDapIF = false;</script>
+      <script type="text/javascript">
+        window.onload = function() {
+          if (parent) {
+            var oHead = document.getElementsByTagName("head")[0];
+            var arrStyleSheets = parent.document.getElementsByTagName("style");
+            for (var i = 0; i < arrStyleSheets.length; i++)
+              oHead.appendChild(arrStyleSheets[i].cloneNode(true));
+          }
+        }
+      </script>
+    </head>
+    <body>
+      <script>
+        window.fbAsyncInit = function() {
+          FB.Event.subscribe(
+            'ad.loaded',
+            function(placementId) {
+              console.log('Audience Network ad loaded');
+              document.getElementById('ad_root').style.display = 'block';
+            }
+          );
+          FB.Event.subscribe(
+            'ad.error',
+            function(errorCode, errorMessage, placementId) {
+              console.log('Audience Network error (' + errorCode + ') ' + errorMessage);
+            }
+          );
+          FB.XFBML.parse();
+        };
+        (function(d, s, id) {
+          var js, fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) return;
+          js = d.createElement(s); js.id = id;
+          js.src = "//connect.facebook.net/en_US/sdk/xfbml.ad.js#xfbml=1&version=v2.5&appId=${unit.appId}";
+          fjs.parentNode.insertBefore(js, fjs);
+        }(document, 'script', 'facebook-jssdk'));
+      </script>
+      <div
+        class="fb-ad"
+        data-placementid="${unit.placementId}"
+        data-format="native"
+        data-nativeadid="ad_root"
+        data-bidid="${bid.bid_id}"
+      >
+      </div>
+      <div id="ad_root">
+        <a class="fbAdLink">
+          <div class="fbAdMedia thirdPartyMediaClass"></div>
+          <div class="fbAdTitle thirdPartyTitleClass"></div>
+          <div class="fbAdBody thirdPartyBodyClass"></div>
+          <div class="fbAdCallToAction thirdPartyCallToActionClass"></div>
+        </a>
+      </div>
+    </body>` :
+
+    `<script>var inDapIF = false;</script>
+    <script>
+      window.fbAsyncInit = function() {
+        FB.Event.subscribe(
+          'ad.loaded',
+          function(placementId) {
+            console.log('Audience Network ad loaded');
+          }
+        );
+        FB.Event.subscribe(
+          'ad.error',
+          function(errorCode, errorMessage, placementId) {
+            console.log('Audience Network error (' + errorCode + ') ' + errorMessage);
+          }
+        );
+        FB.XFBML.parse();
+      };
+      (function(d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s); js.id = id;
+        js.src = "//connect.facebook.net/en_US/sdk/xfbml.ad.js#xfbml=1&version=v2.5&appId=${unit.appId}";
+        fjs.parentNode.insertBefore(js, fjs);
+      }(document, 'script', 'facebook-jssdk'));
+    </script>
+    <div
+      class="fb-ad"
+      data-placementid="${unit.placementId}"
+      data-format="${unit.format}"
+      data-bidid="${bid.bid_id}"
+    >
+    </div>`;
+}
+
+class FANAdapter {
+
+  constructor() {
+    this.units = {};
+    this.handleBids = this.handleBids.bind(this);
+    this.handleError = this.handleError.bind(this);
+    this.addBidErrorForUnit = this.addBidErrorForUnit.bind(this);
+    this.testMode = false;
+  }
+
+  buildUnits({bids}) {
+    (bids || []).forEach(bid => {
+      if (bid.params.testMode) this.testMode = true;
+      this.units[bid.params.placementId] = Object.assign({
+        appId: bid.params.placementId.split('_')[0],
+        code: bid.placementCode,
+        format: getPlacementWebAdFormat(bid)
+      }, bid);
+    });
+  }
+
+  callBids(params) {
+    this.buildUnits(params || {});
+    this.fetchBids((error, bids) => {
+      if (error) {
+        this.handleError(error);
+      } else {
+        this.handleBids(bids);
+      }
+    });
+  }
+
+  get placementIds() {
+    return Object.keys(this.units);
+  }
+
+  get formats() {
+    return Object
+      .keys(this.units)
+      .map(placementId => this.units[placementId].format);
+  }
+
+  fetchBids(done) {
+    let handleResponse = (content, resp) => {
+      if (resp.status < 200 || resp.status > 300) {
+        done(`Error code from FAN: ${resp.status} - ${resp.statusText}`);
+      }
+
+      try {
+        content = JSON.parse(content);
+      } catch (e) {
+        done(e.messsage);
+      }
+
+      if (typeof content !== 'object') {
+        done('Don\'t know how to handle respose from FAN');
+      } else if (content.errors.length) {
+        done(content.errors);
+      } else if (content.bids) {
+        done(null, content.bids);
+      } else {
+        done('unknown error');
+      }
+    };
+
+    ajax(BASE_URL, handleResponse, {
+      placementids: this.placementIds,
+      adformats: this.formats,
+      testmode: this.testMode
+    }, {
+      method: 'GET',
+      withCredentials: true
+    });
+  }
+
+  forEachUnit(fn) {
+    Object.keys(this.units).forEach(placementId => {
+      fn(this.units[placementId], placementId);
+    });
+  }
+
+  handleError() {
+    this.forEachUnit(this.addBidErrorForUnit);
+  }
+
+  handleBids(bids = {}) {
+    this.forEachUnit((unit, placementId) => {
+      let bid = bids[placementId];
+      if (bid) {
+        this.addBidForUnit(bid, unit);
+      } else {
+        this.addBidErrorForUnit(unit);
+      }
+    });
+  }
+
+  addBidForUnit(bid, unit) {
+    let bidObject = bidFactory.createBid(1);
+    Object.assign(bidObject, getBidSize(unit));
+    bidObject.bidderCode = 'fan';
+    bidObject.cpm = bid.bid_price_cents / 100;
+    bidObject.bidId = bid.bid_id;
+    bidObject.ad = buildAd(unit, bid);
+    bidManager.addBidResponse(unit.code, bidObject);
+  }
+
+  addBidErrorForUnit({code}) {
+    let bidObject = bidFactory.createBid(2);
+    bidObject.bidderCode = 'fan';
+    bidManager.addBidResponse(code, bidObject);
+  }
+
+}
+
+module.exports = FANAdapter;

--- a/src/adapters/underdogmedia.js
+++ b/src/adapters/underdogmedia.js
@@ -1,0 +1,75 @@
+var bidfactory = require('../bidfactory.js');
+var bidmanager = require('../bidmanager.js');
+var adloader = require('../adloader.js');
+var utils = require('../utils.js');
+
+var UnderdogMediaAdapter = function UnderdogMediaAdapter() {
+
+  var getJsStaticUrl = window.location.protocol + '//rtb.udmserve.net/udm_header_lib.js';
+
+  function _callBids(params) {
+    if (typeof window.udm_header_lib === 'undefined') {
+      adloader.loadScript(getJsStaticUrl, function () { bid(params); });
+    } else {
+      bid(params);
+    }
+  }
+
+  function bid(params) {
+    var bids = params.bids;
+    for (var i = 0; i < bids.length; i++) {
+      var bidRequest = bids[i];
+      var callback = bidResponseCallback(bidRequest);
+      var udmBidRequest = new window.udm_header_lib.BidRequest({
+        sizes: bidRequest.sizes,
+        siteId: bidRequest.params.siteId,
+        bidfloor: bidRequest.params.bidfloor,
+        placementCode: bidRequest.placementCode,
+        callback: callback
+      });
+      udmBidRequest.send();
+    }
+  }
+
+  function bidResponseCallback(bid) {
+    return function (bidResponse) {
+      bidResponseAvailable(bid, bidResponse);
+    };
+  }
+
+  function bidResponseAvailable(bidRequest, bidResponse) {
+    if(bidResponse.bids.length > 0){
+      for(var i = 0; i < bidResponse.bids.length; i++){
+        var udm_bid = bidResponse.bids[i];
+        var bid = bidfactory.createBid(1);
+        bid.bidderCode = bidRequest.bidder;
+        bid.cpm = udm_bid.cpm;
+        bid.width = udm_bid.width;
+        bid.height = udm_bid.height;
+
+        if(udm_bid.ad_url !== undefined){
+          bid.adUrl = udm_bid.ad_url;
+        }
+        else if(udm_bid.ad_html !== undefined){
+          bid.ad = udm_bid.ad_html;
+        }else{
+          utils.logMessage('Underdogmedia bid is lacking both ad_url and ad_html, skipping bid');
+          continue;
+        }
+
+        bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      }
+    }else{
+      var nobid = bidfactory.createBid(2);
+      nobid.bidderCode = bidRequest.bidder;
+      bidmanager.addBidResponse(bidRequest.placementCode, nobid);
+    }
+  }
+
+  return {
+    callBids: _callBids
+  };
+
+};
+
+module.exports = UnderdogMediaAdapter;

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,3 +1,5 @@
+import {parse as parseURL, format as formatURL} from './url';
+
 /**
  * Simple cross-browser ajax request function
  * https://gist.github.com/Xeoncross/7663273
@@ -7,10 +9,12 @@
  * @param url string url
  * @param callback object callback
  * @param data mixed data
- * @param x null Ajax request
+ * @param options object
  */
 
-export const ajax = function ajax(url, callback, data, x = null) {
+export const ajax = function ajax(url, callback, data, options = {}) {
+  let x;
+
   try {
     if (window.XMLHttpRequest) {
       x = new window.XMLHttpRequest('MSXML2.XMLHTTP.3.0');
@@ -20,10 +24,23 @@ export const ajax = function ajax(url, callback, data, x = null) {
       x = new window.ActiveXObject('MSXML2.XMLHTTP.3.0');
     }
 
+    const method = options.method || (data ? 'POST' : 'GET');
+
+    if (method === 'GET' && data) {
+      let urlInfo = parseURL(url);
+      Object.assign(urlInfo.search, data);
+      url = formatURL(urlInfo);
+    }
+
     //x = new (window.XMLHttpRequest || window.ActiveXObject)('MSXML2.XMLHTTP.3.0');
-    x.open(data ? 'POST' : 'GET', url, 1);
-    x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-    x.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    x.open(method, url, 1);
+
+    if (options.withCredentials) {
+      x.withCredentials = true;
+    } else {
+      x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      x.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    }
 
     //x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
     x.onreadystatechange = function () {
@@ -32,7 +49,7 @@ export const ajax = function ajax(url, callback, data, x = null) {
       }
     };
 
-    x.send(data);
+    x.send(method === 'POST' && data);
   } catch (e) {
     console.log(e);
   }

--- a/src/url.js
+++ b/src/url.js
@@ -1,0 +1,48 @@
+export function parseQS(query) {
+  return !query ? {} : query
+    .replace(/^\?/, '')
+    .split('&')
+    .reduce((acc, criteria) => {
+      let [k, v] = criteria.split('=');
+      if (/\[\]$/.test(k)) {
+        k = k.replace('[]', '');
+        acc[k] = acc[k] || [];
+        acc[k].push(v);
+      } else {
+        acc[k] = v || '';
+      }
+      return acc;
+    }, {});
+}
+
+export function formatQS(query) {
+  return Object
+    .keys(query)
+    .map(k => Array.isArray(query[k]) ?
+      query[k].map(v => `${k}[]=${v}`).join('&') :
+      query[k] !== false ? `${k}=${query[k]}` : '')
+    .join('&');
+}
+
+export function parse(url) {
+  let parsed = document.createElement('a');
+  parsed.href = decodeURIComponent(url);
+  return {
+    protocol: (parsed.protocol || '').replace(/:$/, ''),
+    hostname: parsed.hostname,
+    port: +parsed.port,
+    pathname: parsed.pathname,
+    search: parseQS(parsed.search || ''),
+    hash: (parsed.hash || '').replace(/^#/, ''),
+    host: parsed.host
+  };
+}
+
+export function format(obj) {
+  return (obj.protocol || 'http') + '://' +
+         (obj.host ||
+          obj.hostname + (obj.port ? `:${obj.port}` : '')) +
+         (obj.pathname || '') +
+         (obj.search ? `?${formatQS(obj.search || '')}` : '') +
+         (obj.hash ? `#${obj.hash}` : '');
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -489,9 +489,9 @@ export function getValue(obj, key) {
   return obj[key];
 }
 
-export function getBidderCodes() {
+export function getBidderCodes(adUnits = $$PREBID_GLOBAL$$.adUnits) {
   // this could memoize adUnits
-  return $$PREBID_GLOBAL$$.adUnits.map(unit => unit.bids.map(bid => bid.bidder)
+  return adUnits.map(unit => unit.bids.map(bid => bid.bidder)
     .reduce(flatten, [])).reduce(flatten).filter(uniques);
 }
 

--- a/test/spec/adapters/fan_spec.js
+++ b/test/spec/adapters/fan_spec.js
@@ -1,0 +1,179 @@
+/* jshint -W030 */
+
+import Adapter from '../../../src/adapters/fan';
+import bidManager from '../../../src/bidmanager';
+import {parse as parseURL} from '../../../src/url';
+import {expect} from 'chai';
+
+describe('FAN Adapter', () => {
+
+  let adapter;
+  let server;
+
+  function request() {
+    adapter.callBids({
+      bidderCode: 'fan',
+      bids: [
+        {
+          bidder: 'fan',
+          adUnitCode: 'foo',
+          sizes: [[728, 90]],
+          params: {
+            placementId: '123_456'
+          }
+        },
+        {
+          bidder: 'fan',
+          adUnitCode: 'bar',
+          sizes: [[300, 600]],
+          params: {
+            placementId: '123_789'
+          }
+        }
+      ]
+    });
+  }
+
+  beforeEach(() => {
+    adapter = new Adapter();
+    server = sinon.fakeServer.create();
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  describe('requesting their API', () => {
+
+    let requests;
+
+    beforeEach(() => {
+      requests = [];
+      server.respondWith(request => {
+        request.params = parseURL(request.url).search;
+        requests.push(request);
+      });
+      request();
+      server.respond();
+    });
+
+    it('should send the placement IDs as an array', () => {
+      expect(requests[0].params.placementids).to.eql(['123_456', '123_789']);
+    });
+
+    it('sends the ad formats as FAN expects them', () => {
+      expect(requests[0].params.adformats).to.eql(['728x90', 'native']);
+    });
+
+  });
+
+  describe('adding bids to the manager', () => {
+
+    let firstBid;
+    let secondBid;
+
+    beforeEach(() => {
+      sinon.stub(bidManager, 'addBidResponse');
+      server.respondWith([
+        200,
+        {
+          'access-control-allow-credentials': 'true',
+          'access-control-allow-origin': '*',
+          'content-type': 'text/javascript; charset=UTF-8'
+        },
+        JSON.stringify({
+          "errors": [ ],
+          "bids": {
+            "123_456": {
+              "placement_id": "123_456",
+              "bid_id": "12345_67890",
+              "bid_price_cents": 321.96265882399,
+              "bid_price_currency": "usd",
+              "bid_price_model": "cpm"
+            },
+            "123_789": {
+              "placement_id": "123_789",
+              "bid_id": "12345_09876",
+              "bid_price_cents": 711.28405256274,
+              "bid_price_currency": "usd",
+              "bid_price_model": "cpm"
+            }
+          }
+        })
+      ]);
+      request();
+      server.respond();
+      firstBid = bidManager.addBidResponse.firstCall.args[1];
+      secondBid = bidManager.addBidResponse.secondCall.args[1];
+    });
+
+    afterEach(() => {
+      bidManager.addBidResponse.restore();
+    });
+
+    it('will add a bid object for each bid', () => {
+      sinon.assert.calledTwice(bidManager.addBidResponse);
+    });
+
+    it('will add the CPM to the bid object', () => {
+      expect(firstBid).to.have.property('cpm', 321.96265882399 / 100);
+      expect(secondBid).to.have.property('cpm', 711.28405256274 / 100);
+    });
+
+    it('will add the bidder code to the bid object', () => {
+      expect(firstBid).to.have.property('bidderCode', 'fan');
+      expect(secondBid).to.have.property('bidderCode', 'fan');
+    });
+
+    it('will include the ad to the bid object', () => {
+      expect(firstBid).to.have.property('ad');
+      expect(secondBid).to.have.property('ad');
+    });
+
+    it('will include the size to the bid object', () => {
+      expect(firstBid).to.have.property('width', 728);
+      expect(firstBid).to.have.property('height', 90);
+      expect(secondBid).to.have.property('width', 300);
+      expect(secondBid).to.have.property('height', 600);
+    });
+
+  });
+
+  describe('handling FAN errors', () => {
+
+    let firstBid;
+    let secondBid;
+
+    beforeEach(() => {
+      sinon.stub(bidManager, 'addBidResponse');
+      server.respondWith([
+        200,
+        {
+          'access-control-allow-credentials': 'true',
+          'access-control-allow-origin': '*',
+          'content-type': 'text/javascript; charset=UTF-8'
+        },
+        JSON.stringify({
+          "errors": ['Foo', 'Bar'],
+          "bids": {}
+        })
+      ]);
+      request();
+      server.respond();
+      firstBid = bidManager.addBidResponse.firstCall.args[1];
+      secondBid = bidManager.addBidResponse.secondCall.args[1];
+    });
+
+    afterEach(() => {
+      bidManager.addBidResponse.restore();
+    });
+
+    it('will create an error bid object for each error', () => {
+      sinon.assert.calledTwice(bidManager.addBidResponse);
+      expect(firstBid).to.have.property('statusMessage', 'Bid returned empty or error response');
+      expect(secondBid).to.have.property('statusMessage', 'Bid returned empty or error response');
+    });
+
+  });
+
+});

--- a/test/spec/adapters/underdogmedia_spec.js
+++ b/test/spec/adapters/underdogmedia_spec.js
@@ -1,0 +1,138 @@
+/* jshint -W030 */
+
+import Adapter from '../../../src/adapters/underdogmedia';
+import bidManager from '../../../src/bidmanager';
+import {parse as parseURL} from 'url';
+import {parse as parseQuery} from 'qs';
+import {expect} from 'chai';
+
+describe('underdog media adapter test', () => {
+
+  let adapter;
+  let server;
+
+  // Minimal stub implementation of underdog media header bid API
+  // This will prevent the need to load underdog's static library, and to make requests to underdog's server
+  window.udm_header_lib = {
+
+    BidRequest: function(options){
+      return {
+        send: function(){
+            var siteId = options.siteId;
+            if(siteId == 10272){
+              // Only bid on this particular site id
+              var bids = [];
+              for(var i = 0; i < options.sizes.length; i++){
+                var size = options.sizes[i];
+                bids.push({
+                  cpm: 3.14,
+                  ad_html: `Ad HTML for site ID ${siteId} size ${size[0]}x${size[1]}`,
+                  width:   size[0],
+                  height:  size[1]
+                });
+              }
+              options.callback({
+                bids: bids
+              });
+            } else {
+              options.callback({
+                bids: []
+              });
+            }
+
+        }
+      };
+    }
+
+  };
+
+  // The third bid here is an invalid site id and should return a 'no-bid'.
+  function request() {
+    adapter.callBids({
+      bidderCode: 'underdogmedia',
+      bids: [
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'foo',
+          sizes: [[728, 90]],
+          params: {
+            siteId: '10272'
+          }
+        },
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'bar',
+          sizes: [[300, 250]],
+          params: {
+            siteId: '10272'
+          }
+        },
+        {
+          bidder: 'underdogmedia',
+          adUnitCode: 'nothing',
+          sizes: [[160, 600]],
+          params: {
+            siteId: '31337'
+          }
+        }
+      ]
+    });
+  }
+
+  beforeEach(() => {
+    adapter = new Adapter();
+  });
+
+  afterEach(() => {
+  });
+
+  describe('adding bids to the manager', () => {
+
+    let firstBid;
+    let secondBid;
+    let thirdBid;
+
+    beforeEach(() => {
+      sinon.stub(bidManager, 'addBidResponse');
+      request();
+      firstBid = bidManager.addBidResponse.firstCall.args[1];
+      secondBid = bidManager.addBidResponse.secondCall.args[1];
+      thirdBid = bidManager.addBidResponse.thirdCall.args[1];
+    });
+
+    afterEach(() => {
+      bidManager.addBidResponse.restore();
+    });
+
+    it('will add a bid object for each bid', () => {
+      sinon.assert.calledThrice(bidManager.addBidResponse);
+    });
+
+    it('will add the ad html to the bid object', () => {
+      expect(firstBid).to.have.property('ad', 'Ad HTML for site ID 10272 size 728x90');
+      expect(secondBid).to.have.property('ad', 'Ad HTML for site ID 10272 size 300x250');
+      expect(thirdBid).to.not.have.property('ad');
+    });
+
+    it('will have the right size attached', () => {
+      expect(firstBid).to.have.property('width', 728);
+      expect(firstBid).to.have.property('height', 90);
+      expect(secondBid).to.have.property('width', 300);
+      expect(secondBid).to.have.property('height', 250);
+    });
+
+    it('will add the CPM to the bid object', () => {
+      expect(firstBid).to.have.property('cpm', 3.14);
+      expect(secondBid).to.have.property('cpm', 3.14);
+      expect(thirdBid).to.not.have.property('cpm');
+    });
+
+    it('will add the bidder code to the bid object', () => {
+      expect(firstBid).to.have.property('bidderCode', 'underdogmedia');
+      expect(secondBid).to.have.property('bidderCode', 'underdogmedia');
+      expect(thirdBid).to.have.property('bidderCode', 'underdogmedia');
+    });
+
+  });
+
+});

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -1,0 +1,68 @@
+import {format, parse} from '../../src/url';
+
+describe('helpers.url', () => {
+
+  describe('parse()', () => {
+
+    let parsed;
+
+    beforeEach(() => {
+      parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar#hash');
+    });
+
+    it('extracts the protocol', () => {
+      expect(parsed).to.have.property('protocol', 'http');
+    });
+
+    it('extracts the hostname', () => {
+      expect(parsed).to.have.property('hostname', 'example.com');
+    });
+
+    it('extracts the port', () => {
+      expect(parsed).to.have.property('port', 3000);
+    });
+
+    it('extracts the pathname', () => {
+      expect(parsed).to.have.property('pathname', '/pathname/');
+    });
+
+    it('extracts the search query', () => {
+      expect(parsed).to.have.property('search');
+      expect(parsed.search).to.eql({
+        foo: 'bar',
+        search: 'test'
+      });
+    });
+
+    it('extracts the hash', () => {
+      expect(parsed).to.have.property('hash', 'hash');
+    });
+
+    it('extracts the host', () => {
+      expect(parsed).to.have.property('host', 'example.com:3000');
+    });
+
+  });
+
+  describe('format()', () => {
+
+    it('formats an object in to a URL', () => {
+      expect(format({
+        protocol: 'http',
+        hostname: 'example.com',
+        port: 3000,
+        pathname: '/pathname/',
+        search: {foo: 'bar', search: 'test'},
+        hash: 'hash'
+      })).to.equal('http://example.com:3000/pathname/?foo=bar&search=test#hash');
+    });
+
+    it('will use defaults for missing properties', () => {
+      expect(format({
+        hostname: 'example.com'
+      })).to.equal('http://example.com');
+    });
+
+  });
+
+});


### PR DESCRIPTION
The getBidderCodes call in adapterManager.callBids was incorrectly looping over the global adUnits object rather than the adUnits object that was passed to it.