### PR TITLE
use utils.getTopWindowUrl() to get top window URL for indexexchange a…

### DIFF
--- a/modules/indexExchangeBidAdapter.js
+++ b/modules/indexExchangeBidAdapter.js
@@ -269,11 +269,24 @@ var cygnus_index_start = function () {
     this.siteID = siteID;
     this.impressions = [];
     this._parseFnName = undefined;
+
+    // Get page URL
+    this.sitePage = undefined;
+    try {
+        this.sitePage = utils.getTopWindowUrl();
+    } catch (e) {}
+    // Fallback to old logic if utils.getTopWindowUrl() fails to return site.page
+    if (typeof this.sitePage === 'undefined' || this.sitePage === "") {
+        if (top === self) {
+          this.sitePage = location.href;
+        } else {
+          this.sitePage = document.referrer;
+        }
+    }
+
     if (top === self) {
-      this.sitePage = location.href;
       this.topframe = 1;
     } else {
-      this.sitePage = document.referrer;
       this.topframe = 0;
     }
 

--- a/modules/indexExchangeBidAdapter.js
+++ b/modules/indexExchangeBidAdapter.js
@@ -273,15 +273,15 @@ var cygnus_index_start = function () {
     // Get page URL
     this.sitePage = undefined;
     try {
-        this.sitePage = utils.getTopWindowUrl();
+      this.sitePage = utils.getTopWindowUrl();
     } catch (e) {}
     // Fallback to old logic if utils.getTopWindowUrl() fails to return site.page
-    if (typeof this.sitePage === 'undefined' || this.sitePage === "") {
-        if (top === self) {
-          this.sitePage = location.href;
-        } else {
-          this.sitePage = document.referrer;
-        }
+    if (typeof this.sitePage === 'undefined' || this.sitePage === '') {
+      if (top === self) {
+        this.sitePage = location.href;
+      } else {
+        this.sitePage = document.referrer;
+      }
     }
 
     if (top === self) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- indexexchange adapter now uses the Prebid provided utility function (utils.getTopWindowUrl) to get top window URL

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
No test cases are updated/added because this is a refactoring pull request. No functional changes