### PR TITLE
refactored the way hb_deal is handled in adserverTargeting

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -130,12 +130,8 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
     //if there is any key value pairs to map do here
     var keyValues = {};
-    if (bid.bidderCode && (bid.cpm > 0 || bid.dealId)) {
+    if (bid.bidderCode && bid.cpm > 0) {
       keyValues = getKeyValueTargetingPairs(bid.bidderCode, bid);
-
-      if (bid.dealId) {
-        keyValues[`hb_deal_${bid.bidderCode}`] = bid.dealId;
-      }
     }
 
     bid.adserverTargeting = keyValues;
@@ -204,7 +200,8 @@ function setKeys(keyValues, bidderSettings, custBidObj) {
     }
 
     if (
-      typeof bidderSettings.suppressEmptyKeys !== "undefined" && bidderSettings.suppressEmptyKeys === true &&
+      (typeof bidderSettings.suppressEmptyKeys !== "undefined" && bidderSettings.suppressEmptyKeys === true ||
+      key === "hb_deal") && // hb_deal is suppressed automatically if not set
       (
         utils.isEmptyStr(value) ||
         value === null ||
@@ -400,6 +397,11 @@ function getStandardBidderSettings() {
           key: 'hb_size',
           val: function (bidResponse) {
             return bidResponse.size;
+          }
+        }, {
+          key: 'hb_deal',
+          val: function (bidResponse) {
+            return bidResponse.dealId;
           }
         }
       ]

--- a/src/constants.json
+++ b/src/constants.json
@@ -54,6 +54,7 @@
     "hb_bidder",
     "hb_adid",
     "hb_pb",
-    "hb_size"
+    "hb_size",
+    "hb_deal"
   ]
 }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -168,11 +168,6 @@ function getWinningBids(adUnitCode) {
 function getWinningBidTargeting() {
   let winners = getWinningBids();
 
-  // winning bids with deals need an hb_deal targeting key
-  winners
-    .filter(bid => bid.dealId)
-    .map(bid => bid.adserverTargeting.hb_deal = bid.dealId);
-
   let standardKeys = getStandardKeys();
   winners = winners.map(winner => {
     return {
@@ -186,16 +181,6 @@ function getWinningBidTargeting() {
   });
 
   return winners;
-}
-
-function getDealTargeting() {
-  return $$PREBID_GLOBAL$$._bidsReceived.filter(bid => bid.dealId).map(bid => {
-    const dealKey = `hb_deal_${bid.bidderCode}`;
-    return {
-      [bid.adUnitCode]: getTargetingMap(bid, CONSTANTS.TARGETING_KEYS)
-      .concat({ [dealKey.substring(0, 20)]: [bid.adserverTargeting[dealKey]] })
-    };
-  });
 }
 
 /**
@@ -232,7 +217,9 @@ function getBidLandscapeTargeting(adUnitCodes) {
     .map(bid => {
       if (bid.adserverTargeting) {
         return {
-          [bid.adUnitCode]: getTargetingMap(bid, standardKeys)
+          [bid.adUnitCode]: getTargetingMap(bid, standardKeys.filter(
+            key => typeof bid.adserverTargeting[key] !== "undefined") // mainly for possibly unset hb_deal
+          )
         };
       }
     }).filter(bid => bid); // removes empty elements in array
@@ -253,8 +240,7 @@ function getAllTargeting(adUnitCode) {
   // `alwaysUseBid=true`. If sending all bids is enabled, add targeting for losing bids.
   var targeting = getWinningBidTargeting(adUnitCodes)
     .concat(getAlwaysUseBidTargeting(adUnitCodes))
-    .concat($$PREBID_GLOBAL$$._sendAllBids ? getBidLandscapeTargeting(adUnitCodes) : [])
-    .concat(getDealTargeting(adUnitCodes));
+    .concat($$PREBID_GLOBAL$$._sendAllBids ? getBidLandscapeTargeting(adUnitCodes) : []);
 
   //store a reference of the targeting keys
   targeting.map(adUnitCode => {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -422,6 +422,9 @@ describe('bidmanager.js', function () {
       bidmanager.adjustBids(bid)
       assert.equal(bid.cpm, 0);
 
+      // reset bidderSettings so we don't mess up further tests
+      $$PREBID_GLOBAL$$.bidderSettings = {};
+
     });
   });
 
@@ -474,7 +477,7 @@ describe('bidmanager.js', function () {
       bid.dealId = "test deal";
       bidmanager.addBidResponse(bid.adUnitCode, bid);
       const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
-      assert.equal(addedBid.adserverTargeting[`hb_deal_${bid.bidderCode}`], bid.dealId, 'dealId placed in adserverTargeting');
+      assert.equal(addedBid.adserverTargeting[`hb_deal`], bid.dealId, 'dealId placed in adserverTargeting');
     });
 
     it('should not alter bid adID', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Changed the way `hb_deal` is handled in the code to behave more like a standard targeting key.

## Other information
Should fix #827
