### PR TITLE
Fixing Adyoulike adapter for Safari iOS7

### DIFF
--- a/src/adapters/adyoulike.js
+++ b/src/adapters/adyoulike.js
@@ -66,9 +66,16 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
       Placements: placements,
     };
 
-    if (performance && performance.navigation) {
-      body.PageRefreshed = performance.navigation.type === performance.navigation.TYPE_RELOAD;
-    }
+    // performance isn't supported by mobile safari iOS7. window.performance works, but
+    // evaluates to true during unit tests, which is a failure.
+    //
+    // try/catch was added to un-block the Prebid 0.25 release, but the adyoulike adapter
+    // maintainers should revisit this and see if it's really what they want.
+    try {
+      if (performance && performance.navigation) {
+        body.PageRefreshed = performance.navigation.type === performance.navigation.TYPE_RELOAD;
+      }
+    } catch (e) { }
 
     return JSON.stringify(body);
   }

--- a/src/adapters/adyoulike.js
+++ b/src/adapters/adyoulike.js
@@ -67,7 +67,7 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
     };
 
     // performance isn't supported by mobile safari iOS7. window.performance works, but
-    // evaluates to true during unit tests, which is a failure.
+    // evaluates to true on a unit test which expects false.
     //
     // try/catch was added to un-block the Prebid 0.25 release, but the adyoulike adapter
     // maintainers should revisit this and see if it's really what they want.
@@ -75,7 +75,9 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
       if (performance && performance.navigation) {
         body.PageRefreshed = performance.navigation.type === performance.navigation.TYPE_RELOAD;
       }
-    } catch (e) { }
+    } catch (e) {
+      body.PageRefreshed = false;
+    }
 
     return JSON.stringify(body);
   }


### PR DESCRIPTION
`performance` isn't supported by iOS7. `window.performance` gets rid of that error, but then the unit tests fail because PageRefreshed gets set to `true`.

Wrapping this in a try/catch to un-block the release. @jbAdyoulike you might want to take another pass at this to see if it's really what you want. 