### PR TITLE
Fixing some fragile tests

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -137,6 +137,10 @@ describe('Unit: Prebid Module', function () {
     $$PREBID_GLOBAL$$.adUnits = [];
   })
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
+    beforeEach(() => {
+      resetAuction();
+    });
+
     it('should return targeting info as a string', function () {
       const adUnitCode = config.adUnitCodes[0];
       $$PREBID_GLOBAL$$.enableSendAllBids();
@@ -331,10 +335,9 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getBidResponses', function () {
-    var result = $$PREBID_GLOBAL$$.getBidResponses();
-    var compare = getBidResponsesFromAPI();
-
     it('should return expected bid responses when not passed an adunitCode', function () {
+      var result = $$PREBID_GLOBAL$$.getBidResponses();
+      var compare = getBidResponsesFromAPI();
       assert.deepEqual(result, compare, 'expected bid responses are returned');
     });
 


### PR DESCRIPTION
When working on #1277, I bumped into some fragile tests in `pbjs_api_spec`. Am fixing them in a separate PR because the changes are small, and not really related to the video cache PR.

You can't really see the problem unless you add other unit test files. In my case, I added a file `test/spec/unit/bidmanager_spec.js` like this:

```
import { expect } from 'chai';
import { addBidResponse } from 'src/bidmanager';

describe('The bidmanager', () => {
  before(() => {
    $$PREBID_GLOBAL$$.cbTimeout = 5000;
    $$PREBID_GLOBAL$$.timeoutBuffer = 50;
    $$PREBID_GLOBAL$$._adUnitCodes = $$PREBID_GLOBAL$$.adUnits.map(unit => unit.code);
  });

  beforeEach(() => {
    $$PREBID_GLOBAL$$._bidsRequested = [];
    $$PREBID_GLOBAL$$._bidsReceived = [];
  });

  it('should pass', () => {
    expect(true).to.equal(true);
  })
});
```

If this file exists, then some tests in `pbjs_api_spec.js` start failing, because they implicitly depend on this global state.

These changes make those tests self-contained again, so that they still pass when we can create new unit test files.