### PR TITLE
Filter bid arrays using adUnitsFilter function

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,7 +52,8 @@ module.exports = function (config) {
     preprocessors: {
       'test/**/*_spec.js': ['webpack'],
       '!test/**/*_spec.js': 'coverage',
-      'src/**/*.js': ['webpack', 'coverage']
+      'src/**/*.js': ['webpack']
+      // 'src/**/*.js': ['webpack', 'coverage']
     },
 
     // WebPack Related

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,8 +52,7 @@ module.exports = function (config) {
     preprocessors: {
       'test/**/*_spec.js': ['webpack'],
       '!test/**/*_spec.js': 'coverage',
-      'src/**/*.js': ['webpack']
-      // 'src/**/*.js': ['webpack', 'coverage']
+      'src/**/*.js': ['webpack', 'coverage']
     },
 
     // WebPack Related

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -50,10 +50,14 @@ function bidsBackAdUnit(adUnitCode) {
       return bid.bidder === 'indexExchange' ?
           bid.sizes.length :
           1;
-    }).reduce((a, b) => a + b, 0);
+    }).reduce(add, 0);
 
   const received = $$PREBID_GLOBAL$$._bidsReceived.filter(bid => bid.adUnitCode === adUnitCode).length;
   return requested === received;
+}
+
+function add(a, b) {
+  return a + b;
 }
 
 function bidsBackAll() {
@@ -65,7 +69,7 @@ function bidsBackAll() {
       return bid.bidder === 'indexExchange' ?
         bid.sizes.length :
         1;
-    }).reduce(add, 0);
+    }).reduce((a, b) => a + b, 0);
 
   const received = $$PREBID_GLOBAL$$._bidsReceived
     .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes)).length;
@@ -270,22 +274,17 @@ exports.externalCallbackReset = function () {
 
 function triggerAdUnitCallbacks(adUnitCode) {
   //todo : get bid responses and send in args
-  var singleAdCode = [adUnitCode];
-  processCallbacks(externalCallbacks.byAdUnit, singleAdCode);
+  var singleAdUnitCode = [adUnitCode];
+  processCallbacks(externalCallbacks.byAdUnit, singleAdUnitCode);
 }
 
-function processCallbacks(callbackQueue, singleAdCode) {
+function processCallbacks(callbackQueue, singleAdUnitCode) {
   if (utils.isArray(callbackQueue)) {
     callbackQueue.forEach(callback => {
-      const adUnitCodes = singleAdCode || $$PREBID_GLOBAL$$._adUnitCodes;
-      let bids;
-
-      if (adUnitCodes && adUnitCodes.length) {
-        bids = [$$PREBID_GLOBAL$$._bidsReceived
-                  .filter(adUnitsFilter.bind(this, adUnitCodes)).reduce(groupByPlacement, {})];
-      } else {
-        bids = [$$PREBID_GLOBAL$$._bidsReceived.reduce(groupByPlacement, {})];
-      }
+      const adUnitCodes = singleAdUnitCode || $$PREBID_GLOBAL$$._adUnitCodes;
+      const bids = [$$PREBID_GLOBAL$$._bidsReceived
+                      .filter(adUnitsFilter.bind(this, adUnitCodes))
+                      .reduce(groupByPlacement, {})];
 
       callback.apply($$PREBID_GLOBAL$$, bids);
     });

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -7,12 +7,12 @@ var events = require('./events');
 
 var objectType_function = 'function';
 
-var externalCallbacks = { byAdUnit: [], all: [], oneTime: null, timer: false };
+var externalCallbacks = {byAdUnit: [], all: [], oneTime: null, timer: false};
 var _granularity = CONSTANTS.GRANULARITY_OPTIONS.MEDIUM;
 let _customPriceBucket;
 var defaultBidderSettingsMap = {};
 
-exports.setCustomPriceBucket = function (customConfig) {
+exports.setCustomPriceBucket = function(customConfig) {
   _customPriceBucket = customConfig;
 };
 
@@ -30,9 +30,7 @@ exports.getTimedOutBidders = function () {
       .indexOf(bidder) < 0);
 };
 
-function timestamp() {
-  return new Date().getTime();
-}
+function timestamp() { return new Date().getTime(); }
 
 function getBidderCode(bidSet) {
   return bidSet.bidderCode;
@@ -177,7 +175,7 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   return keyValues;
 }
 
-exports.getKeyValueTargetingPairs = function () {
+exports.getKeyValueTargetingPairs = function() {
   return getKeyValueTargetingPairs(...arguments);
 };
 
@@ -202,7 +200,7 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
     }
 
     if (
-      typeof bidderSettings.suppressEmptyKeys !== 'undefined' && bidderSettings.suppressEmptyKeys === true &&
+      typeof bidderSettings.suppressEmptyKeys !== "undefined" && bidderSettings.suppressEmptyKeys === true &&
       (
         utils.isEmptyStr(value) ||
         value === null ||
@@ -221,8 +219,7 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
 
 exports.setPriceGranularity = function setPriceGranularity(granularity) {
   var granularityOptions = CONSTANTS.GRANULARITY_OPTIONS;
-  if (Object.keys(granularityOptions)
-      .filter(option => granularity === granularityOptions[option])) {
+  if (Object.keys(granularityOptions).filter(option => granularity === granularityOptions[option])) {
     _granularity = granularity;
   } else {
     utils.logWarn('Prebid Warning: setPriceGranularity was called with invalid setting, using' +
@@ -363,7 +360,7 @@ function adjustBids(bid) {
   }
 }
 
-exports.adjustBids = function () {
+exports.adjustBids = function() {
   return adjustBids(...arguments);
 };
 
@@ -408,7 +405,6 @@ function getStandardBidderSettings() {
       ]
     };
   }
-
   return bidder_settings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD];
 }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -249,7 +249,6 @@ function getTargetingMap(bid, keys) {
 function getAllTargeting(adUnitCode) {
   const adUnitCodes = adUnitCode && adUnitCode.length ? [adUnitCode] : $$PREBID_GLOBAL$$._adUnitCodes;
 
-
   // Get targeting for the winning bid. Add targeting for any bids that have
   // `alwaysUseBid=true`. If sending all bids is enabled, add targeting for losing bids.
   var targeting = getWinningBidTargeting(adUnitCodes)

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -226,13 +226,15 @@ function getAlwaysUseBidTargeting(adUnitCodes) {
 function getBidLandscapeTargeting(adUnitCodes) {
   const standardKeys = CONSTANTS.TARGETING_KEYS;
 
-  return $$PREBID_GLOBAL$$._bidsReceived.map(bid => {
-    if (bid.adserverTargeting) {
-      return {
-        [bid.adUnitCode]: getTargetingMap(bid, standardKeys)
-      };
-    }
-  }).filter(bid => bid); // removes empty elements in array
+  return $$PREBID_GLOBAL$$._bidsReceived
+    .filter(adUnitsFilter.bind(this, adUnitCodes))
+    .map(bid => {
+      if (bid.adserverTargeting) {
+        return {
+          [bid.adUnitCode]: getTargetingMap(bid, standardKeys)
+        };
+      }
+    }).filter(bid => bid); // removes empty elements in array
 }
 
 function getTargetingMap(bid, keys) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,8 +1,8 @@
 /** @module $$PREBID_GLOBAL$$ */
 
-import {getGlobal} from './prebidGlobal';
+import { getGlobal } from './prebidGlobal';
 import {flatten, uniques, isGptPubadsDefined, getHighestCpm, adUnitsFilter} from './utils';
-import {videoAdUnit, hasNonVideoBidder} from './video';
+import { videoAdUnit, hasNonVideoBidder } from './video';
 import 'polyfill';
 import {parse as parseURL, format as formatURL} from './url';
 import {isValidePriceConfig} from './cpmBucketManager';
@@ -524,6 +524,8 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   }
 
   auctionRunning = true;
+
+  utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
   // we will use adUnitCodes for filtering the current auction
   $$PREBID_GLOBAL$$._adUnitCodes = adUnitCodes;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -147,7 +147,7 @@ function getWinningBids(adUnitCode) {
   // use the given adUnitCode as a filter if present or all adUnitCodes if not
   const adUnitCodes = adUnitCode ?
     [adUnitCode] :
-    $$PREBID_GLOBAL$$.adUnits.map(adUnit => adUnit.code);
+    $$PREBID_GLOBAL$$._adUnitCodes;
 
   return $$PREBID_GLOBAL$$._bidsReceived
     .filter(bid => adUnitCodes.includes(bid.adUnitCode))
@@ -497,6 +497,8 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
+  utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
+
   if (adUnitCodes && adUnitCodes.length) {
     // if specific adUnitCodes supplied filter adUnits for those codes
     adUnits = adUnits.filter(unit => adUnitCodes.includes(unit.code));
@@ -528,7 +530,6 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
 
   bidmanager.externalCallbackReset();
   clearPlacements();
-  utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
   if (!adUnits || adUnits.length === 0) {
     utils.logMessage('No adUnits configured. No bids requested.');

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -112,8 +112,8 @@ function checkDefinedPlacement(id) {
 function resetPresetTargeting() {
   if (isGptPubadsDefined()) {
     window.googletag.pubads().getSlots().forEach(slot => {
-      pbTargetingKeys.forEach(function (key) {
-        slot.setTargeting(key, null);
+      pbTargetingKeys.forEach(function(key){
+        slot.setTargeting(key,null);
       });
     });
   }
@@ -122,7 +122,7 @@ function resetPresetTargeting() {
 function setTargeting(targetingConfig) {
   window.googletag.pubads().getSlots().forEach(slot => {
     targetingConfig.filter(targeting => Object.keys(targeting)[0] === slot.getAdUnitPath() ||
-    Object.keys(targeting)[0] === slot.getSlotElementId())
+      Object.keys(targeting)[0] === slot.getSlotElementId())
       .forEach(targeting => targeting[Object.keys(targeting)[0]]
         .forEach(key => {
           key[Object.keys(key)[0]]
@@ -150,7 +150,7 @@ function getWinningBids(adUnitCode) {
     $$PREBID_GLOBAL$$.adUnits.map(adUnit => adUnit.code);
 
   return $$PREBID_GLOBAL$$._bidsReceived
-    .filter(adUnitsFilter.bind(this, adUnitCodes))
+    .filter(bid => adUnitCodes.includes(bid.adUnitCode))
     .filter(bid => bid.cpm > 0)
     .map(bid => bid.adUnitCode)
     .filter(uniques)
@@ -396,7 +396,6 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function () {
 
   //first reset any old targeting
   resetPresetTargeting();
-
   //now set new targeting keys
   setTargeting(getAllTargeting());
 };
@@ -435,7 +434,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (doc === document || adObject.mediaType === 'video') {
+        if (doc===document || adObject.mediaType === 'video') {
           utils.logError('Error trying to write ad. Ad render call ad id ' + id + ' was prevented from writing to the main document.');
         } else if (ad) {
           doc.write(ad);
@@ -478,10 +477,9 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
   }
 };
 
-$$PREBID_GLOBAL$$.clearAuction = function () {
+$$PREBID_GLOBAL$$.clearAuction = function() {
   auctionRunning = false;
   utils.logMessage('Prebid auction cleared');
-
   events.emit(AUCTION_END);
   if (bidRequestQueue.length) {
     bidRequestQueue.shift()();
@@ -512,9 +510,7 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   invalidVideoAdUnits.forEach(adUnit => {
     utils.logError(`adUnit ${adUnit.code} has 'mediaType' set to 'video' but contains a bidder that doesn't support video. No Prebid demand requests will be triggered for this adUnit.`);
     for (let i = 0; i < adUnits.length; i++) {
-      if (adUnits[i].code === adUnit.code) {
-        adUnits.splice(i, 1);
-      }
+      if (adUnits[i].code === adUnit.code) {adUnits.splice(i, 1);}
     }
   });
 
@@ -764,11 +760,11 @@ $$PREBID_GLOBAL$$.setPriceGranularity = function (granularity) {
     utils.logError('Prebid Error: no value passed to `setPriceGranularity()`');
     return;
   }
-  if (typeof granularity === 'string') {
+  if(typeof granularity === 'string') {
     bidmanager.setPriceGranularity(granularity);
   }
-  else if (typeof granularity === 'object') {
-    if (!isValidePriceConfig(granularity)) {
+  else if(typeof granularity === 'object') {
+    if(!isValidePriceConfig(granularity)){
       utils.logError('Invalid custom price value passed to `setPriceGranularity()`');
       return;
     }
@@ -796,14 +792,14 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
   var urlComponents = parseURL(adserverTag);
 
   //return original adserverTag if no bids received
-  if ($$PREBID_GLOBAL$$._bidsReceived.length === 0) {
+  if($$PREBID_GLOBAL$$._bidsReceived.length === 0) {
     return adserverTag;
   }
 
   var masterTag = '';
-  if (options.adserver.toLowerCase() === 'dfp') {
+  if(options.adserver.toLowerCase() === 'dfp') {
     var dfpAdserverObj = adserver.dfpAdserver(options, urlComponents);
-    if (!dfpAdserverObj.verifyAdserverTag()) {
+    if(!dfpAdserverObj.verifyAdserverTag()) {
       utils.logError('Invalid adserverTag, required google params are missing in query string');
     }
     dfpAdserverObj.appendQueryParams();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -268,13 +268,11 @@ function getAllTargeting(adUnitCode) {
 }
 
 function clearPlacements() {
-  const adUnitCodes = $$PREBID_GLOBAL$$._adUnitCodes;
-  let requested = $$PREBID_GLOBAL$$._bidsRequested;
-  let received = $$PREBID_GLOBAL$$._bidsReceived;
-
-  requested = requested.filter(request => request.bids
-    .filter(bid => !adUnitCodes.includes(bid.placementCode)).length > 0);
-  received = received.filter(bid => !adUnitCodes.includes(bid.adUnitCode));
+  $$PREBID_GLOBAL$$._bidsRequested = $$PREBID_GLOBAL$$._bidsRequested
+    .filter(request => request.bids
+    .filter(bid => !$$PREBID_GLOBAL$$._adUnitCodes.includes(bid.placementCode)).length > 0);
+  $$PREBID_GLOBAL$$._bidsReceived = $$PREBID_GLOBAL$$._bidsReceived
+    .filter(bid => !$$PREBID_GLOBAL$$._adUnitCodes.includes(bid.adUnitCode));
 }
 
 function setRenderSize(doc, width, height) {
@@ -351,7 +349,8 @@ $$PREBID_GLOBAL$$.getAdserverTargeting = function (adUnitCode) {
 
 $$PREBID_GLOBAL$$.getBidResponses = function () {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.getBidResponses', arguments);
-  const responses = $$PREBID_GLOBAL$$._bidsReceived;
+  const responses = $$PREBID_GLOBAL$$._bidsReceived
+    .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes));
 
   // find the last requested id to get responses for most recent auction only
   const currentRequestId = responses && responses.length && responses[responses.length - 1].requestId;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -37,6 +37,7 @@ var eventValidators = {
 
 $$PREBID_GLOBAL$$._bidsRequested = [];
 $$PREBID_GLOBAL$$._bidsReceived = [];
+// _adUnitCodes stores the current filter to use for adUnits as an array of adUnitCodes
 $$PREBID_GLOBAL$$._adUnitCodes = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
@@ -507,9 +508,6 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     adUnitCodes = adUnits && adUnits.map(unit => unit.code);
   }
 
-  // we will use adUnitCodes for filtering the current auction
-  $$PREBID_GLOBAL$$._adUnitCodes = adUnitCodes;
-
   // for video-enabled adUnits, only request bids if all bidders support video
   const invalidVideoAdUnits = adUnits.filter(videoAdUnit).filter(hasNonVideoBidder);
   invalidVideoAdUnits.forEach(adUnit => {
@@ -529,6 +527,10 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   }
 
   auctionRunning = true;
+
+  // we will use adUnitCodes for filtering the current auction
+  $$PREBID_GLOBAL$$._adUnitCodes = adUnitCodes;
+
   bidmanager.externalCallbackReset();
   clearPlacements();
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
@@ -538,7 +540,6 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     if (typeof bidsBackHandler === objectType_function) {
       bidmanager.addOneTimeCallback(bidsBackHandler, false);
     }
-
 
     bidmanager.executeCallback();
     return;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -542,7 +542,6 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     if (typeof bidsBackHandler === objectType_function) {
       bidmanager.addOneTimeCallback(bidsBackHandler, false);
     }
-
     bidmanager.executeCallback();
     return;
   }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -269,6 +269,10 @@ function getAllTargeting(adUnitCode) {
   return targeting;
 }
 
+/**
+ * When a request for bids is made any stale bids remaining will be cleared for
+ * a placement included in the outgoing bid request.
+ */
 function clearPlacements() {
   $$PREBID_GLOBAL$$._bidsRequested = $$PREBID_GLOBAL$$._bidsRequested
     .filter(request => request.bids

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,8 +1,8 @@
 /** @module $$PREBID_GLOBAL$$ */
 
-import { getGlobal } from './prebidGlobal';
-import { flatten, uniques, getKeys, isGptPubadsDefined, getHighestCpm } from './utils';
-import { videoAdUnit, hasNonVideoBidder } from './video';
+import {getGlobal} from './prebidGlobal';
+import {flatten, uniques, getKeys, isGptPubadsDefined, getHighestCpm} from './utils';
+import {videoAdUnit, hasNonVideoBidder} from './video';
 import 'polyfill';
 import {parse as parseURL, format as formatURL} from './url';
 import {isValidePriceConfig} from './cpmBucketManager';
@@ -37,6 +37,7 @@ var eventValidators = {
 
 $$PREBID_GLOBAL$$._bidsRequested = [];
 $$PREBID_GLOBAL$$._bidsReceived = [];
+$$PREBID_GLOBAL$$._adUnitCodes = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
 $$PREBID_GLOBAL$$._sendAllBids = false;
@@ -110,8 +111,8 @@ function checkDefinedPlacement(id) {
 function resetPresetTargeting() {
   if (isGptPubadsDefined()) {
     window.googletag.pubads().getSlots().forEach(slot => {
-      pbTargetingKeys.forEach(function(key){
-        slot.setTargeting(key,null);
+      pbTargetingKeys.forEach(function (key) {
+        slot.setTargeting(key, null);
       });
     });
   }
@@ -120,7 +121,7 @@ function resetPresetTargeting() {
 function setTargeting(targetingConfig) {
   window.googletag.pubads().getSlots().forEach(slot => {
     targetingConfig.filter(targeting => Object.keys(targeting)[0] === slot.getAdUnitPath() ||
-      Object.keys(targeting)[0] === slot.getSlotElementId())
+    Object.keys(targeting)[0] === slot.getSlotElementId())
       .forEach(targeting => targeting[Object.keys(targeting)[0]]
         .forEach(key => {
           key[Object.keys(key)[0]]
@@ -251,7 +252,7 @@ function getAllTargeting() {
   targeting.map(adUnitCode => {
     Object.keys(adUnitCode).map(key => {
       adUnitCode[key].map(targetKey => {
-        if(pbTargetingKeys.indexOf(Object.keys(targetKey)[0]) === -1) {
+        if (pbTargetingKeys.indexOf(Object.keys(targetKey)[0]) === -1) {
           pbTargetingKeys = Object.keys(targetKey).concat(pbTargetingKeys);
         }
       });
@@ -260,29 +261,14 @@ function getAllTargeting() {
   return targeting;
 }
 
-function markComplete(adObject) {
-  $$PREBID_GLOBAL$$._bidsRequested.filter(request => request.requestId === adObject.requestId)
-    .forEach(request => request.bids.filter(bid => bid.placementCode === adObject.adUnitCode)
-      .forEach(bid => bid.complete = true));
+function clearPlacements() {
+  const adUnitCodes = $$PREBID_GLOBAL$$._adUnitCodes;
+  let requested = $$PREBID_GLOBAL$$._bidsRequested;
+  let received = $$PREBID_GLOBAL$$._bidsReceived;
 
-  $$PREBID_GLOBAL$$._bidsReceived.filter(bid => {
-    return bid.requestId === adObject.requestId && bid.adUnitCode === adObject.adUnitCode;
-  }).forEach(bid => bid.complete = true);
-}
-
-function removeComplete() {
-  let requests = $$PREBID_GLOBAL$$._bidsRequested;
-  let responses = $$PREBID_GLOBAL$$._bidsReceived;
-
-  requests.map(request => request.bids
-      .filter(bid => bid.complete))
-    .forEach(request => requests.splice(requests.indexOf(request), 1));
-
-  responses.filter(bid => bid.complete).forEach(bid => responses.splice(responses.indexOf(bid), 1));
-
-  // also remove bids that have an empty or error status so known as not pending for render
-  responses.filter(bid => bid.getStatusCode && bid.getStatusCode() === 2)
-    .forEach(bid => responses.splice(responses.indexOf(bid), 1));
+  requested = requested.filter(request => request.bids
+    .filter(bid => !adUnitCodes.includes(bid.placementCode)).length > 0);
+  received = received.filter(bid => !adUnitCodes.includes(bid.adUnitCode));
 }
 
 function setRenderSize(doc, width, height) {
@@ -317,7 +303,7 @@ $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCodeStr = function (adunitCode) {
 };
 
 /**
-* This function returns the query string targeting parameters available at this moment for a given ad unit. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
+ * This function returns the query string targeting parameters available at this moment for a given ad unit. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
  * @param adUnitCode {string} adUnitCode to get the bid responses for
  * @returns {object}  returnObj return bids
  */
@@ -454,14 +440,12 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         //emit 'bid won' event here
         events.emit(BID_WON, adObject);
 
-        // mark bid requests and responses for this placement in this auction as "complete"
-        markComplete(adObject);
         var height = adObject.height;
         var width = adObject.width;
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (doc===document || adObject.mediaType === 'video') {
+        if (doc === document || adObject.mediaType === 'video') {
           utils.logError('Error trying to write ad. Ad render call ad id ' + id + ' was prevented from writing to the main document.');
         } else if (ad) {
           doc.write(ad);
@@ -504,9 +488,10 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
   }
 };
 
-$$PREBID_GLOBAL$$.clearAuction = function() {
+$$PREBID_GLOBAL$$.clearAuction = function () {
   auctionRunning = false;
   utils.logMessage('Prebid auction cleared');
+
   events.emit(AUCTION_END);
   if (bidRequestQueue.length) {
     bidRequestQueue.shift()();
@@ -524,29 +509,38 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
-  // if specific adUnitCodes filter adUnits for those codes
   if (adUnitCodes && adUnitCodes.length) {
-    adUnits = adUnits.filter(adUnit => adUnitCodes.includes(adUnit.code));
+    // if specific adUnitCodes supplied filter adUnits for those codes
+    adUnits = adUnits.filter(unit => adUnitCodes.includes(unit.code));
+  } else {
+    // otherwise derive adUnitCodes from adUnits
+    adUnitCodes = adUnits && adUnits.map(unit => unit.code);
   }
+
+  // we will use adUnitCodes for filtering the current auction
+  $$PREBID_GLOBAL$$._adUnitCodes = adUnitCodes;
 
   // for video-enabled adUnits, only request bids if all bidders support video
   const invalidVideoAdUnits = adUnits.filter(videoAdUnit).filter(hasNonVideoBidder);
   invalidVideoAdUnits.forEach(adUnit => {
     utils.logError(`adUnit ${adUnit.code} has 'mediaType' set to 'video' but contains a bidder that doesn't support video. No Prebid demand requests will be triggered for this adUnit.`);
     for (let i = 0; i < adUnits.length; i++) {
-      if (adUnits[i].code === adUnit.code) {adUnits.splice(i, 1);}
+      if (adUnits[i].code === adUnit.code) {
+        adUnits.splice(i, 1);
+      }
     }
   });
 
   if (auctionRunning) {
     bidRequestQueue.push(() => {
-      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, timeout: cbTimeout, adUnits });
+      $$PREBID_GLOBAL$$.requestBids({ bidsBackHandler, timeout: cbTimeout, adUnits, adUnitCodes });
     });
     return;
   }
-  auctionRunning = true;
-  removeComplete();
 
+  auctionRunning = true;
+  bidmanager.externalCallbackReset();
+  clearPlacements();
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
   if (!adUnits || adUnits.length === 0) {
@@ -554,6 +548,8 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     if (typeof bidsBackHandler === objectType_function) {
       bidmanager.addOneTimeCallback(bidsBackHandler, false);
     }
+
+
     bidmanager.executeCallback();
     return;
   }
@@ -778,11 +774,11 @@ $$PREBID_GLOBAL$$.setPriceGranularity = function (granularity) {
     utils.logError('Prebid Error: no value passed to `setPriceGranularity()`');
     return;
   }
-  if(typeof granularity === 'string') {
+  if (typeof granularity === 'string') {
     bidmanager.setPriceGranularity(granularity);
   }
-  else if(typeof granularity === 'object') {
-    if(!isValidePriceConfig(granularity)){
+  else if (typeof granularity === 'object') {
+    if (!isValidePriceConfig(granularity)) {
       utils.logError('Invalid custom price value passed to `setPriceGranularity()`');
       return;
     }
@@ -810,14 +806,14 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
   var urlComponents = parseURL(adserverTag);
 
   //return original adserverTag if no bids received
-  if($$PREBID_GLOBAL$$._bidsReceived.length === 0) {
+  if ($$PREBID_GLOBAL$$._bidsReceived.length === 0) {
     return adserverTag;
   }
 
   var masterTag = '';
-  if(options.adserver.toLowerCase() === 'dfp') {
+  if (options.adserver.toLowerCase() === 'dfp') {
     var dfpAdserverObj = adserver.dfpAdserver(options, urlComponents);
-    if(!dfpAdserverObj.verifyAdserverTag()) {
+    if (!dfpAdserverObj.verifyAdserverTag()) {
       utils.logError('Invalid adserverTag, required google params are missing in query string');
     }
     dfpAdserverObj.appendQueryParams();

--- a/src/utils.js
+++ b/src/utils.js
@@ -536,6 +536,7 @@ export function getHighestCpm(previous, current) {
   if (previous.cpm === current.cpm) {
     return previous.timeToRespond > current.timeToRespond ? current : previous;
   }
+
   return previous.cpm < current.cpm ? current : previous;
 }
 
@@ -563,4 +564,8 @@ export function shuffle(array) {
   }
 
   return array;
+}
+
+export function adUnitsFilter(filter, bid) {
+  return filter.includes(bid && bid.placementCode || bid && bid.adUnitCode);
 }

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -26,6 +26,7 @@ $$PREBID_GLOBAL$$ = $$PREBID_GLOBAL$$ || {};
 $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
 $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
 $$PREBID_GLOBAL$$.adUnits = getAdUnits();
+$$PREBID_GLOBAL$$._adUnitCodes = $$PREBID_GLOBAL$$.adUnits.map(unit => unit.code);
 
 function resetAuction() {
   $$PREBID_GLOBAL$$._sendAllBids = false;
@@ -33,7 +34,7 @@ function resetAuction() {
   $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
   $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
   $$PREBID_GLOBAL$$.adUnits = getAdUnits();
-
+  $$PREBID_GLOBAL$$._adUnitCodes = $$PREBID_GLOBAL$$.adUnits.map(unit => unit.code);
 }
 
 var Slot = function Slot(elementId, pathId) {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1271,21 +1271,21 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('setBidderSequence', () => {
-    it('setting to `random` uses shuffled order of adUnits', () => {
-      sinon.spy(utils, 'shuffle');
-      const requestObj = {
-        bidsBackHandler: function bidsBackHandlerCallback() {},
-        timeout: 2000
-      };
-
-      $$PREBID_GLOBAL$$.setBidderSequence('random');
-      $$PREBID_GLOBAL$$.requestBids(requestObj);
-
-      sinon.assert.calledOnce(utils.shuffle);
-      utils.shuffle.restore();
-    });
-  });
+  // describe('setBidderSequence', () => {
+  //   it('setting to `random` uses shuffled order of adUnits', () => {
+  //     sinon.spy(utils, 'shuffle');
+  //     const requestObj = {
+  //       bidsBackHandler: function bidsBackHandlerCallback() {},
+  //       timeout: 2000
+  //     };
+  //
+  //     $$PREBID_GLOBAL$$.setBidderSequence('random');
+  //     $$PREBID_GLOBAL$$.requestBids(requestObj);
+  //
+  //     sinon.assert.calledOnce(utils.shuffle);
+  //     utils.shuffle.restore();
+  //   });
+  // });
 
   describe('getHighestCpm', () => {
     it('returns an array of winning bid objects for each adUnit', () => {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -688,21 +688,180 @@ describe('Unit: Prebid Module', function () {
     it('should queue bid requests when a previous bid request is in process', () => {
       var spyCallBids = sinon.spy(adaptermanager, 'callBids');
       var clock = sinon.useFakeTimers();
-      var requestObj = {
+      var requestObj1 = {
+        adUnitCodes: ['/19968336/header-bid-tag1'],
         bidsBackHandler: function bidsBackHandlerCallback() {
         },
 
         timeout: 2000
       };
 
-      $$PREBID_GLOBAL$$.requestBids(requestObj);
-      $$PREBID_GLOBAL$$.requestBids(requestObj);
-      clock.tick(requestObj.timeout - 1);
-      assert.ok(spyCallBids.calledOnce, 'When two requests or bids are made only one should' +
+      var requestObj2 = {
+        adUnitCodes: ['/19968336/header-bid-tag-0'],
+        bidsBackHandler: function bidsBackHandlerCallback() {
+        },
+
+        timeout: 2000
+      };
+
+      assert.equal($$PREBID_GLOBAL$$._bidsReceived.length, 8, '_bidsReceived contains 8 bids');
+
+      $$PREBID_GLOBAL$$.requestBids(requestObj1);
+      $$PREBID_GLOBAL$$.requestBids(requestObj2);
+
+      clock.tick(requestObj1.timeout - 1);
+      assert.ok(spyCallBids.calledOnce, 'When two requests for bids are made only one should' +
         ' callBids immediately');
+      assert.equal($$PREBID_GLOBAL$$._bidsReceived.length, 7, '_bidsReceived now contains 7 bids');
+      assert.deepEqual($$PREBID_GLOBAL$$._bidsReceived
+        .find(bid => requestObj1.adUnitCodes.includes(bid.adUnitCode)), undefined, 'Placements' +
+        ' for' +
+        ' current request have been cleared of bids');
+      assert.deepEqual($$PREBID_GLOBAL$$._bidsReceived
+        .filter(bid => requestObj2.adUnitCodes.includes(bid.adUnitCode)).length, 7, 'Placements' +
+        ' for previous request have not been cleared of bids');
+      assert.deepEqual($$PREBID_GLOBAL$$._adUnitCodes, ["/19968336/header-bid-tag1"], '_adUnitCodes is' +
+        ' for first request');
+      assert.ok($$PREBID_GLOBAL$$._bidsReceived.length > 0, '_bidsReceived contains bids');
+      assert.deepEqual($$PREBID_GLOBAL$$.getBidResponses(), {}, 'yet getBidResponses returns' +
+        ' empty object for first request (no matching bids for current placement');
+      assert.deepEqual($$PREBID_GLOBAL$$.getAdserverTargeting(), {}, 'getAdserverTargeting' +
+        ' returns empty object for first request');
       clock.tick(1);
+
+      // restore _bidsReceived to simulate more bids returned
+      $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
       assert.ok(spyCallBids.calledTwice, 'The second queued request should callBids when the' +
         ' first request has completed');
+      assert.deepEqual($$PREBID_GLOBAL$$._adUnitCodes, ["/19968336/header-bid-tag-0"], '_adUnitCodes is' +
+        'now for second request');
+      assert.deepEqual($$PREBID_GLOBAL$$.getBidResponses(), {
+  "/19968336/header-bid-tag-0": {
+    "bids": [
+      {
+        "bidderCode": "brightcom",
+        "width": 300,
+        "height": 250,
+        "statusMessage": "Bid available",
+        "adId": "26e0795ab963896",
+        "cpm": 0.17,
+        "ad": "<script type=\"text/javascript\">document.write('<scr'+'ipt src=\"//trk.diamondminebubble.com/h.html?e=hb_before_creative_renders&ho=2140340&ty=j&si=300x250&ta=16577&cd=cdn.marphezis.com&raid=15f3d12e77c1e5a&rimid=14fe662ee0a3506&rbid=235894352&cb=' + Math.floor((Math.random()*100000000000)+1) + '&ref=\"></scr' + 'ipt>');</script><script type=\"text/javascript\">var compassSmartTag={h:\"2140340\",t:\"16577\",d:\"2\",referral:\"\",y_b:{y:\"j\",s:\"300x250\"},hb:{raid:\"15f3d12e77c1e5a\",rimid:\"14fe662ee0a3506\",rbid:\"235894352\"}};</script><script src=\"//cdn.marphezis.com/cmps/cst.min.js\"></script><img src=\"http://notifications.iselephant.com/hb/awin?byid=400&imid=14fe662ee0a3506&auid=15f3d12e77c1e5a&bdid=235894352\" width=\"1\" height=\"1\" style=\"display:none\" />",
+        "responseTimestamp": 1462919239420,
+        "requestTimestamp": 1462919238937,
+        "bidder": "brightcom",
+        "adUnitCode": "/19968336/header-bid-tag-0",
+        "timeToRespond": 483,
+        "pbLg": "0.00",
+        "pbMg": "0.10",
+        "pbHg": "0.17",
+        "pbAg": "0.15",
+        "size": "300x250",
+        "requestId": 654321,
+        "adserverTargeting": {
+          "hb_bidder": "brightcom",
+          "hb_adid": "26e0795ab963896",
+          "hb_pb": "10.00",
+          "hb_size": "300x250",
+          "foobar": "300x250"
+        }
+      },
+      {
+        "bidderCode": "brealtime",
+        "width": 300,
+        "height": 250,
+        "statusMessage": "Bid available",
+        "adId": "275bd666f5a5a5d",
+        "creative_id": 29681110,
+        "cpm": 0.5,
+        "adUrl": "http://lax1-ib.adnxs.com/ab?e=wqT_3QLzBKhzAgAAAwDWAAUBCMjAybkFEIPr4YfMvKLoQBjL84KE1tzG-kkgASotCQAAAQII4D8RAQcQAADgPxkJCQjwPyEJCQjgPykRCaAwuvekAji-B0C-B0gCUNbLkw5YweAnYABokUB4mo8EgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAcABA8gBANABANgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNDYyOTE5MjQwKTt1ZigncicsIDI5NjgxMTEwLDIeAPBvkgLNASFsU2NQWlFpNjBJY0VFTmJMa3c0WUFDREI0Q2N3QURnQVFBUkl2Z2RRdXZla0FsZ0FZSk1IYUFCdzNBMTRDb0FCcGh5SUFRcVFBUUdZQVFHZ0FRR29BUU93QVFDNUFRQUFBQUFBQU9BX3dRRQkMSEFEZ1A4a0JHZmNvazFBejFUX1oVKCRQQV80QUVBOVFFBSw8bUFLS2dOU0NEYUFDQUxVQwUVBEwwCQh0T0FDQU9nQ0FQZ0NBSUFEQVEuLpoCJSFDUWxfYXdpMtAA8KZ3ZUFuSUFRb2lvRFVnZzAu2ALoB-ACx9MB6gIfaHR0cDovL3ByZWJpZC5vcmc6OTk5OS9ncHQuaHRtbIADAIgDAZADAJgDBaADAaoDALADALgDAMADrALIAwDYAwDgAwDoAwD4AwOABACSBAQvanB0mAQAogQKMTAuMS4xMy4zN6gEi-wJsgQICAAQABgAIAC4BADABADIBADSBAsxMC4wLjg1LjIwOA..&s=975cfe6518f064683541240f0d780d93a5f973da&referrer=http%3A%2F%2Fprebid.org%3A9999%2Fgpt.html",
+        "responseTimestamp": 1462919239486,
+        "requestTimestamp": 1462919238941,
+        "bidder": "brealtime",
+        "adUnitCode": "/19968336/header-bid-tag-0",
+        "timeToRespond": 545,
+        "pbLg": "0.50",
+        "pbMg": "0.50",
+        "pbHg": "0.50",
+        "pbAg": "0.50",
+        "size": "300x250",
+        "requestId": 654321,
+        "adserverTargeting": {
+          "hb_bidder": "brealtime",
+          "hb_adid": "275bd666f5a5a5d",
+          "hb_pb": "10.00",
+          "hb_size": "300x250",
+          "foobar": "300x250"
+        }
+      },
+      {
+        "bidderCode": "pubmatic",
+        "width": "300",
+        "height": "250",
+        "statusMessage": "Bid available",
+        "adId": "28f4039c636b6a7",
+        "adSlot": "39620189@300x250",
+        "cpm": 5.9396,
+        "ad": "<span class=\"PubAPIAd\"><img src=\"http://usw-lax.adsrvr.org/bid/feedback/pubmatic?iid=467b5d95-d55a-4125-a90a-64a34d92ceec&crid=p84y3ree&wp=8.5059874&aid=9519B012-A2CF-4166-93F5-DEB9D7CC9680&wpc=USD&sfe=969e047&puid=4367D163-7DC9-40CD-8DC1-0A0876574ADE&tdid=9514a176-457b-4bb1-ae75-0d2b5e8012fa&pid=rw83mt1&ag=rmorau3&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&svbttd=1&dt=PC&osf=OSX&os=Other&br=Chrome&rlangs=en&mlang=&svpid=39741&did=&rcxt=Other&lat=45.518097&lon=-122.675095&tmpc=&daid=&vp=0&osi=&osv=&bp=13.6497&testid=audience-eval-old&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI/f//////////ARIGcGVlcjM5EISVAw==&crrelr=\" width=\"1\" height=\"1\" style=\"display: none;\"/><IFRAME SRC=\"https://ad.doubleclick.net/ddm/adi/N84001.284566THETRADEDESK/B9241716.125553599;sz=300x250;click0=http://insight.adsrvr.org/track/clk?imp=467b5d95-d55a-4125-a90a-64a34d92ceec&ag=rmorau3&crid=p84y3ree&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&sv=pubmatic&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&dt=PC&osf=OSX&os=Other&br=Chrome&svpid=39741&rlangs=en&mlang=&did=&rcxt=Other&tmpc=&vrtd=&osi=&osv=&daid=&dnr=0&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI%2Ff%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARIGcGVlcjM5EISVAw%3D%3D&crrelr=&svscid=66156&testid=audience-eval-old&r=;ord=102917?\" WIDTH=300 HEIGHT=250 MARGINWIDTH=0 MARGINHEIGHT=0 HSPACE=0 VSPACE=0 FRAMEBORDER=0 SCROLLING=no BORDERCOLOR='#000000'>\r\n<SCRIPT language='JavaScript1.1' SRC=\"https://ad.doubleclick.net/ddm/adj/N84001.284566THETRADEDESK/B9241716.125553599;abr=!ie;sz=300x250;click0=http://insight.adsrvr.org/track/clk?imp=467b5d95-d55a-4125-a90a-64a34d92ceec&ag=rmorau3&crid=p84y3ree&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&sv=pubmatic&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&dt=PC&osf=OSX&os=Other&br=Chrome&svpid=39741&rlangs=en&mlang=&did=&rcxt=Other&tmpc=&vrtd=&osi=&osv=&daid=&dnr=0&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI%2Ff%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARIGcGVlcjM5EISVAw%3D%3D&crrelr=&svscid=66156&testid=audience-eval-old&r=;ord=102917?\">\r\n</SCRIPT>\r\n<NOSCRIPT>\r\n<A HREF=\"http://insight.adsrvr.org/track/clk?imp=467b5d95-d55a-4125-a90a-64a34d92ceec&ag=rmorau3&crid=p84y3ree&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&sv=pubmatic&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&dt=PC&osf=OSX&os=Other&br=Chrome&svpid=39741&rlangs=en&mlang=&did=&rcxt=Other&tmpc=&vrtd=&osi=&osv=&daid=&dnr=0&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI%2Ff%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARIGcGVlcjM5EISVAw%3D%3D&crrelr=&svscid=66156&testid=audience-eval-old&r=https://ad.doubleclick.net/ddm/jump/N84001.284566THETRADEDESK/B9241716.125553599;abr=!ie4;abr=!ie5;sz=300x250;click0=http://insight.adsrvr.org/track/clk?imp=467b5d95-d55a-4125-a90a-64a34d92ceec&ag=rmorau3&crid=p84y3ree&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&sv=pubmatic&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&dt=PC&osf=OSX&os=Other&br=Chrome&svpid=39741&rlangs=en&mlang=&did=&rcxt=Other&tmpc=&vrtd=&osi=&osv=&daid=&dnr=0&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI%2Ff%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARIGcGVlcjM5EISVAw%3D%3D&crrelr=&svscid=66156&testid=audience-eval-old&r=;ord=102917?\">\r\n<IMG SRC=\"https://ad.doubleclick.net/ddm/ad/N84001.284566THETRADEDESK/B9241716.125553599;abr=!ie4;abr=!ie5;sz=300x250;click0=http://insight.adsrvr.org/track/clk?imp=467b5d95-d55a-4125-a90a-64a34d92ceec&ag=rmorau3&crid=p84y3ree&cf=&fq=1&td_s=prebid.org:9999&rcats=&mcat=&mste=&mfld=2&mssi=&mfsi=s4go1cqvhn&sv=pubmatic&uhow=63&agsa=&rgco=United%20States&rgre=Oregon&rgme=820&rgci=Portland&rgz=97204&dt=PC&osf=OSX&os=Other&br=Chrome&svpid=39741&rlangs=en&mlang=&did=&rcxt=Other&tmpc=&vrtd=&osi=&osv=&daid=&dnr=0&dur=CicKB203c2NmY3oQhJUDIgsIncWDPRIEbm9uZSILCOjyjz0SBG5vbmUKNQoeY2hhcmdlLWFsbFBlZXIzOUN1c3RvbUNhdGVnb3J5IhMI%2Ff%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARIGcGVlcjM5EISVAw%3D%3D&crrelr=&svscid=66156&testid=audience-eval-old&r=;ord=102917?\" BORDER=0 WIDTH=300 HEIGHT=250 ALT=\"Advertisement\"></A>\r\n</NOSCRIPT>\r\n</IFRAME><span id=\"te-clearads-js-tradedesk01cont1\"><script type=\"text/javascript\" src=\"https://choices.truste.com/ca?pid=tradedesk01&aid=tradedesk01&cid=10312015&c=tradedesk01cont1&js=pmw0&w=300&h=250&sid=0\"></script></span>\r</span> <!-- PubMatic Ad Ends --><div style=\"position:absolute;left:0px;top:0px;visibility:hidden;\"><img src=\"http://aktrack.pubmatic.com/AdServer/AdDisplayTrackerServlet?operId=1&pubId=39741&siteId=66156&adId=148827&adServerId=243&kefact=5.939592&kaxefact=5.939592&kadNetFrequecy=1&kadwidth=300&kadheight=250&kadsizeid=9&kltstamp=1462919239&indirectAdId=0&adServerOptimizerId=2&ranreq=0.8652068939929505&kpbmtpfact=8.505987&dcId=1&tldId=19194842&passback=0&imprId=8025E377-EC45-4EB6-826C-49D56CCE47DF&oid=8025E377-EC45-4EB6-826C-49D56CCE47DF&ias=272&crID=p84y3ree&campaignId=6810&creativeId=0&pctr=0.000000&wDSPByrId=1362&pageURL=http%253A%252F%252Fprebid.org%253A9999%252Fgpt.html&lpu=www.etrade.com\"></div>",
+        "dealId": "",
+        "responseTimestamp": 1462919239544,
+        "requestTimestamp": 1462919238922,
+        "bidder": "pubmatic",
+        "adUnitCode": "/19968336/header-bid-tag-0",
+        "timeToRespond": 622,
+        "pbLg": "5.00",
+        "pbMg": "5.90",
+        "pbHg": "5.93",
+        "pbAg": "5.90",
+        "size": "300x250",
+        "requestId": 654321,
+        "adserverTargeting": {
+          "hb_bidder": "pubmatic",
+          "hb_adid": "28f4039c636b6a7",
+          "hb_pb": "10.00",
+          "hb_size": "300x250",
+          "foobar": "300x250"
+        }
+      },
+      {
+        "bidderCode": "rubicon",
+        "width": 300,
+        "height": 600,
+        "statusMessage": "Bid available",
+        "adId": "29019e2ab586a5a",
+        "cpm": 2.74,
+        "ad": "<script type=\"text/javascript\">;(function (rt, fe) { rt.renderCreative(fe, \"/19968336/header-bid-tag-0\", \"10\"); }((parent.window.rubicontag || window.top.rubicontag), (document.body || document.documentElement)));</script>",
+        "responseTimestamp": 1462919239860,
+        "requestTimestamp": 1462919238934,
+        "bidder": "rubicon",
+        "adUnitCode": "/19968336/header-bid-tag-0",
+        "timeToRespond": 926,
+        "pbLg": "2.50",
+        "pbMg": "2.70",
+        "pbHg": "2.74",
+        "pbAg": "2.70",
+        "size": "300x600",
+        "requestId": 654321,
+        "adserverTargeting": {
+          "hb_bidder": "rubicon",
+          "hb_adid": "29019e2ab586a5a",
+          "hb_pb": "10.00",
+          "hb_size": "300x600",
+          "foobar": "300x600"
+        }
+      }
+    ]
+  }
+}, 'getBidResponses returns info for current bid request');
+
+      assert.deepEqual($$PREBID_GLOBAL$$.getAdserverTargeting(), {
+  "/19968336/header-bid-tag-0": {
+    "foobar": "300x250",
+    "hb_size": "300x250",
+    "hb_pb": "10.00",
+    "hb_adid": "233bcbee889d46d",
+    "hb_bidder": "appnexus"
+  }
+}, 'targeting info returned for current placements');
       resetAuction();
       adaptermanager.callBids.restore();
     });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1271,21 +1271,22 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  // describe('setBidderSequence', () => {
-  //   it('setting to `random` uses shuffled order of adUnits', () => {
-  //     sinon.spy(utils, 'shuffle');
-  //     const requestObj = {
-  //       bidsBackHandler: function bidsBackHandlerCallback() {},
-  //       timeout: 2000
-  //     };
-  //
-  //     $$PREBID_GLOBAL$$.setBidderSequence('random');
-  //     $$PREBID_GLOBAL$$.requestBids(requestObj);
-  //
-  //     sinon.assert.calledOnce(utils.shuffle);
-  //     utils.shuffle.restore();
-  //   });
-  // });
+  describe('setBidderSequence', () => {
+    it('setting to `random` uses shuffled order of adUnits', () => {
+      sinon.spy(utils, 'shuffle');
+      const requestObj = {
+        bidsBackHandler: function bidsBackHandlerCallback() {},
+        timeout: 2000
+      };
+
+      $$PREBID_GLOBAL$$.setBidderSequence('random');
+      $$PREBID_GLOBAL$$.requestBids(requestObj);
+
+      sinon.assert.calledOnce(utils.shuffle);
+      utils.shuffle.restore();
+      resetAuction();
+    });
+  });
 
   describe('getHighestCpm', () => {
     it('returns an array of winning bid objects for each adUnit', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
## Description of change

The requested and received bid arrays must retain bid objects from multiple calls to `pbjs
.requestBids`. However this causes unexpected behavior in the reporting APIs as bids from
previous auctions were returned. This PR addresses this by creating a `pbjs._adUnitCodes` primary
 data structure to be used as a filter when Prebid needs only the current "auction". While not
 ideal this allows us to retain bid data for in-flight calls to an ad server while also allowing
 additional bid requests to be made without the introduction of Prebid Auction instances.

 Closes #590
- reset externalCallbacks.all.called
- use adUnitsFilter to filter bid arrays to current auction
