### PR TITLE
exclude node_modules from babel-loader as to prevent strict mode errors

### DIFF
--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -17,6 +17,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: /(src|test)/,
+        exclude: /node_modules/,
         loader: 'babel', // 'babel-loader' is also a legal name to reference
         query: {
           presets: ['es2015']


### PR DESCRIPTION
- [x] Bugfix

## Description of change
Fixes a problem we were having when building prebid inside a linux docker container.  The proposed solution [here](http://stackoverflow.com/questions/29105947/babel-karma-chai-gives-typeerror-caller-callee-and-arguments-proper) seems to fix the issue.
