### PR TITLE
Carambola header bidding adaptor - changing the server url.

### DIFF
--- a/modules/carambolaBidAdapter.js
+++ b/modules/carambolaBidAdapter.js
@@ -89,7 +89,7 @@ function CarambolaAdapter() {
         }
       }
 
-      let server = bid.params.server || 'route.carambo.la';
+      let server = bid.params.server || 'hb.route.carambo.la';
       let cbolaHbApiUrl = '//' + server + '/' + REQUEST_PATH;
 
       //  the responses of the bid requests


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
The Server has a new url to point to. this is simply a new CName which points to the same location.

## Other information
