### PR TITLE
Fixes Index exchange failing tests in IE browser

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -38,7 +38,7 @@ export function parse(url, options) {
     pathname: parsed.pathname.replace(/^(?!\/)/, '/'),
     search: parseQS(parsed.search || ''),
     hash: (parsed.hash || '').replace(/^#/, ''),
-    host: parsed.host
+    host: parsed.host || window.location.host
   };
 }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Two IndexExchange test cases were always failing in IE browser because of bug with parse function in IE
https://github.com/prebid/Prebid.js/blob/master/test/spec/modules/indexExchangeBidAdapter_video_spec.js#L907
https://github.com/prebid/Prebid.js/blob/master/test/spec/modules/indexExchangeBidAdapter_video_spec.js#L918

`url.parse(1)` will return `{}` in IE. Hence the workaround implemented here is to return `window.location.host` to fix always failing test cases.

## Other information
https://gist.github.com/jlong/2428561
