### PR TITLE
add option to run tests in a specific file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,10 +173,11 @@ gulp.task('webpack', ['clean'], function () {
 // By default, this runs in headless chrome.
 //
 // If --watch is given, the task will re-run unit tests whenever the source code changes
+// If --file "<path-to-test-file>" is given, the task will only run tests in the specified file.
 // If --browserstack is given, it will run the full suite of currently supported browsers.
 // If --browsers is given, browsers can be chosen explicitly. e.g. --browsers=chrome,firefox,ie9
 gulp.task('test', ['clean'], function (done) {
-  var karmaConf = karmaConfMaker(false, argv.browserstack, argv.watch);
+  var karmaConf = karmaConfMaker(false, argv.browserstack, argv.watch, argv.file);
 
   var browserOverride = helpers.parseBrowserArgs(argv).map(helpers.toCapitalCase);
   if (browserOverride.length > 0) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,8 +187,9 @@ gulp.task('test', ['clean'], function (done) {
   new KarmaServer(karmaConf, newKarmaCallback(done)).start();
 });
 
+// If --file "<path-to-test-file>" is given, the task will only run tests in the specified file.
 gulp.task('test-coverage', ['clean'], function(done) {
-  new KarmaServer(karmaConfMaker(true, false), newKarmaCallback(done)).start();
+  new KarmaServer(karmaConfMaker(true, false, argv.file), newKarmaCallback(done)).start();
 });
 
 // View the code coverage report in the browser.

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -95,9 +95,9 @@ function setBrowsers(karmaConf, browserstack) {
 module.exports = function(codeCoverage, browserstack, watchMode, file) {
   var webpackConfig = newWebpackConfig(codeCoverage);
   var plugins = newPluginsArray(browserstack);
-  var files = file ? [file] : [
+  var files = [
     'test/helpers/prebidGlobal.js',
-    'test/**/*_spec.js'
+    file ? file : 'test/**/*_spec.js'
   ];
   // This file opens the /debug.html tab automatically.
   // It has no real value unless you're running --watch, and intend to do some debugging in the browser.

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -92,10 +92,10 @@ function setBrowsers(karmaConf, browserstack) {
   }
 }
 
-module.exports = function(codeCoverage, browserstack, watchMode) {
+module.exports = function(codeCoverage, browserstack, watchMode, file) {
   var webpackConfig = newWebpackConfig(codeCoverage);
   var plugins = newPluginsArray(browserstack);
-  var files = [
+  var files = file ? [file] : [
     'test/helpers/prebidGlobal.js',
     'test/**/*_spec.js'
   ];


### PR DESCRIPTION
## Type of change
- [x] CI related changes

## Description of change
When developing an adapter, I don't need to run the whole test suite, it's very time consuming. This PR adds an option to run a specific test file. Usage:
```shell
$ gulp test --file "test/spec/modules/vidazooBidAdapter_spec.js"
```
