### PR TITLE
PROPOSAL: Write sandbox ifame for both ad types.

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -452,14 +452,27 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         if (doc===document || adObject.mediaType === 'video') {
           utils.logError('Error trying to write ad. Ad render call ad id ' + id + ' was prevented from writing to the main document.');
         } else if (ad) {
-          doc.write(ad);
+          // Write ad into sandboxed iframe.
+          var iframe = doc.createElement('iframe');
+          iframe.sandbox = 'allow-forms allow-scripts allow-same-origin allow-popups allow-pointer-lock';
+          var style = '';
+          style = style + 'min-height:' + height + ';';
+          style = style + 'min-width:' + width + ';';
+          style = style + 'border:none;';
+          iframe.style = style;
+          doc.body.appendChild(iframe);
+          iframe.contentWindow.document.open('text/htmlreplace');
+          iframe.contentWindow.document.write(ad);
+          iframe.contentWindow.document.close();
           doc.close();
+
           if (doc.defaultView && doc.defaultView.frameElement) {
             doc.defaultView.frameElement.width = width;
             doc.defaultView.frameElement.height = height;
           }
         } else if (url) {
-          doc.write('<IFRAME SRC="' + url + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true" WIDTH="' + width + '" HEIGHT="' + height + '"></IFRAME>');
+          // Write ad into sandboxed iframe.
+          doc.write('<IFRAME SRC="' + url + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true" WIDTH="' + width + '" HEIGHT="' + height + '" SANDBOX="allow-forms allow-scripts allow-same-origin allow-popups allow-pointer-lock"></IFRAME>');
           doc.close();
 
           if (doc.defaultView && doc.defaultView.frameElement) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Ads currently are dropped into the page (`document.write`) with full "power" to interact (and ruin the UI/UX) of the top level page that they are on.  This should do the same, but write the ad into a sandboxed iframe that has almost all of the same capabilities except for the ability to redirect the top level page.  This should help preventing ad related redirects.
We need to improve the control publishers have to control ads.  This is an attempt to start some discussion surrounding that issue.

## Discussion
* We have seen discrepancy go up significantly (unacceptable levels) with multiple partners using this, so it is **not intended for production use**.  
* Does anyone know how this might be causing impressions to not be counted?  Any insight into how that works would be appreciated. **??**
* Is the code right for writing into a sandbox like that?  This code is based on stack-overflow-fu rather than my own knowledge of how `document.write`, `sandbox`, and `iframe`s interact. **??**


