### PR TITLE
Yieldbot refresh - nextPageview with specific refresh slots

### DIFF
--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -104,7 +104,9 @@ function YieldbotAdapter() {
         if (yieldbot._initialized !== true) {
           yieldbot.pub(psn);
           for (var slotName in slots) {
-            yieldbot.defineSlot(slotName, { sizes: slots[slotName] || [] });
+            if (slots.hasOwnProperty(slotName)) {
+              yieldbot.defineSlot(slotName, { sizes: slots[slotName] || [] });
+            }
           }
           yieldbot.enableAsync();
           yieldbot.go();

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -84,24 +84,35 @@ function YieldbotAdapter() {
 
       ybotq.push(function () {
         var yieldbot = window.yieldbot;
-
+        // Empty defined slots bidId array
         ybotlib.definedSlots = [];
+        // Iterate through bids to obtain Yieldbot slot config
+        // - Slot config can be different between initial and refresh requests
+        var psn = 'ERROR_PREBID_DEFINE_YB_PSN';
+        var slots = {};
         utils._each(bids, function (v) {
           var bid = v;
-          var psn = bid.params && bid.params.psn || 'ERROR_DEFINE_YB_PSN';
-          var slot = bid.params && bid.params.slot || 'ERROR_DEFINE_YB_SLOT';
+          // bidder params config: http://prebid.org/dev-docs/bidders/yieldbot.html
+          // - last psn wins
+          psn = bid.params && bid.params.psn || psn;
+          var slotName = bid.params && bid.params.slot || 'ERROR_PREBID_DEFINE_YB_SLOT';
 
-          yieldbot.pub(psn);
-          yieldbot.defineSlot(slot, { sizes: bid.sizes || [] });
+          slots[slotName] = bid.sizes || [];
           ybotlib.definedSlots.push(bid.bidId);
         });
-        yieldbot.enableAsync();
+
         if (yieldbot._initialized !== true) {
+          yieldbot.pub(psn);
+          for (var slotName in slots) {
+            yieldbot.defineSlot(slotName, { sizes: slots[slotName] || [] });
+          }
+          yieldbot.enableAsync();
           yieldbot.go();
         } else {
-          yieldbot.nextPageview();
+          yieldbot.nextPageview(slots);
         }
       });
+
       ybotq.push(function () {
         ybotlib.handleUpdateState();
       });


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change
Fixes #1255

`callBids(params)` after the first i.e. "refresh" bid requests will only include bids for `params.bids`.

## Other information

- Resolves #1255
