### PR TITLE
Improving events & analytics adapter testability

### DIFF
--- a/modules/appnexusAnalyticsAdapter.js
+++ b/modules/appnexusAnalyticsAdapter.js
@@ -11,7 +11,7 @@ const appnexusAdapterFactory = adapter({
   analyticsType: 'bundle'
 });
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   factory: appnexusAdapterFactory,
   code: 'appnexus'
 });

--- a/modules/appnexusAnalyticsAdapter.js
+++ b/modules/appnexusAnalyticsAdapter.js
@@ -3,17 +3,17 @@
  */
 
 import adapter from 'src/AnalyticsAdapter';
-import adaptermanager from 'src/adaptermanager';
+import { analyticsRegistry } from 'src/analyticsAdapterRegistry';
 
-var appnexusAdapter = adapter({
+const appnexusAdapterFactory = adapter({
   global: 'AppNexusPrebidAnalytics',
   handler: 'on',
   analyticsType: 'bundle'
 });
 
-adaptermanager.registerAnalyticsAdapter({
-  adapter: appnexusAdapter,
+analyticsRegistry.registerInjectableAnalyticsAdapter({
+  factory: appnexusAdapterFactory,
   code: 'appnexus'
 });
 
-export default appnexusAdapter;
+export default appnexusAdapterFactory;

--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -2,257 +2,262 @@
  * ga.js - analytics adapter for google analytics
  */
 
-var events = require('src/events');
 var utils = require('src/utils');
 var CONSTANTS = require('src/constants.json');
-var adaptermanager = require('src/adaptermanager');
+import {analyticsRegistry} from 'src/analyticsAdapterRegistry';
 
 var BID_REQUESTED = CONSTANTS.EVENTS.BID_REQUESTED;
 var BID_TIMEOUT = CONSTANTS.EVENTS.BID_TIMEOUT;
 var BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
 var BID_WON = CONSTANTS.EVENTS.BID_WON;
 
-var _disableInteraction = { nonInteraction: true };
-var _analyticsQueue = [];
-var _gaGlobal = null;
-var _enableCheck = true;
-var _category = 'Prebid.js Bids';
-var _eventCount = 0;
-var _enableDistribution = false;
-var _trackerSend = null;
-var _sampled = true;
+export default function googleAnalyticsFactory(analyticsAdapterDependencies) {
+  var _disableInteraction = { nonInteraction: true };
+  var _analyticsQueue = [];
+  var _gaGlobal = null;
+  var _enableCheck = true;
+  var _category = 'Prebid.js Bids';
+  var _eventCount = 0;
+  var _enableDistribution = false;
+  var _trackerSend = null;
+  var _sampled = true;
 
-/**
- * This will enable sending data to google analytics. Only call once, or duplicate data will be sent!
- * @param  {object} provider use to set GA global (if renamed);
- * @param  {object} options use to configure adapter;
- * @return {[type]}    [description]
- */
-exports.enableAnalytics = function ({ provider, options }) {
-  _gaGlobal = provider || 'ga';
-  _trackerSend = options && options.trackerName ? options.trackerName + '.send' : 'send';
-  _sampled = typeof options === 'undefined' || typeof options.sampling === 'undefined' ||
-             Math.random() < parseFloat(options.sampling);
+  const events = analyticsAdapterDependencies.events;
 
-  if (options && typeof options.global !== 'undefined') {
-    _gaGlobal = options.global;
-  }
-  if (options && typeof options.enableDistribution !== 'undefined') {
-    _enableDistribution = options.enableDistribution;
-  }
+  return {
+    /**
+     * This will enable sending data to google analytics. Only call once, or duplicate data will be sent!
+     * @param  {object} provider use to set GA global (if renamed);
+     * @param  {object} options use to configure adapter;
+     * @return {[type]}    [description]
+     */
+    enableAnalytics: function ({provider, options}) {
+      _gaGlobal = provider || 'ga';
+      _trackerSend = options && options.trackerName ? options.trackerName + '.send' : 'send';
+      _sampled = typeof options === 'undefined' || typeof options.sampling === 'undefined' ||
+        Math.random() < parseFloat(options.sampling);
 
-  var bid = null;
-
-  if (_sampled) {
-    // first send all events fired before enableAnalytics called
-
-    var existingEvents = events.getEvents();
-
-    utils._each(existingEvents, function (eventObj) {
-      if (typeof eventObj !== 'object') {
-        return;
+      if (options && typeof options.global !== 'undefined') {
+        _gaGlobal = options.global;
       }
-      var args = eventObj.args;
-
-      if (eventObj.eventType === BID_REQUESTED) {
-        bid = args;
-        sendBidRequestToGa(bid);
-      } else if (eventObj.eventType === BID_RESPONSE) {
-        // bid is 2nd args
-        bid = args;
-        sendBidResponseToGa(bid);
-      } else if (eventObj.eventType === BID_TIMEOUT) {
-        const bidderArray = args;
-        sendBidTimeouts(bidderArray);
-      } else if (eventObj.eventType === BID_WON) {
-        bid = args;
-        sendBidWonToGa(bid);
+      if (options && typeof options.enableDistribution !== 'undefined') {
+        _enableDistribution = options.enableDistribution;
       }
-    });
 
-    // Next register event listeners to send data immediately
+      var bid = null;
 
-    // bidRequests
-    events.on(BID_REQUESTED, function (bidRequestObj) {
-      sendBidRequestToGa(bidRequestObj);
-    });
+      if (_sampled) {
+        // first send all events fired before enableAnalytics called
 
-    // bidResponses
-    events.on(BID_RESPONSE, function (bid) {
-      sendBidResponseToGa(bid);
-    });
+        var existingEvents = events.getEvents();
 
-    // bidTimeouts
-    events.on(BID_TIMEOUT, function (bidderArray) {
-      sendBidTimeouts(bidderArray);
-    });
+        utils._each(existingEvents, function (eventObj) {
+          if (typeof eventObj !== 'object') {
+            return;
+          }
+          var args = eventObj.args;
 
-    // wins
-    events.on(BID_WON, function (bid) {
-      sendBidWonToGa(bid);
-    });
-  } else {
-    utils.logMessage('Prebid.js google analytics disabled by sampling');
-  }
+          if (eventObj.eventType === BID_REQUESTED) {
+            bid = args;
+            sendBidRequestToGa(bid);
+          } else if (eventObj.eventType === BID_RESPONSE) {
+            // bid is 2nd args
+            bid = args;
+            sendBidResponseToGa(bid);
+          } else if (eventObj.eventType === BID_TIMEOUT) {
+            const bidderArray = args;
+            sendBidTimeouts(bidderArray);
+          } else if (eventObj.eventType === BID_WON) {
+            bid = args;
+            sendBidWonToGa(bid);
+          }
+        });
 
-  // finally set this function to return log message, prevents multiple adapter listeners
-  this.enableAnalytics = function _enable() {
-    return utils.logMessage(`Analytics adapter already enabled, unnecessary call to \`enableAnalytics\`.`);
+        // Next register event listeners to send data immediately
+
+        // bidRequests
+        events.on(BID_REQUESTED, function (bidRequestObj) {
+          sendBidRequestToGa(bidRequestObj);
+        });
+
+        // bidResponses
+        events.on(BID_RESPONSE, function (bid) {
+          sendBidResponseToGa(bid);
+        });
+
+        // bidTimeouts
+        events.on(BID_TIMEOUT, function (bidderArray) {
+          sendBidTimeouts(bidderArray);
+        });
+
+        // wins
+        events.on(BID_WON, function (bid) {
+          sendBidWonToGa(bid);
+        });
+      } else {
+        utils.logMessage('Prebid.js google analytics disabled by sampling');
+      }
+
+      // finally set this function to return log message, prevents multiple adapter listeners
+      this.enableAnalytics = function _enable () {
+        return utils.logMessage(`Analytics adapter already enabled, unnecessary call to \`enableAnalytics\`.`);
+      };
+    },
+
+    getTrackerSend: function getTrackerSend () {
+      return _trackerSend;
+    },
   };
-};
 
-exports.getTrackerSend = function getTrackerSend() {
-  return _trackerSend;
-};
+  /**
+   * Check if gaGlobal or window.ga is defined on page. If defined execute all the GA commands
+   */
+  function checkAnalytics() {
+    if (_enableCheck && typeof window[_gaGlobal] === 'function') {
+      for (var i = 0; i < _analyticsQueue.length; i++) {
+        _analyticsQueue[i].call();
+      }
 
-/**
- * Check if gaGlobal or window.ga is defined on page. If defined execute all the GA commands
- */
-function checkAnalytics() {
-  if (_enableCheck && typeof window[_gaGlobal] === 'function') {
-    for (var i = 0; i < _analyticsQueue.length; i++) {
-      _analyticsQueue[i].call();
+      // override push to execute the command immediately from now on
+      _analyticsQueue.push = function (fn) {
+        fn.call();
+      };
+
+      // turn check into NOOP
+      _enableCheck = false;
     }
 
-    // override push to execute the command immediately from now on
-    _analyticsQueue.push = function (fn) {
-      fn.call();
-    };
-
-    // turn check into NOOP
-    _enableCheck = false;
+    utils.logMessage('event count sent to GA: ' + _eventCount);
   }
 
-  utils.logMessage('event count sent to GA: ' + _eventCount);
-}
+  function convertToCents(dollars) {
+    if (dollars) {
+      return Math.floor(dollars * 100);
+    }
 
-function convertToCents(dollars) {
-  if (dollars) {
-    return Math.floor(dollars * 100);
+    return 0;
   }
 
-  return 0;
-}
+  function getLoadTimeDistribution(time) {
+    var distribution;
+    if (time >= 0 && time < 200) {
+      distribution = '0-200ms';
+    } else if (time >= 200 && time < 300) {
+      distribution = '0200-300ms';
+    } else if (time >= 300 && time < 400) {
+      distribution = '0300-400ms';
+    } else if (time >= 400 && time < 500) {
+      distribution = '0400-500ms';
+    } else if (time >= 500 && time < 600) {
+      distribution = '0500-600ms';
+    } else if (time >= 600 && time < 800) {
+      distribution = '0600-800ms';
+    } else if (time >= 800 && time < 1000) {
+      distribution = '0800-1000ms';
+    } else if (time >= 1000 && time < 1200) {
+      distribution = '1000-1200ms';
+    } else if (time >= 1200 && time < 1500) {
+      distribution = '1200-1500ms';
+    } else if (time >= 1500 && time < 2000) {
+      distribution = '1500-2000ms';
+    } else if (time >= 2000) {
+      distribution = '2000ms above';
+    }
 
-function getLoadTimeDistribution(time) {
-  var distribution;
-  if (time >= 0 && time < 200) {
-    distribution = '0-200ms';
-  } else if (time >= 200 && time < 300) {
-    distribution = '0200-300ms';
-  } else if (time >= 300 && time < 400) {
-    distribution = '0300-400ms';
-  } else if (time >= 400 && time < 500) {
-    distribution = '0400-500ms';
-  } else if (time >= 500 && time < 600) {
-    distribution = '0500-600ms';
-  } else if (time >= 600 && time < 800) {
-    distribution = '0600-800ms';
-  } else if (time >= 800 && time < 1000) {
-    distribution = '0800-1000ms';
-  } else if (time >= 1000 && time < 1200) {
-    distribution = '1000-1200ms';
-  } else if (time >= 1200 && time < 1500) {
-    distribution = '1200-1500ms';
-  } else if (time >= 1500 && time < 2000) {
-    distribution = '1500-2000ms';
-  } else if (time >= 2000) {
-    distribution = '2000ms above';
+    return distribution;
   }
 
-  return distribution;
-}
+  function getCpmDistribution(cpm) {
+    var distribution;
+    if (cpm >= 0 && cpm < 0.5) {
+      distribution = '$0-0.5';
+    } else if (cpm >= 0.5 && cpm < 1) {
+      distribution = '$0.5-1';
+    } else if (cpm >= 1 && cpm < 1.5) {
+      distribution = '$1-1.5';
+    } else if (cpm >= 1.5 && cpm < 2) {
+      distribution = '$1.5-2';
+    } else if (cpm >= 2 && cpm < 2.5) {
+      distribution = '$2-2.5';
+    } else if (cpm >= 2.5 && cpm < 3) {
+      distribution = '$2.5-3';
+    } else if (cpm >= 3 && cpm < 4) {
+      distribution = '$3-4';
+    } else if (cpm >= 4 && cpm < 6) {
+      distribution = '$4-6';
+    } else if (cpm >= 6 && cpm < 8) {
+      distribution = '$6-8';
+    } else if (cpm >= 8) {
+      distribution = '$8 above';
+    }
 
-function getCpmDistribution(cpm) {
-  var distribution;
-  if (cpm >= 0 && cpm < 0.5) {
-    distribution = '$0-0.5';
-  } else if (cpm >= 0.5 && cpm < 1) {
-    distribution = '$0.5-1';
-  } else if (cpm >= 1 && cpm < 1.5) {
-    distribution = '$1-1.5';
-  } else if (cpm >= 1.5 && cpm < 2) {
-    distribution = '$1.5-2';
-  } else if (cpm >= 2 && cpm < 2.5) {
-    distribution = '$2-2.5';
-  } else if (cpm >= 2.5 && cpm < 3) {
-    distribution = '$2.5-3';
-  } else if (cpm >= 3 && cpm < 4) {
-    distribution = '$3-4';
-  } else if (cpm >= 4 && cpm < 6) {
-    distribution = '$4-6';
-  } else if (cpm >= 6 && cpm < 8) {
-    distribution = '$6-8';
-  } else if (cpm >= 8) {
-    distribution = '$8 above';
+    return distribution;
   }
 
-  return distribution;
-}
-
-function sendBidRequestToGa(bid) {
-  if (bid && bid.bidderCode) {
-    _analyticsQueue.push(function () {
-      _eventCount++;
-      window[_gaGlobal](_trackerSend, 'event', _category, 'Requests', bid.bidderCode, 1, _disableInteraction);
-    });
-  }
-
-  // check the queue
-  checkAnalytics();
-}
-
-function sendBidResponseToGa(bid) {
-  if (bid && bid.bidderCode) {
-    _analyticsQueue.push(function () {
-      var cpmCents = convertToCents(bid.cpm);
-      var bidder = bid.bidderCode;
-      if (typeof bid.timeToRespond !== 'undefined' && _enableDistribution) {
+  function sendBidRequestToGa(bid) {
+    if (bid && bid.bidderCode) {
+      _analyticsQueue.push(function () {
         _eventCount++;
-        var dis = getLoadTimeDistribution(bid.timeToRespond);
-        window[_gaGlobal](_trackerSend, 'event', 'Prebid.js Load Time Distribution', dis, bidder, 1, _disableInteraction);
-      }
+        window[_gaGlobal](_trackerSend, 'event', _category, 'Requests', bid.bidderCode, 1, _disableInteraction);
+      });
+    }
 
-      if (bid.cpm > 0) {
-        _eventCount = _eventCount + 2;
-        var cpmDis = getCpmDistribution(bid.cpm);
-        if (_enableDistribution) {
+    // check the queue
+    checkAnalytics();
+  }
+
+  function sendBidResponseToGa(bid) {
+    if (bid && bid.bidderCode) {
+      _analyticsQueue.push(function () {
+        var cpmCents = convertToCents(bid.cpm);
+        var bidder = bid.bidderCode;
+        if (typeof bid.timeToRespond !== 'undefined' && _enableDistribution) {
           _eventCount++;
-          window[_gaGlobal](_trackerSend, 'event', 'Prebid.js CPM Distribution', cpmDis, bidder, 1, _disableInteraction);
+          var dis = getLoadTimeDistribution(bid.timeToRespond);
+          window[_gaGlobal](_trackerSend, 'event', 'Prebid.js Load Time Distribution', dis, bidder, 1, _disableInteraction);
         }
 
-        window[_gaGlobal](_trackerSend, 'event', _category, 'Bids', bidder, cpmCents, _disableInteraction);
-        window[_gaGlobal](_trackerSend, 'event', _category, 'Bid Load Time', bidder, bid.timeToRespond, _disableInteraction);
-      }
-    });
+        if (bid.cpm > 0) {
+          _eventCount = _eventCount + 2;
+          var cpmDis = getCpmDistribution(bid.cpm);
+          if (_enableDistribution) {
+            _eventCount++;
+            window[_gaGlobal](_trackerSend, 'event', 'Prebid.js CPM Distribution', cpmDis, bidder, 1, _disableInteraction);
+          }
+
+          window[_gaGlobal](_trackerSend, 'event', _category, 'Bids', bidder, cpmCents, _disableInteraction);
+          window[_gaGlobal](_trackerSend, 'event', _category, 'Bid Load Time', bidder, bid.timeToRespond, _disableInteraction);
+        }
+      });
+    }
+
+    // check the queue
+    checkAnalytics();
   }
 
-  // check the queue
-  checkAnalytics();
-}
-
-function sendBidTimeouts(timedOutBidders) {
-  _analyticsQueue.push(function () {
-    utils._each(timedOutBidders, function (bidderCode) {
-      _eventCount++;
-      window[_gaGlobal](_trackerSend, 'event', _category, 'Timeouts', bidderCode, _disableInteraction);
+  function sendBidTimeouts(timedOutBidders) {
+    _analyticsQueue.push(function () {
+      utils._each(timedOutBidders, function (bidderCode) {
+        _eventCount++;
+        window[_gaGlobal](_trackerSend, 'event', _category, 'Timeouts', bidderCode, _disableInteraction);
+      });
     });
-  });
 
-  checkAnalytics();
+    checkAnalytics();
+  }
+
+  function sendBidWonToGa(bid) {
+    var cpmCents = convertToCents(bid.cpm);
+    _analyticsQueue.push(function () {
+      _eventCount++;
+      window[_gaGlobal](_trackerSend, 'event', _category, 'Wins', bid.bidderCode, cpmCents, _disableInteraction);
+    });
+
+    checkAnalytics();
+  }
 }
 
-function sendBidWonToGa(bid) {
-  var cpmCents = convertToCents(bid.cpm);
-  _analyticsQueue.push(function () {
-    _eventCount++;
-    window[_gaGlobal](_trackerSend, 'event', _category, 'Wins', bid.bidderCode, cpmCents, _disableInteraction);
-  });
-
-  checkAnalytics();
-}
-
-adaptermanager.registerAnalyticsAdapter({
-  adapter: exports,
+analyticsRegistry.registerInjectableAnalyticsAdapter({
+  adapter: googleAnalyticsFactory,
   code: 'ga'
 });

--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -257,7 +257,7 @@ export default function googleAnalyticsFactory(analyticsAdapterDependencies) {
   }
 }
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   adapter: googleAnalyticsFactory,
   code: 'ga'
 });

--- a/modules/pubwiseAnalyticsAdapter.js
+++ b/modules/pubwiseAnalyticsAdapter.js
@@ -1,6 +1,6 @@
 import {ajax} from 'src/ajax';
 import adapter from 'src/AnalyticsAdapter';
-import adaptermanager from 'src/adaptermanager';
+import { analyticsRegistry } from 'src/analyticsAdapterRegistry';
 const utils = require('src/utils');
 
 /****
@@ -14,40 +14,42 @@ let target_site = 'unknown';
 let target_url = 'https://staging.api.pubwise.io';
 let pw_version = '2.1.3';
 
-let pubwiseAnalytics = Object.assign(adapter(
+const baseAdapterFactory = adapter(
   {
     target_url,
     analyticsType
   }
-),
-{
-  // Override AnalyticsAdapter functions by supplying custom methods
-  track({eventType, args}) {
-    /*
-       The args object is not always available, in addition neither is the config object
-       it is available on the first call and we can setup our config. Potential additional
-       PR for later, but this solves this for now.
-       */
-    if (args !== undefined && args.config !== undefined && args.config.site !== undefined && args.config.endpoint !== undefined) {
-      target_site = args.config.site;
-      target_url = args.config.endpoint;
-    }
-    utils.logInfo('Sending PubWise Analytics Event ' + eventType, args);
-    ajax(target_url,
-      (result) => utils.logInfo('PubWise Analytics Result', result), JSON.stringify({
-        eventType,
-        args,
-        target_site,
-        pw_version
-      })
-    );
-  }
-});
+);
 
-adaptermanager.registerAnalyticsAdapter({
-  adapter: pubwiseAnalytics,
+export default function adapterFactory(adapterDependencies) {
+  const adapter = baseAdapterFactory(adapterDependencies);
+  return Object.assign(adapter, {
+    // Override AnalyticsAdapter functions by supplying custom methods
+    track({eventType, args}) {
+      /*
+         The args object is not always available, in addition neither is the config object
+         it is available on the first call and we can setup our config. Potential additional
+         PR for later, but this solves this for now.
+         */
+      if (args !== undefined && args.config !== undefined && args.config.site !== undefined && args.config.endpoint !== undefined) {
+        target_site = args.config.site;
+        target_url = args.config.endpoint;
+      }
+      utils.logInfo('Sending PubWise Analytics Event ' + eventType, args);
+      ajax(target_url,
+        (result) => utils.logInfo('PubWise Analytics Result', result), JSON.stringify({
+          eventType,
+          args,
+          target_site,
+          pw_version
+        })
+      );
+    }
+  });
+}
+
+
+analyticsRegistry.registerInjectableAnalyticsAdapter({
+  factory: adapterFactory,
   code: 'pubwise'
 });
-
-export default pubwiseAnalytics;
-

--- a/modules/pubwiseAnalyticsAdapter.js
+++ b/modules/pubwiseAnalyticsAdapter.js
@@ -49,7 +49,7 @@ export default function adapterFactory(adapterDependencies) {
 }
 
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   factory: adapterFactory,
   code: 'pubwise'
 });

--- a/modules/pulsepointAnalyticsAdapter.js
+++ b/modules/pulsepointAnalyticsAdapter.js
@@ -11,7 +11,7 @@ var pulsepointAdapterFactory = adapter({
   analyticsType: 'bundle'
 });
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   factory: pulsepointAdapterFactory,
   code: 'pulsepoint'
 });

--- a/modules/pulsepointAnalyticsAdapter.js
+++ b/modules/pulsepointAnalyticsAdapter.js
@@ -3,17 +3,15 @@
  */
 
 import adapter from 'src/AnalyticsAdapter';
-import adaptermanager from 'src/adaptermanager';
+import { analyticsRegistry } from 'src/analyticsAdapterRegistry';
 
-var pulsepointAdapter = adapter({
+var pulsepointAdapterFactory = adapter({
   global: 'PulsePointPrebidAnalytics',
   handler: 'on',
   analyticsType: 'bundle'
 });
 
-adaptermanager.registerAnalyticsAdapter({
-  adapter: pulsepointAdapter,
+analyticsRegistry.registerInjectableAnalyticsAdapter({
+  factory: pulsepointAdapterFactory,
   code: 'pulsepoint'
 });
-
-export default pulsepointAdapter;

--- a/modules/roxotAnalyticsAdapter.js
+++ b/modules/roxotAnalyticsAdapter.js
@@ -102,7 +102,7 @@ const adapterFactory = function(analyticsAdapterDependencies) {
   return roxotAdapter;
 }
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   factory: adapterFactory,
   code: 'roxot'
 });

--- a/modules/sharethroughAnalyticsAdapter.js
+++ b/modules/sharethroughAnalyticsAdapter.js
@@ -1,5 +1,5 @@
 import adapter from 'src/AnalyticsAdapter';
-import adaptermanager from 'src/adaptermanager';
+import { analyticsRegistry } from 'src/analyticsAdapterRegistry';
 const utils = require('src/utils');
 
 const emptyUrl = '';
@@ -7,65 +7,68 @@ const analyticsType = 'endpoint';
 const STR_BIDDER_CODE = 'sharethrough';
 const STR_VERSION = '0.1.0';
 
-var sharethroughAdapter = Object.assign(adapter(
+const baseAdapterFactory = adapter(
   {
     emptyUrl,
     analyticsType
   }
-),
-{
-  STR_BEACON_HOST: document.location.protocol + '//b.sharethrough.com/butler?',
-  placementCodeSet: {},
+);
 
-  track({ eventType, args }) {
-    if (eventType === 'bidRequested' && args.bidderCode === 'sharethrough') {
-      var bids = args.bids;
-      var keys = Object.keys(bids);
-      for (var i = 0; i < keys.length; i++) {
-        this.placementCodeSet[bids[keys[i]].placementCode] = args.bids[keys[i]];
+function sharethroughAdapterFactory(analyticsAdapterDependencies) {
+  return Object.assign(baseAdapterFactory(analyticsAdapterDependencies), {
+    STR_BEACON_HOST: document.location.protocol + '//b.sharethrough.com/butler?',
+    placementCodeSet: {},
+
+    track({ eventType, args }) {
+      if (eventType === 'bidRequested' && args.bidderCode === 'sharethrough') {
+        var bids = args.bids;
+        var keys = Object.keys(bids);
+        for (var i = 0; i < keys.length; i++) {
+          this.placementCodeSet[bids[keys[i]].placementCode] = args.bids[keys[i]];
+        }
       }
+
+      if (eventType === 'bidWon') {
+        this.bidWon(args);
+      }
+    },
+
+    bidWon(args) {
+      const curBidderCode = args.bidderCode;
+
+      if (curBidderCode !== STR_BIDDER_CODE && (args.adUnitCode in this.placementCodeSet)) {
+        let strBid = this.placementCodeSet[args.adUnitCode];
+        this.fireLoseBeacon(curBidderCode, args.cpm, strBid.adserverRequestId, 'headerBidLose');
+      }
+    },
+
+    fireLoseBeacon(winningBidderCode, winningCPM, arid, type) {
+      let loseBeaconUrl = this.STR_BEACON_HOST;
+      loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'winnerBidderCode', winningBidderCode);
+      loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'winnerCpm', winningCPM);
+      loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'arid', arid);
+      loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'type', type);
+      loseBeaconUrl = this.appendEnvFields(loseBeaconUrl);
+
+      this.fireBeacon(loseBeaconUrl);
+    },
+    appendEnvFields(url) {
+      url = utils.tryAppendQueryString(url, 'hbVersion', '$prebid.version$');
+      url = utils.tryAppendQueryString(url, 'strVersion', STR_VERSION);
+      url = utils.tryAppendQueryString(url, 'hbSource', 'prebid');
+
+      return url;
+    },
+    fireBeacon(theUrl) {
+      const img = new Image();
+      img.src = theUrl;
     }
+  });
+}
 
-    if (eventType === 'bidWon') {
-      this.bidWon(args);
-    }
-  },
-
-  bidWon(args) {
-    const curBidderCode = args.bidderCode;
-
-    if (curBidderCode !== STR_BIDDER_CODE && (args.adUnitCode in this.placementCodeSet)) {
-      let strBid = this.placementCodeSet[args.adUnitCode];
-      this.fireLoseBeacon(curBidderCode, args.cpm, strBid.adserverRequestId, 'headerBidLose');
-    }
-  },
-
-  fireLoseBeacon(winningBidderCode, winningCPM, arid, type) {
-    let loseBeaconUrl = this.STR_BEACON_HOST;
-    loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'winnerBidderCode', winningBidderCode);
-    loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'winnerCpm', winningCPM);
-    loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'arid', arid);
-    loseBeaconUrl = utils.tryAppendQueryString(loseBeaconUrl, 'type', type);
-    loseBeaconUrl = this.appendEnvFields(loseBeaconUrl);
-
-    this.fireBeacon(loseBeaconUrl);
-  },
-  appendEnvFields(url) {
-    url = utils.tryAppendQueryString(url, 'hbVersion', '$prebid.version$');
-    url = utils.tryAppendQueryString(url, 'strVersion', STR_VERSION);
-    url = utils.tryAppendQueryString(url, 'hbSource', 'prebid');
-
-    return url;
-  },
-  fireBeacon(theUrl) {
-    const img = new Image();
-    img.src = theUrl;
-  }
-});
-
-adaptermanager.registerAnalyticsAdapter({
-  adapter: sharethroughAdapter,
+analyticsRegistry.registerInjectableAnalyticsAdapter({
+  factory: sharethroughAdapterFactory,
   code: 'sharethrough'
 });
 
-export default sharethroughAdapter;
+export default sharethroughAdapterFactory;

--- a/modules/sharethroughAnalyticsAdapter.js
+++ b/modules/sharethroughAnalyticsAdapter.js
@@ -66,7 +66,7 @@ function sharethroughAdapterFactory(analyticsAdapterDependencies) {
   });
 }
 
-analyticsRegistry.registerInjectableAnalyticsAdapter({
+analyticsRegistry.registerAnalyticsAdapterFactory({
   factory: sharethroughAdapterFactory,
   code: 'sharethrough'
 });

--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -2,7 +2,6 @@ import CONSTANTS from './constants';
 import { loadScript } from './adloader';
 import { ajax } from './ajax';
 
-const events = require('./events');
 const utils = require('./utils');
 
 const AUCTION_INIT = CONSTANTS.EVENTS.AUCTION_INIT;
@@ -21,132 +20,135 @@ var _timedOutBidders = [];
 var _sampled = true;
 
 export default function AnalyticsAdapter({ url, analyticsType, global, handler }) {
-  var _queue = [];
-  var _eventCount = 0;
-  var _enableCheck = true;
-  var _handlers;
+  return function(adapterDependencies) {
+    const events = adapterDependencies.events;
+    var _queue = [];
+    var _eventCount = 0;
+    var _enableCheck = true;
+    var _handlers;
 
-  if (analyticsType === LIBRARY) {
-    loadScript(url, _emptyQueue);
-  }
-
-  if (analyticsType === ENDPOINT || BUNDLE) {
-    _emptyQueue();
-  }
-
-  return {
-    track: _track,
-    enqueue: _enqueue,
-    enableAnalytics: _enable,
-    disableAnalytics: _disable,
-    getAdapterType: () => analyticsType,
-    getGlobal: () => global,
-    getHandler: () => handler,
-    getUrl: () => url
-  };
-
-  function _track({ eventType, args }) {
-    if (this.getAdapterType() === LIBRARY || BUNDLE) {
-      window[global](handler, eventType, args);
+    if (analyticsType === LIBRARY) {
+      loadScript(url, _emptyQueue);
     }
 
-    if (this.getAdapterType() === ENDPOINT) {
-      _callEndpoint(...arguments);
-    }
-  }
-
-  function _callEndpoint({ eventType, args, callback }) {
-    ajax(url, callback, JSON.stringify({ eventType, args }));
-  }
-
-  function _enqueue({ eventType, args }) {
-    const _this = this;
-
-    if (global && window[global] && eventType && args) {
-      this.track({ eventType, args });
-    } else {
-      _queue.push(function () {
-        _eventCount++;
-        _this.track({ eventType, args });
-      });
-    }
-  }
-
-  function _enable(config) {
-    var _this = this;
-
-    if (typeof config === 'object' && typeof config.options === 'object') {
-      _sampled = typeof config.options.sampling === 'undefined' || Math.random() < parseFloat(config.options.sampling);
-    } else {
-      _sampled = true;
+    if (analyticsType === ENDPOINT || BUNDLE) {
+      _emptyQueue();
     }
 
-
-    if (_sampled) {
-      // first send all events fired before enableAnalytics called
-      events.getEvents().forEach(event => {
-        if (!event) {
-          return;
-        }
-
-        const { eventType, args } = event;
-
-        if (eventType === BID_TIMEOUT) {
-          _timedOutBidders = args.bidderCode;
-        } else {
-          _enqueue.call(_this, { eventType, args });
-        }
-      });
-
-      // Next register event listeners to send data immediately
-
-      _handlers = {
-        [BID_REQUESTED]: args => this.enqueue({ eventType: BID_REQUESTED, args }),
-        [BID_RESPONSE]: args => this.enqueue({ eventType: BID_RESPONSE, args }),
-        [BID_TIMEOUT]: args => this.enqueue({ eventType: BID_TIMEOUT, args }),
-        [BID_WON]: args => this.enqueue({ eventType: BID_WON, args }),
-        [BID_ADJUSTMENT]: args => this.enqueue({ eventType: BID_ADJUSTMENT, args }),
-        [AUCTION_END]: args => this.enqueue({ eventType: AUCTION_END, args }),
-        [AUCTION_INIT]: args => {
-          args.config = config.options; // enableAnaltyics configuration object
-          this.enqueue({ eventType: AUCTION_INIT, args });
-        }
-      };
-
-      utils._each(_handlers, (handler, event) => {
-        events.on(event, handler);
-      });
-    } else {
-      utils.logMessage(`Analytics adapter for "${global}" disabled by sampling`);
-    }
-
-
-    // finally set this function to return log message, prevents multiple adapter listeners
-    this.enableAnalytics = function _enable() {
-      return utils.logMessage(`Analytics adapter for "${global}" already enabled, unnecessary call to \`enableAnalytics\`.`);
+    return {
+      track: _track,
+      enqueue: _enqueue,
+      enableAnalytics: _enable,
+      disableAnalytics: _disable,
+      getAdapterType: () => analyticsType,
+      getGlobal: () => global,
+      getHandler: () => handler,
+      getUrl: () => url
     };
-  }
 
-  function _disable() {
-    utils._each(_handlers, (handler, event) => {
-      events.off(event, handler);
-    });
-  }
-
-  function _emptyQueue() {
-    if (_enableCheck) {
-      for (var i = 0; i < _queue.length; i++) {
-        _queue[i]();
+    function _track({ eventType, args }) {
+      if (this.getAdapterType() === LIBRARY || BUNDLE) {
+        window[global](handler, eventType, args);
       }
 
-      // override push to execute the command immediately from now on
-      _queue.push = function (fn) {
-        fn();
-      };
-
-      _enableCheck = false;
+      if (this.getAdapterType() === ENDPOINT) {
+        _callEndpoint(...arguments);
+      }
     }
 
-    utils.logMessage(`event count sent to ${global}: ${_eventCount}`);
+    function _callEndpoint({ eventType, args, callback }) {
+      ajax(url, callback, JSON.stringify({ eventType, args }));
+    }
+
+    function _enqueue({ eventType, args }) {
+      const _this = this;
+
+      if (global && window[global] && eventType && args) {
+        this.track({ eventType, args });
+      } else {
+        _queue.push(function () {
+          _eventCount++;
+          _this.track({ eventType, args });
+        });
+      }
+    }
+
+    function _enable(config) {
+      var _this = this;
+
+      if (typeof config === 'object' && typeof config.options === 'object') {
+        _sampled = typeof config.options.sampling === 'undefined' || Math.random() < parseFloat(config.options.sampling);
+      } else {
+        _sampled = true;
+      }
+
+
+      if (_sampled) {
+        // first send all events fired before enableAnalytics called
+        events.getEvents().forEach(event => {
+          if (!event) {
+            return;
+          }
+
+          const { eventType, args } = event;
+
+          if (eventType === BID_TIMEOUT) {
+            _timedOutBidders = args.bidderCode;
+          } else {
+            _enqueue.call(_this, { eventType, args });
+          }
+        });
+
+        // Next register event listeners to send data immediately
+
+        _handlers = {
+          [BID_REQUESTED]: args => this.enqueue({ eventType: BID_REQUESTED, args }),
+          [BID_RESPONSE]: args => this.enqueue({ eventType: BID_RESPONSE, args }),
+          [BID_TIMEOUT]: args => this.enqueue({ eventType: BID_TIMEOUT, args }),
+          [BID_WON]: args => this.enqueue({ eventType: BID_WON, args }),
+          [BID_ADJUSTMENT]: args => this.enqueue({ eventType: BID_ADJUSTMENT, args }),
+          [AUCTION_END]: args => this.enqueue({ eventType: AUCTION_END, args }),
+          [AUCTION_INIT]: args => {
+            args.config = config.options; // enableAnaltyics configuration object
+            this.enqueue({ eventType: AUCTION_INIT, args });
+          }
+        };
+
+        utils._each(_handlers, (handler, event) => {
+          events.on(event, handler);
+        });
+      } else {
+        utils.logMessage(`Analytics adapter for "${global}" disabled by sampling`);
+      }
+
+
+      // finally set this function to return log message, prevents multiple adapter listeners
+      this.enableAnalytics = function _enable() {
+        return utils.logMessage(`Analytics adapter for "${global}" already enabled, unnecessary call to \`enableAnalytics\`.`);
+      };
+    }
+
+    function _disable() {
+      utils._each(_handlers, (handler, event) => {
+        events.off(event, handler);
+      });
+    }
+
+    function _emptyQueue() {
+      if (_enableCheck) {
+        for (var i = 0; i < _queue.length; i++) {
+          _queue[i]();
+        }
+
+        // override push to execute the command immediately from now on
+        _queue.push = function (fn) {
+          fn();
+        };
+
+        _enableCheck = false;
+      }
+
+      utils.logMessage(`event count sent to ${global}: ${_eventCount}`);
+    }
   }
 }

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,5 +1,6 @@
 /** @module adaptermanger */
 
+import { events } from 'src/events';
 import { flatten, getBidderCodes, shuffle } from './utils';
 import { mapSizes } from './sizeMapping';
 import { processNativeAdUnitParams, nativeAdapters } from './native';
@@ -7,7 +8,6 @@ import { analyticsRegistry } from './analyticsAdapterRegistry'
 
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
-var events = require('./events');
 
 var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;

--- a/src/analyticsAdapterRegistry.js
+++ b/src/analyticsAdapterRegistry.js
@@ -1,0 +1,57 @@
+import { logError, logMessage } from './utils';
+
+// This module serves to manage analytics adapters which are present in the build.
+// Each Analytics Adapter module should register itself here, by importing the global
+// `analyticsRegistry` and calling `registerInjectableAnalyticsAdapter`.
+//
+// See modules/appnexusAnalyticsAdapter.js for an example.
+
+// newAnalyticsRegistry exists so that we can make side-effect-free unit tests.
+export function newAnalyticsRegistry() {
+  const _analyticsRegistry = {};
+
+  function registerAnalyticsAdapter({adapter, code}) {
+    registerInjectableAnalyticsAdapter({
+      factory: function() { return adapter },
+      code: code
+    });
+  }
+
+  function registerInjectableAnalyticsAdapter({factory, code}) {
+    if (factory && code) {
+      _analyticsRegistry[code] = factory;
+    } else {
+      logError('Prebid Error: analyticsAdapterFactory or analyticsCode not specified');
+    }
+  }
+
+  function newAnalyticsAdapter(code, dependencies = {}) {
+    if (_analyticsRegistry[code]) {
+      const analyticsAdapter = _analyticsRegistry[code](dependencies)
+      if (typeof analyticsAdapter.enableAnalytics === 'function') {
+        analyticsAdapter.code = code;
+        return analyticsAdapter;
+      } else {
+        logError(`Analytics adaptor for "${code}" must implement an enableAnalytics() function`);
+      }
+    } else {
+      logError(`Missing analytics adapter for "${code}". No bids will be fetched.`);
+    }
+
+    // In case of errors, return a "no-op" object so that the rest of the code works sensibly.
+    // TODO: Make sure this actually handles the full API.
+    return {
+      code: code,
+      enableAnalytics: function() { }
+    }
+  }
+
+  return {
+    registerAnalyticsAdapter: registerAnalyticsAdapter,
+    registerInjectableAnalyticsAdapter: registerInjectableAnalyticsAdapter,
+    newAnalyticsAdapter: newAnalyticsAdapter,
+  };
+}
+
+// Global instance should be used throughout the prod code.
+export const analyticsRegistry = newAnalyticsRegistry();

--- a/src/analyticsAdapterRegistry.js
+++ b/src/analyticsAdapterRegistry.js
@@ -1,4 +1,4 @@
-import { logError, logMessage } from './utils';
+import { logError } from './utils';
 
 // This module serves to manage analytics adapters which are present in the build.
 // Each Analytics Adapter module should register itself here, by importing the global

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -3,11 +3,12 @@ import {getPriceBucketString} from './cpmBucketManager';
 import {NATIVE_KEYS, nativeBidIsValid} from './native';
 import { store } from './videoCache';
 import { Renderer } from 'src/Renderer';
+import { events } from 'src/events';
+
 
 var CONSTANTS = require('./constants.json');
 var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 var utils = require('./utils.js');
-var events = require('./events');
 
 var objectType_function = 'function';
 

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -5,7 +5,6 @@ import { store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { events } from 'src/events';
 
-
 var CONSTANTS = require('./constants.json');
 var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 var utils = require('./utils.js');

--- a/src/events.js
+++ b/src/events.js
@@ -1,25 +1,25 @@
 /**
  * events.js
  */
-var utils = require('./utils');
-var CONSTANTS = require('./constants');
-var slice = Array.prototype.slice;
-var push = Array.prototype.push;
+const utils = require('./utils');
+const CONSTANTS = require('./constants');
+const slice = Array.prototype.slice;
+const push = Array.prototype.push;
 
 // define entire events
 // var allEvents = ['bidRequested','bidResponse','bidWon','bidTimeout'];
-var allEvents = utils._map(CONSTANTS.EVENTS, function (v) {
+const allEvents = utils._map(CONSTANTS.EVENTS, function (v) {
   return v;
 });
 
-var idPaths = CONSTANTS.EVENT_ID_PATHS;
+const idPaths = CONSTANTS.EVENT_ID_PATHS;
 
-// keep a record of all events fired
-var eventsFired = [];
+export function newEvents() {
+  const _handlers = {};
+  const _public = {};
 
-module.exports = (function () {
-  var _handlers = {};
-  var _public = {};
+  // keep a record of all events fired
+  const eventsFired = [];
 
   /**
    *
@@ -30,15 +30,15 @@ module.exports = (function () {
   function _dispatch(eventString, args) {
     utils.logMessage('Emitting event for: ' + eventString);
 
-    var eventPayload = args[0] || {};
-    var idPath = idPaths[eventString];
-    var key = eventPayload[idPath];
-    var event = _handlers[eventString] || { que: [] };
-    var eventKeys = utils._map(event, function (v, k) {
+    const eventPayload = args[0] || {};
+    const idPath = idPaths[eventString];
+    const key = eventPayload[idPath];
+    const event = _handlers[eventString] || { que: [] };
+    const eventKeys = utils._map(event, function (v, k) {
       return k;
     });
 
-    var callbacks = [];
+    const callbacks = [];
 
     // record the event:
     eventsFired.push({
@@ -78,7 +78,7 @@ module.exports = (function () {
   _public.on = function (eventString, handler, id) {
     // check whether available event or not
     if (_checkAvailableEvent(eventString)) {
-      var event = _handlers[eventString] || { que: [] };
+      const event = _handlers[eventString] || { que: [] };
 
       if (id) {
         event[id] = event[id] || { que: [] };
@@ -94,12 +94,12 @@ module.exports = (function () {
   };
 
   _public.emit = function (event) {
-    var args = slice.call(arguments, 1);
+    const args = slice.call(arguments, 1);
     _dispatch(event, args);
   };
 
   _public.off = function (eventString, handler, id) {
-    var event = _handlers[eventString];
+    const event = _handlers[eventString];
 
     if (utils.isEmpty(event) || utils.isEmpty(event.que) && utils.isEmpty(event[id])) {
       return;
@@ -111,14 +111,14 @@ module.exports = (function () {
 
     if (id) {
       utils._each(event[id].que, function (_handler) {
-        var que = event[id].que;
+        const que = event[id].que;
         if (_handler === handler) {
           que.splice(utils.indexOf.call(que, _handler), 1);
         }
       });
     } else {
       utils._each(event.que, function (_handler) {
-        var que = event.que;
+        const que = event.que;
         if (_handler === handler) {
           que.splice(utils.indexOf.call(que, _handler), 1);
         }
@@ -137,9 +137,9 @@ module.exports = (function () {
    * @return {Array} array of events fired
    */
   _public.getEvents = function () {
-    var arrayCopy = [];
+    const arrayCopy = [];
     utils._each(eventsFired, function (value) {
-      var newProp = Object.assign({}, value);
+      const newProp = Object.assign({}, value);
       arrayCopy.push(newProp);
     });
 
@@ -147,4 +147,6 @@ module.exports = (function () {
   };
 
   return _public;
-}());
+}
+
+export const events = newEvents();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -12,6 +12,7 @@ import { listenMessagesFromCreative } from './secureCreatives';
 import { syncCookies } from './cookie';
 import { loadScript } from './adloader';
 import { setAjaxTimeout } from './ajax';
+import { events } from 'src/events';
 
 
 var $$PREBID_GLOBAL$$ = getGlobal();
@@ -20,7 +21,6 @@ var utils = require('./utils.js');
 var bidmanager = require('./bidmanager.js');
 var adaptermanager = require('./adaptermanager');
 var bidfactory = require('./bidfactory');
-var events = require('./events');
 var adserver = require('./adserver.js');
 var targeting = require('./targeting.js');
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -540,7 +540,10 @@ $$PREBID_GLOBAL$$.registerBidAdapter = function (bidderAdaptor, bidderCode) {
 $$PREBID_GLOBAL$$.registerAnalyticsAdapter = function (options) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.registerAnalyticsAdapter', arguments);
   try {
-    analyticsRegistry.registerAnalyticsAdapter(options);
+    analyticsRegistry.registerAnalyticsAdapterFactory({
+      factory: function() { return options.adapter; },
+      code: options.code,
+    });
   }
   catch (e) {
     utils.logError('Error registering analytics adapter : ' + e.message);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,6 +1,7 @@
 /** @module $$PREBID_GLOBAL$$ */
 
 import { getGlobal } from './prebidGlobal';
+import { analyticsRegistry } from './analyticsAdapterRegistry'
 import { flatten, uniques, isGptPubadsDefined, adUnitsFilter } from './utils';
 import { videoAdUnit, hasNonVideoBidder } from './video';
 import { nativeAdUnit, nativeBidder, hasNonNativeBidder } from './native';
@@ -533,13 +534,13 @@ $$PREBID_GLOBAL$$.registerBidAdapter = function (bidderAdaptor, bidderCode) {
 };
 
 /**
- * Wrapper to register analyticsAdapter externally (adaptermanager.registerAnalyticsAdapter())
+ * Wrapper to register analyticsAdapter externally (adapterregistry.registerAnalyticsAdapter())
  * @param  {[type]} options [description]
  */
 $$PREBID_GLOBAL$$.registerAnalyticsAdapter = function (options) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.registerAnalyticsAdapter', arguments);
   try {
-    adaptermanager.registerAnalyticsAdapter(options);
+    analyticsRegistry.registerAnalyticsAdapter(options);
   }
   catch (e) {
     utils.logError('Error registering analytics adapter : ' + e.message);
@@ -597,7 +598,9 @@ $$PREBID_GLOBAL$$.loadScript = function (tagSrc, callback, useCache) {
 $$PREBID_GLOBAL$$.enableAnalytics = function (config) {
   if (config && !utils.isEmpty(config)) {
     utils.logInfo('Invoking $$PREBID_GLOBAL$$.enableAnalytics for: ', config);
-    adaptermanager.enableAnalytics(config);
+    adaptermanager.enableAnalytics(config, {
+      events: events
+    });
   } else {
     utils.logError('$$PREBID_GLOBAL$$.enableAnalytics should be called with option {}');
   }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -3,7 +3,7 @@
    access to a publisher page from creative payloads.
  */
 
-import events from './events';
+import { events } from 'src/events';
 import { fireNativeImpressions } from './native';
 import { EVENTS } from './constants';
 

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -24,7 +24,10 @@ FEATURE: Analytics Adapters API
     describe(`WHEN an event occurs that is to be tracked\n`, () => {
       const eventType = BID_REQUESTED;
       const args = { some: 'data' };
-      const adapter = new AnalyticsAdapter(config);
+      const adapterFactory = new AnalyticsAdapter(config);
+      const adapter = adapterFactory({
+        events: events,
+      });
       var spyTestGlobal = sinon.spy(window, config.global);
 
       adapter.track({ eventType, args });
@@ -39,8 +42,10 @@ FEATURE: Analytics Adapters API
     describe(`WHEN an event occurs before tracking library is available\n`, () => {
       const eventType = BID_RESPONSE;
       const args = { wat: 'wot' };
-      const adapter = new AnalyticsAdapter(config);
-
+      const adapterFactory = new AnalyticsAdapter(config);
+      const adapter = adapterFactory({
+        events: events,
+      });
       window[config.global] = null;
       events.emit(BID_RESPONSE, args);
 
@@ -66,7 +71,10 @@ FEATURE: Analytics Adapters API
         adapter;
 
       beforeEach(() => {
-        adapter = new AnalyticsAdapter(config);
+        const adapterFactory = new AnalyticsAdapter(config);
+        adapter = adapterFactory({
+          events: events,
+        });
         spyTestGlobal = sinon.spy(window, config.global);
 
         sinon.stub(events, 'getEvents', () => []); // these tests shouldn't be affected by previous tests

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import events from 'src/events';
+import { newEvents } from 'src/events';
 import CONSTANTS from 'src/constants.json';
 
 const BID_REQUESTED = CONSTANTS.EVENTS.BID_REQUESTED;
@@ -22,6 +22,7 @@ FEATURE: Analytics Adapters API
     GIVEN a global object \`window['testGlobal']\`
     AND an  \`example\` instance of \`AnalyticsAdapter\`\n`, () => {
     describe(`WHEN an event occurs that is to be tracked\n`, () => {
+      const events = newEvents();
       const eventType = BID_REQUESTED;
       const args = { some: 'data' };
       const adapterFactory = new AnalyticsAdapter(config);
@@ -43,6 +44,7 @@ FEATURE: Analytics Adapters API
       const eventType = BID_RESPONSE;
       const args = { wat: 'wot' };
       const adapterFactory = new AnalyticsAdapter(config);
+      const events = newEvents();
       const adapter = adapterFactory({
         events: events,
       });
@@ -68,9 +70,11 @@ FEATURE: Analytics Adapters API
 
     describe(`WHEN an event occurs after enable analytics\n`, () => {
       var spyTestGlobal,
-        adapter;
+        adapter,
+        events;
 
       beforeEach(() => {
+        events = newEvents();
         const adapterFactory = new AnalyticsAdapter(config);
         adapter = adapterFactory({
           events: events,

--- a/test/spec/modules/appnexusAnalyticsAdapter_spec.js
+++ b/test/spec/modules/appnexusAnalyticsAdapter_spec.js
@@ -1,6 +1,11 @@
-import appnexusAnalytics from 'modules/appnexusAnalyticsAdapter';
+import appnexusAnalyticsFactory from 'modules/appnexusAnalyticsAdapter';
+import events from 'src/events'
 import { assert } from 'chai';
 import { getBidRequestedPayload } from 'test/fixtures/fixtures';
+
+const appnexusAnalytics = appnexusAnalyticsFactory({
+  events: events,
+});
 
 const spyEnqueue = sinon.spy(appnexusAnalytics, 'enqueue');
 const spyTrack = sinon.spy(appnexusAnalytics, 'track');

--- a/test/spec/modules/appnexusAnalyticsAdapter_spec.js
+++ b/test/spec/modules/appnexusAnalyticsAdapter_spec.js
@@ -1,10 +1,10 @@
 import appnexusAnalyticsFactory from 'modules/appnexusAnalyticsAdapter';
-import events from 'src/events'
+import { newEvents } from 'src/events'
 import { assert } from 'chai';
 import { getBidRequestedPayload } from 'test/fixtures/fixtures';
 
 const appnexusAnalytics = appnexusAnalyticsFactory({
-  events: events,
+  events: newEvents(),
 });
 
 const spyEnqueue = sinon.spy(appnexusAnalytics, 'enqueue');

--- a/test/spec/modules/googleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/googleAnalyticsAdapter_spec.js
@@ -1,4 +1,4 @@
-import events from 'src/events';
+import { newEvents } from 'src/events';
 import gaFactory from 'modules/googleAnalyticsAdapter';
 
 var assert = require('assert');
@@ -7,7 +7,7 @@ describe('Ga', function () {
   describe('enableAnalytics', function () {
     it('should accept a tracker name option and output prefixed send string', function () {
       const ga = gaFactory({
-        events: events,
+        events: newEvents(),
       });
       var config = { options: { trackerName: 'foo' } };
       ga.enableAnalytics(config);

--- a/test/spec/modules/googleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/googleAnalyticsAdapter_spec.js
@@ -1,9 +1,14 @@
+import events from 'src/events';
+import gaFactory from 'modules/googleAnalyticsAdapter';
+
 var assert = require('assert');
-var ga = require('modules/googleAnalyticsAdapter');
 
 describe('Ga', function () {
   describe('enableAnalytics', function () {
     it('should accept a tracker name option and output prefixed send string', function () {
+      const ga = gaFactory({
+        events: events,
+      });
       var config = { options: { trackerName: 'foo' } };
       ga.enableAnalytics(config);
 

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -1,19 +1,17 @@
-import pubwiseAnalytics from 'modules/pubwiseAnalyticsAdapter';
+import pubwiseAnalyticsFactory from 'modules/pubwiseAnalyticsAdapter';
 let events = require('src/events');
-let adaptermanager = require('src/adaptermanager');
 let constants = require('src/constants.json');
 
 describe('PubWise Prebid Analytics', function () {
+  const pubwiseAnalytics = pubwiseAnalyticsFactory({
+    events: events,
+  });
+
   describe('enableAnalytics', function () {
     it('should catch all events', function () {
       sinon.spy(pubwiseAnalytics, 'track');
 
-      adaptermanager.registerAnalyticsAdapter({
-        code: 'pubwiseanalytics',
-        adapter: pubwiseAnalytics
-      });
-
-      adaptermanager.enableAnalytics({
+      pubwiseAnalytics.enableAnalytics({
         provider: 'pubwiseanalytics',
         options: {
           site: ['test-test-test-test']

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -1,14 +1,14 @@
 import pubwiseAnalyticsFactory from 'modules/pubwiseAnalyticsAdapter';
-let events = require('src/events');
+import { newEvents } from 'src/events';
 let constants = require('src/constants.json');
 
 describe('PubWise Prebid Analytics', function () {
-  const pubwiseAnalytics = pubwiseAnalyticsFactory({
-    events: events,
-  });
-
   describe('enableAnalytics', function () {
     it('should catch all events', function () {
+      const events = newEvents();
+      const pubwiseAnalytics = pubwiseAnalyticsFactory({
+        events: events,
+      });
       sinon.spy(pubwiseAnalytics, 'track');
 
       pubwiseAnalytics.enableAnalytics({

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -1,19 +1,16 @@
-import roxotAnalytic from 'modules/roxotAnalyticsAdapter';
+import roxotAnalyticFactory from 'modules/roxotAnalyticsAdapter';
 let events = require('src/events');
-let adaptermanager = require('src/adaptermanager');
 let constants = require('src/constants.json');
 
 describe('Roxot Prebid Analytic', function () {
   describe('enableAnalytics', function () {
     it('should catch all events', function () {
+      const roxotAnalytic = roxotAnalyticFactory({
+        events: events,
+      });
       sinon.spy(roxotAnalytic, 'track');
 
-      adaptermanager.registerAnalyticsAdapter({
-        code: 'roxot',
-        adapter: roxotAnalytic
-      });
-
-      adaptermanager.enableAnalytics({
+      roxotAnalytic.enableAnalytics({
         provider: 'roxot',
         options: {
           publisherIds: ['test_roxot_prebid_analytid_publisher_id']

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -1,10 +1,12 @@
 import roxotAnalyticFactory from 'modules/roxotAnalyticsAdapter';
-let events = require('src/events');
+import { newEvents } from 'src/events';
+
 let constants = require('src/constants.json');
 
 describe('Roxot Prebid Analytic', function () {
   describe('enableAnalytics', function () {
     it('should catch all events', function () {
+      const events = newEvents();
       const roxotAnalytic = roxotAnalyticFactory({
         events: events,
       });

--- a/test/spec/modules/sharethroughAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sharethroughAnalyticsAdapter_spec.js
@@ -1,7 +1,11 @@
-import sharethroughAnalytics from 'modules/sharethroughAnalyticsAdapter';
+import sharethroughAnalyticsFactory from 'modules/sharethroughAnalyticsAdapter';
+import events from 'src/events'
 import { expect } from 'chai';
 
 describe('sharethrough analytics adapter', () => {
+  const sharethroughAnalytics = sharethroughAnalyticsFactory({
+    events: events
+  });
   let sandbox;
 
   beforeEach(() => {

--- a/test/spec/modules/sharethroughAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sharethroughAnalyticsAdapter_spec.js
@@ -1,15 +1,16 @@
 import sharethroughAnalyticsFactory from 'modules/sharethroughAnalyticsAdapter';
-import events from 'src/events'
+import { newEvents } from 'src/events'
 import { expect } from 'chai';
 
 describe('sharethrough analytics adapter', () => {
-  const sharethroughAnalytics = sharethroughAnalyticsFactory({
-    events: events
-  });
+  let sharethroughAnalytics;
   let sandbox;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    sharethroughAnalytics = sharethroughAnalyticsFactory({
+      events: newEvents()
+    });
   });
 
   afterEach(() => {

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import constants from 'src/constants';
-import events from 'src/events';
+import { events } from 'src/events';
 
 import * as bidManager from 'src/bidmanager';
 import useVideoCacheStubs from 'test/mocks/videoCacheStub';

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -7,6 +7,7 @@ import {
   getTargetingKeysBidLandscape,
   getAdUnits
 } from 'test/fixtures/fixtures';
+import { events } from 'src/events';
 
 var assert = require('chai').assert;
 var expect = require('chai').expect;
@@ -19,7 +20,6 @@ var bidmanager = require('src/bidmanager');
 var bidfactory = require('src/bidfactory');
 var adloader = require('src/adloader');
 var adaptermanager = require('src/adaptermanager');
-var events = require('src/events');
 var adserver = require('src/adserver');
 var CONSTANTS = require('src/constants.json');
 


### PR DESCRIPTION
## Type of change
Refactoring (no functional changes, no api changes)

## Description of change
This is refactor is designed to show three things in a proof-of-concept:

1. How a prebid-core utility with global state can be structured for global or local use without repeating lots of code.
2. How modules can be structured to be agnostic about whether the state is global or local.
3. How today's prebid-core can support this structure without API changes.
4. How we can make local versions of the utilities to get side-effect-free unit tests.
5. That we don't have to redesign the entire Prebid architecture.

For (1), see `events.js`.
For (2), see any of the AnalyticsAdapters.
For (3), see `analyticsAdapterRegistry`.
For (4), see any of the AnalyticsAdapter unit tests.

## Still TODO
If you think this structure is an improvement, I will add unit tests for `events` and the `analyticsAdapterRegistry`. Didn't want to spend the time if something was wrong with the core idea, though.