### PR TITLE
Set outstream mediaType based on renderer in response

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -197,7 +197,7 @@ function AppnexusAstAdapter() {
       const bid = createBid(status, tag);
       if (type === 'native') bid.mediaType = 'native';
       if (type === 'video') bid.mediaType = 'video';
-      if (type === 'video-outstream') bid.mediaType = 'video-outstream';
+      if (ad && ad.renderer_url) bid.mediaType = 'video-outstream';
 
       if (bid.adId in bidRequests) {
         const placement = bidRequests[bid.adId].placementCode;


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Outstream responses to appnexusAst bid adapter contain the type `video`. In bidmanager, bids of type `video` must also contain a `vastUrl`--since appnexusAst outstream bids contain renderers rather than a `vastUrl`, they weren't passing validation in bidmanager. This change sets the `mediaType` for appnexusAst outstream bids based on the presence of a renderer in the bid response.

## Other information
Fixes #1390