### PR TITLE
Ignore test html pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ build
 # Test Files
 test/app
 gpt.html
-gpt-mlane.html
 gpt-each-bidder3.html
 
 # Selenium files
@@ -13,8 +12,8 @@ bin
 selenium*.log
 
 # Dev File
-
 integrationExamples/gpt/gpt.html
+integrationExamples/gpt/*-test.html
 integrationExamples/implementations/
 src/adapters/analytics/libraries
 


### PR DESCRIPTION
## Type of change
- [x] Repository related changes

## Description of change
This change tells git to ignore any page ending with `-test.html` in the `integrations/gpt` directory. This allows for conveniently creating test pages and not worrying about them being added to the repository.

## Other information
@prebid/core Feedback requested on file pattern used