### PR TITLE
Amp ad size fix

### DIFF
--- a/integrationExamples/gpt/amp/creative.html
+++ b/integrationExamples/gpt/amp/creative.html
@@ -15,7 +15,7 @@
         document.write(data.ad);
         document.close();
       } else if (data.adUrl) {
-        document.write('<IFRAME SRC="' + data.adUrl + '" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true"></IFRAME>');
+        document.write('<IFRAME SRC="' + data.adUrl + '" WIDTH="'+ data.width +'" HEIGHT="'+ data.height +'" FRAMEBORDER="0" SCROLLING="no" MARGINHEIGHT="0" MARGINWIDTH="0" TOPMARGIN="0" LEFTMARGIN="0" ALLOWTRANSPARENCY="true"></IFRAME>');
         document.close();
       }
     }

--- a/integrationExamples/gpt/amp/remote.html
+++ b/integrationExamples/gpt/amp/remote.html
@@ -115,11 +115,16 @@ document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
 
         var ad = adObject.ad;
         var adUrl = adObject.adUrl;
+        var width = adObject.width;
+        var height = adObject.height;
         var message = JSON.stringify({
           message: 'Prebid creative sent: ' + data.adId,
           ad: ad,
-          adUrl: adUrl
+          adUrl: adUrl,
+          width: width,
+          height: height
         });
+
         ev.source.postMessage(message, '*');
       }
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
Prebid ads were being cut off in amp pages as width and height was not defined on iframe. To fix this added width and height.

