### PR TITLE
Add a new generated field transactionId to each adunits.

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -29,6 +29,7 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
         return Object.assign(bid, {
           placementCode: adUnit.code,
           mediaType: adUnit.mediaType,
+          transactionId : adUnit.transactionId,
           sizes: sizes,
           bidId: utils.getUniqueIdentifierStr(),
           bidderRequestId,

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -429,9 +429,13 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
 $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.addAdUnits', arguments);
   if (utils.isArray(adUnitArr)) {
-    //append array to existing
+    // generate transactionid for each new adUnits
+    // Append array to existing
+    adUnitArr.forEach(adUnit => adUnit.transactionId = utils.generateUUID());
     $$PREBID_GLOBAL$$.adUnits.push.apply($$PREBID_GLOBAL$$.adUnits, adUnitArr);
   } else if (typeof adUnitArr === objectType_object) {
+    // Generate the transaction id for the adunit
+    adUnitArr.transactionId = utils.generateUUID();
     $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);
   }
 };

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -28,7 +28,8 @@ export function getBidRequests() {
           "bidderRequestId": "2946b569352ef2",
           "requestId": "1863e370099523",
           "startTime": 1462918897462,
-          "status": 1
+          "status": 1,
+          "transactionId": "fsafsa"
         },
         {
           "bidder": "appnexus",
@@ -50,7 +51,8 @@ export function getBidRequests() {
           "bidderRequestId": "2946b569352ef2",
           "requestId": "1863e370099523",
           "startTime": 1462918897463,
-          "status": 1
+          "status": 1,
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897460
@@ -79,7 +81,8 @@ export function getBidRequests() {
           ],
           "bidId": "6d11aa2d5b3659",
           "bidderRequestId": "5e1525bae3eb11",
-          "requestId": "1863e370099523"
+          "requestId": "1863e370099523",
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897463
@@ -112,7 +115,7 @@ export function getBidRequests() {
             "sizes": [
               15,
               10
-            ]
+            ],
           },
           "placementCode": "/19968336/header-bid-tag-0",
           "sizes": [
@@ -127,7 +130,8 @@ export function getBidRequests() {
           ],
           "bidId": "96aff279720d39",
           "bidderRequestId": "8778750ee15a77",
-          "requestId": "1863e370099523"
+          "requestId": "1863e370099523",
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897474
@@ -156,7 +160,8 @@ export function getBidRequests() {
           "bidId": "1144e2f0de84363",
           "bidderRequestId": "107f5e6e98dcf09",
           "requestId": "1863e370099523",
-          "startTime": 1462918897477
+          "startTime": 1462918897477,
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897475
@@ -185,7 +190,8 @@ export function getBidRequests() {
           "bidId": "135e89c039705da",
           "bidderRequestId": "12eeded736650b4",
           "requestId": "1863e370099523",
-          "status": 1
+          "status": 1,
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897477
@@ -215,7 +221,8 @@ export function getBidRequests() {
           "bidderRequestId": "167c4d79b615948",
           "requestId": "1863e370099523",
           "startTime": 1462918897480,
-          "status": 1
+          "status": 1,
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897479
@@ -245,7 +252,8 @@ export function getBidRequests() {
           "bidderRequestId": "18bed198c172a69",
           "requestId": "1863e370099523",
           "startTime": 1462918897481,
-          "status": 1
+          "status": 1,
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897480
@@ -273,7 +281,8 @@ export function getBidRequests() {
           ],
           "bidId": "21ae8131ec04f6e",
           "bidderRequestId": "20d0d30333715a7",
-          "requestId": "1863e370099523"
+          "requestId": "1863e370099523",
+          "transactionId": "fsafsa"
         }
       ],
       "start": 1462918897482

--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -83,6 +83,13 @@ describe('Publisher API _ AdUnits', function () {
       assert.strictEqual(bids2[1].params.placementId, '827326', 'adUnit2 bids2 params.placementId');
     });
 
+    it ('both add unit should contains a transactionid.'), function() {
+      assert.exist(adUnit1.transationId)
+      assert.exist(adUnit2.transationId)
+
+      assert.strictEqual(false, adUnit1.transationId === adUnit2.transationId)
+    }
+
     it('the second adUnits value should be same with the adUnits that is added by $$PREBID_GLOBAL$$.addAdUnits();', function () {
 
       assert.strictEqual(adUnit2.code, '/1996833/slot-2', 'adUnit2 code');


### PR DESCRIPTION
Transaction ID that must be common across all participants in
this bid request (e.g., potentially multiple exchanges) (OpenRTB v2.5).

## Type of change
- [x] Feature

## Description of change
As a buyer integrated with several adaptors, I want to be able to know when the same impression is being offered by two or more of them. The goal of this PR is to generate a unique transaction ID in prebid.js and then distributing it through adaptors and their own integrations.

Note that OpenRTB has already introduced the notion of "source" in its 2.5 version, and in particular a "tid" field to relay this impression identifier.

## Other information
This feature was first requested by https://github.com/prebid/Prebid.js/issues/877
