### PR TITLE
Add support for video stream context

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -289,7 +289,13 @@ function bidToTag(bid) {
     }
   }
 
-  if (bid.mediaType === 'video') { tag.require_asset_url = true; }
+  const videoMediaType = utils.deepAccess(bid, 'mediaTypes.video');
+  const context = utils.deepAccess(bid, 'mediaTypes.video.context');
+
+  if (bid.mediaType === 'video' || (videoMediaType && context !== 'outstream')) {
+    tag.require_asset_url = true;
+  }
+
   if (bid.params.video) {
     tag.video = {};
     // place any valid video params on the tag

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -5,7 +5,7 @@ import { NATIVE, VIDEO } from 'src/mediaTypes';
 
 const BIDDER_CODE = 'appnexusAst';
 const URL = '//ib.adnxs.com/ut/v3/prebid';
-const SUPPORTED_AD_TYPES = ['banner', 'video', 'video-outstream', 'native'];
+const SUPPORTED_AD_TYPES = ['banner', 'video', 'native'];
 const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
@@ -218,6 +218,7 @@ function newBid(serverBid, rtbBid) {
 
   return bid;
 }
+
 function bidToTag(bid) {
   const tag = {};
   tag.sizes = transformSizes(bid.sizes);
@@ -362,9 +363,7 @@ function handleOutstreamRendererEvents(bid, id, eventName) {
 
 function parseMediaType(rtbBid) {
   const adType = rtbBid.ad_type;
-  if (rtbBid.renderer_url) {
-    return 'video-outstream';
-  } else if (adType === 'video') {
+  if (adType === 'video') {
     return 'video';
   } else if (adType === 'native') {
     return 'native';

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -106,6 +106,8 @@ function UnrulyAdapter() {
   return adapter
 }
 
-adaptermanager.registerBidAdapter(new UnrulyAdapter(), 'unruly')
+adaptermanager.registerBidAdapter(new UnrulyAdapter(), 'unruly', {
+  supportedMediaTypes: ['video']
+});
 
 module.exports = UnrulyAdapter

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -85,6 +85,11 @@ function UnrulyAdapter() {
         return
       }
 
+      const context = utils.deepAccess(bidRequestBids[0], 'mediaTypes.video.context')
+      if (context !== 'outstream') {
+        return
+      }
+
       const payload = {
         bidRequests: bidRequestBids
       }

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -85,8 +85,9 @@ function UnrulyAdapter() {
         return
       }
 
+      const videoMediaType = utils.deepAccess(bidRequestBids[0], 'mediaTypes.video')
       const context = utils.deepAccess(bidRequestBids[0], 'mediaTypes.video.context')
-      if (context !== 'outstream') {
+      if (videoMediaType && context !== 'outstream') {
         return
       }
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -48,9 +48,16 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
           });
         }
 
+        if (adUnit.mediaTypes) {
+          if (utils.mediaTypesValid(adUnit.mediaTypes)) {
+            bid = Object.assign({}, bid, { mediaTypes: adUnit.mediaTypes });
+          } else {
+            utils.logError(`mediaTypes is not correctly configured`);
+          }
+        }
+
         bid = Object.assign({}, bid, getDefinedParams(adUnit, [
           'mediaType',
-          'mediaTypes',
           'renderer'
         ]));
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -49,7 +49,7 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
         }
 
         if (adUnit.mediaTypes) {
-          if (utils.mediaTypesValid(adUnit.mediaTypes)) {
+          if (utils.isValidMediaTypes(adUnit.mediaTypes)) {
             bid = Object.assign({}, bid, { mediaTypes: adUnit.mediaTypes });
           } else {
             utils.logError(`mediaTypes is not correctly configured`);

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,6 +1,6 @@
 /** @module adaptermanger */
 
-import { flatten, getBidderCodes, shuffle } from './utils';
+import { flatten, getBidderCodes, getDefinedParams, shuffle } from './utils';
 import { mapSizes } from './sizeMapping';
 import { processNativeAdUnitParams, nativeAdapters } from './native';
 import { StorageManager, pbjsSyncsKey } from './storagemanager';
@@ -48,10 +48,14 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
           });
         }
 
+        bid = Object.assign({}, bid, getDefinedParams(adUnit, [
+          'mediaType',
+          'context',
+          'renderer'
+        ]));
+
         return Object.assign({}, bid, {
           placementCode: adUnit.code,
-          mediaType: adUnit.mediaType,
-          renderer: adUnit.renderer,
           transactionId: adUnit.transactionId,
           sizes: sizes,
           bidId: bid.bid_id || utils.getUniqueIdentifierStr(),

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -50,7 +50,7 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
 
         bid = Object.assign({}, bid, getDefinedParams(adUnit, [
           'mediaType',
-          'context',
+          'mediaTypes',
           'renderer'
         ]));
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -52,7 +52,9 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
           if (utils.isValidMediaTypes(adUnit.mediaTypes)) {
             bid = Object.assign({}, bid, { mediaTypes: adUnit.mediaTypes });
           } else {
-            utils.logError(`mediaTypes is not correctly configured`);
+            utils.logError(
+              `mediaTypes is not correctly configured for adunit ${adUnit.code}`
+            );
           }
         }
 

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,6 +1,7 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
 import { getPriceBucketString } from './cpmBucketManager';
 import { NATIVE_KEYS, nativeBidIsValid } from './native';
+import { videoBidIsValid } from './video';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { config } from 'src/config';
@@ -113,8 +114,8 @@ exports.addBidResponse = function (adUnitCode, bid) {
       utils.logError(errorMessage('Native bid missing some required properties.'));
       return false;
     }
-    if (bid.mediaType === 'video' && !(bid.vastUrl || bid.vastXml)) {
-      utils.logError(errorMessage(`Video bid has no vastUrl or vastXml property.`));
+    if (bid.mediaType === 'video' && !videoBidIsValid(bid)) {
+      utils.logError(errorMessage(`Video bid does not have required vastUrl or renderer property`));
       return false;
     }
     if (bid.mediaType === 'banner' && !validBidSize(bid)) {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,7 +1,7 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
 import { getPriceBucketString } from './cpmBucketManager';
 import { NATIVE_KEYS, nativeBidIsValid } from './native';
-import { videoBidIsValid } from './video';
+import { isValidVideoBid } from './video';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { config } from 'src/config';
@@ -114,7 +114,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
       utils.logError(errorMessage('Native bid missing some required properties.'));
       return false;
     }
-    if (bid.mediaType === 'video' && !videoBidIsValid(bid)) {
+    if (bid.mediaType === 'video' && !isValidVideoBid(bid)) {
       utils.logError(errorMessage(`Video bid does not have required vastUrl or renderer property`));
       return false;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -720,3 +720,13 @@ export function deepAccess(obj, path) {
   }
   return obj;
 }
+
+/*
+ * Build an object consisting of only defined parameters to avoid creating an
+ * object with defined keys and undefined values.
+ */
+export function getDefinedParams(object, params) {
+  return params
+    .filter(param => object[param])
+    .reduce((bid, param) => Object.assign(bid, { [param]: object[param] }), {});
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -721,12 +721,44 @@ export function deepAccess(obj, path) {
   return obj;
 }
 
-/*
+/**
  * Build an object consisting of only defined parameters to avoid creating an
  * object with defined keys and undefined values.
+ * @param {object} object The object to pick defined params out of
+ * @param {string[]} params An array of strings representing properties to look for in the object
+ * @returns {object} An object containing all the specified values that are defined
  */
 export function getDefinedParams(object, params) {
   return params
     .filter(param => object[param])
     .reduce((bid, param) => Object.assign(bid, { [param]: object[param] }), {});
+}
+
+/**
+ * @typedef {Object} MediaTypes
+ * @property {Object} banner banner configuration
+ * @property {Object} native native configuration
+ * @property {Object} video video configuration
+ */
+
+/**
+ * Validates an adunit's `mediaTypes` parameter
+ * @param{MediaTypes} mediaTypes mediaTypes parameter to validate
+ * @returns{boolean} If object is valie
+ */
+export function mediaTypesValid(mediaTypes) {
+  const SUPPORTED_MEDIA_TYPES = ['banner', 'native', 'video'];
+  const SUPPORTED_STREAM_TYPES = ['instream', 'outstream'];
+
+  const types = Object.keys(mediaTypes);
+
+  if (!types.every(type => SUPPORTED_MEDIA_TYPES.includes(type))) {
+    return false;
+  }
+
+  if (mediaTypes.video && mediaTypes.video.context) {
+    return SUPPORTED_STREAM_TYPES.includes(mediaTypes.video.context);
+  }
+
+  return true;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -743,10 +743,10 @@ export function getDefinedParams(object, params) {
 
 /**
  * Validates an adunit's `mediaTypes` parameter
- * @param{MediaTypes} mediaTypes mediaTypes parameter to validate
- * @returns{boolean} If object is valie
+ * @param {MediaTypes} mediaTypes mediaTypes parameter to validate
+ * @return {boolean} If object is valid
  */
-export function mediaTypesValid(mediaTypes) {
+export function isValidMediaTypes(mediaTypes) {
   const SUPPORTED_MEDIA_TYPES = ['banner', 'native', 'video'];
   const SUPPORTED_STREAM_TYPES = ['instream', 'outstream'];
 

--- a/src/video.js
+++ b/src/video.js
@@ -1,5 +1,5 @@
 import { videoAdapters } from './adaptermanager';
-import { getBidRequest } from './utils';
+import { getBidRequest, deepAccess } from './utils';
 
 const VIDEO_MEDIA_TYPE = 'video';
 const INSTREAM = 'instream';
@@ -10,7 +10,8 @@ const OUTSTREAM = 'outstream';
  */
 export const videoAdUnit = adUnit => adUnit.mediaType === VIDEO_MEDIA_TYPE;
 const nonVideoBidder = bid => !videoAdapters.includes(bid.bidder);
-export const hasNonVideoBidder = adUnit => adUnit.bids.filter(nonVideoBidder).length;
+export const hasNonVideoBidder = adUnit =>
+  adUnit.bids.filter(nonVideoBidder).length;
 
 /*
  * Validate that the assets required for video context are present on the bid
@@ -18,10 +19,7 @@ export const hasNonVideoBidder = adUnit => adUnit.bids.filter(nonVideoBidder).le
 export function videoBidIsValid(bid) {
   const bidRequest = getBidRequest(bid.adId);
   const context =
-    bidRequest &&
-    bidRequest.mediaTypes &&
-    bidRequest.mediaTypes.video &&
-    bidRequest.mediaTypes.video.context;
+    bidRequest && deepAccess(bidRequest, 'mediaTypes.video.context');
 
   // if context not defined assume default 'instream' for video bids
   if (!bidRequest || !context || context === INSTREAM) {

--- a/src/video.js
+++ b/src/video.js
@@ -13,10 +13,17 @@ const nonVideoBidder = bid => !videoAdapters.includes(bid.bidder);
 export const hasNonVideoBidder = adUnit =>
   adUnit.bids.filter(nonVideoBidder).length;
 
-/*
- * Validate that the assets required for video context are present on the bid
+/**
+ * @typedef {object} VideoBid
+ * @property {string} adId id of the bid
  */
-export function videoBidIsValid(bid) {
+
+/**
+ * Validate that the assets required for video context are present on the bid
+ * @param {VideoBid} bid video bid to validate
+ * @return {boolean} If object is valid
+ */
+export function isValidVideoBid(bid) {
   const bidRequest = getBidRequest(bid.adId);
   const context =
     bidRequest && deepAccess(bidRequest, 'mediaTypes.video.context');

--- a/src/video.js
+++ b/src/video.js
@@ -1,7 +1,7 @@
 import { videoAdapters } from './adaptermanager';
 import { getBidRequest } from './utils';
 
-const VIDEO_MEDIA_TYPE = 'video'
+const VIDEO_MEDIA_TYPE = 'video';
 const INSTREAM = 'instream';
 const OUTSTREAM = 'outstream';
 
@@ -17,14 +17,19 @@ export const hasNonVideoBidder = adUnit => adUnit.bids.filter(nonVideoBidder).le
  */
 export function videoBidIsValid(bid) {
   const bidRequest = getBidRequest(bid.adId);
+  const context =
+    bidRequest &&
+    bidRequest.mediaTypes &&
+    bidRequest.mediaTypes.video &&
+    bidRequest.mediaTypes.video.context;
 
   // if context not defined assume default 'instream' for video bids
-  if (!bidRequest || !bidRequest.context || bidRequest.context === INSTREAM) {
+  if (!bidRequest || !context || context === INSTREAM) {
     return !!(bid.vastUrl || bid.vastPayload);
   }
 
   // outstream bids require a renderer on the bid or pub-defined on adunit
-  if (bidRequest.context === OUTSTREAM) {
+  if (context === OUTSTREAM) {
     return !!(bid.renderer || bidRequest.renderer);
   }
 

--- a/src/video.js
+++ b/src/video.js
@@ -1,8 +1,32 @@
 import { videoAdapters } from './adaptermanager';
+import { getBidRequest } from './utils';
+
+const VIDEO_MEDIA_TYPE = 'video'
+const INSTREAM = 'instream';
+const OUTSTREAM = 'outstream';
 
 /**
  * Helper functions for working with video-enabled adUnits
  */
-export const videoAdUnit = adUnit => adUnit.mediaType === 'video';
+export const videoAdUnit = adUnit => adUnit.mediaType === VIDEO_MEDIA_TYPE;
 const nonVideoBidder = bid => !videoAdapters.includes(bid.bidder);
 export const hasNonVideoBidder = adUnit => adUnit.bids.filter(nonVideoBidder).length;
+
+/*
+ * Validate that the assets required for video context are present on the bid
+ */
+export function videoBidIsValid(bid) {
+  const bidRequest = getBidRequest(bid.adId);
+
+  // if context not defined assume default 'instream' for video bids
+  if (!bidRequest || !bidRequest.context || bidRequest.context === INSTREAM) {
+    return !!(bid.vastUrl || bid.vastPayload);
+  }
+
+  // outstream bids require a renderer on the bid or pub-defined on adunit
+  if (bidRequest.context === OUTSTREAM) {
+    return !!(bid.renderer || bidRequest.renderer);
+  }
+
+  return true;
+}

--- a/src/video.js
+++ b/src/video.js
@@ -30,7 +30,7 @@ export function isValidVideoBid(bid) {
 
   // if context not defined assume default 'instream' for video bids
   if (!bidRequest || !context || context === INSTREAM) {
-    return !!(bid.vastUrl || bid.vastPayload);
+    return !!(bid.vastUrl || bid.vastXml);
   }
 
   // outstream bids require a renderer on the bid or pub-defined on adunit

--- a/src/video.js
+++ b/src/video.js
@@ -2,7 +2,6 @@ import { videoAdapters } from './adaptermanager';
 import { getBidRequest, deepAccess } from './utils';
 
 const VIDEO_MEDIA_TYPE = 'video';
-const INSTREAM = 'instream';
 const OUTSTREAM = 'outstream';
 
 /**
@@ -25,11 +24,14 @@ export const hasNonVideoBidder = adUnit =>
  */
 export function isValidVideoBid(bid) {
   const bidRequest = getBidRequest(bid.adId);
-  const context =
-    bidRequest && deepAccess(bidRequest, 'mediaTypes.video.context');
+
+  const videoMediaType =
+    bidRequest && deepAccess(bidRequest, 'mediaTypes.video');
+  const context = videoMediaType && deepAccess(videoMediaType, 'context');
 
   // if context not defined assume default 'instream' for video bids
-  if (!bidRequest || !context || context === INSTREAM) {
+  // instream bids require a vast url or vast xml content
+  if (!bidRequest || (videoMediaType && context !== OUTSTREAM)) {
     return !!(bid.vastUrl || bid.vastXml);
   }
 

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -597,5 +597,28 @@ describe('bidmanager.js', function () {
 
       utils.getBidderRequest.restore();
     });
+
+    it('requires a renderer on outstream bids', () => {
+      sinon.stub(utils, 'getBidRequest', () => ({
+        bidder: 'appnexusAst',
+        mediaType: 'video',
+        context: 'outstream',
+      }));
+
+      const bid = Object.assign({},
+        bidfactory.createBid(1),
+        {
+          bidderCode: 'appnexusAst',
+          mediaType: 'video',
+          renderer: {render: () => true, url: 'render.js'},
+        }
+      );
+
+      const bidsRecCount = $$PREBID_GLOBAL$$._bidsReceived.length;
+      bidmanager.addBidResponse('adUnit-code', bid);
+      assert.equal(bidsRecCount + 1, $$PREBID_GLOBAL$$._bidsReceived.length);
+
+      utils.getBidRequest.restore();
+    });
   });
 });

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -601,8 +601,9 @@ describe('bidmanager.js', function () {
     it('requires a renderer on outstream bids', () => {
       sinon.stub(utils, 'getBidRequest', () => ({
         bidder: 'appnexusAst',
-        mediaType: 'video',
-        context: 'outstream',
+        mediaTypes: {
+          video: {context: 'outstream'}
+        },
       }));
 
       const bid = Object.assign({},

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -599,7 +599,7 @@ describe('bidmanager.js', function () {
     });
 
     it('requires a renderer on outstream bids', () => {
-      sinon.stub(utils, 'getBidRequest', () => ({
+      getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
         bidder: 'appnexusAst',
         mediaTypes: {
           video: {context: 'outstream'}
@@ -618,8 +618,6 @@ describe('bidmanager.js', function () {
       const bidsRecCount = $$PREBID_GLOBAL$$._bidsReceived.length;
       bidmanager.addBidResponse('adUnit-code', bid);
       assert.equal(bidsRecCount + 1, $$PREBID_GLOBAL$$._bidsReceived.length);
-
-      utils.getBidRequest.restore();
     });
   });
 });

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -599,7 +599,7 @@ describe('bidmanager.js', function () {
     });
 
     it('requires a renderer on outstream bids', () => {
-      getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
+      sinon.stub(utils, 'getBidRequest', () => ({
         bidder: 'appnexusAst',
         mediaTypes: {
           video: {context: 'outstream'}
@@ -618,6 +618,8 @@ describe('bidmanager.js', function () {
       const bidsRecCount = $$PREBID_GLOBAL$$._bidsReceived.length;
       bidmanager.addBidResponse('adUnit-code', bid);
       assert.equal(bidsRecCount + 1, $$PREBID_GLOBAL$$._bidsReceived.length);
+
+      utils.getBidRequest.restore();
     });
   });
 });

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -17,7 +17,7 @@ describe('UnrulyAdapter', () => {
         'placementId': '5768085'
       },
       'placementCode': placementCode,
-      'mediaType': 'video',
+      'mediaTypes': { video: { context: 'outstream' } },
       'transactionId': '62890707-3770-497c-a3b8-d905a2d0cb98',
       'sizes': [
         640,

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -568,4 +568,23 @@ describe('Utils', function () {
       assert.equal(value, undefined);
     });
   });
+
+  describe('getDefinedParams', () => {
+    it('builds an object consisting of defined params', () => {
+      const adUnit = {
+        mediaType: 'video',
+        comeWithMe: 'ifuwant2live',
+        notNeeded: 'do not include',
+      };
+
+      const builtObject = utils.getDefinedParams(adUnit, [
+        'mediaType', 'comeWithMe'
+      ]);
+
+      assert.deepEqual(builtObject, {
+        mediaType: 'video',
+        comeWithMe: 'ifuwant2live',
+      });
+    });
+  });
 });

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,9 +1,12 @@
+import useSandbox from 'test/mocks/sandbox';
 import { isValidVideoBid } from 'src/video';
 const utils = require('src/utils');
 
 describe('video.js', () => {
+  const getSandbox = useSandbox()
+
   it('validates valid instream bids', () => {
-    sinon.stub(utils, 'getBidRequest', () => ({
+    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'instream' },
@@ -15,12 +18,10 @@ describe('video.js', () => {
     });
 
     expect(valid).to.be(true);
-
-    utils.getBidRequest.restore();
   });
 
   it('catches invalid instream bids', () => {
-    sinon.stub(utils, 'getBidRequest', () => ({
+    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'instream' },
@@ -30,31 +31,28 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
-
-    utils.getBidRequest.restore();
   });
 
   it('validates valid outstream bids', () => {
-    sinon.stub(utils, 'getBidRequest', () => ({
+    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'outstream' },
       },
+    }));
+
+    const valid = isValidVideoBid({
       renderer: {
         url: 'render.url',
         render: () => true,
       }
-    }));
-
-    const valid = isValidVideoBid({});
+    });
 
     expect(valid).to.be(true);
-
-    utils.getBidRequest.restore();
   });
 
   it('catches invalid outstream bids', () => {
-    sinon.stub(utils, 'getBidRequest', () => ({
+    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'outstream' },
@@ -64,7 +62,5 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
-
-    utils.getBidRequest.restore();
   });
 });

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,0 +1,70 @@
+import { isValidVideoBid } from 'src/video';
+const utils = require('src/utils');
+
+describe('video.js', () => {
+  it('validates valid instream bids', () => {
+    sinon.stub(utils, 'getBidRequest', () => ({
+      bidder: 'appnexusAst',
+      mediaTypes: {
+        video: { context: 'instream' },
+      },
+    }));
+
+    const valid = isValidVideoBid({
+      vastUrl: 'http://www.example.com/vastUrl'
+    });
+
+    expect(valid).to.be(true);
+
+    utils.getBidRequest.restore();
+  });
+
+  it('catches invalid instream bids', () => {
+    sinon.stub(utils, 'getBidRequest', () => ({
+      bidder: 'appnexusAst',
+      mediaTypes: {
+        video: { context: 'instream' },
+      },
+    }));
+
+    const valid = isValidVideoBid({});
+
+    expect(valid).to.be(false);
+
+    utils.getBidRequest.restore();
+  });
+
+  it('validates valid outstream bids', () => {
+    sinon.stub(utils, 'getBidRequest', () => ({
+      bidder: 'appnexusAst',
+      mediaTypes: {
+        video: { context: 'outstream' },
+      },
+      renderer: {
+        url: 'render.url',
+        render: () => true,
+      }
+    }));
+
+    const valid = isValidVideoBid({});
+
+    expect(valid).to.be(true);
+
+    utils.getBidRequest.restore();
+  });
+
+  it('catches invalid outstream bids', () => {
+    sinon.stub(utils, 'getBidRequest', () => ({
+      bidder: 'appnexusAst',
+      mediaTypes: {
+        video: { context: 'outstream' },
+      },
+    }));
+
+    const valid = isValidVideoBid({});
+
+    expect(valid).to.be(false);
+
+    utils.getBidRequest.restore();
+  });
+});

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,12 +1,9 @@
-import useSandbox from 'test/mocks/sandbox';
 import { isValidVideoBid } from 'src/video';
 const utils = require('src/utils');
 
 describe('video.js', () => {
-  const getSandbox = useSandbox()
-
   it('validates valid instream bids', () => {
-    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
+    sinon.stub(utils, 'getBidRequest', () => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'instream' },
@@ -18,10 +15,12 @@ describe('video.js', () => {
     });
 
     expect(valid).to.be(true);
+
+    utils.getBidRequest.restore();
   });
 
   it('catches invalid instream bids', () => {
-    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
+    sinon.stub(utils, 'getBidRequest', () => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'instream' },
@@ -31,10 +30,12 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
+
+    utils.getBidRequest.restore();
   });
 
   it('validates valid outstream bids', () => {
-    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
+    sinon.stub(utils, 'getBidRequest', () => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'outstream' },
@@ -49,10 +50,12 @@ describe('video.js', () => {
     });
 
     expect(valid).to.be(true);
+
+    utils.getBidRequest.restore();
   });
 
   it('catches invalid outstream bids', () => {
-    getSandbox().stub(utils, 'getBidRequest').callsFake(() => ({
+    sinon.stub(utils, 'getBidRequest', () => ({
       bidder: 'appnexusAst',
       mediaTypes: {
         video: { context: 'outstream' },
@@ -62,5 +65,7 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
+
+    utils.getBidRequest.restore();
   });
 });

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -2,6 +2,10 @@ import { isValidVideoBid } from 'src/video';
 const utils = require('src/utils');
 
 describe('video.js', () => {
+  afterEach(() => {
+    utils.getBidRequest.restore();
+  });
+
   it('validates valid instream bids', () => {
     sinon.stub(utils, 'getBidRequest', () => ({
       bidder: 'appnexusAst',
@@ -15,8 +19,6 @@ describe('video.js', () => {
     });
 
     expect(valid).to.be(true);
-
-    utils.getBidRequest.restore();
   });
 
   it('catches invalid instream bids', () => {
@@ -30,8 +32,6 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
-
-    utils.getBidRequest.restore();
   });
 
   it('validates valid outstream bids', () => {
@@ -50,8 +50,6 @@ describe('video.js', () => {
     });
 
     expect(valid).to.be(true);
-
-    utils.getBidRequest.restore();
   });
 
   it('catches invalid outstream bids', () => {
@@ -65,7 +63,5 @@ describe('video.js', () => {
     const valid = isValidVideoBid({});
 
     expect(valid).to.be(false);
-
-    utils.getBidRequest.restore();
   });
 });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
This pull request adds support for video-enabled adapters to participate on both instream and outstream impressions by removing the `video-outstream` mediaType and introducing a new ad unit parameter `mediaTypes` that can be used to configure `video` ad units to either `instream` (default) or `outstream`. No changes are required for adapters that support the current `video` mediaType, though the `mediaTypes` parameter of an adUnit, which may contain a stream context, is now given to adapters in the `callBids` parameter, and adapters may use this to target instream and outstream impressions differently if they wish.

In the case of instream context, bid response objects must contain a `vastUrl` property (this is an existing requirement and not introduced by this PR). Outstream bid response objects must have an associated renderer, either directly on the bid or one defined on the ad unit with the `renderer` ad unit parameter.

## Example AdUnits with Video Context
```JavaScript
pbjs.addAdUnits({
  code: 'video-example',
  sizes: [640, 480],
  mediaTypes: {
    video: { context: 'instream' }
  },

  bids: [{
    bidder: 'appnexusAst',
    params: { placementId: '9333431' }
  }]
});
```

```JavaScript
pbjs.addAdUnits({
  code: 'video-example',
  sizes: [ 640, 480 ],
  mediaTypes: {
    video: { context: 'outstream' }
  },

  // appnexusAst contains a renderer so this isn't required, but if
  // present it will be used in favor of the response renderer
  renderer: {
    url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
    render: function(bid) {
      ANOutstreamVideo.renderAd({
        targetId: bid.adUnitCode,
        adResponse: bid.adResponse
      });
    }
  },

  bids: [{
    bidder: 'appnexusAst',
    params: { placementId: '5768085' }
  }]
});
```

## Other informatin
@unrulydevelopers unruly adapter is updated by this PR to check for outstream context, please feel free to review and make updates or suggestions to this change