### PR TITLE
Revert to running browser tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
+sudo: required
+dist: trusty
+
 language: node_js
 
 node_js:
   - "5.1"
+
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 before_install:
   - npm install -g gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,7 +92,7 @@ gulp.task('test', function () {
   var browserArgs = helpers.parseBrowserArgs(argv).map(helpers.toCapitalCase);
 
   if (process.env.TRAVIS) {
-    browserArgs = ['bs_chrome_56_mac_sierra'];
+    browserArgs = ['Chrome_travis_ci'];
   }
 
   if (argv.browserstack) {


### PR DESCRIPTION
## Type of change
- CI related changes

## Description of change
The keys needed to run Browserstack tests aren't available to external pull requests, so tests aren't running for PRs from forks. This reverts back to running browser tests within Travis.
