### PR TITLE
Reset hb_* keys only for registered adunits

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -10,7 +10,13 @@ targeting.resetPresetTargeting = function() {
   if (isGptPubadsDefined()) {
     window.googletag.pubads().getSlots().forEach(slot => {
       pbTargetingKeys.forEach(function(key){
-        slot.setTargeting(key,null);
+        // reset only registered adunits
+        $$PREBID_GLOBAL$$.adUnits.find(function(unit) {
+          if (unit.code === slot.getAdUnitPath() ||
+              unit.code === slot.getSlotElementId()) {
+            slot.setTargeting(key, null);
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Resets targeting only for registered adunits

## Other information
This PR is a rebased and fixed version of the one originally submitted by @darbh in #902