### PR TITLE
Add support for custom floor value in rubicon video

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -162,7 +162,7 @@ function RubiconAdapter() {
       site_id: params.siteId,
       zone_id: params.zoneId,
       position: params.position || 'btf',
-      floor: 0.01,
+      floor: parseFloat(params.floor) > 0.01 ? params.floor : 0.01,
       element_id: bid.placementCode,
       name: bid.placementCode,
       language: params.video.language,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Other

## Description of change
Video for rubicon now allows a custom floor override variable through `bid.params.floor`.  Regular Rubicon requests already allowed this, so there is no API change; but video now honors that parameter.

## Other information
A few more unit tests were added around video as well.