### PR TITLE
Add Piximedia adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -9,6 +9,7 @@
     "indexExchange",
     "kruxlink",
     "openx",
+    "piximedia",
     "pubmatic",
     "pulsepoint",
     "rubicon",

--- a/src/adapters/piximedia.js
+++ b/src/adapters/piximedia.js
@@ -1,0 +1,157 @@
+var CONSTANTS = require('../constants.json');
+var utils = require('../utils.js');
+var bidmanager = require('../bidmanager.js');
+var bidfactory = require('../bidfactory.js');
+var adloader = require('../adloader.js');
+var Adapter = require('./adapter.js');
+
+var PiximediaAdapter = function PiximediaAdapter() {
+  var PREBID_URL = '//static.adserver.pm/prebid';
+  var baseAdapter = Adapter.createNew('piximedia');
+  var bidStash = {};
+
+  var tryAppendPixiQueryString = function(url, name, value) {
+    return url + "/" + encodeURIComponent(name) + "=" + value;
+  };
+
+  baseAdapter.callBids = function callBidsPiximedia(params) {
+    utils._each(params.bids, function(bid) {
+
+      // valid bids must include a siteId and an placementId
+      if (bid.placementCode && bid.sizes && bid.params && bid.params.siteId && bid.params.placementId) {
+
+        var sizes = bid.params.hasOwnProperty('sizes')? bid.params.sizes: bid.sizes;
+        sizes = utils.parseSizesInput(sizes);
+
+        var cbid = utils.getUniqueIdentifierStr();
+
+        // we allow overriding the URL in the params
+        var url = bid.params.prebidUrl || PREBID_URL;
+
+        // params are passed to the Piximedia endpoint, including custom params
+        for(var key in bid.params) {
+          /* istanbul ignore else */
+          if(bid.params.hasOwnProperty(key)) {
+            var value = bid.params[key];
+            switch(key) {
+              case "siteId":
+                url = tryAppendPixiQueryString(url, 'site_id', encodeURIComponent(value));
+                break;
+
+              case "placementId":
+                url = tryAppendPixiQueryString(url, 'placement_id', encodeURIComponent(value));
+                break;
+
+              case "dealId":
+                url = tryAppendPixiQueryString(url, 'l_id', encodeURIComponent(value));
+                break;
+
+              case "sizes":
+              case "prebidUrl":
+                break;
+
+              default:
+                if(typeof value === "function") {
+                  url = tryAppendPixiQueryString(url, key, encodeURIComponent((value(baseAdapter, params, bid) || "").toString()));
+                } else {
+                  url = tryAppendPixiQueryString(url, key, encodeURIComponent((value || "").toString()));
+                }
+                break;
+            }
+          }
+        }
+
+        url = tryAppendPixiQueryString(url, 'jsonp', '$$PREBID_GLOBAL$$.handlePiximediaCallback');
+        url = tryAppendPixiQueryString(url, 'sizes', encodeURIComponent(sizes.join(",")));
+        url = tryAppendPixiQueryString(url, 'cbid', encodeURIComponent(cbid));
+        url = tryAppendPixiQueryString(url, 'rand', String(Math.floor(Math.random() * 1000000000)));
+
+        bidStash[cbid] = {
+          'bidObj': bid,
+          'url': url,
+          'start': new Date().getTime()
+        };
+        utils.logMessage('[Piximedia] Dispatching header Piximedia to URL ' + url);
+        adloader.loadScript(url);
+      }
+    });
+  };
+
+  /*
+   * Piximedia's bidResponse should look like:
+   *
+   * {
+   *   'foundbypm': true,            // a Boolean, indicating if an ad was found
+   *   'currency': 'EUR',        // the currency, as a String
+   *   'cpm': 1.99,              // the win price as a Number, in currency
+   *   'dealId': null,           // or string value of winning deal ID
+   *   'width': 300,             // width in pixels of winning ad
+   *   'height': 250,            // height in pixels of winning ad
+   *   'html': 'tag_here'        // HTML tag to load if we are picked
+   * }
+   *
+   */
+  $$PREBID_GLOBAL$$.handlePiximediaCallback = function(bidResponse) {
+    if (bidResponse && bidResponse.hasOwnProperty("foundbypm")) {
+      var stash = bidStash[bidResponse.cbid]; // retrieve our stashed data, by using the cbid
+      var bid;
+
+      if (stash) {
+        var bidObj = stash.bidObj;
+        var timelapsed = new Date().getTime();
+        timelapsed = timelapsed - stash.start;
+
+        if (bidResponse.foundbypm && bidResponse.width && bidResponse.height && bidResponse.html && bidResponse.cpm && bidResponse.currency) {
+          
+          /* we have a valid ad to display */
+          bid = bidfactory.createBid(CONSTANTS.STATUS.GOOD);
+          bid.bidderCode = bidObj.bidder;
+          bid.width = bidResponse.width;
+          bid.height = bidResponse.height;
+          bid.ad = bidResponse.html;
+          bid.cpm = bidResponse.cpm;
+          bid.currency = bidResponse.currency;
+
+          if (bidResponse.dealId) {
+            bid.dealId = bidResponse.dealId;
+          } else {
+            bid.dealId = null;
+          }
+
+          bidmanager.addBidResponse(bidObj.placementCode, bid);
+
+          utils.logMessage('[Piximedia] Registered bidresponse from URL ' + stash.url +
+                           ' (time: ' + String(timelapsed) + ')');
+          utils.logMessage('[Piximedia] ======> BID placementCode: ' + bidObj.placementCode +
+                           ' CPM: ' + String(bid.cpm) + ' ' + bid.currency +
+                           ' Format: ' + String(bid.width) + 'x' + String(bid.height));
+        } else {
+
+          /* we have no ads to display */
+          bid = bidfactory.createBid(CONSTANTS.STATUS.NO_BID);
+          bid.bidderCode = bidObj.bidder;
+          bidmanager.addBidResponse(bidObj.placementCode, bid);
+
+          utils.logMessage('[Piximedia] Registered BLANK bidresponse from URL ' + stash.url +
+                           ' (time: ' + String(timelapsed) + ')');
+          utils.logMessage('[Piximedia] ======> NOBID placementCode: ' + bidObj.placementCode);
+        }
+
+        // We should no longer need this stashed object, so drop reference:
+        bidStash[bidResponse.cbid] = null;
+
+      } else {
+        utils.logMessage("[Piximedia] Couldn't find stash for cbid=" + bidResponse.cbid);
+      }
+    }
+  };
+
+  // return an object with PiximediaAdapter methods
+  return {
+    callBids: baseAdapter.callBids,
+    setBidderCode: baseAdapter.setBidderCode,
+    getBidderCode: baseAdapter.getBidderCode
+  };
+};
+
+module.exports = PiximediaAdapter;

--- a/test/spec/adapters/piximedia_spec.js
+++ b/test/spec/adapters/piximedia_spec.js
@@ -1,0 +1,419 @@
+describe('Piximedia adapter tests', function () {
+
+    var expect = require('chai').expect;
+    var urlParse = require('url-parse');
+    
+    //var querystringify = require('querystringify');
+
+    var adapter = require('src/adapters/piximedia');
+    var adLoader = require('src/adloader');
+    var bidmanager = require('src/bidmanager');
+    var utils = require('src/utils');
+    var CONSTANTS = require('src/constants.json');
+
+    var pbjs = window.pbjs = window.pbjs || {};
+    var spyLoadScript;
+
+    beforeEach(function () {
+        spyLoadScript = sinon.spy(adLoader, 'loadScript');
+    });
+
+    afterEach(function () {
+        spyLoadScript.restore();
+    });
+
+    describe('creation of prebid url', function () {
+       if (typeof(pbjs._bidsReceived)==="undefined"){ 
+           pbjs._bidsReceived = [];
+       }
+       if (typeof(pbjs._bidsRequested)==="undefined"){
+           pbjs._bidsRequested = [];
+       }
+       if (typeof(pbjs._adsReceived)==="undefined"){
+           pbjs._adsReceived = [];
+       }
+
+        it('should call the Piximedia prebid URL once on valid calls', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            sinon.assert.calledOnce(spyLoadScript);
+        });
+
+        it('should not call the Piximedia prebid URL once on invalid calls', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { prebidUrl: "//resources.pm/tests/prebid/bids.js" }, // this is invalid: site and placement ID are missing
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            sinon.assert.notCalled(spyLoadScript);
+        });
+
+        it('should call the correct Prebid URL when using the default URL', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { siteId: 'TEST', placementId: "TEST" },
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            var bidUrl = spyLoadScript.getCall(0).args[0];
+
+            sinon.assert.calledWith(spyLoadScript, bidUrl);
+
+            var parsedBidUrl = urlParse(bidUrl);
+ 
+            expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
+            expect(parsedBidUrl.query).to.equal("");
+            expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
+        });
+
+        it('should call the correct Prebid URL when using the default URL with a deal and custom data', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { siteId: 'TEST', placementId: "TEST", dealId: 1295, custom: "bespoke", custom2: function() { return "bespoke2"; }, custom3: null, custom4: function() {} },
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            var bidUrl = spyLoadScript.getCall(0).args[0];
+
+            sinon.assert.calledWith(spyLoadScript, bidUrl);
+
+            var parsedBidUrl = urlParse(bidUrl);
+ 
+            expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
+            expect(parsedBidUrl.query).to.equal("");
+            expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/l_id=1295/custom=bespoke/custom2=bespoke2/custom3=/custom4=/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
+        });
+
+        it('should call the correct Prebid URL when using the default URL and overridding sizes', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { siteId: 'TEST', placementId: "TEST", sizes: [[300,600],[728,90]] },
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            var bidUrl = spyLoadScript.getCall(0).args[0];
+
+            sinon.assert.calledWith(spyLoadScript, bidUrl);
+
+            var parsedBidUrl = urlParse(bidUrl);
+ 
+            expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
+            expect(parsedBidUrl.query).to.equal("");
+            expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x600%2C728x90/cbid=210af5668b1e23/rand=42");
+        });
+
+        it('should call the correct Prebid URL when supplying a custom URL', function () {
+            var params = {
+                bidderCode: 'piximedia',
+                bidder: 'piximedia',
+                bids: [
+                        {
+                            bidId: '4d3819cffc4d12',
+                            sizes: [[300, 250]],
+                            bidder: 'piximedia',
+                            params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
+                            requestId: '59c318fd382219',
+                            placementCode: '/20164912/header-bid-tag-0'
+                        } 
+                ]
+            };
+
+            adapter().callBids(params);
+            var bidUrl = spyLoadScript.getCall(0).args[0];
+
+            sinon.assert.calledWith(spyLoadScript, bidUrl);
+
+            var parsedBidUrl = urlParse(bidUrl);
+ 
+            expect(parsedBidUrl.hostname).to.equal("resources.pm");
+            expect(parsedBidUrl.query).to.equal("");
+            expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/tests/prebid/bids.js/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
+        });
+    });
+
+    describe('handling of the callback response', function () {
+        if (typeof(pbjs._bidsReceived)==="undefined"){
+            pbjs._bidsReceived = [];
+        }
+        if (typeof(pbjs._bidsRequested)==="undefined"){
+            pbjs._bidsRequested = [];
+        }
+        if (typeof(pbjs._adsReceived)==="undefined"){
+            pbjs._adsReceived = [];
+        }
+
+        var params = {
+            bidderCode: 'piximedia',
+            bidder: 'piximedia',
+            bids: [
+                    {
+                        bidId: '4d3819cffc4d12',
+                        sizes: [[300, 250]],
+                        bidder: 'piximedia',
+                        params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
+                        requestId: '59c318fd382219',
+                        placementCode: '/20164912/header-bid-tag-0'
+                    } 
+            ]
+        };
+
+        it('Piximedia callback function should exist', function () {
+            expect(pbjs.handlePiximediaCallback).to.exist.and.to.be.a('function');
+        });
+
+        it('bidmanager.addBidResponse should be called once with correct arguments', function () {
+            var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+            var stubGetUniqueIdentifierStr = sinon.spy(utils, "getUniqueIdentifierStr");
+
+            var response = {
+                foundbypm: true,
+                currency: "EUR",
+                cpm: 1.23,
+                dealId: 9948,
+                width: 300,
+                height: 250,
+                html: "<div>ad</div>"
+            };
+
+            adapter().callBids(params);
+
+            var adUnits = [];
+            var unit = {};
+            unit.bids = [params];
+            unit.code = '/20164912/header-bid-tag';
+            unit.sizes=[[300,250],[728,90]];
+            adUnits.push(unit);
+
+            if (typeof(pbjs._bidsRequested)==="undefined"){
+                pbjs._bidsRequested = [params];
+            } else {
+                pbjs._bidsRequested.push(params);
+            } 
+            pbjs.adUnits = adUnits;
+            response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
+
+            pbjs.handlePiximediaCallback(response);
+
+            sinon.assert.calledOnce(stubAddBidResponse);
+            var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+            var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+
+            expect(bidPlacementCode1).to.equal('/20164912/header-bid-tag-0');
+            expect(bidObject1.cpm).to.equal(1.23);
+            expect(bidObject1.ad).to.equal("<div>ad</div>");
+            expect(bidObject1.width).to.equal(300);
+            expect(bidObject1.dealId).to.equal(9948);
+            expect(bidObject1.height).to.equal(250);
+            expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+
+            stubAddBidResponse.restore(); 
+            stubGetUniqueIdentifierStr.restore(); 
+        }); 
+
+        it('bidmanager.addBidResponse should be called once with correct arguments on partial response', function () {
+            var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+            var stubGetUniqueIdentifierStr = sinon.spy(utils, "getUniqueIdentifierStr");
+
+            // this time, we do not provide dealId 
+            var response = {
+                foundbypm: true,
+                cpm: 1.23,
+                width: 300,
+                height: 250,
+                currency: "EUR",
+                html: "<div>ad</div>"
+            };
+
+            adapter().callBids(params);
+
+            var adUnits = [];
+            var unit = {};
+            unit.bids = [params];
+            unit.code = '/20164912/header-bid-tag';
+            unit.sizes=[[300,250],[728,90]];
+            adUnits.push(unit);
+
+            if (typeof(pbjs._bidsRequested)==="undefined"){
+                pbjs._bidsRequested = [params];
+            } else {
+                pbjs._bidsRequested.push(params);
+            } 
+            pbjs.adUnits = adUnits;
+            response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
+
+            pbjs.handlePiximediaCallback(response);
+
+            sinon.assert.calledOnce(stubAddBidResponse);
+            var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+            var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+
+            expect(bidPlacementCode1).to.equal('/20164912/header-bid-tag-0');
+            expect(bidObject1.cpm).to.equal(1.23);
+            expect(bidObject1.ad).to.equal("<div>ad</div>");
+            expect(bidObject1.width).to.equal(300);
+            expect(bidObject1.height).to.equal(250);
+            expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+
+            stubAddBidResponse.restore(); 
+            stubGetUniqueIdentifierStr.restore(); 
+        }); 
+
+        it('bidmanager.addBidResponse should be called once without any ads', function () {
+            var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+            var stubGetUniqueIdentifierStr = sinon.spy(utils, "getUniqueIdentifierStr");
+
+            var response = {
+                foundbypm: false
+            };
+
+            adapter().callBids(params);
+
+            var adUnits = [];
+            var unit = {};
+            unit.bids = [params];
+            unit.code = '/20164912/header-bid-tag';
+            unit.sizes=[[300,250],[728,90]];
+            adUnits.push(unit);
+
+            if (typeof(pbjs._bidsRequested)==="undefined"){
+                pbjs._bidsRequested = [params];
+            } else {
+                pbjs._bidsRequested.push(params);
+            } 
+            pbjs.adUnits = adUnits;
+            response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
+
+            pbjs.handlePiximediaCallback(response);
+
+            sinon.assert.calledOnce(stubAddBidResponse);
+            var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+            var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+
+            expect(bidPlacementCode1).to.equal('/20164912/header-bid-tag-0');
+            expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+
+            stubAddBidResponse.restore(); 
+            stubGetUniqueIdentifierStr.restore(); 
+        }); 
+
+        it('bidmanager.addBidResponse should not be called on bogus cbid', function () {
+            var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+            var stubGetUniqueIdentifierStr = sinon.spy(utils, "getUniqueIdentifierStr");
+
+            var response = {
+                foundbypm: false
+            };
+
+            adapter().callBids(params);
+
+            var adUnits = [];
+            var unit = {};
+            unit.bids = [params];
+            unit.code = '/20164912/header-bid-tag';
+            unit.sizes=[[300,250],[728,90]];
+            adUnits.push(unit);
+
+            if (typeof(pbjs._bidsRequested)==="undefined"){
+                pbjs._bidsRequested = [params];
+            } else {
+                pbjs._bidsRequested.push(params);
+            } 
+            pbjs.adUnits = adUnits;
+            response.cbid = stubGetUniqueIdentifierStr.returnValues[0] + "_BOGUS";
+
+            pbjs.handlePiximediaCallback(response);
+
+            sinon.assert.notCalled(stubAddBidResponse);
+
+            stubAddBidResponse.restore(); 
+            stubGetUniqueIdentifierStr.restore(); 
+        }); 
+
+        it('bidmanager.addBidResponse should not be called on bogus response', function () {
+            var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+            var response = null; // this is bogus: we expect an object
+
+            adapter().callBids(params);
+
+            var adUnits = [];
+            var unit = {};
+            unit.bids = [params];
+            unit.code = '/20164912/header-bid-tag';
+            unit.sizes=[[300,250],[728,90]];
+            adUnits.push(unit);
+
+            if (typeof(pbjs._bidsRequested)==="undefined"){
+                pbjs._bidsRequested = [params];
+            } else {
+                pbjs._bidsRequested.push(params);
+            } 
+            pbjs.adUnits = adUnits;
+
+            pbjs.handlePiximediaCallback(response);
+
+            sinon.assert.notCalled(stubAddBidResponse);
+
+            stubAddBidResponse.restore(); 
+        }); 
+    });
+});
+


### PR DESCRIPTION
Hello Team,

We would like to add our Piximedia adapter to Prebid. 

This PR also include full test coverage for our adapter (100 % statements, branches, functions, lines).

Here is a sample bidder configuration for testing everything works as expected:
```
{
    bidder: 'piximedia',
    params: {
        siteId: 'PIXIMEDIA',
        placementId: 'PREBID'
    }
}
```
We have set-up a test example showing how everything works together:
http://resources.pm/sandbox/prebid/

Feel free to contact me if you need more info, or check out our web site: http://www.piximedia.com/

Thanks!