### PR TITLE
Map sponsor request param to endpoint param

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -19,7 +19,8 @@ const NATIVE_MAPPING = {
       required: true,
       sizes: [{}]
     }
-  }
+  },
+  sponsoredBy: 'sponsored_by'
 };
 
 /**

--- a/test/spec/adapters/appnexusAst_spec.js
+++ b/test/spec/adapters/appnexusAst_spec.js
@@ -133,7 +133,8 @@ describe('AppNexusAdapter', () => {
       REQUEST.bids[0].mediaType = 'native';
       REQUEST.bids[0].nativeParams = {
         title: {required: true},
-        body: {required: true}
+        body: {required: true},
+        sponsoredBy: {required: true}
       };
 
       adapter.callBids(REQUEST);
@@ -141,7 +142,8 @@ describe('AppNexusAdapter', () => {
       const request = JSON.parse(requests[0].requestBody);
       expect(request.tags[0].native.layouts[0]).to.deep.equal({
         title: {required: true},
-        description: {required: true}
+        description: {required: true},
+        sponsored_by: {required: true}
       });
 
       delete REQUEST.bids[0].mediaType;


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
This updates appnexusAst to map the `sponsoredBy` native parameter to the parameter the appnexusAst endpoint expects for that field. Ad units defined with
```
nativeParams: {
  sponsoredBy: {required: true}
}
```
will now properly request that field for appnexusAst