### PR TITLE
Use package dependencies for ES6 Array shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
     "webpack-stream": "^3.1.0",
     "yargs": "^1.3.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "array-includes": "^3.0.2",
+    "array.prototype.find": "^2.0.3"
+  }
 }

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -2,59 +2,15 @@
 Misc polyfills
 */
 /*jshint -W121 */
-if (!Array.prototype.find) {
-  Object.defineProperty(Array.prototype, "find", {
-    value: function(predicate) {
-      if (this === null) {
-        throw new TypeError('Array.prototype.find called on null or undefined');
-      }
-      if (typeof predicate !== 'function') {
-        throw new TypeError('predicate must be a function');
-      }
-      var list = Object(this);
-      var length = list.length >>> 0;
-      var thisArg = arguments[1];
-      var value;
+import shimArrayFind from 'array.prototype.find/shim';
+import shimArrayIncludes from 'array-includes/shim';
 
-      for (var i = 0; i < length; i++) {
-        value = list[i];
-        if (predicate.call(thisArg, value, i, list)) {
-          return value;
-        }
-      }
-      return undefined;
-    }
-  });
+if (!Array.prototype.find) {
+  shimArrayFind();
 }
 
 if (!Array.prototype.includes) {
-  Object.defineProperty(Array.prototype, "includes", {
-    value: function(searchElement) {
-      var O = Object(this);
-      var len = parseInt(O.length, 10) || 0;
-      if (len === 0) {
-        return false;
-      }
-      var n = parseInt(arguments[1], 10) || 0;
-      var k;
-      if (n >= 0) {
-        k = n;
-      } else {
-        k = len + n;
-        if (k < 0) {k = 0;}
-      }
-      var currentElement;
-      while (k < len) {
-        currentElement = O[k];
-        if (searchElement === currentElement ||
-           (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
-          return true;
-        }
-        k++;
-      }
-      return false;
-    }
-  });
+  shimArrayIncludes();
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger


### PR DESCRIPTION
The shims that are vendored in to the library break in IE; also, no reason to reinvent the wheel. Instead, use the `array.prototype.find` and `array-includes` modules to ensure compatibility.

Original error message in IE:

![](https://dl.dropboxusercontent.com/u/37033819/2017-01-31_1526.png?raw=1)