### PR TITLE
Make bid.vastUrl use the cache URL if the bid didnt already have one.

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,7 +1,7 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
 import {getPriceBucketString} from './cpmBucketManager';
 import {NATIVE_KEYS, nativeBidIsValid} from './native';
-import { store } from './videoCache';
+import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { config } from 'src/config';
 
@@ -210,6 +210,9 @@ exports.addBidResponse = function (adUnitCode, bid) {
           utils.logWarn(`Failed to save to the video cache: ${error}. Video bid must be discarded.`);
         } else {
           bid.videoCacheKey = cacheIds[0].uuid;
+          if (!bid.vastUrl) {
+            bid.vastUrl = getCacheUrl(bid.videoCacheKey);
+          }
           addBidToAuction(bid);
         }
         doCallbacksIfNeeded();

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -11,7 +11,7 @@
 
 import { ajax } from './ajax';
 
-const ENDPOINT = 'https://prebid.adnxs.com/pbc/v1/cache'
+const BASE_URL = 'https://prebid.adnxs.com/pbc/v1/cache'
 
 /**
  * @typedef {object} CacheableUrlBid
@@ -119,12 +119,12 @@ export function store(bids, done) {
     puts: bids.map(toStorageRequest)
   };
 
-  ajax(ENDPOINT, shimStorageCallback(done), JSON.stringify(requestData), {
+  ajax(BASE_URL, shimStorageCallback(done), JSON.stringify(requestData), {
     contentType: 'text/plain',
     withCredentials: true
   });
 }
 
 export function getCacheUrl(id) {
-  return `${ENDPOINT}?uuid=${id}`;
+  return `${BASE_URL}?uuid=${id}`;
 }

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -11,7 +11,7 @@
 
 import { ajax } from './ajax';
 
-const PUT_URL = 'https://prebid.adnxs.com/pbc/v1/cache'
+const ENDPOINT = 'https://prebid.adnxs.com/pbc/v1/cache'
 
 /**
  * @typedef {object} CacheableUrlBid
@@ -119,12 +119,12 @@ export function store(bids, done) {
     puts: bids.map(toStorageRequest)
   };
 
-  ajax(PUT_URL, shimStorageCallback(done), JSON.stringify(requestData), {
+  ajax(ENDPOINT, shimStorageCallback(done), JSON.stringify(requestData), {
     contentType: 'text/plain',
     withCredentials: true
   });
 }
 
 export function getCacheUrl(id) {
-  return `${PUT_URL}?uuid=${id}`;
+  return `${ENDPOINT}?uuid=${id}`;
 }

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -124,3 +124,7 @@ export function store(bids, done) {
     withCredentials: true
   });
 }
+
+export function getCacheUrl(id) {
+  return `${PUT_URL}?uuid=${id}`;
+}

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -60,6 +60,9 @@ describe('The Bid Manager', () => {
 
           if (usePayloadResponse) {
             expect(bid.vastPayload).to.equal('<VAST version="3.0"></VAST>');
+            if (usePrebidCache) {
+              expect(bid.vastUrl).to.equal(`https://prebid.adnxs.com/pbc/v1/cache?uuid=FAKE_UUID`);
+            }
           } else {
             expect(bid.vastUrl).to.equal('www.myVastUrl.com');
           }

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -1,6 +1,6 @@
 import 'mocha';
 import chai from 'chai';
-import { store } from 'src/videoCache';
+import { getCacheUrl, store } from 'src/videoCache';
 
 const should = chai.should();
 
@@ -126,3 +126,11 @@ describe('The video cache', () => {
     }
   });
 });
+
+describe('The getCache function', () => {
+  it('should return the expected URL', () => {
+    const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
+    const url = getCacheUrl(uuid);
+    url.should.equal(`https://prebid.adnxs.com/pbc/v1/cache?uuid=${uuid}`);
+  });
+})


### PR DESCRIPTION
## Type of change
Feature

## Description of change
If the pub is using prebid cache, and the bidder doesn't include their own `vastUrl` on the bid, then we can use the prebid cache one.

This just helps normalize the data in the bid that the publisher sees.