### PR TITLE
Match /ab URL to same origin as DFP VAST creative URL

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -18,6 +18,7 @@ function AppnexusAstAdapter() {
 
   let baseAdapter = Adapter.createNew('appnexusAst');
   let bidRequests = {};
+  let https = false;
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
@@ -40,7 +41,11 @@ function AppnexusAstAdapter() {
           tag.keywords = getKeywords(bid.params.keywords);
         }
 
-        if (bid.mediaType === 'video') {tag.require_asset_url = true;}
+        if (bid.mediaType === 'video') {
+          tag.require_asset_url = true;
+          https = true;
+        }
+
         if (bid.params.video) {
           tag.video = {};
           // place any valid video params on the tag
@@ -54,7 +59,11 @@ function AppnexusAstAdapter() {
 
     if (!utils.isEmpty(tags)) {
       const payload = JSON.stringify({tags: [...tags]});
-      ajax(ENDPOINT, handleResponse, payload, {
+
+      // video requests require secure connection
+      const URL = https ? `https:${ENDPOINT}`: ENDPOINT;
+
+      ajax(URL, handleResponse, payload, {
         contentType: 'text/plain',
         withCredentials : true
       });

--- a/src/adserver.js
+++ b/src/adserver.js
@@ -1,4 +1,4 @@
-import {formatQS} from './url';
+import {format, formatQS, parse} from './url';
 
 //Adserver parent class
 const AdServer = function(attr) {
@@ -28,9 +28,22 @@ exports.dfpAdserver = function (options, urlComponents) {
     return encodeURIComponent(formatQS(targeting));
   };
 
+  /**
+   * Replace regional-specific url to match DFP origin url
+   */
+  const matchOriginUrl = function(url) {
+    const parsedUrl = parse(url);
+
+    parsedUrl.protocol = 'https';
+    parsedUrl.host = 'ib.adnxs.com';
+
+    const matchedUrl = format(parsedUrl);
+    return encodeURIComponent(matchedUrl);
+  };
+
   adserver.appendQueryParams = function() {
     var bid = adserver.getWinningBidByCode();
-    this.urlComponents.search.description_url = encodeURIComponent(bid.vastUrl);
+    this.urlComponents.search.description_url = matchOriginUrl(bid.vastUrl);
     this.urlComponents.search.cust_params = getCustomParams(bid.adserverTargeting);
     this.urlComponents.correlator = Date.now();
   };

--- a/test/spec/adapters/appnexusAst_spec.js
+++ b/test/spec/adapters/appnexusAst_spec.js
@@ -120,6 +120,15 @@ describe('AppNexusAdapter', () => {
       expect(requests[0].method).to.equal('POST');
     });
 
+    it('sends video requests to secure endpoint', () => {
+      REQUEST.bids[0].mediaType = 'video';
+
+      adapter.callBids(REQUEST);
+      expect(requests[0].url).to.equal(`https:${ENDPOINT}`);
+
+      delete REQUEST.bids[0].mediaType;
+    });
+
     it('converts keyword params to proper form and attaches to request', () => {
       REQUEST.bids[0].params.keywords = {
         single: 'val',

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -18,6 +18,7 @@ var adloader = require('src/adloader');
 var adaptermanager = require('src/adaptermanager');
 var events = require('src/events');
 var adserver = require('src/adserver');
+var url = require('src/url');
 var CONSTANTS = require('src/constants.json');
 
 var config = require('test/fixtures/config.json');
@@ -1427,6 +1428,20 @@ describe('Unit: Prebid Module', function () {
       var masterTagUrl = $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag(adserverTag, options);
       assert.ok(logErrorSpy.calledOnce, true);
       utils.logError.restore();
+    });
+
+    it('should convert regional-specific URLs to match orgin URLs', () => {
+      const masterTagUrl = $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag(
+        adserverTag,
+        options
+      );
+
+      const parsedTag = url.parse(masterTagUrl);
+      const descriptionUrl = parsedTag.search.description_url;
+      const parsedDescription = url.parse(descriptionUrl);
+
+      expect(parsedDescription.protocol).to.equal('https');
+      expect(parsedDescription.host).to.equal('ib.adnxs.com');
     });
   });
 


### PR DESCRIPTION
## Description of change
Set the /ab url to the same format that DFP VAST Creative URLs are expecting, to comply with CORS spec. This should allow pre-roll video to work on Safari 9.1.