### PR TITLE
Babel plugin fixes to make the generated code syntax valid in ie8

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
 	"presets": ["es2015"],
-	"plugins": ["transform-object-assign"]
+	"plugins": ["transform-object-assign", "transform-es3-property-literals", "transform-es3-member-expression-literals"]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.3",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-es3-property-literals": "^6.8.0",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
     "babel-preset-es2015": "^6.5.0",
     "block-loader": "^2.1.0",
     "chai": "^3.3.0",


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

I require() prebid.js in my project. I try to ensure my code runs in ie8. Thus, I actually use require() inside a try{}catch{} block -- because prebid itself doesn't run in ie8.

At some point a change was made to the build process that prevents ie8 from even parsing the _syntax_ of the code - thus stopping all execution.

This change simply ensures that at least the _syntax_ of the code doesn't confuse the ie8 parser, so as to allow catching an error in attempting to run it.

This fix was inspired from here: https://github.com/babel/babel/issues/4168