### PR TITLE
add () for correct order of operations in scaling increments for currency

### DIFF
--- a/src/cpmBucketManager.js
+++ b/src/cpmBucketManager.js
@@ -117,7 +117,7 @@ function getCpmTarget(cpm, increment, precision, granularityMultiplier) {
   if (!precision) {
     precision = _defaultPrecision;
   }
-  let bucketSize = 1 / increment * granularityMultiplier;
+  let bucketSize = 1 / (increment * granularityMultiplier);
   return (Math.floor(cpm * bucketSize) / bucketSize).toFixed(precision);
 }
 

--- a/test/spec/cpmBucketManager_spec.js
+++ b/test/spec/cpmBucketManager_spec.js
@@ -53,7 +53,7 @@ describe('cpmBucketManager', () => {
       }
       ]
     };
-    let expected = '{"low":"552.45","med":"1824.09","high":"1824.09","auto":"1824.09","dense":"1824.09","custom":"1824.0882"}';
+    let expected = '{"low":"552.45","med":"1823.09","high":"1823.09","auto":"1823.09","dense":"1823.09","custom":"1823.0850"}';
     let output = getPriceBucketString(cpm, customConfig, 110.49);
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently there is a bug when scaling the bucketing increments for currency.  Order of operations was ending up with unexpected values for the scaling component.