### PR TITLE
Updated documentaion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,32 @@
 # Contributing to Prebid.js
-Contributions are always welcome. To contribute, [fork](https://help.github.com/articles/fork-a-repo/) Prebid.js, commit your changes, and [open a pull request](https://help.github.com/articles/using-pull-requests/).
+Contributions are always welcome. To contribute, [fork](https://help.github.com/articles/fork-a-repo/) Prebid.js, commit your changes, and [open a pull request](https://help.github.com/articles/using-pull-requests/) against the master branch.
 
-## Pull Requests
-Please make sure that pull requests are scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See [Testing Prebid.js](#testing-prebidjs) for help on writing tests.
+Details about the Pull Request process can be found [here](./pr_review.md).
 
 ## Issues
-[prebid.org](http://prebid.org/) contains documentation that may help answer questions you have about using Prebid.js. If you can't find the answer there, try searching for a similar issue on the [issues page](https://github.com/prebid/Prebid.js/issues). If you don't find an answer there, [open a new issue](https://github.com/prebid/Prebid.js/issues/new).
+[prebid.org](http://prebid.org/) contains documentation that may help answer questions you have about using Prebid.js.
+If you can't find the answer there, try searching for a similar issue on the [issues page](https://github.com/prebid/Prebid.js/issues).
+If you don't find an answer there, [open a new issue](https://github.com/prebid/Prebid.js/issues/new).
 
 ## Documentation
 If you have a documentation issue or pull request, please open a ticket or PR in the [documentation repository](https://github.com/prebid/prebid.github.io).
 
-## Testing Prebid.js
-Pull requests to the Prebid.js library will need to include tests with greater than 80% code coverage for any changed/added code before they can be merged into master.
+## Writing Tests
+Tests are stored in the [test/spec](test/spec) directory. Tests for Adapters are located in [test/spec/adapters](test/spec/adapters).
+They can be run with the following commands:
 
-This section describes how to test code in the Prebid.js repository to help prepare your pull request.
+- `gulp test` - run the test suite once (`npm test` is aliased to call `gulp test`)
+- `gulp serve` - run the test suite once, but re-run it whenever a file in the `src` or `test` directory is modified
 
-### Writing tests
+Before your Pull Request will be considered for merge:
+
+- All new and existing tests must pass
+- Added or modified code must have greater than 80% coverage. The coverage report will be generated in `build/coverage/lcov/lcov-report/index.html`
+
+### Test Standards
 When you are adding code to Prebid.js, or modifying code that isn't covered by an existing test, test the code according to these guidelines:
 
-- If the module you are working on is already partially tested by a file within the `test` directory, add tests to that file
+- If the module you are working on is already partially tested by a file within the `test/spec` directory, add tests to that file
 - If the module does not have any tests, create a new test file
 - Group tests in a `describe` block
 - Test individual units of code within an `it` block
@@ -36,31 +44,8 @@ When you are adding code to Prebid.js, or modifying code that isn't covered by a
 - If you need to check `adloader.loadScript` in a test, use a `stub` rather than a `spy`. `spy`s trigger a network call which can result in a `script error` and cause unrelated unit tests to fail. `stub`s will let you gather information about the `adloader.loadScript` call without affecting external resources
 - When writing tests you may use ES2015 syntax if desired
 
-### Running tests
-After checking out the Prebid.js repository and installing dev dependencies with `npm install`, use the following commands to run tests as you are working on code:
-
-- `gulp test` will run the test suite once (`npm test` is aliased to call `gulp test`)
-- `gulp serve` will run tests once and stay open, re-running tests whenever a file in the `src` or `test` directory is modified
-
-### Checking results and code coverage
-Check the test results using these guidelines:
-
-- Look at the total number of tests run, passed, and failed in the shell window.
-- If all tests are passing, great.
-- Otherwise look for errors printed in the console for a description of the failing test.
-- You may need to iterate on your code or tests until all tests are passing.
-- Make sure existing tests still pass.
-- There is a table below the testing report that shows code coverage percentage, for each file under the `src` directory.
-- Each time you run tests, a code coverage report is generated in `build/coverage/lcov/lcov-report/index.html`.
-- This is a static HTML page that you can load in your browser.
-- On that page, navigate to the file you are testing to see which lines are being tested.
-- Red indicates that a line isn't covered by a test.
-- Gray indicates a line that doesn't need coverage, such as a comment or blank line.
-- Green indicates a line that is covered by tests.
-- The code you have added or modified must have greater than 80% coverage to be accepted.
-
 ### Examples
-Prebid.js already has lots of tests. Read them to see how Prebid.js is tested, and for inspiration:
+Prebid.js already has many tests. Read them to see how Prebid.js is tested, and for inspiration:
 
 - Look in `test/spec` and its subdirectories
 - Tests for bidder adaptors are located in `test/spec/adapters`
@@ -87,5 +72,6 @@ describe('<Adapter>', () => {
 The Prebid.js testing stack contains some of the following tools. It may be helpful to consult their documentation during the testing process.
 
 - [Mocha - test framework](http://mochajs.org/)
+- [Karma - test runner](https://karma-runner.github.io/1.0/index.html)
 - [Chai - BDD/TDD assertion library](http://chaijs.com/)
 - [Sinon - spy, stub, and mock library](http://sinonjs.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,10 @@
 # Contributing to Prebid.js
-Contributions are always welcome. To contribute, [fork](https://help.github.com/articles/fork-a-repo/) Prebid.js, commit your changes, and [open a pull request](https://help.github.com/articles/using-pull-requests/) against the master branch.
+Contributions are always welcome. To contribute, [fork](https://help.github.com/articles/fork-a-repo/) Prebid.js,
+commit your changes, and [open a pull request](https://help.github.com/articles/using-pull-requests/) against the
+master branch.
 
-Details about the Pull Request process can be found [here](./pr_review.md).
+Pull requests must have 80% code coverage before beign considered for merge.
+Additional details about the process can be found [here](./pr_review.md).
 
 ## Issues
 [prebid.org](http://prebid.org/) contains documentation that may help answer questions you have about using Prebid.js.
@@ -12,16 +15,21 @@ If you don't find an answer there, [open a new issue](https://github.com/prebid/
 If you have a documentation issue or pull request, please open a ticket or PR in the [documentation repository](https://github.com/prebid/prebid.github.io).
 
 ## Writing Tests
+
+Prebid uses [Mocha](http://mochajs.org/) and [Chai](http://chaijs.com/) for unit tests. [Sinon](http://sinonjs.org/)
+provides mocks, stubs, and spies. [Karma](https://karma-runner.github.io/1.0/index.html) runs the tests and generates
+code coverage reports at `build/coverage/lcov/lcov-report/index.html`.
+
 Tests are stored in the [test/spec](test/spec) directory. Tests for Adapters are located in [test/spec/adapters](test/spec/adapters).
 They can be run with the following commands:
 
 - `gulp test` - run the test suite once (`npm test` is aliased to call `gulp test`)
 - `gulp serve` - run the test suite once, but re-run it whenever a file in the `src` or `test` directory is modified
 
-Before your Pull Request will be considered for merge:
+Before a Pull Request will be considered for merge:
 
 - All new and existing tests must pass
-- Added or modified code must have greater than 80% coverage. The coverage report will be generated in `build/coverage/lcov/lcov-report/index.html`
+- Added or modified code must have greater than 80% coverage
 
 ### Test Guidelines
 When you are adding code to Prebid.js, or modifying code that isn't covered by an existing test, test the code according to these guidelines:
@@ -67,11 +75,3 @@ describe('<Adapter>', () => {
   // Add other `describe` or `it` blocks as necessary
 });
 ```
-
-### Resources
-The Prebid.js testing stack contains some of the following tools. It may be helpful to consult their documentation during the testing process.
-
-- [Mocha - test framework](http://mochajs.org/)
-- [Karma - test runner](https://karma-runner.github.io/1.0/index.html)
-- [Chai - BDD/TDD assertion library](http://chaijs.com/)
-- [Sinon - spy, stub, and mock library](http://sinonjs.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Before your Pull Request will be considered for merge:
 - All new and existing tests must pass
 - Added or modified code must have greater than 80% coverage. The coverage report will be generated in `build/coverage/lcov/lcov-report/index.html`
 
-### Test Standards
+### Test Guidelines
 When you are adding code to Prebid.js, or modifying code that isn't covered by an existing test, test the code according to these guidelines:
 
 - If the module you are working on is already partially tested by a file within the `test/spec` directory, add tests to that file
@@ -44,7 +44,7 @@ When you are adding code to Prebid.js, or modifying code that isn't covered by a
 - If you need to check `adloader.loadScript` in a test, use a `stub` rather than a `spy`. `spy`s trigger a network call which can result in a `script error` and cause unrelated unit tests to fail. `stub`s will let you gather information about the `adloader.loadScript` call without affecting external resources
 - When writing tests you may use ES2015 syntax if desired
 
-### Examples
+### Test Examples
 Prebid.js already has many tests. Read them to see how Prebid.js is tested, and for inspiration:
 
 - Look in `test/spec` and its subdirectories

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 > A free and open source library for publishers to quickly implement header bidding.
 
-This README is for developers who want to contribute to Prebid.js.  For user-facing documentation, see [Prebid.org](http://prebid.org).
+This README is for developers who want to contribute to Prebid.js.
+Additional documentation can be found at [the Prebid homepage](http://prebid.org).
+Working examples can be found in [the developer docs](http://prebid.org/dev-docs/getting-started.html).
 
 **Table of Contents**
 
@@ -194,7 +196,3 @@ Prebid.js is supported on IE9+ and modern browsers.
 
 ### Governance
 Review our governance model [here](https://github.com/prebid/Prebid.js/tree/master/governance.md).
-
-### Additional Resources
-
- - [Prebid Examples](http://prebid.org/dev-docs/getting-started.html)

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ This README is for developers who want to contribute to Prebid.js.  For user-fac
     $ cd Prebid.js
     $ yarn install
 
-Prebid now supports the `yarn` npm client. This is an alternative to using `npm` for package management, though `npm` will continue to work as before.
+Prebid also supports the `yarn` npm client. This is an alternative to using `npm` for package management, though `npm` will continue to work as before.
 
-For more info about yarn see https://yarnpkg.com
+For more info, see [the Yarn documentation](https://yarnpkg.com).
 
 <a name="Build"></a>
 
-## Build for Dev
+## Build for Development
 
 To build the project on your local machine, run:
 
@@ -148,6 +148,8 @@ A watch is also in place that will run continuous tests in the terminal as you e
 
 Many SSPs, bidders, and publishers have contributed to this project. [60+ Bidders](https://github.com/prebid/Prebid.js/tree/master/src/adapters) are supported by Prebid.js.
 
+For guidelines, see [Contributing](./CONTRIBUTING.md).
+
 Our PR review process can be found [here](https://github.com/prebid/Prebid.js/tree/master/pr_review.md).
 
 ### Add a Bidder Adapter
@@ -192,3 +194,7 @@ Prebid.js is supported on IE9+ and modern browsers.
 
 ### Governance
 Review our governance model [here](https://github.com/prebid/Prebid.js/tree/master/governance.md).
+
+### Additional Resources
+
+ - [Prebid Examples](http://prebid.org/dev-docs/getting-started.html)


### PR DESCRIPTION
## Type of change
- [x] Other (documentation)

## Description of change
Removed some duplicate docs by linking the .md files together. Added a link to Karma, which is part of the testing tech stack.

More controversially: Deleted a chunk of docs which... honestly just made my eyes glaze over when I read them. I would place "how to fix unit tests" and "how to use a code coverage report" a bit outside of the scope of Prebid. Even [Istanbul](https://github.com/gotwarlost/istanbul#getting-started) just links you to a sample report without any more real explanation.