### PR TITLE
Single-size sizes array now can be taken, too

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -57,8 +57,9 @@ function Spotx() {
       bid.url = adServerKVPs.spotx_ad_key;
       bid.cur = 'USD';
       bid.bidderCode = 'spotx';
-      bid.height = bidReq.sizes[0][1];
-      bid.width = bidReq.sizes[0][0];
+      var sizes = utils.isArray(bidReq.sizes[0]) ? bidReq.sizes[0] : bidReq.sizes;
+      bid.height = sizes[1];
+      bid.width = sizes[0];
       resp.bids.push(bid);
       KVP_Object = adServerKVPs;
       handleResponse(resp);
@@ -86,8 +87,9 @@ function Spotx() {
       bid.vastUrl = url;
       bid.ad = url;
 
-      bid.width = bidReq.sizes[0][0];
-      bid.height = bidReq.sizes[0][1];
+      var sizes = utils.isArray(bidReq.sizes[0]) ? bidReq.sizes[0] : bidReq.sizes;
+      bid.height = sizes[1];
+      bid.width = sizes[0];
     }
 
     return bid;


### PR DESCRIPTION
A bug was, that the only sizes array would be taken as [[640,480]], not as it is usually given as [640,480]. I fix this.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Single-size sizes array can now be accepted, too (was: only [[640,480]], now also: [640,480])

