### PR TITLE
Add Index Exchange Video Adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -21,6 +21,7 @@
     "hiromedia",
     "indexExchange",
     "innity",
+    "ixVideo",
     "kruxlink",
     "getintent",
     "inneractive",
@@ -137,6 +138,11 @@
     {
       "stickyadstv": {
         "alias": "freewheel-ssp"
+      }
+    },
+    {
+      "ixVideo": {
+        "supportedMediaTypes": ["video"]
       }
     },
     {

--- a/src/adapters/ixVideo.js
+++ b/src/adapters/ixVideo.js
@@ -55,8 +55,8 @@ const DEFAULT_VPAID_MIMES_MAP = {
   HTML5: ['application/javascript']
 };
 
-const BASE_CYGNUS_VIDEO_URL_INSECURE = 'http://as.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse';
-const BASE_CYGNUS_VIDEO_URL_SECURE = 'https://as-sec.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse';
+const BASE_CYGNUS_VIDEO_URL_INSECURE = `http://as.casalemedia.com/cygnus?v=8&fn=$$PREBID_GLOBAL$$.handleCygnusResponse`;
+const BASE_CYGNUS_VIDEO_URL_SECURE = `https://as-sec.casalemedia.com/cygnus?v=8&fn=$$PREBID_GLOBAL$$.handleCygnusResponse`;
 
 function IndexExchangeVideoAdapter() {
   let baseAdapter = Adapter.createNew('ixVideo');
@@ -149,7 +149,7 @@ function IndexExchangeVideoAdapter() {
   }
 
   /* Notify Prebid of bid responses so bids can get in the auction */
-  window.handleCygnusResponse = function (response) {
+  $$PREBID_GLOBAL$$.handleCygnusResponse = function (response) {
     if (!response || !response.seatbid || utils.isEmpty(response.seatbid)) {
       utils.logInfo('Cynus returned no bids');
 
@@ -240,7 +240,7 @@ function IndexExchangeVideoAdapter() {
       utils.hasValidBidRequest(bid.params.video, Object.keys(VIDEO_REQUIRED_PARAMS_MAP), baseAdapter) &&
       isValidSite(bid.params.video.siteID) &&
       isValidPlayerType(bid.params.video.playerType) &&
-      isValidProtolArray(bid.params.video.protocols) &&
+      isValidProtocolArray(bid.params.video.protocols) &&
       isValidDuration(bid.params.video.maxduration) && bid.params.video.maxduration > 0
     ) {
       return bid;
@@ -269,7 +269,7 @@ function IndexExchangeVideoAdapter() {
     return true;
   }
 
-  function isValidProtolArray(protocolArray) {
+  function isValidProtocolArray(protocolArray) {
     if (!utils.isArray(protocolArray) || utils.isEmpty(protocolArray)) {
       utils.logError(`Protocol array is not an array. Got: ${protocolArray}`);
       return false;

--- a/src/adapters/ixVideo.js
+++ b/src/adapters/ixVideo.js
@@ -1,0 +1,443 @@
+import Adapter from 'src/adapters/adapter';
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import * as utils from 'src/utils';
+import { STATUS } from 'src/constants';
+import * as url from 'src/url';
+import adloader from 'src/adloader';
+
+const VIDEO_REQUIRED_PARAMS_MAP = {
+  siteID: true,
+  playerType: true,
+  protocols: true,
+  maxduration: true
+};
+const VIDEO_OPTIONAL_PARAMS_MAP = {
+  minduration: 0,
+  startdelay: 'preroll',
+  linearity: 'linear',
+  mimes: [],
+  allowVPAID: true,
+  apiList: []
+};
+const SUPPORTED_PLAYER_TYPES_MAP = {
+  HTML5: true,
+  FLASH: true
+};
+const SUPPORTED_PROTOCOLS_MAP = {
+  'VAST2': [2, 5],
+  'VAST3': [3, 6]
+};
+const SUPPORTED_API_MAP = {
+  FLASH: [1, 2],
+  HTML5: [2]
+};
+const LINEARITY_MAP = {
+  linear: 1,
+  nonlinear: 2
+};
+const START_DELAY_MAP = {
+  preroll: 0,
+  midroll: -1,
+  postroll: -2
+};
+const SLOT_ID_PREFIX_MAP = {
+  preroll: 'pr',
+  midroll: 'm',
+  postroll: 'po'
+};
+const DEFAULT_MIMES_MAP = {
+  FLASH: ['video/mp4', 'video/x-flv'],
+  HTML5: ['video/mp4', 'video/webm']
+};
+const DEFAULT_VPAID_MIMES_MAP = {
+  FLASH: ['application/x-shockwave-flash'],
+  HTML5: ['application/javascript']
+};
+
+const BASE_CYGNUS_VIDEO_URL_INSECURE = 'http://as.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse';
+const BASE_CYGNUS_VIDEO_URL_SECURE = 'https://as-sec.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse';
+
+function IndexExchangeVideoAdapter() {
+  let baseAdapter = Adapter.createNew('ixVideo');
+  let bidRequests = {};
+
+  baseAdapter.callBids = function (bidRequest) {
+    if (typeof bidRequest === 'undefined' || utils.isEmpty(bidRequest)) {
+      return;
+    }
+    const bids = bidRequest.bids;
+    const cygnusImpressions = bids
+      .filter(bid => validateBid(bid))
+      .map(bid => {
+        bid = transformBid(bid);
+
+        // map request id to bid object to retrieve adUnit code in callback
+        bidRequests[bid.bidId] = {};
+        bidRequests[bid.bidId].prebid = bid;
+
+        let cygnusImpression = {};
+        cygnusImpression.id = bid.bidId;
+
+        cygnusImpression.ext = {};
+        cygnusImpression.ext.siteID = bid.params.video.siteID;
+        delete bid.params.video.siteID;
+
+        let podType = bid.params.video.startdelay;
+        if (bid.params.video.startdelay === 0) {
+          podType = 'preroll';
+        } else if (typeof START_DELAY_MAP[bid.params.video.startdelay] === 'undefined') {
+          podType = 'midroll';
+        }
+        cygnusImpression.ext.sid = [SLOT_ID_PREFIX_MAP[podType], 1, 1, 's'].join('_');
+
+        cygnusImpression.video = {};
+
+        if (bid.params.video) {
+          Object.keys(bid.params.video)
+            .filter(param => typeof VIDEO_REQUIRED_PARAMS_MAP[param] !== 'undefined' || typeof VIDEO_OPTIONAL_PARAMS_MAP[param] !== 'undefined')
+            .forEach(param => {
+              if (param === 'startdelay' && typeof START_DELAY_MAP[bid.params.video[param]] !== 'undefined') {
+                bid.params.video[param] = START_DELAY_MAP[bid.params.video[param]];
+              }
+              if (param === 'linearity' && typeof LINEARITY_MAP[bid.params.video[param]] !== 'undefined') {
+                bid.params.video[param] = LINEARITY_MAP[bid.params.video[param]];
+              }
+              cygnusImpression.video[param] = bid.params.video[param];
+            });
+        } else {
+          return;
+        }
+
+        let bidSize = getSizes(bid.sizes).shift();
+        if (!bidSize || !bidSize.width || !bidSize.height) {
+          return;
+        }
+        cygnusImpression.video.w = bidSize.width;
+        cygnusImpression.video.h = bidSize.height;
+
+        bidRequests[bid.bidId].cygnus = cygnusImpression;
+
+        return cygnusImpression;
+      });
+
+    let cygnusRequest = {
+      'id': bidRequest.bidderRequestId,
+      'imp': cygnusImpressions,
+      'site': {
+        'page': utils.getTopWindowUrl()
+      }
+    };
+
+    if (!utils.isEmpty(cygnusRequest.imp)) {
+      let cygnusRequestUrl = createCygnusRequest(cygnusRequest.imp[0].ext.siteID, cygnusRequest);
+
+      sendCygnusRequest(cygnusRequestUrl);
+    }
+  };
+
+  function createCygnusRequest(siteID, cygnusRequest) {
+    let cygnusUrl = (window.location.protocol === 'https:') ? url.parse(BASE_CYGNUS_VIDEO_URL_SECURE) : url.parse(BASE_CYGNUS_VIDEO_URL_INSECURE);
+    cygnusUrl.search.s = siteID;
+    cygnusUrl.search.r = encodeURIComponent(JSON.stringify(cygnusRequest));
+    let formattedCygnusUrl = url.format(cygnusUrl);
+    return formattedCygnusUrl;
+  }
+
+  function sendCygnusRequest(cygnusRequest) {
+    adloader.loadScript(cygnusRequest);
+  }
+
+  /* Notify Prebid of bid responses so bids can get in the auction */
+  window.handleCygnusResponse = function (response) {
+    if (!response || !response.seatbid || utils.isEmpty(response.seatbid)) {
+      utils.logInfo('Cynus returned no bids');
+
+      // signal this response is complete
+      Object.keys(bidRequests)
+        .forEach(bidId => {
+          let prebidRequest = bidRequests[bidId].prebid;
+          let bid = createBidObj(STATUS.NO_BID, prebidRequest);
+          utils.logInfo(JSON.stringify(bid));
+          bidmanager.addBidResponse(prebidRequest.placementCode, bid);
+        });
+
+      return;
+    }
+
+    response.seatbid
+      .forEach(seat => {
+        seat.bid.forEach(cygnusBid => {
+          let validBid = true;
+
+          if (typeof bidRequests[cygnusBid.impid] === 'undefined') {
+            utils.logInfo('Cynus returned mismatched id');
+
+            // signal this response is complete
+            Object.keys(bidRequests)
+              .forEach(bidId => {
+                let prebidRequest = bidRequests[bidId].prebid;
+                let bid = createBidObj(STATUS.NO_BID, prebidRequest);
+                bidmanager.addBidResponse(prebidRequest.placementCode, bid);
+              });
+            return;
+          }
+
+          if (!cygnusBid.ext.vasturl) {
+            utils.logInfo('Cynus returned no vast url');
+            validBid = false;
+          }
+
+          if (url.parse(cygnusBid.ext.vasturl).host === window.location.host) {
+            utils.logInfo('Cynus returned no vast url');
+            validBid = false;
+          }
+
+          let cpm;
+          if (typeof cygnusBid.ext.pricelevel === 'string') {
+            cpm = cygnusBid.ext.pricelevel.slice(1) / 100;
+            if (!utils.isNumber(cpm) || isNaN(cpm)) {
+              utils.logInfo('Cynus returned invalid price');
+              validBid = false;
+            }
+          } else {
+            validBid = false;
+          }
+
+          let prebidRequest = bidRequests[cygnusBid.impid].prebid;
+          let cygnusRequest = bidRequests[cygnusBid.impid].cygnus;
+
+          if (!validBid) {
+            let bid = createBidObj(STATUS.NO_BID, prebidRequest);
+            bidmanager.addBidResponse(prebidRequest.placementCode, bid);
+            return;
+          }
+
+          let bid = createBidObj(STATUS.GOOD, prebidRequest);
+          bid.cpm = cpm;
+          bid.width = cygnusRequest.video.w;
+          bid.height = cygnusRequest.video.h;
+          bid.vastUrl = cygnusBid.ext.vasturl;
+          bid.descriptionUrl = cygnusBid.ext.vasturl;
+
+          bidmanager.addBidResponse(prebidRequest.placementCode, bid);
+        });
+      });
+  };
+
+  function createBidObj(status, request) {
+    let bid = bidfactory.createBid(status, request);
+    bid.code = baseAdapter.getBidderCode();
+    bid.bidderCode = baseAdapter.getBidderCode();
+
+    return bid;
+  }
+
+  /* Check that a bid has required paramters */
+  function validateBid(bid) {
+    if (
+      bid.mediaType === 'video' &&
+      utils.hasValidBidRequest(bid.params.video, Object.keys(VIDEO_REQUIRED_PARAMS_MAP), baseAdapter) &&
+      isValidSite(bid.params.video.siteID) &&
+      isValidPlayerType(bid.params.video.playerType) &&
+      isValidProtolArray(bid.params.video.protocols) &&
+      isValidDuration(bid.params.video.maxduration) && bid.params.video.maxduration > 0
+    ) {
+      return bid;
+    }
+  }
+
+  function isValidSite(siteID) {
+    let intSiteID = +siteID;
+    if (isNaN(intSiteID) || !utils.isNumber(intSiteID) || intSiteID < 0 || utils.isArray(siteID)) {
+      utils.logError(`Site ID is invalid, must be a number > 0. Got: ${siteID}`);
+      return false;
+    }
+    return true;
+  }
+
+  function isValidPlayerType(playerType) {
+    if (typeof playerType === 'undefined' || !utils.isStr(playerType)) {
+      utils.logError(`Player type is invalid, must be one of: ${Object.keys(SUPPORTED_PLAYER_TYPES_MAP)}`);
+      return false;
+    }
+    playerType = playerType.toUpperCase();
+    if (!SUPPORTED_PLAYER_TYPES_MAP[playerType]) {
+      utils.logError(`Player type is invalid, must be one of: ${Object.keys(SUPPORTED_PLAYER_TYPES_MAP)}`);
+      return false;
+    }
+    return true;
+  }
+
+  function isValidProtolArray(protocolArray) {
+    if (!utils.isArray(protocolArray) || utils.isEmpty(protocolArray)) {
+      utils.logError(`Protocol array is not an array. Got: ${protocolArray}`);
+      return false;
+    } else {
+      for (var i = 0; i < protocolArray.length; i++) {
+        let protocol = protocolArray[i];
+        if (!SUPPORTED_PROTOCOLS_MAP[protocol]) {
+          utils.logError(`Protocol array contains an invalid protocol, must be one of: ${SUPPORTED_PROTOCOLS_MAP}. Got: ${protocol}`);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function isValidDuration(duration) {
+    let intDuration = +duration;
+    if (isNaN(intDuration) || !utils.isNumber(intDuration) || utils.isArray(duration)) {
+      utils.logError(`Duration is invalid, must be a number. Got: ${duration}`);
+      return false;
+    }
+    return true;
+  }
+
+  function isValidMimeArray(mimeArray) {
+    if (!utils.isArray(mimeArray) || utils.isEmpty(mimeArray)) {
+      utils.logError(`MIMEs array is not an array. Got: ${mimeArray}`);
+      return false;
+    } else {
+      for (var i = 0; i < mimeArray.length; i++) {
+        let mimeType = mimeArray[i];
+        if (!utils.isStr(mimeType) || utils.isEmptyStr(mimeType) || !/^\w+\/[\w-]+$/.test(mimeType)) {
+          utils.logError(`MIMEs array contains an invalid MIME type. Got: ${mimeType}`);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function isValidLinearity(linearity) {
+    if (!LINEARITY_MAP[linearity]) {
+      utils.logInfo(`Linearity is invalid, must be one of: ${Object.keys(LINEARITY_MAP)}. Got: ${linearity}`);
+      return false;
+    }
+    return true;
+  }
+
+  function isValidStartDelay(startdelay) {
+    if (typeof START_DELAY_MAP[startdelay] === 'undefined') {
+      let intStartdelay = +startdelay;
+      if (isNaN(intStartdelay) || !utils.isNumber(intStartdelay) || intStartdelay < -2 || utils.isArray(startdelay)) {
+        utils.logInfo(`Start delay is invalid, must be a number >= -2. Got: ${startdelay}`);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function isValidApiArray(apiArray, playerType) {
+    if (!utils.isArray(apiArray) || utils.isEmpty(apiArray)) {
+      utils.logInfo(`API array is not an array. Got: ${apiArray}`);
+      return false;
+    } else {
+      for (var i = 0; i < apiArray.length; i++) {
+        let api = +apiArray[i];
+        if (isNaN(api) || !SUPPORTED_API_MAP[playerType].includes(api)) {
+          utils.logInfo(`API array contains an invalid API version. Got: ${api}`);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function transformBid(bid) {
+    bid.params.video.siteID = +bid.params.video.siteID;
+    bid.params.video.maxduration = +bid.params.video.maxduration;
+
+    bid.params.video.protocols = bid.params.video.protocols.reduce((arr, protocol) => {
+      return arr.concat(SUPPORTED_PROTOCOLS_MAP[protocol]);
+    }, []);
+
+    let minduration = bid.params.video.minduration;
+    if (typeof minduration === 'undefined' || !isValidDuration(minduration)) {
+      utils.logInfo(`Using default value for 'minduration', default: ${VIDEO_OPTIONAL_PARAMS_MAP.minduration}`);
+      bid.params.video.minduration = VIDEO_OPTIONAL_PARAMS_MAP.minduration;
+    }
+
+    let startdelay = bid.params.video.startdelay;
+    if (typeof startdelay === 'undefined' || !isValidStartDelay(startdelay)) {
+      utils.logInfo(`Using default value for 'startdelay', default: ${VIDEO_OPTIONAL_PARAMS_MAP.startdelay}`);
+      bid.params.video.startdelay = VIDEO_OPTIONAL_PARAMS_MAP.startdelay;
+    }
+
+    let linearity = bid.params.video.linearity;
+    if (typeof linearity === 'undefined' || !isValidLinearity(linearity)) {
+      utils.logInfo(`Using default value for 'linearity', default: ${VIDEO_OPTIONAL_PARAMS_MAP.linearity}`);
+      bid.params.video.linearity = VIDEO_OPTIONAL_PARAMS_MAP.linearity;
+    }
+
+    let mimes = bid.params.video.mimes;
+    let playerType = bid.params.video.playerType.toUpperCase();
+    if (typeof mimes === 'undefined' || !isValidMimeArray(mimes)) {
+      utils.logInfo(`Using default value for 'mimes', player type: '${playerType}', default: ${DEFAULT_MIMES_MAP[playerType]}`);
+      bid.params.video.mimes = DEFAULT_MIMES_MAP[playerType];
+    }
+
+    let apiList = bid.params.video.apiList;
+    if (typeof apiList !== 'undefined' && !isValidApiArray(apiList, playerType)) {
+      utils.logInfo(`Removing invalid api versions from api list.`);
+      if (utils.isArray(apiList)) {
+        bid.params.video.apiList = apiList.filter(api => SUPPORTED_API_MAP[playerType].includes(api));
+      } else {
+        bid.params.video.apiList = [];
+      }
+    }
+
+    if (typeof apiList === 'undefined' && bid.params.video.allowVPAID && utils.isA(bid.params.video.allowVPAID, 'Boolean')) {
+      bid.params.video.mimes = bid.params.video.mimes.concat(DEFAULT_VPAID_MIMES_MAP[playerType]);
+      bid.params.video.apiList = SUPPORTED_API_MAP[playerType];
+    }
+
+    if (utils.isEmpty(bid.params.video.apiList)) {
+      utils.logInfo(`API list is empty, VPAID ads will not be requested.`);
+      delete bid.params.video.apiList;
+    }
+
+    delete bid.params.video.playerType;
+    delete bid.params.video.allowVPAID;
+
+    return bid;
+  }
+
+  /* Turn bid request sizes into ut-compatible format */
+  function getSizes(requestSizes) {
+    let sizes = [];
+    let sizeObj = {};
+
+    if (utils.isArray(requestSizes) && requestSizes.length === 2 && !utils.isArray(requestSizes[0])) {
+      if (!utils.isNumber(requestSizes[0]) || !utils.isNumber(requestSizes[1])) {
+        return sizes;
+      }
+      sizeObj.width = requestSizes[0];
+      sizeObj.height = requestSizes[1];
+      sizes.push(sizeObj);
+    } else if (typeof requestSizes === 'object') {
+      for (let i = 0; i < requestSizes.length; i++) {
+        let size = requestSizes[i];
+        sizeObj = {};
+        sizeObj.width = parseInt(size[0], 10);
+        sizeObj.height = parseInt(size[1], 10);
+        sizes.push(sizeObj);
+      }
+    }
+
+    return sizes;
+  }
+
+  return {
+    createNew: IndexExchangeVideoAdapter.createNew,
+    callBids: baseAdapter.callBids,
+    setBidderCode: baseAdapter.setBidderCode
+  };
+}
+
+IndexExchangeVideoAdapter.createNew = function () {
+  return new IndexExchangeVideoAdapter();
+};
+
+module.exports = IndexExchangeVideoAdapter;

--- a/test/spec/adapters/ixVideo_spec.js
+++ b/test/spec/adapters/ixVideo_spec.js
@@ -1,0 +1,974 @@
+import { expect } from 'chai';
+import Adapter from 'src/adapters/ixVideo';
+import bidmanager from 'src/bidmanager';
+import adloader from 'src/adloader';
+import * as url from 'src/url';
+
+const PREBID_REQUEST = { 'bidderCode': 'ixVideo', 'requestId': '6f4cb846-1901-4fc4-a1a4-5daf58a26e71', 'bidderRequestId': '16940e979c42d4', 'bids': [{ 'bidder': 'ixVideo', 'params': { 'video': { 'siteID': 6, 'playerType': 'HTML5', 'protocols': ['VAST2', 'VAST3'], 'maxduration': 15 } }, 'placementCode': 'video1', 'mediaType': 'video', 'sizes': [640, 480], 'bidId': '2f4e1cc0f992f2', 'bidderRequestId': '16940e979c42d4', 'requestId': '6f4cb846-1901-4fc4-a1a4-5daf58a26e71' }], 'start': 1488236870659, 'auctionStart': 1488236870656, 'timeout': 3000 };
+
+const CYGNUS_REQUEST_R_PARAM = { 'id': '16940e979c42d4', 'imp': [{ 'id': '2f4e1cc0f992f2', 'ext': { 'siteID': 6, 'sid': 'pr_1_1_s' }, 'video': { 'protocols': [2, 5, 3, 6], 'maxduration': 15, 'minduration': 0, 'startdelay': 0, 'linearity': 1, 'mimes': ['video/mp4', 'video/webm'], 'w': 640, 'h': 480 } }], 'site': { 'page': 'http://localhost:9876/' }};
+
+const PREBID_RESPONSE = { 'bidderCode': 'ixVideo', 'width': 640, 'height': 480, 'statusMessage': 'Bid available', 'adId': '2f4e1cc0f992f2', 'code': 'ixVideo', 'cpm': 10, 'vastUrl': 'http://vast.url', 'descriptionUrl': 'http://vast.url' };
+
+const CYGNUS_RESPONSE = { 'seatbid': [{ 'bid': [{ 'crid': '1', 'adomain': ['vastdsp.com'], 'adid': '1', 'impid': '2f4e1cc0f992f2', 'cid': '1', 'id': '1', 'ext': { 'vasturl': 'http://vast.url', 'errorurl': 'http://error.url', 'dspid': 1, 'pricelevel': '_1000', 'advbrandid': 75, 'advbrand': 'Nacho Momma' } }], 'seat': '1' }], 'cur': 'USD', 'id': '16940e979c42d4' };
+
+const EMPTY_MESSAGE = 'Bid returned empty or error response';
+const ERROR_MESSAGE = 'Bid returned empty or error response';
+const AVAILABLE_MESSAGE = 'Bid available';
+
+const CYGNUS_REQUEST_BASE_URL_INSECURE = 'http://as.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse&s=6&r=';
+
+const CYGNUS_REQUEST_BASE_URL_SECURE = 'https://as-sec.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse&s=6&r=';
+
+const DEFAULT_MIMES_MAP = {
+  FLASH: ['video/mp4', 'video/x-flv'],
+  HTML5: ['video/mp4', 'video/webm']
+};
+const DEFAULT_VPAID_MIMES_MAP = {
+  FLASH: ['application/x-shockwave-flash'],
+  HTML5: ['application/javascript']
+};
+const SUPPORTED_API_MAP = {
+  FLASH: [1, 2],
+  HTML5: [2]
+};
+
+describe('IndexExchangeVideoAdapter', () => {
+  let adapter;
+
+  beforeEach(() => adapter = Adapter.createNew());
+
+  describe('request to prebid', () => {
+    let prebidRequest;
+
+    beforeEach(() => {
+      prebidRequest = JSON.parse(JSON.stringify(PREBID_REQUEST));
+      sinon.stub(adloader, 'loadScript');
+    });
+
+    afterEach(() => {
+      adloader.loadScript.restore();
+    });
+
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+
+    describe('should make request with specified values', () => {
+      let insecureExpectedUrl = url.parse(CYGNUS_REQUEST_BASE_URL_INSECURE.concat(encodeURIComponent(JSON.stringify(CYGNUS_REQUEST_R_PARAM))));
+
+      let secureExpectedUrl = url.parse(CYGNUS_REQUEST_BASE_URL_SECURE.concat(encodeURIComponent(JSON.stringify(CYGNUS_REQUEST_R_PARAM))));
+
+      it('when valid HTML5 required bid request parameters are present', () => {
+        adapter.callBids(prebidRequest);
+        sinon.assert.calledOnce(adloader.loadScript);
+        let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+        cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+        expect(cygnusRequestUrl.protocol).to.equal(insecureExpectedUrl.protocol);
+        expect(cygnusRequestUrl.hostname).to.equal(insecureExpectedUrl.hostname);
+        expect(cygnusRequestUrl.port).to.equal(insecureExpectedUrl.port);
+        expect(cygnusRequestUrl.pathname).to.equal(insecureExpectedUrl.pathname);
+
+        expect(cygnusRequestUrl.search.v).to.equal(insecureExpectedUrl.search.v);
+        expect(cygnusRequestUrl.search.s).to.equal(insecureExpectedUrl.search.s);
+        expect(cygnusRequestUrl.search.fn).to.equal(insecureExpectedUrl.search.fn);
+        expect(cygnusRequestUrl.search.r).to.exist;
+
+        expect(cygnusRequestUrl.search.r.id).to.equal(prebidRequest.bidderRequestId);
+
+        expect(cygnusRequestUrl.search.r.site.page).to.have.string(CYGNUS_REQUEST_R_PARAM.site.page);
+
+        expect(cygnusRequestUrl.search.r.imp).to.be.a('array');
+        expect(cygnusRequestUrl.search.r.imp[0]).to.have.all.keys(Object.keys(CYGNUS_REQUEST_R_PARAM.imp[0]));
+
+        expect(cygnusRequestUrl.search.r.imp[0].id).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].id);
+
+        expect(cygnusRequestUrl.search.r.imp[0].ext.siteID).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].ext.siteID);
+        expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+
+        expect(cygnusRequestUrl.search.r.imp[0].video.protocols).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.protocols);
+        expect(cygnusRequestUrl.search.r.imp[0].video.maxduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.maxduration);
+        expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+        expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(DEFAULT_MIMES_MAP.HTML5);
+        expect(cygnusRequestUrl.search.r.imp[0].video.w).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.w);
+        expect(cygnusRequestUrl.search.r.imp[0].video.h).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.h);
+      });
+
+      it('when valid FLASH required bid request parameters are present', () => {
+        prebidRequest.bids[0].params.video.playerType = 'FLASH';
+        adapter.callBids(prebidRequest);
+        sinon.assert.calledOnce(adloader.loadScript);
+        let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+        cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+        expect(cygnusRequestUrl.protocol).to.equal(insecureExpectedUrl.protocol);
+        expect(cygnusRequestUrl.hostname).to.equal(insecureExpectedUrl.hostname);
+        expect(cygnusRequestUrl.port).to.equal(insecureExpectedUrl.port);
+        expect(cygnusRequestUrl.pathname).to.equal(insecureExpectedUrl.pathname);
+
+        expect(cygnusRequestUrl.search.v).to.equal(insecureExpectedUrl.search.v);
+        expect(cygnusRequestUrl.search.s).to.equal(insecureExpectedUrl.search.s);
+        expect(cygnusRequestUrl.search.fn).to.equal(insecureExpectedUrl.search.fn);
+        expect(cygnusRequestUrl.search.r).to.exist;
+
+        expect(cygnusRequestUrl.search.r.id).to.equal(prebidRequest.bidderRequestId);
+
+        expect(cygnusRequestUrl.search.r.site.page).to.have.string(CYGNUS_REQUEST_R_PARAM.site.page);
+
+        expect(cygnusRequestUrl.search.r.imp).to.be.a('array');
+        expect(cygnusRequestUrl.search.r.imp[0]).to.have.all.keys(Object.keys(CYGNUS_REQUEST_R_PARAM.imp[0]));
+
+        expect(cygnusRequestUrl.search.r.imp[0].id).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].id);
+
+        expect(cygnusRequestUrl.search.r.imp[0].ext.siteID).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].ext.siteID);
+        expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+
+        expect(cygnusRequestUrl.search.r.imp[0].video.protocols).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.protocols);
+        expect(cygnusRequestUrl.search.r.imp[0].video.maxduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.maxduration);
+        expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+        expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(DEFAULT_MIMES_MAP.FLASH);
+        expect(cygnusRequestUrl.search.r.imp[0].video.w).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.w);
+        expect(cygnusRequestUrl.search.r.imp[0].video.h).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.h);
+      });
+
+      it('when required field site ID is a numeric string', () => {
+        prebidRequest.bids[0].params.video.siteID = '6';
+        adapter.callBids(prebidRequest);
+        sinon.assert.calledOnce(adloader.loadScript);
+        let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+        cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+        expect(cygnusRequestUrl.search.s).to.equal(insecureExpectedUrl.search.s);
+        expect(cygnusRequestUrl.search.r).to.exist;
+
+        expect(cygnusRequestUrl.search.r.imp[0].ext.siteID).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].ext.siteID);
+      });
+
+      it('when required field maxduration is a numeric string', () => {
+        prebidRequest.bids[0].params.video.maxduration = '15';
+        adapter.callBids(prebidRequest);
+        sinon.assert.calledOnce(adloader.loadScript);
+        let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+        cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+        expect(cygnusRequestUrl.search.r.imp[0].video.maxduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.maxduration);
+      });
+
+      describe('when optional field minduration', () => {
+        it('is valid number', () => {
+          prebidRequest.bids[0].params.video.minduration = 5;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(prebidRequest.bids[0].params.video.minduration);
+        });
+
+        it('is valid number string', () => {
+          prebidRequest.bids[0].params.video.minduration = '5';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(prebidRequest.bids[0].params.video.minduration);
+        });
+      });
+
+      describe('when optional field startdelay', () => {
+        it('is valid string', () => {
+          prebidRequest.bids[0].params.video.startdelay = 'midroll';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(prebidRequest.bids[0].params.video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string('m_1_1_s');
+        });
+
+        it('is valid number string', () => {
+          prebidRequest.bids[0].params.video.startdelay = '5';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(prebidRequest.bids[0].params.video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string('m_1_1_s');
+        });
+
+        it('is valid midroll number', () => {
+          prebidRequest.bids[0].params.video.startdelay = 5;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(prebidRequest.bids[0].params.video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string('m_1_1_s');
+        });
+
+        it('is valid preroll number', () => {
+          prebidRequest.bids[0].params.video.startdelay = 0;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(prebidRequest.bids[0].params.video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string('pr_1_1_s');
+        });
+      });
+
+      describe('when optional field linearity', () => {
+        it('is valid string', () => {
+          prebidRequest.bids[0].params.video.linearity = 'nonlinear';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(2);
+        });
+      });
+
+      describe('when optional field mimes', () => {
+        it('is valid mime', () => {
+          prebidRequest.bids[0].params.video.mimes = ['a/b'];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(prebidRequest.bids[0].params.video.mimes);
+        });
+      });
+
+      describe('when optional field API list', () => {
+        it('is valid array', () => {
+          prebidRequest.bids[0].params.video.apiList = [2];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.include.members([2]);
+        });
+      });
+
+      describe('when optional field allowVPAID', () => {
+        it('is valid boolean', () => {
+          prebidRequest.bids[0].params.video.allowVPAID = true;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.include.members(DEFAULT_VPAID_MIMES_MAP.HTML5);
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.include.members(SUPPORTED_API_MAP.HTML5);
+        });
+      });
+    });
+
+    describe('should make request with default values', () => {
+      describe('when optional field minduration', () => {
+        it('is invalid string', () => {
+          prebidRequest.bids[0].params.video.minduration = 'a';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.minduration = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.minduration = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.minduration = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.minduration).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.minduration);
+        });
+      });
+
+      describe('when optional field startdelay', () => {
+        it('is invalid string', () => {
+          prebidRequest.bids[0].params.video.startdelay = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+
+        it('is invalid number string', () => {
+          prebidRequest.bids[0].params.video.startdelay = '-5';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+
+        it('is invalid number', () => {
+          prebidRequest.bids[0].params.video.startdelay = -5;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.startdelay = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.startdelay = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.startdelay = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.startdelay).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.startdelay);
+          expect(cygnusRequestUrl.search.r.imp[0].ext.sid).to.have.string(CYGNUS_REQUEST_R_PARAM.imp[0].ext.sid);
+        });
+      });
+
+      describe('when optional field linearity', () => {
+        it('is invalid string', () => {
+          prebidRequest.bids[0].params.video.linearity = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.linearity = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.linearity = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.linearity = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.linearity).to.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.linearity);
+        });
+      });
+
+      describe('when optional field mimes', () => {
+        it('is invalid mime string', () => {
+          prebidRequest.bids[0].params.video.mimes = 'a';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.mimes = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.mimes = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.mimes = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.deep.equal(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+        });
+      });
+
+      describe('when optional field API list', () => {
+        it('is invalid array', () => {
+          prebidRequest.bids[0].params.video.apiList = ['cucumber'];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.apiList = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.apiList = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is string', () => {
+          prebidRequest.bids[0].params.video.apiList = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.apiList = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+      });
+
+      describe('when optional field allowVPAID', () => {
+        it('is not boolean', () => {
+          prebidRequest.bids[0].params.video.allowVPAID = 'a';
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.have.members(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is empty object', () => {
+          prebidRequest.bids[0].params.video.allowVPAID = {};
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.have.members(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.allowVPAID = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.have.members(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.allowVPAID = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.calledOnce(adloader.loadScript);
+          let cygnusRequestUrl = url.parse(encodeURIComponent(adloader.loadScript.firstCall.args[0]));
+          cygnusRequestUrl.search.r = JSON.parse(decodeURIComponent(cygnusRequestUrl.search.r));
+
+          expect(cygnusRequestUrl.search.r.imp[0].video.mimes).to.have.members(CYGNUS_REQUEST_R_PARAM.imp[0].video.mimes);
+          expect(cygnusRequestUrl.search.r.imp[0].video.apiList).to.not.exist;
+        });
+      });
+    })
+
+    describe('should not make request', () => {
+      describe('when request', () => {
+        it('is empty', () => {
+          adapter.callBids({});
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is for no bids', () => {
+          adapter.callBids({ bids: [] });
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          adapter.callBids(undefined);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+
+      describe('when request media type', () => {
+        it('is not for video', () => {
+          prebidRequest.bids[0].mediaType = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is a number', () => {
+          prebidRequest.bids[0].mediaType = 1;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].mediaType = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+
+      describe('when request site ID', () => {
+        it('is negative number', () => {
+          prebidRequest.bids[0].params.video.siteID = -5;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is negative number string', () => {
+          prebidRequest.bids[0].params.video.siteID = '-5';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is invalid string', () => {
+          prebidRequest.bids[0].params.video.siteID = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.siteID = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+
+      describe('when request player type', () => {
+        it('is invalid string', () => {
+          prebidRequest.bids[0].params.video.playerType = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is number', () => {
+          prebidRequest.bids[0].params.video.playerType = 1;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.playerType = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+
+      describe('when request protocols', () => {
+        it('is empty array', () => {
+          prebidRequest.bids[0].params.video.protocols = [];
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is a string', () => {
+          prebidRequest.bids[0].params.video.protocols = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is an invalid array', () => {
+          prebidRequest.bids[0].params.video.protocols = ['cucumber'];
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.protocols = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+
+      describe('when request maxduration', () => {
+        it('is a non-numeric string', () => {
+          prebidRequest.bids[0].params.video.maxduration = 'cucumber';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is a negative number', () => {
+          prebidRequest.bids[0].params.video.maxduration = -1;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is a negative number string', () => {
+          prebidRequest.bids[0].params.video.maxduration = '-1';
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+
+        it('is undefined', () => {
+          prebidRequest.bids[0].params.video.maxduration = undefined;
+          adapter.callBids(prebidRequest);
+          sinon.assert.notCalled(adloader.loadScript);
+        });
+      });
+    });
+  });
+
+  describe('response from cygnus', () => {
+    let response;
+    let request;
+    let width;
+    let height;
+
+    beforeEach(() => {
+      sinon.stub(bidmanager, 'addBidResponse');
+
+      [width, height] = PREBID_REQUEST.bids[0].sizes;
+
+      request = JSON.parse(JSON.stringify(PREBID_REQUEST));
+      response = JSON.parse(JSON.stringify(CYGNUS_RESPONSE));
+    });
+
+    afterEach(() => {
+      bidmanager.addBidResponse.restore();
+    });
+
+    describe('should add empty bid', () => {
+      describe('when response', () => {
+        beforeEach(() => {
+          adapter.callBids(request);
+        });
+
+        it('is empty object', () => {
+          global.window.handleCygnusResponse({});
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is empty array', () => {
+          global.window.handleCygnusResponse({});
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is undefined', () => {
+          global.window.handleCygnusResponse(undefined);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is number', () => {
+          global.window.handleCygnusResponse(1);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is string', () => {
+          global.window.handleCygnusResponse('cucumber');
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is explicit pass', () => {
+          global.window.handleCygnusResponse({ id: CYGNUS_RESPONSE.id });
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+      });
+
+      describe('when impid', () => {
+        beforeEach(() => {
+          adapter.callBids(request);
+        });
+
+        it('is mismatched', () => {
+          response.seatbid[0].bid[0].impid = 'cucumber';
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is undefined', () => {
+          response.seatbid[0].bid[0].impid = undefined;
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is array', () => {
+          response.seatbid[0].bid[0].impid = [];
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is object', () => {
+          response.seatbid[0].bid[0].impid = {};
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is string', () => {
+          response.seatbid[0].bid[0].impid = {};
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+      });
+
+      describe('when price level', () => {
+        beforeEach(() => {
+          adapter.callBids(request);
+        });
+
+        it('is string', () => {
+          response.seatbid[0].bid[0].ext.pricelevel = 'cucumber';
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is undefined', () => {
+          response.seatbid[0].bid[0].ext.pricelevel = undefined;
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is array', () => {
+          response.seatbid[0].bid[0].ext.pricelevel = [];
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is object', () => {
+          response.seatbid[0].bid[0].ext.pricelevel = {};
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+      });
+
+      describe('when vasturl', () => {
+        beforeEach(() => {
+          adapter.callBids(request);
+        });
+
+        it('is undefined', () => {
+          response.seatbid[0].bid[0].ext.vasturl = undefined;
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is number', () => {
+          response.seatbid[0].bid[0].ext.vasturl = 1;
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+
+        it('is not a url', () => {
+          response.seatbid[0].bid[0].ext.vasturl = 'cucumber';
+          global.window.handleCygnusResponse(response);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
+          expect(bidResponse).to.have.property('code', PREBID_RESPONSE.code);
+          expect(bidResponse).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(bidResponse).to.have.property('statusMessage', EMPTY_MESSAGE);
+        });
+      });
+    });
+
+    describe('should add available bid', () => {
+      describe('when response', () => {
+        beforeEach(() => {
+          adapter.callBids(request);
+        });
+
+        it('is success', () => {
+          global.window.handleCygnusResponse(CYGNUS_RESPONSE);
+          sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+          const response = bidmanager.addBidResponse.firstCall.args[1];
+          expect(response).to.have.property('code', PREBID_RESPONSE.code);
+          expect(response).to.have.property('bidderCode', PREBID_RESPONSE.bidderCode);
+          expect(response).to.have.property('statusMessage', PREBID_RESPONSE.statusMessage);
+          expect(response).to.have.property('cpm', PREBID_RESPONSE.cpm);
+          expect(response).to.have.property('vastUrl', PREBID_RESPONSE.vastUrl);
+          expect(response).to.have.property('descriptionUrl', PREBID_RESPONSE.descriptionUrl);
+          expect(response).to.have.property('width', PREBID_RESPONSE.width);
+          expect(response).to.have.property('height', PREBID_RESPONSE.height);
+        });
+      });
+    });
+  });
+});

--- a/test/spec/adapters/ixVideo_spec.js
+++ b/test/spec/adapters/ixVideo_spec.js
@@ -16,9 +16,9 @@ const EMPTY_MESSAGE = 'Bid returned empty or error response';
 const ERROR_MESSAGE = 'Bid returned empty or error response';
 const AVAILABLE_MESSAGE = 'Bid available';
 
-const CYGNUS_REQUEST_BASE_URL_INSECURE = 'http://as.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse&s=6&r=';
+const CYGNUS_REQUEST_BASE_URL_INSECURE = 'http://as.casalemedia.com/cygnus?v=8&fn=$$PREBID_GLOBAL$$.handleCygnusResponse&s=6&r=';
 
-const CYGNUS_REQUEST_BASE_URL_SECURE = 'https://as-sec.casalemedia.com/cygnus?v=8&fn=handleCygnusResponse&s=6&r=';
+const CYGNUS_REQUEST_BASE_URL_SECURE = 'https://as-sec.casalemedia.com/cygnus?v=8&fn=$$PREBID_GLOBAL$$.handleCygnusResponse&s=6&r=';
 
 const DEFAULT_MIMES_MAP = {
   FLASH: ['video/mp4', 'video/x-flv'],
@@ -735,7 +735,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is empty object', () => {
-          global.window.handleCygnusResponse({});
+          $$PREBID_GLOBAL$$.handleCygnusResponse({});
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -745,7 +745,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is empty array', () => {
-          global.window.handleCygnusResponse({});
+          $$PREBID_GLOBAL$$.handleCygnusResponse({});
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -757,7 +757,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is undefined', () => {
-          global.window.handleCygnusResponse(undefined);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(undefined);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -767,7 +767,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is number', () => {
-          global.window.handleCygnusResponse(1);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(1);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -777,7 +777,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is string', () => {
-          global.window.handleCygnusResponse('cucumber');
+          $$PREBID_GLOBAL$$.handleCygnusResponse('cucumber');
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -787,7 +787,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is explicit pass', () => {
-          global.window.handleCygnusResponse({ id: CYGNUS_RESPONSE.id });
+          $$PREBID_GLOBAL$$.handleCygnusResponse({ id: CYGNUS_RESPONSE.id });
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];
@@ -804,7 +804,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is mismatched', () => {
           response.seatbid[0].bid[0].impid = 'cucumber';
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -815,7 +815,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is undefined', () => {
           response.seatbid[0].bid[0].impid = undefined;
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -826,7 +826,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is array', () => {
           response.seatbid[0].bid[0].impid = [];
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -837,7 +837,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is object', () => {
           response.seatbid[0].bid[0].impid = {};
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -848,7 +848,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is string', () => {
           response.seatbid[0].bid[0].impid = {};
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -865,7 +865,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is string', () => {
           response.seatbid[0].bid[0].ext.pricelevel = 'cucumber';
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -876,7 +876,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is undefined', () => {
           response.seatbid[0].bid[0].ext.pricelevel = undefined;
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -887,7 +887,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is array', () => {
           response.seatbid[0].bid[0].ext.pricelevel = [];
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -898,7 +898,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is object', () => {
           response.seatbid[0].bid[0].ext.pricelevel = {};
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -915,7 +915,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is undefined', () => {
           response.seatbid[0].bid[0].ext.vasturl = undefined;
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -926,7 +926,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is number', () => {
           response.seatbid[0].bid[0].ext.vasturl = 1;
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -937,7 +937,7 @@ describe('IndexExchangeVideoAdapter', () => {
 
         it('is not a url', () => {
           response.seatbid[0].bid[0].ext.vasturl = 'cucumber';
-          global.window.handleCygnusResponse(response);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(response);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const bidResponse = bidmanager.addBidResponse.firstCall.args[1];
@@ -955,7 +955,7 @@ describe('IndexExchangeVideoAdapter', () => {
         });
 
         it('is success', () => {
-          global.window.handleCygnusResponse(CYGNUS_RESPONSE);
+          $$PREBID_GLOBAL$$.handleCygnusResponse(CYGNUS_RESPONSE);
           sinon.assert.calledOnce(bidmanager.addBidResponse);
 
           const response = bidmanager.addBidResponse.firstCall.args[1];


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other
## Description of change
<!-- Describe the change proposed in this pull request -->
Add new video adapter for Index Exchange
Documentation: https://github.com/prebid/prebid.github.io/pull/257
<!-- For new bidder adapters, please provide the following -->
- Change your /etc/hosts to point as.casalemedia.com to 192.139.80.22 (Or create a redirect rule using using a browser plugin to point as.casalemedia.com to sandbox.ht.indexexchange.com)
```
192.139.80.22        as.casalemedia.com
````
- test parameters for validating bids
```
{
  bidder: "indexExchangeVideo",
  params: {
    video: {
    siteID: 188233,
    playerType: "HTML5",
    protocols: ["VAST2", "VAST3"],
    maxduration: 15,
    allowVPAID: true
    }
  }
}
```
- contact email of the adapter’s maintainer
- [x] official adapter submission