### PR TITLE
Size mapping functionality

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,6 +1,7 @@
 /** @module adaptermanger */
 
 import { flatten, getBidderCodes } from './utils';
+import { mapSizes } from './sizeMapping';
 
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -18,7 +19,7 @@ function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
       .map(bid => Object.assign(bid, {
         placementCode: adUnit.code,
         mediaType: adUnit.mediaType,
-        sizes: adUnit.sizes,
+        sizes: mapSizes(adUnit),
         bidId: utils.getUniqueIdentifierStr(),
         bidderRequestId,
         requestId

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,0 +1,35 @@
+/**
+ * @module sizeMapping
+ */
+import { isArray, logError, logMsg } from './utils';
+
+exports.mapSizes = function(adUnit) {
+  if(!adUnit.sizeMapping){
+    return adUnit.sizes;
+  }
+  if(!isSizeMappingValid){
+    return adUnit.sizes;
+  }
+  const width = getScreenWidth();
+  if(width) {
+    adUnit.sizes = adUnit.sizeMapping.find(sizeMapping =>{
+      return width > sizeMapping.minWidth;
+    }).sizes;
+    logMsg(`AdUnit : ${adUnit.code} resized based on device widith to : ${adUnit.sizes}`);
+  }
+};
+
+function isSizeMappingValid(sizeMapping) {
+  if(!isArray(sizeMapping)){
+    logError('sizeMapping needs at least one screen size defined');
+    return false;
+  }
+  return true;
+}
+
+function getScreenWidth() {
+  const w = window;
+  const docElem = document.documentElement;
+  const  body = document.getElementsByTagName('body')[0];
+  return w.innerWidth || docElem.clientWidth || body.clientWidth;
+}

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -9,6 +9,13 @@ exports.mapSizes = function(adUnit) {
   }
   const width = this.getScreenWidth();
   if(!width) {
+    //size not detected - get largest value set for desktop
+    const mapping = adUnit.sizeMapping.reduce((prev, curr) => {
+      return prev.minWidth < curr.minWidth ? curr : prev;
+    });
+    if(mapping.sizes) {
+      return mapping.sizes;
+    }
     return adUnit.sizes;
   }
   const sizes = adUnit.sizeMapping.find(sizeMapping =>{

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,35 +1,44 @@
 /**
  * @module sizeMapping
  */
-import { isArray, logError, logMsg } from './utils';
+import * as utils from './utils';
 
 exports.mapSizes = function(adUnit) {
-  if(!adUnit.sizeMapping){
+  if(!isSizeMappingValid(adUnit.sizeMapping)){
     return adUnit.sizes;
   }
-  if(!isSizeMappingValid){
+  const width = this.getScreenWidth();
+  if(!width) {
     return adUnit.sizes;
   }
-  const width = getScreenWidth();
-  if(width) {
-    adUnit.sizes = adUnit.sizeMapping.find(sizeMapping =>{
-      return width > sizeMapping.minWidth;
-    }).sizes;
-    logMsg(`AdUnit : ${adUnit.code} resized based on device widith to : ${adUnit.sizes}`);
-  }
+  const sizes = adUnit.sizeMapping.find(sizeMapping =>{
+    return width > sizeMapping.minWidth;
+  }).sizes;
+  utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${adUnit.sizes}`);
+  return sizes;
+
 };
 
 function isSizeMappingValid(sizeMapping) {
-  if(!isArray(sizeMapping)){
-    logError('sizeMapping needs at least one screen size defined');
-    return false;
+  if(utils.isArray(sizeMapping) && sizeMapping.length > 0){
+    return true;
   }
-  return true;
+  utils.logError('sizeMapping needs at least one screen size defined');
+  return false;
 }
 
-function getScreenWidth() {
-  const w = window;
-  const docElem = document.documentElement;
-  const  body = document.getElementsByTagName('body')[0];
-  return w.innerWidth || docElem.clientWidth || body.clientWidth;
-}
+exports.getScreenWidth = function(win) {
+  const w = win || window;
+  const docElem = w.document.documentElement;
+  const body = w.document.getElementsByTagName('body')[0];
+  if(w.innerWidth) {
+    return w.innerWidth;
+  }
+  else if(docElem && docElem.clientWidth ) {
+    return docElem.clientWidth;
+  }
+  else if(body && body.clientWidth){
+    return body.clientWidth;
+  }
+  return 0;
+};

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -2,12 +2,14 @@
  * @module sizeMapping
  */
 import * as utils from './utils';
+let _win;
 
-exports.mapSizes = function(adUnit) {
+function mapSizes(adUnit) {
   if(!isSizeMappingValid(adUnit.sizeMapping)){
     return adUnit.sizes;
   }
-  const width = this.getScreenWidth();
+  const width = getScreenWidth();
+  console.log('internal screen width: ' + width);
   if(!width) {
     //size not detected - get largest value set for desktop
     const mapping = adUnit.sizeMapping.reduce((prev, curr) => {
@@ -21,21 +23,21 @@ exports.mapSizes = function(adUnit) {
   const sizes = adUnit.sizeMapping.find(sizeMapping =>{
     return width > sizeMapping.minWidth;
   }).sizes;
-  utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${adUnit.sizes}`);
+  utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
   return sizes;
 
-};
+}
 
 function isSizeMappingValid(sizeMapping) {
   if(utils.isArray(sizeMapping) && sizeMapping.length > 0){
     return true;
   }
-  utils.logError('sizeMapping needs at least one screen size defined');
+  utils.logInfo('No size mapping defined');
   return false;
 }
 
-exports.getScreenWidth = function(win) {
-  const w = win || window;
+function getScreenWidth(win) {
+  const w = win || _win || window;
   const docElem = w.document.documentElement;
   const body = w.document.getElementsByTagName('body')[0];
   if(w.innerWidth) {
@@ -48,4 +50,10 @@ exports.getScreenWidth = function(win) {
     return body.clientWidth;
   }
   return 0;
-};
+}
+
+function setWindow(win) {
+  _win = win;
+}
+
+export { mapSizes, getScreenWidth, setWindow };

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -9,7 +9,6 @@ function mapSizes(adUnit) {
     return adUnit.sizes;
   }
   const width = getScreenWidth();
-  console.log('internal screen width: ' + width);
   if(!width) {
     //size not detected - get largest value set for desktop
     const mapping = adUnit.sizeMapping.reduce((prev, curr) => {

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -2,62 +2,59 @@ import { expect } from 'chai';
 import * as sizeMapping from 'src/sizeMapping';
 
 var validAdUnit = {
-  "sizes" : [300,250],
-  "sizeMapping": [
+  'sizes': [300,250],
+  'sizeMapping': [
     {
-        "minWidth": 1024,
-        "sizes" : [[300,250],[728,90]]
+      'minWidth': 1024,
+      'sizes': [[300,250],[728,90]]
     },
     {
-        "minWidth": 480,
-        "sizes": [120,60]
+      'minWidth': 480,
+      'sizes': [120,60]
     },
     {
-        "minWidth": 0,
-        "sizes": [20,20]
+      'minWidth': 0,
+      'sizes': [20,20]
     }
   ]
 };
 
 var invalidAdUnit = {
-  "sizes" : [300,250],
-  "sizeMapping": {} // wrong type
+  'sizes': [300,250],
+  'sizeMapping': {} // wrong type
 };
 
 let mockWindow = {};
 
 function resetMockWindow() {
   mockWindow = {
-    document : { getElementsByTagName : function(){ return [{}]; } },
-    innerWidth : 1024,
+    document: {getElementsByTagName: function() { return [{}]; }},
+    innerWidth: 1024,
   };
 }
 
-describe('sizeMapping', function () {
+describe('sizeMapping', function() {
 
   beforeEach(resetMockWindow);
 
-  it('mapSizes 1029 width', function () {
+  it('mapSizes 1029 width', function() {
     let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     console.log(sizeMapping.getScreenWidth());
     expect(sizes).to.deep.equal([[300,250],[728,90]]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
-
     stub.restore();
-
   });
 
-  it('mapSizes 400 width', function () {
+  it('mapSizes 400 width', function() {
     let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(400);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([20,20]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
     stub.restore();
-
   });
 
-  it('mapSizes - invalid adUnit - should return sizes', function () {
+  it('mapSizes - invalid adUnit - should return sizes', function() {
     let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
     let sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
@@ -67,37 +64,32 @@ describe('sizeMapping', function () {
     sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
-
     stub.restore();
-
   });
 
-  it('mapSizes - should return desktop (largest) sizes if screen width not detected', function () {
+  it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
     let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
     let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[ 300, 250 ], [ 728, 90 ]]);
+    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
     stub.restore();
-
   });
 
-  it('getScreenWidth', function () {
+  it('getScreenWidth', function() {
     mockWindow.innerWidth = 900;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
   });
 
-  it('getScreenWidth - should sizes in older browsers', function () {
+  it('getScreenWidth - should sizes in older browsers', function() {
     mockWindow.innerWidth = null;
-    mockWindow.document.documentElement = {clientWidth : 901};
+    mockWindow.document.documentElement = {clientWidth: 901};
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(901);
-
   });
 
-  it('getScreenWidth - should sizes in really old browsers', function () {
+  it('getScreenWidth - should sizes in really old browsers', function() {
     mockWindow.innerWidth = null;
-    mockWindow.document.getElementsByTagName = function() { return [{clientWidth : 902}]; };
+    mockWindow.document.getElementsByTagName = function() { return [{clientWidth: 902}]; };
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(902);
-
   });
 
 });

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -24,6 +24,13 @@ var invalidAdUnit = {
   'sizeMapping': {} // wrong type
 };
 
+var invalidAdUnit2 = {
+  'sizes': [300,250],
+  'sizeMapping': [{
+    foo : 'bar'  //bad
+  }]
+};
+
 let mockWindow = {};
 
 function resetMockWindow() {
@@ -75,6 +82,16 @@ describe('sizeMapping', function() {
     stub.restore();
   });
 
+
+  it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
+    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
+    let sizes = sizeMapping.mapSizes(invalidAdUnit2);
+    expect(sizes).to.deep.equal([300,250]);
+    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    stub.restore();
+  });
+
+
   it('getScreenWidth', function() {
     mockWindow.innerWidth = 900;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
@@ -90,6 +107,11 @@ describe('sizeMapping', function() {
     mockWindow.innerWidth = null;
     mockWindow.document.getElementsByTagName = function() { return [{clientWidth: 902}]; };
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(902);
+  });
+
+  it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
+    mockWindow.innerWidth = null;
+    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
   });
 
 });

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -45,50 +45,50 @@ describe('sizeMapping', function() {
   beforeEach(resetMockWindow);
 
   it('mapSizes 1029 width', function() {
-    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
+    mockWindow.innerWidth = 1029;
+    sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
-    console.log(sizeMapping.getScreenWidth());
     expect(sizes).to.deep.equal([[300,250],[728,90]]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
-    stub.restore();
   });
 
   it('mapSizes 400 width', function() {
-    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(400);
+    mockWindow.innerWidth = 400;
+    sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([20,20]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
-    stub.restore();
   });
 
   it('mapSizes - invalid adUnit - should return sizes', function() {
-    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
+    mockWindow.innerWidth = 1029;
+    sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
 
-    stub.returns(400);
+    mockWindow.innerWidth = 400;
+    sizeMapping.setWindow(mockWindow);
     sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
-    stub.restore();
   });
 
   it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
-    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
+    mockWindow.innerWidth = 0;
+    sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
-    stub.restore();
   });
 
 
   it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
-    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
+    mockWindow.innerWidth = 0;
+    sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit2);
     expect(sizes).to.deep.equal([300,250]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
-    stub.restore();
   });
 
 

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -72,10 +72,10 @@ describe('sizeMapping', function () {
 
   });
 
-  it('mapSizes - should return sizes if screen width not detected', function () {
+  it('mapSizes - should return desktop (largest) sizes if screen width not detected', function () {
     let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
     let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([300,250]);
+    expect(sizes).to.deep.equal([[ 300, 250 ], [ 728, 90 ]]);
     expect(validAdUnit.sizes).to.deep.equal([300,250]);
     stub.restore();
 

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import * as sizeMapping from 'src/sizeMapping';
+
+var validAdUnit = {
+  "sizes" : [300,250],
+  "sizeMapping": [
+    {
+        "minWidth": 1024,
+        "sizes" : [[300,250],[728,90]]
+    },
+    {
+        "minWidth": 480,
+        "sizes": [120,60]
+    },
+    {
+        "minWidth": 0,
+        "sizes": [20,20]
+    }
+  ]
+};
+
+var invalidAdUnit = {
+  "sizes" : [300,250],
+  "sizeMapping": {} // wrong type
+};
+
+let mockWindow = {};
+
+function resetMockWindow() {
+  mockWindow = {
+    document : { getElementsByTagName : function(){ return [{}]; } },
+    innerWidth : 1024,
+  };
+}
+
+describe('sizeMapping', function () {
+
+  beforeEach(resetMockWindow);
+
+  it('mapSizes 1029 width', function () {
+    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
+    let sizes = sizeMapping.mapSizes(validAdUnit);
+    console.log(sizeMapping.getScreenWidth());
+    expect(sizes).to.deep.equal([[300,250],[728,90]]);
+    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+
+    stub.restore();
+
+  });
+
+  it('mapSizes 400 width', function () {
+    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(400);
+    let sizes = sizeMapping.mapSizes(validAdUnit);
+    expect(sizes).to.deep.equal([20,20]);
+    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    stub.restore();
+
+  });
+
+  it('mapSizes - invalid adUnit - should return sizes', function () {
+    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(1029);
+    let sizes = sizeMapping.mapSizes(invalidAdUnit);
+    expect(sizes).to.deep.equal([300,250]);
+    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
+
+    stub.returns(400);
+    sizes = sizeMapping.mapSizes(invalidAdUnit);
+    expect(sizes).to.deep.equal([300,250]);
+    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
+
+    stub.restore();
+
+  });
+
+  it('mapSizes - should return sizes if screen width not detected', function () {
+    let stub = sinon.stub(sizeMapping, 'getScreenWidth').returns(0);
+    let sizes = sizeMapping.mapSizes(validAdUnit);
+    expect(sizes).to.deep.equal([300,250]);
+    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    stub.restore();
+
+  });
+
+  it('getScreenWidth', function () {
+    mockWindow.innerWidth = 900;
+    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
+  });
+
+  it('getScreenWidth - should sizes in older browsers', function () {
+    mockWindow.innerWidth = null;
+    mockWindow.document.documentElement = {clientWidth : 901};
+    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(901);
+
+  });
+
+  it('getScreenWidth - should sizes in really old browsers', function () {
+    mockWindow.innerWidth = null;
+    mockWindow.document.getElementsByTagName = function() { return [{clientWidth : 902}]; };
+    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(902);
+
+  });
+
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Adding support for https://github.com/prebid/Prebid.js/issues/87 - size mapping. 

- Usage:
```
var adUnit = {
  code: 'code',
  sizeMapping: [  //new!
    {
      minWidth : 1024,  //if device screen width is greater than 1024, use these sizes
      sizes : [[300,250],[728,90]]
    },
    {
      minWidth : 480,  //if device screen width is < 1024 && > 480, use these sizes
      sizes : [120,60]
    },
    {
      minWidth : 0,  //if device screen width is < 480 && > 0, use these sizes
      sizes : [20,20]
    }
  ]
  bids: [...]
}
```

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@prebid/core  for review. 