### PR TITLE
remove createNew requirement and use .constructor instead

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -8,7 +8,7 @@ var utils = require('src/utils.js');
 var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
-var adapter = require('src/adapter.js');
+var Adapter = require('src/adapter.js').default;
 var constants = require('src/constants.json');
 var adaptermanager = require('src/adaptermanager');
 
@@ -96,7 +96,7 @@ var AARDVARK_CALLBACK_NAME = 'aardvarkResponse',
   },
 
   AardvarkAdapter = function() {
-    var baseAdapter = adapter.createNew(AARDVARK_BIDDER_CODE);
+    var baseAdapter = new Adapter(AARDVARK_BIDDER_CODE);
 
     $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP] = $$PREBID_GLOBAL$$[AARDVARK_REQUESTS_MAP] || {};
 
@@ -115,14 +115,9 @@ var AARDVARK_CALLBACK_NAME = 'aardvarkResponse',
 
     return {
       callBids: baseAdapter.callBids,
-      setBidderCode: baseAdapter.setBidderCode,
-      createNew: exports.createNew
+      setBidderCode: baseAdapter.setBidderCode
     };
   };
-
-exports.createNew = function() {
-  return new AardvarkAdapter();
-};
 
 adaptermanager.registerBidAdapter(new AardvarkAdapter(), 'aardvark');
 

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -20,7 +20,7 @@ const AdKernelAdapter = function AdKernelAdapter() {
   const VIDEO_TARGETING = ['mimes', 'minduration', 'maxduration', 'protocols', 'startdelay', 'linearity', 'sequence',
     'boxingallowed', 'playbackmethod', 'delivery', 'pos', 'api', 'ext'];
 
-  let baseAdapter = Adapter.createNew('adkernel');
+  let baseAdapter = new Adapter('adkernel');
 
   /**
    * Helper object to build multiple bid requests in case of multiple zones/ad-networks
@@ -295,16 +295,8 @@ const AdKernelAdapter = function AdKernelAdapter() {
   return {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-    getBidderCode: baseAdapter.getBidderCode,
-    createNew: AdKernelAdapter.createNew
+    getBidderCode: baseAdapter.getBidderCode
   };
-};
-
-/**
- * Creates new instance of AdKernel bidder adapter
- */
-AdKernelAdapter.createNew = function() {
-  return new AdKernelAdapter();
 };
 
 adaptermanager.registerBidAdapter(new AdKernelAdapter(), 'adkernel', {

--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -10,7 +10,7 @@ import adaptermanager from 'src/adaptermanager';
 var AdyoulikeAdapter = function AdyoulikeAdapter() {
   const _VERSION = '0.1';
 
-  const baseAdapter = Adapter.createNew('adyoulike');
+  const baseAdapter = new Adapter('adyoulike');
 
   baseAdapter.callBids = function (bidRequest) {
     const bidRequests = {};
@@ -189,14 +189,9 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
   }
 
   return {
-    createNew: AdyoulikeAdapter.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
   };
-};
-
-AdyoulikeAdapter.createNew = function () {
-  return new AdyoulikeAdapter();
 };
 
 adaptermanager.registerBidAdapter(new AdyoulikeAdapter(), 'adyoulike');

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -4,7 +4,7 @@ const bidfactory = require('src/bidfactory.js');
 const bidmanager = require('src/bidmanager.js');
 const constants = require('src/constants.json');
 const adaptermanager = require('src/adaptermanager');
-const BaseAdapter = require('src/adapter');
+const BaseAdapter = require('src/adapter').default;
 
 const AOL_BIDDERS_CODES = {
   aol: 'aol',
@@ -324,11 +324,8 @@ const AolAdapter = function AolAdapter() {
     });
   }
 
-  return Object.assign(BaseAdapter.createNew(AOL_BIDDERS_CODES.aol), {
-    callBids: _callBids,
-    createNew: function () {
-      return new AolAdapter();
-    }
+  return Object.assign(new BaseAdapter(AOL_BIDDERS_CODES.aol), {
+    callBids: _callBids
   });
 };
 

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -31,7 +31,7 @@ const NATIVE_MAPPING = {
  * to Prebid.js. This adapter supports alias bidding.
  */
 function AppnexusAstAdapter() {
-  let baseAdapter = Adapter.createNew('appnexusAst');
+  let baseAdapter = new Adapter('appnexusAst');
   let bidRequests = {};
   let usersync = false;
 
@@ -368,15 +368,10 @@ function AppnexusAstAdapter() {
   }
 
   return {
-    createNew: AppnexusAstAdapter.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
   };
 }
-
-AppnexusAstAdapter.createNew = function() {
-  return new AppnexusAstAdapter();
-};
 
 adaptermanager.registerBidAdapter(new AppnexusAstAdapter(), 'appnexusAst', {
   supportedMediaTypes: ['video', 'native']

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -6,11 +6,11 @@ var utils = require('src/utils');
 var adloader = require('src/adloader');
 var bidmanager = require('src/bidmanager');
 var bidfactory = require('src/bidfactory');
-var Adapter = require('src/adapter');
+var Adapter = require('src/adapter').default;
 
 var AppNexusAdapter;
 AppNexusAdapter = function AppNexusAdapter() {
-  var baseAdapter = Adapter.createNew('appnexus');
+  var baseAdapter = new Adapter('appnexus');
   var usersync = false;
 
   baseAdapter.callBids = function (params) {
@@ -217,13 +217,8 @@ AppNexusAdapter = function AppNexusAdapter() {
   return {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-    createNew: AppNexusAdapter.createNew,
     buildJPTCall: buildJPTCall
   };
-};
-
-AppNexusAdapter.createNew = function () {
-  return new AppNexusAdapter();
 };
 
 adaptermanager.registerBidAdapter(new AppNexusAdapter(), 'appnexus');

--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -7,10 +7,10 @@ import { addBidResponse } from 'src/bidmanager';
 import { STATUS } from 'src/constants.json';
 import { format } from 'src/url';
 import { logError } from 'src/utils';
-import { createNew } from 'src/adapter';
+import Adapter from 'src/adapter';
 import adaptermanager from 'src/adaptermanager';
 
-const { setBidderCode, getBidderCode } = createNew('audienceNetwork');
+const { setBidderCode, getBidderCode } = new Adapter('audienceNetwork');
 
 /**
  * Does this bid request contain valid parameters?

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -9,7 +9,7 @@ import adaptermanager from 'src/adaptermanager';
 const ENDPOINT = '//reachms.bfmio.com/bid.json?exchange_id=';
 
 function BeachfrontAdapter() {
-  var baseAdapter = Adapter.createNew('beachfront');
+  var baseAdapter = new Adapter('beachfront');
 
   baseAdapter.callBids = function (bidRequests) {
     const bids = bidRequests.bids || [];
@@ -123,15 +123,10 @@ function BeachfrontAdapter() {
   }
 
   return {
-    createNew: BeachfrontAdapter.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
   };
 }
-
-BeachfrontAdapter.createNew = function () {
-  return new BeachfrontAdapter();
-};
 
 adaptermanager.registerBidAdapter(new BeachfrontAdapter(), 'beachfront', {
   supportedMediaTypes: ['video']

--- a/modules/huddledmassesBidAdapter.js
+++ b/modules/huddledmassesBidAdapter.js
@@ -1,4 +1,4 @@
-import * as Adapter from 'src/adapter.js';
+import Adapter from 'src/adapter';
 import bidfactory from 'src/bidfactory';
 import bidmanager from 'src/bidmanager';
 import * as utils from 'src/utils';
@@ -129,9 +129,8 @@ function HuddledMassesAdapter() {
     bidmanager.addBidResponse(bidRequest.placementCode, bid);
   }
 
-  return Object.assign(Adapter.createNew(BIDDER_CODE), { // BIDDER_CODE huddledmasses
-    callBids: _callBids,
-    createNew: HuddledMassesAdapter.createNew
+  return Object.assign(new Adapter(BIDDER_CODE), { // BIDDER_CODE huddledmasses
+    callBids: _callBids
   });
 }
 
@@ -161,10 +160,6 @@ HuddledMassesAdapter.masSizeOrdering = function (sizes) {
 
       return first - second;
     });
-};
-
-HuddledMassesAdapter.createNew = function () {
-  return new HuddledMassesAdapter();
 };
 
 adaptermanager.registerBidAdapter(new HuddledMassesAdapter(), 'huddledmasses');

--- a/modules/inneractiveBidAdapter.js
+++ b/modules/inneractiveBidAdapter.js
@@ -250,7 +250,9 @@ const Http = {
  */
 class InnerActiveAdapter {
   constructor() {
-    this.iaAdapter = Adapter.createNew(CONSTANTS.ADAPTER_NAME);
+    this.iaAdapter = new Adapter(CONSTANTS.ADAPTER_NAME);
+    this.setBidderCode = this.iaAdapter.setBidderCode.bind(this);
+
     this.bidByBidId = {};
   }
 
@@ -448,14 +450,6 @@ class InnerActiveAdapter {
    */
   static _getUtils() {
     return {Reporter};
-  }
-
-  /**
-   * Creates new instance of InnerActiveAdapter for prebid auction
-   * @returns {InnerActiveAdapter}
-   */
-  static createNew() {
-    return new InnerActiveAdapter();
   }
 }
 

--- a/modules/komoonaBidAdapter.js
+++ b/modules/komoonaBidAdapter.js
@@ -9,7 +9,7 @@ import adaptermanager from 'src/adaptermanager';
 const ENDPOINT = '//bidder.komoona.com/v1/GetSBids';
 
 function KomoonaAdapter() {
-  let baseAdapter = Adapter.createNew('komoona');
+  let baseAdapter = new Adapter('komoona');
   let bidRequests = {};
 
   /* Prebid executes this function when the page asks to send out bid requests */
@@ -107,15 +107,10 @@ function KomoonaAdapter() {
   }
 
   return {
-    createNew: KomoonaAdapter.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
   };
 }
-
-KomoonaAdapter.createNew = function() {
-  return new KomoonaAdapter();
-};
 
 adaptermanager.registerBidAdapter(new KomoonaAdapter(), 'komoona');
 

--- a/modules/piximediaBidAdapter.js
+++ b/modules/piximediaBidAdapter.js
@@ -3,12 +3,12 @@ var utils = require('src/utils.js');
 var bidmanager = require('src/bidmanager.js');
 var bidfactory = require('src/bidfactory.js');
 var adloader = require('src/adloader.js');
-var Adapter = require('src/adapter.js');
+var Adapter = require('src/adapter.js').default;
 var adaptermanager = require('src/adaptermanager');
 
 var PiximediaAdapter = function PiximediaAdapter() {
   var PREBID_URL = '//static.adserver.pm/prebid';
-  var baseAdapter = Adapter.createNew('piximedia');
+  var baseAdapter = new Adapter('piximedia');
   var bidStash = {};
 
   var tryAppendPixiQueryString = function(url, name, value) {

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -39,7 +39,7 @@ let _cookiesQueued = false;
  * Bidder adapter for Prebid Server
  */
 function PrebidServer() {
-  let baseAdapter = Adapter.createNew('prebidServer');
+  let baseAdapter = new Adapter('prebidServer');
   let config;
 
   baseAdapter.setConfig = function(s2sconfig) {
@@ -201,16 +201,11 @@ function PrebidServer() {
   return {
     queueSync: baseAdapter.queueSync,
     setConfig: baseAdapter.setConfig,
-    createNew: PrebidServer.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     type: TYPE
   };
 }
-
-PrebidServer.createNew = function() {
-  return new PrebidServer();
-};
 
 adaptermanager.registerBidAdapter(new PrebidServer(), 'prebidServer');
 

--- a/modules/pulsepointLiteBidAdapter.js
+++ b/modules/pulsepointLiteBidAdapter.js
@@ -285,9 +285,6 @@ function PulsePointLiteAdapter() {
   };
 }
 
-PulsePointLiteAdapter.createNew = function() {
-  return new PulsePointLiteAdapter();
-}
 /**
  * "pulseLite" will be the adapter name going forward. "pulsepointLite" to be
  * deprecated, but kept here for backwards compatibility.

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -125,10 +125,6 @@ var QuantcastAdapter = function QuantcastAdapter() {
   };
 };
 
-exports.createNew = function() {
-  return new QuantcastAdapter();
-};
-
 adaptermanager.registerBidAdapter(new QuantcastAdapter(), 'quantcast');
 
 module.exports = QuantcastAdapter;

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1,4 +1,4 @@
-import * as Adapter from 'src/adapter';
+import Adapter from 'src/adapter';
 import bidfactory from 'src/bidfactory';
 import bidmanager from 'src/bidmanager';
 import adaptermanager from 'src/adaptermanager';
@@ -71,6 +71,8 @@ var sizeMap = {
 utils._each(sizeMap, (item, key) => sizeMap[item] = key);
 
 function RubiconAdapter() {
+  var baseAdapter = new Adapter(RUBICON_BIDDER_CODE);
+
   function _callBids(bidderRequest) {
     var bids = bidderRequest.bids || [];
 
@@ -128,7 +130,7 @@ function RubiconAdapter() {
 
       function addErrorBid() {
         let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
-        badBid.bidderCode = bid.bidder;
+        badBid.bidderCode = baseAdapter.getBidderCode();
         bidmanager.addBidResponse(bid.placementCode, badBid);
       }
     });
@@ -341,7 +343,7 @@ function RubiconAdapter() {
       // bid status is good (indicating 1)
       var bid = bidfactory.createBid(STATUS.GOOD, bidRequest);
       bid.creative_id = ad.ad_id;
-      bid.bidderCode = bidRequest.bidder;
+      bid.bidderCode = baseAdapter.getBidderCode();
       bid.cpm = ad.cpm || 0;
       bid.dealId = ad.deal;
       if (bidRequest.mediaType === 'video') {
@@ -374,9 +376,8 @@ function RubiconAdapter() {
     return (adB.cpm || 0.0) - (adA.cpm || 0.0);
   }
 
-  return Object.assign(Adapter.createNew(RUBICON_BIDDER_CODE), {
-    callBids: _callBids,
-    createNew: RubiconAdapter.createNew
+  return Object.assign(baseAdapter, {
+    callBids: _callBids
   });
 }
 
@@ -410,10 +411,6 @@ RubiconAdapter.masSizeOrdering = function(sizes) {
       // and finally ascending order
       return first - second;
     });
-};
-
-RubiconAdapter.createNew = function() {
-  return new RubiconAdapter();
 };
 
 adaptermanager.registerBidAdapter(new RubiconAdapter(), RUBICON_BIDDER_CODE, {

--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -6,7 +6,7 @@ import { ajax } from 'src/ajax';
 import adaptermanager from 'src/adaptermanager';
 
 const ServerBidAdapter = function ServerBidAdapter() {
-  const baseAdapter = Adapter.createNew('serverbid');
+  const baseAdapter = new Adapter('serverbid');
 
   const BASE_URI = '//e.serverbid.com/api/v2';
 
@@ -145,10 +145,6 @@ const ServerBidAdapter = function ServerBidAdapter() {
   return {
     callBids: baseAdapter.callBids
   };
-};
-
-ServerBidAdapter.createNew = function() {
-  return new ServerBidAdapter();
 };
 
 adaptermanager.registerBidAdapter(new ServerBidAdapter(), 'serverbid');

--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -1,4 +1,4 @@
-import * as Adapter from 'src/adapter.js';
+import Adapter from 'src/adapter';
 import bidfactory from 'src/bidfactory';
 import bidmanager from 'src/bidmanager';
 import * as utils from 'src/utils';
@@ -139,9 +139,8 @@ function SmartyadsAdapter() {
     bidmanager.addBidResponse(bidRequest.placementCode, bid);
   }
 
-  return Object.assign(Adapter.createNew(SMARTYADS_BIDDER_CODE), { // SMARTYADS_BIDDER_CODE smartyads
-    callBids: _callBids,
-    createNew: SmartyadsAdapter.createNew
+  return Object.assign(new Adapter(SMARTYADS_BIDDER_CODE), { // SMARTYADS_BIDDER_CODE smartyads
+    callBids: _callBids
   });
 }
 
@@ -174,10 +173,6 @@ SmartyadsAdapter.masSizeOrdering = function (sizes) {
 
       return first - second;
     });
-};
-
-SmartyadsAdapter.createNew = function () {
-  return new SmartyadsAdapter();
 };
 
 adaptermanager.registerBidAdapter(new SmartyadsAdapter(), 'smartyads');

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -7,7 +7,7 @@ import { STATUS } from 'src/constants';
 import adaptermanager from 'src/adaptermanager';
 
 function Spotx() {
-  let baseAdapter = Adapter.createNew('Spotx');
+  let baseAdapter = new Adapter('Spotx');
   let bidReq;
   let KVP_Object;
 
@@ -124,15 +124,10 @@ function Spotx() {
   }
 
   return {
-    createNew: Spotx.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
   };
 }
-
-Spotx.createNew = function() {
-  return new Spotx();
-};
 
 adaptermanager.registerBidAdapter(new Spotx(), 'spotx', {
   supportedMediaTypes: ['video']

--- a/modules/stickyadstvBidAdapter.js
+++ b/modules/stickyadstvBidAdapter.js
@@ -1,4 +1,4 @@
-var Adapter = require('src/adapter.js');
+var Adapter = require('src/adapter.js').default;
 var bidfactory = require('src/bidfactory.js');
 var bidmanager = require('src/bidmanager.js');
 var adloader = require('src/adloader.js');
@@ -252,7 +252,7 @@ var StickyAdsTVAdapter = function StickyAdsTVAdapter() {
     };
   };
 
-  return Object.assign(Adapter.createNew(STICKYADS_BIDDERCODE), {
+  return Object.assign(new Adapter(STICKYADS_BIDDERCODE), {
     callBids: _callBids,
     formatBidObject: formatBidObject,
     formatAdHTML: formatAdHTML,
@@ -260,13 +260,8 @@ var StickyAdsTVAdapter = function StickyAdsTVAdapter() {
     getBid: getBid,
     getTopMostWindow: getTopMostWindow,
     getComponentId: getComponentId,
-    getAPIName: getAPIName,
-    createNew: StickyAdsTVAdapter.createNew // enable alias feature (to be used for freewheel-ssp alias)
+    getAPIName: getAPIName
   });
-};
-
-StickyAdsTVAdapter.createNew = function() {
-  return new StickyAdsTVAdapter();
 };
 
 adaptermanager.registerBidAdapter(new StickyAdsTVAdapter(), 'stickyadstv');

--- a/modules/trionBidAdapter.js
+++ b/modules/trionBidAdapter.js
@@ -3,14 +3,14 @@ var utils = require('src/utils.js');
 var adloader = require('src/adloader.js');
 var bidmanager = require('src/bidmanager.js');
 var bidfactory = require('src/bidfactory.js');
-var Adapter = require('src/adapter.js');
+var Adapter = require('src/adapter.js').default;
 var adaptermanager = require('src/adaptermanager');
 
 const BID_REQUEST_BASE_URL = 'https://in-appadvertising.com/api/bidRequest?';
 const USER_SYNC_URL = 'https://in-appadvertising.com/api/userSync.js';
 
 function TrionAdapter() {
-  var baseAdapter = Adapter.createNew('trion');
+  var baseAdapter = new Adapter('trion');
   var userTag = null;
 
   baseAdapter.callBids = function (params) {
@@ -121,14 +121,9 @@ function TrionAdapter() {
   return {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-    createNew: TrionAdapter.createNew,
     buildTrionUrl: buildTrionUrl
   };
-};
-
-TrionAdapter.createNew = function () {
-  return new TrionAdapter();
-};
+}
 
 adaptermanager.registerBidAdapter(new TrionAdapter(), 'trion');
 

--- a/modules/twengaBidAdapter.js
+++ b/modules/twengaBidAdapter.js
@@ -3,11 +3,11 @@ var utils = require('src/utils.js');
 var adloader = require('src/adloader.js');
 var bidmanager = require('src/bidmanager.js');
 var bidfactory = require('src/bidfactory.js');
-var Adapter = require('src/adapter.js');
+var Adapter = require('src/adapter.js').default;
 var adaptermanager = require('src/adaptermanager');
 
 function TwengaAdapter() {
-  var baseAdapter = Adapter.createNew('twenga');
+  var baseAdapter = new Adapter('twenga');
 
   baseAdapter.callBids = function (params) {
     for (var i = 0; i < params.bids.length; i++) {
@@ -127,14 +127,9 @@ function TwengaAdapter() {
   return {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-    createNew: TwengaAdapter.createNew,
     buildBidCall: buildBidCall
   };
-};
-
-TwengaAdapter.createNew = function () {
-  return new TwengaAdapter();
-};
+}
 
 adaptermanager.registerBidAdapter(new TwengaAdapter(), 'twenga');
 

--- a/modules/vertamediaBidAdapter.js
+++ b/modules/vertamediaBidAdapter.js
@@ -9,7 +9,7 @@ import adaptermanager from 'src/adaptermanager';
 const ENDPOINT = '//rtb.vertamedia.com/hb/';
 
 function VertamediaAdapter() {
-  var baseAdapter = Adapter.createNew('vertamedia'),
+  var baseAdapter = new Adapter('vertamedia'),
     bidRequest;
 
   baseAdapter.callBids = function (bidRequests) {
@@ -107,15 +107,10 @@ function VertamediaAdapter() {
   }
 
   return {
-    createNew: VertamediaAdapter.createNew,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
   };
 }
-
-VertamediaAdapter.createNew = function () {
-  return new VertamediaAdapter();
-};
 
 adaptermanager.registerBidAdapter(new VertamediaAdapter(), 'vertamedia', {
   supportedMediaTypes: ['video']

--- a/modules/xhbBidAdapter.js
+++ b/modules/xhbBidAdapter.js
@@ -1,4 +1,4 @@
-import * as Adapter from 'src/adapter';
+import Adapter from 'src/adapter';
 import bidfactory from 'src/bidfactory';
 import bidmanager from 'src/bidmanager';
 import * as utils from 'src/utils';
@@ -7,7 +7,7 @@ import adaptermanager from 'src/adaptermanager';
 import { loadScript } from 'src/adloader';
 
 const XhbAdapter = function XhbAdapter() {
-  const baseAdapter = Adapter.createNew('xhb');
+  const baseAdapter = new Adapter('xhb');
   let usersync = false;
 
   const _defaultBidderSettings = {
@@ -157,13 +157,8 @@ const XhbAdapter = function XhbAdapter() {
   return {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-    createNew: XhbAdapter.createNew,
     buildJPTCall: buildJPTCall
   };
-};
-
-XhbAdapter.createNew = function () {
-  return new XhbAdapter();
 };
 
 adaptermanager.registerBidAdapter(new XhbAdapter(), 'xhb');

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,4 +1,4 @@
-function Adapter(code) {
+export default function Adapter(code) {
   var bidderCode = code;
 
   function setBidderCode(code) {
@@ -18,7 +18,3 @@ function Adapter(code) {
     getBidderCode: getBidderCode
   };
 }
-
-exports.createNew = function (bidderCode) {
-  return new Adapter(bidderCode);
-};

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -202,8 +202,7 @@ exports.aliasBidAdapter = function (bidderCode, alias) {
       utils.logError('bidderCode "' + bidderCode + '" is not an existing bidder.', 'adaptermanager.aliasBidAdapter');
     } else {
       try {
-        let newAdapter = null;
-        newAdapter = bidAdaptor.createNew();
+        let newAdapter = new bidAdaptor.constructor();
         newAdapter.setBidderCode(alias);
         this.registerBidAdapter(newAdapter, alias);
       } catch (e) {

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -98,7 +98,7 @@ describe('Adkernel adapter', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    adapter = Adapter.createNew();
+    adapter = new Adapter();
     ajaxStub = sandbox.stub(ajax, 'ajax');
   });
 

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -118,10 +118,7 @@ describe('Adyoulike Adapter', () => {
   });
 
   describe('adapter public API', () => {
-    const adapter = AdyoulikAdapter.createNew();
-    it('createNew', () => {
-      expect(adapter.createNew).to.be.a('function');
-    });
+    const adapter = new AdyoulikAdapter();
 
     it('setBidderCode', () => {
       expect(adapter.setBidderCode).to.be.a('function');

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -63,7 +63,7 @@ const RESPONSE = {
 describe('AppNexusAdapter', () => {
   let adapter;
 
-  beforeEach(() => adapter = Adapter.createNew());
+  beforeEach(() => adapter = new Adapter());
 
   describe('request function', () => {
     let xhr;

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -44,7 +44,7 @@ var RESPONSE = {
 describe('BeachfrontAdapter', () => {
   let adapter;
 
-  beforeEach(() => adapter = BeachfrontAdapter.createNew());
+  beforeEach(() => adapter = new BeachfrontAdapter());
 
   describe('request function', () => {
     let xhr;

--- a/test/spec/modules/inneractiveBidAdapter_spec.js
+++ b/test/spec/modules/inneractiveBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('InneractiveAdapter', function () {
     bidRequest;
 
   beforeEach(function () {
-    adapter = InneractiveAdapter.createNew();
+    adapter = new InneractiveAdapter();
     bidRequest = {
       bidderCode: 'inneractive',
       bids: [
@@ -85,13 +85,11 @@ describe('InneractiveAdapter', function () {
     });
   });
 
-  describe('.createNew()', function () {
-    it('should return an instance of this adapter having a "callBids" method', function () {
-      expect(adapter)
-        .to.be.instanceOf(InneractiveAdapter).and
-        .to.have.property('callBids').and
-        .to.be.a('function');
-    });
+  it('should return an instance of this adapter having a "callBids" method', function () {
+    expect(adapter)
+      .to.be.instanceOf(InneractiveAdapter).and
+      .to.have.property('callBids').and
+      .to.be.a('function');
   });
 
   describe('when sending out bid requests to the ad server', function () {

--- a/test/spec/modules/komoonaBidAdapter_spec.js
+++ b/test/spec/modules/komoonaBidAdapter_spec.js
@@ -43,7 +43,7 @@ const RESPONSE = {
 describe('komoonaAdapter', () => {
   let adapter;
 
-  beforeEach(() => adapter = Adapter.createNew());
+  beforeEach(() => adapter = new Adapter());
 
   describe('request function', () => {
     let xhr;

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -151,7 +151,7 @@ const RESPONSE_NO_PBS_COOKIE = {
 describe('S2S Adapter', () => {
   let adapter;
 
-  beforeEach(() => adapter = Adapter.createNew());
+  beforeEach(() => adapter = new Adapter());
 
   describe('request function', () => {
     let xhr;

--- a/test/spec/modules/pulsepointLiteBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointLiteBidAdapter_spec.js
@@ -227,8 +227,8 @@ describe('PulsePoint Lite Adapter Tests', () => {
     expect(bid.native.impressionTrackers[1]).to.equal('http://imp1.contextweb.com/');
   });
 
-  it('Verify createNew', function () {
-    const adapter = PulsePointAdapter.createNew();
+  it('Verify adapter interface', function () {
+    const adapter = new PulsePointAdapter();
     expect(adapter).to.have.property('callBids');
   });
 });

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -61,7 +61,7 @@ const RESPONSE = {
 describe('serverbidAdapter', () => {
   let adapter;
 
-  beforeEach(() => adapter = Adapter.createNew());
+  beforeEach(() => adapter = new Adapter());
 
   describe('request function', () => {
     let xhr;

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -87,7 +87,7 @@ describe('spotx adapter tests', () => {
     let adapter;
 
     beforeEach(() => {
-      adapter = Adapter.createNew();
+      adapter = new Adapter();
 
       var slot = document.createElement('div');
       slot.setAttribute('id', 'contentSpotx');

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import trionAdapter from 'modules/trionBidAdapter';
+import TrionAdapter from 'modules/trionBidAdapter';
 import bidmanager from 'src/bidmanager';
 import * as utils from 'src/utils';
 const CONSTANTS = require('src/constants.json');
@@ -43,7 +43,7 @@ describe('Trion adapter tests', () => {
   let adapter;
 
   beforeEach(() => {
-    adapter = trionAdapter.createNew();
+    adapter = new TrionAdapter();
     sinon.stub(document.body, 'appendChild');
   });
 

--- a/test/spec/modules/twengaBidAdapter_spec.js
+++ b/test/spec/modules/twengaBidAdapter_spec.js
@@ -1,7 +1,7 @@
 describe('twenga adapter tests', function () {
   var urlParse = require('url-parse');
   var querystringify = require('querystringify');
-  var adapter = require('modules/twengaBidAdapter');
+  var Adapter = require('modules/twengaBidAdapter');
   var adLoader = require('src/adloader');
   var expect = require('chai').expect;
   var bidmanager = require('src/bidmanager');
@@ -40,7 +40,7 @@ describe('twenga adapter tests', function () {
   it('sets url parameters', function () {
     var stubLoadScript = sinon.stub(adLoader, 'loadScript');
 
-    adapter().callBids(DEFAULT_PARAMS);
+    (new Adapter()).callBids(DEFAULT_PARAMS);
 
     var bidUrl = stubLoadScript.getCall(0).args[0];
     var parsedBidUrl = urlParse(bidUrl);
@@ -79,7 +79,7 @@ describe('twenga adapter tests', function () {
     });
     var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
 
-    adapter.createNew().callBids(DEFAULT_PARAMS);
+    (new Adapter()).callBids(DEFAULT_PARAMS);
 
     expect(stubAddBidResponse.getCall(0)).to.be.null;
 
@@ -104,7 +104,7 @@ describe('twenga adapter tests', function () {
     });
     var stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
 
-    adapter.createNew().callBids(DEFAULT_PARAMS);
+    (new Adapter()).callBids(DEFAULT_PARAMS);
 
     var bidResponseAd = stubAddBidResponse.getCall(0).args[1];
 

--- a/test/spec/modules/vertamediaBidAdapter_spec.js
+++ b/test/spec/modules/vertamediaBidAdapter_spec.js
@@ -43,7 +43,7 @@ var RESPONSE = {
 describe('VertamediaAdater', () => {
   let adapter;
 
-  beforeEach(() => adapter = Adapter.createNew());
+  beforeEach(() => adapter = new Adapter());
 
   describe('request function', () => {
     let xhr;


### PR DESCRIPTION
## Type of change
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Getting rid of the createNew requirement for bidder aliasing in favor of Prebid.js just using [`Object.prototype.constructor` which is supported in all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor).  This makes for cleaner and more obvious code usage.  However, bidder aliasing still expects that an adapter adhere to the `setBidderCode` interface of `Adapter`.

All the bid adapters and test files that used the `createNew` syntax were updated and replaced with just regular `new` calls.