### PR TITLE
Use stable version of Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 
 before_install:
   - npm install -g gulp
-  - export CHROME_BIN=chromium-browser
+  - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 


### PR DESCRIPTION
## Type of change
- CI related changes

## Description of change
This configures Travis to use the stable version of Chrome when running browser tests