### PR TITLE
adds support for pbjs.bidderSetting "suppressEmptyKeys".

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -206,13 +206,25 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
 
     if (utils.isFn(value)) {
       try {
-        keyValues[key] = value(custBidObj);
+        value = value(custBidObj);
       } catch (e) {
         utils.logError('bidmanager', 'ERROR', e);
       }
+    }
+
+    if (
+      typeof bidderSettings.suppressEmptyKeys !== "undefined" && bidderSettings.suppressEmptyKeys === true &&
+      (
+        utils.isEmptyStr(value) ||
+        value === null ||
+        value === undefined
+      )
+    ) {
+      utils.logInfo("suppressing empty key '" + key + "' from adserver targeting");
     } else {
       keyValues[key] = value;
     }
+
   });
 
   return keyValues;

--- a/src/utils.js
+++ b/src/utils.js
@@ -357,6 +357,15 @@ exports.isEmpty = function (object) {
 };
 
 /**
+ * Return if string is empty, null, or undefined
+ * @param str string to test
+ * @returns {boolean} if string is empty
+ */
+exports.isEmptyStr = function(str) {
+  return this.isStr(str) && (!str || 0 === str.length);
+};
+
+/**
  * Iterate object with the function
  * falls back to es5 `forEach`
  * @param {Array|Object} object

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -348,6 +348,32 @@ describe('bidmanager.js', function () {
 
     });
 
+    it('suppressEmptyKeys=true' , function() {
+      $$PREBID_GLOBAL$$.bidderSettings =
+      {
+        standard: {
+          suppressEmptyKeys: true,
+          adserverTargeting: [
+            {
+              key: "aKeyWithAValue",
+              val: 42
+            },
+            {
+              key: "aKeyWithAnEmptyValue",
+              val: ""
+            }
+          ]
+        }
+      };
+
+      var expected = {
+        "aKeyWithAValue": 42
+      };
+
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+    })
+
   });
 
   describe('adjustBids', () => {


### PR DESCRIPTION
As discussed, keys with no value should be suppressed from the ad server if there's a bidderSetting of 'suppressEmptyKeys: true'. Default suppressEmptyKeys is false.