### PR TITLE
delete the callback before calling clearAuction #600

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -277,8 +277,8 @@ exports.executeCallback = function (timedOut) {
       processCallbacks([externalOneTimeCallback]);
     }
     finally {
-      $$PREBID_GLOBAL$$.clearAuction();
       externalOneTimeCallback = null;
+      $$PREBID_GLOBAL$$.clearAuction();
     }
   }
 };


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
A call to `pbjs.clearAuction()` will send through a pending request for bids, if any, which will set a new `bidsBackHandler` callback. The previously called callback should be deleted before calling `pbjs.clearAuction()`.

fixes #600
/ht to @anxobotana for the fix