### PR TITLE
fixes #1331 module bundling on windows

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -67,7 +67,7 @@ module.exports = {
       internalModules = fs.readdirSync(MODULE_PATH)
         .filter(file => !(/(^|\/)\.[^\/\.]/g).test(file))
         .reduce((memo, file) => {
-          var moduleName = file.split(new RegExp('[.' + path.sep + ']'))[0];
+          var moduleName = file.split(new RegExp('[.\\' + path.sep + ']'))[0];
           var filePath = path.join(MODULE_PATH, file);
           var modulePath = path.join(__dirname, filePath)
           if (fs.lstatSync(filePath).isDirectory()) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes bug in windows where path separator in windows "\\" causing regular expression to fail because of unintentional backslash escaping.