### PR TITLE
Address #642 - stubbing`adLoader` to resolve `script error` build failure

### DIFF
--- a/test/spec/adapters/centro_spec.js
+++ b/test/spec/adapters/centro_spec.js
@@ -14,13 +14,13 @@ describe('centro adapter tests', function () {
         var pbjs = window.pbjs;
     }
 
-    var spyLoadScript;
+    let stubLoadScript;
     beforeEach(function () {
-        spyLoadScript = sinon.spy(adLoader, 'loadScript');
+        stubLoadScript = sinon.stub(adLoader, 'loadScript');
     });
 
     afterEach(function () {
-        spyLoadScript.restore();
+        stubLoadScript.restore();
     });
 
     var logErrorSpy;
@@ -70,11 +70,11 @@ describe('centro adapter tests', function () {
             };
 
             adapter().callBids(params);
-            var bidUrl1 = spyLoadScript.getCall(0).args[0];
-            var bidUrl2 = spyLoadScript.getCall(1).args[0];
+            var bidUrl1 = stubLoadScript.getCall(0).args[0];
+            var bidUrl2 = stubLoadScript.getCall(1).args[0];
 
             sinon.assert.calledWith(logErrorSpy, 'Bid has no unit', 'centro');
-            sinon.assert.calledWith(spyLoadScript, bidUrl1);
+            sinon.assert.calledWith(stubLoadScript, bidUrl1);
 
             var parsedBidUrl = urlParse(bidUrl1);
             var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
@@ -88,7 +88,7 @@ describe('centro adapter tests', function () {
             expect(parsedBidUrlQueryString).to.have.property('sz').and.to.equal('300x250');
             expect(parsedBidUrlQueryString).to.have.property('callback').and.to.equal(generatedCallback);
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl2);
+            sinon.assert.calledWith(stubLoadScript, bidUrl2);
 
             parsedBidUrl = urlParse(bidUrl2);
             parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);

--- a/test/spec/adapters/jcm_spec.js
+++ b/test/spec/adapters/jcm_spec.js
@@ -2,7 +2,7 @@ describe('jcm adapter tests', function () {
 
     var expect = require('chai').expect;
     var urlParse = require('url-parse');
-    
+
     // FYI: querystringify will perform encoding/decoding
     var querystringify = require('querystringify');
 
@@ -13,21 +13,21 @@ describe('jcm adapter tests', function () {
     window.pbjs = window.pbjs || {};
     if (typeof(pbjs)==="undefined"){
         var pbjs = window.pbjs;
-    }	
-    var spyLoadScript;
+    }
+    let stubLoadScript;
 
         beforeEach(function () {
-            spyLoadScript = sinon.spy(adLoader, 'loadScript');
+            stubLoadScript = sinon.stub(adLoader, 'loadScript');
         });
 
         afterEach(function () {
-            spyLoadScript.restore();
+            stubLoadScript.restore();
         });
 
 
     describe('creation of bid url', function () {
 
-       if (typeof(pbjs._bidsReceived)==="undefined"){ 
+       if (typeof(pbjs._bidsReceived)==="undefined"){
            pbjs._bidsReceived = [];
        }
        if (typeof(pbjs._bidsRequested)==="undefined"){
@@ -50,14 +50,14 @@ describe('jcm adapter tests', function () {
                           params: { siteId: '3608', adSizes:'300x250' },
                           requestId: '10b327aa396609',
                           placementCode: '/19968336/header-bid-tag-0'
-                         } 
+                         }
 
                 ]
             };
 
             adapter().callBids(params);
 
-            sinon.assert.calledOnce(spyLoadScript);
+            sinon.assert.calledOnce(stubLoadScript);
 
         });
 
@@ -80,19 +80,19 @@ describe('jcm adapter tests', function () {
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
-            var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query); 
- 
+            var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
+
             expect(parsedBidUrl.hostname).to.equal('media.adfrontiers.com');
             expect(parsedBidUrl.pathname).to.equal('/pq');
-              
+
             expect(parsedBidUrlQueryString).to.have.property('t').and.to.equal('hb');
             expect(parsedBidUrlQueryString).to.have.property('bids');
-            
+
             var bidObjArr = JSON.parse(parsedBidUrlQueryString.bids);
             expect(bidObjArr).to.have.property('bids');
             var bidObj = bidObjArr.bids[0];
@@ -101,7 +101,7 @@ describe('jcm adapter tests', function () {
             expect(bidObj).to.have.property('siteId').and.to.equal('3608');
             expect(bidObj).to.have.property('callbackId').and.to.equal('3c9408cdbf2f68');
         });
-     
+
    });
 
  describe('placement by size', function () {
@@ -145,9 +145,9 @@ describe('jcm adapter tests', function () {
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
             var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
@@ -227,7 +227,7 @@ describe('jcm adapter tests', function () {
         it('bidmanager.addBidResponse should be called twice with correct arguments', function () {
 
        var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
-      
+
        adapter().callBids(params);
 
        var adUnits = new Array();
@@ -242,7 +242,7 @@ describe('jcm adapter tests', function () {
        }
        else{
            pbjs._bidsRequested.push(params);
-       } 
+       }
        pbjs.adUnits = adUnits;
        pbjs.processJCMResponse(response);
 
@@ -257,16 +257,15 @@ describe('jcm adapter tests', function () {
        expect(bidObject1.width).to.equal(300);
        expect(bidObject1.height).to.equal(250);
        expect(bidObject1.getStatusCode()).to.equal(1);
-       expect(bidObject1.bidderCode).to.equal('jcm'); 
+       expect(bidObject1.bidderCode).to.equal('jcm');
 
        expect(bidPlacementCode2).to.equal('/19968336/header-bid-tag-1');
        expect(bidObject2.getStatusCode()).to.equal(2);
- 
+
        sinon.assert.calledTwice(stubAddBidResponse);
-       stubAddBidResponse.restore(); 
-      }); 
+       stubAddBidResponse.restore();
+      });
 
     });
 
 });
-

--- a/test/spec/adapters/memeglobal_spec.js
+++ b/test/spec/adapters/memeglobal_spec.js
@@ -5,13 +5,13 @@ describe('memeglobal adapter tests', function () {
   const adLoader = require('src/adloader');
   var bidderName = 'memeglobal';
 
-  var spyLoadScript;
+  let stubLoadScript;
       beforeEach(function () {
-          spyLoadScript = sinon.spy(adLoader, 'loadScript');
+          stubLoadScript = sinon.stub(adLoader, 'loadScript');
       });
 
       afterEach(function () {
-          spyLoadScript.restore();
+          stubLoadScript.restore();
       });
 
   function getBidSetForBidder() {
@@ -53,7 +53,7 @@ describe('memeglobal adapter tests', function () {
       };
 
       adapter().callBids(params);
-      sinon.assert.calledOnce(spyLoadScript);
+      sinon.assert.calledOnce(stubLoadScript);
     });
 
     it('callBids empty params', function () {
@@ -72,7 +72,7 @@ describe('memeglobal adapter tests', function () {
       };
 
       adapter().callBids({});
-      expect(spyLoadScript.callCount).to.equal(0);
+      expect(stubLoadScript.callCount).to.equal(0);
     });
   });
 
@@ -169,4 +169,3 @@ describe('memeglobal adapter tests', function () {
     });
   });
 });
-

--- a/test/spec/adapters/piximedia_spec.js
+++ b/test/spec/adapters/piximedia_spec.js
@@ -2,7 +2,7 @@ describe('Piximedia adapter tests', function () {
 
     var expect = require('chai').expect;
     var urlParse = require('url-parse');
-    
+
     //var querystringify = require('querystringify');
 
     var adapter = require('src/adapters/piximedia');
@@ -12,18 +12,18 @@ describe('Piximedia adapter tests', function () {
     var CONSTANTS = require('src/constants.json');
 
     var pbjs = window.pbjs = window.pbjs || {};
-    var spyLoadScript;
+    let stubLoadScript;
 
     beforeEach(function () {
-        spyLoadScript = sinon.spy(adLoader, 'loadScript');
+        stubLoadScript = sinon.stub(adLoader, 'loadScript');
     });
 
     afterEach(function () {
-        spyLoadScript.restore();
+        stubLoadScript.restore();
     });
 
     describe('creation of prebid url', function () {
-       if (typeof(pbjs._bidsReceived)==="undefined"){ 
+       if (typeof(pbjs._bidsReceived)==="undefined"){
            pbjs._bidsReceived = [];
        }
        if (typeof(pbjs._bidsRequested)==="undefined"){
@@ -45,12 +45,12 @@ describe('Piximedia adapter tests', function () {
                             params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            sinon.assert.calledOnce(spyLoadScript);
+            sinon.assert.calledOnce(stubLoadScript);
         });
 
         it('should not call the Piximedia prebid URL once on invalid calls', function () {
@@ -65,12 +65,12 @@ describe('Piximedia adapter tests', function () {
                             params: { prebidUrl: "//resources.pm/tests/prebid/bids.js" }, // this is invalid: site and placement ID are missing
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            sinon.assert.notCalled(spyLoadScript);
+            sinon.assert.notCalled(stubLoadScript);
         });
 
         it('should call the correct Prebid URL when using the default URL', function () {
@@ -85,17 +85,17 @@ describe('Piximedia adapter tests', function () {
                             params: { siteId: 'TEST', placementId: "TEST" },
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
- 
+
             expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
             expect(parsedBidUrl.query).to.equal("");
             expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
@@ -113,17 +113,17 @@ describe('Piximedia adapter tests', function () {
                             params: { siteId: 'TEST', placementId: "TEST", dealId: 1295, custom: "bespoke", custom2: function() { return "bespoke2"; }, custom3: null, custom4: function() {} },
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
- 
+
             expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
             expect(parsedBidUrl.query).to.equal("");
             expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/l_id=1295/custom=bespoke/custom2=bespoke2/custom3=/custom4=/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
@@ -141,17 +141,17 @@ describe('Piximedia adapter tests', function () {
                             params: { siteId: 'TEST', placementId: "TEST", sizes: [[300,600],[728,90]] },
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
- 
+
             expect(parsedBidUrl.hostname).to.equal("static.adserver.pm");
             expect(parsedBidUrl.query).to.equal("");
             expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/prebid/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x600%2C728x90/cbid=210af5668b1e23/rand=42");
@@ -169,17 +169,17 @@ describe('Piximedia adapter tests', function () {
                             params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
                             requestId: '59c318fd382219',
                             placementCode: '/20164912/header-bid-tag-0'
-                        } 
+                        }
                 ]
             };
 
             adapter().callBids(params);
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
- 
+
             expect(parsedBidUrl.hostname).to.equal("resources.pm");
             expect(parsedBidUrl.query).to.equal("");
             expect(parsedBidUrl.pathname.replace(/cbid=[a-f0-9]+/, "cbid=210af5668b1e23").replace(/rand=[0-9]+$/, "rand=42")).to.equal("/tests/prebid/bids.js/site_id=TEST/placement_id=TEST/jsonp=pbjs.handlePiximediaCallback/sizes=300x250/cbid=210af5668b1e23/rand=42");
@@ -208,7 +208,7 @@ describe('Piximedia adapter tests', function () {
                         params: { siteId: 'TEST', placementId: "TEST", prebidUrl: "//resources.pm/tests/prebid/bids.js" },
                         requestId: '59c318fd382219',
                         placementCode: '/20164912/header-bid-tag-0'
-                    } 
+                    }
             ]
         };
 
@@ -243,7 +243,7 @@ describe('Piximedia adapter tests', function () {
                 pbjs._bidsRequested = [params];
             } else {
                 pbjs._bidsRequested.push(params);
-            } 
+            }
             pbjs.adUnits = adUnits;
             response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
 
@@ -260,17 +260,17 @@ describe('Piximedia adapter tests', function () {
             expect(bidObject1.dealId).to.equal(9948);
             expect(bidObject1.height).to.equal(250);
             expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+            expect(bidObject1.bidderCode).to.equal('piximedia');
 
-            stubAddBidResponse.restore(); 
-            stubGetUniqueIdentifierStr.restore(); 
-        }); 
+            stubAddBidResponse.restore();
+            stubGetUniqueIdentifierStr.restore();
+        });
 
         it('bidmanager.addBidResponse should be called once with correct arguments on partial response', function () {
             var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
             var stubGetUniqueIdentifierStr = sinon.spy(utils, "getUniqueIdentifierStr");
 
-            // this time, we do not provide dealId 
+            // this time, we do not provide dealId
             var response = {
                 foundbypm: true,
                 cpm: 1.23,
@@ -293,7 +293,7 @@ describe('Piximedia adapter tests', function () {
                 pbjs._bidsRequested = [params];
             } else {
                 pbjs._bidsRequested.push(params);
-            } 
+            }
             pbjs.adUnits = adUnits;
             response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
 
@@ -309,11 +309,11 @@ describe('Piximedia adapter tests', function () {
             expect(bidObject1.width).to.equal(300);
             expect(bidObject1.height).to.equal(250);
             expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+            expect(bidObject1.bidderCode).to.equal('piximedia');
 
-            stubAddBidResponse.restore(); 
-            stubGetUniqueIdentifierStr.restore(); 
-        }); 
+            stubAddBidResponse.restore();
+            stubGetUniqueIdentifierStr.restore();
+        });
 
         it('bidmanager.addBidResponse should be called once without any ads', function () {
             var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
@@ -336,7 +336,7 @@ describe('Piximedia adapter tests', function () {
                 pbjs._bidsRequested = [params];
             } else {
                 pbjs._bidsRequested.push(params);
-            } 
+            }
             pbjs.adUnits = adUnits;
             response.cbid = stubGetUniqueIdentifierStr.returnValues[0];
 
@@ -348,11 +348,11 @@ describe('Piximedia adapter tests', function () {
 
             expect(bidPlacementCode1).to.equal('/20164912/header-bid-tag-0');
             expect(bidObject1.getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-            expect(bidObject1.bidderCode).to.equal('piximedia'); 
+            expect(bidObject1.bidderCode).to.equal('piximedia');
 
-            stubAddBidResponse.restore(); 
-            stubGetUniqueIdentifierStr.restore(); 
-        }); 
+            stubAddBidResponse.restore();
+            stubGetUniqueIdentifierStr.restore();
+        });
 
         it('bidmanager.addBidResponse should not be called on bogus cbid', function () {
             var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
@@ -375,7 +375,7 @@ describe('Piximedia adapter tests', function () {
                 pbjs._bidsRequested = [params];
             } else {
                 pbjs._bidsRequested.push(params);
-            } 
+            }
             pbjs.adUnits = adUnits;
             response.cbid = stubGetUniqueIdentifierStr.returnValues[0] + "_BOGUS";
 
@@ -383,9 +383,9 @@ describe('Piximedia adapter tests', function () {
 
             sinon.assert.notCalled(stubAddBidResponse);
 
-            stubAddBidResponse.restore(); 
-            stubGetUniqueIdentifierStr.restore(); 
-        }); 
+            stubAddBidResponse.restore();
+            stubGetUniqueIdentifierStr.restore();
+        });
 
         it('bidmanager.addBidResponse should not be called on bogus response', function () {
             var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
@@ -405,15 +405,14 @@ describe('Piximedia adapter tests', function () {
                 pbjs._bidsRequested = [params];
             } else {
                 pbjs._bidsRequested.push(params);
-            } 
+            }
             pbjs.adUnits = adUnits;
 
             pbjs.handlePiximediaCallback(response);
 
             sinon.assert.notCalled(stubAddBidResponse);
 
-            stubAddBidResponse.restore(); 
-        }); 
+            stubAddBidResponse.restore();
+        });
     });
 });
-

--- a/test/spec/adapters/wideorbit_spec.js
+++ b/test/spec/adapters/wideorbit_spec.js
@@ -2,7 +2,7 @@ describe('wideorbit adapter tests', function () {
 
     var expect = require('chai').expect;
     var urlParse = require('url-parse');
-    
+
     // FYI: querystringify will perform encoding/decoding
     var querystringify = require('querystringify');
 
@@ -12,14 +12,14 @@ describe('wideorbit adapter tests', function () {
 
     describe('creation of bid url', function () {
 
-        var spyLoadScript;
+        let stubLoadScript;
 
         beforeEach(function () {
-            spyLoadScript = sinon.spy(adLoader, 'loadScript');
+            stubLoadScript = sinon.stub(adLoader, 'loadScript');
         });
 
         afterEach(function () {
-            spyLoadScript.restore();
+            stubLoadScript.restore();
         });
 
         it('should be called only once', function () {
@@ -52,7 +52,7 @@ describe('wideorbit adapter tests', function () {
 
             adapter().callBids(params);
 
-            sinon.assert.calledOnce(spyLoadScript);
+            sinon.assert.calledOnce(stubLoadScript);
 
         });
 
@@ -86,9 +86,9 @@ describe('wideorbit adapter tests', function () {
 
             adapter().callBids(params);
 
-            var bidUrl = spyLoadScript.getCall(0).args[0];
+            var bidUrl = stubLoadScript.getCall(0).args[0];
 
-            sinon.assert.calledWith(spyLoadScript, bidUrl);
+            sinon.assert.calledWith(stubLoadScript, bidUrl);
 
             var parsedBidUrl = urlParse(bidUrl);
             var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
@@ -164,9 +164,9 @@ describe('wideorbit adapter tests', function () {
 
                 adapter().callBids(params);
 
-                var bidUrl = spyLoadScript.getCall(0).args[0];
+                var bidUrl = stubLoadScript.getCall(0).args[0];
 
-                sinon.assert.calledWith(spyLoadScript, bidUrl);
+                sinon.assert.calledWith(stubLoadScript, bidUrl);
 
                 var parsedBidUrl = urlParse(bidUrl);
                 var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
@@ -240,9 +240,9 @@ describe('wideorbit adapter tests', function () {
 
                 adapter().callBids(params);
 
-                var bidUrl = spyLoadScript.getCall(0).args[0];
+                var bidUrl = stubLoadScript.getCall(0).args[0];
 
-                sinon.assert.calledWith(spyLoadScript, bidUrl);
+                sinon.assert.calledWith(stubLoadScript, bidUrl);
 
                 var parsedBidUrl = urlParse(bidUrl);
                 var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
@@ -389,7 +389,7 @@ describe('wideorbit adapter tests', function () {
             expect(bidObject1.height).to.equal(100);
             expect(bidObject1.getStatusCode()).to.equal(1);
             expect(bidObject1.bidderCode).to.equal('wideorbit');
-            
+
             expect(bidPlacementCode2).to.equal('div-gpt-ad-12345-2');
             expect(bidObject2.cpm).to.equal(1.50);
             expect(bidObject2.ad).to.equal('<img src="http://www.admeta.com/2b.gif"></img><img src="http://www.admeta.com/2a.gif" width="0" height="0" style="position:absolute"></img><div data-id="div-gpt-ad-12345-2">The AD 2 itself...</div>');
@@ -488,4 +488,3 @@ describe('wideorbit adapter tests', function () {
     });
 
 });
-  


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Change `spy` to `stub` on unit tests needed to spy on `adLoader`.

## Other information
@prebid/core for review