### PR TITLE
Bugfix/suppress prebid request if sizeMapping undefined for device width

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -29,6 +29,7 @@ function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
 
 exports.callBids = ({ adUnits, cbTimeout }) => {
   const requestId = utils.generateUUID();
+  //console.log(JSON.stringify(adUnits));
 
   const auctionStart = Date.now();
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -13,35 +13,33 @@ exports.bidderRegistry = _bidderRegistry;
 
 var _analyticsRegistry = {};
 
-function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
+function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
   return adUnits.map(adUnit => {
     return adUnit.bids.filter(bid => bid.bidder === bidderCode)
       .map(bid => {
         let sizes = adUnit.sizes;
-        if(adUnit.sizeMapping) {
+        if (adUnit.sizeMapping) {
           let sizeMapping = mapSizes(adUnit);
-          if(sizeMapping === ''){
+          if (sizeMapping === '') {
             return '';
           }
           sizes = sizeMapping;
         }
-       return Object.assign(bid, {
+        return Object.assign(bid, {
           placementCode: adUnit.code,
           mediaType: adUnit.mediaType,
           sizes: sizes,
           bidId: utils.getUniqueIdentifierStr(),
           bidderRequestId,
           requestId
-      });
-    }
-    );
+        });
+      }
+      );
   }).reduce(flatten, []).filter(val => val !== '');
 }
 
-exports.callBids = ({ adUnits, cbTimeout }) => {
+exports.callBids = ({adUnits, cbTimeout}) => {
   const requestId = utils.generateUUID();
-  //console.log(JSON.stringify(adUnits));
-
   const auctionStart = Date.now();
 
   const auctionInit = {
@@ -58,7 +56,7 @@ exports.callBids = ({ adUnits, cbTimeout }) => {
         bidderCode,
         requestId,
         bidderRequestId,
-        bids: getBids({ bidderCode, requestId, bidderRequestId, adUnits }),
+        bids: getBids({bidderCode, requestId, bidderRequestId, adUnits}),
         start: new Date().getTime(),
         auctionStart: auctionStart,
         timeout: cbTimeout
@@ -75,7 +73,7 @@ exports.callBids = ({ adUnits, cbTimeout }) => {
   });
 };
 
-exports.registerBidAdapter = function (bidAdaptor, bidderCode) {
+exports.registerBidAdapter = function(bidAdaptor, bidderCode) {
   if (bidAdaptor && bidderCode) {
 
     if (typeof bidAdaptor.callBids === CONSTANTS.objectType_function) {
@@ -90,7 +88,7 @@ exports.registerBidAdapter = function (bidAdaptor, bidderCode) {
   }
 };
 
-exports.aliasBidAdapter = function (bidderCode, alias) {
+exports.aliasBidAdapter = function(bidderCode, alias) {
   var existingAlias = _bidderRegistry[alias];
 
   if (typeof existingAlias === CONSTANTS.objectType_undefined) {
@@ -118,7 +116,7 @@ exports.aliasBidAdapter = function (bidderCode, alias) {
   }
 };
 
-exports.registerAnalyticsAdapter = function ({ adapter, code }) {
+exports.registerAnalyticsAdapter = function({adapter, code}) {
   if (adapter && code) {
 
     if (typeof adapter.enableAnalytics === CONSTANTS.objectType_function) {
@@ -133,7 +131,7 @@ exports.registerAnalyticsAdapter = function ({ adapter, code }) {
   }
 };
 
-exports.enableAnalytics = function (config) {
+exports.enableAnalytics = function(config) {
   if (!utils.isArray(config)) {
     config = [config];
   }

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -73,7 +73,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
   });
 };
 
-exports.registerBidAdapter = function(bidAdaptor, bidderCode) {
+exports.registerBidAdapter = function (bidAdaptor, bidderCode) {
   if (bidAdaptor && bidderCode) {
 
     if (typeof bidAdaptor.callBids === CONSTANTS.objectType_function) {
@@ -88,7 +88,7 @@ exports.registerBidAdapter = function(bidAdaptor, bidderCode) {
   }
 };
 
-exports.aliasBidAdapter = function(bidderCode, alias) {
+exports.aliasBidAdapter = function (bidderCode, alias) {
   var existingAlias = _bidderRegistry[alias];
 
   if (typeof existingAlias === CONSTANTS.objectType_undefined) {
@@ -116,7 +116,7 @@ exports.aliasBidAdapter = function(bidderCode, alias) {
   }
 };
 
-exports.registerAnalyticsAdapter = function({adapter, code}) {
+exports.registerAnalyticsAdapter = function ({adapter, code}) {
   if (adapter && code) {
 
     if (typeof adapter.enableAnalytics === CONSTANTS.objectType_function) {
@@ -131,7 +131,7 @@ exports.registerAnalyticsAdapter = function({adapter, code}) {
   }
 };
 
-exports.enableAnalytics = function(config) {
+exports.enableAnalytics = function (config) {
   if (!utils.isArray(config)) {
     config = [config];
   }

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -16,15 +16,26 @@ var _analyticsRegistry = {};
 function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
   return adUnits.map(adUnit => {
     return adUnit.bids.filter(bid => bid.bidder === bidderCode)
-      .map(bid => Object.assign(bid, {
-        placementCode: adUnit.code,
-        mediaType: adUnit.mediaType,
-        sizes: mapSizes(adUnit),
-        bidId: utils.getUniqueIdentifierStr(),
-        bidderRequestId,
-        requestId
-      }));
-  }).reduce(flatten, []);
+      .map(bid => {
+        let sizes = adUnit.sizes;
+        if(adUnit.sizeMapping) {
+          let sizeMapping = mapSizes(adUnit);
+          if(sizeMapping === ''){
+            return '';
+          }
+          sizes = sizeMapping;
+        }
+       return Object.assign(bid, {
+          placementCode: adUnit.code,
+          mediaType: adUnit.mediaType,
+          sizes: sizes,
+          bidId: utils.getUniqueIdentifierStr(),
+          bidderRequestId,
+          requestId
+      });
+    }
+    );
+  }).reduce(flatten, []).filter(val => val !== '');
 }
 
 exports.callBids = ({ adUnits, cbTimeout }) => {

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -61,10 +61,10 @@ exports.callBids = ({adUnits, cbTimeout}) => {
         auctionStart: auctionStart,
         timeout: cbTimeout
       };
-      utils.logMessage(`CALLING BIDDER ======= ${bidderCode}`);
-      $$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
-      events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidderRequest);
-      if (bidderRequest.bids && bidderRequest.bids.length) {
+      if (bidderRequest.bids && bidderRequest.bids.length !== 0) {
+        utils.logMessage(`CALLING BIDDER ======= ${bidderCode}`);
+        $$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
+        events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidderRequest);
         adapter.callBids(bidderRequest);
       }
     } else {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -571,6 +571,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   }
 
   adaptermanager.callBids({ adUnits, adUnitCodes, cbTimeout });
+  if($$PREBID_GLOBAL$$._bidsRequested.length === 0) {
+    bidmanager.executeCallback();
+  }
 };
 
 /**

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -40,17 +40,9 @@ function isSizeMappingValid(sizeMapping) {
 }
 
 function getScreenWidth(win) {
-  const w = win || _win || window;
-  const docElem = w.document.documentElement;
-  const body = w.document.getElementsByTagName('body')[0];
-  if(w.innerWidth) {
-    return w.innerWidth;
-  }
-  else if(docElem && docElem.clientWidth ) {
-    return docElem.clientWidth;
-  }
-  else if(body && body.clientWidth){
-    return body.clientWidth;
+  var w = win || _win || window;
+  if(w.screen && w.screen.width) {
+    return w.screen.width;
   }
   return 0;
 }

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -19,10 +19,14 @@ function mapSizes(adUnit) {
     }
     return adUnit.sizes;
   }
-  const sizes = adUnit.sizeMapping.find(sizeMapping =>{
+  let sizes = '';
+  const mapping = adUnit.sizeMapping.find(sizeMapping =>{
     return width > sizeMapping.minWidth;
-  }).sizes;
-  utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
+  });
+  if(mapping && mapping.sizes){
+    sizes = mapping.sizes;
+    utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
+  }
   return sizes;
 
 }

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -27,6 +27,9 @@ function mapSizes(adUnit) {
     sizes = mapping.sizes;
     utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
   }
+  else{
+    utils.logMessage(`AdUnit : ${adUnit.code} not mapped to any sizes for device width. This request will be suppressed.`);
+  }
   return sizes;
 
 }

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -35,8 +35,9 @@ let mockWindow = {};
 
 function resetMockWindow() {
   mockWindow = {
-    document: {getElementsByTagName: function() { return [{}]; }},
-    innerWidth: 1024,
+    screen : {
+      width : 1024
+    }
   };
 }
 
@@ -45,7 +46,7 @@ describe('sizeMapping', function() {
   beforeEach(resetMockWindow);
 
   it('mapSizes 1029 width', function() {
-    mockWindow.innerWidth = 1029;
+    mockWindow.screen.width = 1029;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([[300,250],[728,90]]);
@@ -53,7 +54,7 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes 400 width', function() {
-    mockWindow.innerWidth = 400;
+    mockWindow.screen.width = 400;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([20,20]);
@@ -61,13 +62,13 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes - invalid adUnit - should return sizes', function() {
-    mockWindow.innerWidth = 1029;
+    mockWindow.screen.width = 1029;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
 
-    mockWindow.innerWidth = 400;
+    mockWindow.screen.width = 400;
     sizeMapping.setWindow(mockWindow);
     sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
@@ -75,7 +76,7 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
-    mockWindow.innerWidth = 0;
+    mockWindow.screen.width = 0;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
@@ -84,7 +85,7 @@ describe('sizeMapping', function() {
 
 
   it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
-    mockWindow.innerWidth = 0;
+    mockWindow.screen.width = 0;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit2);
     expect(sizes).to.deep.equal([300,250]);
@@ -93,24 +94,12 @@ describe('sizeMapping', function() {
 
 
   it('getScreenWidth', function() {
-    mockWindow.innerWidth = 900;
+    mockWindow.screen.width = 900;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
   });
 
-  it('getScreenWidth - should sizes in older browsers', function() {
-    mockWindow.innerWidth = null;
-    mockWindow.document.documentElement = {clientWidth: 901};
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(901);
-  });
-
-  it('getScreenWidth - should sizes in really old browsers', function() {
-    mockWindow.innerWidth = null;
-    mockWindow.document.getElementsByTagName = function() { return [{clientWidth: 902}]; };
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(902);
-  });
-
   it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
-    mockWindow.innerWidth = null;
+    mockWindow.screen.width = null;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently when using `adUnit.sizeMapping`, if the device size does not match any mapping, requests are still made to bidders with undefined sizes. This causes issues with many bidders which expect `adUnit.sizes` to be required. 

This PR changes the behavior to omit those requests. 

## Other information
@prebid/core  to review