### PR TITLE
emit AUCTION_END event before bidsBackHandler callback

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -2,6 +2,7 @@ import {uniques, flatten, adUnitsFilter} from './utils';
 import {getPriceBucketString} from './cpmBucketManager';
 
 var CONSTANTS = require('./constants.json');
+var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 var utils = require('./utils.js');
 var events = require('./events');
 
@@ -257,6 +258,7 @@ exports.executeCallback = function (timedOut) {
 
   //execute one time callback
   if (externalCallbacks.oneTime) {
+    events.emit(AUCTION_END);
     try {
       processCallbacks([externalCallbacks.oneTime]);
     }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -23,7 +23,6 @@ var objectType_function = 'function';
 var objectType_undefined = 'undefined';
 var objectType_object = 'object';
 var BID_WON = CONSTANTS.EVENTS.BID_WON;
-var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 
 var auctionRunning = false;
 var bidRequestQueue = [];
@@ -485,7 +484,6 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
 $$PREBID_GLOBAL$$.clearAuction = function() {
   auctionRunning = false;
   utils.logMessage('Prebid auction cleared');
-  events.emit(AUCTION_END);
   if (bidRequestQueue.length) {
     bidRequestQueue.shift()();
   }


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Emit the AUCTION_END event sooner, before the `bidsBackHandler` is called when closing an auction.