### PR TITLE
Detect browser width instead of the screen width

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -44,8 +44,16 @@ function isSizeMappingValid(sizeMapping) {
 
 function getScreenWidth(win) {
   var w = win || _win || window;
-  if(w.screen && w.screen.width) {
-    return w.screen.width;
+  var d = w.document;
+
+  if (w.innerWidth) {
+    return w.innerWidth;
+  }
+  else if (d.body.clientWidth) {
+    return d.body.clientWidth;
+  }
+  else if (d.documentElement.clientWidth) {
+    return d.documentElement.clientWidth;
   }
   return 0;
 }

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -34,11 +34,17 @@ var invalidAdUnit2 = {
 let mockWindow = {};
 
 function resetMockWindow() {
-  mockWindow = {
-    screen : {
-      width : 1024
-    }
-  };
+    mockWindow = {
+        document: {
+            body: {
+                clientWidth: 1024
+            },
+            documentElement: {
+                clientWidth: 1024
+            }
+        },
+        innerWidth: 1024
+    };
 }
 
 describe('sizeMapping', function() {
@@ -46,7 +52,7 @@ describe('sizeMapping', function() {
   beforeEach(resetMockWindow);
 
   it('mapSizes 1029 width', function() {
-    mockWindow.screen.width = 1029;
+    mockWindow.innerWidth = 1029;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([[300,250],[728,90]]);
@@ -54,7 +60,7 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes 400 width', function() {
-    mockWindow.screen.width = 400;
+    mockWindow.innerWidth = 400;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([20,20]);
@@ -62,13 +68,13 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes - invalid adUnit - should return sizes', function() {
-    mockWindow.screen.width = 1029;
+    mockWindow.innerWidth = 1029;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
 
-    mockWindow.screen.width = 400;
+    mockWindow.innerWidth = 400;
     sizeMapping.setWindow(mockWindow);
     sizes = sizeMapping.mapSizes(invalidAdUnit);
     expect(sizes).to.deep.equal([300,250]);
@@ -76,7 +82,9 @@ describe('sizeMapping', function() {
   });
 
   it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
-    mockWindow.screen.width = 0;
+    mockWindow.innerWidth = 0;
+    mockWindow.document.body.clientWidth = 0;
+    mockWindow.document.documentElement.clientWidth = 0;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(validAdUnit);
     expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
@@ -85,7 +93,9 @@ describe('sizeMapping', function() {
 
 
   it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
-    mockWindow.screen.width = 0;
+    mockWindow.innerWidth = 0;
+    mockWindow.document.body.clientWidth = 0;
+    mockWindow.document.documentElement.clientWidth = 0;
     sizeMapping.setWindow(mockWindow);
     let sizes = sizeMapping.mapSizes(invalidAdUnit2);
     expect(sizes).to.deep.equal([300,250]);
@@ -94,12 +104,16 @@ describe('sizeMapping', function() {
 
 
   it('getScreenWidth', function() {
-    mockWindow.screen.width = 900;
+    mockWindow.innerWidth = 900;
+    mockWindow.document.body.clientWidth = 900;
+    mockWindow.document.documentElement.clientWidth = 900;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
   });
 
   it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
-    mockWindow.screen.width = null;
+    mockWindow.innerWidth = null;
+    mockWindow.document.body.clientWidth = null;
+    mockWindow.document.documentElement.clientWidth = null;
     expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
   });
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Currently the size mapping is detecting the user's screen width instead of the browser. This change will use the browser width to determine which size mapping should be used.
