### PR TITLE
allow adapters to set default adserverTargeting for specific bid

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -168,6 +168,7 @@ function PrebidServer() {
             bidObject.ad = bidObj.adm;
             bidObject.width = bidObj.width;
             bidObject.height = bidObj.height;
+            bidObject.adserverTargeting = bidObj.ad_server_targeting;
             if (bidObj.deal_id) {
               bidObject.dealId = bidObj.deal_id;
             }
@@ -233,7 +234,7 @@ function PrebidServer() {
       contentType: 'text/plain',
       withCredentials: true
     });
-  }
+  };
 
   return Object.assign(this, {
     queueSync: baseAdapter.queueSync,

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -191,12 +191,13 @@ exports.addBidResponse = function (adUnitCode, bid) {
     bid.pbCg = priceStringsObj.custom;
 
     // if there is any key value pairs to map do here
-    var keyValues = {};
+    var keyValues;
     if (bid.bidderCode && (bid.cpm > 0 || bid.dealId)) {
       keyValues = getKeyValueTargetingPairs(bid.bidderCode, bid);
     }
 
-    bid.adserverTargeting = keyValues;
+    // use any targeting provided as defaults, otherwise just set from getKeyValueTargetingPairs
+    bid.adserverTargeting = Object.assign(bid.adserverTargeting || {}, keyValues);
   }
 
   function doCallbacksIfNeeded() {

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -465,6 +465,20 @@ describe('bidmanager.js', function () {
       assert.equal(addedBid.adserverTargeting[`hb_deal`], bid.dealId, 'dealId placed in adserverTargeting');
     });
 
+    it('should pass through default adserverTargeting sent from adapter', () => {
+      const bid = Object.assign({},
+        bidfactory.createBid(2),
+        fixtures.getBidResponses()[0]
+      );
+
+      bid.adserverTargeting.extra = 'stuff';
+
+      bidmanager.addBidResponse(bid.adUnitCode, bid);
+      const addedBid = $$PREBID_GLOBAL$$._bidsReceived.pop();
+      assert.equal(addedBid.adserverTargeting.hb_bidder, 'triplelift');
+      assert.equal(addedBid.adserverTargeting.extra, 'stuff');
+    });
+
     it('should not alter bid adID', () => {
       const bid1 = Object.assign({},
         bidfactory.createBid(2),

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -68,7 +68,10 @@ const RESPONSE = {
       'adm': '<script type="application/javascript" src="http://nym1-ib.adnxs.com/ab?e=wqT_3QL_Baj_AgAAAwDWAAUBCO-s38cFEJG-p6iRgOfvdhivtLWVpomhsWUgASotCQAAAQII4D8RAQc0AADgPxkAAACA61HgPyEREgApEQmgMPLm_AQ4vgdAvgdIAlDWy5MOWOGASGAAaJFAeP3PBIABAYoBA1VTRJIFBvBSmAGsAqAB-gGoAQGwAQC4AQLAAQPIAQLQAQnYAQDgAQHwAQCKAjp1ZignYScsIDQ5NDQ3MiwgMTQ5MjYzNzI5NSk7dWYoJ3InLCAyOTY4MTExMCwyHgDwnJIC7QEhcHpUNkZ3aTYwSWNFRU5iTGt3NFlBQ0RoZ0Vnd0FEZ0FRQVJJdmdkUTh1YjhCRmdBWVBfX19fOFBhQUJ3QVhnQmdBRUJpQUVCa0FFQm1BRUJvQUVCcUFFRHNBRUF1UUVwaTRpREFBRGdQOEVCS1l1SWd3QUE0RF9KQWQ0V2JVTnJmUEVfMlFFQUFBQUFBQUR3UC1BQkFQVUIFD0BKZ0Npb2FvcEFtZ0FnQzFBZwEWBEM5CQjoREFBZ0hJQWdIUUFnSFlBZ0hnQWdEb0FnRDRBZ0NBQXdHUUF3Q1lBd0dvQTdyUWh3US6aAjEhRXduSHU68AAcNFlCSUlBUW8JbARreAFmDQHwui7YAugH4ALH0wHqAg93d3cubnl0aW1lcy5jb23yAhEKBkNQR19JRBIHMTk3NzkzM_ICEAoFQ1BfSUQSBzg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2APjBuADAOgDAPgDA4AEAJIECS9vcGVucnRiMpgEAKIECzEwLjI0NC4wLjIyqAQAsgQKCAAQABgAIAAwALgEAMAEAMgEANIEDDEwLjMuMTM4LjE0ONoEAggB4AQA8ARBXyCIBQGYBQCgBf8RAZwBqgUkNDM3ZmJiZjUtMzNmNS00ODdhLThlMTYtYTcxMTI5MDNjZmU1&s=b52bf8a6265a78a5969444bc846cc6d0f9f3b489&test=1&referrer=www.nytimes.com&pp=${AUCTION_PRICE}&"></script>',
       'width': 300,
       'height': 250,
-      'deal_id': 'test-dealid'
+      'deal_id': 'test-dealid',
+      'ad_server_targeting': {
+        'foo': 'bar'
+      }
     }
   ]
 };
@@ -312,6 +315,16 @@ describe('S2S Adapter', () => {
       server.respond();
       const response = bidmanager.addBidResponse.firstCall.args[1];
       expect(response).to.have.property('dealId', 'test-dealid');
+    });
+
+    it('should pass through default adserverTargeting if present in bidObject', () => {
+      server.respondWith(JSON.stringify(RESPONSE));
+
+      adapter.setConfig(CONFIG);
+      adapter.callBids(REQUEST);
+      server.respond();
+      const response = bidmanager.addBidResponse.firstCall.args[1];
+      expect(response).to.have.property('adserverTargeting').that.deep.equals({'foo': 'bar'});
     });
 
     it('registers bid responses when server requests cookie sync', () => {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -373,57 +373,25 @@ describe('Unit: Prebid Module', function () {
     it('should get correct hb_pb when using bid.cpm is between 0 to 5', () => {
       bid.cpm = 2.1234;
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      var expected = {
-        '/19968336/header-bid-tag-0': {
-          hb_adid: '275bd666f5a5a5d',
-          hb_bidder: 'brealtime',
-          hb_pb: '2.12',
-          hb_size: '300x250'
-        }
-      }
-      expect($$PREBID_GLOBAL$$.getAdserverTargeting()).to.deep.equal(expected);
+      expect($$PREBID_GLOBAL$$.getAdserverTargeting()['/19968336/header-bid-tag-0'].hb_pb).to.equal('2.12');
     });
 
     it('should get correct hb_pb when using bid.cpm is between 5 to 8', () => {
       bid.cpm = 6.78;
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      var expected = {
-        '/19968336/header-bid-tag-0': {
-          hb_adid: '275bd666f5a5a5d',
-          hb_bidder: 'brealtime',
-          hb_pb: '6.75',
-          hb_size: '300x250'
-        }
-      }
-      expect($$PREBID_GLOBAL$$.getAdserverTargeting()).to.deep.equal(expected);
+      expect($$PREBID_GLOBAL$$.getAdserverTargeting()['/19968336/header-bid-tag-0'].hb_pb).to.equal('6.75');
     });
 
     it('should get correct hb_pb when using bid.cpm is between 8 to 20', () => {
       bid.cpm = 19.5234;
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      var expected = {
-        '/19968336/header-bid-tag-0': {
-          hb_adid: '275bd666f5a5a5d',
-          hb_bidder: 'brealtime',
-          hb_pb: '19.50',
-          hb_size: '300x250'
-        }
-      }
-      expect($$PREBID_GLOBAL$$.getAdserverTargeting()).to.deep.equal(expected);
+      expect($$PREBID_GLOBAL$$.getAdserverTargeting()['/19968336/header-bid-tag-0'].hb_pb).to.equal('19.50');
     });
 
     it('should get correct hb_pb when using bid.cpm is between 20 to 25', () => {
       bid.cpm = 21.5234;
       bidmanager.addBidResponse(bid.adUnitCode, bid);
-      var expected = {
-        '/19968336/header-bid-tag-0': {
-          hb_adid: '275bd666f5a5a5d',
-          hb_bidder: 'brealtime',
-          hb_pb: '21.00',
-          hb_size: '300x250'
-        }
-      }
-      expect($$PREBID_GLOBAL$$.getAdserverTargeting()).to.deep.equal(expected);
+      expect($$PREBID_GLOBAL$$.getAdserverTargeting()['/19968336/header-bid-tag-0'].hb_pb).to.equal('21.00');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This change allows adapters to set default adserverTargeting for a bid if desired.  Any adserverTargeting specified in bidderSettings will overwrite these defaults so this is mainly only useful for custom adserverTargeting.  In our case we want to use this to allow the prebidServerBidAdapter to send through custom adserverTargeting from our rubicon server adapter.
