### PR TITLE
fix #1509 - utils.getTopWindowLocation() returns exception object

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -157,6 +157,8 @@ export function parseGPTSingleSizeArray(singleSize) {
 exports.getTopWindowLocation = function () {
   let location;
   try {
+    // force an exception in x-domain enviornments. #1509
+    window.top.location.toString();
     location = window.top.location;
   } catch (e) {
     location = window.location;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
This is a quick fix for #1509 - force an exception in x-domain environments. We might want to make this more robust later but this at least fixes the contract. 

## Other information

