### PR TITLE
replace broken utils.extend functionality with object.assign

### DIFF
--- a/src/adapters/adkernel.js
+++ b/src/adapters/adkernel.js
@@ -176,7 +176,7 @@ const AdKernelAdapter = function AdKernelAdapter() {
    *  Create bid object for the bid manager
    */
   function createBidObject(resp, bid, width, height) {
-    return utils.extend(bidfactory.createBid(1, bid), {
+    return Object.assign(bidfactory.createBid(1, bid), {
       bidderCode: bid.bidder,
       ad: formatAdMarkup(resp),
       width: width,
@@ -189,7 +189,7 @@ const AdKernelAdapter = function AdKernelAdapter() {
    * Create empty bid object for the bid manager
    */
   function createEmptyBidObject(bid) {
-    return utils.extend(bidfactory.createBid(2, bid), {
+    return Object.assign(bidfactory.createBid(2, bid), {
       bidderCode: bid.bidder
     });
   }

--- a/src/adapters/analytics/example2.js
+++ b/src/adapters/analytics/example2.js
@@ -5,12 +5,11 @@ import { ajax } from 'src/ajax';
  */
 
 import adapter from 'AnalyticsAdapter';
-const utils = require('../../utils');
 
 const url = 'https://httpbin.org/post';
 const analyticsType = 'endpoint';
 
-export default utils.extend(adapter(
+export default Object.assign(adapter(
   {
     url,
     analyticsType

--- a/src/adapters/analytics/roxot.js
+++ b/src/adapters/analytics/roxot.js
@@ -6,7 +6,7 @@ const utils = require('../../utils');
 const url = '//d.rxthdr.com/analytics';
 const analyticsType = 'endpoint';
 
-export default utils.extend(adapter(
+export default Object.assign(adapter(
   {
     url,
     analyticsType

--- a/src/adapters/analytics/sharethrough_analytics.js
+++ b/src/adapters/analytics/sharethrough_analytics.js
@@ -6,7 +6,7 @@ const analyticsType = 'endpoint';
 const STR_BIDDER_CODE = "sharethrough";
 const STR_VERSION = "0.1.0";
 
-export default utils.extend(adapter(
+export default Object.assign(adapter(
   {
     emptyUrl,
     analyticsType

--- a/src/adapters/appnexus.js
+++ b/src/adapters/appnexus.js
@@ -98,7 +98,7 @@ AppNexusAdapter = function AppNexusAdapter() {
     }
 
     //append custom attributes:
-    var paramsCopy = utils.extend({}, bid.params);
+    var paramsCopy = Object.assign({}, bid.params);
 
     //delete attributes already used
     delete paramsCopy.placementId;

--- a/src/adapters/xhb.js
+++ b/src/adapters/xhb.js
@@ -69,7 +69,7 @@ const XhbAdapter = function XhbAdapter() {
     }
 
     //append custom attributes:
-    let paramsCopy = utils.extend({}, bid.params);
+    let paramsCopy = Object.assign({}, bid.params);
 
     //delete attributes already used
     delete paramsCopy.placementId;

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -342,7 +342,7 @@ function adjustBids(bid) {
   if (code && $$PREBID_GLOBAL$$.bidderSettings && $$PREBID_GLOBAL$$.bidderSettings[code]) {
     if (typeof $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment === objectType_function) {
       try {
-        bidPriceAdjusted = $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm, utils.extend({}, bid));
+        bidPriceAdjusted = $$PREBID_GLOBAL$$.bidderSettings[code].bidCpmAdjustment.call(null, bid.cpm, Object.assign({}, bid));
       }
       catch (e) {
         utils.logError('Error during bid adjustment', 'bidmanager.js', e);

--- a/src/events.js
+++ b/src/events.js
@@ -142,7 +142,7 @@ module.exports = (function () {
   _public.getEvents = function () {
     var arrayCopy = [];
     utils._each(eventsFired, function (value) {
-      var newProp = utils.extend({}, value);
+      var newProp = Object.assign({}, value);
       arrayCopy.push(newProp);
     });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -585,3 +585,7 @@ export function isSrcdocSupported(doc) {
   //Firefox is excluded due to https://bugzilla.mozilla.org/show_bug.cgi?id=1265961
   return !!doc.defaultView && 'srcdoc' in doc.defaultView.frameElement && !/firefox/i.test(navigator.userAgent);
 }
+
+export function cloneJson(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,22 +109,6 @@ exports.transformAdServerTargetingObj = function (targeting) {
   }
 };
 
-//Copy all of the properties in the source objects over to the target object
-//return the target object.
-exports.extend = function (target, source) {
-  target = target || {};
-
-  this._each(source, function (value, prop) {
-    if (typeof source[prop] === objectType_object) {
-      target[prop] = this.extend(target[prop], source[prop]);
-    } else {
-      target[prop] = source[prop];
-    }
-  });
-
-  return target;
-};
-
 /**
  * Parse a GPT-Style general size Array like `[[300, 250]]` or `"300x250,970x90"` into an array of sizes `["300x250"]` or '['300x250', '970x90']'
  * @param  {array[array|number]} sizeObj Input array or double array [300,250] or [[300,250], [728,90]]

--- a/test/spec/adapters/aol_spec.js
+++ b/test/spec/adapters/aol_spec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai';
-import { cloneDeep } from 'lodash';
 import * as utils from 'src/utils';
 import AolAdapter from 'src/adapters/aol';
 import bidmanager from 'src/bidmanager';
@@ -45,7 +44,7 @@ describe('AolAdapter', () => {
   beforeEach(() => adapter = new AolAdapter());
 
   function createBidderRequest({bids, params} = {}) {
-    var bidderRequest = cloneDeep(DEFAULT_BIDDER_REQUEST);
+    var bidderRequest = utils.cloneJson(DEFAULT_BIDDER_REQUEST);
     if (bids && Array.isArray(bids)) {
       bidderRequest.bids = bids;
     }

--- a/test/spec/adapters/lifestreet_spec.js
+++ b/test/spec/adapters/lifestreet_spec.js
@@ -1,11 +1,8 @@
 import {expect} from 'chai';
+import {cloneJson} from 'src/utils';
 import adloader from 'src/adloader';
 import bidmanager from 'src/bidmanager';
 import LifestreetAdapter from 'src/adapters/lifestreet';
-
-function copy(obj) {
-  return JSON.parse(JSON.stringify(obj));
-}
 
 const BIDDER_REQUEST = {
   auctionStart: new Date().getTime(),
@@ -47,7 +44,7 @@ describe ('LifestreetAdapter', () => {
 
       beforeEach(() => {
         tagRequests = [];
-        request = copy(BIDDER_REQUEST);
+        request = cloneJson(BIDDER_REQUEST);
         sinon.stub(adloader, 'loadScript', (url, callback) => {
           tagRequests.push(url);
           callback();

--- a/test/spec/adapters/lifestreet_spec.js
+++ b/test/spec/adapters/lifestreet_spec.js
@@ -1,8 +1,11 @@
 import {expect} from 'chai';
 import adloader from 'src/adloader';
 import bidmanager from 'src/bidmanager';
-import * as utils from 'src/utils';
 import LifestreetAdapter from 'src/adapters/lifestreet';
+
+function copy(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
 
 const BIDDER_REQUEST = {
   auctionStart: new Date().getTime(),
@@ -44,7 +47,7 @@ describe ('LifestreetAdapter', () => {
 
       beforeEach(() => {
         tagRequests = [];
-        request = utils.extend(request, BIDDER_REQUEST);
+        request = copy(BIDDER_REQUEST);
         sinon.stub(adloader, 'loadScript', (url, callback) => {
           tagRequests.push(url);
           callback();

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -130,7 +130,7 @@ describe('Utils', function () {
         c:'3'
       };
 
-      var output = utils.extend(target, source);
+      var output = Object.assign(target, source);
       assert.deepEqual(output, expectedResult);
     });
 
@@ -140,7 +140,7 @@ describe('Utils', function () {
         c:'3'
       };
 
-      var output = utils.extend(target, source);
+      var output = Object.assign(target, source);
       assert.deepEqual(output, source);
     });
 
@@ -151,7 +151,7 @@ describe('Utils', function () {
       };
       var source = {};
 
-      var output = utils.extend(target, source);
+      var output = Object.assign(target, source);
       assert.deepEqual(output, target);
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The `utils#extend` functionality was erroneously converting array properties in the source object to plain objects in the target object.  I found this bug when attempting to loop over the `bidderRequest.bids` array in a `BID_REQUESTED` event handler and saw that `events.getEvents()` was converting the bids array into a plain object.

Since `Object.assign` is available in Babel I removed `utils.extend` and replaced with `Object.assign` in every place I could find.  `Object.assign` also has the added benefit of allowing multiple sources. 