### PR TITLE
Mention NodeJS 4.0 dependency in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Working examples can be found in [the developer docs](http://prebid.org/dev-docs
 
 ## Install
 
+Prebid requires NodeJS 4.0 or higher.
+
     $ git clone https://github.com/prebid/Prebid.js.git
     $ cd Prebid.js
     $ yarn install
 
-Prebid also supports the `yarn` npm client. This is an alternative to using `npm` for package management, though `npm` will continue to work as before.
+Prebid supports the `yarn` npm client. This is an alternative to using `npm` for package management, though `npm install` will continue to work as before.
 
 For more info, see [the Yarn documentation](https://yarnpkg.com).
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Working examples can be found in [the developer docs](http://prebid.org/dev-docs
 
 ## Install
 
-Prebid requires NodeJS 4.0 or higher.
-
     $ git clone https://github.com/prebid/Prebid.js.git
     $ cd Prebid.js
     $ yarn install
@@ -33,6 +31,8 @@ Prebid requires NodeJS 4.0 or higher.
 Prebid supports the `yarn` npm client. This is an alternative to using `npm` for package management, though `npm install` will continue to work as before.
 
 For more info, see [the Yarn documentation](https://yarnpkg.com).
+
+*Note:* You need to have `NodeJS` 4.x or greater installed.
 
 <a name="Build"></a>
 
@@ -48,8 +48,6 @@ This runs some code quality checks, starts a web server at `http://localhost:999
 + `./build/dev/prebid.js.map` - Source map for dev and debug
 + `./build/dist/prebid.js` - Minified production code
 + `./prebid.js_<version>.zip` - Distributable zip archive
-
-*Note:* You need to have `node.js` 4.x or greater installed to be able to run the `gulp build` commands.
 
 ### Build Optimization
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "globalVarName": "pbjs",
   "author": "the prebid.js contributors",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=4.0"
+  },
   "devDependencies": {
     "babel-core": "6.22.0",
     "babel-loader": "^7.1.1",


### PR DESCRIPTION
This caused me some trouble on a Debian Jessie machine (which ships with NodeJS 0.10).