### PR TITLE
rhythmone: reset auctionEnded and requestCompleted on new auction

### DIFF
--- a/src/adapters/rhythmone.js
+++ b/src/adapters/rhythmone.js
@@ -260,6 +260,9 @@ module.exports = function(bidManager, global, loader){
       bidParams = getBidParameters(params.bids);
   
     debug = (bidParams !== null && bidParams.debug === true);
+
+    auctionEnded = false;
+    requestCompleted = false;
   
     track(debug, 'hb', 'callBids');
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The RhythmOne adapter tracks the auction end and request completion, but doesn't reset the tracking variables on new bid requests. This patch resets those variables so that new bids are not ignored.