### PR TITLE
Fixed syntax error in iframe content template

### DIFF
--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -57,9 +57,9 @@ var PubmaticAdapter = function PubmaticAdapter() {
     content += '' +
       'window.pm_pub_id  = "%%PM_PUB_ID%%";' +
       'window.pm_optimize_adslots     = [%%PM_OPTIMIZE_ADSLOTS%%];' +
-      'window.kaddctr = "%%PM_ADDCTR%%;"' +
-      'window.kadgender = "%%PM_GENDER%%;"' +
-      'window.kadage = "%%PM_AGE%%;"' +
+      'window.kaddctr = "%%PM_ADDCTR%%";' +
+      'window.kadgender = "%%PM_GENDER%%";' +
+      'window.kadage = "%%PM_AGE%%";' +
       'window.pm_async_callback_fn = "window.parent.$$PREBID_GLOBAL$$.handlePubmaticCallback";';
 
     content += '</scr' + 'ipt>';


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Syntax error encountered with script generated by the content template variable. Updated to put the `;` outside of the double quotes, so it wasn't treated as a string.

