### PR TITLE
changed the way sendStandardTargeting works

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -161,24 +161,14 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode] && bidder_settings[bidderCode][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
     setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
-    filterIfSendStandardTargeting(bidder_settings[bidderCode]);
+    custBidObj.sendStandardTargeting = !!bidder_settings[bidderCode].sendStandardTargeting;
   }
 
   //2) set keys from standard setting. NOTE: this API doesn't seem to be in use by any Adapter
   else if (defaultBidderSettingsMap[bidderCode]) {
     setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
-    filterIfSendStandardTargeting(defaultBidderSettingsMap[bidderCode]);
-  }
-
-  function filterIfSendStandardTargeting(bidderSettings) {
-    if (typeof bidderSettings.sendStandardTargeting !== "undefined" && bidderSettings.sendStandardTargeting === false) {
-      for(var key in keyValues) {
-        if(CONSTANTS.TARGETING_KEYS.indexOf(key) !== -1) {
-          delete keyValues[key];
-        }
-      }
-    }
+    custBidObj.sendStandardTargeting = !!defaultBidderSettingsMap[bidderCode].sendStandardTargeting;
   }
 
   return keyValues;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -135,6 +135,12 @@ function setTargeting(targetingConfig) {
   });
 }
 
+function getStandardKeys() {
+  return bidmanager.getStandardBidderAdServerTargeting()        // in case using a custom standard key set
+                   .map(targeting => targeting.key)
+                   .concat(CONSTANTS.TARGETING_KEYS).filter(uniques);     // standard keys defined in the library.
+}
+
 function getWinningBids(adUnitCode) {
   // use the given adUnitCode as a filter if present or all adUnitCodes if not
   const adUnitCodes = adUnitCode ?
@@ -165,12 +171,15 @@ function getWinningBidTargeting() {
     .filter(bid => bid.dealId)
     .map(bid => bid.adserverTargeting.hb_deal = bid.dealId);
 
+  let standardKeys = getStandardKeys();
   winners = winners.map(winner => {
     return {
-      [winner.adUnitCode]: Object.keys(winner.adserverTargeting, key => key)
-        .map(key => {
-          return { [key.substring(0, 20)]: [winner.adserverTargeting[key]] };
-        })
+      [winner.adUnitCode]: Object.keys(winner.adserverTargeting)
+        .filter(key =>
+          typeof winner.sendStandardTargeting === "undefined" ||
+          winner.sendStandardTargeting ||
+          standardKeys.indexOf(key) === -1)
+        .map(key => ({ [key.substring(0, 20)]: [winner.adserverTargeting[key]] }))
     };
   });
 
@@ -191,16 +200,11 @@ function getDealTargeting() {
  * Get custom targeting keys for bids that have `alwaysUseBid=true`.
  */
 function getAlwaysUseBidTargeting() {
-  //in case using a custom standard key set, we'll capture those here
-  let standardKeys = bidmanager.getStandardBidderAdServerTargeting().map(targeting =>{
-    return targeting.key;
-  });
-  //then append standard keys defined in the library.
-  standardKeys = standardKeys.concat(CONSTANTS.TARGETING_KEYS).filter(uniques);
+  let standardKeys = getStandardKeys();
   return $$PREBID_GLOBAL$$._bidsReceived.map(bid => {
     if (bid.alwaysUseBid) {
       return {
-        [bid.adUnitCode]: Object.keys(bid.adserverTargeting, key => key).map(key => {
+        [bid.adUnitCode]: Object.keys(bid.adserverTargeting).map(key => {
           // Get only the non-standard keys of the losing bids, since we
           // don't want to override the standard keys of the winning bid.
           if (standardKeys.indexOf(key) > -1) {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -311,11 +311,12 @@ describe('bidmanager.js', function () {
 
     });
 
-    it('alwaysUseBid=true and inherit custom', function () {
+    it('alwaysUseBid=true, sendStandardTargeting=false, and inherit custom', function () {
       $$PREBID_GLOBAL$$.bidderSettings =
       {
         appnexus: {
           alwaysUseBid: true,
+          sendStandardTargeting: false,
           adserverTargeting: [
             {
               key: "hb_bidder",
@@ -345,7 +346,8 @@ describe('bidmanager.js', function () {
       };
       var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
       assert.deepEqual(response, expected);
-
+      assert.equal(bid.alwaysUseBid, true);
+      assert.equal(bid.sendStandardTargeting, false);
     });
 
     it('suppressEmptyKeys=true' , function() {
@@ -372,44 +374,6 @@ describe('bidmanager.js', function () {
 
       var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
       assert.deepEqual(response, expected);
-    });
-
-    it('sendStandardTargeting=false and inherit custom', function () {
-      $$PREBID_GLOBAL$$.bidderSettings =
-      {
-        appnexus: {
-          alwaysUseBid: true,
-          sendStandardTargeting: false,
-          adserverTargeting: [
-            {
-              key: "hb_bidder",
-              val: function (bidResponse) {
-                return bidResponse.bidderCode;
-              }
-            }, {
-              key: "hb_adid",
-              val: function (bidResponse) {
-                return bidResponse.adId;
-              }
-            }, {
-              key: "hb_pb",
-              val: function (bidResponse) {
-                return bidResponse.pbHg;
-              }
-            }, {
-              key: "custom",
-              val: 42
-            }
-          ]
-        }
-      };
-
-      var expected = {
-        "custom": 42
-      };
-      var response = bidmanager.getKeyValueTargetingPairs(bidderCode, bid);
-      assert.deepEqual(response, expected);
-
     });
 
   });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -223,13 +223,13 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual(targeting, expected);
     });
 
-    it("should not ovewrite winning bids custom keys targeting key when the bid has `alwaysUseBid` set to `true`", () => {
+    it("should not overwrite winning bids custom keys targeting key when the bid has `alwaysUseBid` set to `true`", () => {
 
       //mimic a bidderSetting.standard key here for each bid and alwaysUseBid true for every bid
       $$PREBID_GLOBAL$$._bidsReceived.forEach(bid => {
         bid.adserverTargeting.custom_ad_id = bid.adId;
         bid.alwaysUseBid = true;
-      })
+      });
       $$PREBID_GLOBAL$$.bidderSettings = {
         "standard": {
           adserverTargeting: [{
@@ -282,6 +282,30 @@ describe('Unit: Prebid Module', function () {
 
     });
 
+    it("should not send standard targeting keys when the bid has `sendStandardTargeting` set to `false`", () => {
+
+      $$PREBID_GLOBAL$$._bidsReceived.forEach(bid => {
+        bid.adserverTargeting.custom_ad_id = bid.adId;
+        bid.sendStandardTargeting = false;
+      });
+
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
+
+      var expected = {
+        '/19968336/header-bid-tag-0': {
+          foobar: '300x250',
+          custom_ad_id: '233bcbee889d46d'
+        },
+        '/19968336/header-bid-tag1': {
+          foobar: '728x90',
+          custom_ad_id:'24bd938435ec3fc'
+        }
+      };
+
+      assert.deepEqual(targeting, expected);
+      $$PREBID_GLOBAL$$.bidderSettings = {};
+
+    });
 
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
## Description of change

This is a bit of a refactor to the method that was being used for `sendStandardKeys: false`.  Before it was removing them from the `adserverTargeting`, now it's setting a boolean on the bidResponse and then suppressing them when targeting is requested.

Removing them from `adserverTargeting` was having a weird side-effect with `enableSendAllBids` where it couldn't find the original targeting for the new `enableSendAllBids` values, so it was just sending them as `undefined`.
