### PR TITLE
Added onefiftytwo alias for serverbid adapter

### DIFF
--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -17,6 +17,10 @@ ServerBidAdapter = function ServerBidAdapter() {
     'connectad': {
       'BASE_URI': 'https://i.connectad.io/api/v2',
       'SMARTSYNC_BASE_URI': 'https://s.zkcdn.net/ss'
+    },
+    'onefiftytwo': {
+      'BASE_URI': 'https://e.serverbid.com/api/v2',
+      'SMARTSYNC_BASE_URI': 'https://s.zkcdn.net/ss'
     }
   };
 
@@ -199,5 +203,6 @@ ServerBidAdapter.createNew = function() {
 
 adaptermanager.registerBidAdapter(new ServerBidAdapter(), 'serverbid');
 adaptermanager.aliasBidAdapter('serverbid', 'connectad');
+adaptermanager.aliasBidAdapter('serverbid', 'onefiftytwo');
 
 module.exports = ServerBidAdapter;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
## Description of change
<!-- Describe the change proposed in this pull request -->
New `onefiftytwo` alias for `serverbid` adapter
