### PR TITLE
Reduce dependency of SAS adapter.

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -1,60 +1,39 @@
-var utils = require('src/utils.js');
-var bidfactory = require('src/bidfactory.js');
-var bidmanager = require('src/bidmanager.js');
-var adloader = require('src/adloader.js');
-var url = require('src/url.js');
-var adaptermanager = require('src/adaptermanager');
+import { ajax } from 'src/ajax';
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import { STATUS } from 'src/constants.json';
+import * as utils from 'src/utils';
+import adloader from 'src/adloader.js';
+import adaptermanager from 'src/adaptermanager';
 
-var SmartAdServer = function SmartAdServer() {
-  var generateCallback = function(bid) {
-    var callbackId = 'sas_' + utils.getUniqueIdentifierStr();
-    $$PREBID_GLOBAL$$[callbackId] = function(adUnit) {
-      var bidObject;
-      if (adUnit) {
-        utils.logMessage(`[SmartAdServer] bid response for placementCode ${bid.placementCode}`);
-        bidObject = bidfactory.createBid(1);
-        bidObject.bidderCode = 'smartadserver';
-        bidObject.cpm = adUnit.cpm;
-        bidObject.currency = adUnit.currency;
-        bidObject.ad = adUnit.ad;
-        bidObject.width = adUnit.width;
-        bidObject.height = adUnit.height;
-        bidObject.dealId = adUnit.dealId;
-        bidmanager.addBidResponse(bid.placementCode, bidObject);
-      } else {
-        utils.logMessage(`[SmartAdServer] no bid response for placementCode ${bid.placementCode}`);
-        bidObject = bidfactory.createBid(2);
-        bidObject.bidderCode = 'smartadserver';
-        bidmanager.addBidResponse(bid.placementCode, bidObject);
-      }
+function smartadserverBidAdapter() {
+  var generateCallbackId = function(placementCode) {
+    var callbackId = "sas_" + utils.getUniqueIdentifierStr();
+    $$PREBID_GLOBAL$$[callbackId] = function(adResponse) {
+      var status = adResponse != null ? STATUS.GOOD : STATUS.NO_BID;
+      utils.logMessage(`[SmartAdServer] bid status for placementCode ${placementCode} : ${status}`);
+      var bidObject = bidfactory.createBid(status);
+      bidObject.bidderCode = 'smartadserver';
+      Object.assign(bidObject, adResponse);
+      bidmanager.addBidResponse(placementCode, bidObject);
     };
     return callbackId;
+  };
+
+  var bidCallback = function(params, bidIndex, callbackId) {
+    return function() { pbjs.sas.callBid(params, bidIndex, callbackId); };
   };
 
   return {
     callBids: function(params) {
       for (var i = 0; i < params.bids.length; i++) {
         var bid = params.bids[i];
-        var adCall = url.parse(bid.params.domain);
-        adCall.pathname = '/prebid';
-        adCall.search = {
-          'pbjscbk': '$$PREBID_GLOBAL$$.' + generateCallback(bid),
-          'siteid': bid.params.siteId,
-          'pgid': bid.params.pageId,
-          'fmtid': bid.params.formatId,
-          'ccy': bid.params.currency || 'USD',
-          'bidfloor': bid.params.bidfloor || 0.0,
-          'tgt': encodeURIComponent(bid.params.target || ''),
-          'tag': bid.placementCode,
-          'sizes': bid.sizes.map(size => size[0] + 'x' + size[1]).join(','),
-          'async': 1
-        };
-        adloader.loadScript(url.format(adCall));
+        adloader.loadScript(`//ced.sascdn.com/tag/${bid.params.networkId || 0}/sas-prebid.js`, bidCallback(params, i, generateCallbackId(bid.placementCode)), true);
       }
     }
   };
 };
 
-adaptermanager.registerBidAdapter(new SmartAdServer, 'smartadserver');
+adaptermanager.registerBidAdapter(new smartadserverBidAdapter, 'smartadserver');
 
-module.exports = SmartAdServer;
+module.exports = smartadserverBidAdapter;

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -1,12 +1,12 @@
-describe('smartadserver adapter tests', function () {
-  var urlParse = require('url-parse');
-  var querystringify = require('querystringify');
-  var adapter = require('modules/smartadserverBidAdapter');
-  var adLoader = require('src/adloader');
-  var expect = require('chai').expect;
-  var bidmanager = require('src/bidmanager');
-  var CONSTANTS = require('src/constants.json');
+import {expect} from 'chai';
+import querystringify from 'querystringify';
+import urlParse from 'url-parse';
+import adapter from '../../../modules/smartadserverBidAdapter';
+import bidManager from '../../../src/bidmanager';
+import adLoader from '../../../src/adloader';
+import CONSTANTS from '../../../src/constants.json';
 
+describe('smartadserver adapter tests', function () {
   var DEFAULT_PARAMS = {
     bidderCode: 'smartadserver',
     bids: [{
@@ -28,22 +28,24 @@ describe('smartadserver adapter tests', function () {
     ]
   };
 
-  var DEFAULT_PARAMS_WO_OPTIONAL = {
+  var DEFAULT_PARAMS = {
     bidderCode: 'smartadserver',
     bids: [{
       bidId: 'abcd1234',
       sizes: [[300, 250], [300, 200]],
       bidder: 'smartadserver',
       params: {
+        networkId: 10,
         domain: 'http://www.smartadserver.com',
         siteId: '1234',
         pageId: '5678',
-        formatId: '90'
+        formatId: '90',
+        target: 'test=prebid',
+        currency: 'EUR'
       },
       requestId: 'efgh5678',
       placementCode: 'sas_42'
-    }
-    ]
+    }]
   };
 
   var BID_RESPONSE = {
@@ -53,64 +55,44 @@ describe('smartadserver adapter tests', function () {
     height: 250
   };
 
-  it('set url parameters', function () {
+  it('test Smart script url', function () {
     var stubLoadScript = sinon.stub(adLoader, 'loadScript');
 
-    adapter().callBids(DEFAULT_PARAMS);
+    var params = {
+      bidderCode: 'smartadserver',
+      bids: [{
+        bidId: 'abcd1234',
+        sizes: [[300, 250], [300, 200]],
+        bidder: 'smartadserver',
+        params: {
+          domain: 'http://www.smartadserver.com',
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90'
+        },
+        requestId: 'efgh5678',
+        placementCode: 'sas_42'
+      }]
+    };
 
-    var smartCallback;
-    for (var k in $$PREBID_GLOBAL$$) {
-      if (k.lastIndexOf('sas_', 0) === 0) {
-        smartCallback = k;
-        break;
-      }
-    }
-
-    var bidUrl = stubLoadScript.getCall(0).args[0];
-    var parsedBidUrl = urlParse(bidUrl);
-    var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
-
-    expect(parsedBidUrl.hostname).to.equal('www.smartadserver.com');
-    expect(parsedBidUrl.pathname).to.equal('/prebid');
-
-    expect(parsedBidUrlQueryString).to.have.property('pbjscbk').and.to.equal('pbjs.' + smartCallback);
-    expect(parsedBidUrlQueryString).to.have.property('siteid').and.to.equal('1234');
-    expect(parsedBidUrlQueryString).to.have.property('pgid').and.to.equal('5678');
-    expect(parsedBidUrlQueryString).to.have.property('fmtid').and.to.equal('90');
-    expect(parsedBidUrlQueryString).to.have.property('tgt').and.to.equal('test=prebid');
-    expect(parsedBidUrlQueryString).to.have.property('ccy').and.to.equal('EUR');
-    expect(parsedBidUrlQueryString).to.have.property('bidfloor').and.to.equal('0.42');
-    expect(parsedBidUrlQueryString).to.have.property('tag').and.to.equal('sas_42');
-    expect(parsedBidUrlQueryString).to.have.property('sizes').and.to.equal('300x250,300x200');
-    expect(parsedBidUrlQueryString).to.have.property('async').and.to.equal('1');
-
-    stubLoadScript.restore();
-  });
-
-  it('test optional parameters default value', function () {
-    var stubLoadScript = sinon.stub(adLoader, 'loadScript');
-
-    adapter().callBids(DEFAULT_PARAMS_WO_OPTIONAL);
+    adapter().callBids(params);
 
     var bidUrl = stubLoadScript.getCall(0).args[0];
-    var parsedBidUrl = urlParse(bidUrl);
-    var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
-
-    expect(parsedBidUrlQueryString).to.have.property('tgt').and.to.equal('');
-    expect(parsedBidUrlQueryString).to.have.property('ccy').and.to.equal('USD');
+    expect(bidUrl).to.equal('//ced.sascdn.com/tag/0/sas-prebid.js');
 
     stubLoadScript.restore();
   });
 
   it('creates an empty bid response if no bids', function() {
-    var stubLoadScript = sinon.stub(adLoader, 'loadScript', function(url) {
-      var bidUrl = stubLoadScript.getCall(0).args[0];
-      var parsedBidUrl = urlParse(bidUrl);
-      var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
-
-      pbjs[parsedBidUrlQueryString.pbjscbk.split('.')[1]](null);
+    pbjs.sas = {
+      callBid: function(params, bidIndex, callbackId) {
+        pbjs[callbackId](null);
+      }
+    };
+    var stubLoadScript = sinon.stub(adLoader, 'loadScript', function(url, callback) {
+      callback();
     });
-    var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+    var stubAddBidResponse = sinon.stub(bidManager, 'addBidResponse');
 
     adapter().callBids(DEFAULT_PARAMS);
 
@@ -126,14 +108,15 @@ describe('smartadserver adapter tests', function () {
   });
 
   it('creates a bid response if bid is returned', function() {
-    var stubLoadScript = sinon.stub(adLoader, 'loadScript', function(url) {
-      var bidUrl = stubLoadScript.getCall(0).args[0];
-      var parsedBidUrl = urlParse(bidUrl);
-      var parsedBidUrlQueryString = querystringify.parse(parsedBidUrl.query);
-
-      pbjs[parsedBidUrlQueryString.pbjscbk.split('.')[1]](BID_RESPONSE);
+    pbjs.sas = {
+      callBid: function(params, bidIndex, callbackId) {
+        pbjs[callbackId](BID_RESPONSE);
+      }
+    };
+    var stubLoadScript = sinon.stub(adLoader, 'loadScript', function(url, callback) {
+      callback();
     });
-    var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+    var stubAddBidResponse = sinon.stub(bidManager, 'addBidResponse');
 
     adapter().callBids(DEFAULT_PARAMS);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
The goal of this refactoring is to use the Smart AdServer Prebid Javascript library to build the ad-request independently from the adapter code.