### PR TITLE
fix bid CPM returned from AdformAdapter

### DIFF
--- a/src/adapters/adform.js
+++ b/src/adapters/adform.js
@@ -73,7 +73,7 @@ function AdformAdapter() {
 
           bidObject = bidfactory.createBid(STATUSCODES.GOOD, bid);
           bidObject.bidderCode = bidder;
-          bidObject.cpm = adItem.win_bid;
+          bidObject.cpm = adItem.win_bid * 1000;
           bidObject.cur = adItem.win_cur;
           bidObject.ad = adItem.banner;
           bidObject.width = adItem.width;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
AdformAdapter returns response with incorrect bid CPM. The value is 1000x smaller.

Here are screenshots that demonstrate it:

- setup of a test campaign in Adform with CPM set to 2.60Eur https://goo.gl/RmI0Iu
- chrome debug showing that cpm value is 0.0026 https://goo.gl/aapNW7
- console log of pbjs_debug=True showing that hb_pb value is 0.00 instead of 2.60 https://goo.gl/qEsXty

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

Seems suspicious to me that nobody reported this yet. So, probably an official maintainer of the adform adapter should confirm it?
