### PR TITLE
don't calculate TTR if request not found

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -109,6 +109,13 @@ exports.addBidResponse = function (adUnitCode, bid) {
       utils.logError(errorMessage('No adUnitCode was supplied to addBidResponse.'));
       return false;
     }
+
+    const bidRequest = getBidderRequest(bid.bidderCode, adUnitCode);
+    if (!bidRequest.start) {
+      utils.logError(errorMessage('Cannot find valid matching bid request.'));
+      return false;
+    }
+
     if (bid.mediaType === 'native' && !nativeBidIsValid(bid)) {
       utils.logError(errorMessage('Native bid missing some required properties.'));
       return false;

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -8,6 +8,10 @@ var bidmanager = require('../../src/bidmanager');
 var bidfactory = require('../../src/bidfactory');
 var fixtures = require('../fixtures/fixtures');
 
+function timestamp() {
+  return new Date().getTime();
+}
+
 describe('replaceTokenInString', function () {
   it('should replace all given tokens in a String', function () {
     var tokensToReplace = {
@@ -502,6 +506,7 @@ describe('bidmanager.js', function () {
 
     it('should add banner bids that have no width or height but single adunit size', () => {
       sinon.stub(utils, 'getBidderRequest', () => ({
+        start: timestamp(),
         bids: [{
           sizes: [[300, 250]],
         }]
@@ -528,6 +533,7 @@ describe('bidmanager.js', function () {
 
     it('should not add native bids that do not have required assets', () => {
       sinon.stub(utils, 'getBidRequest', () => ({
+        start: timestamp(),
         bidder: 'appnexusAst',
         nativeParams: {
           title: {'required': true},
@@ -552,13 +558,16 @@ describe('bidmanager.js', function () {
     });
 
     it('should add native bids that do have required assets', () => {
-      sinon.stub(utils, 'getBidRequest', () => ({
+      const bidRequest = () => ({
+        start: timestamp(),
         bidder: 'appnexusAst',
         nativeParams: {
           title: {'required': true},
         },
         mediaType: 'native',
-      }));
+      });
+      sinon.stub(utils, 'getBidRequest', bidRequest);
+      sinon.stub(utils, 'getBidderRequest', bidRequest);
 
       const bid = Object.assign({},
         bidfactory.createBid(1),
@@ -574,10 +583,12 @@ describe('bidmanager.js', function () {
       assert.equal(bidsRecCount + 1, $$PREBID_GLOBAL$$._bidsReceived.length);
 
       utils.getBidRequest.restore();
+      utils.getBidderRequest.restore();
     });
 
     it('installs publisher-defined renderers on bids', () => {
       sinon.stub(utils, 'getBidderRequest', () => ({
+        start: timestamp(),
         bids: [{
           renderer: {
             url: 'renderer.js',

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -10,6 +10,7 @@ const BID_REQUEST_BASE_URL = 'https://in-appadvertising.com/api/bidRequest?';
 const USER_SYNC_URL = 'https://in-appadvertising.com/api/userSync.js';
 
 const TRION_BID_REQUEST = {
+  start: new Date().getTime(),
   bidderCode: 'trion',
   bids: [
     {

--- a/test/spec/unit/bidmanager_spec.js
+++ b/test/spec/unit/bidmanager_spec.js
@@ -195,7 +195,7 @@ describe('The Bid Manager', () => {
               return `${this.height}x${this.width}`;
             };
             delete copy.cpm;
-            bidManager.addBidResponse('mock/code', copy);
+            bidManager.addBidResponse(adUnit.code, copy);
             expect(copy).to.have.property('hadCpmDuringBidAdjustment', true);
             expect(copy).to.have.property('hadAdUnitCodeDuringBidAdjustment', true);
             expect(copy).to.have.property('hadTimeToRespondDuringBidAdjustment', true);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
If the bidrequest can't be found, for example on a very late bid, don't try to calculate TTR. If the start time 
is 0, then TTR will be huge and the current auction will immediately timeout.
