### PR TITLE
allow error handlers in ajax requests

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -62,9 +62,29 @@ function RubiconAdapter() {
       try {
         // Video endpoint only accepts POST calls
         if (bid.mediaType === 'video') {
-          ajax(VIDEO_ENDPOINT, bidCallback, buildVideoRequestPayload(bid, bidderRequest), {withCredentials: true});
+          ajax(
+            VIDEO_ENDPOINT,
+            {
+              success: bidCallback,
+              error: bidError
+            },
+            buildVideoRequestPayload(bid, bidderRequest),
+            {
+              withCredentials: true
+            }
+          );
         } else {
-          ajax(buildOptimizedCall(bid), bidCallback, undefined, {withCredentials: true});
+          ajax(
+            buildOptimizedCall(bid),
+            {
+              success: bidCallback,
+              error: bidError
+            },
+            undefined,
+            {
+              withCredentials: true
+            }
+          );
         }
       } catch(err) {
         utils.logError('Error sending rubicon request for placement code ' + bid.placementCode, null, err);
@@ -83,6 +103,11 @@ function RubiconAdapter() {
           }
           addErrorBid();
         }
+      }
+
+      function bidError(err, xhr) {
+        utils.logError('Request for rubicon responded with:', xhr.status, err);
+        addErrorBid();
       }
 
       function addErrorBid() {

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -9,7 +9,7 @@ const XHR_DONE = 4;
  * Note: x-domain requests in IE9 do not support the use of cookies
  *
  * @param url string url
- * @param callback object callback
+ * @param callback {object | function} callback
  * @param data mixed data
  * @param options object
  */
@@ -19,6 +19,19 @@ export function ajax(url, callback, data, options = {}) {
     let x;
     let useXDomainRequest = false;
     let method = options.method || (data ? 'POST' : 'GET');
+
+    let callbacks = typeof callback === "object" ? callback : {
+      success: function() {
+        utils.logMessage('xhr success');
+      },
+      error: function(e) {
+        utils.logError('xhr error', null, e);
+      }
+    };
+
+    if(typeof callback === "function") {
+      callbacks.success = callback;
+    }
 
     if (!window.XMLHttpRequest) {
       useXDomainRequest = true;
@@ -32,23 +45,28 @@ export function ajax(url, callback, data, options = {}) {
     if (useXDomainRequest) {
       x = new window.XDomainRequest();
       x.onload = function () {
-        callback(x.responseText, x);
+        callbacks.success(x.responseText, x);
       };
 
       // http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
       x.onerror = function () {
-        utils.logMessage('xhr onerror');
+        callbacks.error("error", x);
       };
       x.ontimeout = function () {
-        utils.logMessage('xhr timeout');
+        callbacks.error("timeout", x);
       };
       x.onprogress = function() {
         utils.logMessage('xhr onprogress');
       };
     } else {
       x.onreadystatechange = function () {
-        if (x.readyState === XHR_DONE && callback) {
-          callback(x.responseText, x);
+        if (x.readyState === XHR_DONE) {
+          let status = x.status;
+          if(status >= 200 && status < 300 || status === 304) {
+            callbacks.success(x.responseText, x);
+          } else {
+            callbacks.error(x.statusText, x);
+          }
         }
       };
     }

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -569,6 +569,18 @@ describe('the rubicon adapter', () => {
           expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
         });
 
+        it('should handle error contacting endpoint', () => {
+          server.respondWith([404, {}, ""]);
+
+          rubiconAdapter.callBids(bidderRequest);
+
+          server.respond();
+
+          expect(bidManager.addBidResponse.calledOnce).to.equal(true);
+          expect(bids).to.be.lengthOf(1);
+          expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+        });
+
         it('should not register an error bid when a success call to addBidResponse throws an error', () => {
 
           server.respondWith(JSON.stringify({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Allow error handlers for ajax requests for better error handling.

In addition to allowing the regular callback to default as the success handler:
```javascript
ajax(url, function(responesText, xhr) {
  console.log("succeeded with", responseText);
});
```

the following is now accepted as well
```javascript
ajax(url, {
  success: function(responseText, xhr) {
    console.log("succeeded with", responseText);
  },
  error: function(statusCode, xhr) {
    console.log("failed with status code", status);
  }
}
```