### PR TITLE
Prevent bidmanager TypeError

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -41,7 +41,8 @@ function getBidders(bid) {
 }
 
 function bidsBackAdUnit(adUnitCode) {
-  const requested = $$PREBID_GLOBAL$$.adUnits.find(unit => unit.code === adUnitCode).bids.length;
+  let requested = $$PREBID_GLOBAL$$.adUnits.find(unit => unit.code === adUnitCode);
+  if (requested) {requested = requested.bids.length;}
   const received = $$PREBID_GLOBAL$$._bidsReceived.filter(bid => bid.adUnitCode === adUnitCode).length;
   return requested === received;
 }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `adUnits.find` returns `undefined`, attempting to access the `bids` property will raise a `TypeError`. This causes uncaught exceptions when using Karma in debug mode with `gulp serve --watch`. Fixing this may help stabilize the flaky unit tests observed in #642.