### PR TITLE
AdyoulikeBidAdapter - manage transaction ids for adyoulike adapter

### DIFF
--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -8,7 +8,7 @@ import { STATUS } from 'src/constants';
 import adaptermanager from 'src/adaptermanager';
 
 var AdyoulikeAdapter = function AdyoulikeAdapter() {
-  const _VERSION = '0.1';
+  const _VERSION = '0.2';
 
   const baseAdapter = new Adapter('adyoulike');
 
@@ -21,7 +21,7 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
 
     const placements = validBids.map(bid => bid.params.placement);
     if (!utils.isEmpty(placements)) {
-      const body = createBody(placements);
+      const body = createBody(bidRequests, placements);
       const endpoint = createEndpoint();
       ajax(endpoint,
         (response) => {
@@ -61,10 +61,11 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
   }
 
   /* Create request body */
-  function createBody(placements) {
+  function createBody(bidRequests, placements) {
     const body = {
       Version: _VERSION,
       Placements: placements,
+      TransactionIds: {}
     };
 
     // performance isn't supported by mobile safari iOS7. window.performance works, but
@@ -79,6 +80,8 @@ var AdyoulikeAdapter = function AdyoulikeAdapter() {
     } catch (e) {
       body.PageRefreshed = false;
     }
+
+    placements.forEach(placement => { body.TransactionIds[placement] = bidRequests[placement].transactionId; });
 
     return JSON.stringify(body);
   }

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -29,7 +29,8 @@ describe('Adyoulike Adapter', () => {
         'placementCode': 'adunit/hb-0',
         'params': {
           'placement': 'placement_0'
-        }
+        },
+        'transactionId': 'bid_id_0_transaction_id'
       }
     ],
   };
@@ -43,7 +44,8 @@ describe('Adyoulike Adapter', () => {
         'params': {
           'placement': 'placement_0'
         },
-        'sizes': '300x250'
+        'sizes': '300x250',
+        'transactionId': 'bid_id_0_transaction_id'
       }
     ],
   };
@@ -57,7 +59,8 @@ describe('Adyoulike Adapter', () => {
         'params': {
           'placement': 'placement_0'
         },
-        'sizes': '300x250'
+        'sizes': '300x250',
+        'transactionId': 'bid_id_0_transaction_id'
       },
       {
         'bidId': 'bid_id_1',
@@ -66,14 +69,16 @@ describe('Adyoulike Adapter', () => {
         'params': {
           'placement': 'placement_1'
         },
-        'sizes': [[300, 600]]
+        'sizes': [[300, 600]],
+        'transactionId': 'bid_id_1_transaction_id'
       },
       {
         'bidId': 'bid_id_2',
         'bidder': 'adyoulike',
         'placementCode': 'adunit/hb-2',
         'params': {},
-        'sizes': '300x400'
+        'sizes': '300x400',
+        'transactionId': 'bid_id_2_transaction_id'
       },
       {
         'bidId': 'bid_id_3',
@@ -81,7 +86,8 @@ describe('Adyoulike Adapter', () => {
         'placementCode': 'adunit/hb-3',
         'params': {
           'placement': 'placement_3'
-        }
+        },
+        'transactionId': 'bid_id_3_transaction_id'
       }
     ],
   };
@@ -175,9 +181,10 @@ describe('Adyoulike Adapter', () => {
       expect(requests[0].url).to.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
 
       let body = JSON.parse(requests[0].requestBody);
-      expect(body.Version).to.equal('0.1');
+      expect(body.Version).to.equal('0.2');
       expect(body.Placements).deep.equal(['placement_0']);
       expect(body.PageRefreshed).to.equal(false);
+      expect(body.TransactionIds).deep.equal({'placement_0': 'bid_id_0_transaction_id'});
     });
 
     it('sends bid request to endpoint with single placement without canonical', () => {
@@ -190,9 +197,10 @@ describe('Adyoulike Adapter', () => {
       expect(requests[0].url).to.not.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
 
       let body = JSON.parse(requests[0].requestBody);
-      expect(body.Version).to.equal('0.1');
+      expect(body.Version).to.equal('0.2');
       expect(body.Placements).deep.equal(['placement_0']);
       expect(body.PageRefreshed).to.equal(false);
+      expect(body.TransactionIds).deep.equal({'placement_0': 'bid_id_0_transaction_id'});
     });
 
     it('sends bid request to endpoint with multiple placements', () => {
@@ -203,9 +211,10 @@ describe('Adyoulike Adapter', () => {
       expect(requests[0].url).to.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
 
       let body = JSON.parse(requests[0].requestBody);
-      expect(body.Version).to.equal('0.1');
+      expect(body.Version).to.equal('0.2');
       expect(body.Placements).deep.equal(['placement_0', 'placement_1']);
       expect(body.PageRefreshed).to.equal(false);
+      expect(body.TransactionIds).deep.equal({'placement_0': 'bid_id_0_transaction_id', 'placement_1': 'bid_id_1_transaction_id'});
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Update on Adyoulike adapter to send transaction ids to Adyoulike backend

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
    [dev-ssp@adyoulike.com](dev-ssp@adyoulike.com)
- [x] official adapter submission
