### PR TITLE
use var ad instead of incorrect ads in rubicon adapter

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -134,8 +134,8 @@ var RubiconAdapter = function RubiconAdapter() {
         bidResponse.height = size[1];
 
         // DealId
-        if (ads.deal) {
-          bidResponse.dealId = ads.deal;
+        if (ad.deal) {
+          bidResponse.dealId = ad.deal;
         }
       }
 


### PR DESCRIPTION
there was a variable typo that needed fixing