### PR TITLE
check return from getBidderRequest in addBidResponse

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -108,12 +108,16 @@ exports.addBidResponse = function (adUnitCode, bid) {
       adUnitCode
     });
 
-    bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
+    if (start == null) {
+      utils.logWarn(`Cannot find bidder request for bid, bidderCode: ${bid.bidderCode}, adUnitCode: ${bid.adUnitCode}`);
+    } else {
+      bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
 
-    if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout + $$PREBID_GLOBAL$$.timeoutBuffer) {
-      const timedOut = true;
+      if (bid.timeToRespond > $$PREBID_GLOBAL$$.cbTimeout + $$PREBID_GLOBAL$$.timeoutBuffer) {
+        const timedOut = true;
 
-      exports.executeCallback(timedOut);
+        exports.executeCallback(timedOut);
+      }
     }
 
     // emit the bidAdjustment event before bidResponse, so bid response has the adjusted bid value


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
If getBidderRequest can't find the request and returns nulls, then addBidResponse should not do timeToRespond calculation.

## Other information
Fixes #1232 