### PR TITLE
Allow bundling from node.js or with new gulp task bundle-to-stdout 

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -69,10 +69,9 @@ module.exports = {
         .filter(file => !(/(^|\/)\.[^\/\.]/g).test(file))
         .reduce((memo, file) => {
           var moduleName = file.split(new RegExp('[.\\' + path.sep + ']'))[0];
-          var filePath = path.join(absoluteModulePath, file);
-          var modulePath = path.join(__dirname, filePath)
-          if (fs.lstatSync(filePath).isDirectory()) {
-            modulePath = path.join(__dirname, filePath, "index.js")
+          var modulePath = path.join(absoluteModulePath, file);
+          if (fs.lstatSync(modulePath).isDirectory()) {
+            modulePath = path.join(modulePath, "index.js")
           }
           memo[modulePath] = moduleName;
           return memo;

--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -64,11 +64,12 @@ module.exports = {
     externalModules = externalModules || [];
     var internalModules;
     try {
-      internalModules = fs.readdirSync(MODULE_PATH)
+      var absoluteModulePath = path.join(__dirname, MODULE_PATH);
+      internalModules = fs.readdirSync(absoluteModulePath)
         .filter(file => !(/(^|\/)\.[^\/\.]/g).test(file))
         .reduce((memo, file) => {
           var moduleName = file.split(new RegExp('[.\\' + path.sep + ']'))[0];
-          var filePath = path.join(MODULE_PATH, file);
+          var filePath = path.join(absoluteModulePath, file);
           var modulePath = path.join(__dirname, filePath)
           if (fs.lstatSync(filePath).isDirectory()) {
             modulePath = path.join(__dirname, filePath, "index.js")

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,7 @@ var optimizejs = require('gulp-optimize-js');
 var eslint = require('gulp-eslint');
 var gulpif = require('gulp-if');
 var sourcemaps = require('gulp-sourcemaps');
+var through = require('through2');
 var fs = require('fs');
 
 var prebid = require('./package.json');
@@ -52,8 +53,25 @@ gulp.task('clean', function () {
     .pipe(clean());
 });
 
-function bundle(dev) {
-  var modules = helpers.getArgModules(),
+function gulpBundle(dev) {
+  return bundle(dev).pipe(gulp.dest('build/' + (dev ? 'dev' : 'dist')));
+}
+
+module.exports = function nodeBundle(modules) {
+  return new Promise((resolve, reject) => {
+    bundle(false, modules)
+      .on('error', (err) => {
+        reject(err);
+      })
+      .pipe(through.obj(function(file, enc, done) {
+        resolve(file.contents.toString(enc));
+        done();
+      }));
+  });
+};
+
+function bundle(dev, moduleArr) {
+  var modules = moduleArr || helpers.getArgModules(),
       allModules = helpers.getModuleNames(modules);
 
   if(modules.length === 0) {
@@ -82,8 +100,7 @@ function bundle(dev) {
         global: prebid.globalVarName
       }
     )))
-    .pipe(gulpif(dev, sourcemaps.write('.')))
-    .pipe(gulp.dest('build/' + (dev ? 'dev' : 'dist')));
+    .pipe(gulpif(dev, sourcemaps.write('.')));
 }
 
 // Workaround for incompatibility between Karma & gulp callbacks.
@@ -98,9 +115,9 @@ function newKarmaCallback(done) {
   }
 }
 
-gulp.task('build-bundle-dev', ['devpack'], bundle.bind(null, true));
-gulp.task('build-bundle-prod', ['webpack'], bundle.bind(null, false));
-gulp.task('bundle', bundle.bind(null, false)); // used for just concatenating pre-built files with no build step
+gulp.task('build-bundle-dev', ['devpack'], gulpBundle.bind(null, true));
+gulp.task('build-bundle-prod', ['webpack'], gulpBundle.bind(null, false));
+gulp.task('bundle', gulpBundle.bind(null, false)); // used for just concatenating pre-built files with no build step
 
 gulp.task('devpack', ['clean'], function () {
   var cloned = _.cloneDeep(webpackConfig);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,7 @@ function gulpBundle(dev) {
   return bundle(dev).pipe(gulp.dest('build/' + (dev ? 'dev' : 'dist')));
 }
 
-module.exports = function nodeBundle(modules) {
+function nodeBundle(modules) {
   return new Promise((resolve, reject) => {
     bundle(false, modules)
       .on('error', (err) => {
@@ -68,7 +68,7 @@ module.exports = function nodeBundle(modules) {
         done();
       }));
   });
-};
+}
 
 function bundle(dev, moduleArr) {
   var modules = moduleArr || helpers.getArgModules(),
@@ -118,6 +118,10 @@ function newKarmaCallback(done) {
 gulp.task('build-bundle-dev', ['devpack'], gulpBundle.bind(null, true));
 gulp.task('build-bundle-prod', ['webpack'], gulpBundle.bind(null, false));
 gulp.task('bundle', gulpBundle.bind(null, false)); // used for just concatenating pre-built files with no build step
+
+gulp.task('bundle-to-stdout', function() {
+  nodeBundle().then(file => console.log(file));
+});
 
 gulp.task('devpack', ['clean'], function () {
   var cloned = _.cloneDeep(webpackConfig);
@@ -292,3 +296,5 @@ gulp.task('build-postbid', function() {
     .pipe(uglify())
     .pipe(gulp.dest('build/dist'));
 });
+
+module.exports = nodeBundle;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Can be used in node.js like so:
```javascript
var nodeBundle = require('./gulpfile.js');

nodeBundle(['rubiconBidAdapter', 'currency'])
  .then(output => console.log(output));  // string representation of prebid.js
```

Or can print the bundle to stdout like so:
```bash
gulp bundle-to-stdout --modules=rubiconBidAdapter,currency > prebid.js
```
