### PR TITLE
Show warning if bidCpmAdjustment is set for AOL bidder (closes #725)

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -121,11 +121,10 @@ const AolAdapter = function AolAdapter() {
         // needs to be here in case bidderSettings are defined after requestBids() is called
         if (showCpmAdjustmentWarning &&
           $$PREBID_GLOBAL$$.bidderSettings && $$PREBID_GLOBAL$$.bidderSettings.aol &&
-          typeof $$PREBID_GLOBAL$$.bidderSettings.aol.bidCpmAdjustment === 'function' &&
-          console && console.warn
+          typeof $$PREBID_GLOBAL$$.bidderSettings.aol.bidCpmAdjustment === 'function'
         ) {
-          console.warn(
-            'WARNING: bidCpmAdjustment is active for the AOL adapter. ' +
+          utils.logWarn(
+            'bidCpmAdjustment is active for the AOL adapter. ' +
             'As of Prebid 0.14, AOL can bid in net – please contact your accounts team to enable.'
           );
         }

--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -5,6 +5,7 @@ const bidmanager = require('../bidmanager.js');
 
 const AolAdapter = function AolAdapter() {
 
+  let showCpmAdjustmentWarning = true;
   const pubapiTemplate = template`${'protocol'}://${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'}${'bidfloor'};misc=${'misc'}`;
   const BIDDER_CODE = 'aol';
   const SERVER_MAP = {
@@ -117,6 +118,19 @@ const AolAdapter = function AolAdapter() {
       const pubapiUrl = _buildPubapiUrl(bid);
 
       ajax(pubapiUrl, response => {
+        // needs to be here in case bidderSettings are defined after requestBids() is called
+        if (showCpmAdjustmentWarning &&
+          $$PREBID_GLOBAL$$.bidderSettings && $$PREBID_GLOBAL$$.bidderSettings.aol &&
+          typeof $$PREBID_GLOBAL$$.bidderSettings.aol.bidCpmAdjustment === 'function' &&
+          console && console.warn
+        ) {
+          console.warn(
+            'WARNING: bidCpmAdjustment is active for the AOL adapter. ' +
+            'As of Prebid 0.14, AOL can bid in net – please contact your accounts team to enable.'
+          );
+        }
+        showCpmAdjustmentWarning = false; // warning is shown at most once
+
         if (!response && response.length <= 0) {
           utils.logError('Empty bid response', BIDDER_CODE, bid);
           _addErrorBidResponse(bid, response);

--- a/test/spec/adapters/aol_spec.js
+++ b/test/spec/adapters/aol_spec.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import _ from 'lodash';
+import * as utils from 'src/utils';
 import AolAdapter from 'src/adapters/aol';
 import bidmanager from 'src/bidmanager';
 
@@ -449,7 +450,7 @@ describe('AolAdapter', () => {
       });
 
       it('should show warning in the console', function() {
-        sinon.spy(console, 'warn');
+        sinon.spy(utils, 'logWarn');
         server.respondWith(JSON.stringify(DEFAULT_PUBAPI_RESPONSE));
         $$PREBID_GLOBAL$$.bidderSettings = {
           aol: {
@@ -458,7 +459,7 @@ describe('AolAdapter', () => {
         };
         adapter.callBids(DEFAULT_BIDDER_REQUEST);
         server.respond();
-        expect(console.warn.calledOnce).to.be.true;
+        expect(utils.logWarn.calledOnce).to.be.true;
       });
     });
   });

--- a/test/spec/adapters/aol_spec.js
+++ b/test/spec/adapters/aol_spec.js
@@ -430,5 +430,36 @@ describe('AolAdapter', () => {
         expect(bidResponse.cpm).to.equal('a9334987');
       });
     });
+
+    describe('when bidCpmAdjustment is set', () => {
+      let bidderSettingsBackup;
+      let server;
+
+      beforeEach(() => {
+        bidderSettingsBackup = $$PREBID_GLOBAL$$.bidderSettings;
+        server = sinon.fakeServer.create();
+      });
+
+      afterEach(() => {
+        $$PREBID_GLOBAL$$.bidderSettings = bidderSettingsBackup;
+        server.restore();
+        if (console.warn.restore) {
+          console.warn.restore();
+        }
+      });
+
+      it('should show warning in the console', function() {
+        sinon.spy(console, 'warn');
+        server.respondWith(JSON.stringify(DEFAULT_PUBAPI_RESPONSE));
+        $$PREBID_GLOBAL$$.bidderSettings = {
+          aol: {
+            bidCpmAdjustment: function() {}
+          }
+        };
+        adapter.callBids(DEFAULT_BIDDER_REQUEST);
+        server.respond();
+        expect(console.warn.calledOnce).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
After the recent update of AOL adapter made in #653, the bid price adjustment is not recommended on the client side and it has been moved onto backend. In the PR I suggested a note to be included in the release notes, but I expect that can be not enough and some publishers may over look that.

This PR adds a warning in the console if the publisher has configured bidCpmAdjustment as discussed in #725. It will help publishers to be aware of the change introduced in the upcoming version.

I did not use utils.logWarn() method as it is better to show this warning regardless of whether the debug mode is on or off.