### PR TITLE
check truthiness of adUnitCode

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -93,6 +93,11 @@ function getBidderRequest(bidder, adUnitCode) {
  *   This function should be called to by the bidder adapter to register a bid response
  */
 exports.addBidResponse = function (adUnitCode, bid) {
+  if (!adUnitCode) {
+    utils.logWarn('No adUnitCode supplied to addBidResponse, response discarded');
+    return;
+  }
+
   if (bid) {
 
     const { requestId, start } = getBidderRequest(bid.bidderCode, adUnitCode);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
`adUnitCode` is expected to be passed to `bidmanager.addBidResponse` and if it is not the lookup for originating bid request fails, the time to respond value is incorrect and can end an auction early.
