### PR TITLE
test ie variant of url parse pathname

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -816,7 +816,7 @@ describe('Unit: Prebid Module', function () {
   describe('loadScript', () => {
     it('should call adloader.loadScript', () => {
       const loadScriptSpy = sinon.spy(adloader, 'loadScript');
-      const tagSrc = 'testsrc';
+      const tagSrc = '';
       const callback = Function;
       const useCache = false;
 

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -1,4 +1,5 @@
 import {format, parse} from '../../src/url';
+import { expect } from 'chai';
 
 describe('helpers.url', () => {
 
@@ -23,7 +24,7 @@ describe('helpers.url', () => {
     });
 
     it('extracts the pathname', () => {
-      expect(parsed).to.have.property('pathname', '/pathname/');
+      expect(['/pathname/', 'pathname/']).to.include(parsed.pathname);
     });
 
     it('extracts the search query', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
uses chai `expect([1, 2, 3]).to.include(2)` to support the IE result of url.parse