### PR TITLE
Prevent Pubmatic TypeError

### DIFF
--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -86,8 +86,8 @@ var PubmaticAdapter = function PubmaticAdapter() {
     var adUnit;
     var adUnitInfo;
     var bid;
-    var bidResponseMap = bidDetailsMap;
-    var bidInfoMap = progKeyValueMap;
+    var bidResponseMap = bidDetailsMap || {};
+    var bidInfoMap = progKeyValueMap || {};
     var dimensions;
 
     for (i = 0; i < bids.length; i++) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `bidResponseMap` or `bidInfoMap` are `undefined`, attempting to access properties of those objects will raise a `TypeError`. This occasionally causes uncaught exceptions when using Karma in debug mode (`gulp serve --watch`, check in dev tools console). Fixing this may help stabilize the unit test failures observed in #642.

## Other information
@prebid/pubmatic , please review this change or feel free to submit a PR that handles this exception.