### PR TITLE
getPresetTargeting no longer used

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -27,7 +27,7 @@ var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 
 var auctionRunning = false;
 var bidRequestQueue = [];
-var presetTargeting = [];
+// var presetTargeting = [];
 var pbTargetingKeys = [];
 
 var eventValidators = {
@@ -136,23 +136,23 @@ function setTargeting(targetingConfig) {
   });
 }
 
-function isNotSetByPb(key) {
-  return pbTargetingKeys.indexOf(key) === -1;
-}
+// function isNotSetByPb(key) {
+//   return pbTargetingKeys.indexOf(key) === -1;
+// }
 
-function getPresetTargeting() {
-  if (isGptPubadsDefined()) {
-    presetTargeting = (function getPresetTargeting() {
-      return window.googletag.pubads().getSlots().map(slot => {
-        return {
-          [slot.getAdUnitPath()]: slot.getTargetingKeys().filter(isNotSetByPb).map(key => {
-            return { [key]: slot.getTargeting(key) };
-          })
-        };
-      });
-    }());
-  }
-}
+// function getPresetTargeting() {
+//   if (isGptPubadsDefined()) {
+//     presetTargeting = (function getPresetTargeting() {
+//       return window.googletag.pubads().getSlots().map(slot => {
+//         return {
+//           [slot.getAdUnitPath()]: slot.getTargetingKeys().filter(isNotSetByPb).map(key => {
+//             return { [key]: slot.getTargeting(key) };
+//           })
+//         };
+//       });
+//     }());
+//   }
+// }
 
 function getWinningBids(adUnitCode) {
   // use the given adUnitCode as a filter if present or all adUnitCodes if not
@@ -434,7 +434,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function () {
   }
 
   //first reset any old targeting
-  getPresetTargeting();
+  // getPresetTargeting();
   resetPresetTargeting();
   //now set new targeting keys
   setTargeting(getAllTargeting());

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -415,8 +415,8 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function () {
   }
 
   //first reset any old targeting
-  // getPresetTargeting();
   resetPresetTargeting();
+
   //now set new targeting keys
   setTargeting(getAllTargeting());
 };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -27,7 +27,6 @@ var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 
 var auctionRunning = false;
 var bidRequestQueue = [];
-// var presetTargeting = [];
 var pbTargetingKeys = [];
 
 var eventValidators = {
@@ -135,24 +134,6 @@ function setTargeting(targetingConfig) {
         }));
   });
 }
-
-// function isNotSetByPb(key) {
-//   return pbTargetingKeys.indexOf(key) === -1;
-// }
-
-// function getPresetTargeting() {
-//   if (isGptPubadsDefined()) {
-//     presetTargeting = (function getPresetTargeting() {
-//       return window.googletag.pubads().getSlots().map(slot => {
-//         return {
-//           [slot.getAdUnitPath()]: slot.getTargetingKeys().filter(isNotSetByPb).map(key => {
-//             return { [key]: slot.getTargeting(key) };
-//           })
-//         };
-//       });
-//     }());
-//   }
-// }
 
 function getWinningBids(adUnitCode) {
   // use the given adUnitCode as a filter if present or all adUnitCodes if not


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
Remove `presetTargeting`, `getPresetTargeting` and `isNotSetByPb`. The property and functions are no longer used when clearing targeting on ad slots.