### PR TITLE
Change prebidServer to call client user syncs if they exist

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -180,6 +180,14 @@ function PrebidServer() {
           });
         }
 
+        // do client-side syncs if available
+        requestedBidders.forEach(bidder => {
+          let clientAdapter = adaptermanager.getBidAdapter(bidder);
+          if (clientAdapter && clientAdapter.registerSyncs) {
+            clientAdapter.registerSyncs();
+          }
+        });
+
         if (result.bids) {
           result.bids.forEach(bidObj => {
             let bidRequest = utils.getBidRequest(bidObj.bid_id);

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -286,8 +286,8 @@ export const spec = {
       return bids;
     }, []);
   },
-  getUserSyncs: function() {
-    if (!hasSynced) {
+  getUserSyncs: function(syncOptions) {
+    if (!hasSynced && syncOptions.iframeEnabled) {
       hasSynced = true;
       return {
         type: 'iframe',

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -327,6 +327,10 @@ exports.setBidderSequence = function (order) {
   }
 };
 
+exports.getBidAdapter = function(bidder) {
+  return _bidderRegistry[bidder];
+};
+
 exports.setS2SConfig = function (config) {
   _s2sConfig = config;
 };

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -142,6 +142,7 @@ export function newBidder(spec) {
     getSpec: function() {
       return Object.freeze(spec);
     },
+    registerSyncs,
     callBids: function(bidderRequest) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
@@ -183,20 +184,7 @@ export function newBidder(spec) {
       const responses = [];
       function afterAllResponses() {
         fillNoBids();
-        if (spec.getUserSyncs) {
-          let syncs = spec.getUserSyncs({
-            iframeEnabled: config.getConfig('userSync.iframeEnabled'),
-            pixelEnabled: config.getConfig('userSync.pixelEnabled'),
-          }, responses);
-          if (syncs) {
-            if (!Array.isArray(syncs)) {
-              syncs = [syncs];
-            }
-            syncs.forEach((sync) => {
-              userSync.registerSync(sync.type, spec.code, sync.url)
-            });
-          }
-        }
+        registerSyncs(responses);
       }
 
       const validBidRequests = bidderRequest.bids.filter(filterAndWarn);
@@ -307,6 +295,23 @@ export function newBidder(spec) {
       }
     }
   });
+
+  function registerSyncs(responses) {
+    if (spec.getUserSyncs) {
+      let syncs = spec.getUserSyncs({
+        iframeEnabled: config.getConfig('userSync.iframeEnabled'),
+        pixelEnabled: config.getConfig('userSync.pixelEnabled'),
+      }, responses);
+      if (syncs) {
+        if (!Array.isArray(syncs)) {
+          syncs = [syncs];
+        }
+        syncs.forEach((sync) => {
+          userSync.registerSync(sync.type, spec.code, sync.url)
+        });
+      }
+    }
+  }
 
   function filterAndWarn(bid) {
     if (!spec.isBidRequestValid(bid)) {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import Adapter from 'modules/prebidServerBidAdapter';
+import adapterManager from 'src/adaptermanager';
 import bidmanager from 'src/bidmanager';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils';
@@ -351,6 +352,23 @@ describe('S2S Adapter', () => {
       server.respond();
       const response = bidmanager.addBidResponse.firstCall.args[1];
       expect(response).to.have.property('adserverTargeting').that.deep.equals({'foo': 'bar'});
+    });
+
+    it('registers client user syncs when client bid adapter is present', () => {
+      let rubiconAdapter = {
+        registerSyncs: sinon.spy()
+      };
+      sinon.stub(adapterManager, 'getBidAdapter', () => rubiconAdapter);
+
+      server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
+
+      adapter.setConfig(CONFIG);
+      adapter.callBids(REQUEST);
+      server.respond();
+
+      sinon.assert.calledOnce(rubiconAdapter.registerSyncs);
+
+      adapterManager.getBidAdapter.restore();
     });
 
     it('registers bid responses when server requests cookie sync', () => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { spec, masSizeOrdering, resetUserSync } from 'modules/rubiconBidAdapter'
 import { parse as parseQuery } from 'querystring';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { userSync } from 'src/userSync';
+import { config } from 'src/config';
 
 var CONSTANTS = require('src/constants.json');
 
@@ -779,13 +780,17 @@ describe('the rubicon adapter', () => {
     });
 
     it('should register the Emily iframe', () => {
-      let syncs = spec.getUserSyncs();
+      let syncs = spec.getUserSyncs({
+        iframeEnabled: true
+      });
 
       expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
     });
 
     it('should not register the Emily iframe more than once', () => {
-      let syncs = spec.getUserSyncs();
+      let syncs = spec.getUserSyncs({
+        iframeEnabled: true
+      });
       expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
 
       // when called again, should still have only been called once


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
If client-side bid adapters are available but the bidder was part of a server-side request, this makes sure the user syncs are still called in the client bid adapter.
