### PR TITLE
fix log message not displaying when referencing missing bidder

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -197,20 +197,18 @@ exports.callBids = ({adUnits, cbTimeout}) => {
         $$PREBID_GLOBAL$$._bidsRequested.push(bidderRequest);
         _bidderRequests.push(bidderRequest);
       }
+    } else {
+      utils.logError(`Adapter trying to be called which does not exist: ${bidRequest.bidderCode} adaptermanager.callBids`);
     }
   });
 
   _bidderRequests.forEach(bidRequest => {
     bidRequest.start = new Date().getTime();
     const adapter = _bidderRegistry[bidRequest.bidderCode];
-    if (adapter) {
-      if (bidRequest.bids && bidRequest.bids.length !== 0) {
-        utils.logMessage(`CALLING BIDDER ======= ${bidRequest.bidderCode}`);
-        events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
-        adapter.callBids(bidRequest);
-      }
-    } else {
-      utils.logError(`Adapter trying to be called which does not exist: ${bidRequest.bidderCode} adaptermanager.callBids`);
+    if (bidRequest.bids && bidRequest.bids.length !== 0) {
+      utils.logMessage(`CALLING BIDDER ======= ${bidRequest.bidderCode}`);
+      events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
+      adapter.callBids(bidRequest);
     }
   })
 };

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -198,7 +198,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
         _bidderRequests.push(bidderRequest);
       }
     } else {
-      utils.logError(`Adapter trying to be called which does not exist: ${bidRequest.bidderCode} adaptermanager.callBids`);
+      utils.logError(`Adapter trying to be called which does not exist: ${bidderCode} adaptermanager.callBids`);
     }
   });
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -34,6 +34,30 @@ var appnexusAdapterMock = {
 };
 
 describe('adapterManager tests', () => {
+  describe('callBids', () => {
+    beforeEach(() => {
+      sinon.stub(utils, 'logError');
+    });
+
+    afterEach(() => {
+      utils.logError.restore();
+    });
+
+    it('should log an error if a bidder is used that does not exist', () => {
+      const adUnits = [{
+        code: 'adUnit-code',
+        bids: [
+          {bidder: 'appnexus', params: {placementId: 'id'}},
+          {bidder: 'fakeBidder', params: {placementId: 'id'}}
+        ]
+      }];
+
+      AdapterManager.callBids({adUnits});
+
+      sinon.assert.called(utils.logError);
+    });
+  });
+
   describe('S2S tests', () => {
     beforeEach(() => {
       AdapterManager.setS2SConfig(CONFIG);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -779,6 +779,24 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.callBids.restore();
     });
 
+    it('should log an error if a bidder is used that does not exist', () => {
+      sinon.stub(utils, 'logError');
+
+      const adUnits = [{
+        code: 'adUnit-code',
+        bids: [
+          {bidder: 'appnexus', params: {placementId: 'id'}},
+          {bidder: 'fakeBidder', params: {placementId: 'id'}}
+        ]
+      }];
+
+      $$PREBID_GLOBAL$$.requestBids({adUnits});
+
+      sinon.assert.called(utils.logError);
+
+      utils.logError.restore();
+    });
+
     it('should not callBids if a video adUnit has non-video bidders', () => {
       sinon.spy(adaptermanager, 'callBids');
       const videoAdaptersBackup = adaptermanager.videoAdapters;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -779,24 +779,6 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.callBids.restore();
     });
 
-    it('should log an error if a bidder is used that does not exist', () => {
-      sinon.stub(utils, 'logError');
-
-      const adUnits = [{
-        code: 'adUnit-code',
-        bids: [
-          {bidder: 'appnexus', params: {placementId: 'id'}},
-          {bidder: 'fakeBidder', params: {placementId: 'id'}}
-        ]
-      }];
-
-      $$PREBID_GLOBAL$$.requestBids({adUnits});
-
-      sinon.assert.called(utils.logError);
-
-      utils.logError.restore();
-    });
-
     it('should not callBids if a video adUnit has non-video bidders', () => {
       sinon.spy(adaptermanager, 'callBids');
       const videoAdaptersBackup = adaptermanager.videoAdapters;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes small bug introduced with #1690 that makes error message never display when referencing a missing adapter.