### PR TITLE
Initial value 0 for adder.

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -51,7 +51,7 @@ function add(a, b) {
 }
 
 function bidsBackAll() {
-  const requested = $$PREBID_GLOBAL$$._bidsRequested.map(bidSet => bidSet.bids.length).reduce(add);
+  const requested = $$PREBID_GLOBAL$$._bidsRequested.map(bidSet => bidSet.bids.length).reduce(add, 0);
   const received = $$PREBID_GLOBAL$$._bidsReceived.length;
   return requested === received;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
If no bidders are added to the prebid bid object, `bidsBackAll` will throw a type error of "Attempt to reduce empty array with no initial value".
```
pbjs.addAdUnits([{
    code: code
    sizes: sizes
    bids: []
}]);
```
The `bids: []` is the problem.  With this change, there is an initial value of 0 (which works because of adding), and it won't throw.

