### PR TITLE
Change pbjs to PREBID_GLOBAL

### DIFF
--- a/test/spec/modules/essensBidAdapter_spec.js
+++ b/test/spec/modules/essensBidAdapter_spec.js
@@ -259,7 +259,7 @@ describe('Essens adapter tests', function () {
     })
 
     it('Check method exist', function () {
-      expect(pbjs.essensResponseHandler).to.exist.and.to.be.a('function')
+      expect($$PREBID_GLOBAL$$.essensResponseHandler).to.exist.and.to.be.a('function')
     })
 
     it('Check invalid response', function () {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1034,7 +1034,7 @@ describe('the rubicon adapter', () => {
     let addBidResponseAction;
     let rubiconAdapter;
     const emilyUrl = 'https://tap-secure.rubiconproject.com/partner/scripts/rubicon/emily.html?rtb_ext=1';
-    let origGetConfig = window.pbjs.getConfig;
+    let origGetConfig = window.$$PREBID_GLOBAL$$.getConfig;
 
     beforeEach(() => {
       bids = [];
@@ -1098,11 +1098,11 @@ describe('the rubicon adapter', () => {
     afterEach(() => {
       server.restore();
       clock.restore();
-      window.pbjs.getConfig = origGetConfig;
+      window.$$PREBID_GLOBAL$$.getConfig = origGetConfig;
     });
 
     it('should add the Emily iframe by default', () => {
-      sinon.stub(window.pbjs, 'getConfig', (key) => {
+      sinon.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
         var config = { rubicon: {
           userSync: {delay: 10}
         }};
@@ -1123,7 +1123,7 @@ describe('the rubicon adapter', () => {
     });
 
     it('should add the Emily iframe when enabled', () => {
-      sinon.stub(window.pbjs, 'getConfig', (key) => {
+      sinon.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
         var config = { rubicon: {
           userSync: {enabled: true, delay: 20}
         }};
@@ -1144,7 +1144,7 @@ describe('the rubicon adapter', () => {
     });
 
     it('should not fire more than once', () => {
-      sinon.stub(window.pbjs, 'getConfig', (key) => {
+      sinon.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
         var config = { rubicon: {
           userSync: {enabled: true, delay: 100}
         }};
@@ -1172,7 +1172,7 @@ describe('the rubicon adapter', () => {
     });
 
     it('should not add the Emily iframe when disabled', () => {
-      sinon.stub(window.pbjs, 'getConfig', (key) => {
+      sinon.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
         var config = { rubicon: {
           userSync: {enabled: false, delay: 50}
         }};


### PR DESCRIPTION
#1462 changed several `pbjs` references to `$$PREBID_GLOBAL$$`, found a few more that were still causing the build to fail when changing `globalVarName` to something other than `pbjs`. Fixes #1437