### PR TITLE
Ignore responses to previous auctions

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -81,6 +81,13 @@ function bidsBackAll() {
   return requested === received;
 }
 
+function getCurrentRequestId() {
+  const requested = $$PREBID_GLOBAL$$._bidsRequested;
+  if (requested.length > 0) {
+    return requested[0].requestId;
+  }
+}
+
 exports.bidsBackAll = function () {
   return bidsBackAll();
 };
@@ -140,6 +147,12 @@ exports.addBidResponse = function (adUnitCode, bid) {
       bidder: bid.bidderCode,
       adUnitCode
     });
+
+    const currentRequestId = getCurrentRequestId();
+    if (bidRequest.requestId !== currentRequestId) {
+      utils.logWarn(`Got bid response for request ID ${bidRequest.requestId}, which does not match current request ID ${currentRequestId}. Response discarded.`);
+      return;
+    }
 
     bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
 


### PR DESCRIPTION
## Type of change

<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

Consider the following scenario:

* Auction A sends requests to partners 1, 2, 3
* Partners 1 and 2 send back responses in time
* Auction timeout is triggered; callback invoked
* Auction B sends requests to partners 1, 2, 3
* Then partner 3’s response to **Auction A** comes back
* This response is determined to have timed out based on the delta between the request timestamp and response timestamp
* Bid manager invokes the callback with the `timedOut` flag set to true
* This causes **Auction B** to time out!

In general, when a response comes back, the bid manager should discard it if it isn’t a response to a bid in the current auction. This patch introduces a check in `bidManager.addBidResponse` which does an early check to make sure the `requestId` of the bid matches the `requestId` of the currently running auction (if any), and bails if it doesn’t.
