### PR TITLE
Add publisher sub-id support to the Criteo adapter

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -56,8 +56,8 @@ var CriteoAdapter = function CriteoAdapter() {
               var w = parseInt(sizeString.substring(0, xIndex));
               var h = parseInt(sizeString.substring(xIndex + 1, sizeString.length))
               return new Criteo.PubTag.DirectBidding.Size(w, h);
-            }
-            )
+            }),
+            bid.params.publisherSubId
           )
         );
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Allow clients to pass a custom publisher sub-id to the Criteo bidder.

- Adapter’s maintainers: i.caroulle@criteo.com, h.duthil@criteo.com, n.faure@criteo.com
