### PR TITLE
Widespace adapter validate size fix

### DIFF
--- a/src/adapters/widespace.js
+++ b/src/adapters/widespace.js
@@ -5,7 +5,7 @@ const utils = require('../utils.js');
 const adloader = require('../adloader.js');
 const bidmanager = require('../bidmanager.js');
 const bidfactory = require('../bidfactory.js');
-const WS_ADAPTER_VERSION = '1.0.1';
+const WS_ADAPTER_VERSION = '1.0.2';
 
 function WidespaceAdapter() {
   let useSSL = 'https:' === document.location.protocol,

--- a/src/adapters/widespace.js
+++ b/src/adapters/widespace.js
@@ -68,7 +68,7 @@ function WidespaceAdapter() {
           placementCode = '',
           validSizes = [];
 
-      bid.sizes = {height: bid.height, width: bid.height};
+      bid.sizes = {height: bid.height, width: bid.width};
 
       var inBid = getBidRequest(bid.callbackUid);
 

--- a/src/adapters/widespace.js
+++ b/src/adapters/widespace.js
@@ -95,7 +95,6 @@ function WidespaceAdapter() {
       }
     }
 
-
     function verifySize(bid, validSizes) {
       for (var j = 0, k = validSizes.length; j < k; j++) {
         if (bid.width === validSizes[j][0] &&


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

- A bugfix for Widespace adapter where we was validating the bid sizes wrong. Causing that we rejected bid responses that was not in a square format.
After this fix we can deliver panorama ad´s etc.

- contact email of the adapter’s maintainer
jonas.mattsson@widespace.com

