### PR TITLE
Fix timeout issues #699

### DIFF
--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -23,7 +23,6 @@ function Bid(statusCode, bidRequest) {
   this.height = 0;
   this.statusMessage = _getStatus();
   this.adId = _bidId;
-  this.complete = false;
 
   function _getStatus() {
     switch (_statusCode) {

--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -23,6 +23,7 @@ function Bid(statusCode, bidRequest) {
   this.height = 0;
   this.statusMessage = _getStatus();
   this.adId = _bidId;
+  this.complete = false;
 
   function _getStatus() {
     switch (_statusCode) {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -224,7 +224,7 @@ exports.registerDefaultBidderSetting = function (bidderCode, defaultSetting) {
 
 exports.executeCallback = function (timedOut) {
   // if there's still a timeout running, clear it now
-  if (externalOneTimeCallbackTimer) {
+  if (!timedOut && externalOneTimeCallbackTimer) {
     clearTimeout(externalOneTimeCallbackTimer);
   }
 
@@ -248,6 +248,7 @@ exports.executeCallback = function (timedOut) {
     }
     finally {
       externalOneTimeCallback = null;
+      externalOneTimeCallbackTimer = false;
       $$PREBID_GLOBAL$$.clearAuction();
     }
   }

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -9,6 +9,7 @@ var objectType_function = 'function';
 var externalCallbackByAdUnitArr = [];
 var externalCallbackArr = [];
 var externalOneTimeCallback = null;
+var externalOneTimeCallbackTimer = false;
 var _granularity = CONSTANTS.GRANULARITY_OPTIONS.MEDIUM;
 var defaultBidderSettingsMap = {};
 
@@ -222,6 +223,11 @@ exports.registerDefaultBidderSetting = function (bidderCode, defaultSetting) {
 };
 
 exports.executeCallback = function (timedOut) {
+  // if there's still a timeout running, clear it now
+  if (externalOneTimeCallbackTimer) {
+    clearTimeout(externalOneTimeCallbackTimer);
+  }
+
   if (externalCallbackArr.called !== true) {
     processCallbacks(externalCallbackArr);
     externalCallbackArr.called = true;
@@ -290,10 +296,12 @@ function groupByPlacement(prev, item, idx, arr) {
 
 /**
  * Add a one time callback, that is discarded after it is called
- * @param {Function} callback [description]
+ * @param {Function} callback
+ * @param timer Timer to clear if callback is triggered before timer time's out
  */
-exports.addOneTimeCallback = function (callback) {
+exports.addOneTimeCallback = function (callback, timer) {
   externalOneTimeCallback = callback;
+  externalOneTimeCallbackTimer = timer;
 };
 
 exports.addCallback = function (id, callback, cbEvent) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -276,11 +276,12 @@ function removeComplete() {
   let requests = $$PREBID_GLOBAL$$._bidsRequested;
   let responses = $$PREBID_GLOBAL$$._bidsReceived;
 
-  requests.map(request => request.bids
-      .filter(bid => bid.complete))
-    .forEach(request => requests.splice(requests.indexOf(request), 1));
+  requests.filter(request => {
+    let bids = request.bids.filter(bid => bid.complete === true);
+    return bids.length === request.bids.length;
+  }).forEach(request => requests.splice(requests.indexOf(request), 1));
 
-  responses.filter(bid => bid.complete).forEach(bid => responses.splice(responses.indexOf(bid), 1));
+  responses.filter(bid => bid.complete === true).forEach(bid => responses.splice(responses.indexOf(bid), 1));
 
   // also remove bids that have an empty or error status so known as not pending for render
   responses.filter(bid => bid.getStatusCode && bid.getStatusCode() === 2)

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -37,6 +37,7 @@ var eventValidators = {
 
 $$PREBID_GLOBAL$$._bidsRequested = [];
 $$PREBID_GLOBAL$$._bidsReceived = [];
+$$PREBID_GLOBAL$$._adUnitCodes = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
 $$PREBID_GLOBAL$$._sendAllBids = false;
@@ -262,30 +263,22 @@ function getAllTargeting() {
   return targeting;
 }
 
-function markComplete(adObject) {
-  $$PREBID_GLOBAL$$._bidsRequested.filter(request => request.requestId === adObject.requestId)
-    .forEach(request => request.bids.filter(bid => bid.placementCode === adObject.adUnitCode)
-      .forEach(bid => bid.complete = true));
-
-  $$PREBID_GLOBAL$$._bidsReceived.filter(bid => {
-    return bid.requestId === adObject.requestId && bid.adUnitCode === adObject.adUnitCode;
-  }).forEach(bid => bid.complete = true);
-}
-
-function removeComplete() {
+function removePreviousBids(adUnitCode) {
   let requests = $$PREBID_GLOBAL$$._bidsRequested;
   let responses = $$PREBID_GLOBAL$$._bidsReceived;
 
   requests.filter(request => {
-    let bids = request.bids.filter(bid => bid.complete === true);
-    return bids.length === request.bids.length;
+    request.bids.filter(bid => {
+      // bid has the placementCode, remove it
+      if (bid.placementCode === adUnitCode) {
+        return request.bids.splice(request.bids.indexOf(bid), 1);
+      }
+    });
+    // if there's no more bids, then the request can be removed
+    return request.bids.length === 0;
   }).forEach(request => requests.splice(requests.indexOf(request), 1));
 
-  responses.filter(bid => bid.complete === true).forEach(bid => responses.splice(responses.indexOf(bid), 1));
-
-  // also remove bids that have an empty or error status so known as not pending for render
-  responses.filter(bid => bid.getStatusCode && bid.getStatusCode() === 2)
-    .forEach(bid => responses.splice(responses.indexOf(bid), 1));
+  responses.filter(bid => bid.placementCode === adUnitCode).forEach(bid => responses.splice(responses.indexOf(bid), 1));
 }
 
 //////////////////////////////////
@@ -428,7 +421,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function () {
  */
 $$PREBID_GLOBAL$$.allBidsAvailable = function () {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.allBidsAvailable', arguments);
-  return bidmanager.bidsBackAll();
+  return bidmanager.bidsBack();
 };
 
 /**
@@ -450,8 +443,6 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         //emit 'bid won' event here
         events.emit(BID_WON, adObject);
 
-        // mark bid requests and responses for this placement in this auction as "complete"
-        markComplete(adObject);
         var height = adObject.height;
         var width = adObject.width;
         var url = adObject.adUrl;
@@ -544,13 +535,15 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
 
   if (auctionRunning) {
     bidRequestQueue.push(() => {
-      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, timeout: cbTimeout, adUnits });
+      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, timeout: cbTimeout, adUnits, adUnitCodes });
     });
     return;
-  } else {
-    auctionRunning = true;
-    removeComplete();
   }
+  auctionRunning = true;
+  for (let i = 0; i < adUnitCodes.length; i++) {
+    removePreviousBids(adUnitCodes[i]);
+  }
+  $$PREBID_GLOBAL$$._adUnitCodes = adUnitCodes;
 
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -518,9 +518,10 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
 $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes }) {
   const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
+  adUnitCodes = adUnitCodes || [];
 
   // if specific adUnitCodes filter adUnits for those codes
-  if (adUnitCodes && adUnitCodes.length) {
+  if (adUnitCodes.length) {
     adUnits = adUnits.filter(adUnit => adUnitCodes.includes(adUnit.code));
   }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -543,7 +543,7 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
 
   if (auctionRunning) {
     bidRequestQueue.push(() => {
-      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, cbTimeout, adUnits });
+      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, timeout: cbTimeout, adUnits });
     });
     return;
   } else {
@@ -551,22 +551,23 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     removeComplete();
   }
 
-  if (typeof bidsBackHandler === objectType_function) {
-    bidmanager.addOneTimeCallback(bidsBackHandler);
-  }
-
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
   if (!adUnits || adUnits.length === 0) {
     utils.logMessage('No adUnits configured. No bids requested.');
+    if (typeof bidsBackHandler === objectType_function) {
+      bidmanager.addOneTimeCallback(bidsBackHandler);
+    }
     bidmanager.executeCallback();
     return;
   }
 
   //set timeout for all bids
-  const timedOut = true;
-  const timeoutCallback = bidmanager.executeCallback.bind(bidmanager, timedOut);
-  setTimeout(timeoutCallback, cbTimeout);
+  const timeoutCallback = bidmanager.executeCallback.bind(bidmanager, true);
+  const timer = setTimeout(timeoutCallback, cbTimeout);
+  if (typeof bidsBackHandler === objectType_function) {
+    bidmanager.addOneTimeCallback(bidsBackHandler, timer);
+  }
 
   adaptermanager.callBids({ adUnits, adUnitCodes, cbTimeout });
 };

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -542,6 +542,13 @@ export function getSlotTargeting() {
   };
 }
 
+export function getAdUnitCodes() {
+  return [
+    "/19968336/header-bid-tag-0",
+    "/19968336/header-bid-tag1"
+  ];
+};
+
 export function getAdUnits() {
   return [
     {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -5,6 +5,7 @@ import {
   getBidResponsesFromAPI,
   getTargetingKeys,
   getTargetingKeysBidLandscape,
+  getAdUnitCodes,
   getAdUnits
 } from 'test/fixtures/fixtures';
 
@@ -25,6 +26,7 @@ var config = require('test/fixtures/config.json');
 $$PREBID_GLOBAL$$ = $$PREBID_GLOBAL$$ || {};
 $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
 $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
+$$PREBID_GLOBAL$$._adUnitCodes = getAdUnitCodes();
 $$PREBID_GLOBAL$$.adUnits = getAdUnits();
 
 function resetAuction() {
@@ -32,6 +34,7 @@ function resetAuction() {
   $$PREBID_GLOBAL$$.clearAuction();
   $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
   $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
+  $$PREBID_GLOBAL$$._adUnitCodes = getAdUnitCodes();
   $$PREBID_GLOBAL$$.adUnits = getAdUnits();
 
 }
@@ -432,11 +435,11 @@ describe('Unit: Prebid Module', function () {
 
   describe('allBidsAvailable', function () {
     it('should call bidmanager.allBidsBack', function () {
-      var spyAllBidsBack = sinon.spy(bidmanager, 'bidsBackAll');
+      var spyAllBidsBack = sinon.spy(bidmanager, 'bidsBack');
 
       $$PREBID_GLOBAL$$.allBidsAvailable();
       assert.ok(spyAllBidsBack.called, 'called bidmanager.allBidsBack');
-      bidmanager.bidsBackAll.restore();
+      bidmanager.bidsBack.restore();
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
If all bidders respond within the timeout, the callback is called again as the end of the timer, because it's not cleared. Hence the second auction ends too early.
Also, another bug fix: when an auction is running and another adUnit is sent to requestBids, the timeout was wrongly set as `cbTimeout` instead of `timeout`

New fixes:
- remove old bids when same adUnitCode is called again
- fixed getBidSetForBidder() so that it returns the good bid and fixes the timeout issue in https://github.com/prebid/Prebid.js/issues/643

## Other information
@mkendall07 
https://github.com/prebid/Prebid.js/issues/699