### PR TITLE
Support native click tracking

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -201,6 +201,7 @@ function newBid(serverBid, rtbBid) {
       image: nativeAd.main_img && nativeAd.main_img.url,
       icon: nativeAd.icon && nativeAd.icon.url,
       clickUrl: nativeAd.link.url,
+      clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,
     };
   } else {

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,6 +1,6 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
 import { getPriceBucketString } from './cpmBucketManager';
-import { NATIVE_KEYS, nativeBidIsValid } from './native';
+import { nativeBidIsValid, setNativeTargeting } from './native';
 import { isValidVideoBid } from './video';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
@@ -275,13 +275,8 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
     custBidObj.sendStandardTargeting = defaultBidderSettingsMap[bidderCode].sendStandardTargeting;
   }
 
-  // set native key value targeting
   if (custBidObj['native']) {
-    Object.keys(custBidObj['native']).forEach(asset => {
-      const key = NATIVE_KEYS[asset];
-      const value = custBidObj['native'][asset];
-      if (key) { keyValues[key] = value; }
-    });
+    keyValues = Object.assign({}, keyValues, setNativeTargeting(custBidObj));
   }
 
   return keyValues;

--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -1,6 +1,6 @@
 import { uniques, flatten, adUnitsFilter, getBidderRequest } from './utils';
 import { getPriceBucketString } from './cpmBucketManager';
-import { nativeBidIsValid, setNativeTargeting } from './native';
+import { nativeBidIsValid, getNativeTargeting } from './native';
 import { isValidVideoBid } from './video';
 import { getCacheUrl, store } from './videoCache';
 import { Renderer } from 'src/Renderer';
@@ -276,7 +276,7 @@ function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   }
 
   if (custBidObj['native']) {
-    keyValues = Object.assign({}, keyValues, setNativeTargeting(custBidObj));
+    keyValues = Object.assign({}, keyValues, getNativeTargeting(custBidObj));
   }
 
   return keyValues;

--- a/src/native.js
+++ b/src/native.js
@@ -94,14 +94,60 @@ export function nativeBidIsValid(bid) {
 }
 
 /*
- * Native responses may have impression trackers. This retrieves the
- * impression tracker urls for the given ad object and fires them.
+ * Native responses may have associated impression or click trackers.
+ * This retrieves the appropriate tracker urls for the given ad object and
+ * fires them. As a native creatives may be in a cross-origin frame, it may be
+ * necessary to invoke this function via postMessage. secureCreatives is
+ * configured to fire this function when it receives a `message` of 'Prebid Native'
+ * and an `adId` with the value of the `bid.adId`. When a message is posted with
+ * these parameters, impression trackers are fired. To fire click trackers, the
+ * message should contain an `action` set to 'click'.
+ *
+ * // Native creative template example usage
+ * <a href="%%CLICK_URL_UNESC%%%%PATTERN:hb_native_linkurl%%"
+ *    target="_blank"
+ *    onclick="fireTrackers('click')">
+ *    %%PATTERN:hb_native_title%%
+ * </a>
+ *
+ * <script>
+ *   function fireTrackers(action) {
+ *     var message = {message: 'Prebid Native', adId: '%%PATTERN:hb_adid%%'};
+ *     if (action === 'click') {message.action = 'click';} // fires click trackers
+ *     window.parent.postMessage(JSON.stringify(message), '*');
+ *   }
+ *   fireTrackers(); // fires impressions when creative is loaded
+ * </script>
  */
-export function fireNativeImpressions(adObject) {
-  const impressionTrackers =
-    adObject['native'] && adObject['native'].impressionTrackers;
+export function fireNativeTrackers(message, adObject) {
+  let trackers;
 
-  (impressionTrackers || []).forEach(tracker => {
-    triggerPixel(tracker);
+  if (message.action === 'click') {
+    trackers = adObject['native'] && adObject['native'].clickTrackers;
+  } else {
+    trackers = adObject['native'] && adObject['native'].impressionTrackers;
+  }
+
+  (trackers || []).forEach(triggerPixel);
+
+  return trackers;
+}
+
+/**
+ * Sets native targeting key-value paris
+ * @param {Object} bid
+ * @return {Object} targeting
+ */
+export function setNativeTargeting(bid) {
+  let keyValues = {};
+
+  Object.keys(bid['native']).forEach(asset => {
+    const key = NATIVE_KEYS[asset];
+    const value = bid['native'][asset];
+    if (key) {
+      keyValues[key] = value;
+    }
   });
+
+  return keyValues;
 }

--- a/src/native.js
+++ b/src/native.js
@@ -78,7 +78,7 @@ export function nativeBidIsValid(bid) {
     return false;
   }
 
-  // all native bid responses must defined a landing page url
+  // all native bid responses must define a landing page url
   if (!deepAccess(bid, 'native.clickUrl')) {
     return false;
   }
@@ -134,16 +134,14 @@ export function fireNativeTrackers(message, adObject) {
   }
 
   (trackers || []).forEach(triggerPixel);
-
-  return trackers;
 }
 
 /**
- * Sets native targeting key-value paris
+ * Gets native targeting key-value paris
  * @param {Object} bid
  * @return {Object} targeting
  */
-export function setNativeTargeting(bid) {
+export function getNativeTargeting(bid) {
   let keyValues = {};
 
   Object.keys(bid['native']).forEach(asset => {

--- a/src/native.js
+++ b/src/native.js
@@ -78,6 +78,11 @@ export function nativeBidIsValid(bid) {
     return false;
   }
 
+  // all native bid responses must defined a landing page url
+  if (!deepAccess(bid, 'native.clickUrl')) {
+    return false;
+  }
+
   const requestedAssets = bidRequest.nativeParams;
   if (!requestedAssets) {
     return true;

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -4,7 +4,7 @@
  */
 
 import events from './events';
-import { fireNativeImpressions } from './native';
+import { fireNativeTrackers } from './native';
 import { EVENTS } from './constants';
 
 const BID_WON = EVENTS.BID_WON;
@@ -42,7 +42,7 @@ function receiveMessage(ev) {
     //   adId: '%%PATTERN:hb_adid%%'
     // }), '*');
     if (data.message === 'Prebid Native') {
-      fireNativeImpressions(adObject);
+      fireNativeTrackers(data, adObject);
       $$PREBID_GLOBAL$$._winningBids.push(adObject);
       events.emit(BID_WON, adObject);
     }

--- a/test/spec/bidmanager_spec.js
+++ b/test/spec/bidmanager_spec.js
@@ -590,7 +590,10 @@ describe('bidmanager.js', function () {
         {
           bidderCode: 'appnexusAst',
           mediaType: 'native',
-          native: {title: 'foo'}
+          native: {
+            title: 'foo',
+            clickUrl: 'example.link'
+          }
         }
       );
 

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { fireNativeTrackers, setNativeTargeting } from 'src/native';
+import { fireNativeTrackers, getNativeTargeting } from 'src/native';
+const utils = require('src/utils');
 
 const bid = {
   native: {
@@ -14,20 +15,32 @@ const bid = {
 };
 
 describe('native.js', () => {
-  it('sets native targeting keys', () => {
-    const targeting = setNativeTargeting(bid);
+  let triggerPixelStub;
+
+  beforeEach(() => {
+    triggerPixelStub = sinon.stub(utils, 'triggerPixel');
+  });
+
+  afterEach(() => {
+    utils.triggerPixel.restore();
+  });
+
+  it('gets native targeting keys', () => {
+    const targeting = getNativeTargeting(bid);
     expect(targeting.hb_native_title).to.equal(bid.native.title);
     expect(targeting.hb_native_body).to.equal(bid.native.body);
     expect(targeting.hb_native_linkurl).to.equal(bid.native.clickUrl);
   });
 
   it('fires impression trackers', () => {
-    const fired = fireNativeTrackers({}, bid);
-    expect(fired).to.deep.equal(bid.native.impressionTrackers);
+    fireNativeTrackers({}, bid);
+    sinon.assert.calledOnce(triggerPixelStub);
+    sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
   });
 
   it('fires click trackers', () => {
-    const fired = fireNativeTrackers({ action: 'click' }, bid);
-    expect(fired).to.deep.equal(bid.native.clickTrackers);
+    fireNativeTrackers({ action: 'click' }, bid);
+    sinon.assert.calledOnce(triggerPixelStub);
+    sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
   });
 });

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { fireNativeTrackers, setNativeTargeting } from 'src/native';
+
+const bid = {
+  native: {
+    title: 'Native Creative',
+    body: 'Cool description great stuff',
+    cta: 'Do it',
+    sponsoredBy: 'AppNexus',
+    clickUrl: 'https://www.link.example',
+    clickTrackers: ['https://tracker.example'],
+    impressionTrackers: ['https://impression.example'],
+  }
+};
+
+describe('native.js', () => {
+  it('sets native targeting keys', () => {
+    const targeting = setNativeTargeting(bid);
+    expect(targeting.hb_native_title).to.equal(bid.native.title);
+    expect(targeting.hb_native_body).to.equal(bid.native.body);
+    expect(targeting.hb_native_linkurl).to.equal(bid.native.clickUrl);
+  });
+
+  it('fires impression trackers', () => {
+    const fired = fireNativeTrackers({}, bid);
+    expect(fired).to.deep.equal(bid.native.impressionTrackers);
+  });
+
+  it('fires click trackers', () => {
+    const fired = fireNativeTrackers({ action: 'click' }, bid);
+    expect(fired).to.deep.equal(bid.native.clickTrackers);
+  });
+});


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
As per [OpenRTB Native 1.2 ](https://www.iab.com/wp-content/uploads/2017/04/OpenRTB-Native-Ads-Specification-Draft_1.2_2017-04.pdf), click trackers should be supported as an array of URLs. This PR adds support to Prebid for click trackers associated with native bid responses.

If a native bid response contains click trackers, bidder adapters should attach the click tracker array to the `native.clickTrackers` property of the bid response object (see appnexusAstBidAdapter for an example of this).

As native creatives that are served from adservers are likely to be in a cross-origin frame, it is necessary to use `postMessage` from the native creative template to communicate to Prebid that a link was clicked. Prebid is (even before this PR) configured to fire native impression trackers when it receives a message with the following structure:

```JavaScript
<script>
window.parent.postMessage(JSON.stringify({
  message: 'Prebid Native',
  adId: '%%PATTERN:hb_adid%%'
}), '*');
</script>
```

This PR introduces the ability to fire click trackers for the associated `adId` when a `'click'` `action` is added to the message:

```JavaScript
<script>
window.parent.postMessage(JSON.stringify({
  message: 'Prebid Native',
  action: 'click',
  adId: '%%PATTERN:hb_adid%%'
}), '*');
</script>
```

Ad ops teams may use these structures of `postMessage` in their native creative templates in any way that fits their use case. One example usage is given below:

```HTML
<div class="sponsored-post">
  <div class="content">
      <h1>
        <a
          href="%%CLICK_URL_UNESC%%%%PATTERN:hb_native_linkurl%%"
          target="_blank"
          onclick="fireTrackers('click')"
        >
          %%PATTERN:hb_native_title%%
        </a>
      </h1>
      <p>%%PATTERN:hb_native_body%%</p>
      <div class="attribution">%%PATTERN:hb_native_brand%%</div>
  </div>
</div>

<script>
function fireTrackers(action) {
  var message = {message: 'Prebid Native', adId: '%%PATTERN:hb_adid%%'};
  if (action === 'click') {message.action = 'click';}  // fires click trackers when called via link
  window.parent.postMessage(JSON.stringify(message), '*');
}

fireTrackers(); // fires native impressions on creative load
</script>
```

## Other information
Click through/landing page URLs are a required field in the OpenRTB 1.2 spec. This PR also requires native bid responses to have a landing page url, defined by `native.clickUrl` on the native bid response object.