### PR TITLE
sanitize bidderRequest to rubicon adapter to ensure accountId is sent

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -198,6 +198,10 @@ function RubiconAdapter() {
       throw "no valid sizes";
     }
 
+    if(!/^\d+$/.test(accountId)) {
+      throw "invalid accountId provided";
+    }
+
     // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
     var queryString = [
       'account_id', accountId,

--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -76,7 +76,7 @@ function RubiconAdapter() {
           utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
           handleRpCB(responseText, bid);
         } catch (err) {
-          if (typeof err === "string") {
+          if (typeof err === 'string') {
             utils.logWarn(`${err} when processing rubicon response for placement code ${bid.placementCode}`);
           } else {
             utils.logError('Error processing rubicon response for placement code ' + bid.placementCode, null, err);
@@ -118,7 +118,7 @@ function RubiconAdapter() {
     ) {
       size = bid.sizes[0];
     } else {
-      throw "Invalid Video Bid - No size provided";
+      throw 'Invalid Video Bid - No size provided';
     }
 
     let postData =  {
@@ -149,7 +149,7 @@ function RubiconAdapter() {
     if(params.video.size_id) {
       slotData.size_id = params.video.size_id;
     } else {
-      throw "Invalid Video Bid - Invalid Ad Type!";
+      throw 'Invalid Video Bid - Invalid Ad Type!';
     }
 
     if(params.inventory && typeof params.inventory === 'object') {
@@ -195,11 +195,11 @@ function RubiconAdapter() {
     );
 
     if(parsedSizes.length < 1) {
-      throw "no valid sizes";
+      throw 'no valid sizes';
     }
 
     if(!/^\d+$/.test(accountId)) {
-      throw "invalid accountId provided";
+      throw 'invalid accountId provided';
     }
 
     // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
@@ -217,7 +217,7 @@ function RubiconAdapter() {
       'tk_user_key', userId
     ];
 
-    if(visitor !== null && typeof visitor === "object") {
+    if(visitor !== null && typeof visitor === 'object') {
       utils._each(visitor, (item, key) => queryString.push(`tg_v.${key}`, item));
     }
 

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -201,7 +201,7 @@ describe('the rubicon adapter', () => {
         xhr.restore();
       });
 
-      describe("to fastlane", () => {
+      describe('to fastlane', () => {
 
         it('should make a well-formed request', () => {
 
@@ -312,7 +312,7 @@ describe('the rubicon adapter', () => {
         beforeEach(() => {
           createVideoBidderRequest();
 
-          sandbox.stub(Date, "now", () =>
+          sandbox.stub(Date, 'now', () =>
             bidderRequest.auctionStart + 100
           );
         });
@@ -410,55 +410,55 @@ describe('the rubicon adapter', () => {
         it('should handle a success response and sort by cpm', () => {
 
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "account_id": 14062,
-            "site_id": 70608,
-            "zone_id": 530022,
-            "size_id": 15,
-            "alt_size_ids": [
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
               43
             ],
-            "tracking": "",
-            "inventory": {},
-            "ads": [
+            'tracking': '',
+            'inventory': {},
+            'ads': [
               {
-                "status": "ok",
-                "impression_id": "153dc240-8229-4604-b8f5-256933b9374c",
-                "size_id": "15",
-                "ad_id": "6",
-                "advertiser": 7,
-                "network": 8,
-                "creative_id": 9,
-                "type": "script",
-                "script": "alert('foo')",
-                "campaign_id": 10,
-                "cpm": 0.811,
-                "targeting": [
+                'status': 'ok',
+                'impression_id': '153dc240-8229-4604-b8f5-256933b9374c',
+                'size_id': '15',
+                'ad_id': '6',
+                'advertiser': 7,
+                'network': 8,
+                'creative_id': 9,
+                'type': 'script',
+                'script': 'alert(\'foo\')',
+                'campaign_id': 10,
+                'cpm': 0.811,
+                'targeting': [
                   {
-                    "key": "rpfl_14062",
-                    "values": [
-                      "15_tier_all_test"
+                    'key': 'rpfl_14062',
+                    'values': [
+                      '15_tier_all_test'
                     ]
                   }
                 ]
               },
               {
-                "status": "ok",
-                "impression_id": "153dc240-8229-4604-b8f5-256933b9374d",
-                "size_id": "43",
-                "ad_id": "7",
-                "advertiser": 7,
-                "network": 8,
-                "creative_id": 9,
-                "type": "script",
-                "script": "alert('foo')",
-                "campaign_id": 10,
-                "cpm": 0.911,
-                "targeting": [
+                'status': 'ok',
+                'impression_id': '153dc240-8229-4604-b8f5-256933b9374d',
+                'size_id': '43',
+                'ad_id': '7',
+                'advertiser': 7,
+                'network': 8,
+                'creative_id': 9,
+                'type': 'script',
+                'script': 'alert(\'foo\')',
+                'campaign_id': 10,
+                'cpm': 0.911,
+                'targeting': [
                   {
-                    "key": "rpfl_14062",
-                    "values": [
-                      "15_tier_all_test"
+                    'key': 'rpfl_14062',
+                    'values': [
+                      '15_tier_all_test'
                     ]
                   }
                 ]
@@ -475,7 +475,7 @@ describe('the rubicon adapter', () => {
           expect(bids).to.be.lengthOf(2);
 
           expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-          expect(bids[0].bidderCode).to.equal("rubicon");
+          expect(bids[0].bidderCode).to.equal('rubicon');
           expect(bids[0].width).to.equal(320);
           expect(bids[0].height).to.equal(50);
           expect(bids[0].cpm).to.equal(0.911);
@@ -484,7 +484,7 @@ describe('the rubicon adapter', () => {
             .and.to.contain(`<div data-rp-impression-id='153dc240-8229-4604-b8f5-256933b9374d'>`);
 
           expect(bids[1].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
-          expect(bids[1].bidderCode).to.equal("rubicon");
+          expect(bids[1].bidderCode).to.equal('rubicon');
           expect(bids[1].width).to.equal(300);
           expect(bids[1].height).to.equal(250);
           expect(bids[1].cpm).to.equal(0.811);
@@ -495,20 +495,20 @@ describe('the rubicon adapter', () => {
 
         it('should be fine with a CPM of 0', () => {
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "account_id": 14062,
-            "site_id": 70608,
-            "zone_id": 530022,
-            "size_id": 15,
-            "alt_size_ids": [
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
               43
             ],
-            "tracking": "",
-            "inventory": {},
-            "ads": [{
-                "status": "ok",
-                "cpm": 0,
-                "size_id": 15
+            'tracking': '',
+            'inventory': {},
+            'ads': [{
+                'status': 'ok',
+                'cpm': 0,
+                'size_id': 15
               }]
           }));
 
@@ -523,17 +523,17 @@ describe('the rubicon adapter', () => {
 
         it('should handle an error with no ads returned', () => {
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "account_id": 14062,
-            "site_id": 70608,
-            "zone_id": 530022,
-            "size_id": 15,
-            "alt_size_ids": [
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
               43
             ],
-            "tracking": "",
-            "inventory": {},
-            "ads": []
+            'tracking': '',
+            'inventory': {},
+            'ads': []
           }));
 
           rubiconAdapter.callBids(bidderRequest);
@@ -547,18 +547,18 @@ describe('the rubicon adapter', () => {
 
         it('should handle an error with bad status', () => {
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "account_id": 14062,
-            "site_id": 70608,
-            "zone_id": 530022,
-            "size_id": 15,
-            "alt_size_ids": [
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
               43
             ],
-            "tracking": "",
-            "inventory": {},
-            "ads": [{
-                "status": "not_ok",
+            'tracking': '',
+            'inventory': {},
+            'ads': [{
+                'status': 'not_ok',
               }]
           }));
 
@@ -572,7 +572,7 @@ describe('the rubicon adapter', () => {
         });
 
         it('should handle an error because of malformed json response', () => {
-          server.respondWith("{test{");
+          server.respondWith('{test{');
 
           rubiconAdapter.callBids(bidderRequest);
 
@@ -586,25 +586,25 @@ describe('the rubicon adapter', () => {
         it('should not register an error bid when a success call to addBidResponse throws an error', () => {
 
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "account_id": 14062,
-            "site_id": 70608,
-            "zone_id": 530022,
-            "size_id": 15,
-            "alt_size_ids": [
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
               43
             ],
-            "tracking": "",
-            "inventory": {},
-            "ads": [{
-                "status": "ok",
-                "cpm": .8,
-                "size_id": 15
+            'tracking': '',
+            'inventory': {},
+            'ads': [{
+                'status': 'ok',
+                'cpm': .8,
+                'size_id': 15
               }]
           }));
 
           addBidResponseAction = function() {
-            throw new Error("test error");
+            throw new Error('test error');
           };
 
           rubiconAdapter.callBids(bidderRequest);
@@ -628,29 +628,29 @@ describe('the rubicon adapter', () => {
         it('should register a successful bid', () => {
 
           server.respondWith(JSON.stringify({
-            "status": "ok",
-            "ads": {
-              "/19968336/header-bid-tag-0": [
+            'status': 'ok',
+            'ads': {
+              '/19968336/header-bid-tag-0': [
                 {
-                  "status": "ok",
-                  "cpm": 1,
-                  "tier": "tier0200",
-                  "targeting": {
-                    "rpfl_8000": "201_tier0200",
-                    "rpfl_elemid": "/19968336/header-bid-tag-0"
+                  'status': 'ok',
+                  'cpm': 1,
+                  'tier': 'tier0200',
+                  'targeting': {
+                    'rpfl_8000': '201_tier0200',
+                    'rpfl_elemid': '/19968336/header-bid-tag-0'
                   },
-                  "impression_id": "a40fe16e-d08d-46a9-869d-2e1573599e0c",
-                  "site_id": 88888,
-                  "zone_id": 54321,
-                  "creative_type": "video",
-                  "creative_depot_url": "https://optimized-by-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml",
-                  "ad_id": 999999,
-                  "size_id": 201,
-                  "advertiser": 12345
+                  'impression_id': 'a40fe16e-d08d-46a9-869d-2e1573599e0c',
+                  'site_id': 88888,
+                  'zone_id': 54321,
+                  'creative_type': 'video',
+                  'creative_depot_url': 'https://optimized-by-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml',
+                  'ad_id': 999999,
+                  'size_id': 201,
+                  'advertiser': 12345
                 }
               ]
             },
-            "account_id": 7780
+            'account_id': 7780
           }));
 
           rubiconAdapter.callBids(bidderRequest);

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -277,6 +277,20 @@ describe('the rubicon adapter', () => {
           expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
 
         });
+
+        it('should not send a request and register an error if no account id is present', () => {
+
+          var noAccountBidderRequest = clone(bidderRequest);
+          delete noAccountBidderRequest.bids[0].params.accountId;
+
+          rubiconAdapter.callBids(noAccountBidderRequest);
+
+          expect(xhr.requests.length).to.equal(0);
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+
+        });
         
         it('should allow a floor override', () => {
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
Make sure accountId is sent in bid.params since it is required for Rubicon adapter.  Also, siteId and zoneId are now optional (listed as required on bid params documentation).