### PR TITLE
Create bids for requests without mutating ad units

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -26,7 +26,7 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
           }
           sizes = sizeMapping;
         }
-        return Object.assign(bid, {
+        return Object.assign({}, bid, {
           placementCode: adUnit.code,
           mediaType: adUnit.mediaType,
           sizes: sizes,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
`Object.assign` should be passed first an empty object when creating bids for bid requests. Currently ad units are mutated with bid request data.