### PR TITLE
preserve constructor for aliasing adapters by returning `this`

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -113,10 +113,10 @@ const AardvarkAdapter = function() {
     return requestBids(bidderCode, callbackName, params.bids || []);
   };
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new AardvarkAdapter(), 'aardvark');

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -295,11 +295,11 @@ const AdKernelAdapter = function AdKernelAdapter() {
     }
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     getBidderCode: baseAdapter.getBidderCode
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new AdKernelAdapter(), 'adkernel', {

--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -188,10 +188,10 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
     bidmanager.addBidResponse(placement, bid);
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new AdyoulikeAdapter(), 'adyoulike');

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -324,7 +324,7 @@ const AolAdapter = function AolAdapter() {
     });
   }
 
-  return Object.assign(new BaseAdapter(AOL_BIDDERS_CODES.aol), {
+  return Object.assign(this, new BaseAdapter(AOL_BIDDERS_CODES.aol), {
     callBids: _callBids
   });
 };

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -367,10 +367,10 @@ function AppnexusAstAdapter() {
     return bid;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new AppnexusAstAdapter(), 'appnexusAst', {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -214,11 +214,11 @@ AppNexusAdapter = function AppNexusAdapter() {
     }
   };
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     buildJPTCall: buildJPTCall
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new AppNexusAdapter(), 'appnexus');

--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -242,7 +242,13 @@ const callBids = bidRequest => {
  * @property {Function} setBidderCode - used for bidder aliasing
  * @property {Function} getBidderCode - unique 'audienceNetwork' identifier
  */
-const AudienceNetwork = () => ({ callBids, setBidderCode, getBidderCode });
+function AudienceNetwork() {
+  return Object.assign(this, {
+    callBids,
+    setBidderCode,
+    getBidderCode
+  });
+}
 
 adaptermanager.registerBidAdapter(new AudienceNetwork(), 'audienceNetwork', {
   supportedMediaTypes: ['video']

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -122,10 +122,10 @@ function BeachfrontAdapter() {
     return bid;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new BeachfrontAdapter(), 'beachfront', {

--- a/modules/komoonaBidAdapter.js
+++ b/modules/komoonaBidAdapter.js
@@ -106,10 +106,10 @@ function KomoonaAdapter() {
     return bid;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new KomoonaAdapter(), 'komoona');

--- a/modules/piximediaBidAdapter.js
+++ b/modules/piximediaBidAdapter.js
@@ -143,11 +143,11 @@ var PiximediaAdapter = function PiximediaAdapter() {
   };
 
   // return an object with PiximediaAdapter methods
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     getBidderCode: baseAdapter.getBidderCode
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new PiximediaAdapter(), 'piximedia');

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -212,13 +212,13 @@ function PrebidServer() {
     }
   }
 
-  return {
+  return Object.assign(this, {
     queueSync: baseAdapter.queueSync,
     setConfig: baseAdapter.setConfig,
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     type: TYPE
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new PrebidServer(), 'prebidServer');

--- a/modules/pulsepointLiteBidAdapter.js
+++ b/modules/pulsepointLiteBidAdapter.js
@@ -280,9 +280,9 @@ function PulsePointLiteAdapter() {
     return !!slot.nativeParams;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: _callBids
-  };
+  });
 }
 
 /**

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -378,7 +378,7 @@ function RubiconAdapter() {
     return (adB.cpm || 0.0) - (adA.cpm || 0.0);
   }
 
-  return Object.assign(baseAdapter, {
+  return Object.assign(this, baseAdapter, {
     callBids: _callBids
   });
 }

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -123,10 +123,10 @@ function Spotx() {
     return true;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new Spotx(), 'spotx', {

--- a/modules/stickyadstvBidAdapter.js
+++ b/modules/stickyadstvBidAdapter.js
@@ -251,7 +251,7 @@ var StickyAdsTVAdapter = function StickyAdsTVAdapter() {
     };
   };
 
-  return Object.assign(new Adapter(STICKYADS_BIDDERCODE), {
+  return Object.assign(this, new Adapter(STICKYADS_BIDDERCODE), {
     callBids: _callBids,
     formatBidObject: formatBidObject,
     formatAdHTML: formatAdHTML,

--- a/modules/trionBidAdapter.js
+++ b/modules/trionBidAdapter.js
@@ -118,11 +118,11 @@ function TrionAdapter() {
     bidmanager.addBidResponse(placementCode, bid);
   };
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     buildTrionUrl: buildTrionUrl
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new TrionAdapter(), 'trion');

--- a/modules/twengaBidAdapter.js
+++ b/modules/twengaBidAdapter.js
@@ -124,11 +124,11 @@ function TwengaAdapter() {
     }
   };
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     buildBidCall: buildBidCall
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new TwengaAdapter(), 'twenga');

--- a/modules/vertamediaBidAdapter.js
+++ b/modules/vertamediaBidAdapter.js
@@ -106,10 +106,10 @@ function VertamediaAdapter() {
     return bid;
   }
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode
-  };
+  });
 }
 
 adaptermanager.registerBidAdapter(new VertamediaAdapter(), 'vertamedia', {

--- a/modules/xhbBidAdapter.js
+++ b/modules/xhbBidAdapter.js
@@ -154,11 +154,11 @@ const XhbAdapter = function XhbAdapter() {
     }
   };
 
-  return {
+  return Object.assign(this, {
     callBids: baseAdapter.callBids,
     setBidderCode: baseAdapter.setBidderCode,
     buildJPTCall: buildJPTCall
-  };
+  });
 };
 
 adaptermanager.registerBidAdapter(new XhbAdapter(), 'xhb');

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -28,7 +28,7 @@ const expectToContain = (haystack, needle, n = 1) =>
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
-    const adapter = AudienceNetwork();
+    const adapter = new AudienceNetwork();
     it('getBidderCode', () => {
       expect(adapter.getBidderCode).to.be.a('function');
       expect(adapter.getBidderCode()).to.equal(bidderCode);
@@ -71,7 +71,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify no attempt to fetch response
       expect(requests).to.have.lengthOf(0);
       // Verify no attempt to add a response as no placement was provided
@@ -91,7 +91,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify no attempt to fetch response
       expect(requests).to.have.lengthOf(0);
       // Verify attempt to log error
@@ -109,7 +109,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify attempt to fetch response
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('GET');
@@ -136,7 +136,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify attempt to fetch response
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('GET');
@@ -163,7 +163,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify attempt to fetch response
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('GET');
@@ -189,7 +189,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify attempt to fetch response
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('GET');
@@ -215,7 +215,7 @@ describe('AudienceNetwork adapter', () => {
         }]
       };
       // Request bids
-      AudienceNetwork().callBids(params);
+      new AudienceNetwork().callBids(params);
       // Verify attempt to fetch response
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('GET');
@@ -253,7 +253,7 @@ describe('AudienceNetwork adapter', () => {
         errors: [error]
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -287,7 +287,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -339,7 +339,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -383,7 +383,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -439,7 +439,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -499,7 +499,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,
@@ -562,7 +562,7 @@ describe('AudienceNetwork adapter', () => {
         }
       }));
       // Request bids
-      AudienceNetwork().callBids({
+      new AudienceNetwork().callBids({
         bidderCode,
         bids: [{
           bidder: bidderCode,

--- a/test/spec/modules/piximediaBidAdapter_spec.js
+++ b/test/spec/modules/piximediaBidAdapter_spec.js
@@ -4,7 +4,7 @@ describe('Piximedia adapter tests', function () {
 
   // var querystringify = require('querystringify');
 
-  var adapter = require('modules/piximediaBidAdapter');
+  var Adapter = require('modules/piximediaBidAdapter');
   var adLoader = require('src/adloader');
   var bidmanager = require('src/bidmanager');
   var utils = require('src/utils');
@@ -47,7 +47,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       sinon.assert.calledOnce(stubLoadScript);
     });
 
@@ -67,7 +67,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       sinon.assert.notCalled(stubLoadScript);
     });
 
@@ -87,7 +87,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       var bidUrl = stubLoadScript.getCall(0).args[0];
 
       sinon.assert.calledWith(stubLoadScript, bidUrl);
@@ -115,7 +115,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       var bidUrl = stubLoadScript.getCall(0).args[0];
 
       sinon.assert.calledWith(stubLoadScript, bidUrl);
@@ -143,7 +143,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       var bidUrl = stubLoadScript.getCall(0).args[0];
 
       sinon.assert.calledWith(stubLoadScript, bidUrl);
@@ -171,7 +171,7 @@ describe('Piximedia adapter tests', function () {
         ]
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
       var bidUrl = stubLoadScript.getCall(0).args[0];
 
       sinon.assert.calledWith(stubLoadScript, bidUrl);
@@ -228,7 +228,7 @@ describe('Piximedia adapter tests', function () {
         html: '<div>ad</div>'
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
 
       var adUnits = [];
       var unit = {};
@@ -278,7 +278,7 @@ describe('Piximedia adapter tests', function () {
         html: '<div>ad</div>'
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
 
       var adUnits = [];
       var unit = {};
@@ -321,7 +321,7 @@ describe('Piximedia adapter tests', function () {
         foundbypm: false
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
 
       var adUnits = [];
       var unit = {};
@@ -360,7 +360,7 @@ describe('Piximedia adapter tests', function () {
         foundbypm: false
       };
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
 
       var adUnits = [];
       var unit = {};
@@ -390,7 +390,7 @@ describe('Piximedia adapter tests', function () {
 
       var response = null; // this is bogus: we expect an object
 
-      adapter().callBids(params);
+      new Adapter().callBids(params);
 
       var adUnits = [];
       var unit = {};


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The `.constructor` reference is incorrect for constructor functions that return a new object (rather than `this`).  This can be fixed by making sure the reference to the original object created by `new` is returned.

## Other information
Adapters that require bidder aliasing should make sure the correct `.constructor` is set on new instances of their adapter.  Fixes #1455