### PR TITLE
Allow bypassing ajax preflights with config options

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -54,8 +54,11 @@ export function ajax(url, callback, data, options = {}) {
     if (options.withCredentials) {
       x.withCredentials = true;
     } else {
-      x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-      x.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+      if (options.preflight !== false) {
+        x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      }
+      x.setRequestHeader('Content-Type',
+        options.contentType || 'application/json;charset=UTF-8');
     }
   }
 

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -53,13 +53,11 @@ export function ajax(url, callback, data, options = {}) {
   if (!useXDomainRequest) {
     if (options.withCredentials) {
       x.withCredentials = true;
-    } else {
-      if (options.preflight !== false) {
-        x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-      }
-      x.setRequestHeader('Content-Type',
-        options.contentType || 'application/json;charset=UTF-8');
     }
+    if (options.preflight) {
+      x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    }
+    x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
   }
 
   x.send(method === 'POST' && data);


### PR DESCRIPTION
## Type of change
- [x] Restoration

## Description of change
This change allows ajax calls to be configured with two options related to sending preflight OPTIONS requests. Setting `preflight` to false, and setting `contentType` to one of `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` will prevent a preflight OPTIONS request. Example of setting these options:

      ajax(ENDPOINT, handleResponse, payload, {
        contentType: 'text/plain',
        preflight: false
      });

## Other information
Addresses #625
