### PR TITLE
Bug fix: accept custom timeout #582 & #604

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -81,7 +81,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
     bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
 
-    if (bid.timeToRespond > $$PREBID_GLOBAL$$.bidderTimeout) {
+    if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout) {
       const timedOut = true;
 
       this.executeCallback(timedOut);

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -81,7 +81,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
     bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
 
-    if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout) {
+    if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout + $$PREBID_GLOBAL$$.timeoutBuffer) {
       const timedOut = true;
 
       this.executeCallback(timedOut);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -512,7 +512,7 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
  * @param adUnitCodes
  */
 $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes }) {
-  const cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
+  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
   // if specific adUnitCodes filter adUnits for those codes

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -45,6 +45,9 @@ $$PREBID_GLOBAL$$._sendAllBids = false;
 
 //default timeout for all bids
 $$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout || 3000;
+
+// current timeout set in `requestBids` or to default `bidderTimeout`
+$$PREBID_GLOBAL$$.cbTimeout = null;
 $$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging || false;
 
 //let the world know we are loaded

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -48,6 +48,10 @@ $$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout || 3000;
 
 // current timeout set in `requestBids` or to default `bidderTimeout`
 $$PREBID_GLOBAL$$.cbTimeout = null;
+
+// timeout buffer to adjust for bidder CDN latency
+$$PREBID_GLOBAL$$.timeoutBuffer = 200;
+
 $$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging || false;
 
 //let the world know we are loaded

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -47,7 +47,7 @@ $$PREBID_GLOBAL$$._sendAllBids = false;
 $$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout || 3000;
 
 // current timeout set in `requestBids` or to default `bidderTimeout`
-$$PREBID_GLOBAL$$.cbTimeout = null;
+$$PREBID_GLOBAL$$.cbTimeout = $$PREBID_GLOBAL$$.cbTimeout || 200;
 
 // timeout buffer to adjust for bidder CDN latency
 $$PREBID_GLOBAL$$.timeoutBuffer = 200;


### PR DESCRIPTION
## Type of change
- [x] Bugfix resolves #582 and #604 

## Description of change
Use a global `cbTimeout` to set current timeout for invoking the `bidsBackHandler` callback while preserving default and accepting custom timeout passed to `requestBids`.