### PR TITLE
Resolve IE 10 unit tests failures related to ajax requests.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -120,7 +120,7 @@ module.exports = function (config) {
       'karma-es5-shim',
       'karma-mocha',
       'karma-expect',
-      'karma-sinon',
+      'karma-sinon-ie',
       'karma-webpack',
       'karma-junit-reporter',
       'karma-html-reporter',

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "karma-script-launcher": "^0.1.0",
-    "karma-sinon": "^1.0.4",
+    "karma-sinon-ie": "^2.0.0-rc10",
     "karma-webpack": "^1.5.1",
     "localtunnel": "^1.3.0",
     "mkpath": "^1.0.0",

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -16,11 +16,18 @@ const XHR_DONE = 4;
 
 export function ajax(url, callback, data, options = {}) {
 
-  let x,
-      method = options.method || (data ? 'POST' : 'GET'),
-      // For IE9 support use XDomainRequest instead of XMLHttpRequest.
-      useXDomainRequest = window.XDomainRequest &&
-        (!window.XMLHttpRequest || new window.XMLHttpRequest().responseType === undefined);
+  let x;
+  let useXDomainRequest =false;
+  let method = options.method || (data ? 'POST' : 'GET');
+  if(!window.XMLHttpRequest){
+    useXDomainRequest = true;
+  }
+  else{
+    x = new window.XMLHttpRequest();
+    if(x.responseType === undefined){
+      useXDomainRequest = true;
+    }
+  }
 
   if (useXDomainRequest) {
     x = new window.XDomainRequest();
@@ -40,7 +47,6 @@ export function ajax(url, callback, data, options = {}) {
     };
 
   } else {
-    x = new window.XMLHttpRequest();
     x.onreadystatechange = handler;
   }
 
@@ -61,7 +67,6 @@ export function ajax(url, callback, data, options = {}) {
     }
     x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
   }
-
   x.send(method === 'POST' && data);
 
   function handler() {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Resolve IE 10 unit tests failures related to ajax requests.

Incorporates changes from #689 and also modifies `ajax.js` to not instantiate multiple `xhrHttpRequest` objects which breaks the mock Xhr in IE 10. 


## Other information
@prebid/core  to review

