### PR TITLE
Prevent TripleLift TypeError

### DIFF
--- a/src/adapters/triplelift.js
+++ b/src/adapters/triplelift.js
@@ -76,10 +76,10 @@ var TripleLiftAdapter = function TripleLiftAdapter() {
   $$PREBID_GLOBAL$$.TLCB = function(tlResponseObj) {
     if (tlResponseObj && tlResponseObj.callback_id) {
       var bidObj = utils.getBidRequest(tlResponseObj.callback_id);
-      var placementCode = bidObj.placementCode;
+      var placementCode = bidObj && bidObj.placementCode;
 
       // @if NODE_ENV='debug'
-      utils.logMessage('JSONP callback function called for inventory code: ' + bidObj.params.inventoryCode);
+      if (bidObj) {utils.logMessage('JSONP callback function called for inventory code: ' + bidObj.params.inventoryCode);}
       // @endif
 
       var bid = [];
@@ -97,7 +97,7 @@ var TripleLiftAdapter = function TripleLiftAdapter() {
       } else {
         //no response data
         // @if NODE_ENV='debug'
-        utils.logMessage('No prebid response from TripleLift for inventory code: ' + bidObj.params.inventoryCode);
+        if (bidObj) {utils.logMessage('No prebid response from TripleLift for inventory code: ' + bidObj.params.inventoryCode);}
         // @endif
         bid = bidfactory.createBid(2, bidObj);
         bid.bidderCode = 'triplelift';


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `utils.getBidRequest` returns `undefined`, attempting to access properties of `bidObj` raises a `TypeError`. This occasionally causes uncaught exceptions when using Karma in debug mode (`gulp serve --watch`, check in dev tools console). Fixing this may help stabilize the unit test failures observed in #642.

## Other information
@prebid/triplelift, @tiffwu, please review this change or feel free to submit a PR that handles this exception.