### PR TITLE
Updates to Build Process to Support Building DIST and DEV Together

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,11 +46,23 @@ gulp.task('run-tests', ['lint', 'test-coverage']);
 gulp.task('build', ['build-bundle-prod']);
 
 gulp.task('clean', function () {
-  return gulp.src(['build'], {
-      read: false
-    })
-    .pipe(clean());
+  clean('');
 });
+
+gulp.task('clean-dev', function () {
+  clean('/dev');
+});
+
+gulp.task('clean-dist', function () {
+  clean('/dist');
+});
+
+function clean(type) {
+  return gulp.src(['build'+type], {
+    read: false
+  })
+  .pipe(clean());
+}
 
 function bundle(dev) {
   var modules = helpers.getArgModules(),
@@ -102,7 +114,7 @@ gulp.task('build-bundle-dev', ['devpack'], bundle.bind(null, true));
 gulp.task('build-bundle-prod', ['webpack'], bundle.bind(null, false));
 gulp.task('bundle', bundle.bind(null, false)); // used for just concatenating pre-built files with no build step
 
-gulp.task('devpack', ['clean'], function () {
+gulp.task('devpack', ['clean-dev'], function () {
   var cloned = _.cloneDeep(webpackConfig);
   cloned.devtool = 'source-map';
   var externalModules = helpers.getArgModules();
@@ -118,7 +130,7 @@ gulp.task('devpack', ['clean'], function () {
     .pipe(connect.reload());
 });
 
-gulp.task('webpack', ['clean'], function () {
+gulp.task('webpack', ['clean-dist'], function () {
   var cloned = _.cloneDeep(webpackConfig);
 
   // change output filename if argument --tag given

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,7 +1925,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-dargs@christian-bromann/dargs:
+"dargs@github:christian-bromann/dargs":
   version "4.0.1"
   resolved "https://codeload.github.com/christian-bromann/dargs/tar.gz/7d6d4164a7c4106dbd14ef39ed8d95b7b5e9b770"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,7 +1925,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-"dargs@github:christian-bromann/dargs":
+dargs@christian-bromann/dargs:
   version "4.0.1"
   resolved "https://codeload.github.com/christian-bromann/dargs/tar.gz/7d6d4164a7c4106dbd14ef39ed8d95b7b5e9b770"
   dependencies:


### PR DESCRIPTION
## Type of change
- [ X ] Bugfix

The build process calls the clean task before webpack and devpack. The clean function cleans out the entire build directory, not the subdirectory specific to the built variant (DEV/DIST). This change introduces a simple refactor to have each build clean their respective directory, but also retains a /build level clean option. We use the DEV version in certain places where a map file do not work, so we like to build both together.

There are other reasonable approaches. One sensible one would be to always build DEV when building DIST. Then allow DEV to be built on demand separately. This change was the simplest change I could make while retaining known behavior and allow for the behavior I needed, and that matched functionality that exists around version 23 which previously built both and supported building both together. If we need another approach, then let me know.