### PR TITLE
Use Renderer command queue to render outstream

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -2,19 +2,30 @@ import { loadScript } from 'src/adloader';
 import * as utils from 'src/utils';
 
 export function Renderer(options) {
-  const { url, config, id, callback } = options;
+  const { url, config, id, callback, loaded } = options;
   this.url = url;
   this.config = config;
-  this.callback = callback;
   this.handlers = {};
   this.id = id;
+
+  // a renderer may use the following properties with Renderer.prototype.process
+  // to delay rendering until the render function is loaded
+  this.loaded = loaded;
+  this.cmd = [];
+  this.push = func => {
+    if (typeof func !== 'function') {
+      utils.logError('Commands given to Renderer.push must be wrapped in a function');
+      return;
+    }
+    this.loaded ? func.call() : this.cmd.push(func);
+  };
 
   // we expect to load a renderer url once only so cache the request to load script
   loadScript(url, callback, true);
 }
 
-Renderer.install = function({ url, config, id, callback }) {
-  return new Renderer({ url, config, id, callback });
+Renderer.install = function({ url, config, id, callback, loaded }) {
+  return new Renderer({ url, config, id, callback, loaded });
 };
 
 Renderer.prototype.getConfig = function() {
@@ -35,4 +46,20 @@ Renderer.prototype.handleVideoEvent = function({ id, eventName }) {
   }
 
   utils.logMessage(`Prebid Renderer event for id ${id} type ${eventName}`);
+};
+
+/*
+ * If a Renderer is not loaded at the time renderer.render(bid) is called, add
+ * the render function to the command queue with render.push(() => renderFunc)
+ * then create a renderer callback that sets renderer.loaded to true and call
+ * this function as renderer.process() to begin rendering
+ */
+Renderer.prototype.process = function() {
+  while (this.cmd.length > 0) {
+    try {
+      this.cmd.shift().call();
+    } catch (error) {
+      utils.logError('Error processing Renderer command: ', error);
+    }
+  }
 };

--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -282,12 +282,6 @@ function AppnexusAstAdapter() {
     });
   }
 
-  function onOutstreamRendererLoaded(bid) {
-    // adload.loadScript has loaded ANOutstreamVideo
-    bid.renderer.loaded = true;
-    bid.renderer.process();
-  }
-
   function handleOutstreamRendererEvents(id, eventName) {
     const bid = this;
     bid.renderer.handleVideoEvent({ id, eventName });
@@ -319,9 +313,7 @@ function AppnexusAstAdapter() {
             url: ad.renderer_url,
             config: { adText: `AppNexus Outstream Video Ad via Prebid.js` },
             loaded: false,
-            callback: () => onOutstreamRendererLoaded.call(null, bid)
           });
-
           try {
             bid.renderer.setRender(outstreamRender);
           } catch (err) {

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -53,4 +53,39 @@ describe('Renderer: A renderer installed on a bid response', () => {
     testRenderer1.handleVideoEvent({ id: 1, eventName: 'testEvent' });
     expect(spyEventHandler.called).to.equal(true);
   });
+
+  it('pushes commands to queue if renderer is not loaded', () => {
+    testRenderer1.push(spyRenderFn);
+
+    expect(testRenderer1.cmd.length).to.equal(1);
+
+    // clear queue for next tests
+    testRenderer1.cmd = [];
+  });
+
+  it('fires commands immediately if the renderer is loaded', () => {
+    const func = sinon.spy();
+
+    testRenderer1.loaded = true;
+    testRenderer1.push(func);
+
+    expect(testRenderer1.cmd.length).to.equal(0);
+    sinon.assert.calledOnce(func);
+  });
+
+  it('processes queue by calling each function in queue', () => {
+    testRenderer1.loaded = false;
+    const func1 = sinon.spy();
+    const func2 = sinon.spy();
+
+    testRenderer1.push(func1);
+    testRenderer1.push(func2);
+    expect(testRenderer1.cmd.length).to.equal(2);
+
+    testRenderer1.process();
+
+    sinon.assert.calledOnce(func1);
+    sinon.assert.calledOnce(func2);
+    expect(testRenderer1.cmd.length).to.equal(0);
+  });
 });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
This PR adds properties to the Renderer constructor that can be used to delay rendering until a renderer is loaded. `appnexusAst` then makes use of these capabilities to enable rendering outstream video without the need for an ad server.

A call to `pbjs.renderAd` with a winning outstream bid can potentially be invoked before the render function for this bid is in memory. In this case, the render function pushes to the render command queue, which then gets processed after the renderer is loaded. Calls to `renderer.render(bid)` after the renderer is loaded will skip the command queue and invoke the render function immediately.

As a result, outstream video rendering that is invoked [with an ad server](https://github.com/prebid/Prebid.js/blob/master/test/spec/e2e/gpt-examples/gpt_outstream.html), and outstream video rendering that is invoked [without an adserver](http://acdn.adnxs.com/prebid/demos/outstream-without-adserver/), will both work.