### PR TITLE
Fixes SpringServe adapter

### DIFF
--- a/src/adapters/springserve.js
+++ b/src/adapters/springserve.js
@@ -70,7 +70,7 @@ SpringServeAdapter = function SpringServeAdapter() {
       //var requestObj = bidmanager.getPlacementIdByCBIdentifer(responseBid.impid);
       var requestBids = $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'springserve');
       if (requestBids && requestBids.bids.length > 0) {
-        requestBids = requestBids.bids.filter(bid => bid.params && bid.params.impId === +responseBid.impid);
+        requestBids = requestBids.bids.filter(bid => bid.params && bid.params.impId === responseBid.impid);
       } else {
         requestBids = [];
       }


### PR DESCRIPTION
Fixes - #1100

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
I get this response from bidder.springserve.com:
```
pbjs.handleSpringServeCB({"nbr":0,"id":"1","seatbid":[{"seat":"YH","bid":[{"ext":null,"id":"7777-333-444_1","impid":"7777-333-444","crid":null,"price":0.64083135,"adm":"DEBUG BID CONTENT","dealid":""}]}],"cur":"USD"})
```
https://github.com/prebid/Prebid.js/blob/master/src/adapters/springserve.js#L73
has this check: `bid.params.impId === +responseBid.impid `
response from springserve has `responseBid.impid = "7777-333-444"`. Which becomes `NaN` because of preceding `+`

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
