### PR TITLE
Empty bidRequests in AST adapter each time new auction begins

### DIFF
--- a/src/adapters/appnexusAst.js
+++ b/src/adapters/appnexusAst.js
@@ -34,6 +34,8 @@ function AppnexusAstAdapter() {
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
+    bidRequests = {};
+
     const bids = bidRequest.bids || [];
     var member = 0;
     let userObj;
@@ -193,8 +195,11 @@ function AppnexusAstAdapter() {
       if (type === 'native') bid.mediaType = 'native';
       if (type === 'video') bid.mediaType = 'video';
       if (type === 'video-outstream') bid.mediaType = 'video-outstream';
-      const placement = bidRequests[bid.adId].placementCode;
-      bidmanager.addBidResponse(placement, bid);
+
+      if (bid.adId in bidRequests) {
+        const placement = bidRequests[bid.adId].placementCode;
+        bidmanager.addBidResponse(placement, bid);
+      }
     });
 
     if (!usersync) {


### PR DESCRIPTION
When error occurs adapter issues response for each bid in `bidRequests`
therefore bidRequests must be emptied each time new auction begins

Fixes https://github.com/prebid/Prebid.js/issues/1304


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Empty bidRequests each time new auction begins, because when an error occurs adapter issues a response for each request in this array.

## Other information
https://github.com/prebid/Prebid.js/issues/1304