### PR TITLE
Stub pixel drop to prevent network request in test

### DIFF
--- a/test/spec/adapters/openx_spec.js
+++ b/test/spec/adapters/openx_spec.js
@@ -7,6 +7,9 @@ describe('openx adapter tests', function () {
   const adloader = require('src/adloader');
   const CONSTANTS = require('src/constants.json');
 
+  before(() => sinon.stub(document.body, 'appendChild'));
+  after(() => document.body.appendChild.restore());
+
   describe('test openx callback responce', function () {
 
     it('should exist and be a function', function () {


### PR DESCRIPTION
## Type of change
- Test fix

## Description of change
A pixel for a now-existing test site is getting dropped in the browser launched by Karma and causing tests to fail with errors similar to
> Executed 384 of 756 DISCONNECTED (20.087 secs / 0.791 secs)

This change stubs the DOM method used in the pixel-dropping function so that no network request is made and tests again complete running.

## CC
@lntho 