### PR TITLE
Don't set non-object configurations

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,12 +23,12 @@ const DEFAULT_USERSYNC = {
 };
 
 const GRANULARITY_OPTIONS = {
-  'LOW': 'low',
-  'MEDIUM': 'medium',
-  'HIGH': 'high',
-  'AUTO': 'auto',
-  'DENSE': 'dense',
-  'CUSTOM': 'custom'
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high',
+  AUTO: 'auto',
+  DENSE: 'dense',
+  CUSTOM: 'custom'
 };
 
 const ALL_TOPICS = '*';
@@ -174,6 +174,7 @@ export function newConfig() {
   function setConfig(options) {
     if (typeof options !== 'object') {
       utils.logError('setConfig options must be an object');
+      return;
     }
 
     Object.assign(config, options);

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -1,4 +1,4 @@
-import { excpet } from 'chai';
+import { expect } from 'chai';
 import { assert } from 'chai';
 import { newConfig } from 'src/config';
 
@@ -31,6 +31,11 @@ describe('config API', () => {
   it('sets and gets arbitrary configuarion properties', () => {
     setConfig({ baz: 'qux' });
     expect(getConfig('baz')).to.equal('qux');
+  });
+
+  it('only accepts objects', () => {
+    setConfig('invalid');
+    expect(getConfig('0')).to.not.equal('i');
   });
 
   it('sets multiple config properties', () => {


### PR DESCRIPTION
Return after logging error when a non-object value is given to `pbjs.setConfig` to prevent unexpected config settings