### PR TITLE
Fixing a bug with gulp watch rebuilding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task('clean', function () {
     .pipe(clean());
 });
 
-gulp.task('devpack', function () {
+gulp.task('devpack', ['clean'], function () {
   webpackConfig.devtool = 'source-map';
   const analyticsSources = helpers.getAnalyticsSources(analyticsDirectory);
   return gulp.src([].concat(analyticsSources, 'src/prebid.js'))
@@ -181,12 +181,11 @@ gulp.task('watch', function () {
     'src/**/*.js',
     'test/spec/**/*.js',
     '!test/spec/loaders/**/*.js'
-  ], ['lint', 'webpack', 'devpack', 'test']);
+  ], ['clean', 'lint', 'webpack', 'devpack', 'test']);
   gulp.watch([
     'loaders/**/*.js',
     'test/spec/loaders/**/*.js'
   ], ['lint', 'mocha']);
-  gulp.watch(['integrationExamples/gpt/*.html'], ['test']);
   connect.server({
     https: argv.https,
     port: port,


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
I noticed that the `/dev/` build was getting wiped out when running `gulp serve` and making source code changes. I'm pretty sure this got introduced by adding `clean` as a dependency of `webpack` (but not `devpack`) when stabilitizing the CI for #1111. `clean` would execute concurrently with `devpack`, rather than before it.

I also found it super annoying that tests got re-run when updating the `integrationExamples`. The `karma.conf` file excludes `integrationExamples` anyway, so... I'm not sure why it was being run. So I deleted it.