### PR TITLE
Add Facebook Audience Network adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -12,6 +12,7 @@
     "aol",
     "appnexus",
     "appnexusAst",
+    "audienceNetwork",
     "conversant",
     "districtmDMX",
     "fidelity",

--- a/integrationExamples/gpt/audienceNetwork_dfp.html
+++ b/integrationExamples/gpt/audienceNetwork_dfp.html
@@ -1,0 +1,83 @@
+<html>
+  <head>
+    <script src="/build/dev/prebid.js" async></script>
+    <script>
+      var PREBID_TIMEOUT = 2000;
+      var adUnits = [{
+        code: '/5555555/hb_300x250',
+        sizes: [[300, 250]],
+        bids: [{
+          bidder: 'audienceNetwork',
+          params: {
+            placementId: '555555555555555_555555555555555'
+          }
+        }]
+      }];
+
+      (function () {
+        var gads = document.createElement('script');
+        gads.async = true;
+        gads.type = 'text/javascript';
+        var useSSL = 'https:' == document.location.protocol;
+        gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+        var node = document.getElementsByTagName('script')[0];
+        node.parentNode.insertBefore(gads, node);
+      })();
+
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+      });
+      googletag.cmd.push(function () {
+        googletag.defineSlot('/5555555/hb_300x250', [[300, 250]], 'div-gpt-ad-5555555555555-0').addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+
+      var sendAdserverRequest = function () {
+        if (pbjs.adserverRequestSent) return;
+        pbjs.adserverRequestSent = true;
+        googletag.cmd.push(function() {
+          pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        });
+      };
+
+      setTimeout(function() {
+        sendAdserverRequest();
+      }, PREBID_TIMEOUT);
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+
+      pbjs.que.push(function() {
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({
+            bidsBackHandler: sendAdserverRequest
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <h2>Prebid.js Test</h2>
+    <div id='div-gpt-ad-5555555555555-0'>
+      <script>
+        googletag.cmd.push(function() {
+          googletag.display('div-gpt-ad-5555555555555-0');
+        });
+      </script>
+    </div>
+    <div>
+      <p>Audience Network quick start</p>
+      <ol>
+        <li>Create a new App at <a href="https://developers.facebook.com/apps">https://developers.facebook.com/apps</a></li>
+        <li>Add the Audience Network product to it</li>
+        <li>Create a new Placement to generate your placementId</li>
+        <li>To test, ensure the User-Agent request header represents a mobile device</li>
+      </ol>
+    </div>
+  </body>
+</html>

--- a/src/adapters/audienceNetwork.js
+++ b/src/adapters/audienceNetwork.js
@@ -1,0 +1,208 @@
+/**
+ * @file AudienceNetwork adapter.
+ */
+import { ajax } from '../ajax';
+import { createBid } from '../bidfactory';
+import { addBidResponse } from '../bidmanager';
+import { STATUS } from '../constants.json';
+import { format } from '../url';
+import { logError } from '../utils';
+import { createNew } from './adapter';
+
+const baseAdapter = createNew('audienceNetwork');
+const setBidderCode = baseAdapter.setBidderCode;
+const getBidderCode = baseAdapter.getBidderCode;
+
+/**
+ * Does this bid request contain valid parameters?
+ * @param {Object} bid
+ * @returns {Boolean}
+ */
+const validateBidRequest = bid =>
+  typeof bid.params === 'object' &&
+  typeof bid.params.placementId === 'string' &&
+  bid.params.placementId.length > 0 &&
+  Array.isArray(bid.sizes) && bid.sizes.length > 0;
+
+/**
+ * Does this bid request contain valid sizes?
+ * @param {Object} bid
+ * @returns {Boolean}
+ */
+const validateBidRequestSizes = bid => {
+  bid.sizes = bid.sizes.map(flattenSize);
+  return bid.sizes.every( size =>
+    ['native', 'fullwidth', '300x250', '320x50'].includes(size) );
+};
+
+/**
+ * Flattens a 2-element [W, H] array as a 'WxH' string,
+ * otherwise passes value through.
+ * @params {Array|String} size
+ * @returns {String}
+ */
+const flattenSize = size =>
+  (Array.isArray(size) && size.length === 2) ? `${size[0]}x${size[1]}` : size;
+
+/**
+ * Does the search part of the URL contain "anhb_testmode"
+ * and therefore indicate testmode should be used?
+ * @returns {String} "true" or "false"
+ */
+const isTestmode = () => Boolean(
+  window && window.location &&
+  typeof window.location.search === 'string' &&
+  window.location.search.indexOf('anhb_testmode') !== -1
+).toString();
+
+/**
+ * Parse JSON-as-string into an Object, default to empty.
+ * @param {String} JSON-as-string
+ * @returns {Object}
+ */
+const parseJson = jsonAsString => {
+  let data = {};
+  try {
+    data = JSON.parse(jsonAsString);
+  } catch (err) {}
+  return data;
+};
+
+/**
+ * Is this a native advert size?
+ * @param {String} size
+ * @returns {Boolean}
+ */
+const isNative = (size) => ['native', 'fullwidth'].includes(size);
+
+/**
+ * Generate ad HTML for injection into an iframe
+ * @param {String} placementId
+ * @param {String} size
+ * @param {String} bidId
+ * @returns {String} HTML
+ */
+const createAdHtml = (placementId, size, bidId) => {
+  const nativeStyle = isNative(size) ? '<script>window.onload=function(){if(parent){var o=document.getElementsByTagName("head")[0];var s=parent.document.getElementsByTagName("style");for(var i=0;i<s.length;i++)o.appendChild(s[i].cloneNode(true));}}</script>' : '';
+  const nativeContainer = isNative(size) ? '<div class="thirdPartyRoot"><a class="fbAdLink"><div class="fbAdMedia thirdPartyMediaClass"></div><div class="fbAdSubtitle thirdPartySubtitleClass"></div><div class="fbDefaultNativeAdWrapper"><div class="fbAdCallToAction thirdPartyCallToActionClass"></div><div class="fbAdTitle thirdPartyTitleClass"></div></div></a></div>' : '';
+  return `<html><head>${nativeStyle}</head><body><div style="display:none;position:relative;">
+<script>var data = {placementid:'${placementId}',format:'${size}',bidid:'${bidId}',onAdLoaded:function(e){e.style.display = 'block';},onAdError:function(c,m){console.log('Audience Network error (' + c + ') ' + m);}};
+(function(a,b,c){var d='https://www.facebook.com',e='https://connect.facebook.net/en_US/fbadnw55.js',f={iframeLoaded:true,xhrLoaded:true},g=5,h=a.data,i=0,j=function(ea){if(ea==null)throw new Error();return ea;},k=function(ea){if(ea instanceof HTMLElement)return ea;throw new Error();},l=function(){if(Date.now){return Date.now();}else return +new Date();},m=function(ea){if(++i>g)return;var fa=d+'/audience_network/client_event',ga={cb:l(),event_name:'ADNW_ADERROR',ad_pivot_type:'audience_network_mobile_web',sdk_version:'5.5.web',app_id:h.placementid.split('_')[0],publisher_id:h.placementid.split('_')[1],error_message:ea},ha=[];for(var ia in ga)ha.push(encodeURIComponent(ia)+'='+encodeURIComponent(ga[ia]));var ja=fa+'?'+ha.join('&'),ka=new XMLHttpRequest();ka.open('GET',ja,true);ka.send();},n=function(){if(b.currentScript){return b.currentScript;}else{var ea=b.getElementsByTagName('script');return ea[ea.length-1];}},o=function(ea){try{return ea.document.referrer;}catch(fa){}return '';},p=function(){var ea=a;try{while(ea!=ea.parent){ea.parent.origin;ea=ea.parent;}}catch(fa){}return ea;},q=function(ea){var fa=ea.indexOf('/',ea.indexOf('://')+3);if(fa===-1)return ea;return ea.substring(0,fa);},r=function(ea){return ea.location.href||o(ea);},s=function(ea,fa){if(ea.sdkLoaded)return;var ga=fa.createElement('iframe');ga.name='fbadnw';ga.style.display='none';j(fa.body).appendChild(ga);ga.contentWindow.addEventListener('error',function(event){m(event.message);},false);var ha=ga.contentDocument.createElement('script');ha.src=e;ha.async=true;j(ga.contentDocument.body).appendChild(ha);ea.sdkLoaded=true;},t=function(ea){var fa=/^https?:\\/\\/www\\.google(\\.com?)?.\\w{2,3}$/;return !!ea.match(fa);},u=function(ea){return ea.endsWith('cdn.ampproject.org');},v=function(){var ea=c.ancestorOrigins||[],fa=ea[ea.length-1]||c.origin,ga=ea[ea.length-2]||c.origin;if(t(fa)&&u(ga)){return q(ga);}else return q(fa);},w=function(ea){try{return JSON.parse(ea);}catch(fa){m(fa.message);return null;}},x=function(ea,fa,ga){if(!ea.iframe){var ha=ga.createElement('iframe');ha.src=d+'/audiencenetwork/iframe/';ha.style.display='none';j(ga.body).appendChild(ha);ea.iframe=ha;ea.iframeAppendedTime=l();ea.iframeData={};}fa.iframe=j(ea.iframe);fa.iframeData=ea.iframeData;fa.tagJsIframeAppendedTime=ea.iframeAppendedTime||0;},y=function(ea){var fa=d+'/audiencenetwork/xhr/?sdk=5.5.web';for(var ga in ea)if(typeof ea[ga]!=='function')fa+='&'+ga+'='+encodeURIComponent(ea[ga]);var ha=new XMLHttpRequest();ha.open('GET',fa,true);ha.withCredentials=true;ha.onreadystatechange=function(){if(ha.readyState===4){var ia=w(ha.response);if(ia)ea.events.push({name:'xhrLoaded',source:ea.iframe.contentWindow,data:ia,postMessageTimestamp:l(),receivedTimestamp:l()});}};ha.send();},z=function(ea,fa){var ga=d+'/audiencenetwork/xhriframe/?sdk=5.5.web';for(var ha in fa)if(typeof fa[ha]!=='function')ga+='&'+ha+'='+encodeURIComponent(fa[ha]);var ia=b.createElement('iframe');ia.src=ga;ia.style.display='none';j(b.body).appendChild(ia);fa.iframe=ia;fa.iframeData={};fa.tagJsIframeAppendedTime=l();},aa=function(ea){var fa=function(event){try{var ia=event.data;if(ia.name in f)ea.events.push({name:ia.name,source:event.source,data:ia.data});}catch(ha){}},ga=j(ea.iframe).contentWindow.parent;ga.addEventListener('message',fa,false);},ba=function(ea){if(ea.context)return true;try{return !!JSON.parse(decodeURI(ea.name)).ampcontextVersion;}catch(fa){return false;}},ca=function(ea){var fa=l(),ga=p(),ha=k(n().parentElement),ia=ga!=a.top,ja=ga.$sf&&ga.$sf.ext,ka=r(ga);ga.ADNW=ga.ADNW||{};ga.ADNW.v55=ga.ADNW.v55||{ads:[]};var la=ga.ADNW.v55;s(la,ga.document);var ma={amp:ba(ga),events:[],tagJsInitTime:fa,rootElement:ha,iframe:null,tagJsIframeAppendedTime:la.iframeAppendedTime||0,url:ka,domain:v(),channel:q(r(ga)),width:screen.width,height:screen.height,pixelratio:a.devicePixelRatio,placementindex:la.ads.length,crossdomain:ia,safeframe:!!ja,placementid:h.placementid,format:h.format||'300x250',testmode:!!h.testmode,onAdLoaded:h.onAdLoaded,onAdError:h.onAdError};if(h.bidid)ma.bidid=h.bidid;if(ia){z(la,ma);}else{x(la,ma,ga.document);y(ma);}aa(ma);ma.rootElement.dataset.placementid=ma.placementid;la.ads.push(ma);};try{ca();}catch(da){m(da.message||da);throw da;}})(window,document,location);
+</script>
+${nativeContainer}</div></body></html>`;
+};
+
+/**
+ * Creates a "good" Bid object with the given bid ID and CPM.
+ * @param {String} placementId
+ * @param {String} bidId
+ * @param {String} size
+ * @param {Number} cpmCents
+ * @returns {Object} Bid
+ */
+const createSuccessBidResponse = (placementId, size, bidId, cpmCents) => {
+  const bid = createBid(STATUS.GOOD, { bidId });
+  // Prebid attributes
+  bid.bidderCode = getBidderCode();
+  bid.cpm = cpmCents / 100;
+  bid.ad = createAdHtml(placementId, size, bidId);
+  if (!isNative(size)) {
+    [bid.width, bid.height] = size.split('x').map(Number);
+  }
+  // Audience Network attributes
+  bid.hb_bidder = 'fan';
+  bid.fb_bidid = bidId;
+  bid.fb_format = size;
+  bid.fb_placementid = placementId;
+  return bid;
+};
+
+/**
+ * Creates a "no bid" Bid object.
+ * @returns {Object} Bid
+ */
+const createFailureBidResponse = () => {
+  const bid = createBid(STATUS.NO_BID);
+  bid.bidderCode = getBidderCode();
+  return bid;
+};
+
+/**
+ * Fetch bids for given parameters.
+ * @param {Object} bidRequest
+ * @param {Array} params.bids - list of bids
+ * @param {String} params.bids[].placementCode - Prebid placement identifier
+ * @param {Object} params.bids[].params
+ * @param {String} params.bids[].params.placementId - Audience Network placement identifier
+ * @param {Array} params.bids[].sizes - list of accepted advert sizes
+ * @param {Array|String} params.bids[].sizes[] - one of 'native', '300x250', '300x50', [300, 250], [300, 50]
+ * @returns {void}
+ */
+const callBids = bidRequest => {
+  // Build lists of adUnitCodes, placementids and adformats
+  const adUnitCodes = [];
+  const placementids = [];
+  const adformats = [];
+  bidRequest.bids
+    .filter(validateBidRequest)
+    .filter(validateBidRequestSizes)
+    .forEach( bid => bid.sizes.forEach( size => {
+      adUnitCodes.push(bid.placementCode);
+      placementids.push(bid.params.placementId);
+      adformats.push(size);
+    }));
+
+  if (placementids.length) {
+    // Build URL
+    const testmode = isTestmode();
+    const url = format({
+      protocol: 'https',
+      host: 'an.facebook.com',
+      pathname: '/v2/placementbid.json',
+      search: {
+        sdk: '5.5.web',
+        testmode,
+        placementids,
+        adformats
+      }
+    });
+    // Request
+    ajax(url, res => {
+      // Handle response
+      const data = parseJson(res);
+      if (data.errors && data.errors.length) {
+        const noBid = createFailureBidResponse();
+        adUnitCodes.forEach( adUnitCode => addBidResponse(adUnitCode, noBid) );
+        data.errors.forEach(logError);
+      } else {
+        // For each placementId in bids Object
+        Object.keys(data.bids)
+          // extract Array of bid responses
+          .map( placementId => data.bids[placementId] )
+          // flatten
+          .reduce( (a, b) => a.concat(b), [] )
+          // call addBidResponse
+          .forEach( (bid, i) =>
+            addBidResponse(adUnitCodes[i], createSuccessBidResponse(
+              bid.placement_id, adformats[i], bid.bid_id, bid.bid_price_cents
+            ))
+          );
+      }
+    }, null, { withCredentials: true });
+  } else {
+    // No valid bids
+    logError('No valid bids requested');
+  }
+};
+
+/**
+ * @class AudienceNetwork
+ * @type {Object}
+ * @property {Function} callBids - fetch bids for given parameters
+ * @property {Function} setBidderCode - used for bidder aliasing
+ * @property {Function} getBidderCode - unique 'audienceNetwork' identifier
+ */
+const AudienceNetwork = () => {
+  return { callBids, setBidderCode, getBidderCode };
+};
+module.exports = AudienceNetwork;

--- a/test/spec/adapters/audienceNetwork_spec.js
+++ b/test/spec/adapters/audienceNetwork_spec.js
@@ -1,0 +1,333 @@
+/**
+ * @file Tests for AudienceNetwork adapter.
+ */
+import { expect } from 'chai';
+
+import bidmanager from 'src/bidmanager';
+import { STATUS } from 'src/constants.json';
+import * as utils from 'src/utils';
+
+import AudienceNetwork from 'src/adapters/audienceNetwork';
+
+const bidderCode = 'audienceNetwork';
+const placementId = 'test-placement-id';
+const placementCode = '/test/placement/code';
+
+/**
+ * Expect haystack string to contain needle n times.
+ * @param {String} haystack
+ * @param {String} needle
+ * @param {String} [n=1]
+ * @throws {Error}
+ */
+const expectToContain = (haystack, needle, n = 1) =>
+  expect(haystack.split(needle)).to.have.lengthOf(n + 1,
+    `expected ${n} occurrence(s) of '${needle}' in '${haystack}'`);
+
+
+describe('AudienceNetwork adapter', () => {
+
+  describe('Public API', () => {
+    const adapter = AudienceNetwork();
+    it('getBidderCode', () => {
+      expect(adapter.getBidderCode).to.be.a('function');
+      expect(adapter.getBidderCode()).to.equal(bidderCode);
+    });
+    it('setBidderCode', () => {
+      expect(adapter.setBidderCode).to.be.a('function');
+    });
+    it('callBids', () => {
+      expect(adapter.setBidderCode).to.be.a('function');
+    });
+  });
+
+  describe('callBids parameter parsing', () => {
+
+    let xhr;
+    let requests;
+    let addBidResponse;
+    let logError;
+
+    beforeEach(() => {
+      xhr = sinon.useFakeXMLHttpRequest();
+      xhr.onCreate = request => requests.push(request);
+      requests = [];
+      addBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+      logError = sinon.stub(utils, 'logError');
+    });
+
+    afterEach(() => {
+      xhr.restore();
+      bidmanager.addBidResponse.restore();
+      utils.logError.restore();
+    });
+
+    it('missing placementId parameter', () => {
+      // Invalid parameters
+      const params = {
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          sizes: ['native']
+        }]
+      };
+      // Request bids
+      AudienceNetwork().callBids(params);
+      // Verify no attempt to fetch response
+      expect(requests).to.have.lengthOf(0);
+      // Verify no attempt to add a response as no placement was provided
+      expect(addBidResponse.calledOnce).to.equal(false);
+      // Verify attempt to log error
+      expect(logError.calledOnce).to.equal(true);
+    });
+
+    it('invalid sizes parameter', () => {
+      // Invalid parameters
+      const params = {
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          params: { placementId },
+          sizes: ['', undefined, null, '300x100', [300, 100], [300], {}]
+        }]
+      };
+      // Request bids
+      AudienceNetwork().callBids(params);
+      // Verify no attempt to fetch response
+      expect(requests).to.have.lengthOf(0);
+      // Verify attempt to log error
+      expect(logError.calledOnce).to.equal(true);
+    });
+
+    it('valid parameters', () => {
+      // Valid parameters
+      const params = {
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          params: { placementId },
+          sizes: [[320, 50], [300, 250], '300x250', 'fullwidth', '320x50', 'native']
+        }]
+      };
+      // Request bids
+      AudienceNetwork().callBids(params);
+      // Verify attempt to fetch response
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].method).to.equal('GET');
+      expectToContain(requests[0].url, 'https://an.facebook.com/v2/placementbid.json?');
+      expectToContain(requests[0].url, 'placementids[]=test-placement-id', 6);
+      expectToContain(requests[0].url, 'adformats[]=320x50', 2);
+      expectToContain(requests[0].url, 'adformats[]=300x250', 2);
+      expectToContain(requests[0].url, 'adformats[]=fullwidth');
+      expectToContain(requests[0].url, 'adformats[]=native');
+      // Verify no attempt to log error
+      expect(logError.called).to.equal(false);
+    });
+
+  });
+
+  describe('callBids response handling', () => {
+
+    let server;
+    let addBidResponse;
+    let logError;
+
+    beforeEach( () => {
+      server = sinon.fakeServer.create();
+      addBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+      logError = sinon.stub(utils, 'logError');
+    });
+
+    afterEach( () => {
+      server.restore();
+      bidmanager.addBidResponse.restore();
+      utils.logError.restore();
+    });
+
+    it('error in response', () => {
+      // Error response
+      const error = 'test-error-message';
+      server.respondWith(JSON.stringify({
+        errors: [error]
+      }));
+      // Request bids
+      AudienceNetwork().callBids({
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          params: { placementId },
+          sizes: ['native']
+        }]
+      });
+      server.respond();
+      // Verify attempt to call addBidResponse
+      expect(addBidResponse.calledOnce).to.equal(true);
+      expect(addBidResponse.args[0]).to.have.lengthOf(2);
+      expect(addBidResponse.args[0][1].getStatusCode()).to.equal(STATUS.NO_BID);
+      expect(addBidResponse.args[0][1].bidderCode).to.equal(bidderCode);
+      // Verify attempt to log error
+      expect(logError.calledOnce).to.equal(true);
+      expect(logError.calledWith(error)).to.equal(true);
+    });
+
+    it('valid native bid in response', () => {
+      // Valid response
+      server.respondWith(JSON.stringify({
+        errors: [],
+        bids: {
+          [placementId]: [{
+            placement_id: placementId,
+            bid_id: 'test-bid-id',
+            bid_price_cents: 123,
+            bid_price_currency: 'usd',
+            bid_price_model: 'cpm'
+          }]
+        }
+      }));
+      // Request bids
+      AudienceNetwork().callBids({
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          placementCode,
+          params: { placementId },
+          sizes: ['native']
+        }]
+      });
+      server.respond();
+      // Verify attempt to call addBidResponse
+      expect(addBidResponse.calledOnce).to.equal(true);
+      expect(addBidResponse.args[0]).to.have.lengthOf(2);
+      expect(addBidResponse.args[0][0]).to.equal(placementCode);
+      // Verify Prebid attributes in bid response
+      const bidResponse = addBidResponse.args[0][1];
+      expect(bidResponse.getStatusCode()).to.equal(STATUS.GOOD);
+      expect(bidResponse.cpm).to.equal(1.23);
+      expect(bidResponse.bidderCode).to.equal(bidderCode);
+      expect(bidResponse.width).to.equal(0);
+      expect(bidResponse.height).to.equal(0);
+      expect(bidResponse.ad).to.contain(`placementid:'${placementId}',format:'native',bidid:'test-bid-id'`, 'ad missing parameters');
+      expect(bidResponse.ad).to.contain('getElementsByTagName("style")', 'ad missing native styles');
+      expect(bidResponse.ad).to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad missing native container');
+      // Verify Audience Network attributes in bid response
+      expect(bidResponse.hb_bidder).to.equal('fan');
+      expect(bidResponse.fb_bidid).to.equal('test-bid-id');
+      expect(bidResponse.fb_format).to.equal('native');
+      expect(bidResponse.fb_placementid).to.equal(placementId);
+      // Verify no attempt to log error
+      expect(logError.called).to.equal(false, 'logError called');
+    });
+
+    it('valid IAB bid in response', () => {
+      // Valid response
+      server.respondWith(JSON.stringify({
+        errors: [],
+        bids: {
+          [placementId]: [{
+            placement_id: placementId,
+            bid_id: 'test-bid-id',
+            bid_price_cents: 123,
+            bid_price_currency: 'usd',
+            bid_price_model: 'cpm'
+          }]
+        }
+      }));
+      // Request bids
+      AudienceNetwork().callBids({
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          placementCode,
+          params: { placementId },
+          sizes: ['300x250']
+        }]
+      });
+      server.respond();
+      // Verify attempt to call addBidResponse
+      expect(addBidResponse.calledOnce).to.equal(true);
+      expect(addBidResponse.args[0]).to.have.lengthOf(2);
+      expect(addBidResponse.args[0][0]).to.equal(placementCode);
+      // Verify bidResponse Object
+      const bidResponse = addBidResponse.args[0][1];
+      expect(bidResponse.getStatusCode()).to.equal(STATUS.GOOD);
+      expect(bidResponse.cpm).to.equal(1.23);
+      expect(bidResponse.bidderCode).to.equal(bidderCode);
+      expect(bidResponse.width).to.equal(300);
+      expect(bidResponse.height).to.equal(250);
+      expect(bidResponse.ad).to.contain(`placementid:'${placementId}',format:'300x250',bidid:'test-bid-id'`, 'ad missing parameters');
+      expect(bidResponse.ad).not.to.contain('getElementsByTagName("style")', 'ad should not contain native styles');
+      expect(bidResponse.ad).not.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad should not contain native container');
+      // Verify no attempt to log error
+      expect(logError.called).to.equal(false, 'logError called');
+    });
+
+    it('valid multiple bids in response', () => {
+      const placementIdNative = 'test-placement-id-native';
+      const placementIdIab = 'test-placement-id-iab';
+      const placementCodeNative = 'test-placement-code-native';
+      const placementCodeIab = 'test-placement-code-iab';
+      // Valid response
+      server.respondWith(JSON.stringify({
+        errors: [],
+        bids: {
+          [placementIdNative]: [{
+            placement_id: placementIdNative,
+            bid_id: 'test-bid-id-native',
+            bid_price_cents: 123,
+            bid_price_currency: 'usd',
+            bid_price_model: 'cpm'
+          }],
+          [placementIdIab]: [{
+            placement_id: placementIdIab,
+            bid_id: 'test-bid-id-iab',
+            bid_price_cents: 456,
+            bid_price_currency: 'usd',
+            bid_price_model: 'cpm'
+          }]
+        }
+      }));
+      // Request bids
+      AudienceNetwork().callBids({
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          placementCode: placementCodeNative,
+          params: { placementId: placementIdNative },
+          sizes: ['native']
+        }, {
+          bidder: bidderCode,
+          placementCode: placementCodeIab,
+          params: { placementId: placementIdIab },
+          sizes: ['300x250']
+        }]
+      });
+      server.respond();
+      // Verify multiple attempts to call addBidResponse
+      expect(addBidResponse.calledTwice).to.equal(true);
+      // Verify native
+      const addBidResponseNativeCall = addBidResponse.args[0];
+      expect(addBidResponseNativeCall).to.have.lengthOf(2);
+      expect(addBidResponseNativeCall[0]).to.equal(placementCodeNative);
+      expect(addBidResponseNativeCall[1].getStatusCode()).to.equal(STATUS.GOOD);
+      expect(addBidResponseNativeCall[1].cpm).to.equal(1.23);
+      expect(addBidResponseNativeCall[1].bidderCode).to.equal(bidderCode);
+      expect(addBidResponseNativeCall[1].width).to.equal(0);
+      expect(addBidResponseNativeCall[1].height).to.equal(0);
+      expect(addBidResponseNativeCall[1].ad).to.contain(`placementid:'${placementIdNative}',format:'native',bidid:'test-bid-id-native'`, 'ad missing parameters');
+      // Verify IAB
+      const addBidResponseIabCall = addBidResponse.args[1];
+      expect(addBidResponseIabCall).to.have.lengthOf(2);
+      expect(addBidResponseIabCall[0]).to.equal(placementCodeIab);
+      expect(addBidResponseIabCall[1].getStatusCode()).to.equal(STATUS.GOOD);
+      expect(addBidResponseIabCall[1].cpm).to.equal(4.56);
+      expect(addBidResponseIabCall[1].bidderCode).to.equal(bidderCode);
+      expect(addBidResponseIabCall[1].width).to.equal(300);
+      expect(addBidResponseIabCall[1].height).to.equal(250);
+      expect(addBidResponseIabCall[1].ad).to.contain(`placementid:'${placementIdIab}',format:'300x250',bidid:'test-bid-id-iab'`, 'ad missing parameters');
+      // Verify no attempt to log error
+      expect(logError.called).to.equal(false, 'logError called');
+    });
+
+  });
+
+});


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

Hello, I'm sure some contributors to this very useful header bidding product will be aware of the recent news that Facebook Audience Network now supports header bidding.
https://adexchanger.com/publishers/facebook-launches-header-bidding-turns-partners-tech/

As well as [the adapter itself](https://github.com/lovell/Prebid.js/blob/5610a19b118b7022ebc0a4e9a98f9ef9f3970883/src/adapters/audienceNetwork.js), this PR includes an [integration example](https://github.com/lovell/Prebid.js/blob/5610a19b118b7022ebc0a4e9a98f9ef9f3970883/integrationExamples/gpt/audienceNetwork_dfp.html) of its possible use.

(The branch coverage of the [provided unit tests](https://github.com/lovell/Prebid.js/blob/5610a19b118b7022ebc0a4e9a98f9ef9f3970883/test/spec/adapters/audienceNetwork_spec.js) is 100% but due to the coverage reporter's use of ES5 this is currently displayed as only 59%. I hope this is OK.)

Feedback is very much welcome.

- [x] official adapter submission
