### PR TITLE
Fix how it is determined whether all bid requests have been responded to

### DIFF
--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -467,7 +467,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
           } else {
             let bid = bidfactory.createBid(2);
             bid.bidderCode = ADAPTER_CODE;
-            bidmanager.addBidResponse(adUnitCode, bid);
+            bidmanager.addBidResponse(adUnitCode, [bid]);
           }
 
         }

--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -418,29 +418,30 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
         var indexObj = _IndexRequestData.targetIDToBid;
         var lookupObj = cygnus_index_args;
 
-        // Grab all the bids for each slot
-        for (var adSlotId in slotIdMap) {
-          var bidObj = slotIdMap[adSlotId];
-          var adUnitCode = bidObj.placementCode;
+        var bidsByAdUnitCode = {};
 
-          var bids = [];
+        // Grab all the bids for each slot
+        for (let adSlotId in slotIdMap) {
+          let bidObj = slotIdMap[adSlotId];
+          let adUnitCode = bidObj.placementCode;
+          if(!bidsByAdUnitCode[adUnitCode]){ bidsByAdUnitCode[adUnitCode] = []; }
 
           // Grab the bid for current slot
-          for (var cpmAndSlotId in indexObj) {
-            var match = /^(T\d_)?(.+)_(\d+)$/.exec(cpmAndSlotId);
+          for (let cpmAndSlotId in indexObj) {
+            let match = /^(T\d_)?(.+)_(\d+)$/.exec(cpmAndSlotId);
             // if parse fail, move to next bid
             if (!(match)){
               utils.logError("Unable to parse " + cpmAndSlotId + ", skipping slot", ADAPTER_NAME);
               continue;
             }
-            var tier = match[1] || '';
-            var slotID = match[2];
-            var currentCPM = match[3];
+            let tier = match[1] || '';
+            let slotID = match[2];
+            let currentCPM = match[3];
 
-            var slotObj = getSlotObj(cygnus_index_args, tier + slotID);
+            let slotObj = getSlotObj(cygnus_index_args, tier + slotID);
             // Bid is for the current slot
             if (slotID === adSlotId) {
-              var bid = bidfactory.createBid(1);
+              let bid = bidfactory.createBid(1);
               bid.cpm = currentCPM / 100;
               bid.ad = indexObj[cpmAndSlotId][0];
               bid.ad_id = adSlotId;
@@ -451,23 +452,22 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
               if ( typeof _IndexRequestData.targetIDToResp === 'object' && typeof _IndexRequestData.targetIDToResp[cpmAndSlotId] === 'object' && typeof _IndexRequestData.targetIDToResp[cpmAndSlotId].dealID !== 'undefined' ) {
                 bid.dealId = _IndexRequestData.targetIDToResp[cpmAndSlotId].dealID;
               }
-              bids.push(bid);
+              bidsByAdUnitCode[adUnitCode].push(bid);
             }
           }
+        }
 
-          var currentBid = undefined;
+        for (let adUnitCode in bidsByAdUnitCode) {
 
+          let bids = bidsByAdUnitCode[adUnitCode];
           if (bids.length > 0) {
             // Add all bid responses
-            for (var i = 0; i < bids.length; i++) {
-              bidmanager.addBidResponse(adUnitCode, bids[i]);
-            }
+            bidmanager.addBidResponse(adUnitCode, bids);
           // No bids for expected bid, pass bid
           } else {
-            var bid = bidfactory.createBid(2);
+            let bid = bidfactory.createBid(2);
             bid.bidderCode = ADAPTER_CODE;
-            currentBid = bid;
-            bidmanager.addBidResponse(adUnitCode, currentBid);
+            bidmanager.addBidResponse(adUnitCode, bid);
           }
 
         }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -36,6 +36,7 @@ var eventValidators = {
 /* Public vars */
 
 $$PREBID_GLOBAL$$._bidsRequested = [];
+$$PREBID_GLOBAL$$._bidRequestDone = {};
 $$PREBID_GLOBAL$$._bidsReceived = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];

--- a/test/spec/adapters/indexExchange_response_spec.js
+++ b/test/spec/adapters/indexExchange_response_spec.js
@@ -57,15 +57,16 @@ describe('indexExchange adapter - Response', function () {
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
 			var bids       = bidManager.addBidResponse.getCall(i).args[1];
-
+			
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
 		for ( var i = 0; i < prebidResponsePair.matched.length; i++) {
+		
 			var pair = prebidResponsePair.matched[i];
 
 			assert.equal(pair.prebid[i].siteID,     pair.expected[i].siteID,     "adapter response for " + pair.placementCode + " siteID is set to "+pair.expected[i].siteID);
@@ -104,7 +105,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -149,7 +150,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -193,7 +194,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -241,7 +242,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -289,7 +290,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -345,7 +346,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -394,7 +395,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -443,7 +444,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -498,7 +499,7 @@ describe('indexExchange adapter - Response', function () {
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].concat(bids);
+			adapterResponse[adUnitCode] = adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);

--- a/test/spec/adapters/indexExchange_response_spec.js
+++ b/test/spec/adapters/indexExchange_response_spec.js
@@ -56,12 +56,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -99,12 +99,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -144,12 +144,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -188,12 +188,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -236,12 +236,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -284,12 +284,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -340,12 +340,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -389,12 +389,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -438,12 +438,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);
@@ -493,12 +493,12 @@ describe('indexExchange adapter - Response', function () {
 
 		for ( var i = 0; i < bidManager.addBidResponse.callCount; i++ ) {
 			var adUnitCode = bidManager.addBidResponse.getCall(i).args[0];
-			var bid        = bidManager.addBidResponse.getCall(i).args[1];
+			var bids       = bidManager.addBidResponse.getCall(i).args[1];
 
 			if ( typeof adapterResponse[adUnitCode] === 'undefined'){
 				adapterResponse[adUnitCode] = [];
 			};
-			adapterResponse[adUnitCode].push(bid);
+			adapterResponse[adUnitCode].concat(bids);
 		}
 
 		var prebidResponsePair = IndexUtils.matchOnPlacementCode(expectedAdapterResponse, adapterResponse);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

We discovered a structural problem in Prebid.js with determining when all bid requests have been responded to. As a consequence, the adUnitBidsBack and allRequestedBidsBack callbacks are fired at the wrong time.

### Issues and proposed solution for Prebid

The underlying cause appears to be that adapters are free to call addBidResponse multiple times
if they want to return multiple bids for a single bid request. Our proposed solution is to require adapters to call addBidResponse only once per request, but make it possible to provide an array of bids. A new data structure is used to keep track of the number of addBidResponse calls per ad unit. This changes the API between Prebid and the adapters, but we have made addBidResponse backwards-compatible in that it will accept a bid object or an array of bid objects.

It is still a requirement that each adapter be correctly written to call addBidResponse the correct number of times: once per bid request configured. If only one adapter (that is enabled) fails to do so, and calls addBidResponse too many times, then the number of responses counted as received will equal the number of bid requests configured prematurely, causing the adUnitBidsBack and allRequestedBidsBack callbacks to fire before all bid responses have in fact been received.

### Issues and proposed solution for the indexExchange adapter

In conjuction with the above, the indexExchange adapter also needed to be modified to be compatible with the new API.

As far as we see, previously indexExchange would return a single bid for each request as it used to group the received bids by ad unit and then select the best bid itself. Selecting the best bid was stopped in 11f617781f279989b1387dd18300c11a266e01d5 to enable deal auctions, and the adapter also switched to grouping bids both by ad unit and by size.

Our proposed solution is for indexExchange to group bids by ad unit into separate arrays, and
call addBidResponse with each array. In our setup this fixes the issue of the callbacks being called prematurely, but we are unsure if this solution is sufficient to ensure that IndexEchange calls addBidResponse as many times as there are bid requests (provided it supports multiple requests).

Some variable scopes are also reduced to avoid clashes.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@indexexchange