### PR TITLE
Conversant bidfloor part two

### DIFF
--- a/src/adapters/conversant.js
+++ b/src/adapters/conversant.js
@@ -73,7 +73,7 @@ var ConversantAdapter = function () {
 
     //build impression array for conversant
     utils._each(bidReqs, function (bid) {
-      var bidfloor = utils.getBidIdParamater('bidFloor', bid.params),
+      var bidfloor = utils.getBidIdParamater('bidfloor', bid.params),
         sizeArrayLength = bid.sizes.length,
         adW = 0,
         adH = 0,


### PR DESCRIPTION
Sorry for the back and forth on this. Conversant will update their docs to use "bidfloor" instead of "bidFloor":
https://github.com/prebid/prebid.github.io/pull/131#issuecomment-262083327
so this updates the adapter to match.