### PR TITLE
PROPOSAL: Sandbox using DFP Safe Frame with Post Message

### DIFF
--- a/src/creative.js
+++ b/src/creative.js
@@ -1,0 +1,38 @@
+<script>
+  var rendered = false;
+
+  var renderAd = function (ev) {
+    var key = ev.message ? "message" : "data";
+    var data = {};
+    try {
+      data = JSON.parse(ev[key]);
+    } catch (e) {
+      // Do nothing.  No ad found.
+    }
+    if (!rendered && (data.ad || data.adUrl)) {
+      rendered = true;
+      if (data.ad) {
+        document.write(data.ad);
+        document.close();
+      } else if (data.adUrl) {
+        doc.write('<IFRAME SRC="' + data.adUrl + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true"></IFRAME>');
+        doc.close();
+      }
+    }
+  };
+
+  var requestAdFromPrebid = function () {
+    var message = JSON.stringify({
+      message: 'request ad',
+      adId: '%%PATTERN:hb_adid%%'
+    });
+    window.parent.postMessage(message,"*");
+  };
+
+  var listenAdFromPrebid = function () {
+    window.addEventListener("message", renderAd, false);
+  };
+
+  listenAdFromPrebid();
+  requestAdFromPrebid();
+</script>

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -509,6 +509,33 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
   }
 };
 
+var sendAdToCreative = function (ev) {
+  var key = ev.message ? "message" : "data";
+  var data = {};
+  try {
+    data = JSON.parse(ev[key]);
+  } catch (e) {
+    // Do nothing.  No ad found.
+  }
+  if (data.adId) {
+    var adObject = pbjs._bidsReceived.find(function (bid) {
+      return bid.adId === data.adId;
+    });
+    var ad = adObject.ad;
+    var adUrl = adObject.adUrl;
+    var message = JSON.stringify({
+      message: 'send ad',
+      ad: ad,
+      adUrl: adUrl
+    });
+    ev.source.postMessage(message,"*");
+  }
+};
+
+var listenAdRequestFromCreative = function () {
+  addEventListener("message", sendAdToCreative, false);
+};
+
 /**
  *
  * @param bidsBackHandler
@@ -562,6 +589,7 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   setTimeout(timeoutCallback, cbTimeout);
 
   adaptermanager.callBids({ adUnits, adUnitCodes, cbTimeout });
+  listenAdRequestFromCreative();
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->
## Type of change

<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other
## Description of change

<!-- Describe the change proposed in this pull request -->

Ads currently are dropped into the page (document.write) with full "power" to interact (and ruin the UI/UX) of the top level page that they are on.  To use Google's sandboxed iframes, pbjs has to have a way to render ads communicating to the sandbox frame since `pbjs.renderAd` will not be available.  This uses `postmessage` to communicate the ad data.  We need to improve the control publishers have to control ads. This is an attempt to start some discussion surrounding that issue.
## Discussion
- The creative needed in DFP to work with this branch is included in the files changed.
- This is untested on our site and is **not intended for production use**.
