### PR TITLE
fix data leak in unit tests

### DIFF
--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -465,7 +465,9 @@ describe('bidmanager.js', function () {
     before(() => {
       $$PREBID_GLOBAL$$.adUnits = fixtures.getAdUnits();
     });
-
+    after(() =>{
+      $$PREBID_GLOBAL$$.adUnits = [];
+    });
     it('should return proper price bucket increments for dense mode', () => {
       const bid = Object.assign({},
         bidfactory.createBid(2),


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other


## Description of change
After  $$PREBID_GLOBAL.adUnits gets set in the bidmanager_spec, the values used persist across unit tests. This value was set in a before() function, but it was never set back to its original value. This compromises the integrity of the unit tests. By adding an after() function to reset the adUnits, we no longer get this "data leakage". 

## Other information

I work at sovrn, and we're currently adding our own custom unit tests. However, we quickly realized that the $$PREBID_GLOBAL$$.adUnits property was persisting between tests. I have tracked it down to the before() block, which loads tests data from the fixtures file. By adding an after() block which resets the value of adUnits, we were able to eliminate this problem without breaking any tests.