### PR TITLE
Allow bid to be zero for the floor price to work

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -324,7 +324,7 @@ function adjustBids(bid) {
     }
   }
 
-  if (bidPriceAdjusted !== 0) {
+  if (bidPriceAdjusted >= 0) {
     bid.cpm = bidPriceAdjusted;
   }
 }

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -415,7 +415,7 @@ describe('bidmanager.js', function () {
   });
 
   describe('adjustBids', () => {
-    it('should adjust bids and pass copy of bid object', () => {
+    it('should adjust bids if greater than zero and pass copy of bid object', () => {
       const bid = Object.assign({},
         bidfactory.createBid(2),
         fixtures.getBidResponses()[5]
@@ -428,6 +428,12 @@ describe('bidmanager.js', function () {
         brealtime: {
           bidCpmAdjustment: function (bidCpm, bidObj) {
             assert.deepEqual(bidObj, bid);
+            if (bidObj.adUnitCode === 'negative') {
+              return bidCpm * -0.5;
+            }
+            if (bidObj.adUnitCode === 'zero') {
+              return 0;
+            }
             return bidCpm * 0.5;
           },
         },
@@ -437,8 +443,20 @@ describe('bidmanager.js', function () {
         }
       };
 
+      // negative
+      bid.adUnitCode = 'negative';
+      bidmanager.adjustBids(bid)
+      assert.equal(bid.cpm, .5);
+
+      // positive
+      bid.adUnitCode = 'normal';
       bidmanager.adjustBids(bid)
       assert.equal(bid.cpm, .25);
+
+      // zero
+      bid.adUnitCode = 'zero';
+      bidmanager.adjustBids(bid)
+      assert.equal(bid.cpm, 0);
 
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Allow bid adjusted price to be zero, so that the bid would be ignored. It allows the bidCpmAdjustment to set a floor price, for bidders that don't support it.

## Other information
See https://github.com/prebid/Prebid.js/issues/624#issuecomment-252267252