### PR TITLE
Fixing the BidAdjustmentEvent fire time

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -130,11 +130,6 @@ exports.addBidResponse = function (adUnitCode, bid) {
   // Postprocess the bids so that all the universal properties exist, no matter which bidder they came from.
   // This should be called before addBidToAuction().
   function prepareBidForAuction() {
-    // Let listeners know that now is the time to adjust the bid, if they want to.
-    //
-    // This must be fired first, so that we calculate derived values from the updates
-    events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
-
     const bidRequest = getBidderRequest(bid.bidderCode, adUnitCode);
 
     Object.assign(bid, {
@@ -147,6 +142,12 @@ exports.addBidResponse = function (adUnitCode, bid) {
     });
 
     bid.timeToRespond = bid.responseTimestamp - bid.requestTimestamp;
+
+    // Let listeners know that now is the time to adjust the bid, if they want to.
+    //
+    // CAREFUL: Publishers rely on certain bid properties to be available (like cpm),
+    // but others to not be set yet (like priceStrings). See #1372 and #1389.
+    events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
 
     // a publisher-defined renderer can be used to render bids
     const adUnitRenderer =

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -70,6 +70,9 @@ describe('The Bid Manager', () => {
      */
     function prepAuction(adUnits, bidRequestTweaker) {
       function bidAdjuster(bid) {
+        if (bid.hasOwnProperty('cpm')) {
+          bid.hadCpmDuringAdjuster = true;
+        }
         bid.cpm = adjustCpm(bid.cpm);
       }
       beforeEach(() => {
@@ -141,6 +144,17 @@ describe('The Bid Manager', () => {
         it('should gracefully do nothing when bid is undefined', () => {
           bidManager.addBidResponse('mock/code');
           expect($$PREBID_GLOBAL$$._bidsReceived.length).to.equal(0);
+        });
+
+        it('should define a default cpm *before* the BID_ADJUSTMENT event listeners are called', () => {
+          console.log('testing this bug');
+          const copy = Object.assign({}, bidResponse);
+          copy.getSize = function() {
+            return `${this.height}x${this.width}`;
+          };
+          delete copy.cpm;
+          bidManager.addBidResponse('mock/code', copy);
+          expect(copy).to.have.property('hadCpmDuringAdjuster', true);
         });
       });
 

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -71,7 +71,19 @@ describe('The Bid Manager', () => {
     function prepAuction(adUnits, bidRequestTweaker) {
       function bidAdjuster(bid) {
         if (bid.hasOwnProperty('cpm')) {
-          bid.hadCpmDuringAdjuster = true;
+          bid.hadCpmDuringBidAdjustment = true;
+        }
+        if (bid.hasOwnProperty('adUnitCode')) {
+          bid.hadAdUnitCodeDuringBidAdjustment = true;
+        }
+        if (bid.hasOwnProperty('timeToRespond')) {
+          bid.hadTimeToRespondDuringBidAdjustment = true;
+        }
+        if (bid.hasOwnProperty('requestTimestamp')) {
+          bid.hadRequestTimestampDuringBidAdjustment = true;
+        }
+        if (bid.hasOwnProperty('responseTimestamp')) {
+          bid.hadResponseTimestampDuringBidAdjustment = true;
         }
         bid.cpm = adjustCpm(bid.cpm);
       }
@@ -154,7 +166,11 @@ describe('The Bid Manager', () => {
           };
           delete copy.cpm;
           bidManager.addBidResponse('mock/code', copy);
-          expect(copy).to.have.property('hadCpmDuringAdjuster', true);
+          expect(copy).to.have.property('hadCpmDuringBidAdjustment', true);
+          expect(copy).to.have.property('hadAdUnitCodeDuringBidAdjustment', true);
+          expect(copy).to.have.property('hadTimeToRespondDuringBidAdjustment', true);
+          expect(copy).to.have.property('hadRequestTimestampDuringBidAdjustment', true);
+          expect(copy).to.have.property('hadResponseTimestampDuringBidAdjustment', true);
         });
       });
 

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -159,7 +159,6 @@ describe('The Bid Manager', () => {
         });
 
         it('should attach properties for analytics *before* the BID_ADJUSTMENT event listeners are called', () => {
-          console.log('testing this bug');
           const copy = Object.assign({}, bidResponse);
           copy.getSize = function() {
             return `${this.height}x${this.width}`;

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -158,7 +158,7 @@ describe('The Bid Manager', () => {
           expect($$PREBID_GLOBAL$$._bidsReceived.length).to.equal(0);
         });
 
-        it('should define a default cpm *before* the BID_ADJUSTMENT event listeners are called', () => {
+        it('should attach properties for analytics *before* the BID_ADJUSTMENT event listeners are called', () => {
           console.log('testing this bug');
           const copy = Object.assign({}, bidResponse);
           copy.getSize = function() {


### PR DESCRIPTION
## Type of change
Bugfix

## Description of change
Fixing #1398.

...turns out that the timing of `BidAdjustment` is very fragile, and people are relying on in to be after some bid mutations, but before some others. This puts it (I think) where it's supposed to be, and adds some regression tests.