### PR TITLE
replaced Rubicon adapter with new light-weight adapter

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -1,379 +1,195 @@
 /**
- * @file Rubicon (Rubicon) adapter
+ * @file Rubicon (RubiconRapid) adapter
  */
 
-// jshint ignore:start
-var utils = require('../utils');
-var bidmanager = require('../bidmanager');
-var bidfactory = require('../bidfactory');
-var adloader = require('../adloader');
+var CONSTANTS = require('../constants.json');
+var utils = require('../utils.js');
+var bidmanager = require('../bidmanager.js');
+var bidfactory = require('../bidfactory.js');
+var ajax = require("../ajax.js").ajax;
 
-const TIMEOUT_BUFFER = 100;
+function RubiconAdapter(mockResponse) {
 
-/**
- * @class RubiconAdapter
- * Prebid adapter for Rubicon's header bidding client
- */
-var RubiconAdapter = function RubiconAdapter() {
-  var RUBICONTAG_URL = (window.location.protocol) + '//ads.rubiconproject.com/header/';
-  var RUBICON_BIDDER_CODE = 'rubicon';
-  var RUBICON_SIZE_MAP = {
-    '468x60': 1,
-    '728x90': 2,
-    '120x600': 8,
-    '160x600': 9,
-    '300x600': 10,
-    '300x250': 15,
-    '336x280': 16,
-    '320x50': 43,
-    '300x50': 44,
-    '300x1050': 54,
-    '970x90': 55,
-    '970x250': 57,
-    '1000x90': 58,
-    '320x80': 59,
-    '640x480': 65,
-    '320x480': 67,
-    '1800x1000': 68,
-    '320x320': 72,
-    '320x160': 73,
-    '480x320': 101,
-    '768x1024': 102,
-    '1000x300': 113,
-    '320x100': 117,
-    '800x250': 125,
-    '200x600': 126
+  var sizeMap = {
+    1:'468x60',
+    2:'728x90',
+    8:'120x600',
+    9:'160x600',
+    10:'300x600',
+    15:'300x250',
+    16:'336x280',
+    43:'320x50',
+    44:'300x50',
+    54:'300x1050',
+    55:'970x90',
+    57:'970x250',
+    58:'1000x90',
+    59:'320x80',
+    65:'640x480',
+    67:'320x480',
+    68:'1800x1000',
+    72:'320x320',
+    73:'320x160',
+    101:'480x320',
+    102:'768x1024',
+    113:'1000x300',
+    117:'320x100',
+    125:'800x250',
+    126:'200x600'
   };
-  var RUBICON_INITIALIZED = (window.rubicontag === undefined) ? 0 : 1;
+  utils._each(sizeMap, (item, key) => sizeMap[item] = key);
 
-  // the fastlane creative code
-  var RUBICON_CREATIVE_START = '<script type="text/javascript">;(function (rt, fe) { rt.renderCreative(fe, "';
-  var RUBICON_CREATIVE_END = '"); }((parent.window.rubicontag || window.top.rubicontag), (document.body || document.documentElement)));</script>';
+  function _callBids(bidderRequest) {
+    var bids = bidderRequest.bids || [];
 
-  // pre-initialize the rubicon object
-  // needs to be attached to the window
-  window.rubicontag = window.rubicontag || {};
-  window.rubicontag.cmd = window.rubicontag.cmd || [];
+    bids.forEach(bid => {
+      if(!mockResponse) {
+        ajax(buildOptimizedCall(bid), cb, undefined, {withCredentials: true});
+      } else {
+        cb(mockResponse);
+      }
 
-  // timestamp for logging
-  var _bidStart = null;
+      function cb(responseText) {
+        try {
+          utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
+          handleRpCB(responseText, bid);
+        } catch(err) {
+          if(typeof err === "string") {
+            utils.logWarn(`${err} when processing RubiconRapid for placement code ${bid.placementCode}`);
+          } else {
+            utils.logError('Error processing response in RubiconRapid for placement code ' + bid.placementCode, null, err);
+          }
 
-  /**
-   * Create an error bid
-   * @param {String} placement - the adunit path
-   * @param {Object} slot - the (error) response from fastlane
-   * @return {Bid} a bid, for prebid
-   */
-  function _errorBid(slot, ads) {
-    var bidResponse = bidfactory.createBid(2, slot.bid);
-    bidResponse.bidderCode = RUBICON_BIDDER_CODE;
-
-    // use the raw ads as the 'error'
-    bidResponse.error = ads;
-    return bidResponse;
+          //indicate that there is no bid for this placement
+          let badBid = bidfactory.createBid(2, bid);
+          badBid.bidderCode = bid.bidder;
+          badBid.error = err;
+          bidmanager.addBidResponse(bid.placementCode, badBid);
+        }
+      }
+    });
   }
 
-  /**
-   * Sort function for CPM
-   * @param {Object} adA
-   * @param {Object} adB
-   * @return {Float} sort order value
-   */
+  function buildOptimizedCall(bid) {
+    bid.startTime = new Date().getTime();
+
+    var {
+      accountId,
+      siteId,
+      zoneId,
+      position,
+      keywords,
+      visitor,
+      inventory,
+      userId,
+      referrer: pageUrl
+    } = bid.params;
+
+    // defaults
+    position = position || 'btf';
+
+    var parsedSizes = utils.parseSizesInput(bid.sizes);
+
+    // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
+    var queryString = [
+      'account_id', accountId,
+      'site_id', siteId,
+      'zone_id', zoneId,
+      'size_id', sizeMap[parsedSizes[0]],
+      'alt_size_ids', parsedSizes.slice(1).map(size => sizeMap[size]).join(','),
+      'p_pos', position,
+      'rp_floor', '0.01',
+      'tk_flint', 'pbjs.rapid',
+      'p_screen_res', window.screen.width +'x'+ window.screen.height,
+      'kw', keywords,
+      'tk_user_key', userId
+    ];
+
+    if(visitor !== null && typeof visitor === "object") {
+      utils._each(visitor, (item, key) => queryString.push(`tg_v.${key}`, item));
+    }
+
+    if(inventory !== null && typeof inventory === 'object') {
+      utils._each(inventory, (item, key) => queryString.push(`tg_i.${key}`, item));
+    }
+
+    queryString.push(
+      'rand', Math.random(),
+      'rf', !pageUrl ? utils.getTopWindowUrl() : pageUrl
+    );
+
+    return queryString.reduce(
+      (memo, curr, index) =>
+        index % 2 === 0 && queryString[index + 1] !== undefined ?
+        memo + curr + '=' + encodeURIComponent(queryString[index + 1]) + '&' : memo,
+      '//fastlane.rubiconproject.com/a/api/fastlane.json?' // use protocol relative link for http or https
+    ).slice(0, -1); // remove trailing &
+  }
+
+  let _renderCreative = (script, impId) =>
+    '<html>\n' +
+    '<head>\n' +
+    '<scr' + 'ipt type=\'text\/javascript\'>' +
+    'inDapIF=true;\n' +
+    '<' + '/scr' + 'ipt>\n' +
+    '<\/head>\n' +
+    '<body style=\'margin : 0; padding: 0;\'>\n' +
+    '<!-- Rubicon Project Ad Tag -->\n' +
+    '<div data-rp-impression-id=\'' + impId + '\'>\n' +
+    '<scr' + 'ipt type=\'text\/javascript\'>\n' +
+    ''+ script + '' +
+    '<' + '/scr' + 'ipt>\n' +
+    '</div>\n' +
+    '<\/body>\n' +
+    '<\/html>';
+
+  //expose the callback to the global object:
+  function handleRpCB(responseText, bidRequest) {
+    let responseObj = JSON.parse(responseText); // can throw
+
+    if(
+      typeof responseObj !== 'object' ||
+      responseObj.status !== 'ok' ||
+      !Array.isArray(responseObj.ads) ||
+      responseObj.ads.length < 1
+    ) {
+      throw 'bad response';
+    }
+
+    var ads = responseObj.ads;
+
+    // if there are multiple ads, sort by CPM
+    ads = ads.sort(_adCpmSort);
+
+    ads.forEach(function (ad) {
+      if(ad.status !== 'ok') {
+        throw 'bad ad status';
+      }
+
+      //set the status
+      bidRequest.status = CONSTANTS.STATUS.GOOD;
+
+      //store bid response
+      //bid status is good (indicating 1)
+      var bid = bidfactory.createBid(1, bidRequest);
+      bid.creative_id = ad.ad_id;
+      bid.bidderCode = bidRequest.bidder;
+      bid.cpm = ad.cpm || 0;
+      bid.ad = _renderCreative(ad.script, ad.impression_id);
+      [bid.width, bid.height] = sizeMap[ad.size_id].split('x').map(num => Number(num));
+      bid.dealId = responseObj.deal;
+
+      bidmanager.addBidResponse(bidRequest.placementCode, bid);
+    });
+  }
+
   function _adCpmSort(adA, adB) {
     return (adB.cpm || 0.0) - (adA.cpm || 0.0);
   }
 
-  /**
-   * Produce the code to render a creative
-   * @param {String} elemId the element passed to rubicon; this is essentially the ad-id
-   * @param {Array<Integer,Integer>} size array of width, height
-   * @return {String} creative
-   */
-  function _creative(elemId, size) {
-
-    // convert the size to a rubicon sizeId
-    var sizeId = RUBICON_SIZE_MAP[size.join('x')];
-
-    if (!sizeId) {
-      utils.logError(
-        'fastlane: missing sizeId for size: ' + size.join('x') + ' could not render creative',
-        RUBICON_BIDDER_CODE, RUBICON_SIZE_MAP);
-      return '';
-    }
-
-    return RUBICON_CREATIVE_START + elemId + '", "' + sizeId + RUBICON_CREATIVE_END;
-  }
-
-  /**
-   * Create (successful) bids for a slot,
-   * based on the given response
-   * @param {Object} slot the slot from rubicon
-   * @param {Object} ads the raw responses
-   */
-  function _makeBids(slot, ads) {
-
-    if (!ads || ads.length === 0) {
-
-      bidmanager.addBidResponse(
-        slot.getElementId(),
-        _errorBid(slot, ads)
-      );
-
-    } else {
-
-      // if there are multiple ads, sort by CPM
-      ads = ads.sort(_adCpmSort);
-
-      ads.forEach(function (ad) {
-        _makeBid(slot, ad);
-      });
-
-    }
-
-  }
-
-  /**
-   * Create (successful) bid for a slot size,
-   * based on the given response
-   * @param {Object} slot the slot from rubicon
-   * @param {Object} ad a raw response
-   */
-  function _makeBid(slot, ad) {
-
-    var bidResponse,
-        size = ad.dimensions;
-
-    if (!size) {
-      // this really shouldn't happen
-      utils.logError('no dimensions given', RUBICON_BIDDER_CODE, ad);
-      bidResponse = _errorBid(slot, ad);
-    } else {
-      bidResponse = bidfactory.createBid(1, slot.bid);
-
-      bidResponse.bidderCode = RUBICON_BIDDER_CODE;
-      bidResponse.cpm = ad.cpm;
-
-      // the element id is what the iframe will use to render
-      // itself using the rubicontag.renderCreative API
-      bidResponse.ad = _creative(slot.getElementId(), size);
-      bidResponse.width = size[0];
-      bidResponse.height = size[1];
-
-      // DealId
-      if (ad.deal) {
-        bidResponse.dealId = ad.deal;
-      }
-    }
-
-    bidmanager.addBidResponse(slot.getElementId(), bidResponse);
-
-  }
-
-  /**
-   * Helper to queue functions on rubicontag
-   * ready/available
-   * @param {Function} callback
-   */
-  function _rready(callback) {
-    window.rubicontag.cmd.push(callback);
-  }
-
-  /**
-   * download the rubicontag sdk
-   * @param {Object} options
-   * @param {String} options.accountId
-   * @param {Function} callback
-   */
-  function _initSDK(options, done) {
-    if (RUBICON_INITIALIZED) {
-      return;
-    }
-
-    RUBICON_INITIALIZED = 1;
-
-    var accountId  = options.accountId;
-    var scripttUrl = RUBICONTAG_URL + accountId + '.js';
-
-    adloader.loadScript(scripttUrl, done, true);
-  }
-
-  /**
-   * map the sizes in `bid.sizes` to Rubicon specific keys
-   * @param  {object} array of bids
-   * @return {[type]}      [description]
-   */
-  function _mapSizes(bids) {
-    utils._each(bids, function (bid) {
-      if (bid.params.sizes) {
-        return;
-      }
-
-      //return array like ['300x250', '728x90']
-      var parsedSizes = utils.parseSizesInput(bid.sizes);
-
-      //iterate the bid.sizes array to lookup codes
-      var tempSize = [];
-      for (var i = 0; i < parsedSizes.length; i++) {
-        var rubiconKey = RUBICON_SIZE_MAP[parsedSizes[i]];
-        if (rubiconKey) {
-          tempSize.push(rubiconKey);
-        }
-      }
-
-      bid.params.sizes = tempSize;
-    });
-  }
-
-  /**
-   * Define the slot using the rubicontag.defineSlot API
-   * @param {Object} bid
-   * @returns {RubiconSlot} Instance of RubiconSlot
-   */
-  function _defineSlot(bid) {
-    var userId    = bid.params.userId;
-    var position  = bid.params.position;
-    var visitor   = bid.params.visitor || [];
-    var keywords  = bid.params.keywords || [];
-    var inventory = bid.params.inventory || [];
-    var slot      = window.rubicontag.defineSlot({
-      siteId: bid.params.siteId,
-      zoneId: bid.params.zoneId,
-      sizes: bid.params.sizes,
-      id: bid.placementCode
-    });
-
-    slot.clearTargeting();
-
-    if (userId) {
-      window.rubicontag.setUserKey(userId);
-    }
-
-    if (position) {
-      slot.setPosition(position);
-    }
-
-    for (let key in visitor) {
-      if (visitor.hasOwnProperty(key)) {
-        slot.addFPV(key, visitor[key]);
-      }
-    }
-
-    for (let key in inventory) {
-      if (inventory.hasOwnProperty(key)) {
-        slot.addFPI(key, inventory[key]);
-      }
-    }
-
-    slot.addKW(keywords);
-
-    slot.bid = bid;
-
-    return slot;
-  }
-
-  /**
-   * Handle the bids received (from rubicon)
-   * @param {array} slots
-   */
-  function _bidsReady(slots) {
-    // NOTE: we don't really need to do anything,
-    // because right now we're shimming XMLHttpRequest.open,
-    // but in the future we'll get data from rubicontag here
-    utils.logMessage('Rubicon Project bidding complete: ' + ((new Date).getTime() - _bidStart));
-
-    utils._each(slots, function (slot) {
-      _makeBids(slot, slot.getRawResponses());
-    });
-  }
-
-
-  var _cb;
-  var _eventAvailable;
-  /**
-   * Used to attach (and switch out) callback for listening to rubicon bid events
-   * Rubicon
-   * @param {Function} cb Callback to register with event handler
-   * @return {Boolean} whether we can handle the event or not
-   */
-  function _handleBidEvent(cb) {
-    _cb = cb;
-    if (_eventAvailable) {
-      return true;
-    }
-    if (_eventAvailable === false) {
-      return false;
-    }
-    return _eventAvailable = window.rubicontag.addEventListener('FL_TIER_MAPPED', params => {
-      _cb(params);
-    });
-  }
-
-  /**
-   * Request the specified bids from
-   * Rubicon
-   * @param {Object} bidderRequest the bidder-level params (from prebid)
-   * @param {Array} params.bids the bids requested
-   */
-  function _callBids(bidderRequest) {
-
-    // start the timer; want to measure from
-    // even just loading the SDK
-    _bidStart = (new Date).getTime();
-
-    _mapSizes(bidderRequest.bids);
-
-    if (utils.isEmpty(bidderRequest.bids)) {
-      return;
-    }
-
-    // on the first bid, set up the SDK
-    if (!RUBICON_INITIALIZED) {
-      _initSDK(bidderRequest.bids[0].params);
-    }
-
-    _rready(function () {
-      window.rubicontag.setIntegration('$$PREBID_GLOBAL$$');
-
-      var slots = [];
-      var bids  = bidderRequest.bids;
-
-      for (var i=0, ln=bids.length; i < ln; i++) {
-        slots.push(_defineSlot(bids[i]));
-      }
-
-      var parameters = {
-        slots: slots,
-        timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart - TIMEOUT_BUFFER)
-      };
-      var callback = function noop() {};
-
-      if (!_handleBidEvent(params => {
-
-        var slot = slots.find(slot => slot.getElementId() === params.elementId);
-        var ad = slot.getRawResponseBySizeId(params.sizeId);
-        var time = ((new Date).getTime() - _bidStart);
-
-        utils.logMessage(`Rubicon Project bid back for "${params.elementId}" size ${params.sizeId} at: ${time}`);
-
-        _makeBid(slot, ad);
-
-      })) {
-        callback = () => {
-          _bidsReady(slots);
-        };
-      }
-
-      window.rubicontag.run(callback, parameters);
-    });
-  }
-
   return {
-    /**
-     * @public callBids
-     * the interface to Prebid
-     */
     callBids: _callBids
   };
-};
+}
 
 module.exports = RubiconAdapter;

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -1,45 +1,81 @@
-import { expect } from "chai";
-import adloader from "src/adloader";
-import adapterManager from "src/adaptermanager";
-import bidManager from "src/bidmanager";
-import RubiconAdapter from "src/adapters/rubicon";
+import { expect } from 'chai';
+import adloader from 'src/adloader';
+import adapterManager from 'src/adaptermanager';
+import bidManager from 'src/bidmanager';
+import RubiconAdapter from 'src/adapters/rubicon';
+import {parse as parseQuery} from 'querystring';
 
-var CONSTANTS = require("src/constants.json");
+var CONSTANTS = require('src/constants.json');
 
+describe('the rubicon adapter', () => {
 
-describe("the rubicon adapter", () => {
-
-  let rubiconAdapter = adapterManager.bidderRegistry["rubicon"],
-      sandbox,
-      adUnit;
+  let sandbox,
+      adUnit,
+      bidderRequest;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
 
     adUnit = {
-      code: "/19968336/header-bid-tag-0",
+      code: '/19968336/header-bid-tag-0',
       sizes: [[300, 250], [320, 50]],
       bids: [
         {
-          bidder: "rubicon",
+          bidder: 'rubicon',
           params: {
-            accountId: "14062",
-            siteId: "70608",
-            zoneId: "335918",
-            userId: "12346",
-            keywords: ["a","b","c"],
+            accountId: '14062',
+            siteId: '70608',
+            zoneId: '335918',
+            userId: '12346',
+            keywords: ['a','b','c'],
             inventory: {
-              rating:"5-star",
-              prodtype:"tech"
+              rating:'5-star',
+              prodtype:'tech'
             },
             visitor: {
-              ucat:"new",
-              lastsearch:"iphone"
+              ucat:'new',
+              lastsearch:'iphone'
             },
-            position: "atf"
+            position: 'atf',
+            referrer: 'localhost'
           }
         }
       ]
+    };
+
+    bidderRequest = {
+      bidderCode: 'rubicon',
+      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      bidderRequestId: '178e34bad3658f',
+      bids: [
+        {
+          bidder: 'rubicon',
+          params: {
+            accountId: '14062',
+            siteId: '70608',
+            zoneId: '335918',
+            userId: '12346',
+            keywords: ['a','b','c'],
+            inventory: {
+              rating:'5-star',
+              prodtype:'tech'
+            },
+            visitor: {
+              ucat:'new',
+              lastsearch:'iphone'
+            },
+            position: 'atf',
+            referrer: 'localhost'
+          },
+          placementCode: '/19968336/header-bid-tag-0',
+          sizes: [[300, 250], [320, 50]],
+          bidId: '2ffb201a808da7',
+          bidderRequestId: '178e34bad3658f',
+          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a'
+        }
+      ],
+      start: 1472239426002,
+      timeout: 5000
     };
 
   });
@@ -48,11 +84,13 @@ describe("the rubicon adapter", () => {
     sandbox.restore();
   });
 
-  describe("callBids public interface", () => {
+  describe('callBids public interface', () => {
 
-    it("should receive a well-formed bidRequest from the adaptermanager", () => {
+    let rubiconAdapter = adapterManager.bidderRegistry['rubicon'];
 
-      sandbox.stub(rubiconAdapter, "callBids");
+    it('should receive a well-formed bidRequest from the adaptermanager', () => {
+
+      sandbox.stub(rubiconAdapter, 'callBids');
 
       adapterManager.callBids({
           adUnits: [clone(adUnit)]
@@ -60,23 +98,23 @@ describe("the rubicon adapter", () => {
 
       let bidderRequest = rubiconAdapter.callBids.getCall(0).args[0];
 
-      expect(bidderRequest).to.have.property("bids")
-        .that.is.an("array")
+      expect(bidderRequest).to.have.property('bids')
+        .that.is.an('array')
         .with.lengthOf(1);
 
-      expect(bidderRequest).to.have.deep.property("bids[0]")
-        .to.have.property("bidder", "rubicon");
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('bidder', 'rubicon');
 
-      expect(bidderRequest).to.have.deep.property("bids[0]")
-        .to.have.property("placementCode", adUnit.code);
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('placementCode', adUnit.code);
 
-      expect(bidderRequest).to.have.deep.property("bids[0]")
-        .with.property("sizes")
-        .that.is.an("array")
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('sizes')
+        .that.is.an('array')
         .with.lengthOf(2)
         .that.deep.equals(adUnit.sizes);
 
-      expect(bidderRequest).to.have.deep.property("bids[0]")
+      expect(bidderRequest).to.have.deep.property('bids[0]')
         .with.property('params')
         .that.deep.equals(adUnit.bids[0].params)
 
@@ -84,302 +122,261 @@ describe("the rubicon adapter", () => {
 
   });
 
-  describe("callBids implementation", () => {
+  describe('callBids implementation', () => {
 
-    let bidderRequest,
-        slot;
+    let rubiconAdapter;
 
-    beforeEach(() => {
-      sandbox.stub(adloader, "loadScript");
-      sandbox.spy(rubiconAdapter, "callBids");
+    describe('requests', () => {
 
-      slot = {
-        clearTargeting: sandbox.spy(),
-        setPosition: sandbox.spy(),
-        addFPV: sandbox.spy(),
-        addFPI: sandbox.spy(),
-        addKW: sandbox.spy(),
-        getElementId: () => "/19968336/header-bid-tag-0",
-        getRawResponses: () => {},
-        getRawResponseBySizeId: () => {}
-      };
-
-      window.rubicontag = {
-        cmd: {
-          push: cb => cb()
-        },
-        setIntegration: sandbox.spy(),
-        run: () => {},
-        addEventListener: () => {},
-        setUserKey: sandbox.spy(),
-        defineSlot: sandbox.spy(bid => slot)
-      };
-
-      bidderRequest = {
-        bidderCode: "rubicon",
-        requestId: "c45dd708-a418-42ec-b8a7-b70a6c6fab0a",
-        bidderRequestId: "178e34bad3658f",
-        bids: [
-          {
-            bidder: "rubicon",
-            params: {
-              accountId: "14062",
-              siteId: "70608",
-              zoneId: "335918",
-              userId: "12346",
-              keywords: ["a","b","c"],
-              inventory: {
-                rating:"5-star",
-                prodtype:"tech"
-              },
-              visitor: {
-                ucat:"new",
-                lastsearch:"iphone"
-              },
-              position: "atf"
-            },
-            placementCode: "/19968336/header-bid-tag-0",
-            sizes: [[300, 250], [320, 50]],
-            bidId: "2ffb201a808da7",
-            bidderRequestId: "178e34bad3658f",
-            requestId: "c45dd708-a418-42ec-b8a7-b70a6c6fab0a"
-          }
-        ],
-        start: 1472239426002,
-        timeout: 5000
-      };
-
-    });
-
-    describe("when doing fastlane slot configuration", () => {
+      let xhr,
+          screen;
 
       beforeEach(() => {
-        rubiconAdapter.callBids(bidderRequest);
-      });
-
-      it("should load the fastlane SDK if not loaded", () => {
-
-        let pathToSDK = adloader.loadScript.getCall(0).args[0];
-        expect(pathToSDK).to.equal(`http://ads.rubiconproject.com/header/${bidderRequest.bids[0].params.accountId}.js`);
-
-        rubiconAdapter.callBids(bidderRequest);
-        expect(adloader.loadScript.calledOnce).to.equal(true);
-
-      });
-
-      it("should make a valid call to rubicontag.defineSlot", () => {
-
-        expect(window.rubicontag.defineSlot.calledOnce).to.equal(true);
-
-        let slotParam = window.rubicontag.defineSlot.firstCall.args[0];
-        expect(slotParam).to.contain.all.keys(
-          "siteId",
-          "zoneId",
-          "sizes",
-          "id"
-        );
-        expect(slotParam).to.have.property("sizes")
-          .that.is.an("array")
-          .with.lengthOf(2)
-          .that.deep.equals([15, 43]);
-
-      });
-
-      it("should call rubicontag.setUserKey when params.userId is set", () => {
-
-        expect(window.rubicontag.setUserKey.calledWith(adUnit.bids[0].params.userId)).to.equal(true);
-
-      });
-
-      it("should set proper targeting params for Slot when passed", () => {
-
-        expect(slot.setPosition.calledOnce).to.equal(true);
-        expect(slot.setPosition.firstCall.calledWith("atf")).to.equal(true);
-
-        expect(slot.addFPV.calledTwice).to.equal(true);
-        expect(slot.addFPV.firstCall.calledWith("ucat", "new")).to.equal(true);
-        expect(slot.addFPV.secondCall.calledWith("lastsearch", "iphone")).to.equal(true);
-
-        expect(slot.addFPI.calledTwice).to.equal(true);
-        expect(slot.addFPI.firstCall.calledWith("rating", "5-star")).to.equal(true);
-        expect(slot.addFPI.secondCall.calledWith("prodtype", "tech")).to.equal(true);
-
-        expect(slot.addKW.calledOnce).to.equal(true);
-        expect(slot.addKW.firstCall.calledWith(["a","b","c"])).to.equal(true);
-
-      });
-
-      it("should set the rubicontag integration as prebid.js", () => {
-
-        expect(window.rubicontag.setIntegration.calledWith("$$PREBID_GLOBAL$$")).to.equal(true);
-
-      });
-
-    });
-
-    describe("when handling fastlane responses", () => {
-
-      beforeEach(() => {
-        // need a fresh rubicon adapter for these tests to reset private state.
         rubiconAdapter = new RubiconAdapter();
+
+        xhr = sandbox.useFakeXMLHttpRequest();
+
+        screen = window.screen;
+        window.screen = {
+          width: 1920,
+          height: 1080
+        };
       });
 
-      describe("individually through events", () => {
-
-        let bids;
-        let _callback;
-        let addEventListener;
-
-        beforeEach(() => {
-          bids = [];
-
-          addEventListener = sandbox.stub(window.rubicontag, "addEventListener", (event, callback) => {
-            _callback = callback;
-            return true;
-          });
-
-          sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
-            bids.push(bid);
-          });
-        });
-
-        it("should only register one listener for multiple bid requests", () => {
-
-          rubiconAdapter.callBids(bidderRequest);
-          rubiconAdapter.callBids(bidderRequest);
-
-          expect(addEventListener.calledOnce).to.equal(true);
-
-        });
-
-        it("should register successful bids with the bidmanager", () => {
-
-          sandbox.stub(window.rubicontag, "run", () => {
-            _callback({
-              elementId: "/19968336/header-bid-tag-0",
-              sizeId: "43"
-            });
-            _callback({
-              elementId: "/19968336/header-bid-tag-0",
-              sizeId: "15"
-            });
-          });
-
-          sandbox.stub(slot, "getRawResponseBySizeId", (sizeId) => {
-            return {
-              "43": {
-                "advertiser": 12345,
-                "cpm": 0.811,
-                "dimensions": [
-                  300,
-                  250
-                ],
-                "auction_id": "431ee1bc-3cc4-4bb7-b0d4-eb9faedb433c"
-              },
-              "15": {
-                "advertiser": 12345,
-                "cpm": 0.59,
-                "dimensions": [
-                  320,
-                  50
-                ],
-                "auction_id": "431ee1bc-3cc4-4bb7-b0d4-eb9faedb433c"
-              }
-            }[sizeId];
-          });
-
-          rubiconAdapter.callBids(bidderRequest);
-
-          expect(bidManager.addBidResponse.calledTwice).to.equal(true);
-
-          expect(bids).to.be.lengthOf(2);
-          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-          expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-
-          expect(bids[0].bidderCode).to.equal("rubicon");
-          expect(bids[0].width).to.equal(300);
-          expect(bids[0].height).to.equal(250);
-          expect(bids[0].cpm).to.equal(0.811);
-
-          expect(bids[1].bidderCode).to.equal("rubicon");
-          expect(bids[1].width).to.equal(320);
-          expect(bids[1].height).to.equal(50);
-          expect(bids[1].cpm).to.equal(0.59);
-        })
-
+      afterEach(() => {
+        xhr.restore();
+        window.screen = screen;
       });
 
-      describe("all at once", () => {
+      it('should make a well-formed optimized request', () => {
 
-        let bids;
+        rubiconAdapter.callBids(bidderRequest);
 
-        beforeEach(() => {
-          bids = [];
+        let request = xhr.requests[0];
 
-          sandbox.stub(window.rubicontag, "run", cb => cb());
-          sandbox.stub(window.rubicontag, "addEventListener", () => false);
-          sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
-            bids.push(bid);
-          });
+        expect(request instanceof sinon.FakeXMLHttpRequest).to.equal(true);
+
+        expect(request.withCredentials).to.equal(true);
+
+        let [path, query] = request.url.split('?');
+        query = parseQuery(query);
+
+        expect(path).to.equal(
+          '//fastlane.rubiconproject.com/a/api/fastlane.json'
+        );
+
+        let expectedQuery = {
+          'account_id': '14062',
+          'site_id': '70608',
+          'zone_id': '335918',
+          'size_id': '15',
+          'alt_size_ids': '43',
+          'p_pos': 'atf',
+          'rp_floor': '0.01',
+          'tk_flint': 'pbjs.rapid',
+          'p_screen_res': '1920x1080',
+          'tk_user_key': '12346',
+          'kw': 'a,b,c',
+          'tg_v.ucat': 'new',
+          'tg_v.lastsearch': 'iphone',
+          'tg_i.rating': '5-star',
+          'tg_i.prodtype': 'tech',
+          'rf': 'localhost'
+        };
+
+        // test that all values above are both present and correct
+        Object.keys(expectedQuery).forEach(key => {
+          let value = expectedQuery[key];
+          expect(query[key]).to.equal(value);
         });
 
-        it("should register successful bids with the bidmanager", () => {
-
-          sandbox.stub(slot, "getRawResponses", () => [
-            {
-              "advertiser": 12345,
-              "cpm": 0.811,
-              "dimensions": [
-                300,
-                250
-              ],
-              "auction_id": "431ee1bc-3cc4-4bb7-b0d4-eb9faedb433c"
-            },
-            {
-              "advertiser": 123456,
-              "cpm": 0.59,
-              "dimensions": [
-                320,
-                50
-              ],
-              "auction_id": "a3e042e5-3fb7-498f-b60e-71540f4769a8"
-            }
-          ]);
-
-          rubiconAdapter.callBids(bidderRequest);
-
-          expect(bidManager.addBidResponse.calledTwice).to.equal(true);
-
-          expect(bids).to.be.lengthOf(2);
-          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-          expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-
-          expect(bids[0].bidderCode).to.equal("rubicon");
-          expect(bids[0].width).to.equal(300);
-          expect(bids[0].height).to.equal(250);
-          expect(bids[0].cpm).to.equal(0.811);
-
-          expect(bids[1].bidderCode).to.equal("rubicon");
-          expect(bids[1].width).to.equal(320);
-          expect(bids[1].height).to.equal(50);
-          expect(bids[1].cpm).to.equal(0.59);
-
-        });
-
-        it("should register bad responses as errors with the bidmanager", () => {
-
-          sandbox.stub(slot, "getRawResponses", () => []);
-
-          rubiconAdapter.callBids(bidderRequest);
-
-          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-
-        });
+        expect(query).to.have.property('rand');
 
       });
 
     });
+
+
+    describe('response handler', () => {
+      let bids;
+
+      beforeEach(() => {
+        bids = [];
+
+        sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
+          bids.push(bid);
+        });
+      });
+
+      it('should handle a success response and sort by cpm', () => {
+
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [
+            {
+              "status": "ok",
+              "impression_id": "153dc240-8229-4604-b8f5-256933b9374c",
+              "size_id": "15",
+              "ad_id": "6",
+              "advertiser": 7,
+              "network": 8,
+              "creative_id": 9,
+              "type": "script",
+              "script": "alert('foo')",
+              "campaign_id": 10,
+              "cpm": 0.811,
+              "targeting": [
+                {
+                  "key": "rpfl_14062",
+                  "values": [
+                    "15_tier_all_test"
+                  ]
+                }
+              ]
+            },
+            {
+              "status": "ok",
+              "impression_id": "153dc240-8229-4604-b8f5-256933b9374d",
+              "size_id": "43",
+              "ad_id": "7",
+              "advertiser": 7,
+              "network": 8,
+              "creative_id": 9,
+              "type": "script",
+              "script": "alert('foo')",
+              "campaign_id": 10,
+              "cpm": 0.911,
+              "targeting": [
+                {
+                  "key": "rpfl_14062",
+                  "values": [
+                    "15_tier_all_test"
+                  ]
+                }
+              ]
+            }
+          ]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledTwice).to.equal(true);
+
+        expect(bids).to.be.lengthOf(2);
+
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+        expect(bids[0].bidderCode).to.equal("rubicon");
+        expect(bids[0].width).to.equal(320);
+        expect(bids[0].height).to.equal(50);
+        expect(bids[0].cpm).to.equal(0.911);
+        expect(bids[0].ad).to.contain(`alert('foo')`)
+          .and.to.contain(`<html>`)
+          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374d'>`);
+
+        expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+        expect(bids[1].bidderCode).to.equal("rubicon");
+        expect(bids[1].width).to.equal(300);
+        expect(bids[1].height).to.equal(250);
+        expect(bids[1].cpm).to.equal(0.811);
+        expect(bids[1].ad).to.contain(`alert('foo')`)
+          .and.to.contain(`<html>`)
+          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374c'>`);
+      });
+
+      it('should be fine with a CPM of 0', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [{
+              "status": "ok",
+              "cpm": 0,
+              "size_id": 15
+            }]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+      });
+
+      it('should handle an error with no ads returned', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": []
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+      });
+
+      it('should handle an error with bad status', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [{
+              "status": "not_ok",
+            }]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+      });
+
+      it('should handle an error because of malformed json response', () => {
+        rubiconAdapter = new RubiconAdapter("{test{");
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        expect(bids[0].error instanceof SyntaxError).to.equal(true);
+      });
+
+    })
+
 
   });
 


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This is an updated Rubicon adapter that forgoes the usual deferred loading of the Fastlane library in favor of direct AJAX communication with the Fastlane backend.  This new adapter is meant as a drop-in replacement for the old adapter and supports the same Prebid API; however, since this adapter no longer loads the Fastlane library some prudence should be taken by those upgrading that may have been utilizing various `rubicontag` or Fastlane configuration APIs.

An updated spec of unit tests is also included for this new adapter.