### PR TITLE
Update polyfills to use core-js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "yargs": "^1.3.1"
   },
   "dependencies": {
-    "array-includes": "^3.0.2",
-    "array.prototype.find": "^2.0.3"
+    "core-js": "^2.4.1"
   }
 }

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -2,16 +2,8 @@
 Misc polyfills
 */
 /*jshint -W121 */
-import shimArrayFind from 'array.prototype.find/shim';
-import shimArrayIncludes from 'array-includes/shim';
-
-if (!Array.prototype.find) {
-  shimArrayFind();
-}
-
-if (!Array.prototype.includes) {
-  shimArrayIncludes();
-}
+require('core-js/fn/array/find');
+require('core-js/fn/array/includes');
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
 Number.isInteger = Number.isInteger || function(value) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,7 +828,7 @@ babel-polyfill@^6.13.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@^6.5.0:
+babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -1857,7 +1857,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-"dargs@github:christian-bromann/dargs":
+dargs@christian-bromann/dargs:
   version "4.0.1"
   resolved "https://codeload.github.com/christian-bromann/dargs/tar.gz/7d6d4164a7c4106dbd14ef39ed8d95b7b5e9b770"
   dependencies:
@@ -2353,11 +2353,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.2, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -4853,11 +4853,7 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
-
-lru-cache@2.2.x:
+lru-cache@2, lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 


### PR DESCRIPTION
## Type of change

- [X] Refactoring (no functional changes, no api changes)

## Description of change

Reduces file size by 9K. Fixes #1125. From https://babeljs.io/docs/usage/polyfill/ which recommends https://github.com/zloirock/core-js#commonjs

I'd prefer to revert #962 over this, as I can't reproduce the IE error. I think they were basically the standard polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

When do you run IE tests? Is travis-ci doing this on each PR? Is there coverage for this?