### PR TITLE
Audience Network: bid when at least one valid slot size

### DIFF
--- a/src/adapters/audienceNetwork.js
+++ b/src/adapters/audienceNetwork.js
@@ -9,9 +9,7 @@ import { format } from '../url';
 import { logError } from '../utils';
 import { createNew } from './adapter';
 
-const baseAdapter = createNew('audienceNetwork');
-const setBidderCode = baseAdapter.setBidderCode;
-const getBidderCode = baseAdapter.getBidderCode;
+const { setBidderCode, getBidderCode } = createNew('audienceNetwork');
 
 /**
  * Does this bid request contain valid parameters?
@@ -25,14 +23,15 @@ const validateBidRequest = bid =>
   Array.isArray(bid.sizes) && bid.sizes.length > 0;
 
 /**
- * Does this bid request contain valid sizes?
+ * Return a copy of a bid with slot sizes flattened and filtered
  * @param {Object} bid
- * @returns {Boolean}
+ * @returns {Object} copy of bid
  */
-const validateBidRequestSizes = bid => {
-  bid.sizes = bid.sizes.map(flattenSize);
-  return bid.sizes.every( size =>
-    ['native', 'fullwidth', '300x250', '320x50'].includes(size) );
+const flattenBidRequestSizes = bid => {
+  const sizes = Array.isArray(bid.sizes) && bid.sizes
+    .map(flattenSize)
+    .filter(isValidSize);
+  return Object.assign({}, bid, { sizes });
 };
 
 /**
@@ -43,6 +42,13 @@ const validateBidRequestSizes = bid => {
  */
 const flattenSize = size =>
   (Array.isArray(size) && size.length === 2) ? `${size[0]}x${size[1]}` : size;
+
+/**
+ * Is this a valid slot size?
+ * @param {String} size
+ * @returns  {Boolean}
+ */
+const isValidSize = size => ['native', 'fullwidth', '300x250', '320x50'].includes(size);
 
 /**
  * Does the search part of the URL contain "anhb_testmode"
@@ -144,8 +150,8 @@ const callBids = bidRequest => {
   const placementids = [];
   const adformats = [];
   bidRequest.bids
+    .map(flattenBidRequestSizes)
     .filter(validateBidRequest)
-    .filter(validateBidRequestSizes)
     .forEach( bid => bid.sizes.forEach( size => {
       adUnitCodes.push(bid.placementCode);
       placementids.push(bid.params.placementId);
@@ -202,7 +208,6 @@ const callBids = bidRequest => {
  * @property {Function} setBidderCode - used for bidder aliasing
  * @property {Function} getBidderCode - unique 'audienceNetwork' identifier
  */
-const AudienceNetwork = () => {
-  return { callBids, setBidderCode, getBidderCode };
-};
+const AudienceNetwork = () => ({ callBids, setBidderCode, getBidderCode });
+
 module.exports = AudienceNetwork;

--- a/test/spec/adapters/audienceNetwork_spec.js
+++ b/test/spec/adapters/audienceNetwork_spec.js
@@ -261,6 +261,51 @@ describe('AudienceNetwork adapter', () => {
       expect(logError.called).to.equal(false, 'logError called');
     });
 
+    it('filters invalid slot sizes', () => {
+      // Valid response
+      server.respondWith(JSON.stringify({
+        errors: [],
+        bids: {
+          [placementId]: [{
+            placement_id: placementId,
+            bid_id: 'test-bid-id',
+            bid_price_cents: 123,
+            bid_price_currency: 'usd',
+            bid_price_model: 'cpm'
+          }]
+        }
+      }));
+      // Request bids
+      AudienceNetwork().callBids({
+        bidderCode,
+        bids: [{
+          bidder: bidderCode,
+          placementCode,
+          params: { placementId },
+          sizes: ['350x200']
+        }, {
+          bidder: bidderCode,
+          placementCode,
+          params: { placementId },
+          sizes: ['300x250']
+        }]
+      });
+      server.respond();
+      // Verify attempt to call addBidResponse
+      expect(addBidResponse.calledOnce).to.equal(true);
+      expect(addBidResponse.args[0]).to.have.lengthOf(2);
+      expect(addBidResponse.args[0][0]).to.equal(placementCode);
+      // Verify bidResponse Object
+      const bidResponse = addBidResponse.args[0][1];
+      expect(bidResponse.getStatusCode()).to.equal(STATUS.GOOD);
+      expect(bidResponse.cpm).to.equal(1.23);
+      expect(bidResponse.bidderCode).to.equal(bidderCode);
+      expect(bidResponse.width).to.equal(300);
+      expect(bidResponse.height).to.equal(250);
+      // Verify no attempt to log error
+      expect(logError.called).to.equal(false, 'logError called');
+    });
+
     it('valid multiple bids in response', () => {
       const placementIdNative = 'test-placement-id-native';
       const placementIdIab = 'test-placement-id-iab';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Hello, this change ensures the Audience Network adaptor will bid on *any* supported slot size. The current behaviour expects *all* slot sizes to be supported before bids are requested.

/cc @wheresbarney @dverbru