### PR TITLE
have async getConfig callback get same data as sync getConfig

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -168,7 +168,7 @@ export function newConfig() {
     listeners
       .filter(listener => TOPICS.includes(listener.topic))
       .forEach(listener => {
-        listener.callback({ [listener.topic]: options[listener.topic] });
+        listener.callback(options[listener.topic]);
       });
 
     // call subscribers that didn't give a topic, passing everything that was set

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -88,7 +88,7 @@ describe('config API', () => {
     setConfig({ logging: true, foo: 'bar' });
 
     sinon.assert.calledOnce(listener);
-    sinon.assert.calledWithExactly(listener, { logging: true });
+    sinon.assert.calledWithExactly(listener, true);
   });
 
   it('topic subscribers are only called when that topic is changed', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
I don't know if it's a bug, more of a refactor, but it is slightly changing the config API (that no one is using yet).  

Right now if you do `setConfig({thing: 'value'})`, if you do a sync grab with `getConfig('thing')` you'll get `'value'` but if you subscribe with a callback using `getConfig('thing', cb)` that callback will receive `{thing: 'value'}` as the data.  The listener string being passed as a key in an object doesn't really gain us anything (as the callback should already know what thing its listening to) but it makes the API inconsistent between sync and async versions.

This is just a fix to make them consistent in the data the receive.