### PR TITLE
Fixed error in safari

### DIFF
--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -13,7 +13,7 @@ var PubmaticAdapter = function PubmaticAdapter() {
   var bids;
   var _pm_pub_id;
   var _pm_optimize_adslots = [];
-  let iframeId = '';
+  let iframe;
 
   function _callBids(params) {
     bids = params.bids;
@@ -32,8 +32,8 @@ var PubmaticAdapter = function PubmaticAdapter() {
 
 
     //create the iframe
-    var iframe = utils.createInvisibleIframe();
-    iframeId = iframe.id;
+    iframe = utils.createInvisibleIframe();
+
     var elToAppend = document.getElementsByTagName('head')[0];
 
     //insert the iframe into document
@@ -75,8 +75,8 @@ var PubmaticAdapter = function PubmaticAdapter() {
     let bidDetailsMap = {};
     let progKeyValueMap = {};
     try {
-      bidDetailsMap = window.frames[iframeId].contentWindow.bidDetailsMap;
-      progKeyValueMap = window.frames[iframeId].contentWindow.progKeyValueMap;
+      bidDetailsMap = iframe.contentWindow.bidDetailsMap;
+      progKeyValueMap = iframe.contentWindow.progKeyValueMap;
     }
     catch(e) {
       utils.logError(e, 'Error parsing Pubmatic response');


### PR DESCRIPTION
window.frames[iframeId] return reference to window object, and window object doesn't normally have a contentWindow property

Fixes #538