### PR TITLE
Allow changing of 'ga' global variable

### DIFF
--- a/src/adapters/analytics/ga.js
+++ b/src/adapters/analytics/ga.js
@@ -31,6 +31,9 @@ exports.enableAnalytics = function ({ provider, options }) {
   _gaGlobal = provider || 'ga';
   _trackerSend = options && options.trackerName ? options.trackerName + '.send' : 'send';
 
+  if (options && typeof options.global !== 'undefined') {
+    _gaGlobal = options.global;
+  }
   if (options && typeof options.enableDistribution !== 'undefined') {
     _enableDistribution = options.enableDistribution;
   }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The documentation uses this snippet of code to instruct people how to set up the Google Analytics adapter
```
    pbjs.enableAnalytics({
        provider: 'ga',
        options: {
            global: 'ga', // <string> name of GA global. Default is 'ga'
            enableDistribution: false,
        }
    });
```

However, nothing actually references `options.global`. `src/adapters/analytics/ga.js` sets `_gaGlobal` to `ga` always.

Am I missing something here? Is this a bug, or is the documentation wrong?