### PR TITLE
single-request-bidder: updates to bidderFactory and converted rubiconBidAdapter

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -31,11 +31,11 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param {object} bidParams The params to validate.
+   * @param {BidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
-  areParamsValid: function(bidParams) {
-    return !!(bidParams.placementId || (bidParams.member && bidParams.invCode));
+  isBidRequestValid: function(bid) {
+    return !!(bid.params.placementId || (bid.params.member && bid.params.invCode));
   },
 
   /**
@@ -119,7 +119,7 @@ function newRenderer(adUnitCode, rtbBid) {
   try {
     renderer.setRender(outstreamRender);
   } catch (err) {
-    utils.logWarning('Prebid Error calling setRender on renderer', err);
+    utils.logWarn('Prebid Error calling setRender on renderer', err);
   }
 
   renderer.setEventHandlers({

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1,12 +1,5 @@
-import Adapter from 'src/adapter';
-import bidfactory from 'src/bidfactory';
-import bidmanager from 'src/bidmanager';
-import adaptermanager from 'src/adaptermanager';
 import * as utils from 'src/utils';
-import { ajax } from 'src/ajax';
-import { STATUS } from 'src/constants';
-
-const RUBICON_BIDDER_CODE = 'rubicon';
+import { registerBidder } from 'src/adapters/bidderFactory';
 
 // use deferred function call since version isn't defined yet at this point
 function getIntegration() {
@@ -72,256 +65,175 @@ var sizeMap = {
 };
 utils._each(sizeMap, (item, key) => sizeMap[item] = key);
 
-function RubiconAdapter() {
-  var baseAdapter = new Adapter(RUBICON_BIDDER_CODE);
-  var hasUserSyncFired = false;
-
-  function _callBids(bidderRequest) {
-    var bids = bidderRequest.bids || [];
-
-    bids.forEach(bid => {
-      try {
-        // Video endpoint only accepts POST calls
-        if (bid.mediaType === 'video') {
-          ajax(
-            VIDEO_ENDPOINT,
-            {
-              success: bidCallback,
-              error: bidError
-            },
-            buildVideoRequestPayload(bid, bidderRequest),
-            {
-              withCredentials: true
-            }
-          );
-        } else {
-          ajax(
-            buildOptimizedCall(bid),
-            {
-              success: bidCallback,
-              error: bidError
-            },
-            undefined,
-            {
-              withCredentials: true
-            }
-          );
-        }
-      } catch (err) {
-        utils.logError('Error sending rubicon request for placement code ' + bid.placementCode, null, err);
-        addErrorBid();
-      }
-
-      function bidCallback(responseText) {
-        try {
-          utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
-          handleRpCB(responseText, bid);
-        } catch (err) {
-          if (typeof err === 'string') {
-            utils.logWarn(`${err} when processing rubicon response for placement code ${bid.placementCode}`);
-          } else {
-            utils.logError('Error processing rubicon response for placement code ' + bid.placementCode, null, err);
-          }
-          addErrorBid();
-        }
-      }
-
-      function bidError(err, xhr) {
-        utils.logError('Request for rubicon responded with:', xhr.status, err);
-        addErrorBid();
-      }
-
-      function addErrorBid() {
-        let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
-        badBid.bidderCode = baseAdapter.getBidderCode();
-        bidmanager.addBidResponse(bid.placementCode, badBid);
-      }
-    });
-  }
-
-  function _getScreenResolution() {
-    return [window.screen.width, window.screen.height].join('x');
-  }
-
-  function _getDigiTrustQueryParams() {
-    function getDigiTrustId() {
-      let digiTrustUser = window.DigiTrust && ($$PREBID_GLOBAL$$.getConfig('digiTrustId') || window.DigiTrust.getUser({member: 'T9QSFKPDN9'}));
-      return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
+export const spec = {
+  code: 'rubicon',
+  aliases: ['rubiconLite'],
+  supportedMediaTypes: ['video'],
+  /**
+   * @param {object} bid
+   * @return boolean
+   */
+  isBidRequestValid: function(bid) {
+    if (typeof bid.params !== 'object') {
+      return false;
     }
-    let digiTrustId = getDigiTrustId();
-    // Verify there is an ID and this user has not opted out
-    if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) {
-      return [];
-    }
-    return [
-      'dt.id', digiTrustId.id,
-      'dt.keyv', digiTrustId.keyv,
-      'dt.pref', 0
-    ];
-  }
-
-  function buildVideoRequestPayload(bid, bidderRequest) {
-    bid.startTime = new Date().getTime();
-
     let params = bid.params;
 
-    if (!params || typeof params.video !== 'object') {
-      throw 'Invalid Video Bid';
+    if (!/^\d+$/.test(params.accountId)) {
+      return false;
     }
 
-    let size;
-    if (params.video.playerWidth && params.video.playerHeight) {
-      size = [
-        params.video.playerWidth,
-        params.video.playerHeight
-      ];
-    } else if (
-      Array.isArray(bid.sizes) && bid.sizes.length > 0 &&
-        Array.isArray(bid.sizes[0]) && bid.sizes[0].length > 1
-    ) {
-      size = bid.sizes[0];
-    } else {
-      throw 'Invalid Video Bid - No size provided';
-    }
-
-    let postData = {
-      page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
-      resolution: _getScreenResolution(),
-      account_id: params.accountId,
-      integration: getIntegration(),
-      timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
-      stash_creatives: true,
-      ae_pass_through_parameters: params.video.aeParams,
-      slots: []
-    };
-
-    // Define the slot object
-    let slotData = {
-      site_id: params.siteId,
-      zone_id: params.zoneId,
-      position: params.position || 'btf',
-      floor: parseFloat(params.floor) > 0.01 ? params.floor : 0.01,
-      element_id: bid.placementCode,
-      name: bid.placementCode,
-      language: params.video.language,
-      width: size[0],
-      height: size[1]
-    };
-
-    // check and add inventory, keywords, visitor and size_id data
-    if (params.video.size_id) {
-      slotData.size_id = params.video.size_id;
-    } else {
-      throw 'Invalid Video Bid - Invalid Ad Type!';
-    }
-
-    if (params.inventory && typeof params.inventory === 'object') {
-      slotData.inventory = params.inventory;
-    }
-
-    if (params.keywords && Array.isArray(params.keywords)) {
-      slotData.keywords = params.keywords;
-    }
-
-    if (params.visitor && typeof params.visitor === 'object') {
-      slotData.visitor = params.visitor;
-    }
-
-    postData.slots.push(slotData);
-
-    return (JSON.stringify(postData));
-  }
-
-  function buildOptimizedCall(bid) {
-    bid.startTime = new Date().getTime();
-
-    var {
-      accountId,
-      siteId,
-      zoneId,
-      position,
-      floor,
-      keywords,
-      visitor,
-      inventory,
-      userId,
-      referrer: pageUrl
-    } = bid.params;
-
-    // defaults
-    floor = (floor = parseFloat(floor)) > 0.01 ? floor : 0.01;
-    position = position || 'btf';
-
-    // use rubicon sizes if provided, otherwise adUnit.sizes
-    var parsedSizes = RubiconAdapter.masSizeOrdering(Array.isArray(bid.params.sizes)
-      ? bid.params.sizes.map(size => (sizeMap[size] || '').split('x')) : bid.sizes
-    );
-
+    let parsedSizes = parseSizes(bid);
     if (parsedSizes.length < 1) {
-      throw 'no valid sizes';
+      return false;
     }
 
-    if (!/^\d+$/.test(accountId)) {
-      throw 'invalid accountId provided';
+    if (bid.mediaType === 'video') {
+      if (typeof params.video !== 'object' || !params.video.size_id) {
+        return false;
+      }
     }
+    return true;
+  },
+  /**
+   * @param {BidRequest[]} bidRequests
+   * @param bidderRequest
+   * @return ServerRequest[]
+   */
+  buildRequests: function(bidRequests, bidderRequest) {
+    return bidRequests.map(bidRequest => {
+      bidRequest.startTime = new Date().getTime();
 
-    // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
-    var queryString = [
-      'account_id', accountId,
-      'site_id', siteId,
-      'zone_id', zoneId,
-      'size_id', parsedSizes[0],
-      'alt_size_ids', parsedSizes.slice(1).join(',') || undefined,
-      'p_pos', position,
-      'rp_floor', floor,
-      'rp_secure', isSecure() ? '1' : '0',
-      'tk_flint', getIntegration(),
-      'p_screen_res', _getScreenResolution(),
-      'kw', keywords,
-      'tk_user_key', userId
-    ];
+      if (bidRequest.mediaType === 'video') {
+        let params = bidRequest.params;
+        let size = parseSizes(bidRequest);
 
-    if (visitor !== null && typeof visitor === 'object') {
-      utils._each(visitor, (item, key) => queryString.push(`tg_v.${key}`, item));
-    }
+        let data = {
+          page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
+          resolution: _getScreenResolution(),
+          account_id: params.accountId,
+          integration: getIntegration(),
+          timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
+          stash_creatives: true,
+          ae_pass_through_parameters: params.video.aeParams,
+          slots: []
+        };
 
-    if (inventory !== null && typeof inventory === 'object') {
-      utils._each(inventory, (item, key) => queryString.push(`tg_i.${key}`, item));
-    }
+        // Define the slot object
+        let slotData = {
+          site_id: params.siteId,
+          zone_id: params.zoneId,
+          position: params.position || 'btf',
+          floor: parseFloat(params.floor) > 0.01 ? params.floor : 0.01,
+          element_id: bidRequest.placementCode,
+          name: bidRequest.placementCode,
+          language: params.video.language,
+          width: size[0],
+          height: size[1],
+          size_id: params.video.size_id
+        };
 
-    queryString.push(
-      'rand', Math.random(),
-      'rf', !pageUrl ? utils.getTopWindowUrl() : pageUrl
-    );
+        if (params.inventory && typeof params.inventory === 'object') {
+          slotData.inventory = params.inventory;
+        }
 
-    queryString = queryString.concat(_getDigiTrustQueryParams());
+        if (params.keywords && Array.isArray(params.keywords)) {
+          slotData.keywords = params.keywords;
+        }
 
-    return queryString.reduce(
-      (memo, curr, index) =>
-        index % 2 === 0 && queryString[index + 1] !== undefined
-          ? memo + curr + '=' + encodeURIComponent(queryString[index + 1]) + '&' : memo,
-      FASTLANE_ENDPOINT + '?'
-    ).slice(0, -1); // remove trailing &
-  }
+        if (params.visitor && typeof params.visitor === 'object') {
+          slotData.visitor = params.visitor;
+        }
 
-  let _renderCreative = (script, impId) => `<html>
-<head><script type='text/javascript'>inDapIF=true;</script></head>
-<body style='margin : 0; padding: 0;'>
-<!-- Rubicon Project Ad Tag -->
-<div data-rp-impression-id='${impId}'>
-<script type='text/javascript'>${script}</script>
-</div>
-</body>
-</html>`;
+        data.slots.push(slotData);
 
-  function handleRpCB(responseText, bidRequest) {
-    const responseObj = JSON.parse(responseText); // can throw
+        return {
+          method: 'POST',
+          url: VIDEO_ENDPOINT,
+          data,
+          bidRequest
+        }
+      }
+
+      // non-video request builder
+      let {
+        accountId,
+        siteId,
+        zoneId,
+        position,
+        floor,
+        keywords,
+        visitor,
+        inventory,
+        userId,
+        referrer: pageUrl
+      } = bidRequest.params;
+
+      // defaults
+      floor = (floor = parseFloat(floor)) > 0.01 ? floor : 0.01;
+      position = position || 'btf';
+
+      // use rubicon sizes if provided, otherwise adUnit.sizes
+      let parsedSizes = parseSizes(bidRequest);
+
+      // using array to honor ordering. if order isn't important (it shouldn't be), an object would probably be preferable
+      let data = [
+        'account_id', accountId,
+        'site_id', siteId,
+        'zone_id', zoneId,
+        'size_id', parsedSizes[0],
+        'alt_size_ids', parsedSizes.slice(1).join(',') || undefined,
+        'p_pos', position,
+        'rp_floor', floor,
+        'rp_secure', isSecure() ? '1' : '0',
+        'tk_flint', getIntegration(),
+        'p_screen_res', _getScreenResolution(),
+        'kw', keywords,
+        'tk_user_key', userId
+      ];
+
+      if (visitor !== null && typeof visitor === 'object') {
+        utils._each(visitor, (item, key) => data.push(`tg_v.${key}`, item));
+      }
+
+      if (inventory !== null && typeof inventory === 'object') {
+        utils._each(inventory, (item, key) => data.push(`tg_i.${key}`, item));
+      }
+
+      data.push(
+        'rand', Math.random(),
+        'rf', !pageUrl ? utils.getTopWindowUrl() : pageUrl
+      );
+
+      data = data.concat(_getDigiTrustQueryParams());
+
+      data = data.reduce(
+        (memo, curr, index) =>
+          index % 2 === 0 && data[index + 1] !== undefined
+            ? memo + curr + '=' + encodeURIComponent(data[index + 1]) + '&' : memo,
+        ''
+      ).slice(0, -1); // remove trailing &
+
+      return {
+        method: 'GET',
+        url: FASTLANE_ENDPOINT,
+        data,
+        bidRequest
+      };
+    });
+  },
+  /**
+   * @param {*} responseObj
+   * @return {Bid[]} An array of bids which
+   */
+  interpretResponse: function(responseObj) {
+    let bidRequest = this.bidRequest;
     let ads = responseObj.ads;
     const adResponseKey = bidRequest.placementCode;
 
     // check overall response
     if (typeof responseObj !== 'object' || responseObj.status !== 'ok') {
-      throw 'bad response';
+      return [];
     }
 
     // video ads array is wrapped in an object
@@ -331,25 +243,25 @@ function RubiconAdapter() {
 
     // check the ad response
     if (!Array.isArray(ads) || ads.length < 1) {
-      throw 'invalid ad response';
+      return [];
     }
 
     // if there are multiple ads, sort by CPM
     ads = ads.sort(_adCpmSort);
 
-    ads.forEach(ad => {
+    let bids = ads.reduce((bids, ad) => {
       if (ad.status !== 'ok') {
-        throw 'bad ad status';
+        return;
       }
 
-      // store bid response
-      // bid status is good (indicating 1)
-      var bid = bidfactory.createBid(STATUS.GOOD, bidRequest);
-      bid.currency = 'USD';
-      bid.creative_id = ad.creative_id;
-      bid.bidderCode = baseAdapter.getBidderCode();
-      bid.cpm = ad.cpm || 0;
-      bid.dealId = ad.deal;
+      let bid = {
+        requestId: bidRequest.bidId,
+        currency: 'USD',
+        creative_id: ad.creative_id,
+        bidderCode: spec.code,
+        cpm: ad.cpm || 0,
+        dealId: ad.deal
+      };
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;
@@ -368,26 +280,77 @@ function RubiconAdapter() {
           return memo;
         }, {'rpfl_elemid': bidRequest.placementCode});
 
-      try {
-        bidmanager.addBidResponse(bidRequest.placementCode, bid);
-      } catch (err) {
-        utils.logError('Error from addBidResponse', null, err);
-      }
-    });
-    // Run the Emily user sync
+      bids.push(bid);
+
+      return bids;
+    }, []);
+
     hasUserSyncFired = syncEmily(hasUserSyncFired);
-  }
 
-  function _adCpmSort(adA, adB) {
-    return (adB.cpm || 0.0) - (adA.cpm || 0.0);
+    return bids;
   }
+};
 
-  return Object.assign(this, baseAdapter, {
-    callBids: _callBids
-  });
+function _adCpmSort(adA, adB) {
+  return (adB.cpm || 0.0) - (adA.cpm || 0.0);
 }
 
-RubiconAdapter.masSizeOrdering = function(sizes) {
+function _getScreenResolution() {
+  return [window.screen.width, window.screen.height].join('x');
+}
+
+function _getDigiTrustQueryParams() {
+  function getDigiTrustId() {
+    let digiTrustUser = window.DigiTrust && ($$PREBID_GLOBAL$$.getConfig('digiTrustId') || window.DigiTrust.getUser({member: 'T9QSFKPDN9'}));
+    return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
+  }
+  let digiTrustId = getDigiTrustId();
+  // Verify there is an ID and this user has not opted out
+  if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) {
+    return [];
+  }
+  return [
+    'dt.id', digiTrustId.id,
+    'dt.keyv', digiTrustId.keyv,
+    'dt.pref', 0
+  ];
+}
+
+function _renderCreative(script, impId) {
+  return `<html>
+<head><script type='text/javascript'>inDapIF=true;</script></head>
+<body style='margin : 0; padding: 0;'>
+<!-- Rubicon Project Ad Tag -->
+<div data-rp-impression-id='${impId}'>
+<script type='text/javascript'>${script}</script>
+</div>
+</body>
+</html>`;
+}
+
+function parseSizes(bid) {
+  let params = bid.params;
+  if (bid.mediaType === 'video') {
+    let size = [];
+    if (params.video.playerWidth && params.video.playerHeight) {
+      size = [
+        params.video.playerWidth,
+        params.video.playerHeight
+      ];
+    } else if (
+      Array.isArray(bid.sizes) && bid.sizes.length > 0 &&
+        Array.isArray(bid.sizes[0]) && bid.sizes[0].length > 1
+    ) {
+      size = bid.sizes[0];
+    }
+    return size;
+  }
+  return masSizeOrdering(Array.isArray(params.sizes)
+    ? params.sizes.map(size => (sizeMap[size] || '').split('x')) : bid.sizes
+  );
+}
+
+export function masSizeOrdering(sizes) {
   const MAS_SIZE_PRIORITY = [15, 2, 9];
 
   return utils.parseSizesInput(sizes)
@@ -461,10 +424,10 @@ function syncEmily(hasSynced) {
   setTimeout(() => utils.insertCookieSyncIframe(iframeUrl), Number(userSyncConfig.delay));
   return true;
 }
+var hasUserSyncFired = false;
 
-adaptermanager.registerBidAdapter(new RubiconAdapter(), RUBICON_BIDDER_CODE, {
-  supportedMediaTypes: ['video']
-});
-adaptermanager.aliasBidAdapter(RUBICON_BIDDER_CODE, 'rubiconLite');
+export function resetUserSync() {
+  hasUserSyncFired = false;
+}
 
-module.exports = RubiconAdapter;
+registerBidder(spec);

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -21,7 +21,7 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  *   code: 'myBidderCode',
  *   aliases: ['alias1', 'alias2'],
  *   supportedMediaTypes: ['video', 'native'],
- *   areParamsValid: function(paramsObject) { return true/false },
+ *   isBidRequestValid: function(bid) { return true/false },
  *   buildRequests: function(bidRequests) { return some ServerRequest(s) },
  *   interpretResponse: function(oneServerResponse) { return some Bids, or throw an error. }
  * });
@@ -37,11 +37,11 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  *   one as is used in the call to registerBidAdapter
  * @property {string[]} [aliases] A list of aliases which should also resolve to this bidder.
  * @property {MediaType[]} [supportedMediaTypes]: A list of Media Types which the adapter supports.
- * @property {function(object): boolean} areParamsValid Determines whether or not the given object has all the params
+ * @property {function(object): boolean} isBidRequestValid Determines whether or not the given bid object has all the params
  *   needed to make a valid request.
  * @property {function(BidRequest[]): ServerRequest|ServerRequest[]} buildRequests Build the request to the Server which
  *   requests Bids for the given array of Requests. Each BidRequest in the argument array is guaranteed to have
- *   a "params" property which has passed the areParamsValid() test
+ *   a "params" property which has passed the isBidRequestValid() test
  * @property {function(*): Bid[]} interpretResponse Given a successful response from the Server, interpret it
  *   and return the Bid objects. This function will be run inside a try/catch. If it throws any errors, your
  *   bids will be discarded.
@@ -56,7 +56,7 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  *
  * @property {string} bidId A string which uniquely identifies this BidRequest in the current Auction.
  * @property {object} params Any bidder-specific params which the publisher used in their bid request.
- *   This is guaranteed to have passed the spec.areParamsValid() test.
+ *   This is guaranteed to have passed the spec.isBidRequestValid() test.
  */
 
 /**
@@ -76,6 +76,7 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  * @property {string} requestId The specific BidRequest which this bid is aimed at.
  *   This should correspond to one of the
  * @property {string} ad A URL which can be used to load this ad, if it's chosen by the publisher.
+ * @property {string} currency The currency code for the cpm value
  * @property {number} cpm The bid price, in US cents per thousand impressions.
  * @property {number} height The height of the ad, in pixels.
  * @property {number} width The width of the ad, in pixels.
@@ -172,7 +173,7 @@ export function newBidder(spec) {
         bidRequestMap[bid.bidId] = bid;
       });
 
-      let requests = spec.buildRequests(bidRequests);
+      let requests = spec.buildRequests(bidRequests, bidderRequest);
       if (!requests || requests.length === 0) {
         fillNoBids();
         return;
@@ -205,10 +206,10 @@ export function newBidder(spec) {
         switch (request.method) {
           case 'GET':
             ajax(
-              `${request.url}?${parseQueryStringParameters(request.data)}`,
+              `${request.url}?${typeof request.data === 'object' ? parseQueryStringParameters(request.data) : request.data}`,
               {
-                success: onSuccess,
-                error: onFailure
+                success: onSuccess.bind(request),
+                error: onFailure.bind(request)
               },
               undefined,
               {
@@ -221,8 +222,8 @@ export function newBidder(spec) {
             ajax(
               request.url,
               {
-                success: onSuccess,
-                error: onFailure
+                success: onSuccess.bind(request),
+                error: onFailure.bind(request)
               },
               typeof request.data === 'string' ? request.data : JSON.stringify(request.data),
               {
@@ -249,7 +250,7 @@ export function newBidder(spec) {
 
         let bids;
         try {
-          bids = spec.interpretResponse(response);
+          bids = spec.interpretResponse.call(this, response);
         } catch (err) {
           logError(`Bidder ${spec.code} failed to interpret the server's response. Continuing without bids`, null, err);
           onResponse();
@@ -286,7 +287,7 @@ export function newBidder(spec) {
   });
 
   function filterAndWarn(bid) {
-    if (!spec.areParamsValid(bid.params)) {
+    if (!spec.isBidRequestValid(bid)) {
       logWarn(`Invalid bid sent to bidder ${spec.code}: ${JSON.stringify(bid)}`);
       return false;
     }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import adapterManager from 'src/adaptermanager';
 import bidManager from 'src/bidmanager';
-import RubiconAdapter from 'modules/rubiconBidAdapter';
-import {parse as parseQuery} from 'querystring';
+import { spec, masSizeOrdering, resetUserSync } from 'modules/rubiconBidAdapter';
+import { parse as parseQuery } from 'querystring';
+import { newBidder } from 'src/adapters/bidderFactory';
 
 var CONSTANTS = require('src/constants.json');
 
@@ -161,8 +162,6 @@ describe('the rubicon adapter', () => {
   });
 
   describe('MAS mapping / ordering', () => {
-    let masSizeOrdering = RubiconAdapter.masSizeOrdering;
-
     it('should not include values without a proper mapping', () => {
       // two invalid sizes included: [42, 42], [1, 1]
       let ordering = masSizeOrdering([[320, 50], [42, 42], [300, 250], [640, 480], [1, 1], [336, 280]]);
@@ -196,7 +195,7 @@ describe('the rubicon adapter', () => {
         bids;
 
       beforeEach(() => {
-        rubiconAdapter = new RubiconAdapter();
+        rubiconAdapter = newBidder(spec);
 
         bids = [];
 
@@ -1092,13 +1091,14 @@ describe('the rubicon adapter', () => {
         iframes[i].outerHTML = '';
       }
 
-      rubiconAdapter = new RubiconAdapter();
+      rubiconAdapter = newBidder(spec);
     });
 
     afterEach(() => {
       server.restore();
       clock.restore();
       window.$$PREBID_GLOBAL$$.getConfig = origGetConfig;
+      resetUserSync();
     });
 
     it('should not add the Emily iframe by default', () => {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -33,7 +33,7 @@ describe('bidders created by newBidder', () => {
   beforeEach(() => {
     spec = {
       code: CODE,
-      areParamsValid: sinon.stub(),
+      isBidRequestValid: sinon.stub(),
       buildRequests: sinon.stub(),
       interpretResponse: sinon.stub(),
       getUserSyncs: sinon.stub()
@@ -63,7 +63,7 @@ describe('bidders created by newBidder', () => {
       bidder.callBids({ bids: 'nothing useful' });
 
       expect(ajaxStub.called).to.equal(false);
-      expect(spec.areParamsValid.called).to.equal(false);
+      expect(spec.isBidRequestValid.called).to.equal(false);
       expect(spec.buildRequests.called).to.equal(false);
       expect(spec.interpretResponse.called).to.equal(false);
     });
@@ -71,13 +71,13 @@ describe('bidders created by newBidder', () => {
     it('should call buildRequests(bidRequest) the params are valid', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
       bidder.callBids(MOCK_BIDS_REQUEST);
 
       expect(ajaxStub.called).to.equal(false);
-      expect(spec.areParamsValid.calledTwice).to.equal(true);
+      expect(spec.isBidRequestValid.calledTwice).to.equal(true);
       expect(spec.buildRequests.calledOnce).to.equal(true);
       expect(spec.buildRequests.firstCall.args[0]).to.deep.equal(MOCK_BIDS_REQUEST.bids);
     });
@@ -85,27 +85,27 @@ describe('bidders created by newBidder', () => {
     it('should not call buildRequests the params are invalid', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(false);
+      spec.isBidRequestValid.returns(false);
       spec.buildRequests.returns([]);
 
       bidder.callBids(MOCK_BIDS_REQUEST);
 
       expect(ajaxStub.called).to.equal(false);
-      expect(spec.areParamsValid.calledTwice).to.equal(true);
+      expect(spec.isBidRequestValid.calledTwice).to.equal(true);
       expect(spec.buildRequests.called).to.equal(false);
     });
 
     it('should filter out invalid bids before calling buildRequests', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.onFirstCall().returns(true);
-      spec.areParamsValid.onSecondCall().returns(false);
+      spec.isBidRequestValid.onFirstCall().returns(true);
+      spec.isBidRequestValid.onSecondCall().returns(false);
       spec.buildRequests.returns([]);
 
       bidder.callBids(MOCK_BIDS_REQUEST);
 
       expect(ajaxStub.called).to.equal(false);
-      expect(spec.areParamsValid.calledTwice).to.equal(true);
+      expect(spec.isBidRequestValid.calledTwice).to.equal(true);
       expect(spec.buildRequests.calledOnce).to.equal(true);
       expect(spec.buildRequests.firstCall.args[0]).to.deep.equal([MOCK_BIDS_REQUEST.bids[0]]);
     });
@@ -113,7 +113,7 @@ describe('bidders created by newBidder', () => {
     it("should make no server requests if the spec doesn't return any", () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
       bidder.callBids(MOCK_BIDS_REQUEST);
@@ -125,7 +125,7 @@ describe('bidders created by newBidder', () => {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: url,
@@ -148,7 +148,7 @@ describe('bidders created by newBidder', () => {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'GET',
         url: url,
@@ -170,7 +170,7 @@ describe('bidders created by newBidder', () => {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([
         {
           method: 'POST',
@@ -206,7 +206,7 @@ describe('bidders created by newBidder', () => {
     it('should call spec.interpretResponse() with the response body content', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -222,7 +222,7 @@ describe('bidders created by newBidder', () => {
     it('should call spec.interpretResponse() once for each request made', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([
         {
           method: 'POST',
@@ -252,7 +252,7 @@ describe('bidders created by newBidder', () => {
         width: 300,
         placementCode: 'mock/placement'
       };
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -272,7 +272,7 @@ describe('bidders created by newBidder', () => {
     it('should call spec.getUserSyncs() with the response', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -302,7 +302,7 @@ describe('bidders created by newBidder', () => {
     it('should not spec.interpretResponse()', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -317,7 +317,7 @@ describe('bidders created by newBidder', () => {
     it('should add bids for each placement code into the bidmanager', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -337,7 +337,7 @@ describe('bidders created by newBidder', () => {
     it('should call spec.getUserSyncs() with no responses', () => {
       const bidder = newBidder(spec);
 
-      spec.areParamsValid.returns(true);
+      spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: 'test.url.com',
@@ -369,7 +369,7 @@ describe('registerBidder', () => {
   function newEmptySpec() {
     return {
       code: CODE,
-      areParamsValid: function() { },
+      isBidRequestValid: function() { },
       buildRequests: function() { },
       interpretResponse: function() { },
     };


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Here's my update to the `single-request-bidder` branch that includes a converted rubiconBidAdapter, some updates to the bidderFactory, and a few bug fixes.

Some of the pain points and problem areas in converting that I put fixes in for or want to highlight (we might also want to discuss if they are the _right_ fixes):
1. Renamed `spec.areParamsValid` to `spec.isBidRequestValid` and pass the whole bidRequest rather than just the params.  This was necessary because some of the validation is on the `bid.sizes` that comes from the adUnit, but are not available on the `bid.params`.
2. Passing in the `bidderRequest` as a second parameter to `spec.buildRequests` as our adapter uses some of that information that wasn't available otherwise (specifically the `timeout` and `auctionStart` properties which we use to do some timeout adjustment for our requests).
3. Had to bind the request object that `spec.buildRequests` creates to each of the `onSuccess` handlers so it can be sent in as the context to `spec.interpretResponse`.  I needed to do this to get access to some of the information about the request that is used when formulating the responses but isn't necessarily available through the call to our endpoint.  I don't know if I like this solution that much, but wasn't sure if there was a more elegant solution; and it seems like this might arise as a problem for others as well.
4. I couldn't find any way to port over our instance properties that are unique to an instance of an adapter.  This isn't a frequent problem since there is only usually one instance of an adapter; however, it did prove problematic for testing which creates multiple instances.  For instance, `hasUserSyncFired` which was a private property of `RubiconAdapter` had to be made global to the module and has to be reset manually in the tests by a new method call I added (which is only used for testing).  That private user sync tracking variable was the only property that didn't have an elegant solution in our adapter, but this could be a common problem in other adapters.
5. Before the refactor, our adapter did some size processing and then validated that those sizes were correct before using them in the request.  With this new adapter pattern, we have to do those size processing calculations twice, once in `spec.isBidRequestValid` to determine if the bidRequest is valid, and then again within `spec.buildRequests` so we can use those calculated sizes in our requests.  I'm wondering if there is a better solutions there...

Besides those issues, all unit tests are passing and I performed a functional test of the adapter which had it still working as expected. 

## Other information
Addition to #1494 