### PR TITLE
Add custom bucketing to kruxlink adapter

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -180,7 +180,7 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
     filterIfSendStandardTargeting(bidder_settings[bidderCode]);
   }
 
-  //2) set keys from standard setting. NOTE: this API doesn't seem to be in use by any Adapter
+  //2) set keys from standard setting.
   else if (defaultBidderSettingsMap[bidderCode]) {
     setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
Adds custom bucketing function to set targeting parameter `link_tier` to:
- bid < 0.50 or invalid -> return 0.25
- bid < 10.00 -> bucket into interval of 0.10 and return midpoint
- bid < 20.00 -> bucket into interval of 1.00 and return midpoint
- bid > 20.00 -> return 20.00

## Contact Information
- jgreenspan@krux.com
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@sethyates, please review when you get a chance