### PR TITLE
Getting DigiTrustID in GumGum adapter

### DIFF
--- a/src/adapters/gumgum.js
+++ b/src/adapters/gumgum.js
@@ -40,8 +40,7 @@ const GumgumAdapter = function GumgumAdapter() {
       return {};
     }
     return {
-      'dt.id': digiTrustId.id,
-      'dt.keyv': digiTrustId.keyv
+      'dt': digiTrustId.id
     };
   }
 

--- a/src/adapters/gumgum.js
+++ b/src/adapters/gumgum.js
@@ -15,6 +15,7 @@ const GumgumAdapter = function GumgumAdapter() {
   const requestCache = {};
   const throttleTable = {};
   const defaultThrottle = 3e4;
+  const dtCredentials = { member: 'YcXr87z2lpbB' };
 
   try {
     topWindow = global.top;
@@ -27,6 +28,23 @@ const GumgumAdapter = function GumgumAdapter() {
     return new Date().getTime();
   }
 
+  function _getDigiTrustQueryParams() {
+    function getDigiTrustId () {
+      var digiTrustUser = (window.DigiTrust && window.DigiTrust.getUser) ? window.DigiTrust.getUser(dtCredentials) : {};
+      return digiTrustUser && digiTrustUser.success && digiTrustUser.identity || '';
+    };
+
+    let digiTrustId = getDigiTrustId();
+    // Verify there is an ID and this user has not opted out
+    if (!digiTrustId || digiTrustId.privacy && digiTrustId.privacy.optout) {
+      return {};
+    }
+    return {
+      'dt.id': digiTrustId.id,
+      'dt.keyv': digiTrustId.keyv
+    };
+  }
+
   function _callBids({ bids }) {
     const browserParams = {
       vw: topWindow.innerWidth,
@@ -37,6 +55,7 @@ const GumgumAdapter = function GumgumAdapter() {
       ce: navigator.cookieEnabled,
       dpr: topWindow.devicePixelRatio || 1
     };
+
     utils._each(bids, bidRequest => {
       const { bidId
             , params = {}
@@ -91,7 +110,7 @@ const GumgumAdapter = function GumgumAdapter() {
 
       const callback = { jsonp: `$$PREBID_GLOBAL$$.handleGumGumCB['${bidId}']` };
       CALLBACKS[bidId] = _handleGumGumResponse(cachedBid);
-      const query = Object.assign(callback, browserParams, bid);
+      const query = Object.assign(callback, browserParams, bid, _getDigiTrustQueryParams());
       const bidCall = `${bidEndpoint}?${utils.parseQueryStringParameters(query)}`;
       adloader.loadScript(bidCall);
     });

--- a/test/spec/adapters/gumgum_spec.js
+++ b/test/spec/adapters/gumgum_spec.js
@@ -92,6 +92,77 @@ describe('gumgum adapter', () => {
     sandbox.restore();
   });
 
+  describe('DigiTrust params', () => {
+    beforeEach(() => {
+      sandbox.stub(adLoader, 'loadScript');
+    });
+
+    it('should send digiTrust params', () => {
+      window.DigiTrust = {
+        getUser: function() {}
+      };
+      sandbox.stub(window.DigiTrust, 'getUser', () =>
+        ({
+          success: true,
+          identity: {
+            privacy: {optout: false},
+            id: 'testId',
+            keyv: 'testKeyV'
+          }
+        })
+      );
+
+      adapter.callBids(bidderRequest);
+      expect(adLoader.loadScript.firstCall.args[0]).to.include('dt.id=testId');
+      delete window.DigiTrust;
+    });
+
+    it('should not send DigiTrust params when DigiTrust is not loaded', () => {
+      adapter.callBids(bidderRequest);
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+    });
+
+    it('should not send DigiTrust params due to opt out', () => {
+      window.DigiTrust = {
+        getUser: function() {}
+      };
+      sandbox.stub(window.DigiTrust, 'getUser', () =>
+        ({
+          success: true,
+          identity: {
+            privacy: {optout: true},
+            id: 'testId',
+            keyv: 'testKeyV'
+          }
+        })
+      );
+
+      adapter.callBids(bidderRequest);
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+      delete window.DigiTrust;
+    });
+
+    it('should not send DigiTrust params on failure', () => {
+      window.DigiTrust = {
+        getUser: function() {}
+      };
+      sandbox.stub(window.DigiTrust, 'getUser', () =>
+        ({
+          success: false,
+          identity: {
+            privacy: {optout: false},
+            id: 'testId',
+            keyv: 'testKeyV'
+          }
+        })
+      );
+
+      adapter.callBids(bidderRequest);
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+      delete window.DigiTrust;
+    });
+  });
+
   describe('callBids', () => {
     beforeEach(() => {
       sandbox.stub(adLoader, 'loadScript');

--- a/test/spec/adapters/gumgum_spec.js
+++ b/test/spec/adapters/gumgum_spec.js
@@ -106,20 +106,19 @@ describe('gumgum adapter', () => {
           success: true,
           identity: {
             privacy: {optout: false},
-            id: 'testId',
-            keyv: 'testKeyV'
+            id: 'testId'
           }
         })
       );
 
       adapter.callBids(bidderRequest);
-      expect(adLoader.loadScript.firstCall.args[0]).to.include('dt.id=testId');
+      expect(adLoader.loadScript.firstCall.args[0]).to.include('&dt=testId');
       delete window.DigiTrust;
     });
 
     it('should not send DigiTrust params when DigiTrust is not loaded', () => {
       adapter.callBids(bidderRequest);
-      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('&dt');
     });
 
     it('should not send DigiTrust params due to opt out', () => {
@@ -131,14 +130,13 @@ describe('gumgum adapter', () => {
           success: true,
           identity: {
             privacy: {optout: true},
-            id: 'testId',
-            keyv: 'testKeyV'
+            id: 'testId'
           }
         })
       );
 
       adapter.callBids(bidderRequest);
-      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('&dt');
       delete window.DigiTrust;
     });
 
@@ -151,14 +149,13 @@ describe('gumgum adapter', () => {
           success: false,
           identity: {
             privacy: {optout: false},
-            id: 'testId',
-            keyv: 'testKeyV'
+            id: 'testId'
           }
         })
       );
 
       adapter.callBids(bidderRequest);
-      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('dt.id');
+      expect(adLoader.loadScript.firstCall.args[0]).to.not.include('&dt');
       delete window.DigiTrust;
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
In GumGum adapter, retrieving DigiTrust ID, if DigiTrust service is available, and sending to GumGum endpoint.

- anthony@gumgum.com
- [ ] official adapter submission

## Other info
JIRA: AT-4979_DigiTrust-POC
