### PR TITLE
New aardvark adapter with support for aliasing

### DIFF
--- a/src/adapters/aardvark.js
+++ b/src/adapters/aardvark.js
@@ -1,104 +1,144 @@
-var utils = require('../utils.js');
-var bidfactory = require('../bidfactory.js');
-var bidmanager = require('../bidmanager.js');
-var adloader = require('../adloader');
-
-
-/**
+/*
  * Adapter for requesting bids from RTK Aardvark
  * To request an RTK Aardvark Header bidding account
  * or for additional integration support please contact sales@rtk.io
  */
 
-var AardvarkAdapter = function AardvarkAdapter() {
+var utils      = require('../utils.js');
+var bidfactory = require('../bidfactory.js');
+var bidmanager = require('../bidmanager.js');
+var adloader   = require('../adloader.js');
+var adapter    = require('./adapter.js');
+var constants  = require('../constants.json');
 
-  function _callBids(params) {
-    var rtkBids = params.bids || [];
+var AARDVARK_CALLBACK_NAME = 'aardvarkResponse',
+    AARDVARK_REQUESTS_MAP  = 'aardvarkRequests',
+    AARDVARK_BIDDER_CODE   = 'aardvark',
+    DEFAULT_REFERRER       = 'thor.rtk.io',
+    DEFAULT_ENDPOINT       = 'thor.rtk.io',
 
-    _requestBids(rtkBids);
-  }
+    endpoint               = DEFAULT_ENDPOINT,
 
-  function _requestBids(bidReqs) {
-    let ref;
-    try {
-      ref = window.top.location.host;
-    }
-    catch (err) {
-      ref = "thor.rtk.io";
+    requestBids = function(bidderCode, callbackName, bidReqs) {
+      var ref    = utils.getTopWindowLocation(),
+          ai     = '',
+          scs    = [],
+          bidIds = [];
 
-    }
-    var ai = "";
-    var shortcodes = [];
+      ref = ref ? ref.host : DEFAULT_REFERRER;
 
-    //build bid URL for RTK
-    utils._each(bidReqs, function (bid) {
-      ai = utils.getBidIdParameter('ai', bid.params);
-      var sc = utils.getBidIdParameter('sc', bid.params);
-      shortcodes.push(sc);
-    });
+      for (var i = 0, l = bidReqs.length, bid, _ai, _sc, _endpoint; i < l; i += 1) {
+        bid = bidReqs[i];
+        _ai = utils.getBidIdParameter('ai', bid.params);
+        _sc = utils.getBidIdParameter('sc', bid.params);
+        if (!_ai || !_ai.length || !_sc || !_sc.length)
+          continue;
 
-    var scURL = "";
+        _endpoint = utils.getBidIdParameter('host', bid.params);
+        if (_endpoint)
+          endpoint = _endpoint;
 
-    if (shortcodes.length > 1) {
-      scURL = shortcodes.join("_");
-    } else {
-      scURL = shortcodes[0];
-    }
+        if (!ai.length)
+          ai = _ai;
+        if (_sc)
+          scs.push(_sc);
 
-    var scriptUrl = '//thor.rtk.io/' + ai + "/" + scURL + "/aardvark/?jsonp=window.$$PREBID_GLOBAL$$.aardvarkResponse&rtkreferer=" + ref;
-    adloader.loadScript(scriptUrl);
-  }
+        bidIds.push(_sc + "=" + bid.bidId);
 
-  //expose the callback to the global object:
-  window.$$PREBID_GLOBAL$$.aardvarkResponse = function (rtkResponseObj) {
+        // Create the bidIdsMap for easier mapping back later
+        $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode][bid.bidId] = bid;
+      }
 
-    //Get all initial Aardvark Bid Objects
-    var bidsObj = $$PREBID_GLOBAL$$._bidsRequested.filter(function (bidder) {
-      return bidder.bidderCode === 'aardvark';
-    })[0];
+      if (!ai.length || !scs.length)
+        return utils.logWarn("Bad bid request params given for adapter $" + bidderCode + " (" + AARDVARK_BIDDER_CODE + ")");
 
-    var returnedBidIDs = {};
+      adloader.loadScript([
+        '//' + endpoint + '/', ai, '/', scs.join('_'),
+        '/aardvark/?jsonp=$$PREBID_GLOBAL$$.', callbackName,
+        '&rtkreferer=', ref, '&', bidIds.join('&')
+      ].join(''));
+    },
 
-    if (rtkResponseObj.length > 0) {
-      rtkResponseObj.forEach(function (bid) {
 
-        if (!bid.error) {
-          var currentBid = bidsObj.bids.filter(function (r) {
-            return r.params.sc === bid.id;
-          })[0];
-          if (currentBid) {
-            var bidResponse = bidfactory.createBid(1, currentBid);
-            bidResponse.bidderCode = "aardvark";
-            bidResponse.cpm = bid.cpm;
-            bidResponse.ad = bid.adm;
-            bidResponse.ad += utils.createTrackPixelHtml(decodeURIComponent(bid.nurl));
-            bidResponse.width = currentBid.sizes[0][0];
-            bidResponse.height = currentBid.sizes[0][1];
-            returnedBidIDs[bid.id] = currentBid.placementCode;
-            bidmanager.addBidResponse(currentBid.placementCode, bidResponse);
+
+    registerBidResponse = function(bidderCode, rawBidResponse) {
+      if (rawBidResponse.error)
+        return utils.logWarn("Aardvark bid received with an error, ignoring... [" + rawBidResponse.error + "]");
+
+      if (!rawBidResponse.cid)
+        return utils.logWarn("Aardvark bid received without a callback id, ignoring...");
+
+      var bidObj = $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode][rawBidResponse.cid];
+      if (!bidObj)
+        return utils.logWarn("Aardvark request not found: " + rawBidResponse.cid);
+
+      if (bidObj.params.sc !== rawBidResponse.id)
+        return utils.logWarn("Aardvark bid received with a non matching shortcode " + rawBidResponse.id + " instead of " + bidObj.params.sc);
+
+      var bidResponse = bidfactory.createBid(constants.STATUS.GOOD, bidObj);
+      bidResponse.bidderCode = bidObj.bidder;
+      bidResponse.cpm        = rawBidResponse.cpm;
+      bidResponse.ad         = rawBidResponse.adm + utils.createTrackPixelHtml(decodeURIComponent(rawBidResponse.nurl));
+      bidResponse.width      = bidObj.sizes[0][0];
+      bidResponse.height     = bidObj.sizes[0][1];
+
+      bidmanager.addBidResponse(bidObj.placementCode, bidResponse);
+      $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode][rawBidResponse.cid].responded = true;
+    },
+
+
+
+    registerAardvarkCallback = function(bidderCode, callbackName) {
+      $$PREBID_GLOBAL$$[callbackName] = function(rtkResponseObj) {
+
+        rtkResponseObj.forEach(function(bidResponse) {
+          registerBidResponse(bidderCode, bidResponse);
+        });
+
+        for (var bidRequestId in $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode])
+          if ($$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode].hasOwnProperty(bidRequestId)) {
+            var bidRequest = $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode][bidRequestId];
+            if (!bidRequest.responded) {
+              var bidResponse = bidfactory.createBid(constants.STATUS.NO_BID, bidRequest);
+              bidResponse.bidderCode = bidRequest.bidder;
+              bidmanager.addBidResponse(bidRequest.placementCode, bidResponse);
+            }
           }
-
-        }
-
-      });
-
-    }
-
-    //All bids are back - lets add a bid response for anything that did not receive a bid.
-    let difference = bidsObj.bids.filter(x => Object.keys(returnedBidIDs).indexOf(x.params.sc) === -1);
-
-    difference.forEach(function (bidRequest) {
-      var bidResponse = bidfactory.createBid(2, bidRequest);
-      bidResponse.bidderCode = "aardvark";
-      bidmanager.addBidResponse(bidRequest.placementCode, bidResponse);
-    });
+      };
+    },
 
 
-  }; // aardvarkResponse
 
-  return {
-    callBids: _callBids
-  };
+    AardvarkAdapter = function() {
+      var baseAdapter = adapter.createNew(AARDVARK_BIDDER_CODE);
+
+      $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP] = $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP] || {};
+
+      baseAdapter.callBids = function (params) {
+        var bidderCode   = baseAdapter.getBidderCode(),
+            callbackName = AARDVARK_CALLBACK_NAME;
+
+        if (bidderCode !== AARDVARK_BIDDER_CODE)
+          callbackName = [AARDVARK_CALLBACK_NAME, bidderCode].join('_');
+
+        $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP][bidderCode] = {};
+
+        registerAardvarkCallback(bidderCode, callbackName);
+
+        return requestBids(bidderCode, callbackName, params.bids || []);
+      };
+
+      return {
+        callBids:      baseAdapter.callBids,
+        setBidderCode: baseAdapter.setBidderCode,
+        createNew:     exports.createNew
+      };
+    };
+
+
+
+exports.createNew = function() {
+  return new AardvarkAdapter();
 };
 
 module.exports = AardvarkAdapter;

--- a/test/spec/adapters/aardvark_spec.js
+++ b/test/spec/adapters/aardvark_spec.js
@@ -1,121 +1,216 @@
-import {expect} from 'chai';
-import Adapter from '../../../src/adapters/aardvark';
-import bidManager from '../../../src/bidmanager';
-import adLoader from '../../../src/adloader';
+describe('aardvark adapter tests', function () {
+  const expect = require('chai').expect;
+  const adapter = require('src/adapters/aardvark');
+  const bidmanager = require('src/bidmanager');
+  const adloader = require('src/adloader');
+  const constants  = require('src/constants.json');
 
-describe('aardvark adapter', () => {
-
-  let bidsRequestedOriginal;
-  let adapter;
-  let sandbox;
+  var aardvark,
+      sandbox,
+      bidsRequestedOriginal;
 
   const bidderRequest = {
-    bidderCode: 'aardvark',
-    bids: [
-      {
-        bidId: 'bidId1',
-        bidder: 'aardvark',
-        placementCode: 'foo',
-        sizes: [[728, 90]],
-        params: {
-          ai: 'XBC1',
-          sc: 'AAAA'
-        }
-      },
-      {
-        bidId: 'bidId2',
-        bidder: 'aardvark',
-        placementCode: 'bar',
-        sizes: [[300, 600]],
-        params: {
-          ai: 'XBC1',
-          sc: 'BBBB'
-        }
-      }
-    ]
-  };
+          bidderCode: 'aardvark',
+          bids: [
+            {
+              bidId: 'bidId1',
+              bidder: 'aardvark',
+              placementCode: 'foo',
+              sizes: [[728, 90]],
+              rtkid: 1,
+              params: {
+                ai: 'AH5S',
+                sc: 'BirH'
+              }
+            },
+            {
+              bidId: 'bidId2',
+              bidder: 'aardvark',
+              placementCode: 'bar',
+              sizes: [[300, 600]],
+              rtkid: 1,
+              params: {
+                ai: 'AH5S',
+                sc: '661h'
+              }
+            }
+          ]
+        },
+
+        bidderRequestCustomHost = {
+          bidderCode: 'aardvark',
+          bids: [
+            {
+              bidId: 'bidId1',
+              bidder: 'aardvark',
+              placementCode: 'foo',
+              sizes: [[728, 90]],
+              rtkid: 1,
+              params: {
+                ai: 'AH5S',
+                sc: 'BirH',
+                host: 'custom.server.com'
+              }
+            },
+            {
+              bidId: 'bidId2',
+              bidder: 'aardvark',
+              placementCode: 'bar',
+              sizes: [[300, 600]],
+              rtkid: 1,
+              params: {
+                ai: 'AH5S',
+                sc: '661h',
+                host: 'custom.server.com'
+              }
+            }
+          ]
+        },
+
+
+
+        // respond
+        bidderResponse = [
+          {
+            "adm": "<div></div>",
+            "cpm": 0.39440,
+            "ex": "",
+            "height": "90",
+            "id": "BirH",
+            "nurl": "",
+            "width": "728",
+            "cid": "bidId1"
+          },
+          {
+            "adm": "<div></div>",
+            "cpm": 0.03485,
+            "ex": "",
+            "height": "600",
+            "id": "661h",
+            "nurl": "",
+            "width": "300",
+            "cid": "bidId2"
+          }
+        ];
+
 
   beforeEach(() => {
-    bidsRequestedOriginal = pbjs._bidsRequested;
-    pbjs._bidsRequested = [];
-
-    adapter = new Adapter();
+    aardvark = new adapter();
     sandbox = sinon.sandbox.create();
+    bidsRequestedOriginal = $$PREBID_GLOBAL$$._bidsRequested;
+    $$PREBID_GLOBAL$$._bidsRequested = [];
   });
+
 
   afterEach(() => {
     sandbox.restore();
 
-    pbjs._bidsRequested = bidsRequestedOriginal;
+    $$PREBID_GLOBAL$$._bidsRequested = bidsRequestedOriginal;
   });
+
 
   describe('callBids', () => {
-
     beforeEach(() => {
-      sandbox.stub(adLoader, 'loadScript');
-      adapter.callBids(bidderRequest);
+      sandbox.stub(adloader, 'loadScript');
+      aardvark.callBids(bidderRequest);
     });
-
     it('should load script', () => {
-      sinon.assert.calledOnce(adLoader.loadScript);
-
-      let expected = '//thor.rtk.io/XBC1/AAAA_BBBB/aardvark/?jsonp=window.pbjs.aardvarkResponse&rtkreferer=localhost:9876';
-      expect(adLoader.loadScript.firstCall.args[0]).to.eql(expected);
+      sinon.assert.calledOnce(adloader.loadScript);
+      expect(adloader.loadScript.firstCall.args[0]).to.eql(
+        '//thor.rtk.io/AH5S/BirH_661h/aardvark/?jsonp=$$PREBID_GLOBAL$$.aardvarkResponse&rtkreferer=localhost:9876&BirH=bidId1&661h=bidId2');
     });
-
   });
+
+
+  describe('callBids with custom host', () => {
+    beforeEach(() => {
+      sandbox.stub(adloader, 'loadScript');
+      aardvark.callBids(bidderRequestCustomHost);
+    });
+    it('should load script', () => {
+      sinon.assert.calledOnce(adloader.loadScript);
+      expect(adloader.loadScript.firstCall.args[0]).to.eql(
+        '//custom.server.com/AH5S/BirH_661h/aardvark/?jsonp=$$PREBID_GLOBAL$$.aardvarkResponse&rtkreferer=localhost:9876&BirH=bidId1&661h=bidId2');
+    });
+  });
+
 
   describe('aardvarkResponse', () => {
-
     it('should exist and be a function', () => {
-      expect(pbjs.aardvarkResponse).to.exist.and.to.be.a('function');
+      expect($$PREBID_GLOBAL$$.aardvarkResponse).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('add bids to the manager', () => {
 
+
+  describe('add empty bids if no bid returned', () => {
     let firstBid;
     let secondBid;
 
     beforeEach(() => {
-      sandbox.stub(bidManager, 'addBidResponse');
+      sandbox.stub(bidmanager, 'addBidResponse');
 
-      pbjs._bidsRequested.push(bidderRequest);
+      $$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
+      aardvark.callBids(bidderRequest);
 
-      // respond
-      let bidderReponse = [
-        {
-          "adm": "<div></div>",
-          "cpm": 0.39440,
-          "ex": "",
-          "height": "90",
-          "id": "AAAA",
-          "nurl": "",
-          "width": "728"
-        },
-        {
-          "adm": "<div></div>",
-          "cpm": 0.03485,
-          "ex": "",
-          "height": "600",
-          "id": "BBBB",
-          "nurl": "",
-          "width": "300"
-        }
-      ];
-      pbjs.aardvarkResponse(bidderReponse);
+      $$PREBID_GLOBAL$$.aardvarkResponse([]);
 
-      firstBid = bidManager.addBidResponse.firstCall.args[1];
-      secondBid = bidManager.addBidResponse.secondCall.args[1];
+      firstBid = bidmanager.addBidResponse.firstCall.args[1];
+      secondBid = bidmanager.addBidResponse.secondCall.args[1];
     });
 
     it('should add a bid object for each bid', () => {
-      sinon.assert.calledTwice(bidManager.addBidResponse);
+      sinon.assert.calledTwice(bidmanager.addBidResponse);
+    });
+
+    it('should have an error statusCode', () => {
+      expect(firstBid.getStatusCode()).to.eql(constants.STATUS.NO_BID);
+      expect(secondBid.getStatusCode()).to.eql(constants.STATUS.NO_BID);
+    });
+
+    it('should include bid request bidId as the adId', () => {
+      expect(firstBid).to.have.property('adId', 'bidId1');
+      expect(secondBid).to.have.property('adId', 'bidId2');
     });
 
     it('should pass the correct placement code as first param', () => {
-      let firstPlacementCode = bidManager.addBidResponse.firstCall.args[0];
-      let secondPlacementCode = bidManager.addBidResponse.secondCall.args[0];
+      let firstPlacementCode = bidmanager.addBidResponse.firstCall.args[0];
+      let secondPlacementCode = bidmanager.addBidResponse.secondCall.args[0];
+
+      expect(firstPlacementCode).to.eql('foo');
+      expect(secondPlacementCode).to.eql('bar');
+    });
+
+    it('should add the bidder code to the bid object', () => {
+      expect(firstBid).to.have.property('bidderCode', 'aardvark');
+      expect(secondBid).to.have.property('bidderCode', 'aardvark');
+    });
+
+  });
+
+
+  describe('add bids to the manager', () => {
+    let firstBid;
+    let secondBid;
+
+    beforeEach(() => {
+      sandbox.stub(bidmanager, 'addBidResponse');
+
+      $$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
+      aardvark.callBids(bidderRequest);
+
+      $$PREBID_GLOBAL$$.aardvarkResponse(bidderResponse);
+      firstBid = bidmanager.addBidResponse.firstCall.args[1];
+      secondBid = bidmanager.addBidResponse.secondCall.args[1];
+    });
+
+    it('should add a bid object for each bid', () => {
+      sinon.assert.calledTwice(bidmanager.addBidResponse);
+    });
+
+    it('should pass the correct placement code as first param', () => {
+      let firstPlacementCode = bidmanager.addBidResponse.firstCall.args[0];
+      let secondPlacementCode = bidmanager.addBidResponse.secondCall.args[0];
 
       expect(firstPlacementCode).to.eql('foo');
       expect(secondPlacementCode).to.eql('bar');
@@ -127,8 +222,8 @@ describe('aardvark adapter', () => {
     });
 
     it('should have a good statusCode', () => {
-      expect(firstBid.getStatusCode()).to.eql(1);
-      expect(secondBid.getStatusCode()).to.eql(1);
+      expect(firstBid.getStatusCode()).to.eql(constants.STATUS.GOOD);
+      expect(secondBid.getStatusCode()).to.eql(constants.STATUS.GOOD);
     });
 
     it('should add the CPM to the bid object', () => {
@@ -154,50 +249,8 @@ describe('aardvark adapter', () => {
     });
   });
 
-  describe('add empty bids if no bid returned', () => {
 
-    let firstBid;
-    let secondBid;
 
-    beforeEach(() => {
-      sandbox.stub(bidManager, 'addBidResponse');
 
-      pbjs._bidsRequested.push(bidderRequest);
-
-      // respond
-      let bidderReponse = [];
-      pbjs.aardvarkResponse(bidderReponse);
-
-      firstBid = bidManager.addBidResponse.firstCall.args[1];
-      secondBid = bidManager.addBidResponse.secondCall.args[1];
-    });
-
-    it('should add a bid object for each bid', () => {
-      sinon.assert.calledTwice(bidManager.addBidResponse);
-    });
-
-    it('should have an error statusCode', () => {
-      expect(firstBid.getStatusCode()).to.eql(2);
-      expect(secondBid.getStatusCode()).to.eql(2);
-    });
-
-    it('should include bid request bidId as the adId', () => {
-      expect(firstBid).to.have.property('adId', 'bidId1');
-      expect(secondBid).to.have.property('adId', 'bidId2');
-    });
-
-    it('should pass the correct placement code as first param', () => {
-      let firstPlacementCode = bidManager.addBidResponse.firstCall.args[0];
-      let secondPlacementCode = bidManager.addBidResponse.secondCall.args[0];
-
-      expect(firstPlacementCode).to.eql('foo');
-      expect(secondPlacementCode).to.eql('bar');
-    });
-
-    it('should add the bidder code to the bid object', () => {
-      expect(firstBid).to.have.property('bidderCode', 'aardvark');
-      expect(secondBid).to.have.property('bidderCode', 'aardvark');
-    });
-
-  });
 });
+


### PR DESCRIPTION
## Type of change

- [X] Code style update (formatting, local variables)
- [X] Feature
- [X] Refactoring (no functional changes, no api changes)
- [X] CI related changes

## Description of change

The Aardvark adapter now supports aliasing using the new adapter specs of Prebid.js. Tests have been updated accordingly.

An additional parameter is introduced - "host" which can be used to CNAME the aardvark endpoint.

```
{
  bidder: 'aardvark',
  params: {
    host: 'host.example.net'
    sc: '...',
    ai: '...'
  }
}
```

- [x] official adapter submission
