### PR TITLE
added timeouts to rubicon adapter that consider time-to-start costs

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -29,8 +29,10 @@ function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
 exports.callBids = ({ adUnits, cbTimeout }) => {
   const requestId = utils.generateUUID();
 
+  const auctionStart = Date.now();
+
   const auctionInit = {
-    timestamp: Date.now(),
+    timestamp: auctionStart,
     requestId,
   };
   events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
@@ -45,6 +47,7 @@ exports.callBids = ({ adUnits, cbTimeout }) => {
         bidderRequestId,
         bids: getBids({ bidderCode, requestId, bidderRequestId, adUnits }),
         start: new Date().getTime(),
+        auctionStart: auctionStart,
         timeout: cbTimeout
       };
       utils.logMessage(`CALLING BIDDER ======= ${bidderCode}`);

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -8,6 +8,8 @@ var bidmanager = require('../bidmanager');
 var bidfactory = require('../bidfactory');
 var adloader = require('../adloader');
 
+const TIMEOUT_BUFFER = 100;
+
 /**
  * @class RubiconAdapter
  * Prebid adapter for Rubicon's header bidding client
@@ -313,7 +315,10 @@ var RubiconAdapter = function RubiconAdapter() {
         slots.push(_defineSlot(bids[i]));
       }
 
-      var parameters = { slots: slots };
+      var parameters = {
+        slots: slots,
+        timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart - TIMEOUT_BUFFER)
+      };
       var callback   = function () {
         _bidsReady(slots);
       };


### PR DESCRIPTION
## Type of change
- [x ] Refactoring (no functional changes, no api changes)

## Description of change
updated the timestamp sent to the adapters, use auction start (which I think is what start was meant to represent) instead of generating new timestamps before each call to callBids.  

Also updated the rubicon adapter to use that start timestamp value to generate a relevant timeout to use for rubicon's fastlane calls.
