### PR TITLE
Add iOS devices to Browserstack config

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -191,6 +191,30 @@
     "device": null,
     "os": "OS X"
   },
+  "bs_ios_7": {
+    "base": "BrowserStack",
+    "os": "ios",
+    "os_version": "7.0",
+    "browser": "iphone",
+    "device": "iPhone 5S",
+    "browser_version": null
+  },
+  "bs_ios_8": {
+    "base": "BrowserStack",
+    "os": "ios",
+    "os_version": "8.3",
+    "browser": "iphone",
+    "device": "iPhone 6",
+    "browser_version": null
+  },
+  "bs_ios_9": {
+    "base": "BrowserStack",
+    "os": "ios",
+    "os_version": "9.1",
+    "browser": "iphone",
+    "device": "iPhone 6S",
+    "browser_version": null
+  },
   "Chrome_travis_ci": {
     "base": "Chrome",
     "flags": ["--no-sandbox"]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,7 +120,10 @@ gulp.task('test', function () {
       'bs_chrome_51_mac_yosemite',
       'bs_safari_7.1_mac_mavericks',
       'bs_firefox_46_mac_mavericks',
-      'bs_chrome_49_mac_mavericks'
+      'bs_chrome_49_mac_mavericks',
+      'bs_ios_7',
+      'bs_ios_8',
+      'bs_ios_9',
     ];
   }
 


### PR DESCRIPTION
## Type of change
- [x] CI related changes

## Description of change
Add iOS 7, 8, and 9 configurations as available testing devices

## Other information
Configurations retrieved from https://www.browserstack.com/automate/rest-api#rest-api-browsers
