### PR TITLE
Feature/error shows proper line

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -78,9 +78,10 @@ $$PREBID_GLOBAL$$.adUnits = $$PREBID_GLOBAL$$.adUnits || [];
 $$PREBID_GLOBAL$$.que.push = function (cmd) {
   if (typeof cmd === objectType_function) {
     try {
+      utils.logError('foobar', 'me', 'this');
       cmd.call();
     } catch (e) {
-      utils.logError('Error processing command :' + e.message);
+      utils.logError('Error processing command :', e.message, e.stack);
     }
   } else {
     utils.logError('Commands written into $$PREBID_GLOBAL$$.que.push must wrapped in a function');

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -78,7 +78,6 @@ $$PREBID_GLOBAL$$.adUnits = $$PREBID_GLOBAL$$.adUnits || [];
 $$PREBID_GLOBAL$$.que.push = function (cmd) {
   if (typeof cmd === objectType_function) {
     try {
-      utils.logError('foobar', 'me', 'this');
       cmd.call();
     } catch (e) {
       utils.logError('Error processing command :', e.message, e.stack);

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,13 +215,8 @@ function hasConsoleLogger() {
 
 exports.hasConsoleLogger = hasConsoleLogger;
 
-var errLogFn = (function (hasLogger) {
-  if (!hasLogger) return '';
-  return window.console.error ? 'error' : 'log';
-}(hasConsoleLogger()));
-
 var debugTurnedOn = function () {
-  if ($$PREBID_GLOBAL$$.logging === false && _loggingChecked === false) {
+  if (!$$PREBID_GLOBAL$$.logging  && _loggingChecked === false) {
     $$PREBID_GLOBAL$$.logging = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
     _loggingChecked = true;
   }
@@ -231,12 +226,17 @@ var debugTurnedOn = function () {
 
 exports.debugTurnedOn = debugTurnedOn;
 
-exports.logError = function (msg, code, exception) {
-  var errCode = code || 'ERROR';
-  if (debugTurnedOn() && hasConsoleLogger()) {
-    console[errLogFn](console, errCode + ': ' + msg, exception || '');
+exports.logError =  (() => {
+  if(!debugTurnedOn()) {
+    return () =>{};
   }
-};
+  if(console.error.bind) {
+    return console.error.bind(window.console);
+  }
+  else {
+    return console.error;
+  }
+})();
 
 exports.createInvisibleIframe = function _createInvisibleIframe() {
   var f = document.createElement('iframe');
@@ -260,7 +260,7 @@ exports.createInvisibleIframe = function _createInvisibleIframe() {
  *   Check if a given parameter name exists in query string
  *   and if it does return the value
  */
-var getParameterByName = function (name) {
+function getParameterByName(name) {
   var regexS = '[\\?&]' + name + '=([^&#]*)';
   var regex = new RegExp(regexS);
   var results = regex.exec(window.location.search);
@@ -269,7 +269,7 @@ var getParameterByName = function (name) {
   }
 
   return decodeURIComponent(results[1].replace(/\+/g, ' '));
-};
+}
 
 /**
  * This function validates paramaters.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
+import { getGlobal } from './prebidGlobal';
 var CONSTANTS = require('./constants.json');
+var $$PREBID_GLOBAL$$ = getGlobal();
 
 var objectType_object = 'object';
 var objectType_string = 'string';


### PR DESCRIPTION
## Type of change
- [x] Feature
## Description of change
Been wanting to make this change forever, but this is to show proper line number/call stack when an error happens (caught or uncaught) via `console.error`.

Before :( 

![image](https://cloud.githubusercontent.com/assets/1870166/25149384/3e2fe6f2-244c-11e7-813d-84d096e5bda7.png)

After (YAY!!!)
![snip20170418_13](https://cloud.githubusercontent.com/assets/1870166/25149350/1bd12454-244c-11e7-91e0-eba3334ec629.png)


Also fixes (https://github.com/prebid/Prebid.js/issues/949) - which is an actual issue. 

## Other information
@prebid/core 