### PR TITLE
add lodash as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "karma-sinon-ie": "^2.0.0-rc10",
     "karma-webpack": "^1.5.1",
     "localtunnel": "^1.3.0",
+    "lodash": "^4.17.4",
     "mkpath": "^1.0.0",
     "mocha": "^1.21.4",
     "mock-fs": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,7 +4747,7 @@ lodash@^3.0.1, lodash@^3.10.0, lodash@^3.10.1, lodash@^3.3.1, lodash@^3.5.0, lod
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.2, lodash@^4.2.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.2, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
AOL is using lodash but not declaring it as a dependency.  Lodash is already a dependency of another dependency so the build still works fine with npm 3 but breaks in npm 2 which doesn't use a flat dependency tree.  I've already fixed this once in #1055 here: https://github.com/prebid/Prebid.js/pull/1055/files?diff=unified#diff-baeaea56bb14bac6f8ad04712f1b02bcL2 but they undid my changes and added it back in their latest pulll request #1115 here: https://github.com/prebid/Prebid.js/pull/1115/files?diff=unified#diff-baeaea56bb14bac6f8ad04712f1b02bcR2

Since it's already a dependency of a dependency there's really no harm in just adding it as a first-class dependency, so that's what this pull-request is.