### PR TITLE
Gumgum throttle

### DIFF
--- a/src/adapters/gumgum.js
+++ b/src/adapters/gumgum.js
@@ -63,8 +63,9 @@ const GumgumAdapter = function GumgumAdapter() {
 
       /* throttle based on the latest request for this product */
       const productId     = bid.pi;
+      const requestKey    = productId + '|' + placementCode;
       const throttle      = throttleTable[productId];
-      const latestRequest = requestCache[productId];
+      const latestRequest = requestCache[requestKey];
       if (latestRequest && throttle && (timestamp - latestRequest) < throttle) {
         return utils.logWarn(
           `[GumGum] The refreshes for "${ placementCode }" with the params ` +
@@ -72,7 +73,7 @@ const GumgumAdapter = function GumgumAdapter() {
         );
       }
       /* update the last request */
-      requestCache[productId] = timestamp;
+      requestCache[requestKey] = timestamp;
 
       /* tracking id is required for in-image and in-screen */
       if (trackingId) bid.t = trackingId;

--- a/src/adapters/gumgum.js
+++ b/src/adapters/gumgum.js
@@ -13,12 +13,19 @@ const GumgumAdapter = function GumgumAdapter() {
   let topWindow;
   let topScreen;
   let pageViewId;
+  const requestCache = {};
+  const throttleTable = {};
+  const defaultThrottle = 3e4;
 
   try {
     topWindow = global.top;
     topScreen = topWindow.screen;
   } catch (error) {
     return utils.logError(error);
+  }
+
+  function _getTimeStamp() {
+    return new Date().getTime();
   }
 
   function _callBids({ bids }) {
@@ -36,6 +43,7 @@ const GumgumAdapter = function GumgumAdapter() {
             , params = {}
             , placementCode
             } = bidRequest;
+      const timestamp  = _getTimeStamp();
       const trackingId = params.inScreen;
       const nativeId   = params.native;
       const slotId     = params.inSlot;
@@ -52,6 +60,20 @@ const GumgumAdapter = function GumgumAdapter() {
           ', please check your implementation.'
         );
       }
+
+      /* throttle based on the latest request for this product */
+      const productId     = bid.pi;
+      const throttle      = throttleTable[productId];
+      const latestRequest = requestCache[productId];
+      if (latestRequest && throttle && (timestamp - latestRequest) < throttle) {
+        return utils.logWarn(
+          `[GumGum] The refreshes for "${ placementCode }" with the params ` +
+          `${ JSON.stringify(params) } should be at least ${ throttle / 1e3 }s apart.`
+        );
+      }
+      /* update the last request */
+      requestCache[productId] = timestamp;
+
       /* tracking id is required for in-image and in-screen */
       if (trackingId) bid.t = trackingId;
       /* native ads require a native placement id */
@@ -75,26 +97,30 @@ const GumgumAdapter = function GumgumAdapter() {
     });
   }
 
-  const _handleGumGumResponse = cachedBidRequest => bidResponse => {
-    const ad = bidResponse && bidResponse.ad;
-    const pag = bidResponse && bidResponse.pag;
+  const _handleGumGumResponse = cachedBidRequest => (bidResponse = {}) => {
+    const { pi: productId
+          } = cachedBidRequest;
+    const { ad = {}
+          , pag = {}
+          , thms: throttle
+          } = bidResponse;
     /* cache the pageViewId */
     if (pag && pag.pvid) pageViewId = pag.pvid;
-    /* create the bid */
     if (ad && ad.id) {
+      /* set the new throttle */
+      throttleTable[productId] = throttle || defaultThrottle;
+      /* create the bid */
       const bid = bidfactory.createBid(1);
       const { t: trackingId
-            , pi: productId
-            , placementCode
-            } = cachedBidRequest;
-      bidResponse.placementCode = placementCode;
+            } = pag;
+      bidResponse.request = cachedBidRequest;
       const encodedResponse = encodeURIComponent(JSON.stringify(bidResponse));
       const gumgumAdLoader = `<script>
         (function (context, topWindow, d, s, G) {
           G = topWindow.GUMGUM;
           d = topWindow.document;
           function loadAd() {
-            topWindow.GUMGUM.pbjs("${ trackingId }", ${ productId }, "${ encodedResponse }" , context, topWindow);
+            topWindow.GUMGUM.pbjs("${ trackingId }", ${ productId }, "${ encodedResponse }" , context);
           }
           if (G) {
             loadAd();

--- a/test/spec/adapters/gumgum_spec.js
+++ b/test/spec/adapters/gumgum_spec.js
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import Adapter from '../../../src/adapters/gumgum';
 import bidManager from '../../../src/bidmanager';
 import adLoader from '../../../src/adloader';
+import * as utils from '../../../src/utils';
 import { STATUS } from '../../../src/constants';
 
 describe('gumgum adapter', () => {
@@ -73,10 +74,6 @@ describe('gumgum adapter', () => {
     },
     "pag": pageParams
   };
-  const emptyResponse = {
-    "ad": {},
-    "pag": pageParams
-  }
 
   function mockBidResponse(response) {
     sandbox.stub(bidManager, 'addBidResponse');
@@ -102,11 +99,11 @@ describe('gumgum adapter', () => {
       adapter.callBids(bidderRequest);
     });
 
-    it('should call the endpoint once per valid bid', () => {
+    it('calls the endpoint once per valid bid', () => {
       sinon.assert.callCount(adLoader.loadScript, 4);
     });
 
-    it('should include required browser data', () => {
+    it('includes required browser data', () => {
       const endpointRequest = expect(adLoader.loadScript.firstCall.args[0]);
       endpointRequest.to.include('vw');
       endpointRequest.to.include('vh');
@@ -114,12 +111,12 @@ describe('gumgum adapter', () => {
       endpointRequest.to.include('sh');
     });
 
-    it('should include the global bid timeout', () => {
+    it('includes the global bid timeout', () => {
       const endpointRequest = expect(adLoader.loadScript.firstCall.args[0]);
       endpointRequest.to.include(`tmax=${$$PREBID_GLOBAL$$.cbTimeout}`);
     });
 
-    it('should include the publisher identity', () => {
+    it('includes the publisher identity', () => {
       const endpointRequest = expect(adLoader.loadScript.firstCall.args[0]);
       endpointRequest.to.include('t=' + TEST.PUBLISHER_IDENTITY);
     });
@@ -143,7 +140,7 @@ describe('gumgum adapter', () => {
   });
 
   describe('handleGumGumCB[...]', () => {
-    it('should exist and be a function', () => {
+    it('exists and is function', () => {
       expect(pbjs.handleGumGumCB['InScreenBidId']).to.exist.and.to.be.a('function');
     });
   });
@@ -156,29 +153,29 @@ describe('gumgum adapter', () => {
       successfulBid = mockBidResponse(bidderResponse);
     });
 
-    it('should add one bid', () => {
+    it('adds one bid', () => {
       sinon.assert.calledOnce(bidManager.addBidResponse);
     });
 
-    it('should pass the correct placement code as the first param', () => {
+    it('passes the correct placement code as the first param', () => {
       const [ placementCode ] = bidManager.addBidResponse.firstCall.args;
       expect(placementCode).to.eql(TEST.PLACEMENT);
     });
 
-    it('should have a GOOD status code', () => {
+    it('has a GOOD status code', () => {
       const STATUS_CODE = successfulBid.getStatusCode();
       expect(STATUS_CODE).to.eql(STATUS.GOOD);
     });
 
-    it('should use the CPM returned by the server', () => {
+    it('uses the CPM returned by the server', () => {
       expect(successfulBid).to.have.property('cpm', TEST.CPM);
     });
 
-    it('should have an ad', () => {
+    it('has an ad', () => {
       expect(successfulBid).to.have.property('ad');
     });
 
-    it('should have the size specified by the server', () => {
+    it('has the size specified by the server', () => {
       expect(successfulBid).to.have.property('width', 728);
       expect(successfulBid).to.have.property('height', 90);
     });
@@ -190,24 +187,48 @@ describe('gumgum adapter', () => {
     let noBid;
 
     beforeEach(() => {
-      noBid = mockBidResponse(emptyResponse);
+      noBid = mockBidResponse(undefined);
     });
 
-    it('should add one bid', () => {
+    it('adds one bid', () => {
       sinon.assert.calledOnce(bidManager.addBidResponse);
     });
 
-    it('should have a NO_BID status code', () => {
+    it('has a NO_BID status code', () => {
       expect(noBid.getStatusCode()).to.eql(STATUS.NO_BID);
     });
 
-    it('should pass the correct placement code as the first parameter', () => {
+    it('passes the correct placement code as the first parameter', () => {
       const [ placementCode ] = bidManager.addBidResponse.firstCall.args;
       expect(placementCode).to.eql(TEST.PLACEMENT);
     });
 
-    it('should add the bidder code to the bid object', () => {
+    it('adds the bidder code to the bid object', () => {
       expect(noBid).to.have.property('bidderCode', TEST.BIDDER_CODE);
+    });
+
+  });
+
+  describe('refresh throttle', () => {
+
+    beforeEach(() => {
+      mockBidResponse(bidderResponse);
+    });
+
+    afterEach(() => {
+      if (utils.logWarn.restore) {
+        utils.logWarn.restore();
+      }
+    });
+
+    it('warns about the throttle limit', function() {
+      sinon.spy(utils, 'logWarn');
+      // call all the binds again
+      adapter.callBids(bidderRequest);
+      // the timeout for in-screen should stop one bid request
+      const warning = expect(utils.logWarn.args[0][0]);
+      warning.to.include(TEST.PLACEMENT);
+      warning.to.include('inScreen');
     });
 
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Throttle for the refresh frequency on the GumGum service.

Behavior:

- The throttle kicks in only after we win a bid.
- It works individually by placement and product.
- The default timeout is 30 seconds, but it can be updated dynamically by publisher/product from within the server response.

No implementation changes are required.

- contact email of the adapter’s maintainer
dmejorado@gumgum.com
- [x] official adapter submission
