### PR TITLE
Yieldbot adunit bidder params slot name usage fix

### DIFF
--- a/integrationExamples/gpt/pbjs_yieldbot_gpt.html
+++ b/integrationExamples/gpt/pbjs_yieldbot_gpt.html
@@ -1,0 +1,201 @@
+<html>
+  <head>
+    <script>
+     var PREBID_TIMEOUT = 1000;
+
+     var googletag = googletag || {};
+     googletag.cmd = googletag.cmd || [];
+
+     function initAdserver() {
+       if (pbjs.initAdserverSet) return;
+       (function() {
+         var gads = document.createElement('script');
+         gads.async = true;
+         gads.type = 'text/javascript';
+         var useSSL = 'https:' == document.location.protocol;
+         gads.src = (useSSL ? 'https:' : 'http:') +
+                    '//www.googletagservices.com/tag/js/gpt.js';
+         var node = document.getElementsByTagName('script')[0];
+         node.parentNode.insertBefore(gads, node);
+       })();
+       pbjs.initAdserverSet = true;
+     };
+     setTimeout(initAdserver, PREBID_TIMEOUT);
+
+     var pbjs = pbjs || {};
+     pbjs.que = pbjs.que || [];
+     (function() {
+       var pbjsEl = document.createElement("script");
+       pbjsEl.type = "text/javascript";
+       pbjsEl.async = true;
+       pbjsEl.src = "/build/dev/prebid.js";
+       var pbjsTargetEl = document.getElementsByTagName("head")[0];
+       pbjsTargetEl.insertBefore(pbjsEl, pbjsTargetEl.firstChild);
+     })();
+
+     pbjs.que.push(function() {
+         var adUnits = [
+             {
+                 code: 'div-gpt-ad-1438287399331-0',
+                 sizes: [[728, 90]],
+                 bids: [
+                     {
+                         bidder: 'appnexus',
+                         params: { placementId: '10433394' }
+                     },
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'leaderboard'
+                         }
+                     }
+                 ]
+             },
+             {
+                 code: 'div-gpt-ad-1438287399331-1',
+                 sizes: [[300, 250], [300, 600]],
+                 bids: [
+                     {
+                         bidder: 'appnexus',
+                         params: { placementId: '10433394' }
+                     },
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'test_slot'
+                         }
+                     }
+                 ]
+             },
+             {
+                 code: 'div-gpt-ad-1438287399331-2',
+                 sizes: [[300, 250]],
+                 bids: [
+                     {
+                         bidder: 'appnexus',
+                         params: { placementId: '10433394' }
+                     },
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'test_slot'
+                         }
+                     }
+                 ]
+             }
+         ];
+       pbjs.addAdUnits(adUnits);
+
+       pbjs.requestBids({
+         bidsBackHandler: function(bidResponses) {
+           initAdserver();
+         }
+       })
+     });
+    </script>
+
+    <script>
+     var topSlot;
+     var rightSlot;
+     var leftSlot;
+
+     googletag.cmd.push(function() {
+         topSlot = googletag.defineSlot('/2476204/leaderboard', [[728, 90]], 'div-gpt-ad-1438287399331-0').addService(googletag.pubads());
+
+         rightSlot = googletag.defineSlot('/2476204/multi-size', [[300, 250], [300, 600]], 'div-gpt-ad-1438287399331-1').addService(googletag.pubads());
+
+         leftSlot = googletag.defineSlot('/2476204/multi-size', [[300, 250], [300,600]], 'div-gpt-ad-1438287399331-2').addService(googletag.pubads());
+
+       pbjs.que.push(function() {
+         pbjs.setTargetingForGPTAsync();
+       });
+
+       googletag.pubads().collapseEmptyDivs(true);
+       googletag.pubads().enableSingleRequest();
+       googletag.enableServices();
+     });
+
+     function refreshBid0() {
+       pbjs.que.push(function() {
+         pbjs.requestBids({
+           timeout: PREBID_TIMEOUT,
+           adUnitCodes: ['div-gpt-ad-1438287399331-0'],
+           bidsBackHandler: function() {
+             pbjs.setTargetingForGPTAsync(['div-gpt-ad-1438287399331-0']);
+             googletag.pubads().refresh([topSlot]);
+           }
+         });
+       });
+     }
+
+     function refreshBid1() {
+       pbjs.que.push(function() {
+         pbjs.requestBids({
+           timeout: PREBID_TIMEOUT,
+           adUnitCodes: ['div-gpt-ad-1438287399331-1'],
+           bidsBackHandler: function() {
+             pbjs.setTargetingForGPTAsync(['div-gpt-ad-1438287399331-1']);
+             googletag.pubads().refresh([rightSlot]);
+           }
+         });
+       });
+     }
+
+     function refreshBid2() {
+         pbjs.que.push(function() {
+             pbjs.requestBids({
+                 timeout: PREBID_TIMEOUT,
+                 adUnitCodes: ['div-gpt-ad-1438287399331-2'],
+                 bidsBackHandler: function() {
+                     pbjs.setTargetingForGPTAsync(['div-gpt-ad-1438287399331-2']);
+                     googletag.pubads().refresh([leftSlot]);
+                 }
+             });
+         });
+     }
+    </script>
+  </head>
+
+  <body>
+      <h2>Prebid.js Yieldbot Adapter Basic Example</h2>
+      Use the links below to enable and disable Yieldbot test bids.<br>
+      <br>
+      <b><em>Note:</em></b>
+      <br>
+      The "<b><a href="#enable" target="_self">Enable - Yieldbot Test Bids</a></b>" link below will set a cookie to force Yieldbot bid requests to return static test creative: the cookie expires in 24 hrs.
+      <br>
+      <ul><li>Use the "<b><a href="#enable" target="_self">Disable - Yieldbot Test Bids</a></b>" link when testing is complete to re-enable live bids.</li></ul>
+      <ol>
+          <li><a id="enable" href="http://i.yldbt.com/m/start-testing" target="_blank">Enable - Yieldbot Test Bids</a></li>
+          <li><a id="disable" href="http://i.yldbt.com/m/stop-testing" target="_blank">Disable - Yieldbot Test Bids</a></li>
+      </ol>
+      <h5>Div-0, 728x90</h5>
+      <button onclick="refreshBid0()">Refresh 728x90 Ad Unit</button>
+      <div id='div-gpt-ad-1438287399331-0'>
+          <script type='text/javascript'>
+           googletag.cmd.push(function() { googletag.display('div-gpt-ad-1438287399331-0'); });
+          </script>
+      </div>
+      <h5>Div-1, 300x250 or 300x600</h5>
+      <button onclick="refreshBid1()">Refresh 300x250, 300x600 Ad Unit</button>
+      <div id='div-gpt-ad-1438287399331-1'>
+          <script type='text/javascript'>
+           googletag.cmd.push(function() { googletag.display('div-gpt-ad-1438287399331-1'); });
+          </script>
+      </div>
+      <h5>Div-2, 300x250 or 300x600</h5>
+      The bid for the <code>300x250 | 300x600</code> slot is shown under <b><em>Div-1</em></b> above.
+      <ul>
+          <li>Refresh this slot after initial page view and you should see the Yieldbot test creative.</li>
+      </ul>
+      <button onclick="refreshBid2()">Refresh 300x250, 300x600 Ad Unit</button>
+      <div id='div-gpt-ad-1438287399331-2'>
+          <script type='text/javascript'>
+           googletag.cmd.push(function() { googletag.display('div-gpt-ad-1438287399331-2'); });
+          </script>
+      </div>
+  </body>
+</html>

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -117,8 +117,8 @@ function YieldbotAdapter() {
           var bid = v;
           // bidder params config: http://prebid.org/dev-docs/bidders/yieldbot.html
           // - last psn wins
-          psn = bid.params && bid.params.psn || psn;
-          var slotName = bid.params && bid.params.slot || 'ERROR_PREBID_DEFINE_YB_SLOT';
+          psn = bid.params && bid.params.psn ? bid.params.psn : psn;
+          var slotName = bid.params && bid.params.slot ? bid.params.slot : 'ERROR_PREBID_DEFINE_YB_SLOT';
           var parsedSizes = utils.parseSizesInput(bid.sizes) || [];
           slots[slotName] = slots[slotName] || [];
           slots[slotName] = slots[slotName].concat(parsedSizes);
@@ -138,12 +138,12 @@ function YieldbotAdapter() {
           yieldbot.pub(psn);
           for (var slotName in slots) {
             if (slots.hasOwnProperty(slotName)) {
-              yieldbot.defineSlot(slotName, { sizes: slots[slotName]});
+              yieldbot.defineSlot(slotName, { sizes: slots[slotName] });
             }
           }
           yieldbot.enableAsync();
           yieldbot.go();
-        } else {
+        } else if (!utils.isEmpty(slots)) {
           yieldbot.nextPageview(slots);
         }
       });

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -23,7 +23,6 @@ function YieldbotAdapter() {
       AVAILABLE: 1,
       EMPTY: 2
     },
-    definedSlots: [],
     pageLevelOption: false,
     /**
      * Builds the Yieldbot creative tag.
@@ -72,6 +71,29 @@ function YieldbotAdapter() {
       return bid;
     },
     /**
+     * Unique'ify slot sizes for a Yieldbot bid request<br>
+     * Bids may refer to a slot and dimension multiple times on a page, but should exist once in the request.
+     * @param {Array} sizes An array of sizes to deduplicate
+     * @private
+     */
+    getUniqueSlotSizes: function(sizes) {
+      var newSizes = [];
+      var hasSize = {};
+      if (utils.isArray(sizes)) {
+        for (var idx = 0; idx < sizes.length; idx++) {
+          var bidSize = sizes[idx] || '';
+          if (bidSize && utils.isStr(bidSize) && !hasSize[bidSize]) {
+            var nSize = bidSize.split('x');
+            if (nSize.length > 1) {
+              newSizes.push([nSize[0], nSize[1]]);
+            }
+            hasSize[bidSize] = true;
+          }
+        }
+      }
+      return newSizes;
+    },
+    /**
      * Yieldbot implementation of {@link module:adaptermanger.callBids}
      * @param {Object} params - Adapter bid configuration object
      * @private
@@ -84,8 +106,9 @@ function YieldbotAdapter() {
 
       ybotq.push(function () {
         var yieldbot = window.yieldbot;
-        // Empty defined slots bidId array
-        ybotlib.definedSlots = [];
+        // Empty defined slot bids object
+        ybotlib.bids = {};
+        ybotlib.parsedBidSizes = {};
         // Iterate through bids to obtain Yieldbot slot config
         // - Slot config can be different between initial and refresh requests
         var psn = 'ERROR_PREBID_DEFINE_YB_PSN';
@@ -94,18 +117,28 @@ function YieldbotAdapter() {
           var bid = v;
           // bidder params config: http://prebid.org/dev-docs/bidders/yieldbot.html
           // - last psn wins
-          psn = (bid.params && bid.params.psn) || psn;
-          var slotName = (bid.params && bid.params.slot) || 'ERROR_PREBID_DEFINE_YB_SLOT';
-
-          slots[slotName] = bid.sizes || [];
-          ybotlib.definedSlots.push(bid.bidId);
+          psn = bid.params && bid.params.psn || psn;
+          var slotName = bid.params && bid.params.slot || 'ERROR_PREBID_DEFINE_YB_SLOT';
+          var parsedSizes = utils.parseSizesInput(bid.sizes) || [];
+          slots[slotName] = slots[slotName] || [];
+          slots[slotName] = slots[slotName].concat(parsedSizes);
+          ybotlib.bids[bid.bidId] = bid;
+          ybotlib.parsedBidSizes[bid.bidId] = parsedSizes;
         });
+
+        for (var bidSlots in slots) {
+          if (slots.hasOwnProperty(bidSlots)) {
+            // The same slot name and size may be used for multiple bids. Get unique sizes
+            // for the request.
+            slots[bidSlots] = ybotlib.getUniqueSlotSizes(slots[bidSlots]);
+          }
+        }
 
         if (yieldbot._initialized !== true) {
           yieldbot.pub(psn);
           for (var slotName in slots) {
             if (slots.hasOwnProperty(slotName)) {
-              yieldbot.defineSlot(slotName, { sizes: slots[slotName] || [] });
+              yieldbot.defineSlot(slotName, { sizes: slots[slotName]});
             }
           }
           yieldbot.enableAsync();
@@ -128,27 +161,37 @@ function YieldbotAdapter() {
      */
     handleUpdateState: function () {
       var yieldbot = window.yieldbot;
-      utils._each(ybotlib.definedSlots, function (v) {
-        var ybRequest;
-        var adapterConfig;
+      var slotUsed = {};
 
-        ybRequest = $$PREBID_GLOBAL$$._bidsRequested
-          .find(bidderRequest => bidderRequest.bidderCode === 'yieldbot');
+      for (var bidId in ybotlib.bids) {
+        if (ybotlib.bids.hasOwnProperty(bidId)) {
+          var bidRequest = ybotlib.bids[bidId] || null;
 
-        adapterConfig = ybRequest && ybRequest.bids ? ybRequest.bids.find(bid => bid.bidId === v) : null;
+          if (bidRequest && bidRequest.params && bidRequest.params.slot) {
+            var placementCode = bidRequest.placementCode || 'ERROR_YB_NO_PLACEMENT';
+            var criteria = yieldbot.getSlotCriteria(bidRequest.params.slot);
+            var requestedSizes = ybotlib.parsedBidSizes[bidId] || [];
 
-        if (adapterConfig && adapterConfig.params && adapterConfig.params.slot) {
-          var placementCode = adapterConfig.placementCode || 'ERROR_YB_NO_PLACEMENT';
-          var criteria = yieldbot.getSlotCriteria(adapterConfig.params.slot);
-          var bid = ybotlib.buildBid(criteria);
+            var slotSizeOk = false;
+            for (var idx = 0; idx < requestedSizes.length; idx++) {
+              var requestedSize = requestedSizes[idx];
 
-          bidmanager.addBidResponse(placementCode, bid);
+              if (!slotUsed[criteria.ybot_slot] && requestedSize === criteria.ybot_size) {
+                slotSizeOk = true;
+                slotUsed[criteria.ybot_slot] = true;
+                break;
+              }
+            }
+            var bid = ybotlib.buildBid(slotSizeOk ? criteria : { ybot_ad: 'n' });
+            bidmanager.addBidResponse(placementCode, bid);
+          }
         }
-      });
+      }
     }
   };
   return {
-    callBids: ybotlib.callBids
+    callBids: ybotlib.callBids,
+    getUniqueSlotSizes: ybotlib.getUniqueSlotSizes
   };
 }
 

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -63,11 +63,9 @@ function createYieldbotMockLib() {
     pub: (psn) => {},
     defineSlot: (slotName, optionalDomIdOrConfigObject, optionalTime) => {},
     enableAsync: () => {},
-    go: () => { window.yieldbot._initialized = true; },
+    go: () => {},
     nextPageview: (slots, callback) => {},
-    getSlotCriteria: (slotName) => {
-      return YB_BID_FIXTURE[slotName] || {ybot_ad: 'n'};
-    }
+    getSlotCriteria: (slotName) => {}
   };
 }
 
@@ -83,44 +81,68 @@ function mockYieldbotBidRequest() {
   window.ybotq = [];
 }
 
-const refreshSuiteRegex = /refresh$/;
+const localSetupTestRegex = /localSetupTest$/;
+const MAKE_BID_REQUEST = true;
 let sandbox;
 let bidManagerStub;
 let yieldbotLibStub;
 
-function setupTest(testRequest) {
+/**
+ * Test initialization hook. Makes initial adapter and mock bid requests<br>
+ * unless the test is a special case with "localSetupTest". <br>
+ * 1. All suite tests are initialized with required mocks and stubs<br>
+ * 2. If the test title does <em>not</em> end in "localSetupTest", adapter and
+ *  mock bid requests are executed
+ * 3. Test titles ending in "localSetupTest" are special case tests and are
+ *  expected to call <code>setupTest(object, MAKE_BID_REQUEST)</code> where
+ *  applicable
+ * @param {object} testRequest bidder request bids fixture
+ * @param {boolean} force trigger adapter callBids and Yieldbot library request
+ * @private
+ */
+function setupTest(testRequest, force = false) {
   sandbox = sinon.sandbox.create();
 
   createYieldbotMockLib();
 
   sandbox.stub(adLoader, 'loadScript');
-  yieldbotLibStub = sandbox.stub(window.yieldbot);
-  yieldbotLibStub.getSlotCriteria.restore();
 
-  if (this && this.currentTest.parent.title.match(refreshSuiteRegex)) {
-    yieldbotLibStub.go.restore();
-  }
+  yieldbotLibStub = {};
+  yieldbotLibStub.nextPageview = sandbox.stub(window.yieldbot, 'nextPageview');
+  yieldbotLibStub.defineSlot = sandbox.stub(window.yieldbot, 'defineSlot');
+  yieldbotLibStub.pub = sandbox.stub(window.yieldbot, 'pub');
+  yieldbotLibStub.enableAsync = sandbox.stub(window.yieldbot, 'enableAsync');
+
+  yieldbotLibStub.getSlotCriteria =
+    sandbox.stub(
+      window.yieldbot,
+      'getSlotCriteria',
+      (slotName) => {
+        return YB_BID_FIXTURE[slotName] || {ybot_ad: 'n'};
+      });
+
+  yieldbotLibStub.go =
+    sandbox.stub(
+      window.yieldbot,
+      'go',
+      () => {
+        window.yieldbot._initialized = true;
+      });
 
   bidManagerStub = sandbox.stub(bidManager, 'addBidResponse');
 
   const ybAdapter = new YieldbotAdapter();
   let request = testRequest || cloneJson(bidderRequest);
-  ybAdapter.callBids(request);
-  mockYieldbotBidRequest();
+  if ((this && !this.currentTest.parent.title.match(localSetupTestRegex)) || force === MAKE_BID_REQUEST) {
+    ybAdapter.callBids(request);
+    mockYieldbotBidRequest();
+  }
   return { adapter: ybAdapter, localRequest: request };
 }
 
-function removeBids(bidder) {
-  if (window && window.pbjs) {
-    window.pbjs._bidsRequested = window.pbjs._bidsRequested.filter(o => {
-      return o.bidderCode !== bidder;
-    });
-  }
-}
 function restoreTest() {
   sandbox.restore();
   restoreYieldbotMockLib();
-  removeBids('yieldbot');
 }
 
 describe('Yieldbot adapter tests', function() {
@@ -154,11 +176,6 @@ describe('Yieldbot adapter tests', function() {
 
     it('should return [] for undefined sizes', function() {
       const sizes = adapter.getUniqueSlotSizes(undefined);
-      expect(sizes).to.deep.equal([]);
-    });
-
-    it('should return [] for function sizes', function() {
-      const sizes = adapter.getUniqueSlotSizes(function () {});
       expect(sizes).to.deep.equal([]);
     });
 
@@ -215,14 +232,20 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard', {sizes: [['728', '90'], ['970', '90']]});
     });
 
-    it('should not use inherited Object properties', function() {
-      restoreTest();
-
+    it('should not use inherited Object properties, localSetupTest', function() {
       let oProto = Object.prototype;
       oProto.superProp = ['300', '250'];
 
       expect(Object.prototype.superProp).to.be.an('array');
-      setupTest(localRequest);
+      localRequest.bids.forEach((bid) => {
+        expect(bid.superProp).to.be.an('array');
+      });
+
+      expect(YB_BID_FIXTURE.medrec.superProp).to.deep.equal(['300', '250']);
+      expect(YB_BID_FIXTURE.leaderboard.superProp).to.deep.equal(['300', '250']);
+
+      restoreTest();
+      setupTest(localRequest, MAKE_BID_REQUEST);
 
       sinon.assert.neverCalledWith(yieldbotLibStub.defineSlot, 'superProp', {sizes: ['300', '250']});
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [['300', '250'], ['300', '600']]});
@@ -263,10 +286,10 @@ describe('Yieldbot adapter tests', function() {
       expect(pb_bid2.statusMessage).to.match(/empty.*response/);
     });
 
-    it('should validate slot dimensions', function() {
+    it('should validate slot dimensions, localSetupTest', function() {
       let invalidSizeBid = {
         bidId: '2640ad280208ce',
-        sizes: [[728, 90]],
+        sizes: [[728, 90], [300, 250], [970, 90]],
         bidder: 'yieldbot',
         bidderRequestId: '187a340cb9ccc3',
         params: { psn: '1234', slot: 'medrec' },
@@ -274,12 +297,26 @@ describe('Yieldbot adapter tests', function() {
         placementCode: '/4294967296/adunit3'
       };
 
-      let localBidderRequest = cloneJson(localRequest);
-      localBidderRequest.bids.push(invalidSizeBid);
+      const bidResponseMedrec = {
+        bidderCode: 'yieldbot',
+        width: '300',
+        height: '250',
+        statusMessage: 'Bid available',
+        cpm: 2,
+        ybot_ad: 'y',
+        ybot_slot: 'medrec',
+        ybot_cpm: '200',
+        ybot_size: '300x250'
+      };
 
-      const adapter = new YieldbotAdapter();
-      adapter.callBids(localBidderRequest);
-      mockYieldbotBidRequest();
+      localRequest.bids = [invalidSizeBid];
+      restoreTest();
+      setupTest(localRequest, MAKE_BID_REQUEST);
+
+      let bidManagerFirstCall = bidManagerStub.firstCall;
+
+      expect(bidManagerFirstCall.args[0]).to.equal('/4294967296/adunit3');
+      expect(bidManagerFirstCall.args[1]).to.include(bidResponseMedrec);
     });
 
     it('should make slot bid available once only', function() {
@@ -331,8 +368,6 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec');
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard');
 
-      removeBids('yieldbot');
-
       const refreshBids = localRequest.bids.filter((object) => { return object.placementCode === '/4294967296/adunit1'; });
       let refreshRequest = cloneJson(localRequest);
       refreshRequest.bids = refreshBids;
@@ -347,6 +382,9 @@ describe('Yieldbot adapter tests', function() {
     });
 
     it('should not repeat multiply defined slot sizes', function() {
+      // placementCode: '/4294967296/adunit0'
+      // placementCode: '/4294967296/adunit2'
+      // Both placements declare medrec:300x250
       adapter.callBids(localRequest);
       mockYieldbotBidRequest();
 
@@ -355,33 +393,15 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWithExactly(yieldbotLibStub.nextPageview, expectedSlots);
     });
 
-    /**
-     * Keep test for regression. Yieldbot adapter no longer refers to $$PREBID_GLOBAL$$._bidsRequested
-     * @private
-     */
-    it('should not throw on callBids without bidsRequested', function() {
-      expect(window.yieldbot._initialized).to.equal(true);
-
-      removeBids('yieldbot');
-
-      adapter.callBids(cloneJson(localRequest));
-      mockYieldbotBidRequest();
-      sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
-    });
-
     it('should not add empty bidResponse on callBids without bidsRequested', function() {
       expect(window.yieldbot._initialized).to.equal(true);
+      expect(bidManagerStub.calledThrice).to.equal(true);
 
-      removeBids('yieldbot');
-
-      let bidResponses = window.$$PREBID_GLOBAL$$._bidsReceived.filter(o => {
-        return o.bidderCode === 'yieldbot';
-      });
-      expect(bidResponses.length).to.equal(0);
-
-      adapter.callBids(localRequest);
+      adapter.callBids({});
       mockYieldbotBidRequest();
-      sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
+
+      expect(bidManagerStub.calledThrice).to.equal(true); // the initial bids
+      sinon.assert.notCalled(yieldbotLibStub.nextPageview);
     });
 
     it('should validate slot dimensions', function() {
@@ -400,6 +420,12 @@ describe('Yieldbot adapter tests', function() {
       mockYieldbotBidRequest();
 
       expect(bidManagerStub.getCalls().length).to.equal(6);
+
+      let lastNextPageview = yieldbotLibStub.nextPageview.lastCall;
+      let nextPageviewSlots = lastNextPageview.args[0];
+      expect(nextPageviewSlots.medrec).to.deep.equal([['640', '480'], ['1024', '768']]);
+      expect(nextPageviewSlots.leaderboard).to.deep.equal([['640', '480'], ['1024', '768']]);
+
       let fourthCall = bidManagerStub.getCall(3);
       let fifthCall = bidManagerStub.getCall(4);
       let sixthCall = bidManagerStub.getCall(5);
@@ -414,7 +440,7 @@ describe('Yieldbot adapter tests', function() {
       expect(sixthCall.args[1]).to.include(bidResponseNone);
     });
 
-    it('should make slot bid available once only', function() {
+    it('should not make requests for previously requested bids', function() {
       const bidResponseMedrec = {
         bidderCode: 'yieldbot',
         width: '300',
@@ -434,10 +460,17 @@ describe('Yieldbot adapter tests', function() {
         statusMessage: 'Bid returned empty or error response'
       };
 
+      // Refresh #1
       adapter.callBids(localRequest);
       mockYieldbotBidRequest();
 
       expect(bidManagerStub.getCalls().length).to.equal(6);
+
+      let lastNextPageview = yieldbotLibStub.nextPageview.lastCall;
+      let nextPageviewSlots = lastNextPageview.args[0];
+      expect(nextPageviewSlots.medrec).to.deep.equal([['300', '250'], ['300', '600']]);
+      expect(nextPageviewSlots.leaderboard).to.deep.equal([['728', '90'], ['970', '90']]);
+
       let fourthCall = bidManagerStub.getCall(3);
       let fifthCall = bidManagerStub.getCall(4);
       let sixthCall = bidManagerStub.getCall(5);
@@ -457,10 +490,17 @@ describe('Yieldbot adapter tests', function() {
       let bidForNinethCall = localRequest.bids[localRequest.bids.length - 1];
       bidForNinethCall.sizes = [[300, 250]];
 
+      // Refresh #2
       adapter.callBids(localRequest);
       mockYieldbotBidRequest();
 
       expect(bidManagerStub.getCalls().length).to.equal(9);
+
+      lastNextPageview = yieldbotLibStub.nextPageview.lastCall;
+      nextPageviewSlots = lastNextPageview.args[0];
+      expect(nextPageviewSlots.medrec).to.deep.equal([['640', '480'], ['1024', '768'], ['300', '250']]);
+      expect(nextPageviewSlots.leaderboard).to.deep.equal([['640', '480'], ['1024', '768']]);
+
       let seventhCall = bidManagerStub.getCall(6);
       let eighthCall = bidManagerStub.getCall(7);
       let ninethCall = bidManagerStub.getCall(8);

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import YieldbotAdapter from 'modules/yieldbotBidAdapter';
 import bidManager from 'src/bidmanager';
 import adLoader from 'src/adloader';
+import {cloneJson} from 'src/utils';
 
 const bidderRequest = {
   bidderCode: 'yieldbot',
@@ -14,7 +15,7 @@ const bidderRequest = {
       bidder: 'yieldbot',
       bidderRequestId: '187a340cb9ccc0',
       params: { psn: '1234', slot: 'medrec' },
-      requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ece',
+      requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ec0',
       placementCode: '/4294967296/adunit0'
     },
     {
@@ -23,9 +24,18 @@ const bidderRequest = {
       bidder: 'yieldbot',
       bidderRequestId: '187a340cb9ccc1',
       params: { psn: '1234', slot: 'leaderboard' },
-      requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ece',
+      requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ec1',
       placementCode: '/4294967296/adunit1'
-    }
+    },
+    {
+      bidId: '2640ad280208cd',
+      sizes: [[300, 250]],
+      bidder: 'yieldbot',
+      bidderRequestId: '187a340cb9ccc2',
+      params: { psn: '1234', slot: 'medrec' },
+      requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ec2',
+      placementCode: '/4294967296/adunit2'
+    },
   ]
 };
 
@@ -38,6 +48,12 @@ const YB_BID_FIXTURE = {
   },
   leaderboard: {
     ybot_ad: 'n'
+  },
+  noop: {
+    ybot_ad: 'y',
+    ybot_slot: 'noop',
+    ybot_cpm: '200',
+    ybot_size: '300x250'
   }
 };
 
@@ -67,15 +83,12 @@ function mockYieldbotBidRequest() {
   window.ybotq = [];
 }
 
+const refreshSuiteRegex = /refresh$/;
 let sandbox;
 let bidManagerStub;
 let yieldbotLibStub;
 
-beforeEach(function() {
-  window.$$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
-});
-
-function setupTest() {
+function setupTest(testRequest) {
   sandbox = sinon.sandbox.create();
 
   createYieldbotMockLib();
@@ -84,28 +97,103 @@ function setupTest() {
   yieldbotLibStub = sandbox.stub(window.yieldbot);
   yieldbotLibStub.getSlotCriteria.restore();
 
+  if (this && this.currentTest.parent.title.match(refreshSuiteRegex)) {
+    yieldbotLibStub.go.restore();
+  }
+
   bidManagerStub = sandbox.stub(bidManager, 'addBidResponse');
 
-  const adapter = new YieldbotAdapter();
-  adapter.callBids(bidderRequest);
+  const ybAdapter = new YieldbotAdapter();
+  let request = testRequest || cloneJson(bidderRequest);
+  ybAdapter.callBids(request);
   mockYieldbotBidRequest();
+  return { adapter: ybAdapter, localRequest: request };
 }
 
+function removeBids(bidder) {
+  if (window && window.pbjs) {
+    window.pbjs._bidsRequested = window.pbjs._bidsRequested.filter(o => {
+      return o.bidderCode !== bidder;
+    });
+  }
+}
 function restoreTest() {
   sandbox.restore();
   restoreYieldbotMockLib();
+  removeBids('yieldbot');
 }
 
 describe('Yieldbot adapter tests', function() {
+  let adapter;
+  let localRequest;
+  beforeEach(function () {
+    const testSetupCtx = setupTest.call(this);
+    adapter = testSetupCtx.adapter;
+    localRequest = testSetupCtx.localRequest;
+  });
+
+  afterEach(function() {
+    restoreTest();
+  });
+
+  describe('getUniqueSlotSizes', function() {
+    it('should return [] for string sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes('widthxheight');
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for Object sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes({width: 300, height: 250});
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for boolean sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes(true);
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for undefined sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes(undefined);
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for function sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes(function () {});
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for function sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes(function () {});
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for number sizes', function() {
+      const sizes = adapter.getUniqueSlotSizes(1111);
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return [] for array of numbers', function() {
+      const sizes = adapter.getUniqueSlotSizes([300, 250]);
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('should return array of unique strings', function() {
+      const sizes = adapter.getUniqueSlotSizes(['300x250', '300x600', '728x90', '300x250']);
+      expect(sizes).to.deep.equal([['300', '250'], ['300', '600'], ['728', '90']]);
+    });
+
+    it('should return array of unique strings for string elements only', function() {
+      const sizes = adapter.getUniqueSlotSizes(['300x250', ['threexfour']]);
+      expect(sizes).to.deep.equal([['300', '250']]);
+    });
+
+    it('should return array of unique strings, including non-numeric', function() {
+      const sizes = adapter.getUniqueSlotSizes(['300x250', 'threexfour', 'fivexsix']);
+      expect(sizes).to.deep.equal([['300', '250'], ['three', 'four'], ['five', 'si']]);
+    });
+  });
+
   describe('callBids', function() {
-    beforeEach(function () {
-      setupTest();
-    });
-
-    afterEach(function() {
-      restoreTest();
-    });
-
     it('should request the yieldbot library', function() {
       sinon.assert.calledOnce(adLoader.loadScript);
       sinon.assert.calledWith(adLoader.loadScript, '//cdn.yldbt.com/js/yieldbot.intent.js');
@@ -116,24 +204,29 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWith(yieldbotLibStub.pub, '1234');
     });
 
+    it('should not repeat multiply defined slot sizes', function() {
+      sinon.assert.calledTwice(yieldbotLibStub.defineSlot);
+      sinon.assert.neverCalledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [['300', '250'], ['300', '600'], ['300', '250']]});
+    });
+
     it('should define yieldbot slots', function() {
       sinon.assert.calledTwice(yieldbotLibStub.defineSlot);
-      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [[300, 250], [300, 600]]});
-      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard', {sizes: [[728, 90], [970, 90]]});
+      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [['300', '250'], ['300', '600']]});
+      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard', {sizes: [['728', '90'], ['970', '90']]});
     });
 
     it('should not use inherited Object properties', function() {
       restoreTest();
 
       let oProto = Object.prototype;
-      oProto.superProp = [300, 250];
+      oProto.superProp = ['300', '250'];
 
       expect(Object.prototype.superProp).to.be.an('array');
-      setupTest();
+      setupTest(localRequest);
 
-      sinon.assert.neverCalledWith(yieldbotLibStub.defineSlot, 'superProp', {sizes: [300, 250]});
-      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [[300, 250], [300, 600]]});
-      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard', {sizes: [[728, 90], [970, 90]]});
+      sinon.assert.neverCalledWith(yieldbotLibStub.defineSlot, 'superProp', {sizes: ['300', '250']});
+      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec', {sizes: [['300', '250'], ['300', '600']]});
+      sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard', {sizes: [['728', '90'], ['970', '90']]});
 
       delete oProto.superProp;
       expect(Object.prototype.superProp).to.be.an('undefined');
@@ -145,7 +238,7 @@ describe('Yieldbot adapter tests', function() {
 
     it('should add bid response after yieldbot request callback', function() {
       const plc1 = bidManagerStub.firstCall.args[0];
-      expect(plc1).to.equal(bidderRequest.bids[0].placementCode);
+      expect(plc1).to.equal(localRequest.bids[0].placementCode);
 
       const pb_bid1 = bidManagerStub.firstCall.args[1];
       expect(pb_bid1.bidderCode).to.equal('yieldbot');
@@ -161,7 +254,7 @@ describe('Yieldbot adapter tests', function() {
       expect(pb_bid1.ad).to.match(/yieldbot\.renderAd\('medrec:300x250'\)/);
 
       const plc2 = bidManagerStub.secondCall.args[0];
-      expect(plc2).to.equal(bidderRequest.bids[1].placementCode);
+      expect(plc2).to.equal(localRequest.bids[1].placementCode);
 
       const pb_bid2 = bidManagerStub.secondCall.args[1];
       expect(pb_bid2.bidderCode).to.equal('yieldbot');
@@ -169,104 +262,217 @@ describe('Yieldbot adapter tests', function() {
       expect(pb_bid2.height).to.equal(0);
       expect(pb_bid2.statusMessage).to.match(/empty.*response/);
     });
+
+    it('should validate slot dimensions', function() {
+      let invalidSizeBid = {
+        bidId: '2640ad280208ce',
+        sizes: [[728, 90]],
+        bidder: 'yieldbot',
+        bidderRequestId: '187a340cb9ccc3',
+        params: { psn: '1234', slot: 'medrec' },
+        requestId: '5f297a1f-3163-46c2-854f-b55fd2e74ec3',
+        placementCode: '/4294967296/adunit3'
+      };
+
+      let localBidderRequest = cloneJson(localRequest);
+      localBidderRequest.bids.push(invalidSizeBid);
+
+      const adapter = new YieldbotAdapter();
+      adapter.callBids(localBidderRequest);
+      mockYieldbotBidRequest();
+    });
+
+    it('should make slot bid available once only', function() {
+      const bidResponseMedrec = {
+        bidderCode: 'yieldbot',
+        width: '300',
+        height: '250',
+        statusMessage: 'Bid available',
+        cpm: 2,
+        ybot_ad: 'y',
+        ybot_slot: 'medrec',
+        ybot_cpm: '200',
+        ybot_size: '300x250'
+      };
+
+      const bidResponseNone = {
+        bidderCode: 'yieldbot',
+        width: 0,
+        height: 0,
+        statusMessage: 'Bid returned empty or error response'
+      };
+
+      let firstCall = bidManagerStub.firstCall;
+      let secondCall = bidManagerStub.secondCall;
+      let thirdCall = bidManagerStub.thirdCall;
+
+      expect(firstCall.args[0]).to.equal('/4294967296/adunit0');
+      expect(firstCall.args[1]).to.include(bidResponseMedrec);
+
+      expect(secondCall.args[0]).to.equal('/4294967296/adunit1');
+      expect(secondCall.args[1]).to.include(bidResponseNone);
+
+      expect(thirdCall.args[0]).to.equal('/4294967296/adunit2');
+      expect(thirdCall.args[1]).to.include(bidResponseNone);
+    });
   });
 
   describe('callBids, refresh', function() {
-    beforeEach(function () {
-      if (sandbox) { sandbox.restore(); }
-      sandbox = sinon.sandbox.create();
-
-      createYieldbotMockLib();
-
-      sandbox.stub(adLoader, 'loadScript');
-      yieldbotLibStub = sandbox.stub(window.yieldbot);
-      yieldbotLibStub.getSlotCriteria.restore();
-      yieldbotLibStub.go.restore();
-      bidManagerStub = sandbox.stub(bidManager, 'addBidResponse');
-    });
-
-    afterEach(function() {
-      sandbox.restore();
-      restoreYieldbotMockLib();
-    });
-
     it('should use yieldbot.nextPageview after first callBids', function() {
-      const adapter = new YieldbotAdapter();
-      adapter.callBids(bidderRequest);
-      mockYieldbotBidRequest();
-
       expect(window.yieldbot._initialized).to.equal(true);
 
-      adapter.callBids(bidderRequest);
+      adapter.callBids(localRequest);
       mockYieldbotBidRequest();
       sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
     });
 
     it('should call yieldbot.nextPageview with slot config of requested bids', function() {
-      window.$$PREBID_GLOBAL$$._bidsRequested = window.$$PREBID_GLOBAL$$._bidsRequested.filter(o => {
-        return o.bidderCode !== 'yieldbot';
-      });
-
-      const adapter = new YieldbotAdapter();
-      adapter.callBids(bidderRequest);
-      mockYieldbotBidRequest();
-
       expect(window.yieldbot._initialized).to.equal(true);
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'medrec');
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard');
 
-      window.$$PREBID_GLOBAL$$._bidsRequested = window.$$PREBID_GLOBAL$$._bidsRequested.filter(o => {
-        return o.bidderCode !== 'yieldbot';
-      });
+      removeBids('yieldbot');
 
-      const refreshBids = bidderRequest.bids.filter((object) => { return object.placementCode === '/4294967296/adunit1'; });
-      let refreshRequest = Object.assign({}, bidderRequest);
+      const refreshBids = localRequest.bids.filter((object) => { return object.placementCode === '/4294967296/adunit1'; });
+      let refreshRequest = cloneJson(localRequest);
       refreshRequest.bids = refreshBids;
       expect(refreshRequest.bids.length).to.equal(1);
 
       adapter.callBids(refreshRequest);
       mockYieldbotBidRequest();
 
-      const bid = refreshBids[0];
-      const expectedSlots = { 'leaderboard': [[728, 90], [970, 90]] };
+      const expectedSlots = { 'leaderboard': [['728', '90'], ['970', '90']] };
 
       sinon.assert.calledWithExactly(yieldbotLibStub.nextPageview, expectedSlots);
     });
 
-    it('should not throw on callBids without bidsRequested', function() {
-      const adapter = new YieldbotAdapter();
-      adapter.callBids(bidderRequest);
+    it('should not repeat multiply defined slot sizes', function() {
+      adapter.callBids(localRequest);
       mockYieldbotBidRequest();
 
+      sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
+      const expectedSlots = { 'leaderboard': [['728', '90'], ['970', '90']], 'medrec': [['300', '250'], ['300', '600']]};
+      sinon.assert.calledWithExactly(yieldbotLibStub.nextPageview, expectedSlots);
+    });
+
+    /**
+     * Keep test for regression. Yieldbot adapter no longer refers to $$PREBID_GLOBAL$$._bidsRequested
+     * @private
+     */
+    it('should not throw on callBids without bidsRequested', function() {
       expect(window.yieldbot._initialized).to.equal(true);
 
-      window.$$PREBID_GLOBAL$$._bidsRequested = window.$$PREBID_GLOBAL$$._bidsRequested.filter(o => {
-        return o.bidderCode !== 'yieldbot';
-      });
+      removeBids('yieldbot');
 
-      adapter.callBids(bidderRequest);
+      adapter.callBids(cloneJson(localRequest));
       mockYieldbotBidRequest();
       sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
     });
 
     it('should not add empty bidResponse on callBids without bidsRequested', function() {
-      window.$$PREBID_GLOBAL$$._bidsRequested = window.$$PREBID_GLOBAL$$._bidsRequested.filter(o => {
-        return o.bidderCode !== 'yieldbot';
-      });
+      expect(window.yieldbot._initialized).to.equal(true);
 
-      const adapter = new YieldbotAdapter();
-      adapter.callBids(bidderRequest);
-      mockYieldbotBidRequest();
+      removeBids('yieldbot');
 
       let bidResponses = window.$$PREBID_GLOBAL$$._bidsReceived.filter(o => {
         return o.bidderCode === 'yieldbot';
       });
-
       expect(bidResponses.length).to.equal(0);
 
-      adapter.callBids(bidderRequest);
+      adapter.callBids(localRequest);
       mockYieldbotBidRequest();
       sinon.assert.calledOnce(yieldbotLibStub.nextPageview);
+    });
+
+    it('should validate slot dimensions', function() {
+      localRequest.bids.map(bid => {
+        bid.sizes = [[640, 480], [1024, 768]];
+      });
+
+      const bidResponseNone = {
+        bidderCode: 'yieldbot',
+        width: 0,
+        height: 0,
+        statusMessage: 'Bid returned empty or error response'
+      };
+
+      adapter.callBids(localRequest);
+      mockYieldbotBidRequest();
+
+      expect(bidManagerStub.getCalls().length).to.equal(6);
+      let fourthCall = bidManagerStub.getCall(3);
+      let fifthCall = bidManagerStub.getCall(4);
+      let sixthCall = bidManagerStub.getCall(5);
+
+      expect(fourthCall.args[0]).to.equal('/4294967296/adunit0');
+      expect(fourthCall.args[1]).to.include(bidResponseNone);
+
+      expect(fifthCall.args[0]).to.equal('/4294967296/adunit1');
+      expect(fifthCall.args[1]).to.include(bidResponseNone);
+
+      expect(sixthCall.args[0]).to.equal('/4294967296/adunit2');
+      expect(sixthCall.args[1]).to.include(bidResponseNone);
+    });
+
+    it('should make slot bid available once only', function() {
+      const bidResponseMedrec = {
+        bidderCode: 'yieldbot',
+        width: '300',
+        height: '250',
+        statusMessage: 'Bid available',
+        cpm: 2,
+        ybot_ad: 'y',
+        ybot_slot: 'medrec',
+        ybot_cpm: '200',
+        ybot_size: '300x250'
+      };
+
+      const bidResponseNone = {
+        bidderCode: 'yieldbot',
+        width: 0,
+        height: 0,
+        statusMessage: 'Bid returned empty or error response'
+      };
+
+      adapter.callBids(localRequest);
+      mockYieldbotBidRequest();
+
+      expect(bidManagerStub.getCalls().length).to.equal(6);
+      let fourthCall = bidManagerStub.getCall(3);
+      let fifthCall = bidManagerStub.getCall(4);
+      let sixthCall = bidManagerStub.getCall(5);
+
+      expect(fourthCall.args[0]).to.equal('/4294967296/adunit0');
+      expect(fourthCall.args[1]).to.include(bidResponseMedrec);
+
+      expect(fifthCall.args[0]).to.equal('/4294967296/adunit1');
+      expect(fifthCall.args[1]).to.include(bidResponseNone);
+
+      expect(sixthCall.args[0]).to.equal('/4294967296/adunit2');
+      expect(sixthCall.args[1]).to.include(bidResponseNone);
+
+      localRequest.bids.map(bid => {
+        bid.sizes = [[640, 480], [1024, 768]];
+      });
+      let bidForNinethCall = localRequest.bids[localRequest.bids.length - 1];
+      bidForNinethCall.sizes = [[300, 250]];
+
+      adapter.callBids(localRequest);
+      mockYieldbotBidRequest();
+
+      expect(bidManagerStub.getCalls().length).to.equal(9);
+      let seventhCall = bidManagerStub.getCall(6);
+      let eighthCall = bidManagerStub.getCall(7);
+      let ninethCall = bidManagerStub.getCall(8);
+
+      expect(seventhCall.args[0]).to.equal('/4294967296/adunit0');
+      expect(seventhCall.args[1]).to.include(bidResponseNone);
+
+      expect(eighthCall.args[0]).to.equal('/4294967296/adunit1');
+      expect(eighthCall.args[1]).to.include(bidResponseNone);
+
+      expect(ninethCall.args[0]).to.equal('/4294967296/adunit2');
+      expect(ninethCall.args[1]).to.include(bidResponseMedrec);
     });
   });
 });


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Example

## Description of change

Resolves #1392 

AdUnit configuration that uses the same slot name for the Yieldbot bidder params, i.e. multiple occurrences such as the below, results in erroneous  `bidmanager.addBidResponse(...)` calls.

```
          {
              bidder: 'yieldbot',
              params: {
                  psn: '1234',
                  slot: 'test_slot'
              }
          }
``` 

See Issue #1392 for more details.

## Other information

Resolves #1392 
