### PR TITLE
bidmanager: use explicit 'exports' function references to aid ES6

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -85,7 +85,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
     if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout + $$PREBID_GLOBAL$$.timeoutBuffer) {
       const timedOut = true;
 
-      this.executeCallback(timedOut);
+      exports.executeCallback(timedOut);
     }
 
     //emit the bidAdjustment event before bidResponse, so bid response has the adjusted bid value
@@ -122,7 +122,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
   }
 
   if (bidsBackAll()) {
-    this.executeCallback();
+    exports.executeCallback();
   }
 };
 
@@ -227,7 +227,7 @@ exports.executeCallback = function (timedOut) {
     externalCallbackArr.called = true;
 
     if (timedOut) {
-      const timedOutBidders = this.getTimedOutBidders();
+      const timedOutBidders = exports.getTimedOutBidders();
 
       if (timedOutBidders.length) {
         events.emit(CONSTANTS.EVENTS.BID_TIMEOUT, timedOutBidders);
@@ -445,7 +445,7 @@ function getPriceBucketString(cpm) {
       }
     }
   } catch (e) {
-    this.logError('Exception parsing CPM :' + e.message);
+    utils.logError('Exception parsing CPM', 'bidmanager.js', e);
   }
 
   return returnObj;


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

Hello, I ran into this problem whilst working on a new adapter (which will be a in separate PR).

The "internal" function references within `bidmanager` currently rely on `this` being implicitly bound to `exports`.

This PR changes these references to explicitly use the `exports` Object, which then allows the use of ES6 notation to import named functions from this module.

```javascript
import { addBidResponse } from 'src/bidmanager'; // <-- this PR makes this possible
```

In addition, the error handler in `getPriceBucketString` was attempting to call a non-existing function and generating an error of its own, so details of the underlying error were being lost.