### PR TITLE
Links bidId in request with adId in response for analytics purposes

### DIFF
--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -178,7 +178,7 @@ AppNexusAdapter = function AppNexusAdapter() {
         //store bid response
         //bid status is good (indicating 1)
         var adId = jptResponseObj.result.creative_id;
-        bid = bidfactory.createBid(1);
+        bid = bidfactory.createBid(1, bidObj);
         bid.creative_id = adId;
         bid.bidderCode = bidCode;
         bid.cpm = responseCPM;

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -196,7 +196,7 @@ AppNexusAdapter = function AppNexusAdapter() {
 
         // @endif
         //indicate that there is no bid for this placement
-        bid = bidfactory.createBid(2);
+        bid = bidfactory.createBid(2, bidObj);
         bid.bidderCode = bidCode;
         bidmanager.addBidResponse(placementCode, bid);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

In the AppNexus Adapter, the bidObj wasn't being passed through to the bidfactory.createbid() function. This meant that for analytics purposes, it was impossible to establish a link between bidId in the bid request and adId in the bid response.

An example of another Adapter doing this correctly:
https://github.com/prebid/Prebid.js/blob/master/src/adapters/sovrn.js line 126

Thanks so much!

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

