### PR TITLE
Audience Network: ensure pageurl is always URI encoded

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -127,7 +127,7 @@ const createSuccessBidResponse = (placementId, size, format, bidId, cpmCents, pa
   bid.fb_placementid = placementId;
   // Video attributes
   if (isVideo(format)) {
-    const vast = `https://an.facebook.com/v1/instream/vast.xml?placementid=${placementId}&pageurl=${encodeURIComponent(pageurl)}&playerwidth=${bid.width}&playerheight=${bid.height}&bidid=${bidId}`;
+    const vast = `https://an.facebook.com/v1/instream/vast.xml?placementid=${placementId}&pageurl=${pageurl}&playerwidth=${bid.width}&playerheight=${bid.height}&bidid=${bidId}`;
     bid.mediaType = 'video';
     bid.vastUrl = vast;
     bid.descriptionUrl = vast;
@@ -183,7 +183,7 @@ const callBids = bidRequest => {
   if (placementids.length) {
     // Build URL
     const testmode = isTestmode();
-    const pageurl = location.href;
+    const pageurl = encodeURIComponent(location.href);
     const search = {
       placementids,
       adformats,

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -116,7 +116,8 @@ describe('AudienceNetwork adapter', () => {
       expect(requests[0].url)
         .to.contain('https://an.facebook.com/v2/placementbid.json?')
         .and.to.contain('placementids[]=test-placement-id')
-        .and.to.contain('adformats[]=300x250');
+        .and.to.contain('adformats[]=300x250')
+        .and.to.contain('pageurl=http%3A%2F%2F');
       // Verify no attempt to log error
       expect(logError.called).to.equal(false);
     });
@@ -144,7 +145,8 @@ describe('AudienceNetwork adapter', () => {
         .to.contain('https://an.facebook.com/v2/placementbid.json?')
         .and.to.contain('placementids[]=test-placement-id&placementids[]=test-placement-id')
         .and.to.contain('adformats[]=320x50')
-        .and.to.contain('adformats[]=300x250');
+        .and.to.contain('adformats[]=300x250')
+        .and.to.contain('pageurl=http%3A%2F%2F');
       // Verify no attempt to log error
       expect(logError.called).to.equal(false);
     });
@@ -170,7 +172,8 @@ describe('AudienceNetwork adapter', () => {
       expect(requests[0].url)
         .to.contain('https://an.facebook.com/v2/placementbid.json?')
         .and.to.contain('placementids[]=test-placement-id')
-        .and.to.contain('adformats[]=fullwidth');
+        .and.to.contain('adformats[]=fullwidth')
+        .and.to.contain('pageurl=http%3A%2F%2F');
       // Verify no attempt to log error
       expect(logError.called).to.equal(false);
     });
@@ -196,7 +199,8 @@ describe('AudienceNetwork adapter', () => {
       expect(requests[0].url)
         .to.contain('https://an.facebook.com/v2/placementbid.json?')
         .and.to.contain('placementids[]=test-placement-id')
-        .and.to.contain('adformats[]=native');
+        .and.to.contain('adformats[]=native')
+        .and.to.contain('pageurl=http%3A%2F%2F');
       // Verify no attempt to log error
       expect(logError.called).to.equal(false);
     });
@@ -223,7 +227,8 @@ describe('AudienceNetwork adapter', () => {
         .to.contain('https://an.facebook.com/v2/placementbid.json?')
         .and.to.contain('placementids[]=test-placement-id')
         .and.to.contain('adformats[]=video')
-        .and.to.contain('sdk[]=');
+        .and.to.contain('sdk[]=')
+        .and.to.contain('pageurl=http%3A%2F%2F');
       // Verify no attempt to log error
       expect(logError.called).to.equal(false);
     });


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Hello, this is a fix for #1497 that ensures `pageurl` is correctly URI encoded before calling Prebid's URL `format` function.

It also adds test expectations to verify this behaviour.

This work was commissioned and paid for by Facebook.
