### PR TITLE
fix banner showing up in prebid-core.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ gulp.task('webpack', ['clean'], function () {
     .pipe(webpack(webpackConfig))
     .pipe(replace('$prebid.version$', prebid.version))
     .pipe(uglify())
-    .pipe(gulpif(file => file.basename === 'prebid.js', header(banner, { prebid: prebid })))
+    .pipe(gulpif(file => file.basename === 'prebid-core.js', header(banner, { prebid: prebid })))
     .pipe(optimizejs())
     .pipe(gulp.dest('build/dist'))
     .pipe(connect.reload());


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When we decided to rename the core prebid component from `prebid.js` to `prebid-core.js` I missed the part that attaches the banner, so it was being left out.  This fixes that regression.

## Other information
Fixes #1387 