### PR TITLE
OpenX Adapter: Correctly gets the page domain for cross-domain iframes

### DIFF
--- a/src/adapters/openx.js
+++ b/src/adapters/openx.js
@@ -196,7 +196,8 @@ const OpenxAdapter = function OpenxAdapter() {
   function callBids(params) {
     let isIfr,
       bids = params.bids || [],
-      currentURL = window.location.href && encodeURIComponent(window.location.href);
+      currentURL = (window.parent !== window) ? document.referrer : window.location.href;
+      currentURL = currentURL && encodeURIComponent(currentURL);
     try {
       isIfr = window.self !== window.top;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This change fixes the way page domain is retrieve in cases of cross-domain iframes
