### PR TITLE
fix unit tests so data is compartmentalized

### DIFF
--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -41,7 +41,7 @@ describe('Publisher API _ AdUnits', function () {
                 }
             ]
     }];
-
+    $$PREBID_GLOBAL$$.adUnits = [];
     $$PREBID_GLOBAL$$.addAdUnits(adUnits);
   });
 

--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -41,7 +41,7 @@ describe('Publisher API _ AdUnits', function () {
                 }
             ]
     }];
-    $$PREBID_GLOBAL$$.adUnits = [];
+    pbjsTestOnly.clearAllAdUnits();
     $$PREBID_GLOBAL$$.addAdUnits(adUnits);
   });
 

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -465,9 +465,6 @@ describe('bidmanager.js', function () {
     before(() => {
       $$PREBID_GLOBAL$$.adUnits = fixtures.getAdUnits();
     });
-    after(() =>{
-      $$PREBID_GLOBAL$$.adUnits = [];
-    });
     it('should return proper price bucket increments for dense mode', () => {
       const bid = Object.assign({},
         bidfactory.createBid(2),

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -465,7 +465,9 @@ describe('bidmanager.js', function () {
     before(() => {
       $$PREBID_GLOBAL$$.adUnits = fixtures.getAdUnits();
     });
-
+    after(() =>{
+      $$PREBID_GLOBAL$$.adUnits = [];
+    });
     it('should return proper price bucket increments for dense mode', () => {
       const bid = Object.assign({},
         bidfactory.createBid(2),

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -5,6 +5,7 @@ import {
   getBidResponsesFromAPI,
   getTargetingKeys,
   getTargetingKeysBidLandscape,
+  getAdUnits
 } from 'test/fixtures/fixtures';
 
 var assert = require('chai').assert;
@@ -24,12 +25,15 @@ var config = require('test/fixtures/config.json');
 $$PREBID_GLOBAL$$ = $$PREBID_GLOBAL$$ || {};
 $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
 $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
+$$PREBID_GLOBAL$$.adUnits = getAdUnits();
 
 function resetAuction() {
   $$PREBID_GLOBAL$$._sendAllBids = false;
   $$PREBID_GLOBAL$$.clearAuction();
   $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
   $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
+  $$PREBID_GLOBAL$$.adUnits = getAdUnits();
+
 }
 
 var Slot = function Slot(elementId, pathId) {
@@ -101,7 +105,9 @@ window.googletag = {
 };
 
 describe('Unit: Prebid Module', function () {
-
+  after(function(){
+    $$PREBID_GLOBAL$$.adUnits = [];
+  })
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     it('should return targeting info as a string', function () {
       const adUnitCode = config.adUnitCodes[0];


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other

## Description of change
Revision to PR #693 - Sorry for the multiple failing PRs, I was accidentally working with an old version of Prebid locally

After $$PREBID_GLOBAL$$.adUnits gets set in the bidmanager_spec, the values used persist across tests. This value was set in a before() function, but it was never set back to its original value.  The same global variable persists across the tests, so having this test data "leak" accross spec files compromises their integrity. By adding an after() function to reset the adUnits, we no longer get this "data leakage". adunits_spec and pbjs_api_spec needed similar revisions as well.


## Other information
I work at sovrn, and we're currently adding our own custom tests. However, we quickly realized that the $$PREBID_GLOBAL$$.adUnits property was filled with test data, even though it should have been an empty array. I have tracked it down to the before() block in bidmanager_spec, which loads tests data from the fixtures file. By adding an after() block which resets the value of adUnits, we were able to eliminate this problem 