### PR TITLE
Update spotx video adapter to set the spotx_ad_key used in DFP

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -85,7 +85,7 @@ function Spotx() {
 
       bid.cpm = KVP_Object.spotx_bid;
       bid.vastUrl = url;
-      bid.ad = url;
+      bid.adId = KVP_Object.spotx_ad_key;
 
       var sizes = utils.isArray(bidReq.sizes[0]) ? bidReq.sizes[0] : bidReq.sizes;
       bid.height = sizes[1];

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -11,6 +11,20 @@ function Spotx() {
   let bidReq;
   let KVP_Object;
 
+  const _defaultBidderSettings = {
+    alwaysUseBid: true,
+    adserverTargeting: [
+      {
+        key: 'hb_adid',
+        val: function (bidResponse) {
+          return bidResponse.spotx_ad_key;
+        }
+      }
+    ]
+  };
+
+  bidmanager.registerDefaultBidderSetting('spotx', _defaultBidderSettings);
+
   baseAdapter.callBids = function(bidRequest) {
     if (!bidRequest || !bidRequest.bids || bidRequest.bids.length === 0) {
       return;
@@ -85,7 +99,7 @@ function Spotx() {
 
       bid.cpm = KVP_Object.spotx_bid;
       bid.vastUrl = url;
-      bid.adId = KVP_Object.spotx_ad_key;
+      bid.spotx_ad_key = KVP_Object.spotx_ad_key;
 
       var sizes = utils.isArray(bidReq.sizes[0]) ? bidReq.sizes[0] : bidReq.sizes;
       bid.height = sizes[1];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
In order for DFP targeting to work correctly we need access to the cpm and spotx_ad_key. We were already passing the cpm value but with this update we are now setting the spotx_ad_key to the bid.adId key so that it can be included with the prebid standard targeting keys. 

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
