### PR TITLE
Prevent errors in bidsBackHandler propagating to adapters.

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -261,6 +261,9 @@ exports.executeCallback = function (timedOut) {
     try {
       processCallbacks([externalCallbacks.oneTime]);
     }
+    catch(e){
+      utils.logError('Error executing bidsBackHandler', null, e);
+    }
     finally {
       externalCallbacks.oneTime = null;
       externalCallbacks.timer = false;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -573,6 +573,18 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('requestBids', () => {
+
+    var adUnitsBackup;
+
+    beforeEach(() => {
+      adUnitsBackup = $$PREBID_GLOBAL$$.adUnits;
+    });
+
+    afterEach(() => {
+      $$PREBID_GLOBAL$$.adUnits = adUnitsBackup;
+      resetAuction();
+    });
+
     it('should add bidsBackHandler callback to bidmanager', () => {
       var spyAddOneTimeCallBack = sinon.spy(bidmanager, 'addOneTimeCallback');
       var requestObj = {
@@ -583,20 +595,16 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyAddOneTimeCallBack.calledWith(requestObj.bidsBackHandler),
         'called bidmanager.addOneTimeCallback');
       bidmanager.addOneTimeCallback.restore();
-      resetAuction();
     });
 
     it('should log message when adUnits not configured', () => {
       const logMessageSpy = sinon.spy(utils, 'logMessage');
-      const adUnitsBackup = $$PREBID_GLOBAL$$.adUnits;
 
       $$PREBID_GLOBAL$$.adUnits = [];
       $$PREBID_GLOBAL$$.requestBids({});
 
       assert.ok(logMessageSpy.calledWith('No adUnits configured. No bids requested.'), 'expected message was logged');
       utils.logMessage.restore();
-      $$PREBID_GLOBAL$$.adUnits = adUnitsBackup;
-      resetAuction();
     });
 
     it('should execute callback after timeout', () => {
@@ -619,12 +627,10 @@ describe('Unit: Prebid Module', function () {
 
       bidmanager.executeCallback.restore();
       clock.restore();
-      resetAuction();
     });
 
     it('should execute callback immediately if adUnits is empty', () => {
       var spyExecuteCallback = sinon.spy(bidmanager, 'executeCallback');
-      const adUnitsBackup = $$PREBID_GLOBAL$$.adUnits;
 
       $$PREBID_GLOBAL$$.adUnits = [];
       $$PREBID_GLOBAL$$.requestBids({});
@@ -633,16 +639,30 @@ describe('Unit: Prebid Module', function () {
         ' empty');
 
       bidmanager.executeCallback.restore();
-      $$PREBID_GLOBAL$$.adUnits = adUnitsBackup;
-      resetAuction();
+    });
+
+    it('should not propagate exceptions from bidsBackHandler', () => {
+      $$PREBID_GLOBAL$$.adUnits = [];
+
+      var requestObj = {
+        bidsBackHandler: function bidsBackHandlerCallback() {
+          var test = undefined;
+          return test.test;
+        }
+      };
+
+      expect(() => {
+        $$PREBID_GLOBAL$$.requestBids(requestObj);
+      }).not.to.throw();
+
     });
 
     it('should call callBids function on adaptermanager', () => {
       var spyCallBids = sinon.spy(adaptermanager, 'callBids');
+
       $$PREBID_GLOBAL$$.requestBids({});
       assert.ok(spyCallBids.called, 'called adaptermanager.callBids');
       adaptermanager.callBids.restore();
-      resetAuction();
     });
 
     it('should not callBids if a video adUnit has non-video bidders', () => {
@@ -663,7 +683,6 @@ describe('Unit: Prebid Module', function () {
 
       adaptermanager.callBids.restore();
       adaptermanager.videoAdapters = videoAdaptersBackup;
-      resetAuction();
     });
 
     it('should callBids if a video adUnit has all video bidders', () => {
@@ -683,7 +702,6 @@ describe('Unit: Prebid Module', function () {
 
       adaptermanager.callBids.restore();
       adaptermanager.videoAdapters = videoAdaptersBackup;
-      resetAuction();
     });
 
     it('should queue bid requests when a previous bid request is in process', () => {


### PR DESCRIPTION

## Type of change
- [x] Bugfix

## Description of change
Currently if there is an exception when executing the bidsBackHandler that error will propagate back into the adapter that added the bid response.  Now we just log the error but don't propagate it to the adapter.
