### PR TITLE
Safely reference native keyword to fix compression

### DIFF
--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -88,26 +88,26 @@ function AdxcgAdapter() {
 
         let nativeResponse = adxcgBidReponse.nativeResponse;
 
-        bid.native = {
+        bid['native'] = {
           clickUrl: escape(nativeResponse.link.url),
           impressionTrackers: nativeResponse.imptrackers
         };
 
         nativeResponse.assets.forEach(asset => {
           if (asset.title && asset.title.text) {
-            bid.native.title = asset.title.text;
+            bid['native'].title = asset.title.text;
           }
 
           if (asset.img && asset.img.url) {
-            bid.native.image = asset.img.url;
+            bid['native'].image = asset.img.url;
           }
 
           if (asset.data && asset.data.label == 'DESC' && asset.data.value) {
-            bid.native.body = asset.data.value;
+            bid['native'].body = asset.data.value;
           }
 
           if (asset.data && asset.data.label == 'SPONSORED' && asset.data.value) {
-            bid.native.sponsoredBy = asset.data.value;
+            bid['native'].sponsoredBy = asset.data.value;
           }
         });
       }

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -189,17 +189,17 @@ function newBid(serverBid, rtbBid) {
       bid.adResponse.ad = bid.adResponse.ads[0];
       bid.adResponse.ad.video = bid.adResponse.ad.rtb.video;
     }
-  } else if (rtbBid.rtb.native) {
-    const native = rtbBid.rtb.native;
-    bid.native = {
-      title: native.title,
-      body: native.desc,
-      cta: native.ctatext,
-      sponsoredBy: native.sponsored,
-      image: native.main_img && native.main_img.url,
-      icon: native.icon && native.icon.url,
-      clickUrl: native.link.url,
-      impressionTrackers: native.impression_trackers,
+  } else if (rtbBid.rtb['native']) {
+    const nativeAd = rtbBid.rtb['native'];
+    bid['native'] = {
+      title: nativeAd.title,
+      body: nativeAd.desc,
+      cta: nativeAd.ctatext,
+      sponsoredBy: nativeAd.sponsored,
+      image: nativeAd.main_img && nativeAd.main_img.url,
+      icon: nativeAd.icon && nativeAd.icon.url,
+      clickUrl: nativeAd.link.url,
+      impressionTrackers: nativeAd.impression_trackers,
     };
   } else {
     Object.assign(bid, {
@@ -286,7 +286,7 @@ function bidToTag(bid) {
         );
       });
 
-      tag.native = {layouts: [nativeRequest]};
+      tag['native'] = {layouts: [nativeRequest]};
     }
   }
 

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -148,13 +148,13 @@ var CriteoAdapter = function CriteoAdapter() {
       bidObject.cpm = bidResponse.cpm;
 
       // in case of native
-      if (slot.nativeCallback && bidResponse.native) {
+      if (slot.nativeCallback && bidResponse['native']) {
         if (typeof slot.nativeCallback !== 'function') {
           utils.logError('Criteo bid: nativeCallback parameter is not a function');
         } else {
           // store the callbacks in a global object
           window.criteo_pubtag.native_slots = window.criteo_pubtag.native_slots || {};
-          window.criteo_pubtag.native_slots['' + bidObject.adId] = { callback: slot.nativeCallback, nativeResponse: bidResponse.native };
+          window.criteo_pubtag.native_slots['' + bidObject.adId] = { callback: slot.nativeCallback, nativeResponse: bidResponse['native'] };
 
           // this code is executed in an iframe, we need to get a reference to the
           // publishertag in the main window to retrieve native responses and callbacks.

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -63,7 +63,7 @@ const GumgumAdapter = function GumgumAdapter() {
       } = bidRequest;
       const timestamp = _getTimeStamp();
       const trackingId = params.inScreen;
-      const nativeId = params.native;
+      const nativeId = params['native'];
       const slotId = params.inSlot;
       const bid = { tmax: $$PREBID_GLOBAL$$.cbTimeout };
 
@@ -72,7 +72,7 @@ const GumgumAdapter = function GumgumAdapter() {
         case !!(params.inImage): bid.pi = 1; break;
         case !!(params.inScreen): bid.pi = 2; break;
         case !!(params.inSlot): bid.pi = 3; break;
-        case !!(params.native): bid.pi = 5; break;
+        case !!(params['native']): bid.pi = 5; break;
         default: return utils.logWarn(
           `[GumGum] No product selected for the placement ${placementCode}` +
           ', please check your implementation.'

--- a/modules/pulsepointLiteBidAdapter.js
+++ b/modules/pulsepointLiteBidAdapter.js
@@ -72,7 +72,7 @@ function PulsePointLiteAdapter() {
         bid.cpm = idToBidMap[id].price;
         bid.adId = id;
         if (isNative(idToSlotMap[id])) {
-          bid.native = nativeResponse(idToSlotMap[id], idToBidMap[id]);
+          bid['native'] = nativeResponse(idToSlotMap[id], idToBidMap[id]);
           bid.mediaType = 'native';
         } else {
           bid.ad = idToBidMap[id].adm;
@@ -96,7 +96,7 @@ function PulsePointLiteAdapter() {
     return {
       id: slot.bidId,
       banner: banner(slot),
-      native: native(slot),
+      'native': nativeImpression(slot),
       tagid: slot.params.ct.toString(),
     };
   }
@@ -115,7 +115,7 @@ function PulsePointLiteAdapter() {
   /**
    * Produces an OpenRTB Native object for the slot given.
    */
-  function native(slot) {
+  function nativeImpression(slot) {
     if (slot.nativeParams) {
       const assets = [];
       addAsset(assets, titleAsset(assets.length + 1, slot.nativeParams.title, NATIVE_DEFAULTS.TITLE_LEN));
@@ -255,18 +255,18 @@ function PulsePointLiteAdapter() {
     if (slot.nativeParams) {
       const nativeAd = parse(bid.adm);
       const keys = {};
-      if (nativeAd && nativeAd.native && nativeAd.native.assets) {
-        nativeAd.native.assets.forEach((asset) => {
+      if (nativeAd && nativeAd['native'] && nativeAd['native'].assets) {
+        nativeAd['native'].assets.forEach((asset) => {
           keys.title = asset.title ? asset.title.text : keys.title;
           keys.body = asset.data && asset.data.type === 2 ? asset.data.value : keys.body;
           keys.sponsoredBy = asset.data && asset.data.type === 1 ? asset.data.value : keys.sponsoredBy;
           keys.image = asset.img && asset.img.type === 3 ? asset.img.url : keys.image;
           keys.icon = asset.img && asset.img.type === 1 ? asset.img.url : keys.icon;
         });
-        if (nativeAd.native.link) {
-          keys.clickUrl = encodeURIComponent(nativeAd.native.link.url);
+        if (nativeAd['native'].link) {
+          keys.clickUrl = encodeURIComponent(nativeAd['native'].link.url);
         }
-        keys.impressionTrackers = nativeAd.native.imptrackers;
+        keys.impressionTrackers = nativeAd['native'].imptrackers;
         return keys;
       }
     }

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -8,20 +8,20 @@ import adaptermanager from 'src/adaptermanager'
 
 function createRenderHandler({ bidResponseBid, rendererConfig }) {
   function createApi() {
-    parent.window.unruly.native.prebid = parent.window.unruly.native.prebid || {}
-    parent.window.unruly.native.prebid.uq = parent.window.unruly.native.prebid.uq || []
+    parent.window.unruly['native'].prebid = parent.window.unruly['native'].prebid || {}
+    parent.window.unruly['native'].prebid.uq = parent.window.unruly['native'].prebid.uq || []
 
     return {
       render(bidResponseBid) {
-        parent.window.unruly.native.prebid.uq.push(['render', bidResponseBid])
+        parent.window.unruly['native'].prebid.uq.push(['render', bidResponseBid])
       },
       onLoaded(bidResponseBid) {}
     }
   }
 
   parent.window.unruly = parent.window.unruly || {}
-  parent.window.unruly.native = parent.window.unruly.native || {}
-  parent.window.unruly.native.siteId = parent.window.unruly.native.siteId || rendererConfig.siteId
+  parent.window.unruly['native'] = parent.window.unruly['native'] || {}
+  parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || rendererConfig.siteId
 
   const api = createApi()
   return {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -276,10 +276,10 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   }
 
   // set native key value targeting
-  if (custBidObj.native) {
-    Object.keys(custBidObj.native).forEach(asset => {
+  if (custBidObj['native']) {
+    Object.keys(custBidObj['native']).forEach(asset => {
       const key = NATIVE_KEYS[asset];
-      const value = custBidObj.native[asset];
+      const value = custBidObj['native'][asset];
       if (key) { keyValues[key] = value; }
     });
   }

--- a/src/native.js
+++ b/src/native.js
@@ -17,12 +17,12 @@ export const NATIVE_TARGETING_KEYS = Object.keys(NATIVE_KEYS).map(
 );
 
 const IMAGE = {
-  image: {required: true},
-  title: {required: true},
-  sponsoredBy: {required: true},
-  clickUrl: {required: true},
-  body: {required: false},
-  icon: {required: false},
+  image: { required: true },
+  title: { required: true },
+  sponsoredBy: { required: true },
+  clickUrl: { required: true },
+  body: { required: false },
+  icon: { required: false },
 };
 
 const SUPPORTED_TYPES = {
@@ -70,15 +70,21 @@ export const hasNonNativeBidder = adUnit =>
  */
 export function nativeBidIsValid(bid) {
   const bidRequest = getBidRequest(bid.adId);
-  if (!bidRequest) { return false; }
+  if (!bidRequest) {
+    return false;
+  }
 
   const requestedAssets = bidRequest.nativeParams;
-  if (!requestedAssets) { return true; }
+  if (!requestedAssets) {
+    return true;
+  }
 
   const requiredAssets = Object.keys(requestedAssets).filter(
     key => requestedAssets[key].required
   );
-  const returnedAssets = Object.keys(bid.native).filter(key => bid.native[key]);
+  const returnedAssets = Object.keys(bid['native']).filter(
+    key => bid['native'][key]
+  );
 
   return requiredAssets.every(asset => returnedAssets.includes(asset));
 }
@@ -88,8 +94,8 @@ export function nativeBidIsValid(bid) {
  * impression tracker urls for the given ad object and fires them.
  */
 export function fireNativeImpressions(adObject) {
-  const impressionTrackers = adObject.native &&
-    adObject.native.impressionTrackers;
+  const impressionTrackers =
+    adObject['native'] && adObject['native'].impressionTrackers;
 
   (impressionTrackers || []).forEach(tracker => {
     triggerPixel(tracker);


### PR DESCRIPTION
## Type of change
- Bugfix
- Refactoring (no functional changes, no api changes)

## Description of change
`native` is a reserved word in ECMAScript v3. Its presence as a variable name, object property, and function name within Prebid was causing some compression tools to crash. This PR changes variables and functions that were named `native` to something else, and switches object lookups for `native` properties from dot to bracket form.

## Testing notes
Tested on macOS 10.12 with Java 8 and `brew install yuicompressor`

Built prebid with `gulp serve` than ran:
```
java -jar /usr/local/Cellar/yuicompressor/2.4.8/libexec/yuicompressor-2.4.8.jar build/dev/prebid.js > build/prebid.min.js
```

On master this produces errors, on this PR the compression is successful

## Other information
Fixes #1471