### PR TITLE
Pubmatic - fix terminating semicolon inside string assignment

### DIFF
--- a/src/adapters/pubmatic.js
+++ b/src/adapters/pubmatic.js
@@ -57,9 +57,9 @@ var PubmaticAdapter = function PubmaticAdapter() {
     content += '' +
       'window.pm_pub_id  = "%%PM_PUB_ID%%";' +
       'window.pm_optimize_adslots     = [%%PM_OPTIMIZE_ADSLOTS%%];' +
-      'window.kaddctr = "%%PM_ADDCTR%%;"' +
-      'window.kadgender = "%%PM_GENDER%%;"' +
-      'window.kadage = "%%PM_AGE%%;"' +
+      'window.kaddctr = "%%PM_ADDCTR%%";' +
+      'window.kadgender = "%%PM_GENDER%%";' +
+      'window.kadage = "%%PM_AGE%%";' +
       'window.pm_async_callback_fn = "window.parent.$$PREBID_GLOBAL$$.handlePubmaticCallback";';
 
     content += '</scr' + 'ipt>';


### PR DESCRIPTION
The terminating semicolon is put inside the quoted string here and on the next two lines and causes an "Unexpected identifier" error to be thrown when the string is parsed for DOM insertion by `iframeDoc.write(_createRequestContent());`.

cc: @prebid/pubmatic @ptomasroos 