### PR TITLE
ensure that all deal bid keys are truncated to DFP max length (#578)

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -182,7 +182,7 @@ function getDealTargeting() {
           [`${key}_${bid.bidderCode}`.substring(0, 20)]: [bid.adserverTargeting[key]]
         };
       })
-      .concat({ [dealKey]: [bid.adserverTargeting[dealKey]] })
+      .concat({ [dealKey.substring(0, 20)]: [bid.adserverTargeting[dealKey]] })
     };
   });
 }


### PR DESCRIPTION
This diff ensures that the deal keys are truncated whenever they are set.

resolve #578 