### PR TITLE
allow writing into current document if prebid is loaded inside an iframe

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -301,7 +301,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (!utils.inIframe() || adObject.mediaType === 'video') {
+        if ((doc === document && !utils.inIframe()) || adObject.mediaType === 'video') {
           utils.logError(`Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`);
         } else if (ad) {
           if (isSrcdocSupported(doc)) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -301,7 +301,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (!utils.isInIframe() || adObject.mediaType === 'video') {
+        if (!utils.inIframe() || adObject.mediaType === 'video') {
           utils.logError(`Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`);
         } else if (ad) {
           if (isSrcdocSupported(doc)) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -301,7 +301,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         var url = adObject.adUrl;
         var ad = adObject.ad;
 
-        if (doc === document || adObject.mediaType === 'video') {
+        if (!utils.isInIframe() || adObject.mediaType === 'video') {
           utils.logError(`Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`);
         } else if (ad) {
           if (isSrcdocSupported(doc)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -589,3 +589,11 @@ export function isSrcdocSupported(doc) {
 export function cloneJson(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
+
+export function isInIframe() {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return true;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -590,7 +590,7 @@ export function cloneJson(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-export function isInIframe() {
+export function inIframe() {
   try {
     return window.self !== window.top;
   } catch (e) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -583,7 +583,8 @@ export function adUnitsFilter(filter, bid) {
  */
 export function isSrcdocSupported(doc) {
   //Firefox is excluded due to https://bugzilla.mozilla.org/show_bug.cgi?id=1265961
-  return !!doc.defaultView && 'srcdoc' in doc.defaultView.frameElement && !/firefox/i.test(navigator.userAgent);
+  return doc.defaultView && doc.defaultView.frameElement &&
+    'srcdoc' in doc.defaultView.frameElement && !/firefox/i.test(navigator.userAgent);
 }
 
 export function cloneJson(obj) {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -513,6 +513,7 @@ describe('Unit: Prebid Module', function () {
     var adResponse = {};
     var spyLogError = null;
     var spyLogMessage = null;
+    var inIframe = true;
 
     beforeEach(function () {
       doc = {
@@ -535,6 +536,9 @@ describe('Unit: Prebid Module', function () {
 
       spyLogError = sinon.spy(utils, 'logError');
       spyLogMessage = sinon.spy(utils, 'logMessage');
+
+      inIframe = true;
+      sinon.stub(utils, "inIframe", () => inIframe);
     });
 
     afterEach(function () {
@@ -542,6 +546,7 @@ describe('Unit: Prebid Module', function () {
       $$PREBID_GLOBAL$$._winningBids = [];
       utils.logError.restore();
       utils.logMessage.restore();
+      utils.inIframe.restore();
     });
 
     it('should require doc and id params', function () {
@@ -576,7 +581,8 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyLogError.calledWith(error), 'expected error was logged');
     });
 
-    it('should log an error when doc is document', () => {
+    it('should log an error when not in an iFrame', () => {
+      inIframe = false;
       $$PREBID_GLOBAL$$.renderAd(document, bidId);
       const error = 'Error trying to write ad. Ad render call ad id ' + bidId + ' was prevented from writing to the main document.';
       assert.ok(spyLogError.calledWith(error), 'expected error was logged');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
For PostBid implementations, the secondary iframe ('postbid_if') where the ad is inserted into can cause view-ability metrics to drop. This enhancement allows the passing of the current document to the renderAd provided that prebid is loaded inside an iframe.

Updated PostBid Example: https://gist.github.com/surensilva/bdeec34abf1027acd8a87eb48a79f144