### PR TITLE
use request bidder code as default bidderCode for createBid

### DIFF
--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -18,7 +18,7 @@ function Bid(statusCode, bidRequest) {
   var _bidId = bidRequest && bidRequest.bidId || utils.getUniqueIdentifierStr();
   var _statusCode = statusCode || 0;
 
-  this.bidderCode = '';
+  this.bidderCode = (bidRequest && bidRequest.bidder) || '';
   this.width = 0;
   this.height = 0;
   this.statusMessage = _getStatus();


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
If the bidRequest is passed to createBid, it makes sense to use the bidRequest bidder as the default bidderCode for the bid.

## Other information
Fixes #1232