### PR TITLE
IndexExchange: use random integer for sizeID to allow multiple slots per siteID

### DIFF
--- a/modules/indexExchangeBidAdapter.js
+++ b/modules/indexExchangeBidAdapter.js
@@ -601,7 +601,7 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
       return;
     }
 
-    var sizeID = 0;
+    var sizeID = Math.floor(Math.random() * 1000000);
 
     // Expecting nested arrays for sizes
     if (!utils.isArray(bid.sizes[0])) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->

Setting the sizeID to a constant integer causes subsequent calls to `cygnus_index_init` to overwrite bids with the same siteID. In order to support multiple slots per siteID, the sizeID must be a unique value to each call of `cygnus_index_init` and then incremented for additional sizes. 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
