### PR TITLE
Add api method to shuffle the order bidders are called in

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,6 +1,6 @@
 /** @module adaptermanger */
 
-import { flatten, getBidderCodes } from './utils';
+import { flatten, getBidderCodes, shuffle } from './utils';
 import { mapSizes } from './sizeMapping';
 
 var utils = require('./utils.js');
@@ -38,7 +38,12 @@ exports.callBids = ({ adUnits, cbTimeout }) => {
   };
   events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
 
-  getBidderCodes(adUnits).forEach(bidderCode => {
+  let bidderCodes = getBidderCodes(adUnits);
+  if ($$PREBID_GLOBAL$$._bidderSequence === 'random') {
+    bidderCodes = shuffle(bidderCodes);
+  }
+
+  bidderCodes.forEach(bidderCode => {
     const adapter = _bidderRegistry[bidderCode];
     if (adapter) {
       const bidderRequestId = utils.getUniqueIdentifierStr();

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -12,6 +12,7 @@ var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;
 
 var _analyticsRegistry = {};
+let _bidderSequence = null;
 
 function getBids({ bidderCode, requestId, bidderRequestId, adUnits }) {
   return adUnits.map(adUnit => {
@@ -39,7 +40,7 @@ exports.callBids = ({ adUnits, cbTimeout }) => {
   events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
 
   let bidderCodes = getBidderCodes(adUnits);
-  if ($$PREBID_GLOBAL$$._bidderSequence === 'random') {
+  if (_bidderSequence === CONSTANTS.ORDER.RANDOM) {
     bidderCodes = shuffle(bidderCodes);
   }
 
@@ -140,6 +141,10 @@ exports.enableAnalytics = function (config) {
         ${adapterConfig.provider}.`);
     }
   });
+};
+
+exports.setBidderSequence = function (order) {
+  _bidderSequence = order;
 };
 
 /** INSERT ADAPTERS - DO NOT EDIT OR REMOVE */

--- a/src/constants.json
+++ b/src/constants.json
@@ -39,6 +39,9 @@
   "EVENT_ID_PATHS": {
     "bidWon": "adUnitCode"
   },
+  "ORDER": {
+    "RANDOM": "random"
+  },
   "GRANULARITY_OPTIONS": {
     "LOW": "low",
     "MEDIUM": "medium",

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -41,6 +41,7 @@ $$PREBID_GLOBAL$$._bidsReceived = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
 $$PREBID_GLOBAL$$._sendAllBids = false;
+$$PREBID_GLOBAL$$._bidderSequence = null;
 
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
@@ -828,6 +829,18 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
     return;
   }
   return masterTag;
+};
+
+/**
+ * Set the order bidders are called in. If not set, the bidders are called in
+ * the order they are defined wihin the adUnit.bids array
+ * @param {string} order - Order to call bidders in. Currently the only possible value
+ * is 'random', which randomly shuffles the order
+ */
+$$PREBID_GLOBAL$$.setBidderSequence = function (order) {
+  if (order === 'random') {
+    $$PREBID_GLOBAL$$._bidderSequence = 'random';
+  }
 };
 
 processQue();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -41,7 +41,6 @@ $$PREBID_GLOBAL$$._bidsReceived = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
 $$PREBID_GLOBAL$$._sendAllBids = false;
-$$PREBID_GLOBAL$$._bidderSequence = null;
 
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
@@ -838,8 +837,8 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
  * is 'random', which randomly shuffles the order
  */
 $$PREBID_GLOBAL$$.setBidderSequence = function (order) {
-  if (order === 'random') {
-    $$PREBID_GLOBAL$$._bidderSequence = 'random';
+  if (order === CONSTANTS.ORDER.RANDOM) {
+    adaptermanager.setBidderSequence(CONSTANTS.ORDER.RANDOM);
   }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -538,3 +538,26 @@ export function getHighestCpm(previous, current) {
   }
   return previous.cpm < current.cpm ? current : previous;
 }
+
+/**
+ * Fisher–Yates shuffle
+ */
+export function shuffle(array) {
+  let counter = array.length;
+
+  // while there are elements in the array
+  while (counter > 0) {
+    // pick a random index
+    let index = Math.floor(Math.random() * counter);
+
+    // decrease counter by 1
+    counter--;
+
+    // and swap the last element with it
+    let temp = array[counter];
+    array[counter] = array[index];
+    array[index] = temp;
+  }
+
+  return array;
+}

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1246,4 +1246,20 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
+  describe('setBidderSequence', () => {
+    it('setting to `random` uses shuffled order of adUnits', () => {
+      sinon.spy(utils, 'shuffle');
+      const requestObj = {
+        bidsBackHandler: function bidsBackHandlerCallback() {},
+        timeout: 2000
+      };
+
+      $$PREBID_GLOBAL$$.setBidderSequence('random');
+      $$PREBID_GLOBAL$$.requestBids(requestObj);
+
+      sinon.assert.calledOnce(utils.shuffle);
+      utils.shuffle.restore();
+    });
+  });
+
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Adds api method `pbjs.setBidderSequence` to set the order bidders are called in. The method takes an argument `order` that currently accepts the string `'random'` to shuffle the sequence bidders are called in. If the sequence is not set with this method, the bidders are called in the order they are defined within the `adUnit.bids` array on page which is the current default.

Example use: `pbjs.setBidderSequence('random');`

## Other information
Implements #703. @prebid/core for review