### PR TITLE
sendStandardTargeting must be explicitly false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 # Test Files
 test/app
 gpt.html
+gpt-mlane.html
 gpt-each-bidder3.html
 
 # Selenium files

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -166,14 +166,14 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   if (bidderCode && custBidObj && bidder_settings && bidder_settings[bidderCode] && bidder_settings[bidderCode][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
     setKeys(keyValues, bidder_settings[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = bidder_settings[bidderCode].alwaysUseBid;
-    custBidObj.sendStandardTargeting = !!bidder_settings[bidderCode].sendStandardTargeting;
+    custBidObj.sendStandardTargeting = bidder_settings[bidderCode].sendStandardTargeting;
   }
 
   //2) set keys from standard setting. NOTE: this API doesn't seem to be in use by any Adapter
   else if (defaultBidderSettingsMap[bidderCode]) {
     setKeys(keyValues, defaultBidderSettingsMap[bidderCode], custBidObj);
     custBidObj.alwaysUseBid = defaultBidderSettingsMap[bidderCode].alwaysUseBid;
-    custBidObj.sendStandardTargeting = !!defaultBidderSettingsMap[bidderCode].sendStandardTargeting;
+    custBidObj.sendStandardTargeting = defaultBidderSettingsMap[bidderCode].sendStandardTargeting;
   }
 
   return keyValues;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
sendStandardTargeting property filters out bids if value is `false` explicitly, but if 'undefined' filter should return key. Solution here is to not use the "double bang" `!!` operator to coerce the boolean.