### PR TITLE
Fix error when refreshing individual Ad Units and bidder responds slowly

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -46,7 +46,7 @@ function bidsBackAdUnit(adUnitCode) {
     .map(request => request.bids
       .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes))
       .filter(bid => bid.placementCode === adUnitCode))
-    .reduce(flatten)
+    .reduce(flatten, [])
     .map(bid => {
       return bid.bidder === 'indexExchange' ?
           bid.sizes.length :
@@ -64,7 +64,7 @@ function add(a, b) {
 function bidsBackAll() {
   const requested = $$PREBID_GLOBAL$$._bidsRequested
     .map(request => request.bids)
-    .reduce(flatten)
+    .reduce(flatten, [])
     .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes))
     .map(bid => {
       return bid.bidder === 'indexExchange' ?


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Bugfix for race condition.

Calling .reduce(flatten) in bidsBackAdUnit() and bidsBackAll() throws an exception when refreshing Ad unit.

That happens when some bidder takes long time to respond and second requestBids() (i.e. ad unit refresh) is called in meanwhile.

Here is a sequence diagram explaining in more detail why that happend. https://goo.gl/LPfkXc 
