### PR TITLE
HuddledMasses header bidding adapter

### DIFF
--- a/integrationExamples/gpt/pbjs_example_gpt.html
+++ b/integrationExamples/gpt/pbjs_example_gpt.html
@@ -388,6 +388,12 @@
                         params: {
                             placement_id: 0
                         }
+                    },
+                    {
+                        bidder: 'huddledmasses',
+                        params: {
+                            placement_id: 0
+                        }
                     }
                 ]
             }

--- a/modules/huddledmassesBidAdapter.js
+++ b/modules/huddledmassesBidAdapter.js
@@ -1,0 +1,174 @@
+import Adapter from 'src/adapter';
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import * as utils from 'src/utils';
+import {ajax} from 'src/ajax';
+import {STATUS} from 'src/constants';
+import adaptermanager from 'src/adaptermanager';
+
+var BIDDER_CODE = 'huddledmasses';
+
+var sizeObj = {
+  1: '468x60',
+  2: '728x90',
+  10: '300x600',
+  15: '300x250',
+  19: '300x100',
+  43: '320x50',
+  44: '300x50',
+  48: '300x300',
+  54: '300x1050',
+  55: '970x90',
+  57: '970x250',
+  58: '1000x90',
+  59: '320x80',
+  65: '640x480',
+  67: '320x480',
+  72: '320x320',
+  73: '320x160',
+  83: '480x300',
+  94: '970x310',
+  96: '970x210',
+  101: '480x320',
+  102: '768x1024',
+  113: '1000x300',
+  117: '320x100',
+  118: '800x250',
+  119: '200x600'
+};
+
+utils._each(sizeObj, (item, key) => sizeObj[item] = key);
+
+function HuddledMassesAdapter() {
+  function _callBids(bidderRequest) {
+    var bids = bidderRequest.bids || [];
+
+    bids.forEach((bid) => {
+      function bidCallback(responseText) {
+        try {
+          utils.logMessage('XHR callback function called for ad ID: ' + bid.bidId);
+          handleRpCB(responseText, bid);
+        } catch (err) {
+          if (typeof err === 'string') {
+            utils.logWarn(`${err} when processing huddledmasses response for placement code ${bid.placementCode}`);
+          } else {
+            utils.logError('Error processing huddledmasses response for placement code ' + bid.placementCode, null, err);
+          }
+          var badBid = bidfactory.createBid(STATUS.NO_BID, bid);
+          badBid.bidderCode = bid.bidder;
+          badBid.error = err;
+          bidmanager.addBidResponse(bid.placementCode, badBid);
+        }
+      }
+
+      try {
+        ajax(buildOptimizedCall(bid), bidCallback, undefined, { withCredentials: true });
+      } catch (err) {
+        utils.logError('Error sending huddledmasses request for placement code ' + bid.placementCode, null, err);
+      }
+    });
+  }
+
+  function buildOptimizedCall(bid) {
+    bid.startTime = (new Date()).getTime();
+
+    var parsedSizes = HuddledMassesAdapter.masSizeOrdering(
+      Array.isArray(bid.params.sizes) ? bid.params.sizes.map(size => (sizeObj[size] || '').split('x')) : bid.sizes
+    );
+
+    if (parsedSizes.length < 1) {
+      throw 'no valid sizes';
+    }
+
+    var secure = 0;
+    var win;
+    try {
+      win = window.top;
+    } catch (e) {
+      win = window;
+    }
+
+    if (win.location.protocol !== 'http:') {
+      secure = 1;
+    }
+
+    var host = win.location.host;
+    var page = win.location.pathname;
+    var language = navigator.language;
+    var deviceWidth = win.screen.width;
+    var deviceHeight = win.screen.height;
+
+    var queryString = [
+      'banner_id', bid.params.placement_id,
+      'size_ad', parsedSizes[0],
+      'alt_size_ad', parsedSizes.slice(1).join(',') || [],
+      'host', host,
+      'page', page,
+      'language', language,
+      'deviceWidth', deviceWidth,
+      'deviceHeight', deviceHeight,
+      'secure', secure,
+      'bidId', bid.bidId,
+      'checkOn', 'rf'
+    ];
+
+    return queryString.reduce(
+      (memo, curr, index) =>
+        index % 2 === 0 && queryString[index + 1] !== undefined
+          ? memo + curr + '=' + encodeURIComponent(queryString[index + 1]) + '&'
+          : memo,
+      '//huddledmassessupply.com/?'
+    ).slice(0, -1);
+  }
+
+  function handleRpCB(responseText, bidRequest) {
+    var ad = JSON.parse(responseText);
+
+    var bid = bidfactory.createBid(STATUS.GOOD, bidRequest);
+    bid.creative_id = ad.ad_id;
+    bid.bidderCode = bidRequest.bidder;
+    bid.cpm = ad.cpm || 0;
+    bid.ad = ad.adm;
+    bid.width = ad.width;
+    bid.height = ad.height;
+    bid.dealId = ad.deal;
+
+    bidmanager.addBidResponse(bidRequest.placementCode, bid);
+  }
+
+  return Object.assign(new Adapter(BIDDER_CODE), { // BIDDER_CODE huddledmasses
+    callBids: _callBids
+  });
+}
+
+HuddledMassesAdapter.masSizeOrdering = function (sizes) {
+  var MAS_SIZE_PRIORITY = [15, 2, 9];
+  return utils.parseSizesInput(sizes)
+    .reduce((result, size) => {
+      var mappedSize = parseInt(sizeObj[size], 10);
+      if (mappedSize) {
+        result.push(mappedSize);
+      }
+      return result;
+    }, [])
+    .sort((first, second) => {
+      var firstPriority = MAS_SIZE_PRIORITY.indexOf(first);
+      var secondPriority = MAS_SIZE_PRIORITY.indexOf(second);
+
+      if (firstPriority > -1 || secondPriority > -1) {
+        if (firstPriority === -1) {
+          return 1;
+        }
+        if (secondPriority === -1) {
+          return -1;
+        }
+        return firstPriority - secondPriority;
+      }
+
+      return first - second;
+    });
+};
+
+adaptermanager.registerBidAdapter(new HuddledMassesAdapter(), 'huddledmasses');
+
+module.exports = HuddledMassesAdapter;

--- a/test/spec/modules/huddledmassesBidAdapter_spec.js
+++ b/test/spec/modules/huddledmassesBidAdapter_spec.js
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+import Adapter from '../../../modules/huddledmassesBidAdapter';
+import adapterManager from 'src/adaptermanager';
+import bidManager from 'src/bidmanager';
+import CONSTANTS from 'src/constants.json';
+
+describe('HuddledMasses adapter tests', function () {
+  let sandbox;
+  const adUnit = {
+    code: 'huddledmasses',
+    sizes: [[300, 250], [300, 600]],
+    bids: [{
+      bidder: 'huddledmasses',
+      params: {
+        placement_id: 0
+      }
+    }]
+  };
+
+  const response = {
+    ad_id: 15,
+    adm: '<div>Bid Response</div>',
+    cpm: 0.712,
+    deal: '5e1f0a8f2aa1',
+    width: 300,
+    height: 250
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('HuddledMasses callBids validation', () => {
+    let bids,
+      server;
+
+    beforeEach(() => {
+      bids = [];
+      server = sinon.fakeServer.create();
+      sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
+        bids.push(bid);
+      });
+    });
+
+    afterEach(() => {
+      server.restore();
+    });
+
+    let adapter = adapterManager.bidderRegistry['huddledmasses'];
+
+    it('Valid bid-request', () => {
+      sandbox.stub(adapter, 'callBids');
+      adapterManager.callBids({
+        adUnits: [clone(adUnit)]
+      });
+
+      let bidderRequest = adapter.callBids.getCall(0).args[0];
+
+      expect(bidderRequest).to.have.property('bids')
+        .that.is.an('array')
+        .with.lengthOf(1);
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('bidder', 'huddledmasses');
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('sizes')
+        .that.is.an('array')
+        .with.lengthOf(2)
+        .that.deep.equals(adUnit.sizes);
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('params')
+        .to.have.property('placement_id', 0);
+    });
+
+    it('Valid bid-response', () => {
+      server.respondWith(JSON.stringify(
+        response
+      ));
+      adapterManager.callBids({
+        adUnits: [clone(adUnit)]
+      });
+      server.respond();
+
+      expect(bids).to.be.lengthOf(1);
+      expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+      expect(bids[0].bidderCode).to.equal('huddledmasses');
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].cpm).to.equal(0.712);
+      expect(bids[0].dealId).to.equal('5e1f0a8f2aa1');
+    });
+  });
+
+  describe('MAS mapping / ordering', () => {
+    let masSizeOrdering = Adapter.masSizeOrdering;
+
+    it('should not include values without a proper mapping', () => {
+      let ordering = masSizeOrdering([[320, 50], [42, 42], [300, 250], [640, 480], [0, 0]]);
+      expect(ordering).to.deep.equal([15, 43, 65]);
+    });
+
+    it('should sort values without any MAS priority sizes in regular ascending order', () => {
+      let ordering = masSizeOrdering([[320, 50], [640, 480], [200, 600]]);
+      expect(ordering).to.deep.equal([43, 65, 119]);
+    });
+
+    it('should sort MAS priority sizes in the proper order w/ rest ascending', () => {
+      let ordering = masSizeOrdering([[320, 50], [640, 480], [300, 250], [200, 600]]);
+      expect(ordering).to.deep.equal([15, 43, 65, 119]);
+
+      ordering = masSizeOrdering([[320, 50], [300, 250], [640, 480], [200, 600], [728, 90]]);
+      expect(ordering).to.deep.equal([15, 2, 43, 65, 119]);
+
+      ordering = masSizeOrdering([ [320, 50], [640, 480], [200, 600], [728, 90]]);
+      expect(ordering).to.deep.equal([2, 43, 65, 119]);
+    })
+  });
+});
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter 

## Description of change
Add adapter and tests for the HuddledMasses header bidding adapter

- test parameters for validating bids

```
{
   bidder: 'huddledmasses',
   params: {
      placement_id: 0
    }
}
```
- contact email of the adapter’s maintainer: supply@huddledmasses.com
- [x] official adapter submission
