### PR TITLE
[Criteo Adapter] Use utils lib to parse request sizes

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -43,15 +43,18 @@ var CriteoAdapter = function CriteoAdapter() {
       // build slots before sending one multi-slots bid request
       for (var i = 0; i < bids.length; i++) {
         var bid = bids[i];
-        var sizes = bid.sizes || [];
+        var sizes = utils.parseSizesInput(bid.sizes);
         slots.push(
           new Criteo.PubTag.DirectBidding.DirectBiddingSlot(
             bid.placementCode,
             bid.params.zoneId,
             bid.params.nativeCallback ? bid.params.nativeCallback : undefined,
             bid.transactionId,
-            sizes.map((size) => {
-              return { width: size[0], height: size[1] }
+            sizes.map((sizeString) => {
+              var xIndex = sizeString.indexOf('x');
+              var w = parseInt(sizeString.substring(0, xIndex));
+              var h = parseInt(sizeString.substring(xIndex + 1, sizeString.length))
+              return new Criteo.PubTag.DirectBidding.Size(w, h);
             }
             )
           )

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -30,7 +30,9 @@ before(() => {
               ajax('//bidder.criteo.com/cdb', callbacks)
             }
           }
-        }
+        },
+
+        Size: function Size(width, height) { return {width: width, height: height} }
       }
     }
   };


### PR DESCRIPTION
## Type of change
- [x ] Bugfix


## Description of change
This PR formats the request sizes in Criteo adapter. As those sizes are not formatted, we need to format them before using them in a consistent manner.

- contact email of the adapter’s maintainer: i.caroulle@criteo.com, h.duthil@criteo.com, n.faure@criteo.com