### PR TITLE
Remove do callbacks if needed

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -86,10 +86,10 @@ exports.addBidResponse = function (adUnitCode, bid) {
     prepareBidForAuction();
 
     if (bid.mediaType === 'video') {
-      tryAddVideoBid(bid);
+      tryAddVideoBid();
     } else {
       doCallbacksIfNeeded();
-      addBidToAuction(bid);
+      addBidToAuction();
     }
   }
 
@@ -222,7 +222,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
   }
 
   // Video bids may fail if the cache is down, or there's trouble on the network.
-  function tryAddVideoBid(bid) {
+  function tryAddVideoBid() {
     if (config.getConfig('usePrebidCache')) {
       store([bid], function(error, cacheIds) {
         if (error) {
@@ -232,12 +232,12 @@ exports.addBidResponse = function (adUnitCode, bid) {
           if (!bid.vastUrl) {
             bid.vastUrl = getCacheUrl(bid.videoCacheKey);
           }
-          addBidToAuction(bid);
+          addBidToAuction();
         }
         doCallbacksIfNeeded();
       });
     } else {
-      addBidToAuction(bid);
+      addBidToAuction();
       doCallbacksIfNeeded();
     }
   }


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
A couple bug fixes that were easier to combine into one PR. The first removes the bid parameter to calls to addBidToAuction, since that function doesn't actually accept any parameters. 

The second removes doCallbacksIfNeeded since the calling order with addBidToAuction wasn't standardized, and it seems like it should be. Specifically it seems like the callbacks should always be done after the bid is added to the auction.