### PR TITLE
fixed mixed tabs/spaces in wideorbit adapter

### DIFF
--- a/src/adapters/wideorbit.js
+++ b/src/adapters/wideorbit.js
@@ -117,7 +117,7 @@ var WideOrbitAdapter = function WideOrbitAdapter() {
       _fixParamNames(requestParams);
 
       publisherId = requestParams.pbId;
-	  referrer = referrer || requestParams.referrer;
+      referrer = referrer || requestParams.referrer;
       bidUrl += _setupPlacementParameters(i, requestParams);
     }
 


### PR DESCRIPTION
## Type of change
- [x] Code style update (formatting, local variables)

## Description of change
Fixed some mixed tabs and spaces in one line of the Wideorbit adapter.  It was throwing warnings in the linter when building.