### PR TITLE
Log unsupported ad type only for good bids

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -76,15 +76,15 @@ function AppnexusAstAdapter() {
       const cpm = tag.ads && tag.ads[0].cpm;
       const type = tag.ads && tag.ads[0].ad_type;
 
-      if (type !== 'banner') {
-        utils.logError(`${type} ad type not supported`);
-      }
-
       let status;
       if (cpm !== 0 && type === 'banner') {
         status = STATUS.GOOD;
       } else {
         status = STATUS.NO_BID;
+      }
+
+      if (type && type !== 'banner') {
+        utils.logError(`${type} ad type not supported`);
       }
 
       tag.bidId = tag.uuid;  // bidfactory looks for bidId on requested bid


### PR DESCRIPTION
This addresses an issue mentioned in #322 where bids are returned from the server with a `nobid` field. In that case, bids won't have an `ad_type` field and an error message is logged that states 'undefined ad type not supported', but bids are still registered to the bid manager with status `NO_BID`. This change aims to remove confusion by only logging the error message in cases where a good bid response comes back from the server with an ad_type other than `banner`, which is not currently supported by this adapter.