### PR TITLE
Add ad units event

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -32,7 +32,8 @@
     "BID_RESPONSE": "bidResponse",
     "BID_WON": "bidWon",
     "SET_TARGETING": "setTargeting",
-    "REQUEST_BIDS": "requestBids"
+    "REQUEST_BIDS": "requestBids",
+    "ADD_AD_UNITS": "addAdUnits"
   },
   "EVENT_ID_PATHS": {
     "bidWon": "adUnitCode"

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -447,6 +447,8 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
     adUnitArr.transactionId = utils.generateUUID();
     $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);
   }
+  // emit event
+  events.emit(ADD_AD_UNITS)
 };
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -28,6 +28,7 @@ const { syncUsers, triggerUserSyncs } = userSync;
 
 var BID_WON = CONSTANTS.EVENTS.BID_WON;
 var SET_TARGETING = CONSTANTS.EVENTS.SET_TARGETING;
+var ADD_AD_UNITS = CONSTANTS.EVENTS.ADD_AD_UNITS;
 
 var auctionRunning = false;
 var bidRequestQueue = [];
@@ -448,7 +449,7 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
     $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);
   }
   // emit event
-  events.emit(ADD_AD_UNITS)
+  events.emit(ADD_AD_UNITS);
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Simple additional event for addAdUnits to support the use case where the adunit configuration code is running separately from the ad display logic. There is a potential race condition where you could try to request an auction for an ad unit before the ad units have been loaded in, resulting in no actual auctions being requested. With this event, you can ensure you don't try to run an auction before you have defined your ad units.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
