### PR TITLE
Sharethrough Adapter - set bidderCode on invalid bid

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -48,6 +48,20 @@ var SharethroughAdapter = function SharethroughAdapter() {
   function _strcallback(bidObj, bidResponse) {
     try {
       bidResponse = JSON.parse(bidResponse);
+    } catch (e) {
+      _handleInvalidBid(bidObj);
+      return;
+    }
+
+    if (bidResponse.creatives && bidResponse.creatives.length > 0) {
+      _handleBid(bidObj, bidResponse);
+    } else {
+      _handleInvalidBid(bidObj);
+    }
+  }
+
+  function _handleBid(bidObj, bidResponse) {
+    try {
       const bidId = bidResponse.bidId;
       const bid = bidfactory.createBid(1, bidObj);
       bid.bidderCode = STR_BIDDER_CODE;
@@ -87,6 +101,7 @@ var SharethroughAdapter = function SharethroughAdapter() {
 
   function _handleInvalidBid(bidObj) {
     const bid = bidfactory.createBid(2, bidObj);
+    bid.bidderCode = STR_BIDDER_CODE;
     bidmanager.addBidResponse(bidObj.placementCode, bid);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
- Set bidderCode on bid object for invalid bids
- Don't use exception handling for control flow when there are no creatives

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
jchau@sharethrough.com
- [x] official adapter submission

