### PR TITLE
Override default asset params when set on ad unit

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -111,8 +111,8 @@ function AppnexusAstAdapter() {
               // if the mapping for this identifier specifies required server
               // params via the `serverParams` object, merge that in
               const params = Object.assign({},
-                bid.nativeParams[key],
-                NATIVE_MAPPING[key] && NATIVE_MAPPING[key].serverParams
+                NATIVE_MAPPING[key] && NATIVE_MAPPING[key].serverParams,
+                bid.nativeParams[key]
               );
 
               nativeRequest[requestKey] = params;

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -134,6 +134,7 @@ describe('AppNexusAdapter', () => {
       REQUEST.bids[0].nativeParams = {
         title: {required: true},
         body: {required: true},
+        image: {required: true, sizes: [{ width: 100, height: 100 }] },
         cta: {required: false},
         sponsoredBy: {required: true}
       };
@@ -144,8 +145,26 @@ describe('AppNexusAdapter', () => {
       expect(request.tags[0].native.layouts[0]).to.deep.equal({
         title: {required: true},
         description: {required: true},
+        main_image: {required: true, sizes: [{ width: 100, height: 100 }] },
         ctatext: {required: false},
         sponsored_by: {required: true}
+      });
+
+      delete REQUEST.bids[0].mediaType;
+      delete REQUEST.bids[0].params.nativeParams;
+    });
+
+    it('sets required native asset params when not provided on adunit', () => {
+      REQUEST.bids[0].mediaType = 'native';
+      REQUEST.bids[0].nativeParams = {
+        image: {required: true},
+      };
+
+      adapter.callBids(REQUEST);
+
+      const request = JSON.parse(requests[0].requestBody);
+      expect(request.tags[0].native.layouts[0]).to.deep.equal({
+        main_image: {required: true, sizes: [{}] },
       });
 
       delete REQUEST.bids[0].mediaType;


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change

The appnexusAst endpoint requires certain parameters when requesting certain native assets. These are defined in `NATIVE_MAPPING`, but the code that merged these predefined params into the request was favoring these over user-defined parameters of the same type. This PR fixes the merge order so that user-defined assets will win. An ad unit such as the one defined below will contain the proper size dimensions on a native request sent by appnexusAst

```JavaScript
pbjs.addAdUnits({
  code: slot.code,
  sizes: slot.size,
  mediaType: 'native',
  nativeParams: {
    image: {
      required: true,
      sizes: [{ width: 100, height: 100 }],
    }
  },
  bids: [{
    bidder: 'appnexusAst',
    params: {placementId: 123}
  }]
});
```