### PR TITLE
Update dfp.buildVideoUrl to accept adserver url

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -56,6 +56,16 @@ const defaultParamConstants = {
  *   demand in DFP.
  */
 export default function buildDfpVideoUrl(options) {
+  if (!options.params && !options.url) {
+    logError(`A params object or a url is required to use pbjs.adServers.dfp.buildVideoUrl`);
+    return;
+  }
+
+  if (options.params && options.url) {
+    logError(`Passing both a params object and a url to pbjs.adServers.dfp.buildVideoUrl is invalid.`);
+    return;
+  }
+
   const adUnit = options.adUnit;
   const bid = options.bid || getWinningBids(adUnit.code)[0];
 

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -119,10 +119,12 @@ export default function buildDfpVideoUrl(options) {
 function buildUrlFromAdserverUrl(url, bid) {
   const components = parse(url);
 
-  if (!components.search.description_url) {
-    components.search.description_url = encodeURIComponent(bid.vastUrl);
-  } else {
-    logError(`input url cannnot contain description_url`);
+  if (!config.getConfig('usePrebidCache')) {
+    if (!deepAccess(components, 'search.description_url')) {
+      components.search.description_url = encodeURIComponent(bid.vastUrl);
+    } else {
+      logError(`input url cannnot contain description_url`);
+    }
   }
 
   const customParams = Object.assign({},

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -99,7 +99,8 @@ export default function buildDfpVideoUrl(options) {
 
   if (!config.getConfig('usePrebidCache')) {
     if (!deepAccess(options, 'params.description_url')) {
-      queryParams.description_url = encodeURIComponent(bid.vastUrl);
+      const vastUrl = bid && bid.vastUrl;
+      queryParams.description_url = encodeURIComponent(vastUrl);
     } else {
       logError(`input object cannot contain description_url`);
     }
@@ -123,14 +124,16 @@ export default function buildDfpVideoUrl(options) {
 function buildUrlFromAdserverUrlComponents(components, bid) {
   if (!config.getConfig('usePrebidCache')) {
     if (!deepAccess(components, 'search.description_url')) {
-      components.search.description_url = encodeURIComponent(bid.vastUrl);
+      const vastUrl = bid && bid.vastUrl;
+      components.search.description_url = encodeURIComponent(vastUrl);
     } else {
       logError(`input url cannnot contain description_url`);
     }
   }
 
+  const adserverTargeting = (bid && bid.adserverTargeting) || {};
   const customParams = Object.assign({},
-    bid.adserverTargeting,
+    adserverTargeting,
   );
   components.search.cust_params = encodeURIComponent(formatQS(customParams));
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -339,7 +339,7 @@ exports.isNumber = function(object) {
  */
 exports.isEmpty = function (object) {
   if (!object) return true;
-  if (this.isArray(object) || this.isStr(object)) {
+  if (exports.isArray(object) || exports.isStr(object)) {
     return !(object.length > 0);
   }
 

--- a/src/video.js
+++ b/src/video.js
@@ -1,5 +1,6 @@
 import { videoAdapters } from './adaptermanager';
-import { getBidRequest, deepAccess } from './utils';
+import { getBidRequest, deepAccess, logError } from './utils';
+import { config } from '../src/config';
 
 const VIDEO_MEDIA_TYPE = 'video';
 const OUTSTREAM = 'outstream';
@@ -32,6 +33,15 @@ export function isValidVideoBid(bid) {
   // if context not defined assume default 'instream' for video bids
   // instream bids require a vast url or vast xml content
   if (!bidRequest || (videoMediaType && context !== OUTSTREAM)) {
+    // xml-only video bids require prebid-cache to be enabled
+    if (!config.getConfig('usePrebidCache') && bid.vastXml && !bid.vastUrl) {
+      logError(`
+        This bid contains only vastXml and will not work when prebid-cache is disabled.
+        Try enabling prebid-cache with pbjs.setConfig({ usePrebidCache: true });
+      `);
+      return false;
+    }
+
     return !!(bid.vastUrl || bid.vastXml);
   }
 

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -53,6 +53,26 @@ describe('The DFP video support module', () => {
     expect(queryObject.description_url).to.equal('vastUrl.example');
   });
 
+  it('requires a params object or url', () => {
+    const url = buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bid,
+    });
+
+    expect(url).to.be.undefined;
+  });
+
+  it('rejects calls that contain both a params object and url input', () => {
+    const url = buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bid,
+      params: { 'iu': 'my/adUnit' },
+      url: 'https://video.adserver.example/',
+    });
+
+    expect(url).to.be.undefined;
+  });
+
   it('should override param defaults with user-provided ones', () => {
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -62,15 +62,16 @@ describe('The DFP video support module', () => {
     expect(url).to.be.undefined;
   });
 
-  it('rejects calls that contain both a params object and url input', () => {
-    const url = buildDfpVideoUrl({
+  it('overwrites url params when both url and params object are given', () => {
+    const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
       bid: bid,
-      params: { 'iu': 'my/adUnit' },
-      url: 'https://video.adserver.example/',
-    });
+      url: 'https://video.adserver.example/ads?sz=640x480&iu=/123/aduniturl&impl=s',
+      params: { iu: 'my/adUnit' }
+    }));
 
-    expect(url).to.be.undefined;
+    const queryObject = parseQS(url.query);
+    expect(queryObject.iu).to.equal('my/adUnit');
   });
 
   it('should override param defaults with user-provided ones', () => {

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,5 +1,6 @@
 import { isValidVideoBid } from 'src/video';
-const utils = require('src/utils');
+import { newConfig } from 'src/config';
+import * as utils from 'src/utils';
 
 describe('video.js', () => {
   afterEach(() => {
@@ -30,6 +31,20 @@ describe('video.js', () => {
     }));
 
     const valid = isValidVideoBid({});
+
+    expect(valid).to.be(false);
+  });
+
+  it('catches invalid bids when prebid-cache is disabled', () => {
+    sinon.stub(utils, 'getBidRequest', () => ({
+      bidder: 'vastOnlyVideoBidder',
+      mediaTypes: { video: {} },
+    }));
+
+    const config = newConfig();
+    config.setConfig({ usePrebidCache: false });
+
+    const valid = isValidVideoBid({ vastXml: '<xml>vast</xml>' });
 
     expect(valid).to.be(false);
   });


### PR DESCRIPTION
Updates `pbjs.adServer.dfp.buildVideoUrl` to accept a video adserver url (similar to deprecated `pbjs.buildMasterVideoTagFromAdserverTag` function) with a `url` parameter on the input object:

```JavaScript
var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
  adUnit: videoAdUnit,
  url: 'https://pubads.g.doubleclick.net/gampad/ads?iu=/19968336/prebid_video_adunit...'
});
```

Also updates the function to work without prebid cache enabled when the input contains an object of querystring parameters by appending `description_url` to the output url:
 
```JavaScript
// with usePrebidCache configured to false
var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
  adUnit: videoAdUnit,
  params: { iu: '/19968336/prebid_video_adunit' }
});
```