### PR TITLE
Fix a bug with url encoded parameters in url.parse

### DIFF
--- a/modules/atomxBidAdapter.js
+++ b/modules/atomxBidAdapter.js
@@ -32,7 +32,7 @@ var AtomxAdapter = function AtomxAdapter() {
             id: bid.params.id,
             size: sizes[j],
             prebid: bid.placementCode
-          }, {method: 'GET'});
+          }, {method: 'GET', noDecodeWholeURL: true});
         }
       } else {
         var bidObject = bidfactory.createBid(CONSTANTS.STATUS.NO_BID, bid);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -76,7 +76,7 @@ export function ajax(url, callback, data, options = {}) {
     }
 
     if (method === 'GET' && data) {
-      let urlInfo = parseURL(url);
+      let urlInfo = parseURL(url, options);
       Object.assign(urlInfo.search, data);
       url = formatURL(urlInfo);
     }

--- a/src/url.js
+++ b/src/url.js
@@ -24,9 +24,13 @@ export function formatQS(query) {
     .join('&');
 }
 
-export function parse(url) {
+export function parse(url, options) {
   let parsed = document.createElement('a');
-  parsed.href = decodeURIComponent(url);
+  if (options && 'noDecodeWholeURL' in options && options.noDecodeWholeURL) {
+    parsed.href = url;
+  } else {
+    parsed.href = decodeURIComponent(url);
+  }
   return {
     protocol: (parsed.protocol || '').replace(/:$/, ''),
     hostname: parsed.hostname,

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -6,7 +6,7 @@ describe('helpers.url', () => {
     let parsed;
 
     beforeEach(() => {
-      parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar#hash');
+      parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash');
     });
 
     it('extracts the protocol', () => {
@@ -28,8 +28,9 @@ describe('helpers.url', () => {
     it('extracts the search query', () => {
       expect(parsed).to.have.property('search');
       expect(parsed.search).to.eql({
-        foo: 'bar',
-        search: 'test'
+        foo: 'xxx',
+        search: 'test',
+        bar: 'foo',
       });
     });
 
@@ -42,6 +43,23 @@ describe('helpers.url', () => {
     });
   });
 
+  describe('parse(url, {noDecodeWholeURL: true})', () => {
+    let parsed;
+
+    beforeEach(() => {
+      parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash', {noDecodeWholeURL: true});
+    });
+
+    it('extracts the search query', () => {
+      expect(parsed).to.have.property('search');
+      expect(parsed.search).to.eql({
+        foo: 'bar',
+        search: 'test',
+        bar: 'foo%26foo%3Dxxx',
+      });
+    });
+  });
+
   describe('format()', () => {
     it('formats an object in to a URL', () => {
       expect(format({
@@ -49,9 +67,9 @@ describe('helpers.url', () => {
         hostname: 'example.com',
         port: 3000,
         pathname: '/pathname/',
-        search: {foo: 'bar', search: 'test'},
+        search: {foo: 'bar', search: 'test', bar: 'foo%26foo%3Dxxx'},
         hash: 'hash'
-      })).to.equal('http://example.com:3000/pathname/?foo=bar&search=test#hash');
+      })).to.equal('http://example.com:3000/pathname/?foo=bar&search=test&bar=foo%26foo%3Dxxx#hash');
     });
 
     it('will use defaults for missing properties', () => {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
When you pass an url with url encoded parameters to `Ajax.ajax` but also pass extra parameters in the data argument, such as the [atomx adapter does](https://github.com/prebid/Prebid.js/blob/6956a56383d9f530c961640c4421d5f44f087c6d/modules/atomxBidAdapter.js#L31-L35), it will break the url.

`Ajax.ajax` will parse the url and format it again: https://github.com/prebid/Prebid.js/blob/6956a56383d9f530c961640c4421d5f44f087c6d/src/ajax.js#L78-L82
But `url.parse` decodes the whole url without `url.format` encoding it again: https://github.com/prebid/Prebid.js/blob/6956a56383d9f530c961640c4421d5f44f087c6d/src/url.js#L29

So `Ajax.ajax('http://example.com?foo=foo%26foo%3Dxxx', null, {ignore: 123})` will load the url `http://example.com?foo=foo&foo=xxx&ignore=123` instead of `http://example.com?foo=foo%26foo%3Dxxx&ignore=123` which is just plain wrong.

This can be fixed by not just decoding the whole url but instead decoding and encoding the separate query parameters.

This pull request right now only removes the `decodeURIComponent` in `url.parse` as that doesn't seem to break any tests. Adding `decodeURIComponent` and `encodeURIComponent` to `url.parseQS` and `url.formatQS` seems to break some tests for adapters that already depend on this broken behavior.

