### PR TITLE
Use mediaTypes on video examples

### DIFF
--- a/integrationExamples/gpt/pbjs_video_adUnit.html
+++ b/integrationExamples/gpt/pbjs_video_adUnit.html
@@ -36,7 +36,7 @@ adapters.json.
   var videoAdUnit = {
     code: 'video1',
     sizes: [640,480],
-    mediaType: 'video',
+    mediaTypes: { video: {} },
     bids: [
       {
         bidder: 'appnexusAst',

--- a/test/pages/video.html
+++ b/test/pages/video.html
@@ -31,7 +31,9 @@
       var videoAdUnit = {
         code: 'video1',
         sizes: [640,480],
-        mediaType: 'video',
+        mediaTypes: {
+          video: {context: 'instream'}
+        },
         bids: [
           {
             bidder: 'appnexusAst',


### PR DESCRIPTION
## Type of change
- Examples

## Description of change
Updates video example pages to define media type with `mediaTypes` param. One example for default of 'instream', one explicitly sets 'instream' with `context`