### PR TITLE
Carambola header bidding adaptor (fix)- changing the server url.

### DIFF
--- a/modules/carambolaBidAdapter.js
+++ b/modules/carambolaBidAdapter.js
@@ -89,7 +89,7 @@ function CarambolaAdapter() {
         }
       }
 
-      let server = bid.params.server || 'hb.route.carambo.la';
+      let server = bid.params.server || 'hb.carambo.la';
       let cbolaHbApiUrl = '//' + server + '/' + REQUEST_PATH;
 
       //  the responses of the bid requests

--- a/test/spec/modules/carambolaBidAdapter_spec.js
+++ b/test/spec/modules/carambolaBidAdapter_spec.js
@@ -74,9 +74,9 @@ describe('carambolaAdapter', function () {
         expect(requests[0]).to.be.empty;
       });
 
-      it('should hit the default route.carambo.la endpoint', () => {
+      it('should hit the default hb.carambo.la endpoint', () => {
         adapter.callBids(DEFAULT_BIDDER_REQUEST);
-        expect(requests[0].url).to.contain('route.carambo.la');
+        expect(requests[0].url).to.contain('hb.carambo.la');
       });
 
       it('should verifiy that a page_view_id is sent', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Carambola header bidding adaptor - changing the server url (2).

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] liran@carambo.la

