### PR TITLE
minWidth should be inclusive

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -21,7 +21,7 @@ function mapSizes(adUnit) {
   }
   let sizes = '';
   const mapping = adUnit.sizeMapping.find(sizeMapping => {
-    return width > sizeMapping.minWidth;
+    return width >= sizeMapping.minWidth;
   });
   if (mapping && mapping.sizes && mapping.sizes.length) {
     sizes = mapping.sizes;

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -50,6 +50,13 @@ function resetMockWindow() {
 describe('sizeMapping', function() {
   beforeEach(resetMockWindow);
 
+  it('minWidth should be inclusive', function() {
+    mockWindow.innerWidth = 1024;
+    sizeMapping.setWindow(mockWindow);
+    let sizes = sizeMapping.mapSizes(validAdUnit);
+    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
+  });
+
   it('mapSizes 1029 width', function() {
     mockWindow.innerWidth = 1029;
     sizeMapping.setWindow(mockWindow);


### PR DESCRIPTION
## Type of change
- [x ] Bugfix

## Description of change
sizeMapping.minWidth should be inclusive. 
For following adUnit config
```
{
  'sizes': [300, 250],
  'sizeMapping': [
    {
      'minWidth': 1024,
      'sizes': [[300, 250], [728, 90]]
    },
    {
      'minWidth': 480,
      'sizes': [120, 60]
    },
    {
      'minWidth': 0,
      'sizes': [20, 20]
    }
  ]
};
```
When viewport is set to 1024. Prior to this fix `mapSizes` would return sizes [120,60] which is incorrect.


