### PR TITLE
sharethrough: set bidderCode on invalid bids

### DIFF
--- a/src/adapters/sharethrough.js
+++ b/src/adapters/sharethrough.js
@@ -86,6 +86,7 @@ var SharethroughAdapter = function SharethroughAdapter() {
 
   function _handleInvalidBid(bidObj) {
     const bid = bidfactory.createBid(2, bidObj);
+    bid.bidderCode = STR_BIDDER_CODE;
     bidmanager.addBidResponse(bidObj.placementCode, bid);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Sets bid.bidderCode in _handleInvalidBid so that zero cpm bids are properly handled in addBidResponse.

## Other information
Fixes #1232