### PR TITLE
prevent rubicon adapter from registering two bids on exceptions

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -52,6 +52,7 @@ function RubiconAdapter() {
         ajax(buildOptimizedCall(bid), bidCallback, undefined, {withCredentials: true});
       } catch(err) {
         utils.logError('Error sending rubicon request for placement code ' + bid.placementCode, null, err);
+        addErrorBid();
       }
 
       function bidCallback(responseText) {
@@ -64,13 +65,14 @@ function RubiconAdapter() {
           } else {
             utils.logError('Error processing rubicon response for placement code ' + bid.placementCode, null, err);
           }
-
-          //indicate that there is no bid for this placement
-          let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
-          badBid.bidderCode = bid.bidder;
-          badBid.error = err;
-          bidmanager.addBidResponse(bid.placementCode, badBid);
+          addErrorBid();
         }
+      }
+
+      function addErrorBid() {
+        let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
+        badBid.bidderCode = bid.bidder;
+        bidmanager.addBidResponse(bid.placementCode, badBid);
       }
     });
   }
@@ -180,7 +182,11 @@ function RubiconAdapter() {
       [bid.width, bid.height] = sizeMap[ad.size_id].split('x').map(num => Number(num));
       bid.dealId = responseObj.deal;
 
-      bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      try {
+        bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      } catch (err) {
+        utils.logError('Error from addBidResponse', null, err);
+      }
     });
   }
 

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -159,12 +159,18 @@ describe('the rubicon adapter', () => {
     describe('requests', () => {
 
       let xhr,
-          screen;
+          bids;
 
       beforeEach(() => {
         rubiconAdapter = new RubiconAdapter();
 
+        bids = [];
+
         xhr = sandbox.useFakeXMLHttpRequest();
+
+        sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
+          bids.push(bid);
+        });
       });
 
       afterEach(() => {
@@ -235,7 +241,7 @@ describe('the rubicon adapter', () => {
 
       });
 
-      it('should not send a request if no valid sizes', () => {
+      it('should not send a request and register an error bid if no valid sizes', () => {
 
         var sizesBidderRequest = clone(bidderRequest);
         sizesBidderRequest.bids[0].sizes = [[620,250],[300,251]];
@@ -244,6 +250,10 @@ describe('the rubicon adapter', () => {
 
         expect(xhr.requests.length).to.equal(0);
 
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+
       });
 
     });
@@ -251,7 +261,8 @@ describe('the rubicon adapter', () => {
 
     describe('response handler', () => {
       let bids,
-          server;
+          server,
+          addBidResponseAction;
 
       beforeEach(() => {
         bids = [];
@@ -260,6 +271,10 @@ describe('the rubicon adapter', () => {
 
         sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
           bids.push(bid);
+          if(addBidResponseAction) {
+            addBidResponseAction();
+            addBidResponseAction = undefined;
+          }
         });
       });
 
@@ -441,7 +456,40 @@ describe('the rubicon adapter', () => {
         expect(bidManager.addBidResponse.calledOnce).to.equal(true);
         expect(bids).to.be.lengthOf(1);
         expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-        expect(bids[0].error instanceof SyntaxError).to.equal(true);
+      });
+
+      it('should not register an error bid when a success call to addBidResponse throws an error', () => {
+
+        server.respondWith(JSON.stringify({
+          "status": "ok",
+          "account_id": 14062,
+          "site_id": 70608,
+          "zone_id": 530022,
+          "size_id": 15,
+          "alt_size_ids": [
+            43
+          ],
+          "tracking": "",
+          "inventory": {},
+          "ads": [{
+              "status": "ok",
+              "cpm": .8,
+              "size_id": 15
+            }]
+        }));
+
+        addBidResponseAction = function() {
+          throw new Error("test error");
+        };
+
+        rubiconAdapter.callBids(bidderRequest);
+
+        server.respond();
+
+        // was calling twice for same bid, but should only call once
+        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+        expect(bids).to.be.lengthOf(1);
+
       });
 
     })


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Updated the Rubicon adapter to not handle exceptions thrown from addBidResponse.  There was a case where a success bid call to addBidResponse was throwing an exception (in bidsback callback) back to the adapter which was then causing the adapter to register an error bid as well, creating two bid responses.

Also added error bids for any exceptions thrown when attempting to create the request.
