### PR TITLE
Use local module path

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -4,7 +4,7 @@ import { getGlobal } from './prebidGlobal';
 import { flatten, uniques, isGptPubadsDefined, adUnitsFilter } from './utils';
 import { videoAdUnit, hasNonVideoBidder } from './video';
 import { nativeAdUnit, nativeBidder, hasNonNativeBidder } from './native';
-import 'polyfill';
+import './polyfill';
 import { parse as parseURL, format as formatURL } from './url';
 import { isValidePriceConfig } from './cpmBucketManager';
 import { listenMessagesFromCreative } from './secureCreatives';


### PR DESCRIPTION
## Type of change
- Refactoring (no functional changes, no api changes)

## Description of change
`polyfill` is a local module but importing with `import 'polyfill'` in certain configuration/build setups can make this look like an external dependency. May help fix #1199