### PR TITLE
Explicit win url response format for Adkernel adapter

### DIFF
--- a/src/adapters/adkernel.js
+++ b/src/adapters/adkernel.js
@@ -65,6 +65,7 @@ const AdKernelAdapter = function AdKernelAdapter() {
       try {
         document.body.appendChild(iframe);
       } catch (error) {
+        /* istanbul ignore next */
         utils.logError(error);
       }
     }
@@ -200,7 +201,7 @@ const AdKernelAdapter = function AdKernelAdapter() {
   function formatAdMarkup(bid) {
     var adm = bid.adm;
     if ('nurl' in bid) {
-      adm += utils.createTrackPixelHtml(bid.nurl);
+      adm += utils.createTrackPixelHtml(`${bid.nurl}&px=1`);
     }
     return adm;
   }

--- a/test/spec/adapters/adkernel_spec.js
+++ b/test/spec/adapters/adkernel_spec.js
@@ -238,7 +238,8 @@ describe('Adkernel adapter', () => {
       expect(bidmanager.addBidResponse.firstCall.args[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
       expect(utils.createTrackPixelHtml.calledOnce);
       let result = pbjs.getBidResponsesForAdUnitCode(bid1_zone1.placementCode);
-      expect(result.bids[0].ad).to.include(bidResponse1.seatbid[0].bid[0].nurl);
+      let expectedNurl = bidResponse1.seatbid[0].bid[0].nurl + '&px=1';
+      expect(result.bids[0].ad).to.include(expectedNurl);
     });
 
     it('should perform usersync for each unique host/zone combination', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
- [x] official adapter submission

As bid.nurl is invoked via \<img\> then new parameter has been added to specify expected response format.