### PR TITLE
remove nyan cat reporter as it slows down tests considerably

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,7 +64,7 @@ module.exports = function (config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: CI_MODE ? ['junit', 'coverage'] : ['progress', 'html', 'nyan', 'coverage'],
+    reporters: CI_MODE ? ['junit', 'coverage'] : ['progress', 'html', 'coverage'],
 
     // junit reporter config
     junitReporter: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -115,7 +115,6 @@ module.exports = function (config) {
     plugins: [
       'karma-browserstack-launcher',
       'karma-phantomjs-launcher',
-      'karma-nyan-reporter',
       'karma-coverage',
       'karma-es5-shim',
       'karma-mocha',

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "karma-ie-launcher": "^0.1.5",
     "karma-junit-reporter": "^0.3.8",
     "karma-mocha": "^0.2.0",
-    "karma-nyan-reporter": "0.2.2",
     "karma-opera-launcher": "^0.1.0",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-requirejs": "^0.2.2",


### PR DESCRIPTION
## Type of change
- [x] Build related changes

## Description of change
Removes test coverage Nyan Cat reporter due to performance issues.

## Other information
fixes #774