### PR TITLE
fix rubicon deals to be per ad instead of per response

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -178,7 +178,7 @@ function RubiconAdapter() {
       bid.cpm = ad.cpm || 0;
       bid.ad = _renderCreative(ad.script, ad.impression_id);
       [bid.width, bid.height] = sizeMap[ad.size_id].split('x').map(num => Number(num));
-      bid.dealId = responseObj.deal;
+      bid.dealId = ad.deal;
 
       bidmanager.addBidResponse(bidRequest.placementCode, bid);
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Bug fix so that the new Rubicon adapter will correctly pick up ad deals
