### PR TITLE
Fix build error when installing from NPM

### DIFF
--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -16,7 +16,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        include: /(src|test)/,
+        include: /(src|test|node_modules\/Prebid.js)/,
         exclude: /node_modules/,
         loader: 'babel', // 'babel-loader' is also a legal name to reference
         query: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Build related changes

## Description of change

Fix issue with building prebid from npm install. Babel loader was being skipped because of the project residing in /node_modules/ directory.

Steps to reproduce:
```
mkdir node_modules
cd node_modules/
git clone https://github.com/prebid/Prebid.js.git
cd prebid.js
npm install
gulp webpack
...
Error
    at new JS_Parse_Error (<path>/node_modules/Prebid.js/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:196:18)
```


## Other information
@snapwich 
Please review as this was part of your requested change here (https://github.com/prebid/Prebid.js/commit/98e7dd1bfec7c0fda8560307434bed10c7202ed6) and i'm not sure exactly how to validate your use case. 
