### PR TITLE
New hooks API (replaces monkey-patching for currency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   "dependencies": {
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
-    "gulp-sourcemaps": "^2.6.0",
-    "tinyqueue": "^1.2.2"
+    "gulp-sourcemaps": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   "dependencies": {
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
-    "gulp-sourcemaps": "^2.6.0"
+    "gulp-sourcemaps": "^2.6.0",
+    "tinyqueue": "^1.2.2"
   }
 }

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -5,6 +5,7 @@ import { isValidVideoBid } from './video';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
 import { config } from 'src/config';
+import { createHook } from 'src/hook';
 
 var CONSTANTS = require('./constants.json');
 var AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
@@ -82,7 +83,7 @@ exports.bidsBackAll = function () {
 /*
  *   This function should be called to by the bidder adapter to register a bid response
  */
-exports.addBidResponse = function (adUnitCode, bid) {
+exports.addBidResponse = createHook('asyncSeries', function (adUnitCode, bid) {
   if (isValid()) {
     prepareBidForAuction();
 
@@ -250,7 +251,7 @@ exports.addBidResponse = function (adUnitCode, bid) {
       doCallbacksIfNeeded();
     }
   }
-};
+});
 
 function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   var keyValues = {};

--- a/src/hook.js
+++ b/src/hook.js
@@ -32,14 +32,14 @@ export function createHook(type, fn, hookName) {
     asyncSeries: function(...args) {
       let curr = 0;
 
-      return _hooks[curr].fn.apply(this, args.concat(asyncSeriesNext));
-
-      function asyncSeriesNext(...args) {
+      const asyncSeriesNext = (...args) => {
         let hook = _hooks[++curr];
         if (typeof hook === 'object' && typeof hook.fn === 'function') {
           return hook.fn.apply(this, args.concat(asyncSeriesNext))
         }
-      }
+      };
+
+      return _hooks[curr].fn.apply(this, args.concat(asyncSeriesNext));
     }
   };
 

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,0 +1,78 @@
+
+/**
+ * @typedef {function} PluginFunction
+ * @property {function(function(), [number])} addHook A method that takes a new function to attach as a hook
+ *  to the PluginFunction
+ * @property {function(function())} removeHook A method to remove attached hooks
+ */
+
+/**
+ * A map of global hook methods to allow easy extension of hooked functions that are intended to be extended globally
+ * @type {{}}
+ */
+export const hooks = {};
+
+/**
+ * A utility function for allowing a regular function to be extensible with additional hook functions
+ * @param {string} type The method for applying all attached hooks when this hooked function is called
+ * @param {function()} fn The function to make hookable
+ * @param {string} hookName If provided this allows you to register a name for a global hook to have easy access to
+ *  the addPlugin and removePlugin methods for that hook (which are usually accessed as methods on the function itself)
+ * @returns {PluginFunction} A new function that implements the PluginFunction interface
+ */
+export function createHook(type, fn, hookName) {
+  let _hooks = [{fn, priority: 0}];
+
+  let types = {
+    sync: function(...args) {
+      _hooks.forEach(hook => {
+        hook.fn.apply(null, args);
+      });
+    },
+    asyncSeries: function(...args) {
+      let curr = 0;
+
+      return _hooks[curr].fn.apply(null, args.concat(asyncSeriesNext));
+
+      function asyncSeriesNext(...args) {
+        let hook = _hooks[++curr];
+        if (typeof hook === 'object' && typeof hook.fn === 'function') {
+          return hook.fn.apply(null, args.concat(asyncSeriesNext))
+        }
+      }
+    }
+  };
+
+  if (!types[type]) {
+    throw 'invalid hook type';
+  }
+
+  let methods = {
+    addHook: function(fn, priority = 10) {
+      if (typeof fn === 'function') {
+        _hooks.push({
+          fn,
+          priority: priority
+        });
+
+        _hooks.sort((a, b) => b.priority - a.priority);
+      }
+    },
+    removeHook: function(removeFn) {
+      _hooks = _hooks.filter(hook => hook.fn === fn || hook.fn !== removeFn);
+    }
+  };
+
+  if (typeof hookName === 'string') {
+    hooks[hookName] = methods;
+  }
+
+  function hookedFn(...args) {
+    if (_hooks.length === 0) {
+      return fn.apply(null, args);
+    }
+    return types[type].apply(null, args);
+  }
+
+  return Object.assign(hookedFn, methods);
+}

--- a/src/hook.js
+++ b/src/hook.js
@@ -17,7 +17,7 @@ export const hooks = {};
  * @param {string} type The method for applying all attached hooks when this hooked function is called
  * @param {function()} fn The function to make hookable
  * @param {string} hookName If provided this allows you to register a name for a global hook to have easy access to
- *  the addPlugin and removePlugin methods for that hook (which are usually accessed as methods on the function itself)
+ *  the addHook and removeHook methods for that hook (which are usually accessed as methods on the function itself)
  * @returns {HookedFunction} A new function that implements the HookedFunction interface
  */
 export function createHook(type, fn, hookName) {

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,8 +1,8 @@
 
 /**
- * @typedef {function} PluginFunction
+ * @typedef {function} HookedFunction
  * @property {function(function(), [number])} addHook A method that takes a new function to attach as a hook
- *  to the PluginFunction
+ *  to the HookedFunction
  * @property {function(function())} removeHook A method to remove attached hooks
  */
 
@@ -18,7 +18,7 @@ export const hooks = {};
  * @param {function()} fn The function to make hookable
  * @param {string} hookName If provided this allows you to register a name for a global hook to have easy access to
  *  the addPlugin and removePlugin methods for that hook (which are usually accessed as methods on the function itself)
- * @returns {PluginFunction} A new function that implements the PluginFunction interface
+ * @returns {HookedFunction} A new function that implements the HookedFunction interface
  */
 export function createHook(type, fn, hookName) {
   let _hooks = [{fn, priority: 0}];

--- a/src/hook.js
+++ b/src/hook.js
@@ -74,11 +74,5 @@ export function createHook(type, fn, hookName) {
     return types[type].apply(this, args);
   }
 
-  hookedFn.withContext = function(context) {
-    return function hookedFnWithContext(...args) {
-      hookedFn.apply(context, args);
-    }
-  };
-
   return Object.assign(hookedFn, methods);
 }

--- a/src/hook.js
+++ b/src/hook.js
@@ -26,18 +26,18 @@ export function createHook(type, fn, hookName) {
   let types = {
     sync: function(...args) {
       _hooks.forEach(hook => {
-        hook.fn.apply(null, args);
+        hook.fn.apply(this, args);
       });
     },
     asyncSeries: function(...args) {
       let curr = 0;
 
-      return _hooks[curr].fn.apply(null, args.concat(asyncSeriesNext));
+      return _hooks[curr].fn.apply(this, args.concat(asyncSeriesNext));
 
       function asyncSeriesNext(...args) {
         let hook = _hooks[++curr];
         if (typeof hook === 'object' && typeof hook.fn === 'function') {
-          return hook.fn.apply(null, args.concat(asyncSeriesNext))
+          return hook.fn.apply(this, args.concat(asyncSeriesNext))
         }
       }
     }
@@ -69,10 +69,16 @@ export function createHook(type, fn, hookName) {
 
   function hookedFn(...args) {
     if (_hooks.length === 0) {
-      return fn.apply(null, args);
+      return fn.apply(this, args);
     }
-    return types[type].apply(null, args);
+    return types[type].apply(this, args);
   }
+
+  hookedFn.withContext = function(context) {
+    return function hookedFnWithContext(...args) {
+      hookedFn.apply(context, args);
+    }
+  };
 
   return Object.assign(hookedFn, methods);
 }

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -1,0 +1,105 @@
+
+import { expect } from 'chai';
+import { createHook, hooks } from 'src/hook';
+
+describe('the hook module', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should call all sync hooks attached to a function', () => {
+    let called = [];
+    let calledWith;
+
+    let testFn = () => {
+      called.push(testFn);
+    };
+    let testHook = (...args) => {
+      called.push(testHook);
+      calledWith = args;
+    };
+    let testHook2 = () => {
+      called.push(testHook2);
+    };
+    let testHook3 = () => {
+      called.push(testHook3);
+    };
+
+    let hookedTestFn = createHook('sync', testFn, 'testHook');
+
+    hookedTestFn.addHook(testHook, 50);
+    hookedTestFn.addHook(testHook2, 100);
+
+    // make sure global test hooks work as well (with default priority)
+    hooks['testHook'].addHook(testHook3);
+
+    hookedTestFn(1, 2, 3);
+
+    expect(called).to.deep.equal([
+      testHook2,
+      testHook,
+      testHook3,
+      testFn
+    ]);
+
+    expect(calledWith).to.deep.equal([1, 2, 3]);
+
+    called = [];
+
+    hookedTestFn.removeHook(testHook);
+    hooks['testHook'].removeHook(testHook3);
+
+    hookedTestFn(1, 2, 3);
+
+    expect(called).to.deep.equal([
+      testHook2,
+      testFn
+    ]);
+  });
+
+  describe('asyncSeries', () => {
+    it('should call function as normal if no hooks attached', () => {
+      let fn = sandbox.spy();
+      let hookFn = createHook('asyncSeries', fn);
+
+      hookFn(1);
+
+      expect(fn.calledOnce).to.equal(true);
+      expect(fn.firstCall.args[0]).to.equal(1);
+    });
+
+    it('should call hooks correctly applied in asyncSeries', () => {
+      let called = [];
+
+      let testFn = (called) => {
+        called.push(testFn);
+      };
+      let testHook = (called, next) => {
+        called.push(testHook);
+        next(called);
+      };
+      let testHook2 = (called, next) => {
+        called.push(testHook2);
+        next(called);
+      };
+
+      let hookedTestFn = createHook('asyncSeries', testFn);
+      hookedTestFn.addHook(testHook);
+      hookedTestFn.addHook(testHook2);
+
+      hookedTestFn(called);
+
+      expect(called).to.deep.equal([
+        testHook,
+        testHook2,
+        testFn
+      ]);
+    });
+  });
+});

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -123,5 +123,29 @@ describe('the hook module', () => {
         testFn
       ]);
     });
+
+    it('should allow context to be passed to hooks, but keep bound contexts', () => {
+      let context;
+      let fn = function() {
+        context = this;
+      };
+
+      let boundContext1 = {};
+      let calledBoundContext1;
+      let hook1 = function(next) {
+        calledBoundContext1 = this;
+        next()
+      }.bind(boundContext1);
+
+      let hookFn = createHook('asyncSeries', fn);
+      hookFn.addHook(hook1);
+
+      let newContext = {};
+      hookFn = hookFn.bind(newContext);
+      hookFn();
+
+      expect(context).to.equal(newContext);
+      expect(calledBoundContext1).to.equal(boundContext1);
+    });
   });
 });

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -63,6 +63,28 @@ describe('the hook module', () => {
     ]);
   });
 
+  it('should allow context to be passed to hooks, but keep bound contexts', () => {
+    let context;
+    let fn = function() {
+      context = this;
+    };
+
+    let boundContext = {};
+    let calledBoundContext;
+    let hook = function() {
+      calledBoundContext = this;
+    }.bind(boundContext);
+
+    let hookFn = createHook('sync', fn);
+    hookFn.addHook(hook);
+
+    let newContext = {};
+    hookFn.withContext(newContext)();
+
+    expect(context).to.equal(newContext);
+    expect(calledBoundContext).to.equal(boundContext);
+  });
+
   describe('asyncSeries', () => {
     it('should call function as normal if no hooks attached', () => {
       let fn = sandbox.spy();

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -79,7 +79,7 @@ describe('the hook module', () => {
     hookFn.addHook(hook);
 
     let newContext = {};
-    hookFn.withContext(newContext)();
+    hookFn.bind(newContext)();
 
     expect(context).to.equal(newContext);
     expect(calledBoundContext).to.equal(boundContext);

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -5,7 +5,7 @@ import {
 
 import {
   setConfig,
-  addBidResponseDecorator,
+  addBidResponseHook,
 
   currencySupportEnabled,
   currencyRates
@@ -46,10 +46,6 @@ describe('currency', function () {
       var bid = { cpm: 1, bidder: 'rubicon' };
       var innerBid;
 
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
-      	innerBid = bid;
-      });
-
       setConfig({
         adServerCurrency: 'GBP',
         bidderCurrencyDefault: {
@@ -57,7 +53,9 @@ describe('currency', function () {
         }
       });
 
-      wrappedAddBidResponseFn('elementId', bid);
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
+      	innerBid = bid;
+      });
 
       expect(innerBid.currency).to.equal('GBP')
     });
@@ -68,10 +66,6 @@ describe('currency', function () {
       var bid = { cpm: 1, currency: 'JPY', bidder: 'rubicon' };
       var innerBid;
 
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
-      	innerBid = bid;
-      });
-
       setConfig({
         adServerCurrency: 'JPY',
         bidderCurrencyDefault: {
@@ -79,7 +73,9 @@ describe('currency', function () {
         }
       });
 
-      wrappedAddBidResponseFn('elementId', bid);
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
+      	innerBid = bid;
+      });
 
       expect(innerBid.currency).to.equal('JPY')
     });
@@ -97,11 +93,9 @@ describe('currency', function () {
       var bid = { cpm: 100, currency: 'JPY', bidder: 'rubicon' };
       var innerBid;
 
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-
-      wrappedAddBidResponseFn('elementId', bid);
 
       expect(innerBid.cpm).to.equal('1.0000');
     });
@@ -113,14 +107,15 @@ describe('currency', function () {
 
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
 
-      var marker = false;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
-        marker = true;
-      });
       var bid = { 'cpm': 1, 'currency': 'USD' };
 
       setConfig({ 'adServerCurrency': 'JPY' });
-      wrappedAddBidResponseFn('elementId', bid);
+
+      var marker = false;
+      addBidResponseHook('elementId', bid, function() {
+      	marker = true;
+      });
+
       expect(marker).to.equal(false);
 
       fakeCurrencyFileServer.respond();
@@ -133,10 +128,9 @@ describe('currency', function () {
       setConfig({});
       var bid = { 'cpm': 1, 'currency': 'USD' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.cpm).to.equal(1);
     });
 
@@ -144,10 +138,9 @@ describe('currency', function () {
       setConfig({});
       var bid = { 'cpm': 1, 'currency': 'GBP' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
@@ -157,10 +150,9 @@ describe('currency', function () {
       });
       var bid = { 'cpm': 1, 'currency': 'USD' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(bid).to.equal(innerBid);
     });
 
@@ -170,10 +162,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'ABC' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
@@ -183,10 +174,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'GBP' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
@@ -196,10 +186,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'JPY' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.cpm).to.equal(1);
       expect(innerBid.currency).to.equal('JPY');
     });
@@ -210,10 +199,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'USD' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.cpm).to.equal('0.7798');
       expect(innerBid.currency).to.equal('GBP');
     });
@@ -224,10 +212,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'CNY' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.cpm).to.equal('0.1133');
       expect(innerBid.currency).to.equal('GBP');
     });
@@ -238,10 +225,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       var bid = { 'cpm': 1, 'currency': 'JPY' };
       var innerBid;
-      var wrappedAddBidResponseFn = addBidResponseDecorator(function(adCodeId, bid) {
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
       	innerBid = bid;
       });
-      wrappedAddBidResponseFn('elementId', bid);
       expect(innerBid.cpm).to.equal('0.0623');
       expect(innerBid.currency).to.equal('CNY');
     });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This pull-request provides a new API for adding hooks into the Prebid core functionality.  By wrapping code paths with `createHook`, Prebid.js modules (and possibly external code, if we decide to expose hooks) can extend the functionality of core code through various models provided in `hook.js`.  It follows in the spirit of https://github.com/webpack/tapable (the library webpack uses for adding extensibility).  However, rather than adding extensibility for class methods through mixins (like tapable), I opted for adding extensibility to plain function since much of Prebid core is functional in nature.

So far the only extensibility options for hooks that I added are `sync` and `asyncSeries`, but other could be added if needed as seen within the tapable library's readme.

This replaces the monkey-patching that currently takes place in the currency module.  Once merged, the 1.0 branch can be updated to put the appropriate hook in place for currency to still function properly.

The hook API in this pull-request being used for `bidmanager.addBidResponse` in pre 1.0 is like the following:
```Javascript
// bidmanager.js
import { createHook } from 'src/hook.js';

exports.addBidResponse = createHook('asyncSeries', function(adUnitCode, bid) {
  // add bid response stuff
});
```

This allows any module that wants to extend `bidmanager.addBidResponse` functionality to import the method and add a hook.
```Javascript
// some module
import { addBidResponse } from 'src/bidmanager.js';
addBidResponse.addHook(function(adUnitCode, bid, next) {
  // modify bid or something
  next(adUnitCode, bid); // continue execution of further hooks, or finally call addBidResponse if this is only hook
}, 50); // `addHook` allows for optional parameter specifying priority.  Higher priority hooks will run first
```

For making this compatible with 1.0 we need only to wrap `createHook` around whatever method we want extended (I think a new `addBidResponse` w/o the bidmanager) and expose the hook in a way that modules can get access to them . Either export the function in the new auctionManager (or wherever) or provide a global hook name as a third parameter to `createHook`.

Example:
```Javascript
// auction.js
adaptermanager.callBids(_adUnits, bidRequests, createHook('asyncSeries', addBidResponse.bind(this), 'addBidResponse'), done.bind(this)); // global hook named 'addBidResponse' created

// some module
import { hooks } from 'src/hook.js';

hooks['addBidResponse'].addHook(function() { ... });
```

With this new API we could hopefully start creating more hook-points in Prebid.js core which allows for more code to be moved into modules for optional inclusion.

