### PR TITLE
Add support for publisher-defined outstream renderers

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -42,6 +42,7 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
         return Object.assign({}, bid, {
           placementCode: adUnit.code,
           mediaType: adUnit.mediaType,
+          renderer: adUnit.renderer,
           transactionId: adUnit.transactionId,
           sizes: sizes,
           bidId: bid.bid_id || utils.getUniqueIdentifierStr(),

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -533,5 +533,27 @@ describe('bidmanager.js', function () {
 
       utils.getBidRequest.restore();
     });
+
+    it('installs publisher-defined renderers on bids', () => {
+      sinon.stub(utils, 'getBidderRequest', () => ({
+        bids: [{
+          renderer: {
+            url: 'renderer.js',
+            render: (bid) => bid
+          }
+        }]
+      }));
+
+      const bid = Object.assign({}, bidfactory.createBid(1), {
+        bidderCode: 'appnexusAst',
+        mediaType: 'video-outstream',
+      });
+
+      bidmanager.addBidResponse('adUnit-code', bid);
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
+      assert.equal(addedBid.renderer.url, 'renderer.js');
+
+      utils.getBidderRequest.restore();
+    });
   });
 });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
This change adds the ability to specify a renderer to use for outstream bids. Currently, an outstream bid response is accompanied by a renderer in the form of a url that points to a script containing the renderer software. This supplied renderer is used by Prebid to load and play the winning outstream bid.

If a publisher specifies a renderer on an outstream ad unit, this renderer will be used to load and play the outstream bid, instead of the renderer that is supplied with the bid. If both an ad unit renderer and a bid renderer are present, the ad unit renderer will be used.

In addition to a url pointing to the render script, a function that invokes the renderer is required to tell Prebid how to use the script to render the bid. A publisher can define these pieces with the `renderer` property in an outstream ad unit. The `renderer` property is an object with a `url` that points to the render script, and a `render` function that receives a bid parameter.

```JavaScript
pbjs.addAdUnit({
  code: 'video1',
  sizes: [ 640, 480 ],
  mediaType: 'video-outstream',
  renderer: {
    url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
    render: function(bid) {
      ANOutstreamVideo.renderAd({
        targetId: bid.adUnitCode,
        adResponse: bid.adResponse,
      });
    }
  },
  bids: [
    {
      bidder: 'appnexusAst',
      params: {
        placementId: '5768085',
        video: {
          skippable: true,
          playback_method: [ 'auto_play_sound_off' ]
        }
      }
    }
  ]
});
```