### PR TITLE
wrap getTopWindowUrl in try/catch for iframed cases

### DIFF
--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -118,11 +118,7 @@ AppNexusAdapter = function AppNexusAdapter() {
 
     //append referrer
     if (referrer === '') {
-      try {
-        referrer = utils.getTopWindowUrl();
-      } catch (err) {
-        referrer = 'iframed';
-      }
+      referrer = utils.getTopWindowUrl();
     }
 
     jptCall = utils.tryAppendQueryString(jptCall, 'referrer', referrer);

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -118,7 +118,11 @@ AppNexusAdapter = function AppNexusAdapter() {
 
     //append referrer
     if (referrer === '') {
-      referrer = utils.getTopWindowUrl();
+      try {
+        referrer = utils.getTopWindowUrl();
+      } catch (err) {
+        referrer = 'iframed';
+      }
     }
 
     jptCall = utils.tryAppendQueryString(jptCall, 'referrer', referrer);

--- a/src/utils.js
+++ b/src/utils.js
@@ -180,15 +180,25 @@ exports.parseGPTSingleSizeArray = function (singleSize) {
 };
 
 exports.getTopWindowLocation = function () {
+  let location;
   try {
-    return window.top.location;
+    location = window.top.location;
   } catch (e) {
-    return window.location;
+    location = window.location;
   }
+
+  return location;
 };
 
 exports.getTopWindowUrl = function () {
-  return this.getTopWindowLocation().href;
+  let href;
+  try {
+    href = this.getTopWindowLocation().href;
+  } catch (e) {
+    href = '';
+  }
+
+  return href;
 };
 
 exports.logWarn = function (msg) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If Prebid is running in a x-domain iframe a call to `utils.getTopWindowUrl` will fail silently. Fix is to wrap the call in a try/catch at the adapter level.

## Other information
This will fix the jsfiddle.net examples on Prebid.org once a build is pushed to `not-for-prod` on CDN.
