### PR TITLE
Fix google analytics registration

### DIFF
--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -22,11 +22,6 @@ var _enableDistribution = false;
 var _trackerSend = null;
 var _sampled = true;
 
-adaptermanager.registerAnalyticsAdapter({
-  adapter: exports,
-  code: 'ga'
-});
-
 /**
  * This will enable sending data to google analytics. Only call once, or duplicate data will be sent!
  * @param  {object} provider use to set GA global (if renamed);
@@ -256,3 +251,8 @@ function sendBidWonToGa(bid) {
 
   checkAnalytics();
 }
+
+adaptermanager.registerAnalyticsAdapter({
+  adapter: exports,
+  code: 'ga'
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The google analytics adapter was registering itself before `enableAnalytics` method was attached to object causing the registration to throw an error.  Moving the registration to the end of the file fixes the problem.

## Other information
Noticed this issue while debugging #1373
