### PR TITLE
Add 152Media Appnexus Alias

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -74,6 +74,11 @@
       "appnexus": {
         "alias": "featureforward"
       }
+    },    
+    {
+      "appnexus": {
+        "alias": "oftmedia"
+      }
     },
     {
       "adkernel": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] New bidder adapter

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding 152Media as bidder adapter alias for AppNexus.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'oftmedia',
  params: {
    placementId : 1234
  }
}
```
- contact email of the adapter’s maintainer: alejo@152media.com
- [X] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
