### PR TITLE
Prevent SpringServe TypeError

### DIFF
--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -68,8 +68,12 @@ SpringServeAdapter = function SpringServeAdapter() {
       //look up the request attributs stored in the bidmanager
       var responseBid = responseObj.seatbid[0].bid[0];
       //var requestObj = bidmanager.getPlacementIdByCBIdentifer(responseBid.impid);
-      var requestBids = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'springserve').bids
-        .filter(bid => bid.params && bid.params.impId === +responseBid.impid);
+      var requestBids = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'springserve');
+      if (requestBids) {
+        requestBids = requestBids.bids.filter(bid => bid.params && bid.params.impId === +responseBid.impid);
+      } else {
+        requestBids = [];
+      }
       var bid = bidfactory.createBid(1);
       var placementCode;
 
@@ -84,7 +88,7 @@ SpringServeAdapter = function SpringServeAdapter() {
         }
       }
 
-      bid.bidderCode = requestBids[0].bidder;
+      if (requestBids[0]) {bid.bidderCode = requestBids[0].bidder;}
 
       if (responseBid.hasOwnProperty('price') && responseBid.hasOwnProperty('adm')) {
         //assign properties from the response to the bid object

--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -69,7 +69,7 @@ SpringServeAdapter = function SpringServeAdapter() {
       var responseBid = responseObj.seatbid[0].bid[0];
       //var requestObj = bidmanager.getPlacementIdByCBIdentifer(responseBid.impid);
       var requestBids = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'springserve');
-      if (requestBids) {
+      if (requestBids && requestBids.bids.length > 0) {
         requestBids = requestBids.bids.filter(bid => bid.params && bid.params.impId === +responseBid.impid);
       } else {
         requestBids = [];


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `find` returns `undefined`, attempting to access properties on `requestBids` raises a `TypeError`. This occasionally causes uncaught exceptions when using Karma in debug mode (`gulp serve --watch`, check in dev tools console). Fixing this may help stabilize the unit test failures observed in #642.

## Other information
@prebid/springserve, please review this change or feel free to submit a PR that handles this exception.