### PR TITLE
Make response headers available to the specs

### DIFF
--- a/modules/adbutlerBidAdapter.js
+++ b/modules/adbutlerBidAdapter.js
@@ -74,6 +74,7 @@ export const spec = {
     var width;
     var height;
 
+    serverResponse = serverResponse.body;
     if (serverResponse && serverResponse.status === 'SUCCESS' && bidObj) {
       CPM = serverResponse.cpm;
       minCPM = utils.getBidIdParameter('minCPM', bidObj.params);

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -87,6 +87,7 @@ export const spec = {
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function(serverResponse, {bidderRequest}) {
+    serverResponse = serverResponse.body;
     const bids = [];
     if (!serverResponse || serverResponse.error) {
       let errorMessage = `in response for ${bidderRequest.bidderCode} adapter`;

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -23,6 +23,7 @@ export const spec = {
   },
 
   interpretResponse(response, { bidRequest }) {
+    response = response.body;
     if (!response || !response.url || !response.bidPrice) {
       utils.logWarn(`No valid bids from ${spec.code} bidder`);
       return [];

--- a/modules/jcmBidAdapter.js
+++ b/modules/jcmBidAdapter.js
@@ -44,6 +44,7 @@ export const spec = {
 
   interpretResponse: function(serverResponse) {
     const bidResponses = [];
+    serverResponse = serverResponse.body;
     // loop through serverResponses
     if (serverResponse) {
       if (serverResponse.bids) {

--- a/modules/platformioBidAdapter.js
+++ b/modules/platformioBidAdapter.js
@@ -24,7 +24,7 @@ export const spec = {
     };
   },
   interpretResponse: (response, request) => (
-    bidResponseAvailable(request, response)
+    bidResponseAvailable(request, response.body)
   ),
 };
 function bidResponseAvailable(bidRequest, bidResponse) {

--- a/modules/pulsepointLiteBidAdapter.js
+++ b/modules/pulsepointLiteBidAdapter.js
@@ -69,6 +69,7 @@ export const spec = {
 function bidResponseAvailable(bidRequest, bidResponse) {
   const idToImpMap = {};
   const idToBidMap = {};
+  bidResponse = bidResponse.body
   // extract the request bids and the response bids, keyed by impr-id
   const ortbRequest = parse(bidRequest.data);
   ortbRequest.imp.forEach(imp => {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -230,6 +230,7 @@ export const spec = {
    * @return {Bid[]} An array of bids which
    */
   interpretResponse: function(responseObj, {bidRequest}) {
+    responseObj = responseObj.body
     let ads = responseObj.ads;
 
     // check overall response

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -121,17 +121,19 @@ describe('AdButler adapter', () => {
     describe('bid responses', () => {
       it('should return complete bid response', () => {
         let serverResponse = {
-            status: 'SUCCESS',
-            account_id: 167283,
-            zone_id: 210093,
-            cpm: 1.5,
-            width: 300,
-            height: 250,
-            place: 0,
-            ad_code: '<img src="http://image.source.com/img" alt="" title="" border="0" width="300" height="250">',
-            tracking_pixels: [
-              'http://tracking.pixel.com/params=info'
-            ]
+            body: {
+              status: 'SUCCESS',
+              account_id: 167283,
+              zone_id: 210093,
+              cpm: 1.5,
+              width: 300,
+              height: 250,
+              place: 0,
+              ad_code: '<img src="http://image.source.com/img" alt="" title="" border="0" width="300" height="250">',
+              tracking_pixels: [
+                'http://tracking.pixel.com/params=info'
+              ]
+            }
           },
           bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
 

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -306,7 +306,7 @@ describe('AppNexusAdapter', () => {
       ];
       let bidderRequest;
 
-      let result = spec.interpretResponse(response, {bidderRequest});
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
@@ -322,7 +322,7 @@ describe('AppNexusAdapter', () => {
       };
       let bidderRequest;
 
-      let result = spec.interpretResponse(response, {bidderRequest});
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result.length).to.equal(0);
     });
 
@@ -343,7 +343,7 @@ describe('AppNexusAdapter', () => {
       };
       let bidderRequest;
 
-      let result = spec.interpretResponse(response, {bidderRequest});
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0]).to.have.property('vastUrl');
       expect(result[0]).to.have.property('descriptionUrl');
       expect(result[0]).to.have.property('mediaType', 'video');
@@ -376,7 +376,7 @@ describe('AppNexusAdapter', () => {
       };
       let bidderRequest;
 
-      let result = spec.interpretResponse(response1, {bidderRequest});
+      let result = spec.interpretResponse({ body: response1 }, {bidderRequest});
       expect(result[0].native.title).to.equal('Native Creative');
       expect(result[0].native.body).to.equal('Cool description great stuff');
       expect(result[0].native.cta).to.equal('Do it');

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -104,7 +104,7 @@ describe('BeachfrontAdapter', () => {
 
   describe('spec.interpretResponse', () => {
     it('should return no bids if the response is not valid', () => {
-      const bidResponse = spec.interpretResponse(null, { bidRequest });
+      const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
@@ -112,7 +112,7 @@ describe('BeachfrontAdapter', () => {
       const serverResponse = {
         bidPrice: 5.00
       };
-      const bidResponse = spec.interpretResponse(serverResponse, { bidRequest });
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
@@ -120,7 +120,7 @@ describe('BeachfrontAdapter', () => {
       const serverResponse = {
         url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da'
       };
-      const bidResponse = spec.interpretResponse(serverResponse, { bidRequest });
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
@@ -130,7 +130,7 @@ describe('BeachfrontAdapter', () => {
         url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
         cmpId: '123abc'
       };
-      const bidResponse = spec.interpretResponse(serverResponse, { bidRequest });
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse).to.deep.equal({
         requestId: bidRequest.bidId,
         bidderCode: spec.code,

--- a/test/spec/modules/jcmBidAdapter_spec.js
+++ b/test/spec/modules/jcmBidAdapter_spec.js
@@ -94,7 +94,7 @@ describe('jcmAdapter', () => {
         }
       ];
 
-      let result = spec.interpretResponse(serverResponse);
+      let result = spec.interpretResponse({ body: serverResponse });
       expect(Object.keys(result[0]).length).to.equal(Object.keys(expectedResponse[0]).length);
       expect(Object.keys(result[0]).requestId).to.equal(Object.keys(expectedResponse[0]).requestId);
       expect(Object.keys(result[0]).bidderCode).to.equal(Object.keys(expectedResponse[0]).bidderCode);
@@ -112,7 +112,7 @@ describe('jcmAdapter', () => {
     it('handles nobid responses', () => {
       let serverResponse = {'bids': []};
 
-      let result = spec.interpretResponse(serverResponse);
+      let result = spec.interpretResponse({ body: serverResponse });
       expect(result.length).to.equal(0);
     });
   });

--- a/test/spec/modules/platformioBidAdapter_spec.js
+++ b/test/spec/modules/platformioBidAdapter_spec.js
@@ -63,7 +63,7 @@ describe('Platformio Adapter Tests', () => {
         }]
       }]
     };
-    const bids = spec.interpretResponse(ortbResponse, request);
+    const bids = spec.interpretResponse({ body: ortbResponse }, request);
     expect(bids).to.have.lengthOf(1);
     // verify first bid
     const bid = bids[0];
@@ -78,7 +78,7 @@ describe('Platformio Adapter Tests', () => {
 
   it('Verify full passback', () => {
     const request = spec.buildRequests(slotConfigs);
-    const bids = spec.interpretResponse(null, request)
+    const bids = spec.interpretResponse({ body: null }, request)
     expect(bids).to.have.lengthOf(0);
   });
 

--- a/test/spec/modules/pulsepointLiteBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointLiteBidAdapter_spec.js
@@ -89,7 +89,7 @@ describe('PulsePoint Lite Adapter Tests', () => {
         }]
       }]
     };
-    const bids = spec.interpretResponse(ortbResponse, request);
+    const bids = spec.interpretResponse({ body: ortbResponse }, request);
     expect(bids).to.have.lengthOf(1);
     // verify first bid
     const bid = bids[0];
@@ -104,7 +104,7 @@ describe('PulsePoint Lite Adapter Tests', () => {
 
   it('Verify full passback', () => {
     const request = spec.buildRequests(slotConfigs);
-    const bids = spec.interpretResponse(null, request)
+    const bids = spec.interpretResponse({ body: null }, request)
     expect(bids).to.have.lengthOf(0);
   });
 
@@ -171,7 +171,7 @@ describe('PulsePoint Lite Adapter Tests', () => {
         }]
       }]
     };
-    const bids = spec.interpretResponse(ortbResponse, request);
+    const bids = spec.interpretResponse({ body: ortbResponse }, request);
     // verify bid
     const bid = bids[0];
     expect(bid.cpm).to.equal(1.25);

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -604,7 +604,7 @@ describe('the rubicon adapter', () => {
             ]
           };
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 
@@ -654,7 +654,7 @@ describe('the rubicon adapter', () => {
             }]
           };
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 
@@ -677,7 +677,7 @@ describe('the rubicon adapter', () => {
             'ads': []
           };
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 
@@ -701,7 +701,7 @@ describe('the rubicon adapter', () => {
             }]
           };
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 
@@ -711,7 +711,7 @@ describe('the rubicon adapter', () => {
         it('should handle an error because of malformed json response', () => {
           let response = '{test{';
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 
@@ -752,7 +752,7 @@ describe('the rubicon adapter', () => {
             'account_id': 7780
           };
 
-          let bids = spec.interpretResponse(response, {
+          let bids = spec.interpretResponse({ body: response }, {
             bidRequest: bidderRequest.bids[0]
           });
 


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Some adapters need to pull information from their server's response headers.

This adds that feature, and updates existing adapters so they continue to work.

## Other information
Fixes #1742.