### PR TITLE
Configure ES2015 code coverage

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,13 +1,9 @@
 // Karma configuration
 // Generated on Thu Aug 07 2014 09:45:28 GMT-0700 (PDT)
 var webpackConfig = require('./webpack.conf');
-webpackConfig.module.postLoaders = [
-  {
-    test: /\.js$/,
-    exclude: /(node_modules)|(test)|(integrationExamples)|(build)|polyfill.js/,
-    loader: 'istanbul-instrumenter'
-  }
-];
+webpackConfig.module.loaders[0].query = {
+  plugins: ['istanbul']
+};
 
 var CI_MODE = process.env.NODE_ENV === 'ci';
 
@@ -50,7 +46,7 @@ module.exports = function (config) {
     preprocessors: {
       'test/**/*_spec.js': ['webpack'],
       '!test/**/*_spec.js': 'coverage',
-      'src/**/*.js': ['webpack', 'coverage']
+      'src/**/*.js': ['webpack']
     },
 
     // WebPack Related

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.3",
+    "babel-plugin-istanbul": "^2.0.2",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.5.0",
     "block-loader": "^2.1.0",
@@ -44,7 +45,6 @@
     "gulp-webdriver": "^1.0.1",
     "gulp-zip": "^3.1.0",
     "istanbul": "^0.3.2",
-    "istanbul-instrumenter-loader": "^0.1.2",
     "jshint-stylish": "^2.2.1",
     "json-loader": "^0.5.1",
     "karma": "^0.13.2",


### PR DESCRIPTION
## Type of change
- [x] Build related changes

## Description of change
This PR adds istanbul instrumentation to ES2015 code resulting in reports that reflect pre-transpiled code. Replaces `istanbul-instrumenter` post-loader with [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul).