### PR TITLE
Kargo: removing for...of loops because IE cannot handle them properly

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -56,8 +56,10 @@ const KargoAdapter = function KargoAdapter() {
 
   function _readCookie(name) {
     let nameEquals = `${name}=`;
+    let cookies = document.cookie.split(';');
 
-    for (let cookie of document.cookie.split(';')) {
+    for (let key in cookies) {
+      let cookie = cookies[key];
       while (cookie.charAt(0) === ' ') {
         cookie = cookie.substring(1, cookie.length);
       }

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -55,11 +55,13 @@ describe('kargo adapter tests', function () {
   afterEach(() => {
     sandbox.restore();
 
-    for (let cookie of cookies) {
+    for (let key in cookies) {
+      let cookie = cookies[key];
       removeCookie(cookie);
     }
 
-    for (let localStorageItem of localStorageItems) {
+    for (let key in localStorageItems) {
+      let localStorageItem = localStorageItems[key];
       localStorage.removeItem(localStorageItem);
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Removing `for...of` loops with regard to fixing the bug noted in #1522. Did not affect any production code (Kargo never runs on desktop or IE), but assists in ease of automatic testing across all browsers.