### PR TITLE
OpenX Video Adapter update to Prebid v1.0

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -2,9 +2,9 @@ import { config } from 'src/config';
 import {registerBidder} from 'src/adapters/bidderFactory';
 import * as utils from 'src/utils';
 import {userSync} from 'src/userSync';
-import { BANNER } from 'src/mediaTypes';
+import { BANNER, VIDEO } from 'src/mediaTypes';
 
-const SUPPORTED_AD_TYPES = [BANNER];
+const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'openx';
 const BIDDER_CONFIG = 'hb_pb';
 const BIDDER_VERSION = '2.0.0';
@@ -13,6 +13,11 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: SUPPORTED_AD_TYPES,
   isBidRequestValid: function(bid) {
+    if (bid.mediaType === VIDEO) {
+      if (typeof bid.params.video !== 'object' || !bid.params.video.url) {
+        return false;
+      }
+    }
     return !!(bid.params.unit && bid.params.delDomain);
   },
   buildRequests: function(bids) {
@@ -22,27 +27,59 @@ export const spec = {
       return;
     }
 
-    let delDomain = bids[0].params.delDomain;
-    let configuredBc = bids[0].params.bc;
-    let bc = configuredBc || `${BIDDER_CONFIG}_${BIDDER_VERSION}`;
+    let requests = [];
+    let bannerRequests = [];
+    let videoRequests = [];
+    let bannerBids = bids.filter(function(bid) { return bid.mediaType === BANNER; });
+    let videoBids = bids.filter(function(bid) { return bid.mediaType === VIDEO; });
 
-    return buildOXRequest(bids, {
-      ju: currentURL,
-      jr: currentURL,
-      ch: document.charSet || document.characterSet,
-      res: `${screen.width}x${screen.height}x${screen.colorDepth}`,
-      ifr: isIfr,
-      tz: new Date().getTimezoneOffset(),
-      tws: getViewportDimensions(isIfr),
-      ef: 'bt%2Cdb',
-      be: 1,
-      bc: bc,
-      nocache: new Date().getTime()
-    },
-    delDomain);
+    // build banner requests
+    if (bannerBids.length !== 0) {
+      let delDomain = bannerBids[0].params.delDomain;
+      let configuredBc = bannerBids[0].params.bc;
+      let bc = configuredBc || `${BIDDER_CONFIG}_${BIDDER_VERSION}`;
+      bannerRequests = [ buildOXRequest(bannerBids, {
+        ju: currentURL,
+        jr: currentURL,
+        ch: document.charSet || document.characterSet,
+        res: `${screen.width}x${screen.height}x${screen.colorDepth}`,
+        ifr: isIfr,
+        tz: new Date().getTimezoneOffset(),
+        tws: getViewportDimensions(isIfr),
+        ef: 'bt%2Cdb',
+        be: 1,
+        bc: bc,
+        nocache: new Date().getTime()
+      },
+      delDomain)];
+    }
+    // build video requests
+    if (videoBids.length !== 0) {
+      videoRequests = buildOXVideoRequest(videoBids);
+    }
+
+    requests = bannerRequests.concat(videoRequests);
+    return requests;
   },
   interpretResponse: function({body: oxResponseObj}, bidRequest) {
     let bidResponses = [];
+    let mediaType = BANNER;
+    if (bidRequest && bidRequest.payload) {
+      if (bidRequest.payload.bids) {
+        mediaType = bidRequest.payload.bids[0].mediaType;
+      } else if (bidRequest.payload.bid) {
+        mediaType = bidRequest.payload.bid.mediaType;
+      }
+    }
+
+    if (mediaType === VIDEO) {
+      if (oxResponseObj && oxResponseObj.pixels) {
+        userSync.registerSync('iframe', 'openx', oxResponseObj.pixels);
+      }
+      bidResponses = createVideoBidResponses(oxResponseObj, bidRequest.payload);
+      return bidResponses;
+    }
+
     let adUnits = oxResponseObj.ads.ad;
     if (oxResponseObj.ads && oxResponseObj.ads.pixels) {
       userSync.registerSync('iframe', BIDDER_CODE, oxResponseObj.ads.pixels);
@@ -96,13 +133,13 @@ function createBidResponses(adUnits, {bids, startTime}) {
     if (adUnit.deal_id) {
       bidResponse.dealId = adUnit.deal_id;
     }
-    // default 5 mins 
+    // default 5 mins
     bidResponse.ttl = 300;
-    // true is net, false is gross 
+    // true is net, false is gross
     bidResponse.netRevenue = true;
     bidResponse.currency = adUnit.currency;
 
-    // additional fields to add 
+    // additional fields to add
     if (adUnit.tbd) {
       bidResponse.tbd = adUnit.tbd;
     }
@@ -211,7 +248,7 @@ function formatCustomParms(customKey, customParams) {
     // if value is an array, join them with commas first
     value = value.join(',');
   }
-  // return customKey=customValue format, escaping + to . and / to _ 
+  // return customKey=customValue format, escaping + to . and / to _
   return (customKey.toLowerCase() + '=' + value.toLowerCase()).replace('+', '.').replace('/', '_')
 }
 
@@ -263,6 +300,62 @@ function buildOXRequest(bids, oxParams, delDomain) {
     data: oxParams,
     payload: {'bids': bids, 'startTime': new Date()}
   };
+}
+
+function buildOXVideoRequest(bids) {
+  return bids.map(function(bid) {
+    let url = 'http://' + bid.params.delDomain + '/v/1.0/avjp';
+    let oxVideoParams = generateVideoParameters(bid);
+    return {
+      method: 'GET',
+      url: url,
+      data: oxVideoParams,
+      payload: {'bid': bid, 'startTime': new Date()}
+    };
+  });
+}
+
+function generateVideoParameters(bid) {
+  let oxVideo = bid.params.video;
+  let oxVideoParams = { auid: bid.params.unit };
+
+  Object.keys(oxVideo).forEach(function(key) {
+    if (key === 'openrtb') {
+      oxVideoParams[key] = JSON.stringify(oxVideo[key]);
+    } else {
+      oxVideoParams[key] = oxVideo[key];
+    }
+  });
+  oxVideoParams['be'] = 'true';
+  return oxVideoParams;
+}
+
+function createVideoBidResponses(response, {bid, startTime}) {
+  let bidResponses = [];
+
+  if (response !== undefined && response.cache_key !== '' && response.pub_rev !== '') {
+    let bidResponse = {};
+    bidResponse.requestId = bid.bidId;
+    bidResponse.bidderCode = BIDDER_CODE;
+    // default 5 mins
+    bidResponse.ttl = 300;
+    // true is net, false is gross
+    bidResponse.netRevenue = true;
+    bidResponse.currency = response.currency;
+    bidResponse.cpm = Number(response.pub_rev) / 1000;
+    bidResponse.width = response.width;
+    bidResponse.height = response.height;
+    bidResponse.creativeId = response.adid;
+
+    bidResponse.openx = {
+      ff: response.cache_key,
+      oxcolo: response.per_colo_domain,
+      oxph: response.ph
+    };
+    bidResponses.push(bidResponse);
+  }
+
+  return bidResponses;
 }
 
 registerBidder(spec);

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -333,7 +333,7 @@ function generateVideoParameters(bid) {
 function createVideoBidResponses(response, {bid, startTime}) {
   let bidResponses = [];
 
-  if (response !== undefined && response.cache_key !== '' && response.pub_rev !== '') {
+  if (response !== undefined && response.vastUrl !== '' && response.pub_rev !== '') {
     let bidResponse = {};
     bidResponse.requestId = bid.bidId;
     bidResponse.bidderCode = BIDDER_CODE;
@@ -346,12 +346,9 @@ function createVideoBidResponses(response, {bid, startTime}) {
     bidResponse.width = response.width;
     bidResponse.height = response.height;
     bidResponse.creativeId = response.adid;
+    bidResponse.vastUrl = response.vastUrl;
+    bidResponse.mediaType = VIDEO;
 
-    bidResponse.openx = {
-      ff: response.cache_key,
-      oxcolo: response.per_colo_domain,
-      oxph: response.ph
-    };
     bidResponses.push(bidResponse);
   }
 

--- a/modules/openxBidAdapter.md
+++ b/modules/openxBidAdapter.md
@@ -36,7 +36,7 @@ Module that connects to OpenX's demand sources
                 bidder: 'openx',
                 params: {
                   unit: '539131525',
-                  delDomain: 'se-demo-d.openx.net',
+                  delDomain: 'zdo.com',
                   video: {
                      url: 'abc.com'
                   }

--- a/modules/openxBidAdapter.md
+++ b/modules/openxBidAdapter.md
@@ -16,6 +16,7 @@ Module that connects to OpenX's demand sources
         {
             code: 'test-div',
             sizes: [[728, 90]],  // a display size
+            mediaType: 'banner',
             bids: [
                 {
                     bidder: "openx",
@@ -26,5 +27,22 @@ Module that connects to OpenX's demand sources
                 }
             ]
         },
+        {
+            code: 'video1',
+            sizes: [[640,480]],
+            mediaType: 'video',
+            bids: [
+              {
+                bidder: 'openx',
+                params: {
+                  unit: '539131525',
+                  delDomain: 'se-demo-d.openx.net',
+                  video: {
+                     url: 'abc.com'
+                  }
+                }
+              }
+            ]
+        }
     ];
 ```

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -278,7 +278,7 @@ describe.only('OpenxAdapter', () => {
     });
 
     it('handles nobid responses', () => {
-      bidResponse = {
+      let bidResponse = {
         'ads':
         {
           'version': 1,
@@ -352,7 +352,7 @@ describe.only('OpenxAdapter', () => {
     });
 
     it('handles nobid responses', () => {
-      bidResponse = {'cache_key': '', 'pub_rev': '', 'per_colo_domain': '', 'ph': ''};
+      let bidResponse = {'cache_key': '', 'pub_rev': '', 'per_colo_domain': '', 'ph': ''};
       let result = spec.interpretResponse({body: bidResponse}, bidRequest);
       expect(result.length).to.equal(0);
     });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -5,7 +5,7 @@ import { newBidder } from 'src/adapters/bidderFactory';
 const URLBASE = '/w/1.0/arj';
 const URLBASEVIDEO = '/v/1.0/avjp';
 
-describe.only('OpenxAdapter', () => {
+describe('OpenxAdapter', () => {
   const adapter = newBidder(spec);
 
   describe('inherited functions', () => {
@@ -169,9 +169,7 @@ describe.only('OpenxAdapter', () => {
         'unit': '12345678',
         'delDomain': 'test-del-domain',
         'video': {
-          'be': 'true',
           'url': 'abc.com',
-          'vtest': '1'
         }
       },
       'adUnitCode': 'adunit-code',
@@ -196,8 +194,6 @@ describe.only('OpenxAdapter', () => {
       expect(dataParams.auid).to.equal('12345678');
       expect(dataParams.url).to.exist;
       expect(dataParams.url).to.equal('abc.com');
-      expect(dataParams.vtest).to.exist;
-      expect(dataParams.vtest).to.equal('1');
     });
   });
 
@@ -301,9 +297,7 @@ describe.only('OpenxAdapter', () => {
         'unit': '12345678',
         'delDomain': 'test-del-domain',
         'video': {
-          'be': 'true',
           'url': 'abc.com',
-          'vtest': '1'
         }
       },
       'adUnitCode': 'adunit-code',
@@ -320,11 +314,12 @@ describe.only('OpenxAdapter', () => {
       payload: {'bid': bids[0], 'startTime': new Date()}
     };
     let bidResponse = {
-      'cache_key': 'test_cache_key',
       'pub_rev': '1',
-      'per_colo_domain': 'http://delivery-us-west-1.openx.net',
-      'ph': '7a3b9374-7986-4a41-a79d-034193518aee',
-      'adid': 5678,
+      'width': '640',
+      'height': '480',
+      'adid': '5678',
+      'vastUrl': 'http://testvast.com',
+      'pixels': 'http://testpixels.net'
     };
 
     it('should return correct bid response', () => {
@@ -335,12 +330,9 @@ describe.only('OpenxAdapter', () => {
           'cpm': 1,
           'width': '640',
           'height': '480',
-          'creativeId': 5678,
-          'openx': {
-            'ff': 'test_cache_key',
-            'oxcolo': 'http://delivery-us-west-1.openx.net',
-            'oxph': '7a3b9374-7986-4a41-a79d-034193518aee'
-          },
+          'mediaType': 'video',
+          'creativeId': '5678',
+          'vastUrl': 'http://testvast.com',
           'ttl': 300,
           'netRevenue': true,
           'currency': 'USD'
@@ -352,7 +344,7 @@ describe.only('OpenxAdapter', () => {
     });
 
     it('handles nobid responses', () => {
-      let bidResponse = {'cache_key': '', 'pub_rev': '', 'per_colo_domain': '', 'ph': ''};
+      let bidResponse = {'vastUrl': '', 'pub_rev': '', 'width': '', 'height': '', 'adid': '', 'pixels': ''};
       let result = spec.interpretResponse({body: bidResponse}, bidRequest);
       expect(result.length).to.equal(0);
     });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -3,8 +3,9 @@ import { spec } from 'modules/openxBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
 const URLBASE = '/w/1.0/arj';
+const URLBASEVIDEO = '/v/1.0/avjp';
 
-describe('OpenxAdapter', () => {
+describe.only('OpenxAdapter', () => {
   const adapter = newBidder(spec);
 
   describe('inherited functions', () => {
@@ -21,25 +22,57 @@ describe('OpenxAdapter', () => {
         'delDomain': 'test-del-domain'
       },
       'adUnitCode': 'adunit-code',
+      'mediaType': 'banner',
       'sizes': [[300, 250], [300, 600]],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    let videoBid = {
+      'bidder': 'openx',
+      'params': {
+        'unit': '12345678',
+        'delDomain': 'test-del-domain',
+        'video': {
+          'be': 'true',
+          'url': 'abc.com',
+          'vtest': '1'
+        }
+      },
+      'adUnitCode': 'adunit-code',
+      'mediaType': 'video',
+      'sizes': [640, 480],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+      'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+    };
+
+    it('should return true when required params found for a banner ad', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed for a banner ad', () => {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {'unit': '12345678'};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
+
+    it('should return true when required params found for a video ad', () => {
+      expect(spec.isBidRequestValid(videoBid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed for a video ad', () => {
+      let videoBid = Object.assign({}, videoBid);
+      delete videoBid.params;
+      videoBid.params = {};
+      expect(spec.isBidRequestValid(videoBid)).to.equal(false);
+    });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests for banner ads', () => {
     let bidRequests = [{
       'bidder': 'openx',
       'params': {
@@ -47,6 +80,7 @@ describe('OpenxAdapter', () => {
         'delDomain': 'test-del-domain'
       },
       'adUnitCode': 'adunit-code',
+      'mediaType': 'banner',
       'sizes': [[300, 250], [300, 600]],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
@@ -55,13 +89,13 @@ describe('OpenxAdapter', () => {
 
     it('should send bid request to openx url via GET', () => {
       const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.equal('//' + bidRequests[0].params.delDomain + URLBASE);
-      expect(request.method).to.equal('GET');
+      expect(request[0].url).to.equal('//' + bidRequests[0].params.delDomain + URLBASE);
+      expect(request[0].method).to.equal('GET');
     });
 
     it('should have the correct parameters', () => {
       const request = spec.buildRequests(bidRequests);
-      const dataParams = request.data;
+      const dataParams = request[0].data;
 
       expect(dataParams.auid).to.exist;
       expect(dataParams.auid).to.equal('12345678');
@@ -82,7 +116,7 @@ describe('OpenxAdapter', () => {
       );
 
       const request = spec.buildRequests([bidRequest]);
-      const dataParams = request.data;
+      const dataParams = request[0].data;
 
       expect(dataParams.tps).to.exist;
       expect(dataParams.tps).to.equal(btoa('test1=testval1.&test2=testval2_,testval3'));
@@ -101,7 +135,7 @@ describe('OpenxAdapter', () => {
       );
 
       const request = spec.buildRequests([bidRequest]);
-      const dataParams = request.data;
+      const dataParams = request[0].data;
 
       expect(dataParams.aumfs).to.exist;
       expect(dataParams.aumfs).to.equal('1500');
@@ -120,14 +154,54 @@ describe('OpenxAdapter', () => {
       );
 
       const request = spec.buildRequests([bidRequest]);
-      const dataParams = request.data;
+      const dataParams = request[0].data;
 
       expect(dataParams.bc).to.exist;
       expect(dataParams.bc).to.equal('hb_override');
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('buildRequests for video', () => {
+    let bidRequests = [{
+      'bidder': 'openx',
+      'mediaType': 'video',
+      'params': {
+        'unit': '12345678',
+        'delDomain': 'test-del-domain',
+        'video': {
+          'be': 'true',
+          'url': 'abc.com',
+          'vtest': '1'
+        }
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [640, 480],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+      'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+    }];
+
+    it('should send bid request to openx url via GET', () => {
+      const request = spec.buildRequests(bidRequests);
+      expect(request[0].url).to.equal('http://' + bidRequests[0].params.delDomain + URLBASEVIDEO);
+      expect(request[0].method).to.equal('GET');
+    });
+
+    it('should have the correct parameters', () => {
+      const request = spec.buildRequests(bidRequests);
+      const dataParams = request[0].data;
+
+      expect(dataParams.auid).to.exist;
+      expect(dataParams.auid).to.equal('12345678');
+      expect(dataParams.url).to.exist;
+      expect(dataParams.url).to.equal('abc.com');
+      expect(dataParams.vtest).to.exist;
+      expect(dataParams.vtest).to.equal('1');
+    });
+  });
+
+  describe('interpretResponse for banner ads', () => {
     let bids = [{
       'bidder': 'openx',
       'params': {
@@ -135,6 +209,7 @@ describe('OpenxAdapter', () => {
         'delDomain': 'test-del-domain'
       },
       'adUnitCode': 'adunit-code',
+      'mediaType': 'banner',
       'sizes': [[300, 250], [300, 600]],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
@@ -213,6 +288,71 @@ describe('OpenxAdapter', () => {
         }
       };
 
+      let result = spec.interpretResponse({body: bidResponse}, bidRequest);
+      expect(result.length).to.equal(0);
+    });
+  });
+
+  describe('interpretResponse for video ads', () => {
+    let bids = [{
+      'bidder': 'openx',
+      'mediaType': 'video',
+      'params': {
+        'unit': '12345678',
+        'delDomain': 'test-del-domain',
+        'video': {
+          'be': 'true',
+          'url': 'abc.com',
+          'vtest': '1'
+        }
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [640, 480],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+      'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+    }];
+    let bidRequest = {
+      method: 'GET',
+      url: 'url',
+      data: {},
+      payload: {'bid': bids[0], 'startTime': new Date()}
+    };
+    let bidResponse = {
+      'cache_key': 'test_cache_key',
+      'pub_rev': '1',
+      'per_colo_domain': 'http://delivery-us-west-1.openx.net',
+      'ph': '7a3b9374-7986-4a41-a79d-034193518aee',
+      'adid': 5678,
+    };
+
+    it('should return correct bid response', () => {
+      let expectedResponse = [
+        {
+          'requestId': '30b31c1838de1e',
+          'bidderCode': 'openx',
+          'cpm': 1,
+          'width': '640',
+          'height': '480',
+          'creativeId': 5678,
+          'openx': {
+            'ff': 'test_cache_key',
+            'oxcolo': 'http://delivery-us-west-1.openx.net',
+            'oxph': '7a3b9374-7986-4a41-a79d-034193518aee'
+          },
+          'ttl': 300,
+          'netRevenue': true,
+          'currency': 'USD'
+        }
+      ];
+
+      let result = spec.interpretResponse({body: bidResponse}, bidRequest);
+      expect(JSON.stringify(Object.keys(result[0]).sort())).to.eql(JSON.stringify(Object.keys(expectedResponse[0]).sort()));
+    });
+
+    it('handles nobid responses', () => {
+      bidResponse = {'cache_key': '', 'pub_rev': '', 'per_colo_domain': '', 'ph': ''};
       let result = spec.interpretResponse({body: bidResponse}, bidRequest);
       expect(result.length).to.equal(0);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
OpenX  Adapter for Prebid v1.0 
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'openx',
  mediaType: 'video',
     params: {
        unit: '539131525',
        delDomain: 'zdo.com',
        video: {
           url: 'abc.com'
        }
      }
}
```
Bidder code: openx
Send All Bids Ad Server Keys: hb_pb, hb_adid, hb_size
new openxvideo biddersettings:
```
pbjs.bidderSettings =
    {
        standard: {
          ........
        }
    };
```

- contact email of the adapter’s maintainer team-openx@openx.com

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
The OpenX adapter requires setup and approval from your OpenX team. Please reach out to your OpenX representative or Support@openx.com for more information and to enable using this adapter