### PR TITLE
Count bids with function on adapter if present

### DIFF
--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -530,8 +530,14 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
   }
 
   return {
-    callBids: _callBids
+    callBids: _callBids,
+    countBids: _countBids
   };
 };
+
+function _countBids(bid) {
+  const bidCount = bid.sizes
+  return bid && bid.sizes && bid.sizes.length || null;
+}
 
 module.exports = IndexExchangeAdapter;

--- a/src/adapters/indexExchange.js
+++ b/src/adapters/indexExchange.js
@@ -536,7 +536,6 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
 };
 
 function _countBids(bid) {
-  const bidCount = bid.sizes
   return bid && bid.sizes && bid.sizes.length || null;
 }
 

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -4,7 +4,6 @@ import {getPriceBucketString} from './cpmBucketManager';
 var CONSTANTS = require('./constants.json');
 var utils = require('./utils.js');
 var events = require('./events');
-var adaptermanager = require('./adaptermanager');
 
 var objectType_function = 'function';
 
@@ -50,8 +49,7 @@ function getBidders(bid) {
  * @returns {*|number}
  */
 function countExpectedBids(bid) {
-  const bidder = bid.bidder;
-  const adapter = adaptermanager.bidderRegistry[bidder];
+  const adapter = $$PREBID_GLOBAL$$.getBidderRegistry()[bid.bidder];
   const countBids = adapter && adapter.countBids || function() { return 1; };
   return countBids(bid);
 }

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -51,7 +51,8 @@ function getBidders(bid) {
  */
 function countExpectedBids(bid) {
   const bidder = bid.bidder;
-  const countBids = adaptermanager.bidderRegistry[bidder].countBids || function() { return 1; };
+  const adapter = adaptermanager.bidderRegistry[bidder];
+  const countBids = adapter && adapter.countBids || function() { return 1; };
   return countBids(bid);
 }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -847,4 +847,12 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
   return getWinningBids(adUnitCode);
 };
 
+/**
+ * Returns the adaptermanager.bidderRegistry
+ * @returns {*}
+ */
+$$PREBID_GLOBAL$$.getBidderRegistry = function() {
+  return adaptermanager.bidderRegistry;
+};
+
 processQue();

--- a/src/utils.js
+++ b/src/utils.js
@@ -564,3 +564,7 @@ export function shuffle(array) {
 
   return array;
 }
+
+export function add(a, b) {
+  return a + b;
+}


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
We count bids expected so we know when to invoke callbacks for a placement and for the overall request. To support counting bids in different ways this PR will use a function `countBids`, if available, in place of the default behavior.


