### PR TITLE
remove old adloader#trackPixel

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -83,23 +83,3 @@ function requestResource(tagSrc, callback) {
     elToAppend.insertBefore(jptScript, elToAppend.firstChild);
   }
 }
-
-//track a impbus tracking pixel
-//TODO: Decide if tracking via AJAX is sufficent, or do we need to
-//run impression trackers via page pixels?
-exports.trackPixel = function (pixelUrl) {
-  let delimiter;
-  let trackingPixel;
-
-  if (!pixelUrl || typeof (pixelUrl) !== 'string') {
-    utils.logMessage('Missing or invalid pixelUrl.');
-    return;
-  }
-
-  delimiter = pixelUrl.indexOf('?') > 0 ? '&' : '?';
-
-  //add a cachebuster so we don't end up dropping any impressions
-  trackingPixel = pixelUrl + delimiter + 'rnd=' + Math.floor(Math.random() * 1E7);
-  (new Image()).src = trackingPixel;
-  return trackingPixel;
-};

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -1,40 +1,4 @@
 describe('adLoader', function () {
   var assert = require('chai').assert,
     adLoader = require('../../src/adloader');
-
-  describe('trackPixel', function () {
-    it('correctly appends a cachebuster query paramter to a pixel with no existing parameters', function () {
-      var inputUrl = 'http://www.example.com/tracking_pixel',
-        token = '?rnd=',
-        expectedPartialUrl = inputUrl + token,
-        actual = adLoader.trackPixel(inputUrl),
-        actualPartialUrl = actual.split(token)[0] + token,
-        randomNumber = parseInt(actual.split(token)[1]);
-      assert.strictEqual(actualPartialUrl, expectedPartialUrl);
-      assert.isNumber(randomNumber);
-    });
-  });
-
-  it('correctly appends a cachebuster query paramter to a pixel with one existing parameter', function () {
-    var inputUrl = 'http://www.example.com/tracking_pixel?food=bard',
-      token = '&rnd=',
-      expectedPartialUrl = inputUrl + token,
-      actual = adLoader.trackPixel(inputUrl),
-      actualPartialUrl = actual.split(token)[0] + token,
-      randomNumber = parseInt(actual.split(token)[1]);
-    assert.strictEqual(actualPartialUrl, expectedPartialUrl);
-    assert.isNumber(randomNumber);
-  });
-
-  it('correctly appends a cachebuster query paramter to a pixel with multiple existing parameters', function () {
-    var inputUrl = 'http://www.example.com/tracking_pixel?food=bard&zing=zang',
-      token = '&rnd=',
-      expectedPartialUrl = inputUrl + token,
-      actual = adLoader.trackPixel(inputUrl),
-      actualPartialUrl = actual.split(token)[0] + token,
-      randomNumber = parseInt(actual.split(token)[1]);
-    assert.strictEqual(actualPartialUrl, expectedPartialUrl);
-    assert.isNumber(randomNumber);
-  });
-
 });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Removed adloader#trackPixel which looks like it was added last year but hasn't been used by anything.  I left the adloader spec file (even though all the tests were related to trackPixel and no longer has any tests) on the hope that it may have tests sometime in the future.  