### PR TITLE
OpenX Adapter: Handles fallback ads correctly as a no fill (#39)

### DIFF
--- a/src/adapters/openx.js
+++ b/src/adapters/openx.js
@@ -43,18 +43,16 @@ const OpenxAdapter = function OpenxAdapter() {
       };
 
       // no fill :(
-      if (!auid) {
+      if (!auid || !adUnit.pub_rev) {
         addBidResponse(null, bid);
         continue;
       }
       adUnit.used = true;
 
-      if (adUnit.pub_rev) {
-        beaconParams.br = beaconParams.bt < beaconParams.bd ? 't' : 'p';
-        beaconParams.bp = adUnit.pub_rev;
-        beaconParams.ts = adUnit.ts;
-        addBidResponse(adUnit, bid);
-      }
+      beaconParams.br = beaconParams.bt < beaconParams.bd ? 't' : 'p';
+      beaconParams.bp = adUnit.pub_rev;
+      beaconParams.ts = adUnit.ts;
+      addBidResponse(adUnit, bid);
       buildBoPixel(adUnit.creative[0], beaconParams);
     }
   };

--- a/test/spec/adapters/openx_spec.js
+++ b/test/spec/adapters/openx_spec.js
@@ -135,6 +135,77 @@ describe('openx adapter tests', function () {
     stubAddBidResponse.restore();
   });
 
+  it('should add no fill bid responses if bids are returned, but have empty pub rev', function () {
+    let stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+    let bidderRequest = {
+      bidderCode: 'openx',
+      bids: [
+        {
+          bidId: 'bidId1',
+          bidder: 'openx',
+          params: {
+            delDomain: 'delDomain1',
+            unit: '1234'
+          },
+          sizes: [[300, 250]],
+          placementCode: 'test-gpt-div-1234'
+        }
+      ]
+    };
+
+    // Empty pub rev in bid response
+    let response = {
+      "ads":
+      {
+        "version": 1,
+        "count": 1,
+        "pixels": "http://testpixels.net",
+        "ad": [
+          {
+            "adunitid": 1234,
+            "adid": 5678,
+            "type": "html",
+            "html": "test_html",
+            "framed": 1,
+            "is_fallback": 1,
+            "ts": "ts",
+            "cpipc": 1000,
+            "pub_rev": "",
+            "adv_id": "adv_id",
+            "brand_id": "",
+            "creative": [
+              {
+                "width": "300",
+                "height": "250",
+                "target": "_blank",
+                "mime": "text/html",
+                "media": "test_media",
+                "tracking": {
+                  "impression": "test_impression",
+                  "inview": "test_inview",
+                  "click": "test_click"
+                }
+              }
+            ]
+          }]
+      }
+    };
+
+    pbjs._bidsRequested.push(bidderRequest);
+    // adapter needs to be called, in order for the stub to register.
+    adapter();
+
+    pbjs.oxARJResponse(response);
+
+    let bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+    let bidResponse1 = stubAddBidResponse.getCall(0).args[1];
+    expect(bidPlacementCode1).to.equal('test-gpt-div-1234');
+    expect(bidResponse1.getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+    expect(bidResponse1.bidderCode).to.equal('openx');
+    stubAddBidResponse.restore();
+  });
+
   it('should not call loadscript when inputting with empty params', function () {
     let spyLoadScript = sinon.spy(adloader, 'loadScript');
     adapter().callBids({});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Openx Adapter: This fix correctly categorizes bids with empty pub_rev field as a no fill bid, and attached a corresponding unit test with the change

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
