### PR TITLE
Revert "drop specific code for index adapter (#1487)"

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -40,18 +40,33 @@ function getBidders(bid) {
 function bidsBackAdUnit(adUnitCode) {
   const requested = $$PREBID_GLOBAL$$._bidsRequested
     .map(request => request.bids
+      .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes))
       .filter(bid => bid.placementCode === adUnitCode))
-    .reduce(flatten, []).length;
+    .reduce(flatten, [])
+    .map(bid => {
+      return bid.bidder === 'indexExchange'
+        ? bid.sizes.length
+        : 1;
+    }).reduce(add, 0);
 
   const received = $$PREBID_GLOBAL$$._bidsReceived.filter(bid => bid.adUnitCode === adUnitCode).length;
   return requested === received;
+}
+
+function add(a, b) {
+  return a + b;
 }
 
 function bidsBackAll() {
   const requested = $$PREBID_GLOBAL$$._bidsRequested
     .map(request => request.bids)
     .reduce(flatten, [])
-    .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes)).length;
+    .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes))
+    .map(bid => {
+      return bid.bidder === 'indexExchange'
+        ? bid.sizes.length
+        : 1;
+    }).reduce((a, b) => a + b, 0);
 
   const received = $$PREBID_GLOBAL$$._bidsReceived
     .filter(adUnitsFilter.bind(this, $$PREBID_GLOBAL$$._adUnitCodes)).length;


### PR DESCRIPTION
This reverts commit d3cd2917c264d3388b2be45ee8e6b767e803ce5c.
## Type of change
- [x] Bugfix

## Description of change
IndexExchange bidder is still sending multiple bids for the same adUnit for multiple sizes, potentially ending the auction early. This rolls back the change. 
