### PR TITLE
UnderdogMedia - CDN on a cookieless domain. Optional divId param. Pass bids to library as an array.

### DIFF
--- a/src/adapters/underdogmedia.js
+++ b/src/adapters/underdogmedia.js
@@ -5,7 +5,7 @@ var utils = require('../utils.js');
 
 var UnderdogMediaAdapter = function UnderdogMediaAdapter() {
 
-  var getJsStaticUrl = window.location.protocol + '//rtb.udmserve.net/udm_header_lib.js';
+  var getJsStaticUrl = window.location.protocol + '//bid.underdog.media/udm_header_lib.js';
 
   function _callBids(params) {
     if (typeof window.udm_header_lib === 'undefined') {
@@ -17,18 +17,21 @@ var UnderdogMediaAdapter = function UnderdogMediaAdapter() {
 
   function bid(params) {
     var bids = params.bids;
+    var mapped_bids = [];
     for (var i = 0; i < bids.length; i++) {
       var bidRequest = bids[i];
       var callback = bidResponseCallback(bidRequest);
-      var udmBidRequest = new window.udm_header_lib.BidRequest({
+      mapped_bids.push({
         sizes: bidRequest.sizes,
         siteId: bidRequest.params.siteId,
         bidfloor: bidRequest.params.bidfloor,
         placementCode: bidRequest.placementCode,
+        divId: bidRequest.params.divId,
         callback: callback
       });
-      udmBidRequest.send();
     }
+    var udmBidRequest = new window.udm_header_lib.BidRequestArray(mapped_bids);
+    udmBidRequest.send();
   }
 
   function bidResponseCallback(bid) {

--- a/src/adapters/underdogmedia.js
+++ b/src/adapters/underdogmedia.js
@@ -27,6 +27,7 @@ var UnderdogMediaAdapter = function UnderdogMediaAdapter() {
         bidfloor: bidRequest.params.bidfloor,
         placementCode: bidRequest.placementCode,
         divId: bidRequest.params.divId,
+        subId: bidRequest.params.subId,
         callback: callback
       });
     }

--- a/test/spec/adapters/underdogmedia_spec.js
+++ b/test/spec/adapters/underdogmedia_spec.js
@@ -20,15 +20,14 @@ describe('underdog media adapter test', () => {
             if(siteId == 10272){
               // Only bid on this particular site id
               var bids = [];
-              for(var i = 0; i < options.sizes.length; i++){
-                var size = options.sizes[i];
+              options.sizes.forEach(function(size){
                 bids.push({
                   cpm: 3.14,
                   ad_html: `Ad HTML for site ID ${siteId} size ${size[0]}x${size[1]}`,
                   width:   size[0],
                   height:  size[1]
                 });
-              }
+              });
               options.callback({
                 bids: bids
               });
@@ -45,11 +44,10 @@ describe('underdog media adapter test', () => {
     BidRequestArray: function(arr){
       return {
         send: function(){
-          for(var i = 0; i < arr.length; i++){
-            var req = new window.udm_header_lib.BidRequest(arr[i]);
+          arr.forEach(function(bidRequest){
+            var req = new window.udm_header_lib.BidRequest(bidRequest);
             req.send();
-
-          }
+          });
         }
       };
     }

--- a/test/spec/adapters/underdogmedia_spec.js
+++ b/test/spec/adapters/underdogmedia_spec.js
@@ -40,8 +40,19 @@ describe('underdog media adapter test', () => {
 
         }
       };
-    }
+    },
 
+    BidRequestArray: function(arr){
+      return {
+        send: function(){
+          for(var i = 0; i < arr.length; i++){
+            var req = new window.udm_header_lib.BidRequest(arr[i]);
+            req.send();
+
+          }
+        }
+      };
+    }
   };
 
   // The third bid here is an invalid site id and should return a 'no-bid'.


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

1. Move our header bidding library to a cookieless domain. This is for performance.
2. Pass bid requests to the library as an array, this allows performance enhancements within our library.
3. Add divId as an optional parameter to bidrequests. This can be used for reporting purposes.