### PR TITLE
Map native icon parameter and validate returned asset values

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -16,10 +16,11 @@ const NATIVE_MAPPING = {
   body: 'description',
   image: {
     serverName: 'main_image',
-    serverParams: {
-      required: true,
-      sizes: [{}]
-    }
+    serverParams: { required: true, sizes: [{}] }
+  },
+  icon: {
+    serverName: 'icon',
+    serverParams: { sizes: [{}] }
   },
   sponsoredBy: 'sponsored_by'
 };

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -20,7 +20,7 @@ const NATIVE_MAPPING = {
   },
   icon: {
     serverName: 'icon',
-    serverParams: { sizes: [{}] }
+    serverParams: { required: true, sizes: [{}] }
   },
   sponsoredBy: 'sponsored_by'
 };

--- a/src/native.js
+++ b/src/native.js
@@ -77,7 +77,7 @@ export function nativeBidIsValid(bid) {
   const requiredAssets = Object.keys(requestedAssets).filter(
     key => requestedAssets[key].required
   );
-  const returnedAssets = Object.keys(bid.native);
+  const returnedAssets = Object.keys(bid.native).filter(key => bid.native[key]);
 
   return requiredAssets.every(asset => returnedAssets.includes(asset));
 }

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -485,25 +485,28 @@ describe('bidmanager.js', function () {
     });
 
     it('should not add native bids that do not have required assets', () => {
-      const adUnit = {
-        code: 'adUnit-code',
-        mediaType: 'native',
+      sinon.stub(utils, 'getBidRequest', () => ({
+        bidder: 'appnexusAst',
         nativeParams: {
-          title: {required: true},
+          title: {'required': true},
         },
-        bids: [
-          {bidder: 'appnexusAst', params: {placementId: 'id'}}
-        ]
-      };
+        mediaType: 'native',
+      }));
 
       const bid = Object.assign({},
         bidfactory.createBid(1),
-        {mediaType: 'native'}
+        {
+          bidderCode: 'appnexusAst',
+          mediaType: 'native',
+          native: {title: undefined}
+        }
       );
 
       const bidsRecCount = $$PREBID_GLOBAL$$._bidsReceived.length;
-      bidmanager.addBidResponse(adUnit.code, bid);
+      bidmanager.addBidResponse('adUnit-code', bid);
       assert.equal(bidsRecCount, $$PREBID_GLOBAL$$._bidsReceived.length);
+
+      utils.getBidRequest.restore();
     });
 
     it('should add native bids that do have required assets', () => {


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
This updates appnexusAst to map the `icon` native parameter to pass a `sizes` field on the request to the endpoint, which is a required field when requesting that asset.

Also fixes a bug in the native validation function that was allowing returned native assets with a key but no value to pass validation when `required: true` was set for that asset.