### PR TITLE
remove unnecessary spread operator

### DIFF
--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -49,6 +49,6 @@ function Bid(statusCode, bidRequest) {
 }
 
 // Bid factory function.
-exports.createBid = function () {
-  return new Bid(...arguments);
+exports.createBid = function (statusCode, bidRequest) {
+  return new Bid(statusCode, bidRequest);
 };


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)


## Description of change
The transpiled code was causing an issue with mootools compat (https://mootools.net/core). Normally I'd say that this is cause to fix the incorrect compatibility but there is no reason to use spread here. 
