### PR TITLE
Remove undefined variable usage

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -246,9 +246,6 @@ function PrebidServer() {
     ajax(config.syncEndpoint, (response) => {
       try {
         response = JSON.parse(response);
-        if (response.status === 'ok') {
-          bidderCodes.forEach(code => StorageManager.add(pbjsSyncsKey, code, true));
-        }
         response.bidder_status.forEach(bidder => doBidderSync(bidder.usersync.type, bidder.usersync.url, bidder.bidder));
       } catch (e) {
         utils.logError(e);


### PR DESCRIPTION
I missed this when reviewing #1653, which removed `StorageManager` and `pbjsSyncsKey`. Fixes #1660