### PR TITLE
disable rubicon user-sync by default

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -423,9 +423,9 @@ RubiconAdapter.masSizeOrdering = function(sizes) {
  * syncEmily
  * @summary A user sync dependency for the Rubicon Project adapter
  * Registers an Emily iframe user sync to be called/created later by Prebid
- * Only registers once except that with each winning creative there will be additional, similar calls to the same service.  Must enable iframe syncs which are off by default
+ * Only registers once except that with each winning creative there will be additional, similar calls to the same service.  Must enable iframe syncs globally and rubicon syncs specifically, both of which are off by default
 @example
- *  // Config example for iframe user sync
+ *  // Config example to turn on iframe user sync globally
  *  $$PREBID_GLOBAL$$.setConfig({ userSync: {
  *    syncEnabled: true,
  *    pixelEnabled: true,
@@ -433,12 +433,24 @@ RubiconAdapter.masSizeOrdering = function(sizes) {
  *    syncDelay: 3000,
  *    iframeEnabled: true
  *  }});
+ *  // Config example to enable rubicon sync
+ *  $$PREBID_GLOBAL$$.setConfig({ rubicon: {
+ *    userSync: {
+ *      enabled: true
+ *    }
+ *  }});
  * @return {boolean} Whether or not Emily synced
  */
 function syncEmily(hasSynced) {
   // Check that it has not already been triggered - only meant to fire once
   if (hasSynced) {
     return true;
+  }
+
+  // only do sync if enabled through config
+  var userSyncConfig = $$PREBID_GLOBAL$$.getConfig('rubicon.userSync') || {};
+  if (!userSyncConfig.enabled) {
+    return;
   }
 
   const iframeUrl = 'https://tap-secure.rubiconproject.com/partner/scripts/rubicon/emily.html?rtb_ext=1';

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1035,6 +1035,7 @@ describe('the rubicon adapter', () => {
     let rubiconAdapter;
     let userSyncStub;
     const emilyUrl = 'https://tap-secure.rubiconproject.com/partner/scripts/rubicon/emily.html?rtb_ext=1';
+    let rubiConfig = $$PREBID_GLOBAL$$.getConfig('rubicon');
 
     beforeEach(() => {
       bids = [];
@@ -1099,17 +1100,32 @@ describe('the rubicon adapter', () => {
     afterEach(() => {
       server.restore();
       userSyncStub.restore();
+      $$PREBID_GLOBAL$$.setConfig({rubicon: rubiConfig});
     });
 
-    it('should register the Emily iframe', () => {
+    it('should not register the Emily iframe by default', () => {
+      expect(userSyncStub.notCalled).to.be.true;
+      rubiconAdapter.callBids(bidderRequest);
+      server.respond();
+      expect(userSyncStub.notCalled).to.be.true;
+      // run another auction, should still not have been called
+      rubiconAdapter.callBids(bidderRequest);
+      server.respond();
+      expect(userSyncStub.notCalled).to.be.true;
+    });
+
+    it('should register the Emily iframe when enabled', () => {
+      // enable rubicon sync
+      $$PREBID_GLOBAL$$.setConfig({ rubicon: { userSync: { enabled: true }}});
       expect(userSyncStub.calledOnce).to.be.false;
       rubiconAdapter.callBids(bidderRequest);
       server.respond();
       expect(userSyncStub.calledOnce).to.be.true;
-      expect(userSyncStub.getCall(0).args).to.eql(['iframe', 'rubicon', emilyUrl]);
     });
 
     it('should not register the Emily iframe more than once', () => {
+      // enable rubicon sync
+      $$PREBID_GLOBAL$$.setConfig({ rubicon: { userSync: { enabled: true }}});
       expect(userSyncStub.calledOnce).to.be.false;
       rubiconAdapter.callBids(bidderRequest);
       server.respond();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
