### PR TITLE
Support 'cta' native asset

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -14,6 +14,7 @@ const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const NATIVE_MAPPING = {
   body: 'description',
+  cta: 'ctatext',
   image: {
     serverName: 'main_image',
     serverParams: { required: true, sizes: [{}] }
@@ -344,6 +345,7 @@ function AppnexusAstAdapter() {
         bid.native = {
           title: native.title,
           body: native.desc,
+          cta: native.ctatext,
           sponsoredBy: native.sponsored,
           image: native.main_img && native.main_img.url,
           icon: native.icon && native.icon.url,

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,6 +1,6 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
-import {getPriceBucketString} from './cpmBucketManager';
-import {NATIVE_KEYS, nativeBidIsValid} from './native';
+import { getPriceBucketString } from './cpmBucketManager';
+import { NATIVE_KEYS, nativeBidIsValid } from './native';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { config } from 'src/config';

--- a/src/native.js
+++ b/src/native.js
@@ -9,6 +9,7 @@ export const NATIVE_KEYS = {
   image: 'hb_native_image',
   icon: 'hb_native_icon',
   clickUrl: 'hb_native_linkurl',
+  cta: 'hb_native_cta',
 };
 
 export const NATIVE_TARGETING_KEYS = Object.keys(NATIVE_KEYS).map(

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -134,6 +134,7 @@ describe('AppNexusAdapter', () => {
       REQUEST.bids[0].nativeParams = {
         title: {required: true},
         body: {required: true},
+        cta: {required: false},
         sponsoredBy: {required: true}
       };
 
@@ -143,6 +144,7 @@ describe('AppNexusAdapter', () => {
       expect(request.tags[0].native.layouts[0]).to.deep.equal({
         title: {required: true},
         description: {required: true},
+        ctatext: {required: false},
         sponsored_by: {required: true}
       });
 
@@ -266,6 +268,7 @@ describe('AppNexusAdapter', () => {
       RESPONSE.tags[0].ads[0].rtb.native = {
         'title': 'Native Creative',
         'desc': 'Cool description great stuff',
+        'ctatext': 'Do it',
         'sponsored': 'AppNexus',
         'icon': {
           'width': 0,
@@ -295,6 +298,7 @@ describe('AppNexusAdapter', () => {
 
       expect(response.native.title).to.equal('Native Creative');
       expect(response.native.body).to.equal('Cool description great stuff');
+      expect(response.native.cta).to.equal('Do it');
       expect(response.native.image).to.equal('http://cdn.adnxs.com/img.png');
 
       RESPONSE.tags[0].ads[0].ad_type = 'banner';


### PR DESCRIPTION
Adds support for `cta` (call to action) native asset. Sets targeting for `cta` with `hb_native_cta` key