### PR TITLE
SharethroughBidAdapter - don't download sfp.js library if already defined on page

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -65,20 +65,24 @@ var SharethroughAdapter = function SharethroughAdapter() {
       bid.ad = `<div data-str-native-key="${bid.pkey}" data-stx-response-name='${windowLocation}'>
                 </div>
                 <script>var ${windowLocation} = ${bidJsonString}</script>
-                <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>
-                <script type='text/javascript'>
-                (function() {
-                    var sfp_js = document.createElement('script');
-                    sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
-                    sfp_js.type = 'text/javascript';
-                    sfp_js.charset = 'utf-8';
-                    try {
-                        window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
-                    } catch (e) {
-                      console.log(e);
-                    }
-                })();
-                </script>`;
+                <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>`
+      if (!(window.STR && window.STR.Tag) && !(window.top.STR && window.top.STR.Tag)) {
+        let sfpScriptTag = `
+          <script>
+          (function() {
+            const sfp_js = document.createElement('script');
+            sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
+            sfp_js.type = 'text/javascript';
+            sfp_js.charset = 'utf-8';
+            try {
+                window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
+            } catch (e) {
+              console.log(e);
+            }
+          })()
+          </script>`
+        bid.ad += sfpScriptTag;
+      }
       bidmanager.addBidResponse(bidObj.placementCode, bid);
     } catch (e) {
       _handleInvalidBid(bidObj);

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -5,7 +5,7 @@ var ajax = require('src/ajax.js').ajax;
 var adaptermanager = require('src/adaptermanager');
 
 const STR_BIDDER_CODE = 'sharethrough';
-const STR_VERSION = '1.2.0';
+const STR_VERSION = '1.3.0';
 
 var SharethroughAdapter = function SharethroughAdapter() {
   const str = {};
@@ -66,23 +66,27 @@ var SharethroughAdapter = function SharethroughAdapter() {
                 </div>
                 <script>var ${windowLocation} = ${bidJsonString}</script>
                 <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>`
-      if (!(window.STR && window.STR.Tag) && !(window.top.STR && window.top.STR.Tag)) {
+
+      // if sfp.js/tag.js is not already loaded on top page
+      if (!(window.top.STR && window.top.STR.Tag)) {
         let sfpScriptTag = `
           <script>
-          (function() {
-            const sfp_js = document.createElement('script');
-            sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
-            sfp_js.type = 'text/javascript';
-            sfp_js.charset = 'utf-8';
-            try {
-                window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
-            } catch (e) {
-              console.log(e);
-            }
-          })()
+            (function() {
+              const sfp_js = document.createElement('script');
+              sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
+              sfp_js.type = 'text/javascript';
+              sfp_js.charset = 'utf-8';
+              try {
+                  window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
+              } catch (e) {
+                console.log(e);
+              }
+            })()
           </script>`
+
         bid.ad += sfpScriptTag;
       }
+
       bidmanager.addBidResponse(bidObj.placementCode, bid);
     } catch (e) {
       _handleInvalidBid(bidObj);

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -60,8 +60,8 @@ describe('sharethrough adapter', () => {
 
       sinon.assert.calledTwice(adapter.str.ajax);
 
-      expect(firstBidUrl).to.contain(adapter.str.STR_BTLR_HOST + '/header-bid/v1?bidId=bidId1&placement_key=aaaa1111&hbVersion=%24prebid.version%24&strVersion=1.2.0&hbSource=prebid&');
-      expect(secondBidUrl).to.contain(adapter.str.STR_BTLR_HOST + '/header-bid/v1?bidId=bidId2&placement_key=bbbb2222&hbVersion=%24prebid.version%24&strVersion=1.2.0&hbSource=prebid&');
+      expect(firstBidUrl).to.contain(adapter.str.STR_BTLR_HOST + '/header-bid/v1?bidId=bidId1&placement_key=aaaa1111&hbVersion=%24prebid.version%24&strVersion=1.3.0&hbSource=prebid&');
+      expect(secondBidUrl).to.contain(adapter.str.STR_BTLR_HOST + '/header-bid/v1?bidId=bidId2&placement_key=bbbb2222&hbVersion=%24prebid.version%24&strVersion=1.3.0&hbSource=prebid&');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
- Detect if top page already has the Sharethrough library (`sfp.js`) already loaded and do not try to load again

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
jchau87@gmail.com
jchau@sharethrough.com

- [x] official adapter submission
