### PR TITLE
headbidding alias for adkernel adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -67,6 +67,11 @@
       "appnexus": {
         "alias": "featureforward"
       }
+    },
+    {
+      "adkernel": {
+        "alias": "headbidding"
+      }
     }
 
 ]


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Headbidding (http://headbidding.com/) alias for adkernel adapter

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'headbidding',
  params: {
    zoneId : '27914',
    host : 'rtb.nativeads.com'
  }
}
```
- contact email of the adapter’s maintainer : allen@headbidding.com
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

