### PR TITLE
OpenX official adapter release: Fixing the existing openx adapter and…

### DIFF
--- a/test/spec/adapters/openx_spec.js
+++ b/test/spec/adapters/openx_spec.js
@@ -1,0 +1,195 @@
+describe('openx adapter tests', function () {
+
+  const expect = require('chai').expect;
+  const assert = require('chai').assert;
+  const adapter = require('src/adapters/openx');
+  const bidmanager = require('src/bidmanager');
+  const adloader = require('src/adloader');
+  const CONSTANTS = require('src/constants.json');
+
+  describe('test openx callback responce', function () {
+
+    it('should exist and be a function', function () {
+      expect(pbjs.oxARJResponse).to.exist.and.to.be.a('function');
+    });
+
+    it('should add empty bid responses if no bids returned', function () {
+      let stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+      let bidderRequest = {
+        bidderCode: 'openx',
+        bids: [
+          {
+            bidId: 'bidId1',
+            bidder: 'openx',
+            params: {
+              delDomain: 'delDomain1',
+              unit: '1234'
+            },
+            sizes: [[300, 250]],
+            placementCode: 'test-gpt-div-1234'
+          }
+        ]
+      };
+
+      // empty ads in bidresponse
+      let response = {
+        "ads":
+        {
+          "version": 1,
+          "count": 1,
+          "pixels": "http://testpixels.net",
+          "ad": []
+        }
+      };
+
+      pbjs._bidsRequested.push(bidderRequest);
+      // adapter needs to be called, in order for the stub to register.
+      adapter();
+
+      pbjs.oxARJResponse(response);
+
+      let bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+      let bidResponse1 = stubAddBidResponse.getCall(0).args[1];
+      expect(bidPlacementCode1).to.equal('test-gpt-div-1234');
+      expect(bidResponse1.getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+      expect(bidResponse1.bidderCode).to.equal('openx');
+      stubAddBidResponse.restore();
+    });
+  });
+
+  it('should add bid responses if bids are returned', function () {
+    let stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+    let bidderRequest = {
+      bidderCode: 'openx',
+      bids: [
+        {
+          bidId: 'bidId1',
+          bidder: 'openx',
+          params: {
+            delDomain: 'delDomain1',
+            unit: '1234'
+          },
+          sizes: [[300, 250]],
+          placementCode: 'test-gpt-div-1234'
+        }
+      ]
+    };
+
+    // empty ads in bidresponse
+    let response = {
+      "ads":
+      {
+        "version": 1,
+        "count": 1,
+        "pixels": "http://testpixels.net",
+        "ad": [
+          {
+            "adunitid": 1234,
+            "adid": 5678,
+            "type": "html",
+            "html": "test_html",
+            "framed": 1,
+            "is_fallback": 0,
+            "ts": "ts",
+            "cpipc": 1000,
+            "pub_rev": "1000",
+            "adv_id": "adv_id",
+            "brand_id": "",
+            "creative": [
+              {
+                "width": "300",
+                "height": "250",
+                "target": "_blank",
+                "mime": "text/html",
+                "media": "test_media",
+                "tracking": {
+                  "impression": "test_impression",
+                  "inview": "test_inview",
+                  "click": "test_click"
+                }
+              }
+            ]
+          }]
+      }
+    };
+
+    pbjs._bidsRequested.push(bidderRequest);
+    // adapter needs to be called, in order for the stub to register.
+    adapter();
+
+    pbjs.oxARJResponse(response);
+
+    let bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+    let bidResponse1 = stubAddBidResponse.getCall(0).args[1];
+    let bid1width = '300';
+    let bid1height = '250';
+    let cpm = 1;
+    expect(bidPlacementCode1).to.equal('test-gpt-div-1234');
+    expect(bidResponse1.getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+    expect(bidResponse1.bidderCode).to.equal('openx');
+    expect(bidResponse1.width).to.equal(bid1width);
+    expect(bidResponse1.height).to.equal(bid1height);
+    expect(bidResponse1.cpm).to.equal(cpm);
+    stubAddBidResponse.restore();
+  });
+
+  it('should not call loadscript when inputting with empty params', function () {
+    let spyLoadScript = sinon.spy(adloader, 'loadScript');
+    adapter().callBids({});
+    assert(!spyLoadScript.called);
+    spyLoadScript.restore();
+  });
+
+  it('should call loadscript with the correct params', function () {
+    let spyLoadScript = sinon.spy(adloader, 'loadScript');
+    let params = {
+      bids: [
+        {
+          sizes: [[300, 250], [300, 600]],
+          params: {
+            delDomain: 'testdelDomain',
+            unit: 1234
+          }
+        }
+      ]
+    };
+    adapter().callBids(params);
+
+    sinon.assert.calledOnce(spyLoadScript);
+
+    let bidUrl = spyLoadScript.getCall(0).args[0];
+    expect(bidUrl).to.include('testdelDomain');
+    expect(bidUrl).to.include('1234');
+    expect(bidUrl).to.include('300x250,300x600');
+    spyLoadScript.restore();
+  });
+
+  it('should send out custom params on bids that have customParams specified', function () {
+    let spyLoadScript = sinon.spy(adloader, 'loadScript');
+    let params = {
+      bids: [
+        {
+          sizes: [[300, 250], [300, 600]],
+          params: {
+            delDomain: 'testdelDomain',
+            unit: 1234,
+            customParams: {'test1': 'testval1'}
+          }
+        }
+      ]
+    };
+    adapter().callBids(params);
+
+    sinon.assert.calledOnce(spyLoadScript);
+
+    let bidUrl = spyLoadScript.getCall(0).args[0];
+    expect(bidUrl).to.include('testdelDomain');
+    expect(bidUrl).to.include('1234');
+    expect(bidUrl).to.include('300x250,300x600');
+    expect(bidUrl).to.include('c.test1=testval1');
+    spyLoadScript.restore();
+  });
+
+});


### PR DESCRIPTION
… adding test coverage on it

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->

## Type of change
- [ x ] official adapter submission

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'openx’,
  params: {
    // …
    params: {
              unit: ‘538562284’, // OpenX ad unit ID
              delDomain: 'clientname-d.openx.net',  // OpenX delivery domain
              customParams: {"gender": "female"}   // Publisher specified custom parameters, optional
            }
  }
}
```
bidder code: openx
Send All Bids Ad Server Keys: hb_pb_openx, hb_adid_openx, hb_size_openx
Default Deal ID Ad Server Key: hb_deal_openx

- contact email of the adapter’s maintainer: team-openx@openx.com



## Other information
Note:
The OpenX adapter requires setup and approval from your OpenX team. Please reach out to your OpenX representative or Support@openx.com for more information and to enable using this adapter.

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->