### PR TITLE
Fixes #998 Allow keyvalues, gender and age to be passed in PubMatic

### DIFF
--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -21,6 +21,9 @@ var PubmaticAdapter = function PubmaticAdapter() {
       var bid = bids[i];
       // bidmanager.pbCallbackMap['' + bid.params.adSlot] = bid;
       _pm_pub_id = _pm_pub_id || bid.params.publisherId;
+      _pm_pub_age = _pm_pub_age || (bid.params.age || "");
+      _pm_pub_gender = _pm_pub_gender || (bid.params.gender || "");
+      _pm_pub_kvs = _pm_pub_kvs || (bid.params.kvs || "");
       _pm_optimize_adslots.push(bid.params.adSlot);
     }
 
@@ -51,11 +54,18 @@ var PubmaticAdapter = function PubmaticAdapter() {
     content += '' +
       'window.pm_pub_id  = "%%PM_PUB_ID%%";' +
       'window.pm_optimize_adslots     = [%%PM_OPTIMIZE_ADSLOTS%%];' +
+      'window.kaddctr = "%%PM_ADDCTR%%;"' +
+      'window.kadgender = "%%PM_GENDER%%;"' +
+      'window.kadage = "%%PM_AGE%%;"' +
       'window.pm_async_callback_fn = "window.parent.$$PREBID_GLOBAL$$.handlePubmaticCallback";';
+
     content += '</scr' + 'ipt>';
 
     var map = {};
     map.PM_PUB_ID = _pm_pub_id;
+    map.PM_ADDCTR = _pm_pub_kvs;
+    map.PM_GENDER = _pm_pub_gender;
+    map.PM_AGE = _pm_pub_age;
     map.PM_OPTIMIZE_ADSLOTS = _pm_optimize_adslots.map(function (adSlot) {
       return "'" + adSlot + "'";
     }).join(',');

--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -11,6 +11,9 @@ var bidmanager = require('../bidmanager.js');
 var PubmaticAdapter = function PubmaticAdapter() {
   var bids;
   var _pm_pub_id;
+  var _pm_pub_age;
+  var _pm_pub_gender;
+  var _pm_pub_kvs;
   var _pm_optimize_adslots = [];
   let iframe;
 
@@ -21,9 +24,9 @@ var PubmaticAdapter = function PubmaticAdapter() {
       var bid = bids[i];
       // bidmanager.pbCallbackMap['' + bid.params.adSlot] = bid;
       _pm_pub_id = _pm_pub_id || bid.params.publisherId;
-      _pm_pub_age = _pm_pub_age || (bid.params.age || "");
-      _pm_pub_gender = _pm_pub_gender || (bid.params.gender || "");
-      _pm_pub_kvs = _pm_pub_kvs || (bid.params.kvs || "");
+      _pm_pub_age = _pm_pub_age || (bid.params.age || '');
+      _pm_pub_gender = _pm_pub_gender || (bid.params.gender || '');
+      _pm_pub_kvs = _pm_pub_kvs || (bid.params.kvs || '');
       _pm_optimize_adslots.push(bid.params.adSlot);
     }
 


### PR DESCRIPTION
## Type of change
Feature

## Description of change
This allows the bidder params to take gender, age and key values (in PubMatics required format)

Before
```
bidder: 'pubmatic',
  params: {
    publisherId: 'TO ADD',
    adSlot: 'TO ADD@300x250'
  }
```

Now
```
bidder: 'pubmatic',
  params: {
    publisherId: 'TO ADD',
    adSlot: 'TO ADD@300x250',
    age: '42', // optional
    gender: 'male', // optional
    kvs: 'key1=V1,V2,V3|key2=v1|key3=v3,v5' // optional
}
```

Key values format are documented here: https://developer.pubmatic.com/documentation/http-parameters-details See *dctr*

Issue #998 