### PR TITLE
Removed the standard/object-curly-even-spacing ESLint exclusion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,6 @@ module.exports = {
     "no-useless-escape": "off",
     "one-var": "off",
     "standard/no-callback-literal": "off",
-    "standard/object-curly-even-spacing": "off",
     "valid-typeof": "off"
   }
 };

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -59,7 +59,10 @@ const AdKernelAdapter = function AdKernelAdapter() {
 
     function buildImp(bid) {
       const size = getBidSize(bid);
-      const imp = { 'id': bid.bidId, 'tagid': bid.placementCode};
+      const imp = {
+        'id': bid.bidId,
+        'tagid': bid.placementCode
+      };
 
       if (bid.mediaType === 'video') {
         imp.video = {w: size[0], h: size[1]};

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -73,7 +73,7 @@ export default function buildDfpVideoUrl(options) {
     defaultParamConstants,
     derivedParams,
     options.params,
-    { cust_params: encodeURIComponent(formatQS(customParams))});
+    { cust_params: encodeURIComponent(formatQS(customParams)) });
 
   return buildUrl({
     protocol: 'https',


### PR DESCRIPTION
## Type of change
Code style update (formatting, local variables)

## Description of change
Removed the standard/object-curly-even-spacing ESLint exclusion for #1206 