### PR TITLE
add dt.pref for DigiTrust in rubiconBidAdapter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -150,7 +150,8 @@ function RubiconAdapter() {
     }
     return [
       'dt.id', digiTrustId.id,
-      'dt.keyv', digiTrustId.keyv
+      'dt.keyv', digiTrustId.keyv,
+      'dt.pref', 0
     ];
   }
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -329,7 +329,8 @@ describe('the rubicon adapter', () => {
 
           let expectedQuery = {
             'dt.id': 'testId',
-            'dt.keyv': 'testKeyV'
+            'dt.keyv': 'testKeyV',
+            'dt.pref': '0'
           };
 
           // test that all values above are both present and correct


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
We were missing a necessary parameter for our DigiTrust support.  This pull-request adds it.