### PR TITLE
Bug fix: bids served by secure creatives does not get pushed into _winningBids

### DIFF
--- a/src/secure-creatives.js
+++ b/src/secure-creatives.js
@@ -29,6 +29,10 @@ function receiveMessage(ev) {
 
     if (data.message === 'Prebid Request') {
       sendAdToCreative(adObject, data.adServerDomain, ev.source);
+
+      //save winning bids
+      $$PREBID_GLOBAL$$._winningBids.push(adObject);
+
       events.emit(BID_WON, adObject);
     }
   }


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fix the bug as described in Issue #1187 

This is by simply adding back the Bid object to `pbjs._winningBids` when serving secure creatives.


## Other information

