### PR TITLE
Rubicon video support

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -69,7 +69,8 @@
     },
     {
       "rubicon": {
-        "alias": "rubiconLite"
+        "alias": "rubiconLite",
+        "supportedMediaTypes": ["video"]
       }
     },
     {

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -6,7 +6,11 @@ import { ajax } from 'src/ajax';
 import { STATUS } from 'src/constants';
 
 const RUBICON_BIDDER_CODE = 'rubicon';
-const INTEGRATION = 'pbjs.lite';
+
+// use deferred function call since version isn't defined yet at this point
+function getIntegration() {
+  return 'pbjs_lite_' + $$PREBID_GLOBAL$$.version;
+}
 
 // use protocol relative urls for http or https
 const FASTLANE_ENDPOINT = '//fastlane.rubiconproject.com/a/api/fastlane.json';
@@ -121,7 +125,7 @@ function RubiconAdapter() {
       page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
       resolution:  _getScreenResolution(),
       account_id: params.accountId,
-      integration: INTEGRATION,
+      integration: getIntegration(),
       timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
       stash_creatives: true,
       ae_pass_through_parameters: params.video.aeParams,
@@ -201,7 +205,7 @@ function RubiconAdapter() {
       'alt_size_ids', parsedSizes.slice(1).join(',') || undefined,
       'p_pos', position,
       'rp_floor', '0.01',
-      'tk_flint', INTEGRATION,
+      'tk_flint', getIntegration(),
       'p_screen_res', _getScreenResolution(),
       'kw', keywords,
       'tk_user_key', userId

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -280,7 +280,7 @@ function RubiconAdapter() {
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;
-        bid.vastUrl = ad.creative_depot_url;
+        bid.vastUrl = ad.impression_id;
         bid.impression_id = ad.impression_id;
       } else {
         bid.ad = _renderCreative(ad.script, ad.impression_id);

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -280,7 +280,8 @@ function RubiconAdapter() {
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;
-        bid.vastUrl = ad.impression_id;
+        bid.vastUrl = ad.creative_depot_url;
+        bid.descriptionUrl = ad.impression_id;
         bid.impression_id = ad.impression_id;
       } else {
         bid.ad = _renderCreative(ad.script, ad.impression_id);

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -102,12 +102,27 @@ function RubiconAdapter() {
       throw 'Invalid Video Bid';
     }
 
+    let size;
+    if(params.video.playerWidth && params.video.playerHeight) {
+      size = [
+        params.video.playerWidth,
+        params.video.playerHeight
+      ];
+    } else if(
+        Array.isArray(bid.sizes) && bid.sizes.length > 0 &&
+        Array.isArray(bid.sizes[0]) && bid.sizes[0].length > 1
+    ) {
+      size = bid.sizes[0];
+    } else {
+      throw "Invalid Video Bid - No size provided";
+    }
+
     let postData =  {
       page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
       resolution:  _getScreenResolution(),
       account_id: params.accountId,
       integration: INTEGRATION,
-      timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart - TIMEOUT_BUFFER),
+      timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
       stash_creatives: true,
       ae_pass_through_parameters: params.video.aeParams,
       slots: []
@@ -122,15 +137,15 @@ function RubiconAdapter() {
       element_id: bid.placementCode,
       name: bid.placementCode,
       language: params.video.language,
-      height: params.video.playerHeight,
-      width: params.video.playerWidth
+      width: size[0],
+      height: size[1]
     };
 
     // check and add inventory, keywords, visitor and size_id data
-    if(Array.isArray(params.sizes) && params.sizes.length > 0) {
-      slotData.size_id = params.sizes[0];
+    if(params.video.size_id) {
+      slotData.size_id = params.video.size_id;
     } else {
-      throw "Invalid Video Bid - Invalid Size!";
+      throw "Invalid Video Bid - Invalid Ad Type!";
     }
 
     if(params.inventory && typeof params.inventory === 'object') {

--- a/src/adserver.js
+++ b/src/adserver.js
@@ -32,7 +32,7 @@ exports.dfpAdserver = function (options, urlComponents) {
     var bid = adserver.getWinningBidByCode();
     this.urlComponents.search.description_url = encodeURIComponent(bid.descriptionUrl);
     this.urlComponents.search.cust_params = getCustomParams(bid.adserverTargeting);
-    this.urlComponents.correlator = Date.now();
+    this.urlComponents.search.correlator = Date.now();
   };
 
   adserver.verifyAdserverTag = function() {

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -13,12 +13,30 @@ describe('the rubicon adapter', () => {
       adUnit,
       bidderRequest;
 
+  function createVideoBidderRequest() {
+    let bid = bidderRequest.bids[0];
+    bid.mediaType = 'video';
+    bid.params.video = {
+      'language': 'en',
+      'p_aso.video.ext.skip': true,
+      'p_aso.video.ext.skipdelay': 15,
+      'playerHeight': 320,
+      'playerWidth': 640,
+      'size_id': 201,
+      'aeParams': {
+        'p_aso.video.ext.skip': '1',
+        'p_aso.video.ext.skipdelay': '15'
+      }
+    };
+  }
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
 
     adUnit = {
       code: '/19968336/header-bid-tag-0',
       sizes: [[300, 250], [320, 50]],
+      mediaType: 'video',
       bids: [
         {
           bidder: 'rubicon',
@@ -75,6 +93,7 @@ describe('the rubicon adapter', () => {
         }
       ],
       start: 1472239426002,
+      auctionStart: 1472239426000,
       timeout: 5000
     };
 
@@ -104,6 +123,9 @@ describe('the rubicon adapter', () => {
 
       expect(bidderRequest).to.have.deep.property('bids[0]')
         .to.have.property('bidder', 'rubicon');
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('mediaType', 'video');
 
       expect(bidderRequest).to.have.deep.property('bids[0]')
         .to.have.property('placementCode', adUnit.code);
@@ -156,7 +178,7 @@ describe('the rubicon adapter', () => {
 
     let rubiconAdapter;
 
-    describe('requests', () => {
+    describe('for requests', () => {
 
       let xhr,
           bids;
@@ -177,82 +199,158 @@ describe('the rubicon adapter', () => {
         xhr.restore();
       });
 
-      it('should make a well-formed optimized request', () => {
+      describe("to fastlane", () => {
 
-        rubiconAdapter.callBids(bidderRequest);
+        it('should make a well-formed request', () => {
 
-        let request = xhr.requests[0];
+          rubiconAdapter.callBids(bidderRequest);
 
-        let [path, query] = request.url.split('?');
-        query = parseQuery(query);
+          let request = xhr.requests[0];
 
-        expect(path).to.equal(
-          '//fastlane.rubiconproject.com/a/api/fastlane.json'
-        );
+          let [path, query] = request.url.split('?');
+          query = parseQuery(query);
 
-        let expectedQuery = {
-          'account_id': '14062',
-          'site_id': '70608',
-          'zone_id': '335918',
-          'size_id': '15',
-          'alt_size_ids': '43',
-          'p_pos': 'atf',
-          'rp_floor': '0.01',
-          'tk_flint': 'pbjs.lite',
-          'p_screen_res': /\d+x\d+/,
-          'tk_user_key': '12346',
-          'kw': 'a,b,c',
-          'tg_v.ucat': 'new',
-          'tg_v.lastsearch': 'iphone',
-          'tg_i.rating': '5-star',
-          'tg_i.prodtype': 'tech',
-          'rf': 'localhost'
-        };
+          expect(path).to.equal(
+            '//fastlane.rubiconproject.com/a/api/fastlane.json'
+          );
 
-        // test that all values above are both present and correct
-        Object.keys(expectedQuery).forEach(key => {
-          let value = expectedQuery[key];
-          if(value instanceof RegExp) {
-            expect(query[key]).to.match(value);
-          } else {
-            expect(query[key]).to.equal(value);
-          }
+          let expectedQuery = {
+            'account_id': '14062',
+            'site_id': '70608',
+            'zone_id': '335918',
+            'size_id': '15',
+            'alt_size_ids': '43',
+            'p_pos': 'atf',
+            'rp_floor': '0.01',
+            'tk_flint': 'pbjs.lite',
+            'p_screen_res': /\d+x\d+/,
+            'tk_user_key': '12346',
+            'kw': 'a,b,c',
+            'tg_v.ucat': 'new',
+            'tg_v.lastsearch': 'iphone',
+            'tg_i.rating': '5-star',
+            'tg_i.prodtype': 'tech',
+            'rf': 'localhost'
+          };
+
+          // test that all values above are both present and correct
+          Object.keys(expectedQuery).forEach(key => {
+            let value = expectedQuery[key];
+            if(value instanceof RegExp) {
+              expect(query[key]).to.match(value);
+            } else {
+              expect(query[key]).to.equal(value);
+            }
+          });
+
+          expect(query).to.have.property('rand');
+
         });
 
-        expect(query).to.have.property('rand');
+        it('should use rubicon sizes if present', () => {
+
+          var sizesBidderRequest = clone(bidderRequest);
+          sizesBidderRequest.bids[0].params.sizes = [55, 57, 59];
+
+          rubiconAdapter.callBids(sizesBidderRequest);
+
+          let query = parseQuery(xhr.requests[0].url.split('?')[1]);
+
+          expect(query['size_id']).to.equal('55');
+          expect(query['alt_size_ids']).to.equal('57,59');
+
+        });
+
+        it('should not send a request and register an error bid if no valid sizes', () => {
+
+          var sizesBidderRequest = clone(bidderRequest);
+          sizesBidderRequest.bids[0].sizes = [[620,250],[300,251]];
+
+          rubiconAdapter.callBids(sizesBidderRequest);
+
+          expect(xhr.requests.length).to.equal(0);
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+
+        });
 
       });
 
-      it('should use rubicon sizes if present', () => {
+      describe('for video requests', () => {
 
-        var sizesBidderRequest = clone(bidderRequest);
-        sizesBidderRequest.bids[0].params.sizes = [55, 57, 59];
+        beforeEach(() => {
+          createVideoBidderRequest();
 
-        rubiconAdapter.callBids(sizesBidderRequest);
+          sandbox.stub(Date, "now", () =>
+            bidderRequest.auctionStart + 100
+          );
+        });
 
-        let query = parseQuery(xhr.requests[0].url.split('?')[1]);
+        it('should make a well-formed video request', () => {
 
-        expect(query['size_id']).to.equal('55');
-        expect(query['alt_size_ids']).to.equal('57,59');
+          rubiconAdapter.callBids(bidderRequest);
 
-      });
+          let request = xhr.requests[0];
 
-      it('should not send a request and register an error bid if no valid sizes', () => {
+          let url = request.url;
+          let post = JSON.parse(request.requestBody);
 
-        var sizesBidderRequest = clone(bidderRequest);
-        sizesBidderRequest.bids[0].sizes = [[620,250],[300,251]];
+          expect(url).to.equal('//optimized-by-adv.rubiconproject.com/v1/auction/video');
 
-        rubiconAdapter.callBids(sizesBidderRequest);
+          expect(post).to.have.property('page_url').that.is.a('string');
+          expect(post.resolution).to.match(/\d+x\d+/);
+          expect(post.account_id).to.equal('14062')
+          expect(post.integration).to.equal('pbjs.lite');
+          expect(post).to.have.property('timeout').that.is.a('number');
+          expect(post.timeout < 5000).to.equal(true);
+          expect(post.stash_creatives).to.equal(true);
 
-        expect(xhr.requests.length).to.equal(0);
+          expect(post).to.have.property('ae_pass_through_parameters');
+          expect(post.ae_pass_through_parameters)
+            .to.have.property('p_aso.video.ext.skip')
+            .that.equals('1');
+          expect(post.ae_pass_through_parameters)
+            .to.have.property('p_aso.video.ext.skipdelay')
+            .that.equals('15');
 
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+          expect(post).to.have.property('slots')
+            .with.length.of(1);
+
+          let slot = post.slots[0];
+
+          expect(slot.site_id).to.equal('70608');
+          expect(slot.zone_id).to.equal('335918');
+          expect(slot.position).to.equal('atf');
+          expect(slot.floor).to.equal(.01);
+          expect(slot.element_id).to.equal(bidderRequest.bids[0].placementCode);
+          expect(slot.name).to.equal(bidderRequest.bids[0].placementCode);
+          expect(slot.language).to.equal('en');
+          expect(slot.width).to.equal(640);
+          expect(slot.height).to.equal(320);
+          expect(slot.size_id).to.equal(201);
+
+          expect(slot).to.have.property('inventory').that.is.an('object');
+          expect(slot.inventory).to.have.property('rating').that.equals('5-star');
+          expect(slot.inventory).to.have.property('prodtype').that.equals('tech');
+
+          expect(slot).to.have.property('keywords')
+            .that.is.an('array')
+            .of.length(3)
+            .that.deep.equals(['a', 'b', 'c']);
+
+          expect(slot).to.have.property('visitor').that.is.an('object');
+          expect(slot.visitor).to.have.property('ucat').that.equals('new');
+          expect(slot.visitor).to.have.property('lastsearch').that.equals('iphone');
+
+        })
 
       });
 
     });
+
+
 
 
     describe('response handler', () => {
@@ -278,217 +376,277 @@ describe('the rubicon adapter', () => {
         server.restore();
       });
 
-      it('should handle a success response and sort by cpm', () => {
+      describe('for fastlane', () => {
 
-        server.respondWith(JSON.stringify({
-          "status": "ok",
-          "account_id": 14062,
-          "site_id": 70608,
-          "zone_id": 530022,
-          "size_id": 15,
-          "alt_size_ids": [
-            43
-          ],
-          "tracking": "",
-          "inventory": {},
-          "ads": [
-            {
-              "status": "ok",
-              "impression_id": "153dc240-8229-4604-b8f5-256933b9374c",
-              "size_id": "15",
-              "ad_id": "6",
-              "advertiser": 7,
-              "network": 8,
-              "creative_id": 9,
-              "type": "script",
-              "script": "alert('foo')",
-              "campaign_id": 10,
-              "cpm": 0.811,
-              "targeting": [
+        it('should handle a success response and sort by cpm', () => {
+
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "account_id": 14062,
+            "site_id": 70608,
+            "zone_id": 530022,
+            "size_id": 15,
+            "alt_size_ids": [
+              43
+            ],
+            "tracking": "",
+            "inventory": {},
+            "ads": [
+              {
+                "status": "ok",
+                "impression_id": "153dc240-8229-4604-b8f5-256933b9374c",
+                "size_id": "15",
+                "ad_id": "6",
+                "advertiser": 7,
+                "network": 8,
+                "creative_id": 9,
+                "type": "script",
+                "script": "alert('foo')",
+                "campaign_id": 10,
+                "cpm": 0.811,
+                "targeting": [
+                  {
+                    "key": "rpfl_14062",
+                    "values": [
+                      "15_tier_all_test"
+                    ]
+                  }
+                ]
+              },
+              {
+                "status": "ok",
+                "impression_id": "153dc240-8229-4604-b8f5-256933b9374d",
+                "size_id": "43",
+                "ad_id": "7",
+                "advertiser": 7,
+                "network": 8,
+                "creative_id": 9,
+                "type": "script",
+                "script": "alert('foo')",
+                "campaign_id": 10,
+                "cpm": 0.911,
+                "targeting": [
+                  {
+                    "key": "rpfl_14062",
+                    "values": [
+                      "15_tier_all_test"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }));
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledTwice).to.equal(true);
+
+          expect(bids).to.be.lengthOf(2);
+
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+          expect(bids[0].bidderCode).to.equal("rubicon");
+          expect(bids[0].width).to.equal(320);
+          expect(bids[0].height).to.equal(50);
+          expect(bids[0].cpm).to.equal(0.911);
+          expect(bids[0].ad).to.contain(`alert('foo')`)
+            .and.to.contain(`<html>`)
+            .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374d'>`);
+
+          expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+          expect(bids[1].bidderCode).to.equal("rubicon");
+          expect(bids[1].width).to.equal(300);
+          expect(bids[1].height).to.equal(250);
+          expect(bids[1].cpm).to.equal(0.811);
+          expect(bids[1].ad).to.contain(`alert('foo')`)
+            .and.to.contain(`<html>`)
+            .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374c'>`);
+        });
+
+        it('should be fine with a CPM of 0', () => {
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "account_id": 14062,
+            "site_id": 70608,
+            "zone_id": 530022,
+            "size_id": 15,
+            "alt_size_ids": [
+              43
+            ],
+            "tracking": "",
+            "inventory": {},
+            "ads": [{
+                "status": "ok",
+                "cpm": 0,
+                "size_id": 15
+              }]
+          }));
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+        });
+
+        it('should handle an error with no ads returned', () => {
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "account_id": 14062,
+            "site_id": 70608,
+            "zone_id": 530022,
+            "size_id": 15,
+            "alt_size_ids": [
+              43
+            ],
+            "tracking": "",
+            "inventory": {},
+            "ads": []
+          }));
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        });
+
+        it('should handle an error with bad status', () => {
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "account_id": 14062,
+            "site_id": 70608,
+            "zone_id": 530022,
+            "size_id": 15,
+            "alt_size_ids": [
+              43
+            ],
+            "tracking": "",
+            "inventory": {},
+            "ads": [{
+                "status": "not_ok",
+              }]
+          }));
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        });
+
+        it('should handle an error because of malformed json response', () => {
+          server.respondWith("{test{");
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        });
+
+        it('should not register an error bid when a success call to addBidResponse throws an error', () => {
+
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "account_id": 14062,
+            "site_id": 70608,
+            "zone_id": 530022,
+            "size_id": 15,
+            "alt_size_ids": [
+              43
+            ],
+            "tracking": "",
+            "inventory": {},
+            "ads": [{
+                "status": "ok",
+                "cpm": .8,
+                "size_id": 15
+              }]
+          }));
+
+          addBidResponseAction = function() {
+            throw new Error("test error");
+          };
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          // was calling twice for same bid, but should only call once
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+
+        });
+
+      });
+
+      describe('for video', () => {
+
+        beforeEach(() => {
+          createVideoBidderRequest();
+        });
+
+        it('should register a successful bid', () => {
+
+          server.respondWith(JSON.stringify({
+            "status": "ok",
+            "ads": {
+              "/19968336/header-bid-tag-0": [
                 {
-                  "key": "rpfl_14062",
-                  "values": [
-                    "15_tier_all_test"
-                  ]
+                  "status": "ok",
+                  "cpm": 1,
+                  "tier": "tier0200",
+                  "targeting": {
+                    "rpfl_8000": "201_tier0200",
+                    "rpfl_elemid": "/19968336/header-bid-tag-0"
+                  },
+                  "impression_id": "a40fe16e-d08d-46a9-869d-2e1573599e0c",
+                  "site_id": 88888,
+                  "zone_id": 54321,
+                  "creative_type": "video",
+                  "creative_depot_url": "https://optimized-by-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml",
+                  "ad_id": 999999,
+                  "size_id": 201,
+                  "advertiser": 12345
                 }
               ]
             },
-            {
-              "status": "ok",
-              "impression_id": "153dc240-8229-4604-b8f5-256933b9374d",
-              "size_id": "43",
-              "ad_id": "7",
-              "advertiser": 7,
-              "network": 8,
-              "creative_id": 9,
-              "type": "script",
-              "script": "alert('foo')",
-              "campaign_id": 10,
-              "cpm": 0.911,
-              "targeting": [
-                {
-                  "key": "rpfl_14062",
-                  "values": [
-                    "15_tier_all_test"
-                  ]
-                }
-              ]
-            }
-          ]
-        }));
+            "account_id": 7780
+          }));
 
-        rubiconAdapter.callBids(bidderRequest);
+          rubiconAdapter.callBids(bidderRequest);
 
-        server.respond();
+          server.respond();
 
-        expect(bidManager.addBidResponse.calledTwice).to.equal(true);
+          // was calling twice for same bid, but should only call once
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
 
-        expect(bids).to.be.lengthOf(2);
+          expect(bids).to.be.lengthOf(1);
 
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-        expect(bids[0].bidderCode).to.equal("rubicon");
-        expect(bids[0].width).to.equal(320);
-        expect(bids[0].height).to.equal(50);
-        expect(bids[0].cpm).to.equal(0.911);
-        expect(bids[0].ad).to.contain(`alert('foo')`)
-          .and.to.contain(`<html>`)
-          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374d'>`);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+          expect(bids[0].bidderCode).to.equal('rubicon');
+          expect(bids[0].creative_id).to.equal(999999);
+          expect(bids[0].cpm).to.equal(1);
+          expect(bids[0].vastUrl).to.equal(
+              'https://optimized-by-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml'
+          );
+          expect(bids[0].impression_id).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');
 
-        expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-        expect(bids[1].bidderCode).to.equal("rubicon");
-        expect(bids[1].width).to.equal(300);
-        expect(bids[1].height).to.equal(250);
-        expect(bids[1].cpm).to.equal(0.811);
-        expect(bids[1].ad).to.contain(`alert('foo')`)
-          .and.to.contain(`<html>`)
-          .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374c'>`);
-      });
-
-      it('should be fine with a CPM of 0', () => {
-        server.respondWith(JSON.stringify({
-          "status": "ok",
-          "account_id": 14062,
-          "site_id": 70608,
-          "zone_id": 530022,
-          "size_id": 15,
-          "alt_size_ids": [
-            43
-          ],
-          "tracking": "",
-          "inventory": {},
-          "ads": [{
-              "status": "ok",
-              "cpm": 0,
-              "size_id": 15
-            }]
-        }));
-
-        rubiconAdapter.callBids(bidderRequest);
-
-        server.respond();
-
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-      });
-
-      it('should handle an error with no ads returned', () => {
-        server.respondWith(JSON.stringify({
-          "status": "ok",
-          "account_id": 14062,
-          "site_id": 70608,
-          "zone_id": 530022,
-          "size_id": 15,
-          "alt_size_ids": [
-            43
-          ],
-          "tracking": "",
-          "inventory": {},
-          "ads": []
-        }));
-
-        rubiconAdapter.callBids(bidderRequest);
-
-        server.respond();
-
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-      });
-
-      it('should handle an error with bad status', () => {
-        server.respondWith(JSON.stringify({
-          "status": "ok",
-          "account_id": 14062,
-          "site_id": 70608,
-          "zone_id": 530022,
-          "size_id": 15,
-          "alt_size_ids": [
-            43
-          ],
-          "tracking": "",
-          "inventory": {},
-          "ads": [{
-              "status": "not_ok",
-            }]
-        }));
-
-        rubiconAdapter.callBids(bidderRequest);
-
-        server.respond();
-
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-      });
-
-      it('should handle an error because of malformed json response', () => {
-        server.respondWith("{test{");
-
-        rubiconAdapter.callBids(bidderRequest);
-
-        server.respond();
-
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
-        expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
-      });
-
-      it('should not register an error bid when a success call to addBidResponse throws an error', () => {
-
-        server.respondWith(JSON.stringify({
-          "status": "ok",
-          "account_id": 14062,
-          "site_id": 70608,
-          "zone_id": 530022,
-          "size_id": 15,
-          "alt_size_ids": [
-            43
-          ],
-          "tracking": "",
-          "inventory": {},
-          "ads": [{
-              "status": "ok",
-              "cpm": .8,
-              "size_id": 15
-            }]
-        }));
-
-        addBidResponseAction = function() {
-          throw new Error("test error");
-        };
-
-        rubiconAdapter.callBids(bidderRequest);
-
-        server.respond();
-
-        // was calling twice for same bid, but should only call once
-        expect(bidManager.addBidResponse.calledOnce).to.equal(true);
-        expect(bids).to.be.lengthOf(1);
+        })
 
       });
 
-    })
+    });
 
 
   });

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -7,6 +7,8 @@ import {parse as parseQuery} from 'querystring';
 
 var CONSTANTS = require('src/constants.json');
 
+const INTEGRATION = `pbjs_lite_v$prebid.version$`; // $prebid.version$ will be substituted in by gulp in built prebid
+
 describe('the rubicon adapter', () => {
 
   let sandbox,
@@ -222,7 +224,7 @@ describe('the rubicon adapter', () => {
             'alt_size_ids': '43',
             'p_pos': 'atf',
             'rp_floor': '0.01',
-            'tk_flint': 'pbjs.lite',
+            'tk_flint': INTEGRATION,
             'p_screen_res': /\d+x\d+/,
             'tk_user_key': '12346',
             'kw': 'a,b,c',
@@ -302,7 +304,7 @@ describe('the rubicon adapter', () => {
           expect(post).to.have.property('page_url').that.is.a('string');
           expect(post.resolution).to.match(/\d+x\d+/);
           expect(post.account_id).to.equal('14062')
-          expect(post.integration).to.equal('pbjs.lite');
+          expect(post.integration).to.equal(INTEGRATION);
           expect(post).to.have.property('timeout').that.is.a('number');
           expect(post.timeout < 5000).to.equal(true);
           expect(post.stash_creatives).to.equal(true);

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -114,7 +114,7 @@ describe('the rubicon adapter', () => {
       sandbox.stub(rubiconAdapter, 'callBids');
 
       adapterManager.callBids({
-          adUnits: [clone(adUnit)]
+        adUnits: [clone(adUnit)]
       });
 
       let bidderRequest = rubiconAdapter.callBids.getCall(0).args[0];
@@ -172,7 +172,7 @@ describe('the rubicon adapter', () => {
 
       ordering = masSizeOrdering([[120, 600], [320, 50], [160,600], [640, 480],[336, 280], [200, 600], [728, 90]]);
       expect(ordering).to.deep.equal([2, 9, 8, 16, 43, 65, 126]);
-    })
+    });
 
   });
 
@@ -303,7 +303,7 @@ describe('the rubicon adapter', () => {
 
           expect(post).to.have.property('page_url').that.is.a('string');
           expect(post.resolution).to.match(/\d+x\d+/);
-          expect(post.account_id).to.equal('14062')
+          expect(post.account_id).to.equal('14062');
           expect(post.integration).to.equal(INTEGRATION);
           expect(post).to.have.property('timeout').that.is.a('number');
           expect(post.timeout < 5000).to.equal(true);
@@ -346,7 +346,7 @@ describe('the rubicon adapter', () => {
           expect(slot.visitor).to.have.property('ucat').that.equals('new');
           expect(slot.visitor).to.have.property('lastsearch').that.equals('iphone');
 
-        })
+        });
 
       });
 
@@ -639,12 +639,13 @@ describe('the rubicon adapter', () => {
           expect(bids[0].bidderCode).to.equal('rubicon');
           expect(bids[0].creative_id).to.equal(999999);
           expect(bids[0].cpm).to.equal(1);
+          expect(bids[0].descriptionUrl).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');
           expect(bids[0].vastUrl).to.equal(
               'https://optimized-by-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml'
           );
           expect(bids[0].impression_id).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');
 
-        })
+        });
 
       });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Adds video support for the Rubicon adapter.  An example adUnit for displaying a video ad should look something like this:

```
        var videoAdUnit = {
            code: 'example_video_1',
            sizes: [[640,320]],
            mediaType: 'video',
            bids: [
                {
                    bidder: 'rubicon',
                    params: {
                        accountId: "7780",
                        siteId: "87184",
                        zoneId: "412394",
                        userId: "12346",
                        keywords: ["nhl","hockey","goalie"],
                        inventory: {rating:["4-star"], prodtype:["sports"]},
                        visitor: {ucat: ["new"], lastsearch:["hockey"]},
                        position: "atf",
                        video: { 
                          'language': 'en', 
                          'playerHeight': 320, 
                          'playerWidth': 640, 
                          'size_id': 201,
                          'aeParams': {"p_aso.video.ext.skip": "1","p_aso.video.ext.skipdelay": "15"} 
                        }
                    }
                }
            ]
        };
```
