### PR TITLE
Update build to only run `webpack` to improve build time performance

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('serve-nw', ['clean', 'quality', 'devpack', 'webpack', 'watch', 'e2ete
 
 gulp.task('run-tests', ['clean', 'quality', 'webpack', 'test', 'mocha']);
 
-gulp.task('build', ['clean', 'quality', 'webpack', 'devpack', 'zip']);
+gulp.task('build', ['webpack']);
 
 gulp.task('clean', function () {
   return gulp.src(['build'], {


### PR DESCRIPTION

## Type of change
- [x] Build related changes

## Description of change
Currently, `gulp build` runs essentially the same sub-tasks as `gulp serve` - which is intended for development. 

I purpose to make `gulp build` to be for production builds only, which drops all the other unnecessary tasks, and greatly speeds build time. This is for the download page efficiency. 

Slightly breaking change, as this no longer builds `/build/dev/*` resources. 

## Other information
@prebid/core for review

