### PR TITLE
Add setConfig method

### DIFF
--- a/integrationExamples/gpt/amp/remote.html
+++ b/integrationExamples/gpt/amp/remote.html
@@ -52,7 +52,7 @@ document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
      * */
      function loadPrebidJS() {
         pbjs.que.push(function () {
-            pbjs.logging = true;
+            pbjs.setConfig({ debug: true });
             pbjs.addAdUnits(adUnits);
 
             pbjs.requestBids({

--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -24,7 +24,7 @@
     setTimeout(initAdserver, PREBID_TIMEOUT);
 
     var pbjs = pbjs || {};
-    pbjs.bidderTimeout = 3000;
+    pbjs.setConfig({ bidderTimeout: 3000 });
     pbjs.que = pbjs.que || [];
     (function() {
         var pbjsEl = document.createElement("script");

--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -49,14 +49,16 @@
             ]
           }];
 
-        pbjs.setS2SConfig({
+        pbjs.setConfig({
+          s2sConfig : {
             accountId : '1',
             enabled : true, //default value set to false
             bidders : ['appnexus'],
             timeout : 1000, //default value is 1000
             adapter : 'prebidServer', //if we have any other s2s adapter, default value is s2s
             endpoint : 'https://prebid.adnxs.com/pbs/v1/auction?url_override=http%3A%2F%2Fwww.nytimes.com'
-          });
+          }
+        });
 
         pbjs.addAdUnits(adUnits);
 

--- a/modules/inneractiveBidAdapter.js
+++ b/modules/inneractiveBidAdapter.js
@@ -6,7 +6,7 @@ import bidFactory from 'src/bidfactory';
 import {STATUS} from 'src/constants';
 import {formatQS} from 'src/url';
 import adaptermanager from 'src/adaptermanager';
-import { config } from 'src/config';
+import { getConfig } from 'src/config';
 
 /**
  * @type {{IA_JS: string, ADAPTER_NAME: string, V: string, RECTANGLE_SIZE: {W: number, H: number}, SPOT_TYPES: {INTERSTITIAL: string, RECTANGLE: string, FLOATING: string, BANNER: string}, DISPLAY_AD: number, ENDPOINT_URL: string, EVENTS_ENDPOINT_URL: string, RESPONSE_HEADERS_NAME: {PRICING_VALUE: string, AD_H: string, AD_W: string}}}
@@ -213,7 +213,7 @@ const Url = {
     }
 
     if (typeof $$PREBID_GLOBAL$$ !== 'undefined') {
-      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || config.bidderTimeout;
+      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || getConfig('bidderTimeout');
     }
 
     toQueryString.timestamp = Date.now();

--- a/modules/inneractiveBidAdapter.js
+++ b/modules/inneractiveBidAdapter.js
@@ -6,6 +6,7 @@ import bidFactory from 'src/bidfactory';
 import {STATUS} from 'src/constants';
 import {formatQS} from 'src/url';
 import adaptermanager from 'src/adaptermanager';
+import { config } from 'src/config';
 
 /**
  * @type {{IA_JS: string, ADAPTER_NAME: string, V: string, RECTANGLE_SIZE: {W: number, H: number}, SPOT_TYPES: {INTERSTITIAL: string, RECTANGLE: string, FLOATING: string, BANNER: string}, DISPLAY_AD: number, ENDPOINT_URL: string, EVENTS_ENDPOINT_URL: string, RESPONSE_HEADERS_NAME: {PRICING_VALUE: string, AD_H: string, AD_W: string}}}
@@ -212,7 +213,7 @@ const Url = {
     }
 
     if (typeof $$PREBID_GLOBAL$$ !== 'undefined') {
-      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || $$PREBID_GLOBAL$$.bidderTimeout;
+      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || config.bidderTimeout;
     }
 
     toQueryString.timestamp = Date.now();

--- a/modules/inneractiveBidAdapter.js
+++ b/modules/inneractiveBidAdapter.js
@@ -6,7 +6,7 @@ import bidFactory from 'src/bidfactory';
 import {STATUS} from 'src/constants';
 import {formatQS} from 'src/url';
 import adaptermanager from 'src/adaptermanager';
-import { getConfig } from 'src/config';
+import { config } from 'src/config';
 
 /**
  * @type {{IA_JS: string, ADAPTER_NAME: string, V: string, RECTANGLE_SIZE: {W: number, H: number}, SPOT_TYPES: {INTERSTITIAL: string, RECTANGLE: string, FLOATING: string, BANNER: string}, DISPLAY_AD: number, ENDPOINT_URL: string, EVENTS_ENDPOINT_URL: string, RESPONSE_HEADERS_NAME: {PRICING_VALUE: string, AD_H: string, AD_W: string}}}
@@ -213,7 +213,7 @@ const Url = {
     }
 
     if (typeof $$PREBID_GLOBAL$$ !== 'undefined') {
-      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || getConfig('bidderTimeout');
+      toQueryString.bco = $$PREBID_GLOBAL$$.cbTimeout || config.getConfig('bidderTimeout');
     }
 
     toQueryString.timestamp = Date.now();

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,7 +4,7 @@ const adloader = require('src/adloader');
 const CONSTANTS = require('src/constants.json');
 const utils = require('src/utils.js');
 const adaptermanager = require('src/adaptermanager');
-const { config } = require('src/config');
+const { getConfig } = require('src/config');
 
 const OpenxAdapter = function OpenxAdapter() {
   const BIDDER_CODE = 'openx';
@@ -40,7 +40,7 @@ const OpenxAdapter = function OpenxAdapter() {
       let beaconParams = {
         bd: +(new Date()) - startTime,
         br: '0', // maybe 0, t, or p
-        bt: $$PREBID_GLOBAL$$.cbTimeout || config.bidderTimeout, // For the timeout per bid request
+        bt: $$PREBID_GLOBAL$$.cbTimeout || getConfig('bidderTimeout'), // For the timeout per bid request
         bs: window.location.hostname
       };
 

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,6 +4,7 @@ const adloader = require('src/adloader');
 const CONSTANTS = require('src/constants.json');
 const utils = require('src/utils.js');
 const adaptermanager = require('src/adaptermanager');
+const { config } = require('src/config');
 
 const OpenxAdapter = function OpenxAdapter() {
   const BIDDER_CODE = 'openx';
@@ -39,7 +40,7 @@ const OpenxAdapter = function OpenxAdapter() {
       let beaconParams = {
         bd: +(new Date()) - startTime,
         br: '0', // maybe 0, t, or p
-        bt: $$PREBID_GLOBAL$$.cbTimeout || $$PREBID_GLOBAL$$.bidderTimeout, // For the timeout per bid request
+        bt: $$PREBID_GLOBAL$$.cbTimeout || config.bidderTimeout, // For the timeout per bid request
         bs: window.location.hostname
       };
 

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -1,10 +1,10 @@
+import { config } from 'src/config';
 const bidfactory = require('src/bidfactory.js');
 const bidmanager = require('src/bidmanager.js');
 const adloader = require('src/adloader');
 const CONSTANTS = require('src/constants.json');
 const utils = require('src/utils.js');
 const adaptermanager = require('src/adaptermanager');
-const { getConfig } = require('src/config');
 
 const OpenxAdapter = function OpenxAdapter() {
   const BIDDER_CODE = 'openx';
@@ -40,7 +40,7 @@ const OpenxAdapter = function OpenxAdapter() {
       let beaconParams = {
         bd: +(new Date()) - startTime,
         br: '0', // maybe 0, t, or p
-        bt: $$PREBID_GLOBAL$$.cbTimeout || getConfig('bidderTimeout'), // For the timeout per bid request
+        bt: $$PREBID_GLOBAL$$.cbTimeout || config.getConfig('bidderTimeout'), // For the timeout per bid request
         bs: window.location.hostname
       };
 

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -6,7 +6,8 @@ import { ajax } from 'src/ajax';
 import { STATUS, S2S } from 'src/constants';
 import { queueSync, cookieSet } from 'src/cookie';
 import adaptermanager from 'src/adaptermanager';
-import { getConfig } from 'src/config';
+import { config } from 'src/config';
+const getConfig = config.getConfig;
 
 const TYPE = S2S.SRC;
 const cookieSetUrl = 'https://acdn.adnxs.com/cookieset/cs.js';

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -6,7 +6,7 @@ import { ajax } from 'src/ajax';
 import { STATUS, S2S } from 'src/constants';
 import { queueSync, cookieSet } from 'src/cookie';
 import adaptermanager from 'src/adaptermanager';
-import { getDebugStatus } from 'src/config';
+import { config } from 'src/config';
 
 const TYPE = S2S.SRC;
 const cookieSetUrl = 'https://acdn.adnxs.com/cookieset/cs.js';
@@ -91,7 +91,7 @@ function PrebidServer() {
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
-    const isDebug = !!getDebugStatus();
+    const isDebug = !!config.debug;
     convertTypes(bidRequest.ad_units);
     let requestJson = {
       account_id: config.accountId,

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -6,6 +6,7 @@ import { ajax } from 'src/ajax';
 import { STATUS, S2S } from 'src/constants';
 import { queueSync, cookieSet } from 'src/cookie';
 import adaptermanager from 'src/adaptermanager';
+import { getDebugStatus } from 'src/config';
 
 const TYPE = S2S.SRC;
 const cookieSetUrl = 'https://acdn.adnxs.com/cookieset/cs.js';
@@ -90,7 +91,7 @@ function PrebidServer() {
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
-    const isDebug = !!$$PREBID_GLOBAL$$.logging;
+    const isDebug = !!getDebugStatus();
     convertTypes(bidRequest.ad_units);
     let requestJson = {
       account_id: config.accountId,

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -6,7 +6,7 @@ import { ajax } from 'src/ajax';
 import { STATUS, S2S } from 'src/constants';
 import { queueSync, cookieSet } from 'src/cookie';
 import adaptermanager from 'src/adaptermanager';
-import { config } from 'src/config';
+import { getConfig } from 'src/config';
 
 const TYPE = S2S.SRC;
 const cookieSetUrl = 'https://acdn.adnxs.com/cookieset/cs.js';
@@ -91,7 +91,7 @@ function PrebidServer() {
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
-    const isDebug = !!config.debug;
+    const isDebug = !!getConfig('debug');
     convertTypes(bidRequest.ad_units);
     let requestJson = {
       account_id: config.accountId,

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -1,6 +1,6 @@
 import {ajax} from 'src/ajax';
 import adaptermanager from 'src/adaptermanager';
-import { getConfig } from 'src/config';
+import { config } from 'src/config';
 
 const bidmanager = require('src/bidmanager.js');
 const bidfactory = require('src/bidfactory.js');
@@ -216,7 +216,7 @@ function RhythmoneAdapter (bidManager, global, loader) {
     data.response_ms = (new Date()).getTime() - loadStart;
     data.placement_codes = configuredPlacements.join(',');
     data.bidder_version = version;
-    data.prebid_timeout = prebid_instance.cbTimeout || getConfig('bidderTimeout');
+    data.prebid_timeout = prebid_instance.cbTimeout || config.getConfig('bidderTimeout');
 
     for (var k in data) {
       q.push(encodeURIComponent(k) + '=' + encodeURIComponent((typeof data[k] === 'object' ? JSON.stringify(data[k]) : data[k])));

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -1,6 +1,6 @@
 import {ajax} from 'src/ajax';
 import adaptermanager from 'src/adaptermanager';
-import { config } from 'src/config';
+import { getConfig } from 'src/config';
 
 const bidmanager = require('src/bidmanager.js');
 const bidfactory = require('src/bidfactory.js');
@@ -216,7 +216,7 @@ function RhythmoneAdapter (bidManager, global, loader) {
     data.response_ms = (new Date()).getTime() - loadStart;
     data.placement_codes = configuredPlacements.join(',');
     data.bidder_version = version;
-    data.prebid_timeout = prebid_instance.cbTimeout || config.bidderTimeout;
+    data.prebid_timeout = prebid_instance.cbTimeout || getConfig('bidderTimeout');
 
     for (var k in data) {
       q.push(encodeURIComponent(k) + '=' + encodeURIComponent((typeof data[k] === 'object' ? JSON.stringify(data[k]) : data[k])));

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -1,5 +1,6 @@
 import {ajax} from 'src/ajax';
 import adaptermanager from 'src/adaptermanager';
+import { config } from 'src/config';
 
 const bidmanager = require('src/bidmanager.js');
 const bidfactory = require('src/bidfactory.js');
@@ -215,7 +216,7 @@ function RhythmoneAdapter (bidManager, global, loader) {
     data.response_ms = (new Date()).getTime() - loadStart;
     data.placement_codes = configuredPlacements.join(',');
     data.bidder_version = version;
-    data.prebid_timeout = prebid_instance.cbTimeout || prebid_instance.bidderTimeout;
+    data.prebid_timeout = prebid_instance.cbTimeout || config.bidderTimeout;
 
     for (var k in data) {
       q.push(encodeURIComponent(k) + '=' + encodeURIComponent((typeof data[k] === 'object' ? JSON.stringify(data[k]) : data[k])));

--- a/modules/sekindoUMBidAdapter.js
+++ b/modules/sekindoUMBidAdapter.js
@@ -6,7 +6,7 @@ var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var adaptermanager = require('src/adaptermanager');
-var { config } = require('src/config');
+var { getConfig } = require('src/config');
 
 function SekindoUMAdapter() {
   function _callBids(params) {
@@ -75,7 +75,7 @@ function SekindoUMAdapter() {
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbver', '3');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbobj', '$$PREBID_GLOBAL$$');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'dcpmflr', bidfloor);
-    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', config.bidderTimeout);
+    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', getConfig('bidderTimeout'));
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'protocol', protocol);
 
     adloader.loadScript(scriptSrc);

--- a/modules/sekindoUMBidAdapter.js
+++ b/modules/sekindoUMBidAdapter.js
@@ -1,4 +1,5 @@
 import { getBidRequest } from 'src/utils.js';
+import { config } from 'src/config';
 
 var CONSTANTS = require('src/constants.json');
 var utils = require('src/utils.js');
@@ -6,7 +7,6 @@ var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var adaptermanager = require('src/adaptermanager');
-var { getConfig } = require('src/config');
 
 function SekindoUMAdapter() {
   function _callBids(params) {
@@ -75,7 +75,7 @@ function SekindoUMAdapter() {
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbver', '3');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbobj', '$$PREBID_GLOBAL$$');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'dcpmflr', bidfloor);
-    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', getConfig('bidderTimeout'));
+    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', config.getConfig('bidderTimeout'));
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'protocol', protocol);
 
     adloader.loadScript(scriptSrc);

--- a/modules/sekindoUMBidAdapter.js
+++ b/modules/sekindoUMBidAdapter.js
@@ -6,6 +6,7 @@ var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var adaptermanager = require('src/adaptermanager');
+var { config } = require('src/config');
 
 function SekindoUMAdapter() {
   function _callBids(params) {
@@ -74,7 +75,7 @@ function SekindoUMAdapter() {
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbver', '3');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbobj', '$$PREBID_GLOBAL$$');
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'dcpmflr', bidfloor);
-    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', $$PREBID_GLOBAL$$.bidderTimeout);
+    scriptSrc = utils.tryAppendQueryString(scriptSrc, 'hbto', config.bidderTimeout);
     scriptSrc = utils.tryAppendQueryString(scriptSrc, 'protocol', protocol);
 
     adloader.loadScript(scriptSrc);

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -3,7 +3,7 @@ var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var utils = require('src/utils.js');
 var adaptermanager = require('src/adaptermanager');
-var { config } = require('src/config');
+var { getConfig } = require('src/config');
 
 function UnderdogMediaAdapter() {
   const UDM_ADAPTER_VERSION = '1.0.0';
@@ -77,7 +77,7 @@ function UnderdogMediaAdapter() {
     url += UDM_ADAPTER_VERSION;
     url += ';cb=' + Math.random();
     url += ';qqq=' + (1 / bid.cpm);
-    url += ';hbt=' + config.bidderTimeout;
+    url += ';hbt=' + getConfig('bidderTimeout');
     url += ';style=adapter';
     url += ';vis=' + encodeURIComponent(document.visibilityState);
 

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -3,6 +3,7 @@ var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var utils = require('src/utils.js');
 var adaptermanager = require('src/adaptermanager');
+var { config } = require('src/config');
 
 function UnderdogMediaAdapter() {
   const UDM_ADAPTER_VERSION = '1.0.0';
@@ -76,7 +77,7 @@ function UnderdogMediaAdapter() {
     url += UDM_ADAPTER_VERSION;
     url += ';cb=' + Math.random();
     url += ';qqq=' + (1 / bid.cpm);
-    url += ';hbt=' + $$PREBID_GLOBAL$$.bidderTimeout;
+    url += ';hbt=' + config.bidderTimeout;
     url += ';style=adapter';
     url += ';vis=' + encodeURIComponent(document.visibilityState);
 

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -1,9 +1,9 @@
+import { config } from 'src/config';
 var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
 var utils = require('src/utils.js');
 var adaptermanager = require('src/adaptermanager');
-var { getConfig } = require('src/config');
 
 function UnderdogMediaAdapter() {
   const UDM_ADAPTER_VERSION = '1.0.0';
@@ -77,7 +77,7 @@ function UnderdogMediaAdapter() {
     url += UDM_ADAPTER_VERSION;
     url += ';cb=' + Math.random();
     url += ';qqq=' + (1 / bid.cpm);
-    url += ';hbt=' + getConfig('bidderTimeout');
+    url += ';hbt=' + config.getConfig('bidderTimeout');
     url += ';style=adapter';
     url += ';vis=' + encodeURIComponent(document.visibilityState);
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -243,7 +243,9 @@ exports.enableAnalytics = function (config) {
 };
 
 exports.setBidderSequence = function (order) {
-  _bidderSequence = order;
+  if (order === CONSTANTS.ORDER.RANDOM) {
+    _bidderSequence = order;
+  }
 };
 
 exports.setS2SConfig = function (config) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,64 @@
+const utils = require('./utils');
+
+/**
+ * Methods for managing Prebid configuration
+ */
+
+let setConfigApi;
+let debug;
+
+export function getDebugStatus() {
+  // if debug not set, pub might still be using pbjs.logging, which may still
+  // be used until deprecation
+  if (!setConfigApi) { return $$PREBID_GLOBAL$$.logging; }
+
+  return debug;
+}
+
+export function setDebugStatus(_debug) {
+  debug = _debug;
+}
+
+export function setConfig(options) {
+  if (typeof options !== 'object') {
+    utils.logError('setConfig options must be an object');
+  }
+
+  // while old config properties/methods are in depecration window, set this
+  // to signal to getter/setter methods where to check state
+  setConfigApi = true;
+
+  // TODO: fill out remaning config options
+  // if (options.bidderTimeout) {
+  //   $$PREBID_GLOBAL$$.bidderTimeout = options.bidderTimeout;
+  // }
+
+  // `debug` is equivalent to previous `pbjs.logging` property
+  if (options.debug) {
+    setDebugStatus(options.debug);
+  }
+
+  // if (options.publisherDomain) {
+  //   $$PREBID_GLOBAL$$.publisherDomain = options.publisherDomain;
+  // }
+
+  // if (options.cookieSyncDelay) {
+  //   $$PREBID_GLOBAL$$.cookieSyncDelay = options.cookieSyncDelay;
+  // }
+
+  // if (options.priceGranularity) {
+  //   $$PREBID_GLOBAL$$.setPriceGranularity(options.priceGranularity);
+  // }
+
+  // if (options.enableSendAllBids) {
+  //   $$PREBID_GLOBAL$$.enableSendAllBids();
+  // }
+
+  // if (options.bidderSequence) {
+  //   $$PREBID_GLOBAL$$.setBidderSequence(options.bidderSequence);
+  // }
+
+  // if (options.s2sConfig) {
+  //   $$PREBID_GLOBAL$$.setS2SConfig(options.s2sConfig);
+  // }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,41 +1,34 @@
 const utils = require('./utils');
 
-/**
- * Methods for managing Prebid configuration
- */
+export let config = {
+  _debug: false,
 
-let setConfigApi;
-let debug;
+  get debug() {
+    // this is deprecated but may still be used during deprecation window
+    // `debug` is equivalent to legacy `pbjs.logging` property
+    if ($$PREBID_GLOBAL$$.logging || $$PREBID_GLOBAL$$.logging == false) {
+      return $$PREBID_GLOBAL$$.logging;
+    }
 
-export function getDebugStatus() {
-  // if debug not set, pub might still be using pbjs.logging, which may still
-  // be used until deprecation
-  if (!setConfigApi) { return $$PREBID_GLOBAL$$.logging; }
+    return this._debug;
+  },
 
-  return debug;
-}
-
-export function setDebugStatus(_debug) {
-  debug = _debug;
-}
+  set debug(val) {
+    this._debug = val;
+  },
+};
 
 export function setConfig(options) {
   if (typeof options !== 'object') {
     utils.logError('setConfig options must be an object');
   }
 
-  // while old config properties/methods are in depecration window, set this
-  // to signal to getter/setter methods where to check state
-  setConfigApi = true;
-
-  // TODO: fill out remaning config options
   // if (options.bidderTimeout) {
   //   $$PREBID_GLOBAL$$.bidderTimeout = options.bidderTimeout;
   // }
 
-  // `debug` is equivalent to previous `pbjs.logging` property
   if (options.debug) {
-    setDebugStatus(options.debug);
+    config.debug = options.debug;
   }
 
   // if (options.publisherDomain) {

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ const utils = require('./utils');
 const DEFAULT_DEBUG = false;
 const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
+const DEFAULT_COOKIESYNC_DELAY = 100;
 
 let config = {
   // `debug` is equivalent to legacy `pbjs.logging` property
@@ -43,6 +44,15 @@ let config = {
   set publisherDomain(val) {
     this._publisherDomain = val;
   },
+
+  // delay to request cookie sync to stay out of critical path
+  _cookieSyncDelay: DEFAULT_COOKIESYNC_DELAY,
+  get cookieSyncDelay() {
+    return $$PREBID_GLOBAL$$.cookieSyncDelay || this._cookieSyncDelay;
+  },
+  set cookieSyncDelay(val) {
+    this._cookieSyncDelay = val;
+  },
 };
 
 export function getConfig(option) {
@@ -58,7 +68,7 @@ export function setConfig(options) {
   // [x] $$PREBID_GLOBAL$$.bidderTimeout
   // [x] $$PREBID_GLOBAL$$.logging (renamed `debug`)
   // [x] $$PREBID_GLOBAL$$.publisherDomain
-  // [ ] $$PREBID_GLOBAL$$.cookieSyncDelay
+  // [x] $$PREBID_GLOBAL$$.cookieSyncDelay
   // [ ] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
   // [ ] $$PREBID_GLOBAL$$.enableSendAllBids (function)
   // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)

--- a/src/config.js
+++ b/src/config.js
@@ -7,13 +7,12 @@
  * Defining and access properties in this way is now deprecated, but these will
  * continue to work during a deprecation window.
  */
-
 const utils = require('./utils');
 
 const DEFAULT_DEBUG = false;
 const DEFAULT_BIDDER_TIMEOUT = 3000;
 
-export let config = {
+let config = {
   _debug: DEFAULT_DEBUG,
   get debug() {
     // `debug` is equivalent to legacy `pbjs.logging` property
@@ -38,40 +37,24 @@ export let config = {
   },
 };
 
+export function getConfig(option) {
+  return option ? config[option] : config;
+}
+
 export function setConfig(options) {
   if (typeof options !== 'object') {
     utils.logError('setConfig options must be an object');
   }
 
-  if (options.bidderTimeout) {
-    config.bidderTimeout = options.bidderTimeout;
-  }
+  // codebase conversion:
+  // [x] $$PREBID_GLOBAL$$.bidderTimeout
+  // [x] $$PREBID_GLOBAL$$.logging (renamed `debug`)
+  // [ ] $$PREBID_GLOBAL$$.publisherDomain
+  // [ ] $$PREBID_GLOBAL$$.cookieSyncDelay
+  // [ ] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
+  // [ ] $$PREBID_GLOBAL$$.enableSendAllBids (function)
+  // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)
+  // [ ] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)
 
-  if (options.debug) {
-    config.debug = options.debug;
-  }
-
-  // if (options.publisherDomain) {
-  //   $$PREBID_GLOBAL$$.publisherDomain = options.publisherDomain;
-  // }
-
-  // if (options.cookieSyncDelay) {
-  //   $$PREBID_GLOBAL$$.cookieSyncDelay = options.cookieSyncDelay;
-  // }
-
-  // if (options.priceGranularity) {
-  //   $$PREBID_GLOBAL$$.setPriceGranularity(options.priceGranularity);
-  // }
-
-  // if (options.enableSendAllBids) {
-  //   $$PREBID_GLOBAL$$.enableSendAllBids();
-  // }
-
-  // if (options.bidderSequence) {
-  //   $$PREBID_GLOBAL$$.setBidderSequence(options.bidderSequence);
-  // }
-
-  // if (options.s2sConfig) {
-  //   $$PREBID_GLOBAL$$.setS2SConfig(options.s2sConfig);
-  // }
+  Object.assign(config, options);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,20 +1,40 @@
+/*
+ * Module for getting and setting Prebid configuration.
+ *
+ * Prebid previously defined these properties directly on the global object:
+ * pbjs.logging = true;
+ *
+ * Defining and access properties in this way is now deprecated, but these will
+ * continue to work during a deprecation window.
+ */
+
 const utils = require('./utils');
 
-export let config = {
-  _debug: false,
+const DEFAULT_DEBUG = false;
+const DEFAULT_BIDDER_TIMEOUT = 3000;
 
+export let config = {
+  _debug: DEFAULT_DEBUG,
   get debug() {
-    // this is deprecated but may still be used during deprecation window
     // `debug` is equivalent to legacy `pbjs.logging` property
     if ($$PREBID_GLOBAL$$.logging || $$PREBID_GLOBAL$$.logging == false) {
       return $$PREBID_GLOBAL$$.logging;
     }
-
     return this._debug;
   },
-
   set debug(val) {
     this._debug = val;
+  },
+
+  _bidderTimeout: DEFAULT_BIDDER_TIMEOUT,
+  get bidderTimeout() {
+    if ($$PREBID_GLOBAL$$.bidderTimeout) {
+      return $$PREBID_GLOBAL$$.bidderTimeout;
+    }
+    return this._bidderTimeout;
+  },
+  set bidderTimeout(val) {
+    this._bidderTimeout = val;
   },
 };
 
@@ -23,9 +43,9 @@ export function setConfig(options) {
     utils.logError('setConfig options must be an object');
   }
 
-  // if (options.bidderTimeout) {
-  //   $$PREBID_GLOBAL$$.bidderTimeout = options.bidderTimeout;
-  // }
+  if (options.bidderTimeout) {
+    config.bidderTimeout = options.bidderTimeout;
+  }
 
   if (options.debug) {
     config.debug = options.debug;

--- a/src/config.js
+++ b/src/config.js
@@ -66,6 +66,10 @@ let config = {
   set enableSendAllBids(val) {
     this._sendAllBids = val;
   },
+
+  set s2sConfig(val) {
+    $$PREBID_GLOBAL$$.setS2SConfig(val);
+  },
 };
 
 export function getConfig(option) {
@@ -85,7 +89,7 @@ export function setConfig(options) {
   // [x] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
   // [x] $$PREBID_GLOBAL$$.enableSendAllBids (function)
   // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)
-  // [ ] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)
+  // [x] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)
 
   Object.assign(config, options);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,11 +11,12 @@ const utils = require('./utils');
 
 const DEFAULT_DEBUG = false;
 const DEFAULT_BIDDER_TIMEOUT = 3000;
+const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 
 let config = {
+  // `debug` is equivalent to legacy `pbjs.logging` property
   _debug: DEFAULT_DEBUG,
   get debug() {
-    // `debug` is equivalent to legacy `pbjs.logging` property
     if ($$PREBID_GLOBAL$$.logging || $$PREBID_GLOBAL$$.logging == false) {
       return $$PREBID_GLOBAL$$.logging;
     }
@@ -25,15 +26,22 @@ let config = {
     this._debug = val;
   },
 
+  // default timeout for all bids
   _bidderTimeout: DEFAULT_BIDDER_TIMEOUT,
   get bidderTimeout() {
-    if ($$PREBID_GLOBAL$$.bidderTimeout) {
-      return $$PREBID_GLOBAL$$.bidderTimeout;
-    }
-    return this._bidderTimeout;
+    return $$PREBID_GLOBAL$$.bidderTimeout || this._bidderTimeout;
   },
   set bidderTimeout(val) {
     this._bidderTimeout = val;
+  },
+
+  // domain where prebid is running for cross domain iframe communication
+  _publisherDomain: DEFAULT_PUBLISHER_DOMAIN,
+  get publisherDomain() {
+    return $$PREBID_GLOBAL$$.publisherDomain || this._publisherDomain;
+  },
+  set publisherDomain(val) {
+    this._publisherDomain = val;
   },
 };
 
@@ -49,7 +57,7 @@ export function setConfig(options) {
   // codebase conversion:
   // [x] $$PREBID_GLOBAL$$.bidderTimeout
   // [x] $$PREBID_GLOBAL$$.logging (renamed `debug`)
-  // [ ] $$PREBID_GLOBAL$$.publisherDomain
+  // [x] $$PREBID_GLOBAL$$.publisherDomain
   // [ ] $$PREBID_GLOBAL$$.cookieSyncDelay
   // [ ] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
   // [ ] $$PREBID_GLOBAL$$.enableSendAllBids (function)

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,10 @@ let config = {
   set cookieSyncDelay(val) {
     this._cookieSyncDelay = val;
   },
+
+  set priceGranularity(val) {
+    $$PREBID_GLOBAL$$.setPriceGranularity(val);
+  },
 };
 
 export function getConfig(option) {
@@ -69,7 +73,7 @@ export function setConfig(options) {
   // [x] $$PREBID_GLOBAL$$.logging (renamed `debug`)
   // [x] $$PREBID_GLOBAL$$.publisherDomain
   // [x] $$PREBID_GLOBAL$$.cookieSyncDelay
-  // [ ] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
+  // [x] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
   // [ ] $$PREBID_GLOBAL$$.enableSendAllBids (function)
   // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)
   // [ ] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ const DEFAULT_DEBUG = false;
 const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 const DEFAULT_COOKIESYNC_DELAY = 100;
+const DEFAULT_ENABLE_SEND_ALL_BIDS = false;
 
 let config = {
   // `debug` is equivalent to legacy `pbjs.logging` property
@@ -57,6 +58,14 @@ let config = {
   set priceGranularity(val) {
     $$PREBID_GLOBAL$$.setPriceGranularity(val);
   },
+
+  _sendAllBids: DEFAULT_ENABLE_SEND_ALL_BIDS,
+  get enableSendAllBids() {
+    return this._sendAllBids;
+  },
+  set enableSendAllBids(val) {
+    this._sendAllBids = val;
+  },
 };
 
 export function getConfig(option) {
@@ -74,7 +83,7 @@ export function setConfig(options) {
   // [x] $$PREBID_GLOBAL$$.publisherDomain
   // [x] $$PREBID_GLOBAL$$.cookieSyncDelay
   // [x] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
-  // [ ] $$PREBID_GLOBAL$$.enableSendAllBids (function)
+  // [x] $$PREBID_GLOBAL$$.enableSendAllBids (function)
   // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)
   // [ ] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)
 

--- a/src/config.js
+++ b/src/config.js
@@ -67,6 +67,10 @@ let config = {
     this._sendAllBids = val;
   },
 
+  set bidderSequence(val) {
+    $$PREBID_GLOBAL$$.setBidderSequence(val);
+  },
+
   set s2sConfig(val) {
     $$PREBID_GLOBAL$$.setS2SConfig(val);
   },
@@ -80,16 +84,6 @@ export function setConfig(options) {
   if (typeof options !== 'object') {
     utils.logError('setConfig options must be an object');
   }
-
-  // codebase conversion:
-  // [x] $$PREBID_GLOBAL$$.bidderTimeout
-  // [x] $$PREBID_GLOBAL$$.logging (renamed `debug`)
-  // [x] $$PREBID_GLOBAL$$.publisherDomain
-  // [x] $$PREBID_GLOBAL$$.cookieSyncDelay
-  // [x] $$PREBID_GLOBAL$$.setPriceGranularity (function(granularity), `priceGranularity`)
-  // [x] $$PREBID_GLOBAL$$.enableSendAllBids (function)
-  // [ ] $$PREBID_GLOBAL$$.setBidderSequence (function(order), `bidderSequence`)
-  // [x] $$PREBID_GLOBAL$$.setS2SConfig (function(options), `s2sConfig`)
 
   Object.assign(config, options);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -84,8 +84,12 @@ let config = {
 };
 
 /*
- * Returns configuration object or single configuration property if given
- * a string matching a configuartion property name
+ * Returns configuration object if called without parameters,
+ * or single configuration property if given a string matching a configuartion
+ * property name.
+ *
+ * If called with callback parameter, or a string and a callback parameter,
+ * subscribes to configuration updates. See `subscribe` function for usage.
  */
 export function getConfig(...args) {
   if (args.length <= 1 && typeof args[0] !== 'function') {
@@ -116,12 +120,19 @@ export function setConfig(options) {
  * updates when specific properties are updated by passing a topic string as
  * the first parameter.
  *
+ * Returns an `unsubscribe` function for removing the subscriber from the
+ * set of listeners
+ *
  * Example use:
  * // subscribe to all configuration changes
  * subscribe((config) => console.log('config set:', config));
  *
  * // subscribe to only 'logging' changes
  * subscribe('logging', (config) => console.log('logging set:', config));
+ *
+ * // unsubscribe
+ * const unsubscribe = subscribe(...);
+ * unsubscribe(); // no longer listening
  */
 function subscribe(topic, listener) {
   let callback = listener;

--- a/src/config.js
+++ b/src/config.js
@@ -87,8 +87,13 @@ let config = {
  * Returns configuration object or single configuration property if given
  * a string matching a configuartion property name
  */
-export function getConfig(option) {
-  return option ? config[option] : config;
+export function getConfig(...args) {
+  if (args.length <= 1 && typeof args[0] !== 'function') {
+    const option = args[0];
+    return option ? config[option] : config;
+  }
+
+  return subscribe(...args);
 }
 
 /*
@@ -118,7 +123,7 @@ export function setConfig(options) {
  * // subscribe to only 'logging' changes
  * subscribe('logging', (config) => console.log('logging set:', config));
  */
-export function subscribe(topic, listener) {
+function subscribe(topic, listener) {
   let callback = listener;
 
   if (typeof topic !== 'string') {
@@ -134,6 +139,11 @@ export function subscribe(topic, listener) {
   }
 
   listeners.push({ topic, callback });
+
+  // save and call this function to remove the listener
+  return function unsubscribe() {
+    listeners.splice(listeners.indexOf(listener), 1);
+  };
 }
 
 /*

--- a/src/config.js
+++ b/src/config.js
@@ -17,161 +17,170 @@ const DEFAULT_ENABLE_SEND_ALL_BIDS = false;
 
 const ALL_TOPICS = '*';
 
-let listeners = [];
+export function newConfig() {
+  let listeners = [];
 
-let config = {
-  // `debug` is equivalent to legacy `pbjs.logging` property
-  _debug: DEFAULT_DEBUG,
-  get debug() {
-    if ($$PREBID_GLOBAL$$.logging || $$PREBID_GLOBAL$$.logging === false) {
-      return $$PREBID_GLOBAL$$.logging;
+  let config = {
+    // `debug` is equivalent to legacy `pbjs.logging` property
+    _debug: DEFAULT_DEBUG,
+    get debug() {
+      if ($$PREBID_GLOBAL$$.logging || $$PREBID_GLOBAL$$.logging === false) {
+        return $$PREBID_GLOBAL$$.logging;
+      }
+      return this._debug;
+    },
+    set debug(val) {
+      this._debug = val;
+    },
+
+    // default timeout for all bids
+    _bidderTimeout: DEFAULT_BIDDER_TIMEOUT,
+    get bidderTimeout() {
+      return $$PREBID_GLOBAL$$.bidderTimeout || this._bidderTimeout;
+    },
+    set bidderTimeout(val) {
+      this._bidderTimeout = val;
+    },
+
+    // domain where prebid is running for cross domain iframe communication
+    _publisherDomain: DEFAULT_PUBLISHER_DOMAIN,
+    get publisherDomain() {
+      return $$PREBID_GLOBAL$$.publisherDomain || this._publisherDomain;
+    },
+    set publisherDomain(val) {
+      this._publisherDomain = val;
+    },
+
+    // delay to request cookie sync to stay out of critical path
+    _cookieSyncDelay: DEFAULT_COOKIESYNC_DELAY,
+    get cookieSyncDelay() {
+      return $$PREBID_GLOBAL$$.cookieSyncDelay || this._cookieSyncDelay;
+    },
+    set cookieSyncDelay(val) {
+      this._cookieSyncDelay = val;
+    },
+
+    // calls existing function which may be moved after deprecation
+    set priceGranularity(val) {
+      $$PREBID_GLOBAL$$.setPriceGranularity(val);
+    },
+
+    _sendAllBids: DEFAULT_ENABLE_SEND_ALL_BIDS,
+    get enableSendAllBids() {
+      return this._sendAllBids;
+    },
+    set enableSendAllBids(val) {
+      this._sendAllBids = val;
+    },
+
+    // calls existing function which may be moved after deprecation
+    set bidderSequence(val) {
+      $$PREBID_GLOBAL$$.setBidderSequence(val);
+    },
+
+    // calls existing function which may be moved after deprecation
+    set s2sConfig(val) {
+      $$PREBID_GLOBAL$$.setS2SConfig(val);
+    },
+  };
+
+  /*
+   * Returns configuration object if called without parameters,
+   * or single configuration property if given a string matching a configuartion
+   * property name.
+   *
+   * If called with callback parameter, or a string and a callback parameter,
+   * subscribes to configuration updates. See `subscribe` function for usage.
+   */
+  function getConfig(...args) {
+    if (args.length <= 1 && typeof args[0] !== 'function') {
+      const option = args[0];
+      return option ? config[option] : config;
     }
-    return this._debug;
-  },
-  set debug(val) {
-    this._debug = val;
-  },
 
-  // default timeout for all bids
-  _bidderTimeout: DEFAULT_BIDDER_TIMEOUT,
-  get bidderTimeout() {
-    return $$PREBID_GLOBAL$$.bidderTimeout || this._bidderTimeout;
-  },
-  set bidderTimeout(val) {
-    this._bidderTimeout = val;
-  },
-
-  // domain where prebid is running for cross domain iframe communication
-  _publisherDomain: DEFAULT_PUBLISHER_DOMAIN,
-  get publisherDomain() {
-    return $$PREBID_GLOBAL$$.publisherDomain || this._publisherDomain;
-  },
-  set publisherDomain(val) {
-    this._publisherDomain = val;
-  },
-
-  // delay to request cookie sync to stay out of critical path
-  _cookieSyncDelay: DEFAULT_COOKIESYNC_DELAY,
-  get cookieSyncDelay() {
-    return $$PREBID_GLOBAL$$.cookieSyncDelay || this._cookieSyncDelay;
-  },
-  set cookieSyncDelay(val) {
-    this._cookieSyncDelay = val;
-  },
-
-  // calls existing function which may be moved after deprecation
-  set priceGranularity(val) {
-    $$PREBID_GLOBAL$$.setPriceGranularity(val);
-  },
-
-  _sendAllBids: DEFAULT_ENABLE_SEND_ALL_BIDS,
-  get enableSendAllBids() {
-    return this._sendAllBids;
-  },
-  set enableSendAllBids(val) {
-    this._sendAllBids = val;
-  },
-
-  // calls existing function which may be moved after deprecation
-  set bidderSequence(val) {
-    $$PREBID_GLOBAL$$.setBidderSequence(val);
-  },
-
-  // calls existing function which may be moved after deprecation
-  set s2sConfig(val) {
-    $$PREBID_GLOBAL$$.setS2SConfig(val);
-  },
-};
-
-/*
- * Returns configuration object if called without parameters,
- * or single configuration property if given a string matching a configuartion
- * property name.
- *
- * If called with callback parameter, or a string and a callback parameter,
- * subscribes to configuration updates. See `subscribe` function for usage.
- */
-export function getConfig(...args) {
-  if (args.length <= 1 && typeof args[0] !== 'function') {
-    const option = args[0];
-    return option ? config[option] : config;
+    return subscribe(...args);
   }
 
-  return subscribe(...args);
-}
+  /*
+   * Sets configuration given an object containing key-value pairs and calls
+   * listeners that were added by the `subscribe` function
+   */
+  function setConfig(options) {
+    if (typeof options !== 'object') {
+      utils.logError('setConfig options must be an object');
+    }
 
-/*
- * Sets configuration given an object containing key-value pairs and calls
- * listeners that were added by the `subscribe` function
- */
-export function setConfig(options) {
-  if (typeof options !== 'object') {
-    utils.logError('setConfig options must be an object');
+    Object.assign(config, options);
+    callSubscribers(options);
   }
 
-  Object.assign(config, options);
-  callSubscribers(options);
-}
+  /*
+   * Adds a function to a set of listeners that are invoked whenever `setConfig`
+   * is called. The subscribed function will be passed the options object that
+   * was used in the `setConfig` call. Topics can be subscribed to to only get
+   * updates when specific properties are updated by passing a topic string as
+   * the first parameter.
+   *
+   * Returns an `unsubscribe` function for removing the subscriber from the
+   * set of listeners
+   *
+   * Example use:
+   * // subscribe to all configuration changes
+   * subscribe((config) => console.log('config set:', config));
+   *
+   * // subscribe to only 'logging' changes
+   * subscribe('logging', (config) => console.log('logging set:', config));
+   *
+   * // unsubscribe
+   * const unsubscribe = subscribe(...);
+   * unsubscribe(); // no longer listening
+   */
+  function subscribe(topic, listener) {
+    let callback = listener;
 
-/*
- * Adds a function to a set of listeners that are invoked whenever `setConfig`
- * is called. The subscribed function will be passed the options object that
- * was used in the `setConfig` call. Topics can be subscribed to to only get
- * updates when specific properties are updated by passing a topic string as
- * the first parameter.
- *
- * Returns an `unsubscribe` function for removing the subscriber from the
- * set of listeners
- *
- * Example use:
- * // subscribe to all configuration changes
- * subscribe((config) => console.log('config set:', config));
- *
- * // subscribe to only 'logging' changes
- * subscribe('logging', (config) => console.log('logging set:', config));
- *
- * // unsubscribe
- * const unsubscribe = subscribe(...);
- * unsubscribe(); // no longer listening
- */
-function subscribe(topic, listener) {
-  let callback = listener;
+    if (typeof topic !== 'string') {
+      // first param should be callback function in this case,
+      // meaning it gets called for any config change
+      callback = topic;
+      topic = ALL_TOPICS;
+    }
 
-  if (typeof topic !== 'string') {
-    // first param should be callback function in this case,
-    // meaning it gets called for any config change
-    callback = topic;
-    topic = ALL_TOPICS;
+    if (typeof callback !== 'function') {
+      utils.logError('listener must be a function');
+      return;
+    }
+
+    listeners.push({ topic, callback });
+
+    // save and call this function to remove the listener
+    return function unsubscribe() {
+      listeners.splice(listeners.indexOf(listener), 1);
+    };
   }
 
-  if (typeof callback !== 'function') {
-    utils.logError('listener must be a function');
-    return;
+  /*
+   * Calls listeners that were added by the `subscribe` function
+   */
+  function callSubscribers(options) {
+    const TOPICS = Object.keys(options);
+
+    // call subscribers of a specific topic, passing only that configuration
+    listeners
+      .filter(listener => TOPICS.includes(listener.topic))
+      .forEach(listener => {
+        listener.callback({ [listener.topic]: options[listener.topic] });
+      });
+
+    // call subscribers that didn't give a topic, passing everything that was set
+    listeners
+      .filter(listener => listener.topic === ALL_TOPICS)
+      .forEach(listener => listener.callback(options));
   }
 
-  listeners.push({ topic, callback });
-
-  // save and call this function to remove the listener
-  return function unsubscribe() {
-    listeners.splice(listeners.indexOf(listener), 1);
+  return {
+    getConfig,
+    setConfig
   };
 }
 
-/*
- * Calls listeners that were added by the `subscribe` function
- */
-function callSubscribers(options) {
-  const TOPICS = Object.keys(options);
-
-  // call subscribers of a specific topic, passing only that configuration
-  listeners
-    .filter(listener => TOPICS.includes(listener.topic))
-    .forEach(listener => {
-      listener.callback({ [listener.topic]: options[listener.topic] });
-    });
-
-  // call subscribers that didn't give a topic, passing everything that was set
-  listeners
-    .filter(listener => listener.topic === ALL_TOPICS)
-    .forEach(listener => listener.callback(options));
-}
+export const config = newConfig();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -47,7 +47,7 @@ $$PREBID_GLOBAL$$._sendAllBids = false;
 
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
-/** @deprecated - use pbjs.setConfig({ bidderTimeout: <timeout> ) */
+/** @deprecated - use pbjs.setConfig({ bidderTimeout: <timeout> }) */
 $$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout;
 
 // current timeout set in `requestBids` or to default `bidderTimeout`
@@ -630,6 +630,7 @@ $$PREBID_GLOBAL$$.aliasBidder = function (bidderCode, alias) {
 /**
  * Sets a default price granularity scheme.
  * @param {String|Object} granularity - the granularity scheme.
+ * @deprecated - use pbjs.setConfig({ priceGranularity: <granularity> })
  * "low": $0.50 increments, capped at $5 CPM
  * "medium": $0.10 increments, capped at $20 CPM (the default)
  * "high": $0.01 increments, capped at $20 CPM

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -43,7 +43,6 @@ $$PREBID_GLOBAL$$._bidsReceived = [];
 $$PREBID_GLOBAL$$._adUnitCodes = [];
 $$PREBID_GLOBAL$$._winningBids = [];
 $$PREBID_GLOBAL$$._adsReceived = [];
-$$PREBID_GLOBAL$$._sendAllBids = false;
 
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
@@ -661,8 +660,9 @@ $$PREBID_GLOBAL$$.setPriceGranularity = function (granularity) {
   }
 };
 
+/** @deprecated - use pbjs.setConfig({ enableSendAllBids: <true|false> }) */
 $$PREBID_GLOBAL$$.enableSendAllBids = function () {
-  $$PREBID_GLOBAL$$._sendAllBids = true;
+  setConfig({ enableSendAllBids: true });
 };
 
 $$PREBID_GLOBAL$$.getAllWinningBids = function () {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -757,6 +757,49 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
   adaptermanager.setS2SConfig(config);
 };
 
+/**
+ * Set config options
+ * @param {object} options
+ */
+$$PREBID_GLOBAL$$.setConfig = function(options) {
+  if (typeof options !== objectType_object) {
+    utils.logError('setConfig options must be an object');
+  }
+
+  if (options.bidderTimeout) {
+    $$PREBID_GLOBAL$$.bidderTimeout = options.bidderTimeout;
+  }
+
+  // `logging` was renamed to `debug`
+  if (options.debug) {
+    $$PREBID_GLOBAL$$.logging = options.debug;
+  }
+
+  if (options.publisherDomain) {
+    $$PREBID_GLOBAL$$.publisherDomain = options.publisherDomain;
+  }
+
+  if (options.cookieSyncDelay) {
+    $$PREBID_GLOBAL$$.cookieSyncDelay = options.cookieSyncDelay;
+  }
+
+  if (options.priceGranularity) {
+    $$PREBID_GLOBAL$$.setPriceGranularity(options.priceGranularity);
+  }
+
+  if (options.enableSendAllBids) {
+    $$PREBID_GLOBAL$$.enableSendAllBids();
+  }
+
+  if (options.bidderSequence) {
+    $$PREBID_GLOBAL$$.setBidderSequence(options.bidderSequence);
+  }
+
+  if (options.s2sConfig) {
+    $$PREBID_GLOBAL$$.setS2SConfig(options.s2sConfig);
+  }
+};
+
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -766,6 +766,12 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
  */
 $$PREBID_GLOBAL$$.setConfig = setConfig;
 
+/**
+ * Get Prebid config options
+ * @param {object} options
+ */
+$$PREBID_GLOBAL$$.getConfig = getConfig;
+
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -57,7 +57,7 @@ $$PREBID_GLOBAL$$.cbTimeout = $$PREBID_GLOBAL$$.cbTimeout || 200;
 $$PREBID_GLOBAL$$.timeoutBuffer = 200;
 
 /** @deprecated */
-$$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging || false;
+$$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging;
 
 // domain where prebid is running for cross domain iframe communication
 $$PREBID_GLOBAL$$.publisherDomain = $$PREBID_GLOBAL$$.publisherDomain || window.location.origin;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -47,7 +47,6 @@ $$PREBID_GLOBAL$$._sendAllBids = false;
 
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
-// default timeout for all bids
 /** @deprecated - use pbjs.setConfig({ bidderTimeout: <timeout> ) */
 $$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout;
 
@@ -57,11 +56,11 @@ $$PREBID_GLOBAL$$.cbTimeout = $$PREBID_GLOBAL$$.cbTimeout || 200;
 // timeout buffer to adjust for bidder CDN latency
 $$PREBID_GLOBAL$$.timeoutBuffer = 200;
 
-/** @deprecated */
+/** @deprecated - use pbjs.setConfig({ debug: <true|false> }) */
 $$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging;
 
-// domain where prebid is running for cross domain iframe communication
-$$PREBID_GLOBAL$$.publisherDomain = $$PREBID_GLOBAL$$.publisherDomain || window.location.origin;
+/** @deprecated - use pbjs.setConfig({ publisherDomain: <domain> ) */
+$$PREBID_GLOBAL$$.publisherDomain = $$PREBID_GLOBAL$$.publisherDomain;
 
 // let the world know we are loaded
 $$PREBID_GLOBAL$$.libLoaded = true;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -707,11 +707,10 @@ $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag = function (adserverTag, op
  * the order they are defined within the adUnit.bids array
  * @param {string} order - Order to call bidders in. Currently the only possible value
  * is 'random', which randomly shuffles the order
+ * @deprecated - use pbjs.setConfig({ bidderSequence: <order> })
  */
 $$PREBID_GLOBAL$$.setBidderSequence = function (order) {
-  if (order === CONSTANTS.ORDER.RANDOM) {
-    adaptermanager.setBidderSequence(CONSTANTS.ORDER.RANDOM);
-  }
+  adaptermanager.setBidderSequence(CONSTANTS.ORDER.RANDOM);
 };
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -72,8 +72,8 @@ utils.logInfo('Prebid.js v$prebid.version$ loaded');
 // create adUnit array
 $$PREBID_GLOBAL$$.adUnits = $$PREBID_GLOBAL$$.adUnits || [];
 
-// delay to request cookie sync to stay out of critical path
-$$PREBID_GLOBAL$$.cookieSyncDelay = $$PREBID_GLOBAL$$.cookieSyncDelay || 100;
+/** @deprecated - use pbjs.setConfig({ cookieSyncDelay: <domain> ) */
+$$PREBID_GLOBAL$$.cookieSyncDelay = $$PREBID_GLOBAL$$.cookieSyncDelay;
 
 function checkDefinedPlacement(id) {
   var placementCodes = $$PREBID_GLOBAL$$._bidsRequested.map(bidSet => bidSet.bids.map(bid => bid.placementCode))
@@ -335,7 +335,7 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
 
 $$PREBID_GLOBAL$$.clearAuction = function() {
   auctionRunning = false;
-  syncCookies($$PREBID_GLOBAL$$.cookieSyncDelay);
+  syncCookies(getConfig('cookieSyncDelay'));
   utils.logMessage('Prebid auction cleared');
   if (bidRequestQueue.length) {
     bidRequestQueue.shift()();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -11,7 +11,7 @@ import { listenMessagesFromCreative } from './secureCreatives';
 import { syncCookies } from './cookie';
 import { loadScript } from './adloader';
 import { setAjaxTimeout } from './ajax';
-import { setConfig } from './config';
+import { config, setConfig } from './config';
 
 var $$PREBID_GLOBAL$$ = getGlobal();
 var CONSTANTS = require('./constants.json');
@@ -48,7 +48,8 @@ $$PREBID_GLOBAL$$._sendAllBids = false;
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};
 
 // default timeout for all bids
-$$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout || 3000;
+/** @deprecated - use pbjs.setConfig({ bidderTimeout: <timeout> ) */
+$$PREBID_GLOBAL$$.bidderTimeout = $$PREBID_GLOBAL$$.bidderTimeout;
 
 // current timeout set in `requestBids` or to default `bidderTimeout`
 $$PREBID_GLOBAL$$.cbTimeout = $$PREBID_GLOBAL$$.cbTimeout || 200;
@@ -351,7 +352,7 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
  */
 $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes } = {}) {
   events.emit('requestBids');
-  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || $$PREBID_GLOBAL$$.bidderTimeout;
+  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || config.bidderTimeout;
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -726,6 +726,7 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
 
 /**
  * Set config for server to server header bidding
+ * @deprecated - use pbjs.setConfig({ s2sConfig: <options> })
  * @typedef {Object} options - required
  * @property {boolean} enabled enables S2S bidding
  * @property {string[]} bidders bidders to request S2S

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -11,7 +11,7 @@ import { listenMessagesFromCreative } from './secureCreatives';
 import { syncCookies } from './cookie';
 import { loadScript } from './adloader';
 import { setAjaxTimeout } from './ajax';
-import { config, setConfig } from './config';
+import { getConfig, setConfig } from './config';
 
 var $$PREBID_GLOBAL$$ = getGlobal();
 var CONSTANTS = require('./constants.json');
@@ -352,7 +352,7 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
  */
 $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes } = {}) {
   events.emit('requestBids');
-  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || config.bidderTimeout;
+  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || getConfig('bidderTimeout');
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -764,9 +764,7 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
  * Set Prebid config options
  * @param {object} options
  */
-$$PREBID_GLOBAL$$.setConfig = function(options) {
-  setConfig(options);
-};
+$$PREBID_GLOBAL$$.setConfig = setConfig;
 
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -11,9 +11,10 @@ import { listenMessagesFromCreative } from './secureCreatives';
 import { syncCookies } from './cookie';
 import { loadScript } from './adloader';
 import { setAjaxTimeout } from './ajax';
-import { getConfig, setConfig } from './config';
+import { config } from './config';
 
 var $$PREBID_GLOBAL$$ = getGlobal();
+
 var CONSTANTS = require('./constants.json');
 var utils = require('./utils.js');
 var bidmanager = require('./bidmanager.js');
@@ -334,7 +335,7 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
 
 $$PREBID_GLOBAL$$.clearAuction = function() {
   auctionRunning = false;
-  syncCookies(getConfig('cookieSyncDelay'));
+  syncCookies(config.getConfig('cookieSyncDelay'));
   utils.logMessage('Prebid auction cleared');
   if (bidRequestQueue.length) {
     bidRequestQueue.shift()();
@@ -350,7 +351,7 @@ $$PREBID_GLOBAL$$.clearAuction = function() {
  */
 $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes } = {}) {
   events.emit('requestBids');
-  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || getConfig('bidderTimeout');
+  const cbTimeout = $$PREBID_GLOBAL$$.cbTimeout = timeout || config.getConfig('bidderTimeout');
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
@@ -662,7 +663,7 @@ $$PREBID_GLOBAL$$.setPriceGranularity = function (granularity) {
 
 /** @deprecated - use pbjs.setConfig({ enableSendAllBids: <true|false> }) */
 $$PREBID_GLOBAL$$.enableSendAllBids = function () {
-  setConfig({ enableSendAllBids: true });
+  config.setConfig({ enableSendAllBids: true });
 };
 
 $$PREBID_GLOBAL$$.getAllWinningBids = function () {
@@ -761,16 +762,16 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
 };
 
 /**
- * Set Prebid config options
- * @param {object} options
- */
-$$PREBID_GLOBAL$$.setConfig = setConfig;
-
-/**
  * Get Prebid config options
  * @param {object} options
  */
-$$PREBID_GLOBAL$$.getConfig = getConfig;
+$$PREBID_GLOBAL$$.getConfig = config.getConfig;
+
+/**
+ * Set Prebid config options
+ * @param {object} options
+ */
+$$PREBID_GLOBAL$$.setConfig = config.setConfig;
 
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -11,6 +11,7 @@ import { listenMessagesFromCreative } from './secureCreatives';
 import { syncCookies } from './cookie';
 import { loadScript } from './adloader';
 import { setAjaxTimeout } from './ajax';
+import { setConfig } from './config';
 
 var $$PREBID_GLOBAL$$ = getGlobal();
 var CONSTANTS = require('./constants.json');
@@ -55,6 +56,7 @@ $$PREBID_GLOBAL$$.cbTimeout = $$PREBID_GLOBAL$$.cbTimeout || 200;
 // timeout buffer to adjust for bidder CDN latency
 $$PREBID_GLOBAL$$.timeoutBuffer = 200;
 
+/** @deprecated */
 $$PREBID_GLOBAL$$.logging = $$PREBID_GLOBAL$$.logging || false;
 
 // domain where prebid is running for cross domain iframe communication
@@ -758,46 +760,11 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
 };
 
 /**
- * Set config options
+ * Set Prebid config options
  * @param {object} options
  */
 $$PREBID_GLOBAL$$.setConfig = function(options) {
-  if (typeof options !== objectType_object) {
-    utils.logError('setConfig options must be an object');
-  }
-
-  if (options.bidderTimeout) {
-    $$PREBID_GLOBAL$$.bidderTimeout = options.bidderTimeout;
-  }
-
-  // `logging` was renamed to `debug`
-  if (options.debug) {
-    $$PREBID_GLOBAL$$.logging = options.debug;
-  }
-
-  if (options.publisherDomain) {
-    $$PREBID_GLOBAL$$.publisherDomain = options.publisherDomain;
-  }
-
-  if (options.cookieSyncDelay) {
-    $$PREBID_GLOBAL$$.cookieSyncDelay = options.cookieSyncDelay;
-  }
-
-  if (options.priceGranularity) {
-    $$PREBID_GLOBAL$$.setPriceGranularity(options.priceGranularity);
-  }
-
-  if (options.enableSendAllBids) {
-    $$PREBID_GLOBAL$$.enableSendAllBids();
-  }
-
-  if (options.bidderSequence) {
-    $$PREBID_GLOBAL$$.setBidderSequence(options.bidderSequence);
-  }
-
-  if (options.s2sConfig) {
-    $$PREBID_GLOBAL$$.setS2SConfig(options.s2sConfig);
-  }
+  setConfig(options);
 };
 
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -2,6 +2,7 @@ import { uniques, isGptPubadsDefined, getHighestCpm, adUnitsFilter } from './uti
 import { NATIVE_TARGETING_KEYS } from './native';
 const bidmanager = require('./bidmanager');
 const utils = require('./utils');
+const { getConfig } = require('./config');
 var CONSTANTS = require('./constants');
 
 var targeting = exports;
@@ -32,7 +33,7 @@ targeting.getAllTargeting = function(adUnitCode) {
   // `alwaysUseBid=true`. If sending all bids is enabled, add targeting for losing bids.
   var targeting = getWinningBidTargeting(adUnitCodes)
     .concat(getAlwaysUseBidTargeting(adUnitCodes))
-    .concat($$PREBID_GLOBAL$$._sendAllBids ? getBidLandscapeTargeting(adUnitCodes) : []);
+    .concat(getConfig('enableSendAllBids') ? getBidLandscapeTargeting(adUnitCodes) : []);
 
   // store a reference of the targeting keys
   targeting.map(adUnitCode => {

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -1,8 +1,8 @@
 import { uniques, isGptPubadsDefined, getHighestCpm, adUnitsFilter } from './utils';
+import { config } from './config';
 import { NATIVE_TARGETING_KEYS } from './native';
 const bidmanager = require('./bidmanager');
 const utils = require('./utils');
-const { getConfig } = require('./config');
 var CONSTANTS = require('./constants');
 
 var targeting = exports;
@@ -33,7 +33,7 @@ targeting.getAllTargeting = function(adUnitCode) {
   // `alwaysUseBid=true`. If sending all bids is enabled, add targeting for losing bids.
   var targeting = getWinningBidTargeting(adUnitCodes)
     .concat(getAlwaysUseBidTargeting(adUnitCodes))
-    .concat(getConfig('enableSendAllBids') ? getBidLandscapeTargeting(adUnitCodes) : []);
+    .concat(config.getConfig('enableSendAllBids') ? getBidLandscapeTargeting(adUnitCodes) : []);
 
   // store a reference of the targeting keys
   targeting.map(adUnitCode => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
+import { config } from './config';
 var CONSTANTS = require('./constants');
-const { getConfig, setConfig } = require('./config');
 
 var _loggingChecked = false;
 
@@ -214,13 +214,13 @@ var errLogFn = (function (hasLogger) {
 }(hasConsoleLogger()));
 
 var debugTurnedOn = function () {
-  if (getConfig('debug') === false && _loggingChecked === false) {
+  if (config.getConfig('debug') === false && _loggingChecked === false) {
     const debug = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
-    setConfig({ debug });
+    config.setConfig({ debug });
     _loggingChecked = true;
   }
 
-  return !!getConfig('debug');
+  return !!config.getConfig('debug');
 };
 
 exports.debugTurnedOn = debugTurnedOn;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 var CONSTANTS = require('./constants');
+const config = require('./config');
 
 var _loggingChecked = false;
 
@@ -213,12 +214,13 @@ var errLogFn = (function (hasLogger) {
 }(hasConsoleLogger()));
 
 var debugTurnedOn = function () {
-  if ($$PREBID_GLOBAL$$.logging === false && _loggingChecked === false) {
-    $$PREBID_GLOBAL$$.logging = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
+  if (config.getDebugStatus() === false && _loggingChecked === false) {
+    const debug = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
+    config.setDebugStatus(debug);
     _loggingChecked = true;
   }
 
-  return !!$$PREBID_GLOBAL$$.logging;
+  return !!config.getDebugStatus();
 };
 
 exports.debugTurnedOn = debugTurnedOn;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 var CONSTANTS = require('./constants');
-const config = require('./config');
+const { config } = require('./config');
 
 var _loggingChecked = false;
 
@@ -214,13 +214,13 @@ var errLogFn = (function (hasLogger) {
 }(hasConsoleLogger()));
 
 var debugTurnedOn = function () {
-  if (config.getDebugStatus() === false && _loggingChecked === false) {
+  if (config.debug === false && _loggingChecked === false) {
     const debug = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
-    config.setDebugStatus(debug);
+    config.debug = debug;
     _loggingChecked = true;
   }
 
-  return !!config.getDebugStatus();
+  return !!config.debug;
 };
 
 exports.debugTurnedOn = debugTurnedOn;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 var CONSTANTS = require('./constants');
-const { config } = require('./config');
+const { getConfig, setConfig } = require('./config');
 
 var _loggingChecked = false;
 
@@ -214,13 +214,13 @@ var errLogFn = (function (hasLogger) {
 }(hasConsoleLogger()));
 
 var debugTurnedOn = function () {
-  if (config.debug === false && _loggingChecked === false) {
+  if (getConfig('debug') === false && _loggingChecked === false) {
     const debug = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
-    config.debug = debug;
+    setConfig({ debug });
     _loggingChecked = true;
   }
 
-  return !!config.debug;
+  return !!getConfig('debug');
 };
 
 exports.debugTurnedOn = debugTurnedOn;

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -1106,7 +1106,7 @@ export function getBidResponsesFromAPI() {
   };
 }
 
-// Ad server targeting when `$$PREBID_GLOBAL$$.enableSendAllBids()` is called.
+// Ad server targeting when `setConfig({ enableSendAllBids: true })` is set.
 export function getAdServerTargeting() {
   return {
     '/19968336/header-bid-tag-0': {

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -1,9 +1,18 @@
 import { excpet } from 'chai';
-import { getConfig, setConfig } from 'src/config';
+import { getConfig, setConfig, subscribe } from 'src/config';
 
-describe('setConfig', () => {
-  it('is a function', () => {
+describe('config API', () => {
+  it('setConfig is a function', () => {
     expect(setConfig).to.be.a('function');
+  });
+
+  it('getConfig returns an object', () => {
+    expect(getConfig()).to.be.a('object');
+  });
+
+  it('sets and gets arbitrary configuarion properties', () => {
+    setConfig({ baz: 'qux' });
+    expect(getConfig('baz')).to.equal('qux');
   });
 
   it('sets debugging', () => {
@@ -11,7 +20,8 @@ describe('setConfig', () => {
     expect(getConfig('debug')).to.be.true;
   });
 
-  it('recognizes legacy logging in deprecation window', () => {
+  // remove test when @deprecated $$PREBID_GLOBAL$$.logging removed
+  it('gets legacy logging in deprecation window', () => {
     $$PREBID_GLOBAL$$.logging = false;
     expect(getConfig('debug')).to.equal(false);
   });
@@ -21,8 +31,30 @@ describe('setConfig', () => {
     expect(getConfig('bidderTimeout')).to.be.equal(1000);
   });
 
+  // remove test when @deprecated $$PREBID_GLOBAL$$.bidderTimeout removed
   it('gets legacy bidderTimeout in deprecation window', () => {
     $$PREBID_GLOBAL$$.bidderTimeout = 5000;
     expect(getConfig('bidderTimeout')).to.equal(5000);
+  });
+
+  it('gets user-defined publisherDomain', () => {
+    setConfig({ publisherDomain: 'fc.kahuna' });
+    expect(getConfig('publisherDomain')).to.equal('fc.kahuna');
+  });
+
+  // remove test when @deprecated $$PREBID_GLOBAL$$.publisherDomain removed
+  it('gets legacy publisherDomain in deprecation window', () => {
+    $$PREBID_GLOBAL$$.publisherDomain = 'ad.example.com';
+    expect(getConfig('publisherDomain')).to.equal('ad.example.com');
+  });
+
+  it('has a subscribe function for adding listeners to config updates', () => {
+    const listener = sinon.spy();
+
+    subscribe(listener);
+    setConfig({ foo: 'bar' });
+
+    sinon.assert.calledOnce(listener);
+    sinon.assert.calledWith(listener, { foo: 'bar' });
   });
 });

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -1,5 +1,5 @@
 import { excpet } from 'chai';
-import { config, setConfig } from 'src/config';
+import { getConfig, setConfig } from 'src/config';
 
 describe('setConfig', () => {
   it('is a function', () => {
@@ -8,21 +8,21 @@ describe('setConfig', () => {
 
   it('sets debugging', () => {
     setConfig({ debug: true });
-    expect(config.debug).to.be.true;
+    expect(getConfig('debug')).to.be.true;
   });
 
   it('recognizes legacy logging in deprecation window', () => {
     $$PREBID_GLOBAL$$.logging = false;
-    expect(config.debug).to.equal(false);
+    expect(getConfig('debug')).to.equal(false);
   });
 
   it('sets bidderTimeout', () => {
     setConfig({ bidderTimeout: 1000 });
-    expect(config.bidderTimeout).to.be.equal(1000);
+    expect(getConfig('bidderTimeout')).to.be.equal(1000);
   });
 
   it('gets legacy bidderTimeout in deprecation window', () => {
     $$PREBID_GLOBAL$$.bidderTimeout = 5000;
-    expect(config.bidderTimeout).to.equal(5000);
+    expect(getConfig('bidderTimeout')).to.equal(5000);
   });
 });

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -15,4 +15,14 @@ describe('setConfig', () => {
     $$PREBID_GLOBAL$$.logging = false;
     expect(config.debug).to.equal(false);
   });
+
+  it('sets bidderTimeout', () => {
+    setConfig({ bidderTimeout: 1000 });
+    expect(config.bidderTimeout).to.be.equal(1000);
+  });
+
+  it('gets legacy bidderTimeout in deprecation window', () => {
+    $$PREBID_GLOBAL$$.bidderTimeout = 5000;
+    expect(config.bidderTimeout).to.equal(5000);
+  });
 });

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -1,0 +1,18 @@
+import { excpet } from 'chai';
+import { config, setConfig } from 'src/config';
+
+describe('setConfig', () => {
+  it('is a function', () => {
+    expect(setConfig).to.be.a('function');
+  });
+
+  it('sets debugging', () => {
+    setConfig({ debug: true });
+    expect(config.debug).to.be.true;
+  });
+
+  it('recognizes legacy logging in deprecation window', () => {
+    $$PREBID_GLOBAL$$.logging = false;
+    expect(config.debug).to.equal(false);
+  });
+});

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -1,5 +1,5 @@
 import { excpet } from 'chai';
-import { getConfig, setConfig, subscribe } from 'src/config';
+import { getConfig, setConfig } from 'src/config';
 
 describe('config API', () => {
   it('setConfig is a function', () => {
@@ -48,20 +48,23 @@ describe('config API', () => {
     expect(getConfig('publisherDomain')).to.equal('ad.example.com');
   });
 
-  it('has a subscribe function for adding listeners to config updates', () => {
+  it('has subscribe functionality for adding listeners to config updates', () => {
     const listener = sinon.spy();
 
-    subscribe(listener);
+    const unsubscribe = getConfig(listener);
     setConfig({ foo: 'bar' });
 
     sinon.assert.calledOnce(listener);
     sinon.assert.calledWith(listener, { foo: 'bar' });
+
+    unsubscribe();
   });
 
   it('subscribers can subscribe to topics', () => {
     const listener = sinon.spy();
 
-    subscribe('logging', listener);
+    const unsubscribe = getConfig('logging', listener);
+    console.log('setConfig test', JSON.stringify(getConfig(), null, 4));
     setConfig({ logging: true, foo: 'bar' });
 
     sinon.assert.calledOnce(listener);
@@ -72,12 +75,15 @@ describe('config API', () => {
     const listener = sinon.spy();
     const wildcard = sinon.spy();
 
-    subscribe('subject', listener);
-    subscribe(wildcard);
+    const subjectUnsubscribe = getConfig('subject', listener);
+    const wildcardUnsubscribe = getConfig(wildcard);
 
     setConfig({ foo: 'bar' });
 
     sinon.assert.notCalled(listener);
     sinon.assert.calledOnce(wildcard);
+
+    subjectUnsubscribe();
+    wildcardUnsubscribe();
   });
 });

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -57,4 +57,27 @@ describe('config API', () => {
     sinon.assert.calledOnce(listener);
     sinon.assert.calledWith(listener, { foo: 'bar' });
   });
+
+  it('subscribers can subscribe to topics', () => {
+    const listener = sinon.spy();
+
+    subscribe('logging', listener);
+    setConfig({ logging: true, foo: 'bar' });
+
+    sinon.assert.calledOnce(listener);
+    sinon.assert.calledWithExactly(listener, { logging: true });
+  });
+
+  it('topic subscribers are only called when that topic is changed', () => {
+    const listener = sinon.spy();
+    const wildcard = sinon.spy();
+
+    subscribe('subject', listener);
+    subscribe(wildcard);
+
+    setConfig({ foo: 'bar' });
+
+    sinon.assert.notCalled(listener);
+    sinon.assert.calledOnce(wildcard);
+  });
 });

--- a/test/spec/e2e/gpt-examples/all_bidders_instant_load.html
+++ b/test/spec/e2e/gpt-examples/all_bidders_instant_load.html
@@ -92,7 +92,7 @@
             };
 
             pbjs.registerBidAdapter(A9Adaptor, 'amazon');
-            //pbjs.logging = true;
+            // pbjs.setConfig({ debug: true });
 
             var adUnits = [
                 {

--- a/test/spec/e2e/gpt-examples/all_bidders_instant_load.html
+++ b/test/spec/e2e/gpt-examples/all_bidders_instant_load.html
@@ -438,7 +438,7 @@
             };
 
             // Optional: excepted values are `medium` (default), `low` and `high`
-            pbjs.setPriceGranularity('medium');
+            pbjs.setConfig({ priceGranularity: 'medium' });
 
             pbjs.requestBids({
                 bidsBackHandler: function (bidResponses) {

--- a/test/spec/e2e/gpt-examples/gpt_default.html
+++ b/test/spec/e2e/gpt-examples/gpt_default.html
@@ -51,7 +51,7 @@
         //pbjs.ading = true;
         pbjs.que.push(function () {
 
-          //pbjs.enableSendAllBids();
+          // setConfig({ enableSendAllBids: true });
 
             var A9Adaptor = function A9Adaptor() {
                 return {

--- a/test/spec/e2e/gpt-examples/gpt_default.html
+++ b/test/spec/e2e/gpt-examples/gpt_default.html
@@ -51,7 +51,7 @@
         //pbjs.ading = true;
         pbjs.que.push(function () {
 
-          // setConfig({ enableSendAllBids: true });
+          // pbjs.setConfig({ enableSendAllBids: true });
 
             var A9Adaptor = function A9Adaptor() {
                 return {

--- a/test/spec/e2e/gpt-examples/gpt_outstream.html
+++ b/test/spec/e2e/gpt-examples/gpt_outstream.html
@@ -8,8 +8,6 @@
     var pbjs = pbjs || {};
     pbjs.que = pbjs.que || [];
 
-    pbjs.logging = true;
-
     var googletag = googletag || {};
     googletag.cmd = googletag.cmd || [];
 
@@ -78,6 +76,7 @@
     ];
 
     pbjs.que.push(function () {
+      pbjs.setConfig({ debug: true });
       pbjs.addAdUnits(videoAdUnits);
       pbjs.requestBids({
         timeout: 3000,

--- a/test/spec/e2e/gpt-examples/gpt_outstream.html
+++ b/test/spec/e2e/gpt-examples/gpt_outstream.html
@@ -22,7 +22,7 @@
 
       googletag.cmd.push(function () {
         pbjs.que.push(function () {
-          pbjs.enableSendAllBids();
+          setConfig({ enableSendAllBids: true });
           pbjs.setTargetingForGPTAsync();
           googletag.pubads().refresh();
         });

--- a/test/spec/e2e/gpt-examples/gpt_outstream.html
+++ b/test/spec/e2e/gpt-examples/gpt_outstream.html
@@ -22,7 +22,7 @@
 
       googletag.cmd.push(function () {
         pbjs.que.push(function () {
-          setConfig({ enableSendAllBids: true });
+          pbjs.setConfig({ enableSendAllBids: true });
           pbjs.setTargetingForGPTAsync();
           googletag.pubads().refresh();
         });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -37,7 +37,7 @@ $$PREBID_GLOBAL$$.adUnits = getAdUnits();
 $$PREBID_GLOBAL$$._adUnitCodes = $$PREBID_GLOBAL$$.adUnits.map(unit => unit.code);
 
 function resetAuction() {
-  $$PREBID_GLOBAL$$._sendAllBids = false;
+  setConfig({ enableSendAllBids: false });
   $$PREBID_GLOBAL$$.clearAuction();
   $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
   $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
@@ -148,7 +148,7 @@ describe('Unit: Prebid Module', function () {
 
     it('should return targeting info as a string', function () {
       const adUnitCode = config.adUnitCodes[0];
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       var expected = 'foobar=300x250&hb_size=300x250&hb_pb=10.00&hb_adid=233bcbee889d46d&hb_bidder=appnexus&hb_size_triplelift=0x0&hb_pb_triplelift=10.00&hb_adid_triplelift=222bb26f9e8bd&hb_bidder_triplelift=triplelift&hb_size_appnexus=300x250&hb_pb_appnexus=10.00&hb_adid_appnexus=233bcbee889d46d&hb_bidder_appnexus=appnexus&hb_size_pagescience=300x250&hb_pb_pagescience=10.00&hb_adid_pagescience=25bedd4813632d7&hb_bidder_pagescienc=pagescience&hb_size_brightcom=300x250&hb_pb_brightcom=10.00&hb_adid_brightcom=26e0795ab963896&hb_bidder_brightcom=brightcom&hb_size_brealtime=300x250&hb_pb_brealtime=10.00&hb_adid_brealtime=275bd666f5a5a5d&hb_bidder_brealtime=brealtime&hb_size_pubmatic=300x250&hb_pb_pubmatic=10.00&hb_adid_pubmatic=28f4039c636b6a7&hb_bidder_pubmatic=pubmatic&hb_size_rubicon=300x600&hb_pb_rubicon=10.00&hb_adid_rubicon=29019e2ab586a5a&hb_bidder_rubicon=rubicon';
       var result = $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCodeStr(adUnitCode);
       assert.equal(expected, result, 'returns expected string of ad targeting info');
@@ -166,7 +166,7 @@ describe('Unit: Prebid Module', function () {
   describe('getAdserverTargetingForAdUnitCode', function () {
     it('should return targeting info as an object', function () {
       const adUnitCode = config.adUnitCodes[0];
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       var result = $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCode(adUnitCode);
       const expected = getAdServerTargeting()[adUnitCode];
       assert.deepEqual(result, expected, 'returns expected' +
@@ -184,7 +184,7 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should return current targeting data for slots', function () {
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       const targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
       const expected = getAdServerTargeting();
       assert.deepEqual(targeting, expected, 'targeting ok');
@@ -212,7 +212,7 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should return correct targeting with bid landscape targeting on', () => {
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
       var expected = getAdServerTargeting();
       assert.deepEqual(targeting, expected);
@@ -394,7 +394,7 @@ describe('Unit: Prebid Module', function () {
     it('should set targeting when passed a string ad unit code with enableSendAllBids', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
 
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync('/19968336/header-bid-tag-0');
       expect(slots[0].spySetTargeting.args).to.deep.contain.members([['hb_bidder', 'appnexus'], ['hb_adid_appnexus', '233bcbee889d46d'], ['hb_pb_appnexus', '10.00']]);
@@ -403,7 +403,7 @@ describe('Unit: Prebid Module', function () {
     it('should set targeting when passed an array of ad unit codes with enableSendAllBids', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
 
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync(['/19968336/header-bid-tag-0']);
       expect(slots[0].spySetTargeting.args).to.deep.contain.members([['hb_bidder', 'appnexus'], ['hb_adid_appnexus', '233bcbee889d46d'], ['hb_pb_appnexus', '10.00']]);
@@ -424,7 +424,7 @@ describe('Unit: Prebid Module', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
 
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync();
 
       var expected = getTargetingKeysBidLandscape();
@@ -1681,7 +1681,7 @@ describe('Unit: Prebid Module', function () {
 
     it('should not find hb_adid key in lowercase for all bidders', () => {
       const adUnitCode = '/19968336/header-bid-tag-0';
-      $$PREBID_GLOBAL$$.enableSendAllBids();
+      setConfig({ enableSendAllBids: true });
       $$PREBID_GLOBAL$$.setTargetingForAst();
       const keywords = Object.keys(window.apntag.tags[adUnitCode].keywords).filter(keyword => (keyword.substring(0, 'hb_adid'.length) === 'hb_adid'));
       expect(keywords.length).to.equal(0);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1609,7 +1609,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('setBidderSequence', () => {
+  describe('bidderSequence', () => {
     it('setting to `random` uses shuffled order of adUnits', () => {
       sinon.spy(utils, 'shuffle');
       const requestObj = {
@@ -1617,7 +1617,7 @@ describe('Unit: Prebid Module', function () {
         timeout: 2000
       };
 
-      $$PREBID_GLOBAL$$.setBidderSequence('random');
+      $$PREBID_GLOBAL$$.setConfig({ bidderSequence: 'random' });
       $$PREBID_GLOBAL$$.requestBids(requestObj);
 
       sinon.assert.calledOnce(utils.shuffle);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -21,6 +21,7 @@ var adloader = require('src/adloader');
 var adaptermanager = require('src/adaptermanager');
 var events = require('src/events');
 var adserver = require('src/adserver');
+var { setConfig } = require('src/config');
 var CONSTANTS = require('src/constants.json');
 
 // These bid adapters are required to be loaded for the following tests to work
@@ -1256,7 +1257,7 @@ describe('Unit: Prebid Module', function () {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'Prebid Error: no value passed to `setPriceGranularity()`';
 
-      $$PREBID_GLOBAL$$.setPriceGranularity();
+      setConfig({ priceGranularity: null });
       assert.ok(logErrorSpy.calledWith(error), 'expected error was logged');
       utils.logError.restore();
     });
@@ -1265,7 +1266,7 @@ describe('Unit: Prebid Module', function () {
       const setPriceGranularitySpy = sinon.spy(bidmanager, 'setPriceGranularity');
       const granularity = 'low';
 
-      $$PREBID_GLOBAL$$.setPriceGranularity(granularity);
+      setConfig({ priceGranularity: granularity });
       assert.ok(setPriceGranularitySpy.called, 'called bidmanager.setPriceGranularity');
       bidmanager.setPriceGranularity.restore();
     });
@@ -1288,7 +1289,7 @@ describe('Unit: Prebid Module', function () {
         ]
       };
 
-      $$PREBID_GLOBAL$$.setPriceGranularity(badConfig);
+      setConfig({ priceGranularity: badConfig });
       assert.ok(logErrorSpy.calledWith(error), 'expected error was logged');
       utils.logError.restore();
     });
@@ -1306,7 +1307,7 @@ describe('Unit: Prebid Module', function () {
         ]
       };
 
-      $$PREBID_GLOBAL$$.setPriceGranularity(goodConfig);
+      setConfig({ priceGranularity: goodConfig });
       assert.ok(setCustomPriceBucket.called, 'called bidmanager.setCustomPriceBucket');
       bidmanager.setCustomPriceBucket.restore();
       assert.ok(setPriceGranularitySpy.calledWith('custom'), 'called bidmanager.setPriceGranularity');

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1742,7 +1742,7 @@ describe('Unit: Prebid Module', function () {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/auction'
       };
 
-      $$PREBID_GLOBAL$$.setS2SConfig(options);
+      $$PREBID_GLOBAL$$.setConfig({ s2sConfig: {options} });
       assert.ok(logErrorSpy.calledOnce, true);
     });
 
@@ -1755,7 +1755,7 @@ describe('Unit: Prebid Module', function () {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/auction'
       };
 
-      $$PREBID_GLOBAL$$.setS2SConfig(options);
+      $$PREBID_GLOBAL$$.setConfig({ s2sConfig: {options} });
       assert.ok(logErrorSpy.calledOnce, true);
     });
   });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -21,7 +21,6 @@ var adloader = require('src/adloader');
 var adaptermanager = require('src/adaptermanager');
 var events = require('src/events');
 var adserver = require('src/adserver');
-var { setConfig } = require('src/config');
 var CONSTANTS = require('src/constants.json');
 
 // These bid adapters are required to be loaded for the following tests to work
@@ -37,7 +36,7 @@ $$PREBID_GLOBAL$$.adUnits = getAdUnits();
 $$PREBID_GLOBAL$$._adUnitCodes = $$PREBID_GLOBAL$$.adUnits.map(unit => unit.code);
 
 function resetAuction() {
-  setConfig({ enableSendAllBids: false });
+  $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: false });
   $$PREBID_GLOBAL$$.clearAuction();
   $$PREBID_GLOBAL$$._bidsRequested = getBidRequests();
   $$PREBID_GLOBAL$$._bidsReceived = getBidResponses();
@@ -148,7 +147,7 @@ describe('Unit: Prebid Module', function () {
 
     it('should return targeting info as a string', function () {
       const adUnitCode = config.adUnitCodes[0];
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       var expected = 'foobar=300x250&hb_size=300x250&hb_pb=10.00&hb_adid=233bcbee889d46d&hb_bidder=appnexus&hb_size_triplelift=0x0&hb_pb_triplelift=10.00&hb_adid_triplelift=222bb26f9e8bd&hb_bidder_triplelift=triplelift&hb_size_appnexus=300x250&hb_pb_appnexus=10.00&hb_adid_appnexus=233bcbee889d46d&hb_bidder_appnexus=appnexus&hb_size_pagescience=300x250&hb_pb_pagescience=10.00&hb_adid_pagescience=25bedd4813632d7&hb_bidder_pagescienc=pagescience&hb_size_brightcom=300x250&hb_pb_brightcom=10.00&hb_adid_brightcom=26e0795ab963896&hb_bidder_brightcom=brightcom&hb_size_brealtime=300x250&hb_pb_brealtime=10.00&hb_adid_brealtime=275bd666f5a5a5d&hb_bidder_brealtime=brealtime&hb_size_pubmatic=300x250&hb_pb_pubmatic=10.00&hb_adid_pubmatic=28f4039c636b6a7&hb_bidder_pubmatic=pubmatic&hb_size_rubicon=300x600&hb_pb_rubicon=10.00&hb_adid_rubicon=29019e2ab586a5a&hb_bidder_rubicon=rubicon';
       var result = $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCodeStr(adUnitCode);
       assert.equal(expected, result, 'returns expected string of ad targeting info');
@@ -166,7 +165,7 @@ describe('Unit: Prebid Module', function () {
   describe('getAdserverTargetingForAdUnitCode', function () {
     it('should return targeting info as an object', function () {
       const adUnitCode = config.adUnitCodes[0];
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       var result = $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCode(adUnitCode);
       const expected = getAdServerTargeting()[adUnitCode];
       assert.deepEqual(result, expected, 'returns expected' +
@@ -184,7 +183,7 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should return current targeting data for slots', function () {
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       const targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
       const expected = getAdServerTargeting();
       assert.deepEqual(targeting, expected, 'targeting ok');
@@ -212,7 +211,7 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should return correct targeting with bid landscape targeting on', () => {
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
       var expected = getAdServerTargeting();
       assert.deepEqual(targeting, expected);
@@ -394,7 +393,7 @@ describe('Unit: Prebid Module', function () {
     it('should set targeting when passed a string ad unit code with enableSendAllBids', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
 
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync('/19968336/header-bid-tag-0');
       expect(slots[0].spySetTargeting.args).to.deep.contain.members([['hb_bidder', 'appnexus'], ['hb_adid_appnexus', '233bcbee889d46d'], ['hb_pb_appnexus', '10.00']]);
@@ -403,7 +402,7 @@ describe('Unit: Prebid Module', function () {
     it('should set targeting when passed an array of ad unit codes with enableSendAllBids', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
 
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync(['/19968336/header-bid-tag-0']);
       expect(slots[0].spySetTargeting.args).to.deep.contain.members([['hb_bidder', 'appnexus'], ['hb_adid_appnexus', '233bcbee889d46d'], ['hb_pb_appnexus', '10.00']]);
@@ -424,7 +423,7 @@ describe('Unit: Prebid Module', function () {
       var slots = createSlotArray();
       window.googletag.pubads().setSlots(slots);
 
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync();
 
       var expected = getTargetingKeysBidLandscape();
@@ -1257,7 +1256,7 @@ describe('Unit: Prebid Module', function () {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'Prebid Error: no value passed to `setPriceGranularity()`';
 
-      setConfig({ priceGranularity: null });
+      $$PREBID_GLOBAL$$.setConfig({ priceGranularity: null });
       assert.ok(logErrorSpy.calledWith(error), 'expected error was logged');
       utils.logError.restore();
     });
@@ -1266,7 +1265,7 @@ describe('Unit: Prebid Module', function () {
       const setPriceGranularitySpy = sinon.spy(bidmanager, 'setPriceGranularity');
       const granularity = 'low';
 
-      setConfig({ priceGranularity: granularity });
+      $$PREBID_GLOBAL$$.setConfig({ priceGranularity: granularity });
       assert.ok(setPriceGranularitySpy.called, 'called bidmanager.setPriceGranularity');
       bidmanager.setPriceGranularity.restore();
     });
@@ -1289,7 +1288,7 @@ describe('Unit: Prebid Module', function () {
         ]
       };
 
-      setConfig({ priceGranularity: badConfig });
+      $$PREBID_GLOBAL$$.setConfig({ priceGranularity: badConfig });
       assert.ok(logErrorSpy.calledWith(error), 'expected error was logged');
       utils.logError.restore();
     });
@@ -1307,7 +1306,7 @@ describe('Unit: Prebid Module', function () {
         ]
       };
 
-      setConfig({ priceGranularity: goodConfig });
+      $$PREBID_GLOBAL$$.setConfig({ priceGranularity: goodConfig });
       assert.ok(setCustomPriceBucket.called, 'called bidmanager.setCustomPriceBucket');
       bidmanager.setCustomPriceBucket.restore();
       assert.ok(setPriceGranularitySpy.calledWith('custom'), 'called bidmanager.setPriceGranularity');
@@ -1681,7 +1680,7 @@ describe('Unit: Prebid Module', function () {
 
     it('should not find hb_adid key in lowercase for all bidders', () => {
       const adUnitCode = '/19968336/header-bid-tag-0';
-      setConfig({ enableSendAllBids: true });
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       $$PREBID_GLOBAL$$.setTargetingForAst();
       const keywords = Object.keys(window.apntag.tags[adUnitCode].keywords).filter(keyword => (keyword.substring(0, 'hb_adid'.length) === 'hb_adid'));
       expect(keywords.length).to.equal(0);


### PR DESCRIPTION
## Type of change
- Feature
- Refactoring

## Description of change
Adds `pbjs.setConfig` and `pbjs.getConfig` api methods for working with Prebid configuration.

Usage:
- `pbjs.setConfig({ debug: <true|false> });` to enable/disable logging (this will replace `pbjs.logging = <true|false>`, which still works for now but will be depreciated).

- `pbjs.setConfig({ <key>: <value> });` for setting arbitrary configuration

The  `getConfig` function is for retrieving the current configuration object or subscribing to configuration updates. When called with no parameters, the entire config object is returned. When called with a string parameter, a single configuration property matching that parameter is returned.

- `config.getConfig()` => get config object
- `config.getConfig('debug')` => get `debug` config

The `getConfig` function also contains a 'subscribe' ability that adds a callback function to a set of listeners that are invoked whenever `setConfig` is called. The subscribed function will be passed the options object that was used in the `setConfig` call. Individual topics can be subscribed to by passing a string as the first parameter and a callback function as the second

```JavaScript
// subscribe to all configuration changes
getConfig((config) => console.log('config set:', config));

// subscribe to only 'logging' changes
getConfig('logging', (config) => console.log('logging set:', config));

// unsubscribe
const unsubscribe = getConfig(...);
unsubscribe(); // no longer listening
```

## Other information
Implements #1247