### PR TITLE
sharethrough: wait for document.body to exist

### DIFF
--- a/src/adapters/sharethrough.js
+++ b/src/adapters/sharethrough.js
@@ -51,7 +51,12 @@ var SharethroughAdapter = function SharethroughAdapter() {
     iframe.src = url;
     iframe.style.cssText = 'display:none;';
 
-    document.body.appendChild(iframe);
+    if (document.body)
+      document.body.appendChild(iframe);
+    else
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.appendChild(iframe);
+      });
   };
 
   function _receiveMessage(event) {


### PR DESCRIPTION
## Type of change
- [x ] Bugfix

## Description of change

If document.body doesn't exist yet, wait for content loaded event
from document before adding iframe.

## Other information

Fixes issue #1025