### PR TITLE
fix sending timeout to analytics

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -56,6 +56,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
   const auctionInit = {
     timestamp: auctionStart,
     requestId,
+    timeout: cbTimeout
   };
   events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
`timeout` was not wired up on the `initAuction` event. 
- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
@protonate @matthewlane  for review
