### PR TITLE
Prevent renderAd from rendering videos

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -174,7 +174,7 @@ function AppnexusAstAdapter() {
       if (tag.ads[0].rtb.video) {
         bid.width = tag.ads[0].rtb.video.player_width;
         bid.height = tag.ads[0].rtb.video.player_height;
-        bid.adUrl = tag.ads[0].rtb.video.asset_url;
+        bid.vastUrl = tag.ads[0].rtb.video.asset_url;
       } else {
         bid.width = tag.ads[0].rtb.banner.width;
         bid.height = tag.ads[0].rtb.banner.height;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -442,7 +442,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (doc===document) {
+        if (doc===document || adObject.mediaType === 'video') {
           utils.logError('Error trying to write ad. Ad render call ad id ' + id + ' was prevented from writing to the main document.');
         } else if (ad) {
           doc.write(ad);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -441,6 +441,19 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyLogError.calledWith(error), 'expected error was logged');
     });
 
+    it('should log an error when doc is document', () => {
+      $$PREBID_GLOBAL$$.renderAd(document, bidId);
+      const error = 'Error trying to write ad. Ad render call ad id ' + bidId + ' was prevented from writing to the main document.';
+      assert.ok(spyLogError.calledWith(error), 'expected error was logged');
+    });
+
+    it('should not render videos', () => {
+      adResponse.mediatype = 'video';
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      sinon.assert.notCalled(doc.write);
+      delete adResponse.mediatype;
+    });
+
     it('should catch errors thrown when trying to write ads to the page', function () {
       adResponse.ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Prevents pbjs.renderAd from writing a video url to the page. Also updates appnexusAst video url property name to `vastUrl`.