### PR TITLE
Match port when testing legacy browser

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1571,11 +1571,15 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should return original adservertag if there are no bids for the given placement code', () => {
-      var options = {
+      // urls.js:parse returns port 443 for IE11, blank for other browsers
+      const ie11port = !!window.MSInputMethodContext && !!document.documentMode ? ':443' : '';
+      const adserverTag = `https://pubads.g.doubleclick.net${ie11port}/gampad/ads?sz=640x480&iu=/19968336/header-bid-tag-0&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com`;
+
+      const masterTagUrl = $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag(adserverTag, {
         'adserver': 'dfp',
         'code': 'one-without-bids'
-      };
-      var masterTagUrl = $$PREBID_GLOBAL$$.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+      });
+
       expect(masterTagUrl).to.equal(adserverTag);
     });
 


### PR DESCRIPTION
## Type of change
- Testfix

## Description of change
The `parse` function in urls.js returns a port of 443 when tested in IE11, blank in other browsers. A hardcoded url that is matched against doesn't contain this port and causes the test mentioned in #1302 to fail. This PR adds that port to the hardcoded string when tested in IE11 and fixes #1302.