### PR TITLE
XDomainRequest does not support `readyState` and callback not firing

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -24,7 +24,9 @@ export function ajax(url, callback, data, options = {}) {
 
   if (useXDomainRequest) {
     x = new window.XDomainRequest();
-    x.onload = handler;
+    x.onload = function () {
+      callback(x.responseText, x);
+    };
 
     // http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
     x.onerror = function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Bugfix for IE 9 not handling CORS XHR.

## Other information
@matthewlane @protonate for review