### PR TITLE
Fixing some recent bugs in addBidResponse

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -129,7 +129,13 @@ exports.addBidResponse = function (adUnitCode, bid) {
   // Postprocess the bids so that all the universal properties exist, no matter which bidder they came from.
   // This should be called before addBidToAuction().
   function prepareBidForAuction() {
+    // Let listeners know that now is the time to adjust the bid, if they want to.
+    //
+    // This must be fired first, so that we calculate derived values from the updates
+    events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
+
     const { requestId, start } = getBidderRequest(bid.bidderCode, adUnitCode);
+
     Object.assign(bid, {
       requestId: requestId,
       responseTimestamp: timestamp(),
@@ -141,7 +147,6 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
     bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
 
-    // append price strings
     const priceStringsObj = getPriceBucketString(bid.cpm, _customPriceBucket);
     bid.pbLg = priceStringsObj.low;
     bid.pbMg = priceStringsObj.med;
@@ -168,9 +173,6 @@ exports.addBidResponse = function (adUnitCode, bid) {
 
   // Add a bid to the auction.
   function addBidToAuction() {
-    // Make sure that the bidAdjustment event fires before bidResponse, so that the bid response
-    // has the adjusted bid value
-    events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
     events.emit(CONSTANTS.EVENTS.BID_RESPONSE, bid);
 
     $$PREBID_GLOBAL$$._bidsReceived.push(bid);

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -108,11 +108,11 @@ exports.addBidResponse = function (adUnitCode, bid) {
     }
 
     if (!adUnitCode) {
-      utils.logWarn(errorMessage('No adUnitCode was supplied to addBidResponse.'));
+      utils.logWarn('No adUnitCode was supplied to addBidResponse.');
       return false;
     }
     if (!bid) {
-      utils.logWarn(errorMessage(`Some adapter tried to add an undefined bid for ${adUnitCode}.`));
+      utils.logWarn(`Some adapter tried to add an undefined bid for ${adUnitCode}.`);
       return false;
     }
     if (bid.mediaType === 'native' && !nativeBidIsValid(bid)) {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -111,6 +111,10 @@ exports.addBidResponse = function (adUnitCode, bid) {
       utils.logWarn(errorMessage('No adUnitCode was supplied to addBidResponse.'));
       return false;
     }
+    if (!bid) {
+      utils.logWarn(errorMessage(`Some adapter tried to add an undefined bid for ${adUnitCode}.`));
+      return false;
+    }
     if (bid.mediaType === 'native' && !nativeBidIsValid(bid)) {
       utils.logError(errorMessage('Native bid missing some required properties.'));
       return false;

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -112,6 +112,16 @@ describe('The Bid Manager', () => {
 
         it('should add valid video bids and then execute the callbacks signaling the end of the auction',
           testAddVideoBid(true, true, stubProvider));
+
+        it('should gracefully do nothing when adUnitCode is undefined', () => {
+          bidManager.addBidResponse(undefined, {});
+          expect($$PREBID_GLOBAL$$._bidsReceived.length).to.equal(0);
+        });
+
+        it('should gracefully do nothing when bid is undefined', () => {
+          bidManager.addBidResponse('mock/code');
+          expect($$PREBID_GLOBAL$$._bidsReceived.length).to.equal(0);
+        });
       });
 
       describe('when the auction has timed out', () => {


### PR DESCRIPTION
## Type of change
Bugfix

## Description of change
Fixing some regressions introduced in #1277 

1. The old code allowed adapters to call `addBidResponse` without supplying a bid. This permissibility may or may not be a good idea... but #1277 definitely isn't a good place to make that change. The `(!bid)` check is added back in here.

2. The `bidAdustment` event needs to be fired before the `getPriceBucketStrings` gets called, because listeners for that event may mutate the bid's cpm.