### PR TITLE
use `splice` rather than `slice` to remove bids from array #594

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -272,7 +272,7 @@ function removeComplete() {
 
   // also remove bids that have an empty or error status so known as not pending for render
   responses.filter(bid => bid.getStatusCode && bid.getStatusCode() === 2)
-    .forEach(bid => responses.slice(responses.indexOf(bid), 1));
+    .forEach(bid => responses.splice(responses.indexOf(bid), 1));
 }
 
 //////////////////////////////////


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fix for bug that failed to remove bids for rendered slots if the bid had an empty or error status.
Fixes #594 
/ht to @anxobotana for the fix