### PR TITLE
Fixed imports and made adform support aliasing

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -1,14 +1,15 @@
-var utils = require('src/utils.js');
-var adloader = require('src/adloader.js');
-var bidmanager = require('src/bidmanager.js');
-var bidfactory = require('src/bidfactory.js');
+var utils = require('src/utils');
+var adloader = require('src/adloader');
+var bidmanager = require('src/bidmanager');
+var bidfactory = require('src/bidfactory');
 var STATUSCODES = require('src/constants.json').STATUS;
 var adaptermanager = require('src/adaptermanager');
+var Adapter = require('src/adapter').default;
+
+const ADFORM_BIDDER_CODE = 'adform';
 
 function AdformAdapter() {
-  return {
-    callBids: _callBids
-  };
+  let baseAdapter = new Adapter(ADFORM_BIDDER_CODE);
 
   function _callBids(params) {
     var bid, _value, _key, i, j, k, l, reqParams;
@@ -47,7 +48,7 @@ function AdformAdapter() {
     $$PREBID_GLOBAL$$[callbackName] = handleCallback(bids);
 
     adloader.loadScript(request.join('&'));
-  }
+  };
 
   function formRequestUrl(reqData) {
     var key;
@@ -63,7 +64,7 @@ function AdformAdapter() {
   function handleCallback(bids) {
     return function handleResponse(adItems) {
       var bidObject;
-      var bidder = 'adform';
+      var bidder = baseAdapter.getBidderCode();
       var adItem;
       var bid;
       for (var i = 0, l = adItems.length; i < l; i++) {
@@ -160,8 +161,11 @@ function AdformAdapter() {
 
     return utftext;
   }
+
+  return Object.assign(this, baseAdapter, {
+    callBids: _callBids
+  });
 }
 
-adaptermanager.registerBidAdapter(new AdformAdapter(), 'adform');
-
+adaptermanager.registerBidAdapter(new AdformAdapter(), ADFORM_BIDDER_CODE);
 module.exports = AdformAdapter;

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import * as utils from '../../../src/utils';
 import adLoader from '../../../src/adloader';
 import bidManager from '../../../src/bidmanager';
-import adapter from '../../../modules/adformBidAdapter';
+import AdformAdapter from '../../../modules/adformBidAdapter';
 
 describe('Adform adapter', () => {
   let _adapter, sandbox;
@@ -112,7 +112,7 @@ describe('Adform adapter', () => {
 
   beforeEach(() => {
     var transactionId = 'transactionId';
-    _adapter = adapter();
+    _adapter = new AdformAdapter();
     utils.getUniqueIdentifierStr = () => 'callback';
     sandbox = sinon.sandbox.create();
     sandbox.stub(adLoader, 'loadScript');

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
-import * as utils from '../../../src/utils';
-import adLoader from '../../../src/adloader';
-import bidManager from '../../../src/bidmanager';
-import AdformAdapter from '../../../modules/adformBidAdapter';
+import * as utils from 'src/utils';
+import adLoader from 'src/adloader';
+import bidManager from 'src/bidmanager';
+import AdformAdapter from 'modules/adformBidAdapter';
 
 describe('Adform adapter', () => {
   let _adformAdapter, sandbox;

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -5,7 +5,7 @@ import bidManager from '../../../src/bidmanager';
 import AdformAdapter from '../../../modules/adformBidAdapter';
 
 describe('Adform adapter', () => {
-  let _adapter, sandbox;
+  let _adformAdapter, sandbox;
 
   describe('request', () => {
     it('should create callback method on PREBID_GLOBAL', () => {
@@ -112,11 +112,11 @@ describe('Adform adapter', () => {
 
   beforeEach(() => {
     var transactionId = 'transactionId';
-    _adapter = new AdformAdapter();
+    _adformAdapter = new AdformAdapter();
     utils.getUniqueIdentifierStr = () => 'callback';
     sandbox = sinon.sandbox.create();
     sandbox.stub(adLoader, 'loadScript');
-    _adapter.callBids({
+    _adformAdapter.callBids({
       bids: [
         {
           bidId: 'abc',


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Updated the adform adapter to support aliasing since we're having a partner on the sell side who runs the adform platform and by allowing aliasing we can make them bid under their own bidderCode.