### PR TITLE
added new rubiconLite adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -17,6 +17,7 @@
     "pubmatic",
     "pulsepoint",
     "rubicon",
+    "rubiconLite",
     "sekindo",
     "sonobi",
     "sovrn",

--- a/src/adapters/rubiconLite.js
+++ b/src/adapters/rubiconLite.js
@@ -1,0 +1,195 @@
+/**
+ * @file Rubicon (RubiconLite) adapter
+ */
+
+var CONSTANTS = require('../constants.json');
+var utils = require('../utils.js');
+var bidmanager = require('../bidmanager.js');
+var bidfactory = require('../bidfactory.js');
+var ajax = require("../ajax.js").ajax;
+
+function RubiconAdapter(mockResponse) {
+
+  var sizeMap = {
+    1:'468x60',
+    2:'728x90',
+    8:'120x600',
+    9:'160x600',
+    10:'300x600',
+    15:'300x250',
+    16:'336x280',
+    43:'320x50',
+    44:'300x50',
+    54:'300x1050',
+    55:'970x90',
+    57:'970x250',
+    58:'1000x90',
+    59:'320x80',
+    65:'640x480',
+    67:'320x480',
+    68:'1800x1000',
+    72:'320x320',
+    73:'320x160',
+    101:'480x320',
+    102:'768x1024',
+    113:'1000x300',
+    117:'320x100',
+    125:'800x250',
+    126:'200x600'
+  };
+  utils._each(sizeMap, (item, key) => sizeMap[item] = key);
+
+  function _callBids(bidderRequest) {
+    var bids = bidderRequest.bids || [];
+
+    bids.forEach(bid => {
+      if(!mockResponse) {
+        ajax(buildOptimizedCall(bid), cb, undefined, {withCredentials: true});
+      } else {
+        cb(mockResponse);
+      }
+
+      function cb(responseText) {
+        try {
+          utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
+          handleRpCB(responseText, bid);
+        } catch(err) {
+          if(typeof err === "string") {
+            utils.logWarn(`${err} when processing RubiconLite for placement code ${bid.placementCode}`);
+          } else {
+            utils.logError('Error processing response in RubiconLite for placement code ' + bid.placementCode, null, err);
+          }
+
+          //indicate that there is no bid for this placement
+          let badBid = bidfactory.createBid(2, bid);
+          badBid.bidderCode = bid.bidder;
+          badBid.error = err;
+          bidmanager.addBidResponse(bid.placementCode, badBid);
+        }
+      }
+    });
+  }
+
+  function buildOptimizedCall(bid) {
+    bid.startTime = new Date().getTime();
+
+    var {
+      accountId,
+      siteId,
+      zoneId,
+      position,
+      keywords,
+      visitor,
+      inventory,
+      userId,
+      referrer: pageUrl
+    } = bid.params;
+
+    // defaults
+    position = position || 'btf';
+
+    var parsedSizes = utils.parseSizesInput(bid.sizes);
+
+    // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
+    var queryString = [
+      'account_id', accountId,
+      'site_id', siteId,
+      'zone_id', zoneId,
+      'size_id', sizeMap[parsedSizes[0]],
+      'alt_size_ids', parsedSizes.slice(1).map(size => sizeMap[size]).join(','),
+      'p_pos', position,
+      'rp_floor', '0.01',
+      'tk_flint', 'pbjs.lite',
+      'p_screen_res', window.screen.width +'x'+ window.screen.height,
+      'kw', keywords,
+      'tk_user_key', userId
+    ];
+
+    if(visitor !== null && typeof visitor === "object") {
+      utils._each(visitor, (item, key) => queryString.push(`tg_v.${key}`, item));
+    }
+
+    if(inventory !== null && typeof inventory === 'object') {
+      utils._each(inventory, (item, key) => queryString.push(`tg_i.${key}`, item));
+    }
+
+    queryString.push(
+      'rand', Math.random(),
+      'rf', !pageUrl ? utils.getTopWindowUrl() : pageUrl
+    );
+
+    return queryString.reduce(
+      (memo, curr, index) =>
+        index % 2 === 0 && queryString[index + 1] !== undefined ?
+        memo + curr + '=' + encodeURIComponent(queryString[index + 1]) + '&' : memo,
+      '//fastlane.rubiconproject.com/a/api/fastlane.json?' // use protocol relative link for http or https
+    ).slice(0, -1); // remove trailing &
+  }
+
+  let _renderCreative = (script, impId) =>
+    '<html>\n' +
+    '<head>\n' +
+    '<scr' + 'ipt type=\'text\/javascript\'>' +
+    'inDapIF=true;\n' +
+    '<' + '/scr' + 'ipt>\n' +
+    '<\/head>\n' +
+    '<body style=\'margin : 0; padding: 0;\'>\n' +
+    '<!-- Rubicon Project Ad Tag -->\n' +
+    '<div data-rp-impression-id=\'' + impId + '\'>\n' +
+    '<scr' + 'ipt type=\'text\/javascript\'>\n' +
+    ''+ script + '' +
+    '<' + '/scr' + 'ipt>\n' +
+    '</div>\n' +
+    '<\/body>\n' +
+    '<\/html>';
+
+  //expose the callback to the global object:
+  function handleRpCB(responseText, bidRequest) {
+    let responseObj = JSON.parse(responseText); // can throw
+
+    if(
+      typeof responseObj !== 'object' ||
+      responseObj.status !== 'ok' ||
+      !Array.isArray(responseObj.ads) ||
+      responseObj.ads.length < 1
+    ) {
+      throw 'bad response';
+    }
+
+    var ads = responseObj.ads;
+
+    // if there are multiple ads, sort by CPM
+    ads = ads.sort(_adCpmSort);
+
+    ads.forEach(function (ad) {
+      if(ad.status !== 'ok') {
+        throw 'bad ad status';
+      }
+
+      //set the status
+      bidRequest.status = CONSTANTS.STATUS.GOOD;
+
+      //store bid response
+      //bid status is good (indicating 1)
+      var bid = bidfactory.createBid(1, bidRequest);
+      bid.creative_id = ad.ad_id;
+      bid.bidderCode = bidRequest.bidder;
+      bid.cpm = ad.cpm || 0;
+      bid.ad = _renderCreative(ad.script, ad.impression_id);
+      [bid.width, bid.height] = sizeMap[ad.size_id].split('x').map(num => Number(num));
+      bid.dealId = responseObj.deal;
+
+      bidmanager.addBidResponse(bidRequest.placementCode, bid);
+    });
+  }
+
+  function _adCpmSort(adA, adB) {
+    return (adB.cpm || 0.0) - (adA.cpm || 0.0);
+  }
+
+  return {
+    callBids: _callBids
+  };
+}
+
+module.exports = RubiconAdapter;

--- a/src/adapters/rubiconLite.js
+++ b/src/adapters/rubiconLite.js
@@ -8,7 +8,7 @@ import * as utils from 'src/utils';
 import { ajax } from 'src/ajax';
 import { STATUS } from 'src/constants';
 
-function RubiconAdapter(mockResponse) {
+function RubiconAdapter() {
 
   var sizeMap = {
     1:'468x60',
@@ -43,18 +43,12 @@ function RubiconAdapter(mockResponse) {
     var bids = bidderRequest.bids || [];
 
     bids.forEach(bid => {
-      if(!mockResponse) {
-        ajax(buildOptimizedCall(bid), cb, undefined, {withCredentials: true});
-      } else {
-        cb(mockResponse);
-      }
-
-      function cb(responseText) {
+      ajax(buildOptimizedCall(bid), function bidCallback(responseText) {
         try {
           utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
           handleRpCB(responseText, bid);
-        } catch(err) {
-          if(typeof err === "string") {
+        } catch (err) {
+          if (typeof err === "string") {
             utils.logWarn(`${err} when processing RubiconLite for placement code ${bid.placementCode}`);
           } else {
             utils.logError('Error processing response in RubiconLite for placement code ' + bid.placementCode, null, err);
@@ -66,7 +60,7 @@ function RubiconAdapter(mockResponse) {
           badBid.error = err;
           bidmanager.addBidResponse(bid.placementCode, badBid);
         }
-      }
+      }, undefined, {withCredentials: true});
     });
   }
 

--- a/src/adapters/rubiconLite.js
+++ b/src/adapters/rubiconLite.js
@@ -2,11 +2,11 @@
  * @file Rubicon (RubiconLite) adapter
  */
 
-var CONSTANTS = require('../constants.json');
-var utils = require('../utils.js');
-var bidmanager = require('../bidmanager.js');
-var bidfactory = require('../bidfactory.js');
-var ajax = require("../ajax.js").ajax;
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import * as utils from 'src/utils';
+import { ajax } from 'src/ajax';
+import { STATUS } from 'src/constants';
 
 function RubiconAdapter(mockResponse) {
 
@@ -61,7 +61,7 @@ function RubiconAdapter(mockResponse) {
           }
 
           //indicate that there is no bid for this placement
-          let badBid = bidfactory.createBid(2, bid);
+          let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
           badBid.bidderCode = bid.bidder;
           badBid.error = err;
           bidmanager.addBidResponse(bid.placementCode, badBid);
@@ -126,24 +126,16 @@ function RubiconAdapter(mockResponse) {
     ).slice(0, -1); // remove trailing &
   }
 
-  let _renderCreative = (script, impId) =>
-    '<html>\n' +
-    '<head>\n' +
-    '<scr' + 'ipt type=\'text\/javascript\'>' +
-    'inDapIF=true;\n' +
-    '<' + '/scr' + 'ipt>\n' +
-    '<\/head>\n' +
-    '<body style=\'margin : 0; padding: 0;\'>\n' +
-    '<!-- Rubicon Project Ad Tag -->\n' +
-    '<div data-rp-impression-id=\'' + impId + '\'>\n' +
-    '<scr' + 'ipt type=\'text\/javascript\'>\n' +
-    ''+ script + '' +
-    '<' + '/scr' + 'ipt>\n' +
-    '</div>\n' +
-    '<\/body>\n' +
-    '<\/html>';
+  let _renderCreative = (script, impId) => `<html>
+<head><script type='text/javascript'>inDapIF=true;</script></head>
+<body style='margin : 0; padding: 0;'>
+<!-- Rubicon Project Ad Tag -->
+<div data-rp-impression-id='${impId}'>
+<script type='text/javascript'>${script}</script>
+</div>
+</body>
+</html>`;
 
-  //expose the callback to the global object:
   function handleRpCB(responseText, bidRequest) {
     let responseObj = JSON.parse(responseText); // can throw
 
@@ -166,12 +158,9 @@ function RubiconAdapter(mockResponse) {
         throw 'bad ad status';
       }
 
-      //set the status
-      bidRequest.status = CONSTANTS.STATUS.GOOD;
-
       //store bid response
       //bid status is good (indicating 1)
-      var bid = bidfactory.createBid(1, bidRequest);
+      var bid = bidfactory.createBid(STATUS.GOOD, bidRequest);
       bid.creative_id = ad.ad_id;
       bid.bidderCode = bidRequest.bidder;
       bid.cpm = ad.cpm || 0;

--- a/test/spec/adapters/rubiconLite_spec.js
+++ b/test/spec/adapters/rubiconLite_spec.js
@@ -1,0 +1,384 @@
+import { expect } from 'chai';
+import adloader from 'src/adloader';
+import adapterManager from 'src/adaptermanager';
+import bidManager from 'src/bidmanager';
+import RubiconAdapter from 'src/adapters/rubiconLite';
+import {parse as parseQuery} from 'querystring';
+
+var CONSTANTS = require('src/constants.json');
+
+describe('the rubiconLite adapter', () => {
+
+  let sandbox,
+      adUnit,
+      bidderRequest;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    adUnit = {
+      code: '/19968336/header-bid-tag-0',
+      sizes: [[300, 250], [320, 50]],
+      bids: [
+        {
+          bidder: 'rubiconLite',
+          params: {
+            accountId: '14062',
+            siteId: '70608',
+            zoneId: '335918',
+            userId: '12346',
+            keywords: ['a','b','c'],
+            inventory: {
+              rating:'5-star',
+              prodtype:'tech'
+            },
+            visitor: {
+              ucat:'new',
+              lastsearch:'iphone'
+            },
+            position: 'atf',
+            referrer: 'localhost'
+          }
+        }
+      ]
+    };
+
+    bidderRequest = {
+      bidderCode: 'rubiconLite',
+      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      bidderRequestId: '178e34bad3658f',
+      bids: [
+        {
+          bidder: 'rubiconLite',
+          params: {
+            accountId: '14062',
+            siteId: '70608',
+            zoneId: '335918',
+            userId: '12346',
+            keywords: ['a','b','c'],
+            inventory: {
+              rating:'5-star',
+              prodtype:'tech'
+            },
+            visitor: {
+              ucat:'new',
+              lastsearch:'iphone'
+            },
+            position: 'atf',
+            referrer: 'localhost'
+          },
+          placementCode: '/19968336/header-bid-tag-0',
+          sizes: [[300, 250], [320, 50]],
+          bidId: '2ffb201a808da7',
+          bidderRequestId: '178e34bad3658f',
+          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a'
+        }
+      ],
+      start: 1472239426002,
+      timeout: 5000
+    };
+
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('callBids public interface', () => {
+
+    let rubiconAdapter = adapterManager.bidderRegistry['rubiconLite'];
+
+    it('should receive a well-formed bidRequest from the adaptermanager', () => {
+
+      sandbox.stub(rubiconAdapter, 'callBids');
+
+      adapterManager.callBids({
+          adUnits: [clone(adUnit)]
+      });
+
+      let bidderRequest = rubiconAdapter.callBids.getCall(0).args[0];
+
+      expect(bidderRequest).to.have.property('bids')
+        .that.is.an('array')
+        .with.lengthOf(1);
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('bidder', 'rubiconLite');
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('placementCode', adUnit.code);
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('sizes')
+        .that.is.an('array')
+        .with.lengthOf(2)
+        .that.deep.equals(adUnit.sizes);
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('params')
+        .that.deep.equals(adUnit.bids[0].params)
+
+    });
+
+  });
+
+  describe('callBids implementation', () => {
+
+    let rubiconAdapter;
+
+    describe('requests', () => {
+
+      let xhr,
+          screen;
+
+      beforeEach(() => {
+        rubiconAdapter = new RubiconAdapter();
+
+        xhr = sandbox.useFakeXMLHttpRequest();
+      });
+
+      afterEach(() => {
+        xhr.restore();
+      });
+
+      it('should make a well-formed optimized request', () => {
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        let request = xhr.requests[0];
+
+        expect(request instanceof sinon.FakeXMLHttpRequest).to.equal(true);
+
+        expect(request.withCredentials).to.equal(true);
+
+        let [path, query] = request.url.split('?');
+        query = parseQuery(query);
+
+        expect(path).to.equal(
+          '//fastlane.rubiconproject.com/a/api/fastlane.json'
+        );
+
+        let expectedQuery = {
+          'account_id': '14062',
+          'site_id': '70608',
+          'zone_id': '335918',
+          'size_id': '15',
+          'alt_size_ids': '43',
+          'p_pos': 'atf',
+          'rp_floor': '0.01',
+          'tk_flint': 'pbjs.lite',
+          'p_screen_res': /\d+x\d+/,
+          'tk_user_key': '12346',
+          'kw': 'a,b,c',
+          'tg_v.ucat': 'new',
+          'tg_v.lastsearch': 'iphone',
+          'tg_i.rating': '5-star',
+          'tg_i.prodtype': 'tech',
+          'rf': 'localhost'
+        };
+
+        // test that all values above are both present and correct
+        Object.keys(expectedQuery).forEach(key => {
+          let value = expectedQuery[key];
+          if(value instanceof RegExp) {
+            expect(query[key]).to.match(value);
+          } else {
+            expect(query[key]).to.equal(value);
+          }
+        });
+
+        expect(query).to.have.property('rand');
+
+      });
+
+    });
+
+
+    describe('response handler', () => {
+      let bids;
+
+      beforeEach(() => {
+        bids = [];
+
+        sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
+          bids.push(bid);
+        });
+      });
+
+      it('should handle a success response and sort by cpm', () => {
+
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [
+            {
+              "status": "ok",
+              "impression_id": "153dc240-8229-4604-b8f5-256933b9374c",
+              "size_id": "15",
+              "ad_id": "6",
+              "advertiser": 7,
+              "network": 8,
+              "creative_id": 9,
+              "type": "script",
+              "script": "alert('foo')",
+              "campaign_id": 10,
+              "cpm": 0.811,
+              "targeting": [
+                {
+                  "key": "rpfl_14062",
+                  "values": [
+                    "15_tier_all_test"
+                  ]
+                }
+              ]
+            },
+            {
+              "status": "ok",
+              "impression_id": "153dc240-8229-4604-b8f5-256933b9374d",
+              "size_id": "43",
+              "ad_id": "7",
+              "advertiser": 7,
+              "network": 8,
+              "creative_id": 9,
+              "type": "script",
+              "script": "alert('foo')",
+              "campaign_id": 10,
+              "cpm": 0.911,
+              "targeting": [
+                {
+                  "key": "rpfl_14062",
+                  "values": [
+                    "15_tier_all_test"
+                  ]
+                }
+              ]
+            }
+          ]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledTwice).to.equal(true);
+
+        expect(bids).to.be.lengthOf(2);
+
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+        expect(bids[0].bidderCode).to.equal("rubiconLite");
+        expect(bids[0].width).to.equal(320);
+        expect(bids[0].height).to.equal(50);
+        expect(bids[0].cpm).to.equal(0.911);
+        expect(bids[0].ad).to.contain(`alert('foo')`)
+          .and.to.contain(`<html>`)
+          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374d'>`);
+
+        expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+        expect(bids[1].bidderCode).to.equal("rubiconLite");
+        expect(bids[1].width).to.equal(300);
+        expect(bids[1].height).to.equal(250);
+        expect(bids[1].cpm).to.equal(0.811);
+        expect(bids[1].ad).to.contain(`alert('foo')`)
+          .and.to.contain(`<html>`)
+          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374c'>`);
+      });
+
+      it('should be fine with a CPM of 0', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [{
+              "status": "ok",
+              "cpm": 0,
+              "size_id": 15
+            }]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+      });
+
+      it('should handle an error with no ads returned', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": []
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+      });
+
+      it('should handle an error with bad status', () => {
+        rubiconAdapter = new RubiconAdapter(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [{
+              "status": "not_ok",
+            }]
+        }));
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+      });
+
+      it('should handle an error because of malformed json response', () => {
+        rubiconAdapter = new RubiconAdapter("{test{");
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        expect(bids[0].error instanceof SyntaxError).to.equal(true);
+      });
+
+    })
+
+
+  });
+
+});
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
This is a lightweight Rubicon adapter that no longer includes the Fastlane library when participating in an auction.  Due to the lack of Fastlane library, some APIs are unavailable (such as those on the `rubicontag`). For those who still require access to those APIs they can use the regular `rubicon` adapter; for those that don't need those APIs, there is now the option to use this `rubiconLite` adapter for a performance increase.

- test parameters for validating bids
```
{
  bidder: 'rubiconLite',
  params: {
    // ... (same as regular Rubicon adapter)
  }
}
```