### PR TITLE
Catch cross-origin DOMException

### DIFF
--- a/src/adapters/gumgum.js
+++ b/src/adapters/gumgum.js
@@ -10,8 +10,16 @@ const GumgumAdapter = function GumgumAdapter() {
 
   const bidEndpoint = `https://g2.gumgum.com/hbid/imp`;
 
-  const WINDOW = global.top;
-  const SCREEN = WINDOW.screen;
+  let WINDOW;
+  let SCREEN;
+
+  try {
+    WINDOW = global.top;
+    SCREEN = WINDOW.screen;
+  } catch (error) {
+    utils.logError(error);
+    return;
+  }
 
   function _callBids({ bids }) {
     const browserParams = {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Accessing `global.top` from the GumGum adapter is causing `Uncaught DOMException: Blocked a frame with origin "<url>" from accessing a cross-origin frame.` in setups such as the prebid.org [example pages](http://prebid.org/dev-docs/examples/basic-example.html). This change catches that exception.

## Other information
cc @davidmh