### PR TITLE
modify 'featureforward' adapter to be an indepandant adapter

### DIFF
--- a/adapters.json
+++ b/adapters.json
@@ -69,6 +69,7 @@
     "trion",
     "prebidServer",
     "adsupply",
+    "featureforward",
     {
       "appnexus": {
         "alias": "brealtime"
@@ -113,11 +114,6 @@
       "rubicon": {
         "alias": "rubiconLite",
         "supportedMediaTypes": ["video"]
-      }
-    },
-    {
-      "appnexus": {
-        "alias": "featureforward"
       }
     },
     {

--- a/src/adapters/featureforward.js
+++ b/src/adapters/featureforward.js
@@ -1,0 +1,93 @@
+import {createBid} from 'src/bidfactory';
+import {addBidResponse} from 'src/bidmanager';
+import {logError,getTopWindowLocation} from 'src/utils';
+import {ajax} from 'src/ajax';
+import {STATUS} from 'src/constants';
+
+function FeatureForwardAdapter() {
+
+  const bidUrl = window.location.protocol + '//prmbdr.featureforward.com/newbidder/bidder1_prm.php?';
+  const ajaxOptions = {
+    method: 'POST',
+    //method: 'GET',
+    withCredentials: true,
+    contentType: 'text/plain'
+  };
+
+  function _callBids(bidderRequest) {
+    var i = 0;
+    bidderRequest.bids.forEach(bidRequest => {
+      try {
+	while (bidRequest.sizes[i] !== undefined)
+	{
+		var params = Object.assign({}, environment(), bidRequest.params,{"size":bidRequest.sizes[i]});
+		var postRequest  = JSON.stringify(params);
+		var url = bidUrl;
+		i++;
+		ajax(url, (bidResponse) => {
+		  bidResponseAvailable(bidRequest, bidResponse);
+		}, postRequest, ajaxOptions);
+	}
+      } catch(e) {
+        //register passback on any exceptions while attempting to fetch response.
+        logError('featureforward.requestBid', 'ERROR', e);
+        bidResponseAvailable(bidRequest);
+      }
+    });
+  }
+
+  function environment() {
+    return {
+      ca: 'BID',
+      'if': 0,
+      url: getTopWindowLocation().href,
+      refurl: referrer(),
+      ew: document.documentElement.clientWidth,
+      eh: document.documentElement.clientHeight,
+      ln: (navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage)
+    };
+  }
+
+  function referrer() {
+    try {
+      return window.top.document.referrer;
+    } catch (e) {
+      return document.referrer;
+    }
+  }
+
+  function bidResponseAvailable(bidRequest, rawResponse) {
+    if (rawResponse) {
+      var bidResponse = parse(rawResponse);
+      if(bidResponse) {
+        var bid = createBid(STATUS.GOOD, bidRequest);
+        bid.bidderCode = bidRequest.bidder;
+        bid.cpm = bidResponse.bidCpm;
+        bid.ad = bidResponse.html;
+        bid.width = bidResponse.width;
+        bid.height = bidResponse.height;
+        addBidResponse(bidRequest.placementCode, bid);
+        return;
+      }
+    }
+    var passback = createBid(STATUS.NO_BID, bidRequest);
+    passback.bidderCode = bidRequest.bidder;
+    addBidResponse(bidRequest.placementCode, passback);
+  }
+
+  function parse(rawResponse) {
+    try {
+      return JSON.parse(rawResponse);
+    } catch (ex) {
+      logError('featureforward.safeParse', 'ERROR', ex);
+      return null;
+    }
+  }
+
+  return {
+    callBids: _callBids
+  };
+
+}
+
+module.exports = FeatureForwardAdapter;

--- a/src/adapters/featureforward.js
+++ b/src/adapters/featureforward.js
@@ -1,15 +1,13 @@
 import {createBid} from 'src/bidfactory';
 import {addBidResponse} from 'src/bidmanager';
-import {logError,getTopWindowLocation} from 'src/utils';
+import {logError, getTopWindowLocation} from 'src/utils';
 import {ajax} from 'src/ajax';
 import {STATUS} from 'src/constants';
 
 function FeatureForwardAdapter() {
-
   const bidUrl = window.location.protocol + '//prmbdr.featureforward.com/newbidder/bidder1_prm.php?';
   const ajaxOptions = {
     method: 'POST',
-    //method: 'GET',
     withCredentials: true,
     contentType: 'text/plain'
   };
@@ -18,18 +16,18 @@ function FeatureForwardAdapter() {
     var i = 0;
     bidderRequest.bids.forEach(bidRequest => {
       try {
-	while (bidRequest.sizes[i] !== undefined)
+        while (bidRequest.sizes[i] !== undefined)
 	{
-		var params = Object.assign({}, environment(), bidRequest.params,{"size":bidRequest.sizes[i]});
-		var postRequest  = JSON.stringify(params);
-		var url = bidUrl;
-		i++;
-		ajax(url, (bidResponse) => {
-		  bidResponseAvailable(bidRequest, bidResponse);
-		}, postRequest, ajaxOptions);
+	  var params = Object.assign({}, environment(), bidRequest.params, {'size':bidRequest.sizes[i]});
+	  var postRequest  = JSON.stringify(params);
+	  var url = bidUrl;
+	  i++;
+	  ajax(url, (bidResponse) => {
+	    bidResponseAvailable(bidRequest, bidResponse);
+	  }, postRequest, ajaxOptions);
 	}
-      } catch(e) {
-        //register passback on any exceptions while attempting to fetch response.
+      } catch (e) {
+        // register passback on any exceptions while attempting to fetch response.
         logError('featureforward.requestBid', 'ERROR', e);
         bidResponseAvailable(bidRequest);
       }
@@ -59,7 +57,7 @@ function FeatureForwardAdapter() {
   function bidResponseAvailable(bidRequest, rawResponse) {
     if (rawResponse) {
       var bidResponse = parse(rawResponse);
-      if(bidResponse) {
+      if (bidResponse) {
         var bid = createBid(STATUS.GOOD, bidRequest);
         bid.bidderCode = bidRequest.bidder;
         bid.cpm = bidResponse.bidCpm;
@@ -87,7 +85,6 @@ function FeatureForwardAdapter() {
   return {
     callBids: _callBids
   };
-
 }
 
 module.exports = FeatureForwardAdapter;

--- a/src/adapters/featureforward.js
+++ b/src/adapters/featureforward.js
@@ -16,16 +16,15 @@ function FeatureForwardAdapter() {
     var i = 0;
     bidderRequest.bids.forEach(bidRequest => {
       try {
-        while (bidRequest.sizes[i] !== undefined)
-	{
-	  var params = Object.assign({}, environment(), bidRequest.params, {'size':bidRequest.sizes[i]});
-	  var postRequest  = JSON.stringify(params);
-	  var url = bidUrl;
-	  i++;
-	  ajax(url, (bidResponse) => {
-	    bidResponseAvailable(bidRequest, bidResponse);
-	  }, postRequest, ajaxOptions);
-	}
+        while (bidRequest.sizes[i] !== undefined) {
+          var params = Object.assign({}, environment(), bidRequest.params, {'size': bidRequest.sizes[i]});
+          var postRequest  = JSON.stringify(params);
+          var url = bidUrl;
+          i++;
+          ajax(url, (bidResponse) => {
+            bidResponseAvailable(bidRequest, bidResponse);
+          }, postRequest, ajaxOptions);
+        }
       } catch (e) {
         // register passback on any exceptions while attempting to fetch response.
         logError('featureforward.requestBid', 'ERROR', e);

--- a/test/spec/adapters/featureforward_spec.js
+++ b/test/spec/adapters/featureforward_spec.js
@@ -35,7 +35,7 @@ describe('FeatureForward Adapter Tests', () => {
     featureForwardAdapter.callBids(slotConfigs);
     var call = ajaxStub.firstCall.args[0];
     var request = JSON.parse(ajaxStub.args[0][2]);
-    var creds  = ajaxStub.args[0][3];		
+    var creds = ajaxStub.args[0][3];	
     expect(call).to.equal('http://prmbdr.featureforward.com/newbidder/bidder1_prm.php?');
     expect(request.ca).to.equal('BID');
     expect(request.pubId).to.equal('001');
@@ -43,7 +43,7 @@ describe('FeatureForward Adapter Tests', () => {
     expect(request.placementId).to.equal('1');
     expect(request.size[0]).to.equal(300);
     expect(request.size[1]).to.equal(250);
-    expect(creds.method).to.equal('POST');	
+    expect(creds.method).to.equal('POST');
   });
 
   it('Verify bid', () => {

--- a/test/spec/adapters/featureforward_spec.js
+++ b/test/spec/adapters/featureforward_spec.js
@@ -1,33 +1,26 @@
 import {expect} from 'chai';
 import FeatureForwardAdapter from 'src/adapters/featureforward.js';
 import bidManager from 'src/bidmanager';
-import * as ajax from "src/ajax";
+import * as ajax from 'src/ajax';
 import {parse as parseURL} from 'src/url';
 
-
-
-
-
-describe("FeatureForward Adapter Tests", () => {
-
+describe('FeatureForward Adapter Tests', () => {
   let featureForwardAdapter = new FeatureForwardAdapter();
   let slotConfigs;
   let ajaxStub;
-
   beforeEach(() => {
     sinon.stub(bidManager, 'addBidResponse');
     ajaxStub = sinon.stub(ajax, 'ajax');
-
     slotConfigs = {
       bids: [
         {
 	  sizes: [[300, 250]],
-          bidder: "featureforward",
+          bidder: 'featureforward',
 	  placementCode: 'test1_placement',
           params: {
-                pubId:'001',
-                siteId:'111',
-                placementId:'1',
+            pubId: '001',
+            siteId: '111',
+            placementId: '1',
           }
         }]
     };
@@ -43,14 +36,14 @@ describe("FeatureForward Adapter Tests", () => {
     var call = ajaxStub.firstCall.args[0];
     var request = JSON.parse(ajaxStub.args[0][2]);
     var creds  = ajaxStub.args[0][3];		
-    expect(call).to.equal("http://prmbdr.featureforward.com/newbidder/bidder1_prm.php?");
-    expect(request.ca).to.equal("BID");
-    expect(request.pubId).to.equal("001");
-    expect(request.siteId).to.equal("111");
-    expect(request.placementId).to.equal("1");
+    expect(call).to.equal('http://prmbdr.featureforward.com/newbidder/bidder1_prm.php?');
+    expect(request.ca).to.equal('BID');
+    expect(request.pubId).to.equal('001');
+    expect(request.siteId).to.equal('111');
+    expect(request.placementId).to.equal('1');
     expect(request.size[0]).to.equal(300);
     expect(request.size[1]).to.equal(250);
-    expect(creds.method).to.equal("POST");	
+    expect(creds.method).to.equal('POST');	
   });
 
   it('Verify bid', () => {
@@ -58,8 +51,8 @@ describe("FeatureForward Adapter Tests", () => {
     ajaxStub.firstCall.args[1](JSON.stringify({
       html: 'FF Test Ad',
       bidCpm: 0.555,
-      width:300,
-      height:250			
+      width: 300,
+      height: 250
     }));
     let bid = bidManager.addBidResponse.firstCall.args[1];
     expect(bid.bidderCode).to.equal('featureforward');
@@ -69,10 +62,9 @@ describe("FeatureForward Adapter Tests", () => {
     expect(bid.height).to.equal(250);
   });
 
-
   it('Verify passback', () => {
     featureForwardAdapter.callBids(slotConfigs);
-    //trigger a mock ajax callback with no bid.
+    // trigger a mock ajax callback with no bid.
     ajaxStub.firstCall.args[1](null);
     let placement = bidManager.addBidResponse.firstCall.args[0];
     let bid = bidManager.addBidResponse.firstCall.args[1];
@@ -92,5 +84,4 @@ describe("FeatureForward Adapter Tests", () => {
     expect(bid).to.not.have.property('ad');
     expect(bid).to.not.have.property('cpm');
   });
-
 });

--- a/test/spec/adapters/featureforward_spec.js
+++ b/test/spec/adapters/featureforward_spec.js
@@ -1,0 +1,96 @@
+import {expect} from 'chai';
+import FeatureForwardAdapter from 'src/adapters/featureforward.js';
+import bidManager from 'src/bidmanager';
+import * as ajax from "src/ajax";
+import {parse as parseURL} from 'src/url';
+
+
+
+
+
+describe("FeatureForward Adapter Tests", () => {
+
+  let featureForwardAdapter = new FeatureForwardAdapter();
+  let slotConfigs;
+  let ajaxStub;
+
+  beforeEach(() => {
+    sinon.stub(bidManager, 'addBidResponse');
+    ajaxStub = sinon.stub(ajax, 'ajax');
+
+    slotConfigs = {
+      bids: [
+        {
+	  sizes: [[300, 250]],
+          bidder: "featureforward",
+	  placementCode: 'test1_placement',
+          params: {
+                pubId:'001',
+                siteId:'111',
+                placementId:'1',
+          }
+        }]
+    };
+  });
+
+  afterEach(() => {
+    bidManager.addBidResponse.restore();
+    ajaxStub.restore();
+  });
+
+  it('Verify requests sent to FeatureForward', () => {
+    featureForwardAdapter.callBids(slotConfigs);
+    var call = ajaxStub.firstCall.args[0];
+    var request = JSON.parse(ajaxStub.args[0][2]);
+    var creds  = ajaxStub.args[0][3];		
+    expect(call).to.equal("http://prmbdr.featureforward.com/newbidder/bidder1_prm.php?");
+    expect(request.ca).to.equal("BID");
+    expect(request.pubId).to.equal("001");
+    expect(request.siteId).to.equal("111");
+    expect(request.placementId).to.equal("1");
+    expect(request.size[0]).to.equal(300);
+    expect(request.size[1]).to.equal(250);
+    expect(creds.method).to.equal("POST");	
+  });
+
+  it('Verify bid', () => {
+    featureForwardAdapter.callBids(slotConfigs);
+    ajaxStub.firstCall.args[1](JSON.stringify({
+      html: 'FF Test Ad',
+      bidCpm: 0.555,
+      width:300,
+      height:250			
+    }));
+    let bid = bidManager.addBidResponse.firstCall.args[1];
+    expect(bid.bidderCode).to.equal('featureforward');
+    expect(bid.cpm).to.equal(0.555);
+    expect(bid.ad).to.equal('FF Test Ad');
+    expect(bid.width).to.equal(300);
+    expect(bid.height).to.equal(250);
+  });
+
+
+  it('Verify passback', () => {
+    featureForwardAdapter.callBids(slotConfigs);
+    //trigger a mock ajax callback with no bid.
+    ajaxStub.firstCall.args[1](null);
+    let placement = bidManager.addBidResponse.firstCall.args[0];
+    let bid = bidManager.addBidResponse.firstCall.args[1];
+    expect(placement).to.equal('test1_placement');
+    expect(bid.bidderCode).to.equal('featureforward');
+    expect(bid).to.not.have.property('ad');
+    expect(bid).to.not.have.property('cpm');
+  });
+
+  it('Verify passback when ajax call fails', () => {
+    ajaxStub.throws();
+    featureForwardAdapter.callBids(slotConfigs);
+    let placement = bidManager.addBidResponse.firstCall.args[0];
+    let bid = bidManager.addBidResponse.firstCall.args[1];
+    expect(placement).to.equal('test1_placement');
+    expect(bid.bidderCode).to.equal('featureforward');
+    expect(bid).to.not.have.property('ad');
+    expect(bid).to.not.have.property('cpm');
+  });
+
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
