### PR TITLE
Integrate Browserstack tests into Travis CI build

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -119,6 +119,14 @@
     "device": null,
     "os": "Windows"
   },
+  "bs_chrome_56_mac_sierra": {
+    "base": "BrowserStack",
+    "os": "OS X",
+    "os_version": "Sierra",
+    "browser": "chrome",
+    "device": null,
+    "browser_version": "56.0"
+  },
   "bs_safari_9.1_mac_elcapitan": {
     "base": "BrowserStack",
     "os_version": "El Capitan",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,7 +92,7 @@ gulp.task('test', function () {
   var browserArgs = helpers.parseBrowserArgs(argv).map(helpers.toCapitalCase);
 
   if (process.env.TRAVIS) {
-    browserArgs = ['Chrome_travis_ci'];
+    browserArgs = ['bs_chrome_56_mac_sierra'];
   }
 
   if (argv.browserstack) {


### PR DESCRIPTION
## Type of change
- [x] CI related changes

## Description of change
This configures Travis to run unit tests on Browserstack. This PR sets Chrome 56 on Mac 10.12 (Travis natively uses Chrome 37 on Ubunut). In the future we may set additional browsers to run.

## Other information
Resolves #766