### PR TITLE
Responsive bids

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,7 +1,6 @@
 /** @module adaptermanger */
 
 import { flatten, getBidderCodes, shuffle } from './utils';
-import { mapSizes } from './sizeMapping';
 
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -16,26 +15,18 @@ let _bidderSequence = null;
 
 function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
   return adUnits.map(adUnit => {
-    return adUnit.bids.filter(bid => bid.bidder === bidderCode)
+    return adUnit.bids
+      .filter(bid => bid.bidder === bidderCode)
       .map(bid => {
-        let sizes = adUnit.sizes;
-        if (adUnit.sizeMapping) {
-          let sizeMapping = mapSizes(adUnit);
-          if (sizeMapping === '') {
-            return '';
-          }
-          sizes = sizeMapping;
-        }
         return Object.assign({}, bid, {
           placementCode: adUnit.code,
           mediaType: adUnit.mediaType,
-          sizes: sizes,
+          sizes: adUnit.sizes,
           bidId: utils.getUniqueIdentifierStr(),
           bidderRequestId,
           requestId
         });
-      }
-      );
+      });
   }).reduce(flatten, []).filter(val => val !== '');
 }
 
@@ -55,6 +46,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
   }
 
   bidderCodes.forEach(bidderCode => {
+    console.log('bidder code' + bidderCode);
     const adapter = _bidderRegistry[bidderCode];
     if (adapter) {
       const bidderRequestId = utils.getUniqueIdentifierStr();

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -46,7 +46,6 @@ exports.callBids = ({adUnits, cbTimeout}) => {
   }
 
   bidderCodes.forEach(bidderCode => {
-    console.log('bidder code' + bidderCode);
     const adapter = _bidderRegistry[bidderCode];
     if (adapter) {
       const bidderRequestId = utils.getUniqueIdentifierStr();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -7,6 +7,7 @@ import 'polyfill';
 import {parse as parseURL, format as formatURL} from './url';
 import {isValidePriceConfig} from './cpmBucketManager';
 import {listenMessagesFromCreative} from './secure-creatives';
+import { getResponsiveAdUnits } from './sizeMapping';
 
 var $$PREBID_GLOBAL$$ = getGlobal();
 var CONSTANTS = require('./constants.json');
@@ -428,6 +429,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
 /**
  *
  * Add adunit(s)
+ * If adUnits have a sizeMapping with 'sizes' and 'bids', this will grab those arrays
+ * and put them in place of the adUnit.sizes and adUnit.bids depending on the user's
+ * screen size.
  * @param {Array|String} adUnitArr Array of adUnits or single adUnit Object.
  * @alias module:$$PREBID_GLOBAL$$.addAdUnits
  */
@@ -435,9 +439,9 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.addAdUnits', arguments);
   if (utils.isArray(adUnitArr)) {
     //append array to existing
-    $$PREBID_GLOBAL$$.adUnits.push.apply($$PREBID_GLOBAL$$.adUnits, adUnitArr);
+    $$PREBID_GLOBAL$$.adUnits.push.apply($$PREBID_GLOBAL$$.adUnits, getResponsiveAdUnits(adUnitArr));
   } else if (typeof adUnitArr === objectType_object) {
-    $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);
+    $$PREBID_GLOBAL$$.adUnits.push($$PREBID_GLOBAL$$.adUnits, getResponsiveAdUnits([adUnitArr]));
   }
 };
 

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -5,31 +5,31 @@ import * as utils from './utils';
 let _win;
 
 function getResponsiveAdUnits(adUnits) {
-  adUnits.forEach(function (adUnit) {
+  return adUnits.map(adUnit => {
     if(!isSizeMappingValid(adUnit.sizeMapping)){
       return adUnit;
     }
     let sizeMap = getActiveSizeMap(adUnit);
-    adUnit.bids = sizeMap.bids;
-    adUnit.sizes = sizeMap.sizes;
+    return Object.assign({}, adUnit, {
+            bids: sizeMap.bids ? sizeMap.bids : adUnit.bids,
+            sizes: sizeMap.sizes ? sizeMap.sizes : adUnit.sizes
+          });
   });
-  return adUnits;
 }
 
 function getActiveSizeMap(adUnit) {
   const width = getScreenWidth();
   if(!width) {
     //size not detected - get largest value set for desktop
-    const mapping = adUnit.sizeMapping.reduce((prev, curr) => {
+    const sizeMap = adUnit.sizeMapping.reduce((prev, curr) => {
       return prev.minWidth < curr.minWidth ? curr : prev;
     });
-    if(mapping.sizes) {
-      return mapping.sizes;
+    if(sizeMap) {
+      return sizeMap;
     }
-    return adUnit.sizes;
   }
   const sizeMap = adUnit.sizeMapping.find(sizeMapping =>{
-    return width > sizeMapping.minWidth;
+    return width >= sizeMapping.minWidth;
   });
   if (sizeMap) {
     utils.logMessage(`AdUnit : ${adUnit.code} using sizeMapping for minWidth : ${sizeMap.minWidth}`);

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -4,10 +4,19 @@
 import * as utils from './utils';
 let _win;
 
-function mapSizes(adUnit) {
-  if(!isSizeMappingValid(adUnit.sizeMapping)){
-    return adUnit.sizes;
-  }
+function getResponsiveAdUnits(adUnits) {
+  adUnits.forEach(function (adUnit) {
+    if(!isSizeMappingValid(adUnit.sizeMapping)){
+      return adUnit;
+    }
+    let sizeMap = getActiveSizeMap(adUnit);
+    adUnit.bids = sizeMap.bids;
+    adUnit.sizes = sizeMap.sizes;
+  });
+  return adUnits;
+}
+
+function getActiveSizeMap(adUnit) {
   const width = getScreenWidth();
   if(!width) {
     //size not detected - get largest value set for desktop
@@ -19,19 +28,15 @@ function mapSizes(adUnit) {
     }
     return adUnit.sizes;
   }
-  let sizes = '';
-  const mapping = adUnit.sizeMapping.find(sizeMapping =>{
+  const sizeMap = adUnit.sizeMapping.find(sizeMapping =>{
     return width > sizeMapping.minWidth;
   });
-  if(mapping && mapping.sizes){
-    sizes = mapping.sizes;
-    utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
+  if (sizeMap) {
+    utils.logMessage(`AdUnit : ${adUnit.code} using sizeMapping for minWidth : ${sizeMap.minWidth}`);
+  } else {
+    utils.logMessage(`AdUnit : ${adUnit.code} not mapped to any sizes for device width. Using default sizes and bids for adUnit. This request will be suppressed.`);
   }
-  else{
-    utils.logMessage(`AdUnit : ${adUnit.code} not mapped to any sizes for device width. This request will be suppressed.`);
-  }
-  return sizes;
-
+  return sizeMap;
 }
 
 function isSizeMappingValid(sizeMapping) {
@@ -62,4 +67,4 @@ function setWindow(win) {
   _win = win;
 }
 
-export { mapSizes, getScreenWidth, setWindow };
+export { getResponsiveAdUnits, getActiveSizeMap, getScreenWidth, setWindow };

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -1,26 +1,120 @@
 import { expect } from 'chai';
 import * as sizeMapping from 'src/sizeMapping';
 
-var validAdUnit = {
-  'sizes': [300,250],
-  'sizeMapping': [
+
+var validAdUnits = [{
+  code: '/1996833/slot-1',
+  sizes: [[300, 250], [728, 90]],
+  bids: [{
+          bidder: 'appnexus',
+          params: {
+            placementId: '987654'
+          }
+        }],
+  sizeMapping: [
     {
-      'minWidth': 1024,
-      'sizes': [[300,250],[728,90]]
+      minWidth: 1200,
+      sizes: [728, 90],
+      bids: [
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '2342353',
+                unit: '234234',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '234235'
+              }
+            }
+        ]
     },
     {
-      'minWidth': 480,
-      'sizes': [120,60]
+      minWidth: 768,
+      sizes: [[728,90], [300, 100], [300, 50]],
+      bids: [
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '123456',
+                unit: '123456',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '123456'
+              }
+            }
+        ]
     },
     {
-      'minWidth': 0,
-      'sizes': [20,20]
+      minWidth: 580,
+      bids: [
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '543211',
+                unit: '543211',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '543211'
+              }
+            }
+        ]
+    },
+    {
+      minWidth: 480,
+      sizes: [[300, 100], [300, 50]]
+    },
+    {
+      minWidth: 0,
+      sizes: [[300, 250], [300, 100], [300, 50]],
+      bids: []
     }
   ]
-};
+}, {
+  code: '/1996833/slot-2',
+  sizes: [[468, 60]],
+  bids: [
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ]
+}];
 
 var invalidAdUnit = {
   'sizes': [300,250],
+  'bids': [
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ],
   'sizeMapping': {} // wrong type
 };
 
@@ -51,57 +145,230 @@ describe('sizeMapping', function() {
 
   beforeEach(resetMockWindow);
 
-  it('mapSizes 1029 width', function() {
-    mockWindow.innerWidth = 1029;
+  it('getResponsiveAdUnits 1980 width', function() {
+    mockWindow.innerWidth = 1980;
     sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[300,250],[728,90]]);
-    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    let normalAdUnit = adUnits[1];
+    expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
+    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
+    expect(responsiveAdUnit.bids).to.deep.equal(
+        [
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '2342353',
+                unit: '234234',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '234235'
+              }
+            }
+        ]);
   });
 
-  it('mapSizes 400 width', function() {
-    mockWindow.innerWidth = 400;
+  it('getResponsiveAdUnits 1024 width', function() {
+    mockWindow.innerWidth = 1024;
     sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([20,20]);
-    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    let normalAdUnit = adUnits[1];
+    expect(responsiveAdUnit.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
+    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
+    expect(responsiveAdUnit.bids).to.deep.equal(
+        [
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '123456',
+                unit: '123456',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '123456'
+              }
+            }
+        ]);
   });
 
-  it('mapSizes - invalid adUnit - should return sizes', function() {
-    mockWindow.innerWidth = 1029;
+  it('getResponsiveAdUnits - invalid adUnit - should return default sizes', function() {
+    mockWindow.innerWidth = 1980;
     sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(invalidAdUnit);
-    expect(sizes).to.deep.equal([300,250]);
+    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+    let responsiveAdUnit = adUnits[0];
+    expect(responsiveAdUnit.sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
 
-    mockWindow.innerWidth = 400;
+    mockWindow.innerWidth = 1024;
     sizeMapping.setWindow(mockWindow);
-    sizes = sizeMapping.mapSizes(invalidAdUnit);
-    expect(sizes).to.deep.equal([300,250]);
+    let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+    let responsiveAdUnit2 = adUnits2[0];
+    expect(responsiveAdUnit2.sizes).to.deep.equal([300,250]);
     expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
   });
 
-  it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
+  it('getResponsiveAdUnits - invalid adUnit - should return default bids', function() {
+    mockWindow.innerWidth = 1980;
+    sizeMapping.setWindow(mockWindow);
+    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+    let responsiveAdUnit = adUnits[0];
+    expect(responsiveAdUnit.bids).to.deep.equal([
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ]);
+    expect(invalidAdUnit.bids).to.deep.equal([
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ]);
+
+    mockWindow.innerWidth = 1024;
+    sizeMapping.setWindow(mockWindow);
+    let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+    let responsiveAdUnit2 = adUnits2[0];
+    expect(responsiveAdUnit2.bids).to.deep.equal([
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ]);
+    expect(invalidAdUnit.bids).to.deep.equal([
+        {
+          bidder: 'rubicon',
+          params: {
+            rp_account: '4934',
+            rp_site: '13945',
+            rp_zonesize: '23948-15'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            placementId: '827326'
+          }
+        }
+        ]);
+  });
+
+  it('getResponsiveAdUnits - should return empty bid array if empty bid array in sizemapping', function() {
+    mockWindow.innerWidth = 320;
+    sizeMapping.setWindow(mockWindow);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    expect(responsiveAdUnit.bids).to.deep.equal([]);
+  });
+
+  it('getResponsiveAdUnits - should return default bids if sizeMapping.bids not defined ', function() {
+    mockWindow.innerWidth = 520;
+    sizeMapping.setWindow(mockWindow);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    expect(responsiveAdUnit.bids).to.deep.equal(
+      [{
+        bidder: 'appnexus',
+        params: {
+          placementId: '987654'
+        }
+      }]
+    );
+  });
+
+  it('getResponsiveAdUnits - should return desktop (largest) sizes if screen width not detected', function() {
     mockWindow.innerWidth = 0;
     mockWindow.document.body.clientWidth = 0;
     mockWindow.document.documentElement.clientWidth = 0;
     sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
-    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    let normalAdUnit = adUnits[1];
+    expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
+    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
   });
 
+  it('getResponsiveAdUnits - should return default sizes if sizemapping.sizes not defined ', function() {
+    mockWindow.innerWidth = 600;
+    sizeMapping.setWindow(mockWindow);
+    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+    let responsiveAdUnit = adUnits[0];
+    expect(responsiveAdUnit.sizes).to.deep.equal([[300, 250], [728, 90]]);
+  });
 
-  it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
+  it('getResponsiveAdUnits - should return default sizes if sizemapping improperly defined ', function() {
     mockWindow.innerWidth = 0;
     mockWindow.document.body.clientWidth = 0;
     mockWindow.document.documentElement.clientWidth = 0;
     sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(invalidAdUnit2);
-    expect(sizes).to.deep.equal([300,250]);
-    expect(validAdUnit.sizes).to.deep.equal([300,250]);
+    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit2]);
+    let invalidAdUnit = adUnits[0]
+    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
   });
 
+  it('getActiveSizeMap - should return the sizeMap depending upon the screen size', function() {
+    mockWindow.innerWidth = 769;
+    sizeMapping.setWindow(mockWindow);
+    let AdUnit = validAdUnits[0];
+    let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
+    expect(sizeMap.minWidth).to.equal(768);
+    expect(sizeMap.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
+    expect(sizeMap.bids).to.deep.equal([
+            {
+              bidder: 'openx',
+              params: {
+                pgid: '123456',
+                unit: '123456',
+                jstag_url: 'http://'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '123456'
+              }
+            }
+        ]);
+  });
+
+  it('getActiveSizeMap - should return exact minWidth if screen equals the minWidth', function() {
+    mockWindow.innerWidth = 768;
+    sizeMapping.setWindow(mockWindow);
+    let AdUnit = validAdUnits[0];
+    let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
+    expect(sizeMap.minWidth).to.equal(768);
+  });
 
   it('getScreenWidth', function() {
     mockWindow.innerWidth = 900;

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -1,387 +1,419 @@
 import { expect } from 'chai';
 import * as sizeMapping from 'src/sizeMapping';
 
+describe('sizeMapping', function () {
+  var pbjsTestOnly = require('../helpers/pbjs-test-only').pbjsTestOnly;
+  var validAdUnits = []
+  var invalidAdUnit = []
+  var invalidAdUnit2 = []
+  var mockWindow = {};
 
-var validAdUnits = [{
-  code: '/1996833/slot-1',
-  sizes: [[300, 250], [728, 90]],
-  bids: [{
+  function resetMockWindow() {
+      mockWindow = {
+          document: {
+              body: {
+                  clientWidth: 1024
+              },
+              documentElement: {
+                  clientWidth: 1024
+              }
+          },
+          innerWidth: 1024
+      };
+  }
+
+  function resetAdUnits() {
+    validAdUnits = [{
+      code: '/1996833/slot-1',
+      sizes: [[300, 250], [728, 90]],
+      bids: [{
+              bidder: 'appnexus',
+              params: {
+                placementId: '987654'
+              }
+            }],
+      sizeMapping: [
+        {
+          minWidth: 1200,
+          sizes: [728, 90],
+          bids: [
+                {
+                  bidder: 'openx',
+                  params: {
+                    pgid: '2342353',
+                    unit: '234234',
+                    jstag_url: 'http://'
+                  }
+                }, {
+                  bidder: 'appnexus',
+                  params: {
+                    placementId: '234235'
+                  }
+                }
+            ]
+        },
+        {
+          minWidth: 768,
+          sizes: [[728,90], [300, 100], [300, 50]],
+          bids: [
+                {
+                  bidder: 'openx',
+                  params: {
+                    pgid: '123456',
+                    unit: '123456',
+                    jstag_url: 'http://'
+                  }
+                }, {
+                  bidder: 'appnexus',
+                  params: {
+                    placementId: '123456'
+                  }
+                }
+            ]
+        },
+        {
+          minWidth: 580,
+          bids: [
+                {
+                  bidder: 'openx',
+                  params: {
+                    pgid: '543211',
+                    unit: '543211',
+                    jstag_url: 'http://'
+                  }
+                }, {
+                  bidder: 'appnexus',
+                  params: {
+                    placementId: '543211'
+                  }
+                }
+            ]
+        },
+        {
+          minWidth: 480,
+          sizes: [[300, 100], [300, 50]]
+        },
+        {
+          minWidth: 0,
+          sizes: [[300, 250], [300, 100], [300, 50]],
+          bids: []
+        }
+      ]
+    }, {
+      code: '/1996833/slot-2',
+      sizes: [[468, 60]],
+      bids: [
+            {
+              bidder: 'rubicon',
+              params: {
+                rp_account: '4934',
+                rp_site: '13945',
+                rp_zonesize: '23948-15'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '827326'
+              }
+            }
+            ]
+    }];
+
+    invalidAdUnit = {
+      'sizes': [300,250],
+      'bids': [
+            {
+              bidder: 'rubicon',
+              params: {
+                rp_account: '4934',
+                rp_site: '13945',
+                rp_zonesize: '23948-15'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                placementId: '827326'
+              }
+            }
+            ],
+      'sizeMapping': {} // wrong type
+    };
+
+    invalidAdUnit2 = {
+      'sizes': [300,250],
+      'sizeMapping': [{
+        foo : 'bar'  //bad
+      }]
+    };
+  }
+
+  before(function() {
+    resetAdUnits();
+  })
+
+
+  describe('getResponsiveAdUnits', function() {
+
+    beforeEach(function() {
+      resetMockWindow();
+      resetAdUnits();
+    });
+
+    it('getResponsiveAdUnits 1980 width', function() {
+      mockWindow.innerWidth = 1980;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      let normalAdUnit = adUnits[1];
+      expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
+      expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
+      expect(responsiveAdUnit.bids).to.deep.equal(
+          [
+              {
+                bidder: 'openx',
+                params: {
+                  pgid: '2342353',
+                  unit: '234234',
+                  jstag_url: 'http://'
+                }
+              }, {
+                bidder: 'appnexus',
+                params: {
+                  placementId: '234235'
+                }
+              }
+          ]);
+    });
+
+    it('getResponsiveAdUnits 1024 width', function() {
+      mockWindow.innerWidth = 1024;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      let normalAdUnit = adUnits[1];
+      expect(responsiveAdUnit.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
+      expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
+      expect(responsiveAdUnit.bids).to.deep.equal(
+          [
+              {
+                bidder: 'openx',
+                params: {
+                  pgid: '123456',
+                  unit: '123456',
+                  jstag_url: 'http://'
+                }
+              }, {
+                bidder: 'appnexus',
+                params: {
+                  placementId: '123456'
+                }
+              }
+          ]);
+    });
+
+    it('getResponsiveAdUnits - invalid adUnit - should return default sizes', function() {
+      mockWindow.innerWidth = 1980;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+      let responsiveAdUnit = adUnits[0];
+      expect(responsiveAdUnit.sizes).to.deep.equal([300,250]);
+      expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
+
+      mockWindow.innerWidth = 1024;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+      let responsiveAdUnit2 = adUnits2[0];
+      expect(responsiveAdUnit2.sizes).to.deep.equal([300,250]);
+      expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
+    });
+
+    it('getResponsiveAdUnits - invalid adUnit - should return default bids', function() {
+      mockWindow.innerWidth = 1980;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+      let responsiveAdUnit = adUnits[0];
+      expect(responsiveAdUnit.bids).to.deep.equal([
+          {
+            bidder: 'rubicon',
+            params: {
+              rp_account: '4934',
+              rp_site: '13945',
+              rp_zonesize: '23948-15'
+            }
+          }, {
+            bidder: 'appnexus',
+            params: {
+              placementId: '827326'
+            }
+          }
+          ]);
+      expect(invalidAdUnit.bids).to.deep.equal([
+          {
+            bidder: 'rubicon',
+            params: {
+              rp_account: '4934',
+              rp_site: '13945',
+              rp_zonesize: '23948-15'
+            }
+          }, {
+            bidder: 'appnexus',
+            params: {
+              placementId: '827326'
+            }
+          }
+          ]);
+
+      mockWindow.innerWidth = 1024;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
+      let responsiveAdUnit2 = adUnits2[0];
+      expect(responsiveAdUnit2.bids).to.deep.equal([
+          {
+            bidder: 'rubicon',
+            params: {
+              rp_account: '4934',
+              rp_site: '13945',
+              rp_zonesize: '23948-15'
+            }
+          }, {
+            bidder: 'appnexus',
+            params: {
+              placementId: '827326'
+            }
+          }
+          ]);
+      expect(invalidAdUnit.bids).to.deep.equal([
+          {
+            bidder: 'rubicon',
+            params: {
+              rp_account: '4934',
+              rp_site: '13945',
+              rp_zonesize: '23948-15'
+            }
+          }, {
+            bidder: 'appnexus',
+            params: {
+              placementId: '827326'
+            }
+          }
+          ]);
+    });
+
+    it('getResponsiveAdUnits - should return empty bid array if empty bid array in sizemapping', function() {
+      mockWindow.innerWidth = 320;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      expect(responsiveAdUnit.bids).to.deep.equal([]);
+    });
+
+    it('getResponsiveAdUnits - should return default bids if sizeMapping.bids not defined ', function() {
+      mockWindow.innerWidth = 520;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      expect(responsiveAdUnit.bids).to.deep.equal(
+        [{
           bidder: 'appnexus',
           params: {
             placementId: '987654'
           }
-        }],
-  sizeMapping: [
-    {
-      minWidth: 1200,
-      sizes: [728, 90],
-      bids: [
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '2342353',
-                unit: '234234',
-                jstag_url: 'http://'
+        }]
+      );
+    });
+
+    it('getResponsiveAdUnits - should return desktop (largest) sizes if screen width not detected', function() {
+      mockWindow.innerWidth = 0;
+      mockWindow.document.body.clientWidth = 0;
+      mockWindow.document.documentElement.clientWidth = 0;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      let normalAdUnit = adUnits[1];
+      expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
+      expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
+    });
+
+    it('getResponsiveAdUnits - should return default sizes if sizemapping.sizes not defined ', function() {
+      mockWindow.innerWidth = 600;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
+      let responsiveAdUnit = adUnits[0];
+      expect(responsiveAdUnit.sizes).to.deep.equal([[300, 250], [728, 90]]);
+    });
+
+    it('getResponsiveAdUnits - should return default sizes if sizemapping improperly defined ', function() {
+      mockWindow.innerWidth = 0;
+      mockWindow.document.body.clientWidth = 0;
+      mockWindow.document.documentElement.clientWidth = 0;
+      sizeMapping.setWindow(mockWindow);
+      let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit2]);
+      let invalidAdUnit = adUnits[0]
+      expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
+    });
+  });
+
+
+  describe('getActiveSizeMap', function() {
+    
+    beforeEach(function() {
+      resetMockWindow();
+      resetAdUnits();
+    });
+
+    it('getActiveSizeMap - should return the sizeMap depending upon the screen size', function() {
+      mockWindow.innerWidth = 769;
+      sizeMapping.setWindow(mockWindow);
+      let AdUnit = validAdUnits[0];
+      let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
+      expect(sizeMap.minWidth).to.equal(768);
+      expect(sizeMap.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
+      expect(sizeMap.bids).to.deep.equal([
+              {
+                bidder: 'openx',
+                params: {
+                  pgid: '123456',
+                  unit: '123456',
+                  jstag_url: 'http://'
+                }
+              }, {
+                bidder: 'appnexus',
+                params: {
+                  placementId: '123456'
+                }
               }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '234235'
-              }
-            }
-        ]
-    },
-    {
-      minWidth: 768,
-      sizes: [[728,90], [300, 100], [300, 50]],
-      bids: [
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '123456',
-                unit: '123456',
-                jstag_url: 'http://'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '123456'
-              }
-            }
-        ]
-    },
-    {
-      minWidth: 580,
-      bids: [
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '543211',
-                unit: '543211',
-                jstag_url: 'http://'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '543211'
-              }
-            }
-        ]
-    },
-    {
-      minWidth: 480,
-      sizes: [[300, 100], [300, 50]]
-    },
-    {
-      minWidth: 0,
-      sizes: [[300, 250], [300, 100], [300, 50]],
-      bids: []
-    }
-  ]
-}, {
-  code: '/1996833/slot-2',
-  sizes: [[468, 60]],
-  bids: [
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ]
-}];
+          ]);
+    });
 
-var invalidAdUnit = {
-  'sizes': [300,250],
-  'bids': [
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ],
-  'sizeMapping': {} // wrong type
-};
-
-var invalidAdUnit2 = {
-  'sizes': [300,250],
-  'sizeMapping': [{
-    foo : 'bar'  //bad
-  }]
-};
-
-let mockWindow = {};
-
-function resetMockWindow() {
-    mockWindow = {
-        document: {
-            body: {
-                clientWidth: 1024
-            },
-            documentElement: {
-                clientWidth: 1024
-            }
-        },
-        innerWidth: 1024
-    };
-}
-
-describe('sizeMapping', function() {
-
-  beforeEach(resetMockWindow);
-
-  it('getResponsiveAdUnits 1980 width', function() {
-    mockWindow.innerWidth = 1980;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    let normalAdUnit = adUnits[1];
-    expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
-    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
-    expect(responsiveAdUnit.bids).to.deep.equal(
-        [
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '2342353',
-                unit: '234234',
-                jstag_url: 'http://'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '234235'
-              }
-            }
-        ]);
+    it('getActiveSizeMap - should return exact minWidth if screen equals the minWidth', function() {
+      mockWindow.innerWidth = 768;
+      sizeMapping.setWindow(mockWindow);
+      let AdUnit = validAdUnits[0];
+      let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
+      expect(sizeMap.minWidth).to.equal(768);
+    });
   });
 
-  it('getResponsiveAdUnits 1024 width', function() {
-    mockWindow.innerWidth = 1024;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    let normalAdUnit = adUnits[1];
-    expect(responsiveAdUnit.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
-    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
-    expect(responsiveAdUnit.bids).to.deep.equal(
-        [
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '123456',
-                unit: '123456',
-                jstag_url: 'http://'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '123456'
-              }
-            }
-        ]);
+  describe('getScreenWidth', function() {
+
+    beforeEach(function() {
+      resetMockWindow();
+      resetAdUnits();
+    });
+
+    it('getScreenWidth', function() {
+      mockWindow.innerWidth = 900;
+      mockWindow.document.body.clientWidth = 900;
+      mockWindow.document.documentElement.clientWidth = 900;
+      expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
+    });
+
+    it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
+      mockWindow.innerWidth = null;
+      mockWindow.document.body.clientWidth = null;
+      mockWindow.document.documentElement.clientWidth = null;
+      expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
+    });
+
   });
-
-  it('getResponsiveAdUnits - invalid adUnit - should return default sizes', function() {
-    mockWindow.innerWidth = 1980;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
-    let responsiveAdUnit = adUnits[0];
-    expect(responsiveAdUnit.sizes).to.deep.equal([300,250]);
-    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
-
-    mockWindow.innerWidth = 1024;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
-    let responsiveAdUnit2 = adUnits2[0];
-    expect(responsiveAdUnit2.sizes).to.deep.equal([300,250]);
-    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
-  });
-
-  it('getResponsiveAdUnits - invalid adUnit - should return default bids', function() {
-    mockWindow.innerWidth = 1980;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
-    let responsiveAdUnit = adUnits[0];
-    expect(responsiveAdUnit.bids).to.deep.equal([
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ]);
-    expect(invalidAdUnit.bids).to.deep.equal([
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ]);
-
-    mockWindow.innerWidth = 1024;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits2 = sizeMapping.getResponsiveAdUnits([invalidAdUnit]);
-    let responsiveAdUnit2 = adUnits2[0];
-    expect(responsiveAdUnit2.bids).to.deep.equal([
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ]);
-    expect(invalidAdUnit.bids).to.deep.equal([
-        {
-          bidder: 'rubicon',
-          params: {
-            rp_account: '4934',
-            rp_site: '13945',
-            rp_zonesize: '23948-15'
-          }
-        }, {
-          bidder: 'appnexus',
-          params: {
-            placementId: '827326'
-          }
-        }
-        ]);
-  });
-
-  it('getResponsiveAdUnits - should return empty bid array if empty bid array in sizemapping', function() {
-    mockWindow.innerWidth = 320;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    expect(responsiveAdUnit.bids).to.deep.equal([]);
-  });
-
-  it('getResponsiveAdUnits - should return default bids if sizeMapping.bids not defined ', function() {
-    mockWindow.innerWidth = 520;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    expect(responsiveAdUnit.bids).to.deep.equal(
-      [{
-        bidder: 'appnexus',
-        params: {
-          placementId: '987654'
-        }
-      }]
-    );
-  });
-
-  it('getResponsiveAdUnits - should return desktop (largest) sizes if screen width not detected', function() {
-    mockWindow.innerWidth = 0;
-    mockWindow.document.body.clientWidth = 0;
-    mockWindow.document.documentElement.clientWidth = 0;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    let normalAdUnit = adUnits[1];
-    expect(responsiveAdUnit.sizes).to.deep.equal([728, 90]);
-    expect(normalAdUnit.sizes).to.deep.equal([[468, 60]]);
-  });
-
-  it('getResponsiveAdUnits - should return default sizes if sizemapping.sizes not defined ', function() {
-    mockWindow.innerWidth = 600;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits(validAdUnits);
-    let responsiveAdUnit = adUnits[0];
-    expect(responsiveAdUnit.sizes).to.deep.equal([[300, 250], [728, 90]]);
-  });
-
-  it('getResponsiveAdUnits - should return default sizes if sizemapping improperly defined ', function() {
-    mockWindow.innerWidth = 0;
-    mockWindow.document.body.clientWidth = 0;
-    mockWindow.document.documentElement.clientWidth = 0;
-    sizeMapping.setWindow(mockWindow);
-    let adUnits = sizeMapping.getResponsiveAdUnits([invalidAdUnit2]);
-    let invalidAdUnit = adUnits[0]
-    expect(invalidAdUnit.sizes).to.deep.equal([300,250]);
-  });
-
-  it('getActiveSizeMap - should return the sizeMap depending upon the screen size', function() {
-    mockWindow.innerWidth = 769;
-    sizeMapping.setWindow(mockWindow);
-    let AdUnit = validAdUnits[0];
-    let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
-    expect(sizeMap.minWidth).to.equal(768);
-    expect(sizeMap.sizes).to.deep.equal([[728,90], [300, 100], [300, 50]]);
-    expect(sizeMap.bids).to.deep.equal([
-            {
-              bidder: 'openx',
-              params: {
-                pgid: '123456',
-                unit: '123456',
-                jstag_url: 'http://'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                placementId: '123456'
-              }
-            }
-        ]);
-  });
-
-  it('getActiveSizeMap - should return exact minWidth if screen equals the minWidth', function() {
-    mockWindow.innerWidth = 768;
-    sizeMapping.setWindow(mockWindow);
-    let AdUnit = validAdUnits[0];
-    let sizeMap = sizeMapping.getActiveSizeMap(AdUnit);
-    expect(sizeMap.minWidth).to.equal(768);
-  });
-
-  it('getScreenWidth', function() {
-    mockWindow.innerWidth = 900;
-    mockWindow.document.body.clientWidth = 900;
-    mockWindow.document.documentElement.clientWidth = 900;
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
-  });
-
-  it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
-    mockWindow.innerWidth = null;
-    mockWindow.document.body.clientWidth = null;
-    mockWindow.document.documentElement.clientWidth = null;
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
-  });
-
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
To fully support responsive designs, we needed to figure out which bids are relevant based on the user's screen size. The current sizeMapping is just a piece of the puzzle, but this should make it so that we're not sending off a bunch of irrelevant bids, which solves the issue of having one of the irrelevant bids win and break our responsive layout.

This is implemented as a very early hook while pushing the initial adUnits into pbjs to put everything in its proper place before anything else starts touching the adUnits.

It allows for a 'bids' array to go into each sizeMapping instead of at the adUnit level. Depending on the screen size, it'll place the proper sizeMapping.bids into the adUnit.bids array, or just use the default bids if none exist or if sizeMapping doesn't exist at all for that adUnit.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Related to issue #1007 