### PR TITLE
Add back devpack to the build task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('serve-nw', ['clean', 'quality', 'devpack', 'webpack', 'watch', 'e2ete
 
 gulp.task('run-tests', ['clean', 'quality', 'webpack', 'test', 'mocha']);
 
-gulp.task('build', ['webpack']);
+gulp.task('build', ['devpack', 'webpack']);
 
 gulp.task('clean', function () {
   return gulp.src(['build'], {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Adds back `devpack` task to the `build` task to match the documentation.

Fixes #863