### PR TITLE
Reject sizeless banner bids

### DIFF
--- a/modules/getintentBidAdapter.js
+++ b/modules/getintentBidAdapter.js
@@ -55,6 +55,7 @@ var GetIntentAdapter = function GetIntentAdapter() {
             if (br.mediaType === 'video') {
               bid.vastUrl = bidResponse.vast_url;
               bid.descriptionUrl = bidResponse.vast_url;
+              bid.mediaType = 'video';
             } else {
               bid.ad = bidResponse.ad;
             }

--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -23,6 +23,7 @@ function Bid(statusCode, bidRequest) {
   this.height = 0;
   this.statusMessage = _getStatus();
   this.adId = _bidId;
+  this.mediaType = 'banner';
 
   function _getStatus() {
     switch (_statusCode) {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -136,6 +136,16 @@ exports.addBidResponse = function (adUnitCode, bid) {
     events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
 
     const bidRequest = getBidderRequest(bid.bidderCode, adUnitCode);
+    // 'banner' is default and may not be explicitly set on mediaType, so any other mediaType isn't checked
+    if (!['video', 'video-outstream', 'native'].includes(bid.mediaType)) {
+      if (bid.width === undefined || bid.height === undefined) {
+        const adUnit = getBidderRequest(bid.bidderCode, adUnitCode);
+        const sizes = adUnit && adUnit.bids && adUnit.bids[0] && adUnit.bids[0].sizes;
+        // TODO: set width and height if one valid size
+        utils.logError(`banner bids require a width and height. ${bid.bidderCode} bid id ${bid.adId} won't be added to the auction`);
+        return;
+      }
+    }
 
     Object.assign(bid, {
       requestId: bidRequest.requestId,

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -124,7 +124,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
       utils.logError(errorMessage(`Video bid does not have required vastUrl property.`));
       return false;
     }
-    if (bid.mediaType === 'banner' && !hasSize(bid)) {
+    if (bid.mediaType === 'banner' && !validBidSize(bid)) {
       utils.logError(errorMessage(`Banner bids require a width and height`));
       return false;
     }
@@ -133,23 +133,25 @@ exports.addBidResponse = function (adUnitCode, bid) {
   }
 
   // check that the bid has a width and height set
-  function hasSize(bid) {
+  function validBidSize(bid) {
+    if ((bid.width || bid.width === 0) && (bid.height || bid.height === 0)) {
+      return true;
+    }
+
     const adUnit = getBidderRequest(bid.bidderCode, adUnitCode);
     const sizes = adUnit && adUnit.bids && adUnit.bids[0] && adUnit.bids[0].sizes;
     const parsedSizes = utils.parseSizesInput(sizes);
 
     // if a banner impression has one valid size, we assign that size to any bid
-    // response that does not explicitly set width or height, so pass validation
+    // response that does not explicitly set width or height
     if (parsedSizes.length === 1) {
+      const [ width, height ] = parsedSizes[0].split('x');
+      bid.width = width;
+      bid.height = height;
       return true;
     }
 
-    // falsy value except 0 are not valid
-    if ((!bid.width && bid.width !== 0) || (!bid.height && bid.height !== 0)) {
-      return false;
-    }
-
-    return true;
+    return false;
   }
 
   // Postprocess the bids so that all the universal properties exist, no matter which bidder they came from.

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -500,6 +500,32 @@ describe('bidmanager.js', function () {
       assert.notEqual(bid.adId, addedBid.adId);
     });
 
+    it('should add banner bids that have no width or height but single adunit size', () => {
+      sinon.stub(utils, 'getBidderRequest', () => ({
+        bids: [{
+          sizes: [[300, 250]],
+        }]
+      }));
+
+      const bid = Object.assign({},
+        bidfactory.createBid(1),
+        {
+          width: undefined,
+          height: undefined
+        }
+      );
+
+      bidmanager.addBidResponse('adUnitCode', bid);
+
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived[$$PREBID_GLOBAL$$._bidsReceived.length - 1];
+
+      assert.equal(bid.adId, addedBid.adId);
+      assert.equal(addedBid.width, 300);
+      assert.equal(addedBid.height, 250);
+
+      utils.getBidderRequest.restore();
+    });
+
     it('should not add native bids that do not have required assets', () => {
       sinon.stub(utils, 'getBidRequest', () => ({
         bidder: 'appnexusAst',

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -486,7 +486,7 @@ describe('bidmanager.js', function () {
 
     it('should not add banner bids that have no width or height', () => {
       const bid = Object.assign({},
-        bidfactory.createBid(2),
+        bidfactory.createBid(1),
         {
           width: undefined,
           height: undefined
@@ -494,25 +494,10 @@ describe('bidmanager.js', function () {
       );
 
       bidmanager.addBidResponse('adUnitCode', bid);
-      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
+
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived[$$PREBID_GLOBAL$$._bidsReceived.length - 1];
 
       assert.notEqual(bid.adId, addedBid.adId);
-    });
-
-    it('should add valid non-banner bids regardless of width or height', () => {
-      const bid = Object.assign({},
-        bidfactory.createBid(2),
-        {
-          mediaType: 'video',
-          width: undefined,
-          height: undefined
-        }
-      );
-
-      bidmanager.addBidResponse('adUnitCode', bid);
-      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
-
-      assert.equal(bid.adId, addedBid.adId);
     });
 
     it('should not add native bids that do not have required assets', () => {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -484,6 +484,37 @@ describe('bidmanager.js', function () {
       assert.equal(addedBid1.adId, bid1.adId);
     });
 
+    it('should not add banner bids that have no width or height', () => {
+      const bid = Object.assign({},
+        bidfactory.createBid(2),
+        {
+          width: undefined,
+          height: undefined
+        }
+      );
+
+      bidmanager.addBidResponse('adUnitCode', bid);
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
+
+      assert.notEqual(bid.adId, addedBid.adId);
+    });
+
+    it('should add valid non-banner bids regardless of width or height', () => {
+      const bid = Object.assign({},
+        bidfactory.createBid(2),
+        {
+          mediaType: 'video',
+          width: undefined,
+          height: undefined
+        }
+      );
+
+      bidmanager.addBidResponse('adUnitCode', bid);
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
+
+      assert.equal(bid.adId, addedBid.adId);
+    });
+
     it('should not add native bids that do not have required assets', () => {
       sinon.stub(utils, 'getBidRequest', () => ({
         bidder: 'appnexusAst',

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -207,7 +207,6 @@ describe('spotx adapter tests', () => {
           expect(bid.bidderCode).to.equal('spotx');
           expect(bid.statusMessage).to.equal('Bid returned empty or error response');
           expect(bid.cpm).to.be.undefined;
-          expect(bid.mediaType).to.be.undefined;
           expect(bid.vastUrl).to.be.undefined;
 
           bidManager.addBidResponse.restore();


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
In cases where banner bid responses do not have a width or height, when these bids are rendered, we seem to be setting the width and height of the adserver iframe to "undefined", messing up the page formatting. This change rejects bids that do not have a width or height, unless the impression has one valid size, in which case that size is assigned to any bid that does not explicitly set a width or height.