### PR TITLE
Add GourmetAds AppNexus Alias

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -73,6 +73,11 @@
       }
     },
     {
+      "appnexus": {
+        "alias": "gourmetads"
+      }
+    },
+    {
       "appnexusAst": {
         "supportedMediaTypes": ["video"]
       }


### PR DESCRIPTION
Adding Gourmet Ads as an alias of AppNexus adapter.