### PR TITLE
wrap setConfig for bidderTimeout in pbjs.que block

### DIFF
--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -24,7 +24,6 @@
     setTimeout(initAdserver, PREBID_TIMEOUT);
 
     var pbjs = pbjs || {};
-    pbjs.setConfig({ bidderTimeout: 3000 });
     pbjs.que = pbjs.que || [];
     (function() {
         var pbjsEl = document.createElement("script");
@@ -50,6 +49,7 @@
           }];
 
         pbjs.setConfig({
+          bidderTimeout: 3000,
           s2sConfig : {
             accountId : '1',
             enabled : true, //default value set to false


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Minor edit to example page to put setConfig for bidderTimeout inside the pbjs.que.
