### PR TITLE
Add PubWise Bid Simulator

### DIFF
--- a/src/adapters/pubwiseSim.js
+++ b/src/adapters/pubwiseSim.js
@@ -1,0 +1,126 @@
+var CONSTANTS = require('../constants.json');
+var utils = require('../utils.js');
+var bidfactory = require('../bidfactory.js');
+var bidmanager = require('../bidmanager.js');
+var adloader = require('../adloader');
+
+/******
+ * PubWise.io Bid Simulator Adapter
+ * Contact: support@pubwise.io
+ * Developer: Stephen Johnston
+ ***/
+
+var PubwiseSimAdapter = function PubwiseSimAdapter() {
+  var pubwiseUrl = "adtest.pubwise.io/api/v1/bid/get";
+
+  $$PREBID_GLOBAL$$.pubwiseSimResponseHandler = pubwiseSimResponseHandler;
+
+  return {
+    callBids: _callBids
+  };
+
+  function _callBids(bidReqs) {
+    utils.logInfo('pubwise callBids adapter beginning');
+
+    var domain = window.location.host;
+    var page = window.location.pathname + location.search + location.hash;
+
+    var pubwiseBidReqs = {
+      id: utils.getUniqueIdentifierStr(),
+      bids: bidReqs,
+      site: {
+        domain: domain,
+        page: page
+      }
+    };
+
+    var scriptUrl = '//' + pubwiseUrl + '?callback=$$PREBID_GLOBAL$$.pubwiseSimResponseHandler' +
+      '&src=' + CONSTANTS.REPO_AND_VERSION +
+      '&bidpayload=' + encodeURIComponent(JSON.stringify(pubwiseBidReqs));
+
+    adloader.loadScript(scriptUrl);
+    utils.logInfo('pubwise callBids complete');
+  }
+
+  function pubwiseSimResponseHandler(pubwiseResponseObject) {
+    utils.logInfo('pubwiseSim ResponseHandler beginning');
+    utils.logInfo('Response Object', pubwiseResponseObject);
+    var placements = [];
+
+    if (isInvalidResponse()) {
+      utils.logInfo('invalid response');
+      return fillEmptyBidReturns();
+    }
+
+    pubwiseResponseObject.bids.forEach(addPubwiseBidResponse);
+    var allBidResponse = fillEmptyBidReturns(placements);
+    utils.logInfo('pubwise Response handler complete');
+
+    return allBidResponse;
+
+    function addPubwiseBidResponse(pubwiseBid) {
+      utils.logInfo('pubwiseSim Bid', pubwiseBid);
+      utils.logInfo('pubwiseSim Reqs', $$PREBID_GLOBAL$$._bidsRequested.find(bidSet => bidSet.bidderCode === 'pubwiseSim'));
+      var placementCode = '';
+
+      var bidReq = $$PREBID_GLOBAL$$
+        ._bidsRequested.find(bidSet => bidSet.bidderCode === 'pubwiseSim')
+        .bids.find(bid => bid.bidId === pubwiseBid.bidId);
+
+      if (!bidReq) {
+        utils.logMessage('pubwiseSim No bidReq');
+        return addErrorBidResponse(placementCode);
+      }
+
+      bidReq.status = CONSTANTS.STATUS.GOOD;
+      utils.logInfo('Bid Request', bidReq);
+      placementCode = bidReq.placementCode;
+      placements.push(placementCode);
+
+      var cpm = pubwiseBid.cpm;
+
+      if (!cpm) {
+        utils.logMessage('pubwiseSim No CPM');
+        return addErrorBidResponse(placementCode);
+      }
+
+      var bid = bidfactory.createBid(1, bidReq);
+
+      bid.creative_id = pubwiseBid.id;
+      bid.bidderCode = 'pubwiseSim';
+      bid.cpm = cpm;
+      bid.ad = decodeURIComponent(pubwiseBid.adm);
+      bid.width = parseInt(pubwiseBid.w);
+      bid.height = parseInt(pubwiseBid.h);
+      utils.logInfo('adding pubwiseSim bid');
+      bidmanager.addBidResponse(placementCode, bid);
+    }
+
+    function fillEmptyBidReturns(placements) {
+      utils.logInfo('Fill Placement Bids', placements);
+      $$PREBID_GLOBAL$$
+        ._bidsRequested.find(bidSet => bidSet.bidderCode === 'pubwiseSim')
+        .bids.forEach(fillEmpty);
+
+      function fillEmpty(bid) {
+        if (utils.contains(placements, bid.placementCode)) {
+          return null;
+        }
+
+        addErrorBidResponse(bid);
+      }
+    }
+
+    function addErrorBidResponse(bidRequest) {
+      var bid = bidfactory.createBid(2, bidRequest);
+      bid.bidderCode = 'pubwiseSim';
+      bidmanager.addBidResponse(bidRequest.placementCode, bid);
+    }
+
+    function isInvalidResponse() {
+      return !pubwiseResponseObject || !pubwiseResponseObject.bids || !Array.isArray(pubwiseResponseObject.bids) || pubwiseResponseObject.bids.length <= 0;
+    }
+  }
+};
+
+module.exports = PubwiseSimAdapter;

--- a/test/spec/adapters/pubwiseSim_spec.js
+++ b/test/spec/adapters/pubwiseSim_spec.js
@@ -1,0 +1,154 @@
+describe('PubWise Sim bid adapter tests', function(){
+  const expect = require('chai').expect;
+  const adapter = require('src/adapters/pubwiseSim');
+  const bidmanager = require('src/bidmanager');
+
+  describe('pubwiseSimResponseHandler', function () {
+
+    it('should exist and be a function', function () {
+      adapter();
+      expect(pbjs.pubwiseSimResponseHandler).to.exist.and.to.be.a('function');
+    });
+
+    it('should add empty bid responses if no bids returned', function () {
+      var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+      var bidderRequest = {
+        bidderCode: 'pubwiseSim',
+        bids: [
+          {
+            bidId: 'testId1',
+            bidder: 'pubwiseSim',
+            params: {
+              site_id: 'test-test-test-test',
+              height: '728',
+              width: '90',
+              cpm: 20,
+              delay: 0,
+            },
+            sizes: [[160, 600]],
+            placementCode: 'div-gpt-test-1'
+          },
+          {
+            bidId: 'testId2',
+            bidder: 'pubwiseSim',
+            params: {
+              site_id: 'test-test-test-test',
+              height: '728',
+              width: '90',
+              cpm: 20,
+              delay: 0,
+            },
+            sizes: [[160, 600]],
+            placementCode: 'div-gpt-test-2'
+          },
+        ]
+      };
+
+
+      // return no bids
+      var response = {
+        "id": "123456",
+        "bids": []
+      };
+
+      pbjs._bidsRequested.push(bidderRequest);
+
+      // get the stub registered
+      adapter();
+
+      pbjs.pubwiseSimResponseHandler(response);
+
+      var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+      var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+      var bidPlacementCode2 = stubAddBidResponse.getCall(1).args[0];
+      var bidObject2 = stubAddBidResponse.getCall(1).args[1];
+
+      expect(bidPlacementCode1).to.equal('div-gpt-test-1');
+      expect(bidObject1.getStatusCode()).to.equal(2);
+      expect(bidObject1.bidderCode).to.equal('pubwiseSim');
+
+      expect(bidPlacementCode2).to.equal('div-gpt-test-2');
+      expect(bidObject2.getStatusCode()).to.equal(2);
+      expect(bidObject2.bidderCode).to.equal('pubwiseSim');
+
+      stubAddBidResponse.restore();
+    });
+
+    it('should add a bid response for bids returned and empty bid responses for the rest', () => {
+
+      var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+
+      var bidderRequest = {
+        bidderCode: 'pubwiseSim',
+        bids: [
+          {
+            bidId: 'testId1',
+            bidder: 'pubwiseSim',
+            params: {
+              site_id: 'test-test-test-test',
+              height: '728',
+              width: '90',
+              cpm: 20,
+              delay: 0,
+            },
+            sizes: [[728, 90]],
+            placementCode: 'div-gpt-test-1'
+          },
+          {
+            bidId: 'testId2',
+            bidder: 'pubwiseSim',
+            params: {
+              site_id: 'test-test-test-test',
+              height: '728',
+              width: '90',
+              cpm: 20,
+              delay: 0,
+            },
+            sizes: [[160, 600]],
+            placementCode: 'div-gpt-test-2'
+          },
+        ]
+      };
+
+      // return just one bid
+      var response = {
+        "id": "123456",
+        "bids": [
+          {
+            "bidId" : "testId1",
+            "cpm" : 20,
+            "adm" : "<<adm creative placehold>>",
+            "h" : 320,
+            "w" : 50
+          }
+        ]};
+
+      pbjs._bidsRequested.push(bidderRequest);
+
+      // get the stub registered
+      adapter();
+
+      pbjs.pubwiseSimResponseHandler(response);
+
+      var bidPlacementCode1 = stubAddBidResponse.getCall(0).args[0];
+      var bidObject1 = stubAddBidResponse.getCall(0).args[1];
+      var bidPlacementCode2 = stubAddBidResponse.getCall(1).args[0];
+      var bidObject2 = stubAddBidResponse.getCall(1).args[1];
+
+      expect(bidPlacementCode1).to.equal('div-gpt-test-1');
+      expect(bidObject1.getStatusCode()).to.equal(1);
+      expect(bidObject1.bidderCode).to.equal('pubwiseSim');
+      expect(bidObject1.cpm).to.equal(20);
+      expect(bidObject1.height).to.equal(320);
+      expect(bidObject1.width).to.equal(50);
+      expect(bidObject1.ad).to.equal('<<adm creative placehold>>');
+
+      expect(bidPlacementCode2).to.equal('div-gpt-test-2');
+      expect(bidObject2.getStatusCode()).to.equal(2);
+      expect(bidObject2.bidderCode).to.equal('pubwiseSim');
+
+      stubAddBidResponse.restore();
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [X ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
Addition of PubWise Bid Simulator Adapter. The Bid Simulator is part of the testing package we use internally for PubWise.io. We are making it publicly available because we feel the Prebid community will get some value from it.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
        bidderCode: 'pubwiseSim',
        bids: [
          {
            bidId: 'testId1',
            bidder: 'pubwiseSim',
            params: {
              site_id: 'test-test-test-test',
              height: '728',
              width: '90',
              cpm: 20,
              delay: 0,
            },
            sizes: [[160, 600]],
            placementCode: 'div-gpt-test-1'
          }
        ]
      }
```
- stephenj@pubwise.io
- [ x ] official adapter submission

## Other information
