### PR TITLE
Pass user object parameters on bid request

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -8,6 +8,9 @@ import { STATUS } from 'src/constants';
 const ENDPOINT = '//ib.adnxs.com/ut/v2/prebid';
 const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
+const USER_PARAMS = [
+  'age', 'externalUid', 'segments', 'gender', 'dnt', 'language'
+];
 
 /**
  * Bidder adapter for /ut endpoint. Given the list of all ad unit tag IDs,
@@ -47,6 +50,13 @@ function AppnexusAstAdapter() {
           Object.keys(bid.params.video)
             .filter(param => VIDEO_TARGETING.includes(param))
             .forEach(param => tag.video[param] = bid.params.video[param]);
+        }
+
+        if (bid.params.user) {
+          tag.user = {};
+          Object.keys(bid.params.user)
+            .filter(param => USER_PARAMS.includes(param))
+            .forEach(param => tag.user[param] = bid.params.user[param]);
         }
 
         return tag;

--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -9,7 +9,7 @@ const ENDPOINT = '//ib.adnxs.com/ut/v2/prebid';
 const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = [
-  'age', 'externalUid', 'segments', 'gender', 'dnt', 'language'
+  'age', 'external_uid', 'segments', 'gender', 'dnt', 'language'
 ];
 
 /**

--- a/test/spec/adapters/appnexusAst_spec.js
+++ b/test/spec/adapters/appnexusAst_spec.js
@@ -116,7 +116,7 @@ describe('AppNexusAdapter', () => {
 
     it('attaches valid user params to the tag', () => {
       REQUEST.bids[0].params.user = {
-        externalUid: '123',
+        external_uid: '123',
         foobar: 'invalid'
       };
 
@@ -125,7 +125,7 @@ describe('AppNexusAdapter', () => {
       const request = JSON.parse(requests[0].requestBody).tags[0];
       expect(request.user).to.exist;
       expect(request.user).to.deep.equal({
-        externalUid: '123',
+        external_uid: '123',
       });
 
       delete REQUEST.bids[0].params.user;

--- a/test/spec/adapters/appnexusAst_spec.js
+++ b/test/spec/adapters/appnexusAst_spec.js
@@ -114,6 +114,23 @@ describe('AppNexusAdapter', () => {
       delete REQUEST.bids[0].params.video;
     });
 
+    it('attaches valid user params to the tag', () => {
+      REQUEST.bids[0].params.user = {
+        externalUid: '123',
+        foobar: 'invalid'
+      };
+
+      adapter.callBids(REQUEST);
+
+      const request = JSON.parse(requests[0].requestBody).tags[0];
+      expect(request.user).to.exist;
+      expect(request.user).to.deep.equal({
+        externalUid: '123',
+      });
+
+      delete REQUEST.bids[0].params.user;
+    });
+
     it('sends bid request to ENDPOINT via POST', () => {
       adapter.callBids(REQUEST);
       expect(requests[0].url).to.equal(ENDPOINT);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Provides ability to pass user objects on the /ut bid request. Data is defined in the appnexusAst bidder parameters under `user`:

```JavaScript
{
  bidder: 'appnexusAst',
  params: {
    placementId: '123',
    user: {
      externalUid: '456'
    }
  }
}
```

Valid user fields are:
`'age', 'externalUid', 'segments', 'gender', 'dnt', 'language'`