### PR TITLE
Make sure AUCTION_END event is dispatched before BID_WON event in a post-bid scenario.

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -257,13 +257,13 @@ exports.executeCallback = function (timedOut) {
 
   //execute one time callback
   if (externalCallbacks.oneTime) {
+    $$PREBID_GLOBAL$$.clearAuction();
     try {
       processCallbacks([externalCallbacks.oneTime]);
     }
     finally {
       externalCallbacks.oneTime = null;
       externalCallbacks.timer = false;
-      $$PREBID_GLOBAL$$.clearAuction();
     }
   }
 };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring

## Description of change
Updated to have the AUCTION_END event dispatched before BID_WON event in a post-bid scenario where `pbjs.renderAd` is called inside the `pbjs.requestBids` handler.

## Other information
https://github.com/prebid/Prebid.js/issues/797

