### PR TITLE
Add native param support to mediaTypes

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -260,7 +260,7 @@ function bidToTag(bid) {
     tag.keywords = getKeywords(bid.params.keywords);
   }
 
-  if (bid.mediaType === 'native') {
+  if (bid.mediaType === 'native' || utils.deepAccess(bid, 'mediaTypes.native')) {
     tag.ad_types = ['native'];
 
     if (bid.nativeParams) {

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -42,12 +42,6 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
           sizes = sizeMapping;
         }
 
-        if (adUnit.nativeParams) {
-          bid = Object.assign({}, bid, {
-            nativeParams: processNativeAdUnitParams(adUnit.nativeParams),
-          });
-        }
-
         if (adUnit.mediaTypes) {
           if (utils.isValidMediaTypes(adUnit.mediaTypes)) {
             bid = Object.assign({}, bid, { mediaTypes: adUnit.mediaTypes });
@@ -56,6 +50,14 @@ function getBids({bidderCode, requestId, bidderRequestId, adUnits}) {
               `mediaTypes is not correctly configured for adunit ${adUnit.code}`
             );
           }
+        }
+
+        const nativeParams =
+          adUnit.nativeParams || utils.deepAccess(adUnit, 'mediaTypes.native');
+        if (nativeParams) {
+          bid = Object.assign({}, bid, {
+            nativeParams: processNativeAdUnitParams(nativeParams),
+          });
         }
 
         bid = Object.assign({}, bid, getDefinedParams(adUnit, [

--- a/src/native.js
+++ b/src/native.js
@@ -1,4 +1,4 @@
-import { getBidRequest, logError, triggerPixel } from './utils';
+import { deepAccess, getBidRequest, logError, triggerPixel } from './utils';
 
 export const nativeAdapters = [];
 
@@ -59,7 +59,11 @@ function typeIsSupported(type) {
  * TODO: abstract this and the video helper functions into general
  * adunit validation helper functions
  */
-export const nativeAdUnit = adUnit => adUnit.mediaType === 'native';
+export const nativeAdUnit = adUnit => {
+  const mediaType = adUnit.mediaType === 'native';
+  const mediaTypes = deepAccess(adUnit, 'mediaTypes.native');
+  return mediaType || mediaTypes;
+}
 export const nativeBidder = bid => nativeAdapters.includes(bid.bidder);
 export const hasNonNativeBidder = adUnit =>
   adUnit.bids.filter(bid => !nativeBidder(bid)).length;

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -549,10 +549,11 @@ describe('bidmanager.js', function () {
       sinon.stub(utils, 'getBidRequest', () => ({
         start: timestamp(),
         bidder: 'appnexusAst',
-        nativeParams: {
-          title: {'required': true},
+        mediaTypes: {
+          native: {
+            title: {required: true},
+          }
         },
-        mediaType: 'native',
       }));
 
       const bid = Object.assign({},
@@ -575,10 +576,11 @@ describe('bidmanager.js', function () {
       const bidRequest = () => ({
         start: timestamp(),
         bidder: 'appnexusAst',
-        nativeParams: {
-          title: {'required': true},
+        mediaTypes: {
+          native: {
+            title: {required: true},
+          }
         },
-        mediaType: 'native',
       });
       sinon.stub(utils, 'getBidRequest', bidRequest);
       sinon.stub(utils, 'getBidderRequest', bidRequest);


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
This PR allows specifying requested native assets in the new `mediaTypes` ad unit parameter object. This can currently be done with the `nativeParams` ad unit object, and that continues to work. All values that work in `nativeParams` may now be specified in `mediaTypes.native`

```JavaScript
mediaTypes: {
  native: {
    title: {required: true},
    sponsoredBy: {required: true},
  }
}
```

is equivalent to

```JavaScript
mediaType: 'native',
nativeParams: {
  title: {required: true},
  sponsoredBy: {required: true},
}
```

the `image` type also works in the new `mediaTypes` form
```JavaScript
mediaTypes: {
  native: {
    type: 'image',
  }
}
```