### PR TITLE
Save the last bid before auction closes. Resolves #1298

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -88,8 +88,8 @@ exports.addBidResponse = function (adUnitCode, bid) {
     if (bid.mediaType === 'video') {
       tryAddVideoBid(bid);
     } else {
-      doCallbacksIfNeeded();
       addBidToAuction(bid);
+      doCallbacksIfNeeded();
     }
   }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Include the last bid that closes the auction. 

