### PR TITLE
Prevent Sovrn TypeError

### DIFF
--- a/src/adapters/sovrn.js
+++ b/src/adapters/sovrn.js
@@ -72,8 +72,12 @@ var SovrnAdapter = function SovrnAdapter() {
   }
 
   function addBlankBidResponses(impidsWithBidBack) {
-    var missing = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'sovrn').bids
-      .filter(bid => impidsWithBidBack.indexOf(bid.bidId) < 0);
+    var missing = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'sovrn');
+    if (missing) {
+      missing = missing.bids.filter(bid => impidsWithBidBack.indexOf(bid.bidId) < 0);
+    } else {
+      missing = [];
+    }
 
     missing.forEach(function (bidRequest) {
       // Add a no-bid response for this bid request.


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `find` returns `undefined`, attempting to access properties of `missing` will throw a TypeError. This occasionally causes uncaught exceptions when using Karma in debug mode (`gulp serve --watch`, check in dev tools console). Fixing this may help stabilize the unit test failures observed in #642.

## Other information
@prebid/sovrn, please review this change or feel free to submit a PR that handles this exception.