### PR TITLE
check OX for undefined

### DIFF
--- a/src/adapters/openx.js
+++ b/src/adapters/openx.js
@@ -46,6 +46,7 @@ var OpenxAdapter = function OpenxAdapter(options) {
   }
 
   function _requestBids() {
+    if (typeof OX === 'undefined') return;
 
     if (scriptUrl) {
       adloader.loadScript(scriptUrl, function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If `typeof OX === undefined` return from `openx.requestBids()`.

An error was thrown running `gulp test` due to OX being undefined in the OpenX adapter. This fix is a workaround until OpenX can determine the cause or this fix is accepted.

@prebid/openx 
