### PR TITLE
Fix renderer test for new validation rule

### DIFF
--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -624,12 +624,16 @@ describe('bidmanager.js', function () {
     });
 
     it('requires a renderer on outstream bids', () => {
-      sinon.stub(utils, 'getBidRequest', () => ({
+      const bidRequest = () => ({
+        start: timestamp(),
         bidder: 'appnexusAst',
         mediaTypes: {
           video: {context: 'outstream'}
         },
-      }));
+      });
+
+      sinon.stub(utils, 'getBidRequest', bidRequest);
+      sinon.stub(utils, 'getBidderRequest', bidRequest);
 
       const bid = Object.assign({},
         bidfactory.createBid(1),
@@ -645,6 +649,7 @@ describe('bidmanager.js', function () {
       assert.equal(bidsRecCount + 1, $$PREBID_GLOBAL$$._bidsReceived.length);
 
       utils.getBidRequest.restore();
+      utils.getBidderRequest.restore();
     });
   });
 });


### PR DESCRIPTION
`bidmanager.addBidResponse` now requires bids to have a `start` property. Adds this to a bid stub used in a test created before rule was merged