### PR TITLE
Validating bid response params

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -181,7 +181,7 @@ function newBid(serverBid, rtbBid) {
   const bid = {
     requestId: serverBid.uuid,
     cpm: rtbBid.cpm,
-    creative_id: rtbBid.creative_id,
+    creativeId: rtbBid.creative_id,
     dealId: rtbBid.deal_id,
     currency: 'USD',
     netRevenue: true,

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -183,6 +183,9 @@ function newBid(serverBid, rtbBid) {
     cpm: rtbBid.cpm,
     creative_id: rtbBid.creative_id,
     dealId: rtbBid.deal_id,
+    currency: 'USD',
+    netRevenue: true,
+    ttl: 300
   };
 
   if (rtbBid.rtb.video) {
@@ -190,7 +193,8 @@ function newBid(serverBid, rtbBid) {
       width: rtbBid.rtb.video.player_width,
       height: rtbBid.rtb.video.player_height,
       vastUrl: rtbBid.rtb.video.asset_url,
-      descriptionUrl: rtbBid.rtb.video.asset_url
+      descriptionUrl: rtbBid.rtb.video.asset_url,
+      ttl: 3600
     });
     // This supports Outstream Video
     if (rtbBid.renderer_url) {

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -107,7 +107,7 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  * @property {string} url The URL which makes the sync happen.
  */
 
-const BID_RESPONSE_KEYS = ['id', 'bidderCode', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId', 'netRevenue', 'currency'];
+const BID_RESPONSE_KEYS = ['requestId', 'bidderCode', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId', 'netRevenue', 'currency'];
 
 /**
  * Register a bidder with prebid, using the given spec.

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -107,7 +107,7 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  * @property {string} url The URL which makes the sync happen.
  */
 
-const BID_RESPONSE_KEYS = ['currency', 'netRevenue', 'ttl'];
+const BID_RESPONSE_KEYS = ['id', 'bidderCode', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId', 'netRevenue', 'currency'];
 
 /**
  * Register a bidder with prebid, using the given spec.

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -107,7 +107,8 @@ import { logWarn, logError, parseQueryStringParameters, delayExecution } from 's
  * @property {string} url The URL which makes the sync happen.
  */
 
-const BID_RESPONSE_KEYS = ['requestId', 'bidderCode', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId', 'netRevenue', 'currency'];
+// common params for all mediaTypes
+const COMMON_BID_RESPONSE_KEYS = ['requestId', 'cpm', 'ttl', 'creativeId', 'netRevenue', 'currency'];
 
 /**
  * Register a bidder with prebid, using the given spec.
@@ -325,7 +326,7 @@ export function newBidder(spec) {
 
   function hasValidKeys(bid) {
     let bidKeys = Object.keys(bid);
-    return BID_RESPONSE_KEYS.every(key => bidKeys.includes(key));
+    return COMMON_BID_RESPONSE_KEYS.every(key => bidKeys.includes(key));
   }
 
   function newEmptyBid() {

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -301,13 +301,16 @@ describe('AppNexusAdapter', () => {
           'width': 300,
           'height': 250,
           'ad': '<!-- Creative -->',
-          'mediaType': 'banner'
+          'mediaType': 'banner',
+          'currency': 'USD',
+          'ttl': 300,
+          'netRevenue': true
         }
       ];
       let bidderRequest;
 
       let result = spec.interpretResponse(response, {bidderRequest});
-      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
     it('handles nobid responses', () => {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -328,6 +328,9 @@ describe('bidders created by newBidder', () => {
       const bidder = newBidder(spec);
 
       const bid = {
+        id: 'id',
+        creativeId: 'creative-id',
+        bidderCode: 'code',
         requestId: 'some-id',
         ad: 'ad-url.com',
         cpm: 0.5,

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -5,6 +5,7 @@ import * as ajax from 'src/ajax';
 import { expect } from 'chai';
 import { STATUS } from 'src/constants';
 import { userSync } from 'src/userSync'
+import * as utils from 'src/utils';
 
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
@@ -113,7 +114,7 @@ describe('bidders created by newBidder', () => {
       expect(spec.buildRequests.firstCall.args[0]).to.deep.equal([MOCK_BIDS_REQUEST.bids[0]]);
     });
 
-    it("should make no server requests if the spec doesn't return any", () => {
+    it('should make no server requests if the spec doesn\'t return any', () => {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -262,17 +263,20 @@ describe('bidders created by newBidder', () => {
   describe('when the ajax call succeeds', () => {
     let ajaxStub;
     let userSyncStub;
+    let logErrorSpy;
 
     beforeEach(() => {
       ajaxStub = sinon.stub(ajax, 'ajax', function(url, callbacks) {
         callbacks.success('response body');
       });
       userSyncStub = sinon.stub(userSync, 'registerSync')
+      logErrorSpy = sinon.spy(utils, 'logError');
     });
 
     afterEach(() => {
       ajaxStub.restore();
       userSyncStub.restore();
+      utils.logError.restore();
     });
 
     it('should call spec.interpretResponse() with the response body content', () => {
@@ -320,7 +324,7 @@ describe('bidders created by newBidder', () => {
       expect(spec.interpretResponse.calledTwice).to.equal(true);
     });
 
-    it("should add bids for each placement code into the bidmanager, even if the bidder doesn't bid on all of them", () => {
+    it('should add bids for each placement code into the bidmanager, even if the bidder doesn\'t bid on all of them', () => {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -329,7 +333,10 @@ describe('bidders created by newBidder', () => {
         cpm: 0.5,
         height: 200,
         width: 300,
-        placementCode: 'mock/placement'
+        placementCode: 'mock/placement',
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 300
       };
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
@@ -348,6 +355,7 @@ describe('bidders created by newBidder', () => {
         [bidmanager.addBidResponse.firstCall.args[0], bidmanager.addBidResponse.secondCall.args[0]];
       expect(placementsWithBids).to.contain('mock/placement');
       expect(placementsWithBids).to.contain('mock/placement2');
+      expect(logErrorSpy.callCount).to.equal(0);
     });
 
     it('should call spec.getUserSyncs() with the response', () => {
@@ -383,6 +391,32 @@ describe('bidders created by newBidder', () => {
       expect(userSyncStub.firstCall.args[0]).to.equal('iframe');
       expect(userSyncStub.firstCall.args[1]).to.equal(spec.code);
       expect(userSyncStub.firstCall.args[2]).to.equal('usersync.com');
+    });
+
+    it('should logError when required bid response params are missing', () => {
+      const bidder = newBidder(spec);
+
+      const bid = {
+        requestId: 'some-id',
+        ad: 'ad-url.com',
+        cpm: 0.5,
+        height: 200,
+        width: 300,
+        placementCode: 'mock/placement'
+      };
+      spec.isBidRequestValid.returns(true);
+      spec.buildRequests.returns({
+        method: 'POST',
+        url: 'test.url.com',
+        data: {}
+      });
+      spec.getUserSyncs.returns([]);
+
+      spec.interpretResponse.returns(bid);
+
+      bidder.callBids(MOCK_BIDS_REQUEST);
+
+      expect(logErrorSpy.calledOnce).to.equal(true);
     });
   });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -328,7 +328,6 @@ describe('bidders created by newBidder', () => {
       const bidder = newBidder(spec);
 
       const bid = {
-        id: 'id',
         creativeId: 'creative-id',
         bidderCode: 'code',
         requestId: 'some-id',


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Validating bid response params `currency`, 'netRevenue` and `ttl` for 1.0 adapters.