### PR TITLE
add new rp_secure param to rubicon adapter

### DIFF
--- a/src/adapters/rubicon.js
+++ b/src/adapters/rubicon.js
@@ -12,6 +12,10 @@ function getIntegration() {
   return 'pbjs_lite_' + $$PREBID_GLOBAL$$.version;
 }
 
+function isSecure() {
+  return location.protocol === 'https:';
+}
+
 // use protocol relative urls for http or https
 const FASTLANE_ENDPOINT = '//fastlane.rubiconproject.com/a/api/fastlane.json';
 const VIDEO_ENDPOINT = '//fastlane-adv.rubiconproject.com/v1/auction/video';
@@ -236,6 +240,7 @@ function RubiconAdapter() {
       'alt_size_ids', parsedSizes.slice(1).join(',') || undefined,
       'p_pos', position,
       'rp_floor', floor,
+      'rp_secure', isSecure() ? '1' : '0',
       'tk_flint', getIntegration(),
       'p_screen_res', _getScreenResolution(),
       'kw', keywords,

--- a/test/spec/adapters/rubicon_spec.js
+++ b/test/spec/adapters/rubicon_spec.js
@@ -245,6 +245,7 @@ describe('the rubicon adapter', () => {
             'alt_size_ids': '43',
             'p_pos': 'atf',
             'rp_floor': '0.01',
+            'rp_secure': /[01]/,
             'tk_flint': INTEGRATION,
             'p_screen_res': /\d+x\d+/,
             'tk_user_key': '12346',
@@ -283,7 +284,7 @@ describe('the rubicon adapter', () => {
           expect(query['alt_size_ids']).to.equal('57,59');
 
         });
-       
+
         it('should not send a request and register an error bid if no valid sizes', () => {
 
           var sizesBidderRequest = clone(bidderRequest);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added a new parameter sent to fastlane endpoint for rubicon adapter `rp_secure` that tells the endpoint whether we are http or https