### PR TITLE
Districtdmx adapter fix

### DIFF
--- a/modules/districtmDMXBidAdapter.js
+++ b/modules/districtmDMXBidAdapter.js
@@ -19,7 +19,7 @@ var DistrictmAdaptor = function districtmAdaptor() {
   this.handlerRes = function(response, bidObject) {
     let bid;
     if (parseFloat(response.result.cpm) > 0) {
-      bid = bidfactory.createBid(1);
+      bid = bidfactory.createBid(1, bidObject);
       bid.bidderCode = bidObject.bidder;
       bid.cpm = response.result.cpm;
       bid.width = response.result.width;
@@ -27,7 +27,7 @@ var DistrictmAdaptor = function districtmAdaptor() {
       bid.ad = response.result.banner;
       bidmanager.addBidResponse(bidObject.placementCode, bid);
     } else {
-      bid = bidfactory.createBid(2);
+      bid = bidfactory.createBid(2, bidObject);
       bid.bidderCode = bidObject.bidder;
       bidmanager.addBidResponse(bidObject.placementCode, bid);
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Passing bidRequest to createBid function to match bid request and bid response. 

This is done to reduce impression discrepancies. When bidRequest is not passed, the id which is used to match bidRequest and bidResponse are different. So there can be a scenario where two impressions can be recorded in reporting. 


## Other information
@stevealliance 
