### PR TITLE
Add pbjs.getHighestCpmBids for getting winning bids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -154,18 +154,24 @@ function getPresetTargeting() {
   }
 }
 
+function getWinningBids() {
+  const bids = $$PREBID_GLOBAL$$._bidsReceived.map(bid => bid.adUnitCode)
+  .filter(uniques)
+  .map(adUnitCode => $$PREBID_GLOBAL$$._bidsReceived
+    .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
+    .reduce(getHighestCpm,
+      {
+        adUnitCode: adUnitCode,
+        cpm: 0,
+        adserverTargeting: {},
+        timeToRespond: 0
+      }));
+
+  return bids;
+}
+
 function getWinningBidTargeting() {
-  let winners = $$PREBID_GLOBAL$$._bidsReceived.map(bid => bid.adUnitCode)
-    .filter(uniques)
-    .map(adUnitCode => $$PREBID_GLOBAL$$._bidsReceived
-      .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
-      .reduce(getHighestCpm,
-        {
-          adUnitCode: adUnitCode,
-          cpm: 0,
-          adserverTargeting: {},
-          timeToRespond: 0
-        }));
+  let winners = getWinningBids();
 
   // winning bids with deals need an hb_deal targeting key
   winners

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -155,15 +155,19 @@ function getPresetTargeting() {
 }
 
 function getWinningBids(code) {
-  const getWinningBidForAdUnit = (adUnitCode) =>
-    $$PREBID_GLOBAL$$._bidsReceived
-      .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
-      .reduce(getHighestCpm, {
+  const getWinningBidForAdUnit = (adUnitCode) => {
+    const adUnits = $$PREBID_GLOBAL$$._bidsReceived
+      .filter(bid => bid.adUnitCode === adUnitCode ? bid : null);
+
+    if (adUnits.length) {
+      return adUnits.reduce(getHighestCpm, {
         adUnitCode: adUnitCode,
         cpm: 0,
         adserverTargeting: {},
         timeToRespond: 0
       });
+    }
+  };
 
   if (code) {
     return getWinningBidForAdUnit(code);
@@ -849,6 +853,20 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
 $$PREBID_GLOBAL$$.setBidderSequence = function (order) {
   if (order === CONSTANTS.ORDER.RANDOM) {
     adaptermanager.setBidderSequence(CONSTANTS.ORDER.RANDOM);
+  }
+};
+
+/**
+ * Get array of highest cpm bids for all adUnits, or highest cpm bid
+ * object for the given adUnit
+ * @param {string} optional adUnitCode ad unit code
+ * @return {array|object} array or object containing highest cpm bid(s)
+ */
+$$PREBID_GLOBAL$$.getHighestCpmBid = function (adUnitCode) {
+  if (adUnitCode) {
+    return getWinningBids(adUnitCode);
+  } else {
+    return getWinningBids();
   }
 };
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -162,6 +162,7 @@ function getWinningBids(adUnitCode) {
 
   return $$PREBID_GLOBAL$$._bidsReceived
     .filter(bid => adUnitCodes.includes(bid.adUnitCode))
+    .filter(bid => bid.cpm > 0)
     .map(bid => bid.adUnitCode)
     .filter(uniques)
     .map(adUnitCode => $$PREBID_GLOBAL$$._bidsReceived

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -156,9 +156,9 @@ function getPresetTargeting() {
 
 function getWinningBids(adUnitCode) {
   // use the given adUnitCode as a filter if present or all adUnitCodes if not
-  const adUnitCodes = adUnitCode
-    ? [adUnitCode]
-    : $$PREBID_GLOBAL$$.adUnits.map(adUnit => adUnit.code);
+  const adUnitCodes = adUnitCode ?
+    [adUnitCode] :
+    $$PREBID_GLOBAL$$.adUnits.map(adUnit => adUnit.code);
 
   return $$PREBID_GLOBAL$$._bidsReceived
     .filter(bid => adUnitCodes.includes(bid.adUnitCode))

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -154,9 +154,14 @@ function getPresetTargeting() {
   }
 }
 
-function getWinningBids(adUnitCodes) {
+function getWinningBids(adUnitCode) {
+  // use the given adUnitCode as a filter if present or all adUnitCodes if not
+  const adUnitCodes = adUnitCode
+    ? [adUnitCode]
+    : $$PREBID_GLOBAL$$.adUnits.map(adUnit => adUnit.code);
+
   return $$PREBID_GLOBAL$$._bidsReceived
-    .filter(adUnitsFilter.bind(this, adUnitCodes))
+    .filter(bid => adUnitCodes.includes(bid.adUnitCode))
     .map(bid => bid.adUnitCode)
     .filter(uniques)
     .map(adUnitCode => $$PREBID_GLOBAL$$._bidsReceived
@@ -170,8 +175,8 @@ function getWinningBids(adUnitCodes) {
         }));
 }
 
-function getWinningBidTargeting(adUnitCodes) {
-  let winners = getWinningBids(adUnitCodes);
+function getWinningBidTargeting() {
+  let winners = getWinningBids();
 
   // winning bids with deals need an hb_deal targeting key
   winners
@@ -850,15 +855,11 @@ $$PREBID_GLOBAL$$.setBidderSequence = function (order) {
 /**
  * Get array of highest cpm bids for all adUnits, or highest cpm bid
  * object for the given adUnit
- * @param {string} optional adUnitCode ad unit code
+ * @param {string} adUnitCode - optional ad unit code
  * @return {array} array containing highest cpm bid object(s)
  */
 $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
-  const adUnitCodes = adUnitCode && adUnitCode.length ?
-    [adUnitCode] :
-    $$PREBID_GLOBAL$$._adUnitCodes;
-
-  return getWinningBids(adUnitCodes);
+  return getWinningBids(adUnitCode);
 };
 
 processQue();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -154,20 +154,25 @@ function getPresetTargeting() {
   }
 }
 
-function getWinningBids() {
-  const bids = $$PREBID_GLOBAL$$._bidsReceived.map(bid => bid.adUnitCode)
-  .filter(uniques)
-  .map(adUnitCode => $$PREBID_GLOBAL$$._bidsReceived
-    .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
-    .reduce(getHighestCpm,
-      {
+function getWinningBids(code) {
+  const getWinningBidForAdUnit = (adUnitCode) =>
+    $$PREBID_GLOBAL$$._bidsReceived
+      .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
+      .reduce(getHighestCpm, {
         adUnitCode: adUnitCode,
         cpm: 0,
         adserverTargeting: {},
         timeToRespond: 0
-      }));
+      });
 
-  return bids;
+  if (code) {
+    return getWinningBidForAdUnit(code);
+  } else {
+    return $$PREBID_GLOBAL$$._bidsReceived
+      .map(bid => bid.adUnitCode)
+      .filter(uniques)
+      .map(getWinningBidForAdUnit);
+  }
 }
 
 function getWinningBidTargeting() {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1262,4 +1262,27 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
+  describe('getHighestCpm', () => {
+    it('returns an array of winning bids for each adUnit', () => {
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBid();
+
+      expect(highestCpmBids.length).to.equal(2);
+      expect(highestCpmBids[0]).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[1]);
+      expect(highestCpmBids[1]).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[2]);
+    });
+
+    it('returns the highest bid for the given adUnitCode', () => {
+      const highestCpmBid = $$PREBID_GLOBAL$$.getHighestCpmBid('/19968336/header-bid-tag-0');
+
+      expect(highestCpmBid).to.be.an('object');
+      expect(highestCpmBid).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[1]);
+    });
+
+    it('returns nothing when the given adUnit is invalid', () => {
+      const shouldBeUndefined = $$PREBID_GLOBAL$$.getHighestCpmBid('Stallone');
+
+      expect(shouldBeUndefined).to.be.undefined;
+    });
+  });
+
 });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1263,25 +1263,22 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getHighestCpm', () => {
-    it('returns an array of winning bids for each adUnit', () => {
-      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBid();
-
+    it('returns an array of winning bid objects for each adUnit', () => {
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids();
       expect(highestCpmBids.length).to.equal(2);
       expect(highestCpmBids[0]).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[1]);
       expect(highestCpmBids[1]).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[2]);
     });
 
-    it('returns the highest bid for the given adUnitCode', () => {
-      const highestCpmBid = $$PREBID_GLOBAL$$.getHighestCpmBid('/19968336/header-bid-tag-0');
-
-      expect(highestCpmBid).to.be.an('object');
-      expect(highestCpmBid).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[1]);
+    it('returns an array containing the highest bid object for the given adUnitCode', () => {
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/19968336/header-bid-tag-0');
+      expect(highestCpmBids.length).to.equal(1);
+      expect(highestCpmBids[0]).to.deep.equal($$PREBID_GLOBAL$$._bidsReceived[1]);
     });
 
-    it('returns nothing when the given adUnit is invalid', () => {
-      const shouldBeUndefined = $$PREBID_GLOBAL$$.getHighestCpmBid('Stallone');
-
-      expect(shouldBeUndefined).to.be.undefined;
+    it('returns an empty array when the given adUnit is not found', () => {
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/stallone');
+      expect(highestCpmBids.length).to.equal(0);
     });
   });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1280,6 +1280,14 @@ describe('Unit: Prebid Module', function () {
       const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/stallone');
       expect(highestCpmBids.length).to.equal(0);
     });
+
+    it('returns an empty array when the given adUnit has no bids', () => {
+      $$PREBID_GLOBAL$$._bidsReceived = [$$PREBID_GLOBAL$$._bidsReceived[0]];
+      $$PREBID_GLOBAL$$._bidsReceived[0].cpm = 0;
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/19968336/header-bid-tag-0');
+      expect(highestCpmBids.length).to.equal(0);
+      resetAuction();
+    });
   });
 
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
## Description of change

Adds `pbjs.getHighestCpmBids` to public api for retrieving winning bids.

```
pbjs.getHighestCpmBids() => array of winning bid objects for each ad unit on page
pbjs.getHighestCpmBids(adUnitCode) => array with the winning bid object for the given ad unit
```
## Other information

This make use of the changes introduced in #750 and should only be merged after that is in master.
