### PR TITLE
Make x-domain safe frame example work out of the box

### DIFF
--- a/integrationExamples/gpt/x-domain/creative.html
+++ b/integrationExamples/gpt/x-domain/creative.html
@@ -17,7 +17,7 @@ function renderAd(ev) {
     }
 
     if (adObject.ad || adObject.adUrl) {
-      var doc = window.document;
+      var body = window.document.body;
       var ad = adObject.ad;
       var url = adObject.adUrl;
       var width = adObject.width;
@@ -28,11 +28,22 @@ function renderAd(ev) {
       } else
 
       if (ad) {
-        doc.write(ad);
-        doc.close();
+        var frame = document.createElement('iframe');
+        frame.setAttribute('FRAMEBORDER', 0);
+        frame.setAttribute('SCROLLING', 'no');
+        frame.setAttribute('MARGINHEIGHT', 0);
+        frame.setAttribute('MARGINWIDTH', 0);
+        frame.setAttribute('TOPMARGIN', 0);
+        frame.setAttribute('LEFTMARGIN', 0);
+        frame.setAttribute('ALLOWTRANSPARENCY', 'true');
+        frame.setAttribute('width', width);
+        frame.setAttribute('height', height);
+        body.appendChild(frame);
+        frame.contentDocument.open();
+        frame.contentDocument.write(ad);
+        frame.contentDocument.close();
       } else if (url) {
-        doc.write('<IFRAME SRC="' + url + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true" WIDTH="' + width + '" HEIGHT="' + height + '"></IFRAME>');
-        doc.close();
+        body.insertAdjacentHTML('beforeend', '<IFRAME SRC="' + url + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true" WIDTH="' + width + '" HEIGHT="' + height + '"></IFRAME>');
       } else {
         console.log('Error trying to write ad. No ad for bid response id: ' + id);
       }

--- a/integrationExamples/gpt/x-domain/creative.html
+++ b/integrationExamples/gpt/x-domain/creative.html
@@ -1,11 +1,11 @@
+<script>
 // this script can be returned by an ad server delivering a cross domain iframe, into which the
 // creative will be rendered, e.g. DFP delivering a SafeFrame
 
-// set these domains as fits your environment and ensure matching protocols
-// alternatively this can be passed as a macro on the query string of the ad server call, for
-// example `%%PUBLISHER_DOMAIN%%`.
-const publisherDomain = 'http://localhost:9999';
-const adServerDomain = 'http://tpc.googlesyndication.com';
+var urlParser = document.createElement('a');
+urlParser.href = '%%PATTERN:url%%';
+var publisherDomain = urlParser.protocol + '//' + urlParser.host;
+var adServerDomain = 'https://tpc.googlesyndication.com';
 
 function renderAd(ev) {
     var key = ev.message ? 'message' : 'data';
@@ -43,7 +43,7 @@ function requestAdFromPrebid() {
   var message = JSON.stringify({
     message: 'Prebid Request',
     adId: '%%PATTERN:hb_adid%%',
-    adServerDomain
+    adServerDomain: adServerDomain
   });
   window.parent.postMessage(message, publisherDomain);
 }
@@ -54,3 +54,4 @@ function listenAdFromPrebid() {
 
 listenAdFromPrebid();
 requestAdFromPrebid();
+</script>


### PR DESCRIPTION
* Nest in <script> tags
* Use garden-variety JS
* Dynamically parse host domain
* Use https for ad server

This addresses some of the #954 issues.  I didn't know what a valid replacement for `id` would be, and the IE HTTPS issue is outstanding as well.
