### PR TITLE
custom sendStandardTargeting implemented in bidderSettings per bidder

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -177,12 +177,24 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode] && bidder_settings[bidderCode][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
     setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
+    filterIfSendStandardTargeting(bidder_settings[bidderCode]);
   }
 
   //2) set keys from standard setting. NOTE: this API doesn't seem to be in use by any Adapter
   else if (defaultBidderSettingsMap[bidderCode]) {
     setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
+    filterIfSendStandardTargeting(defaultBidderSettingsMap[bidderCode]);
+  }
+
+  function filterIfSendStandardTargeting(bidderSettings) {
+    if (typeof bidderSettings.sendStandardTargeting !== "undefined" && bidder_settings[bidderCode].sendStandardTargeting === false) {
+      for(var key in keyValues) {
+        if(CONSTANTS.TARGETING_KEYS.indexOf(key) !== -1) {
+          delete keyValues[key];
+        }
+      }
+    }
   }
 
   return keyValues;

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -372,7 +372,45 @@ describe('bidmanager.js', function () {
 
       var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
       assert.deepEqual(response, expected);
-    })
+    });
+
+    it('sendStandardTargeting=false and inherit custom', function () {
+      $$PREBID_GLOBAL$$.bidderSettings =
+      {
+        appnexus: {
+          alwaysUseBid: true,
+          sendStandardTargeting: false,
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                return bidResponse.pbHg;
+              }
+            }, {
+              key: "custom",
+              val: 42
+            }
+          ]
+        }
+      };
+
+      var expected = {
+        "custom": 42
+      };
+      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
+      assert.deepEqual(response, expected);
+
+    });
 
   });
 


### PR DESCRIPTION
As discussed, if a particular bidder has a bidderSetting of 'sendStandardTargeting: false' Don't send the standard targeting values to the ad server.