### PR TITLE
Optimera Adapter for 1.0 (#1759)

### DIFF
--- a/modules/optimeraBidAdapter.js
+++ b/modules/optimeraBidAdapter.js
@@ -11,7 +11,11 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bidRequest) {
-    return !!(bidRequest.params.custom.clientID);
+    if (typeof bidRequest.params.custom != 'undefined' && typeof bidRequest.params.custom.clientID != 'undefined') {
+      return true;
+    } else {
+      return false;
+    }
   },
   /**
    * Make a server request from the list of BidRequests.
@@ -23,12 +27,12 @@ export const spec = {
     var optimeraHost = window.location.host;
     var optimeraPathName = window.location.pathname;
     var timestamp = Math.round(new Date().getTime() / 1000);
-    var clientID = validBidRequests[0].params.custom.clientID;
     var oDv = [];
-    if (clientID != undefined) {
+    if (typeof validBidRequests[0].params.custom.clientID != 'undefined') {
+      var clientID = validBidRequests[0].params.custom.clientID;
       oDv.push(clientID);
       for (var i = 0; i < validBidRequests.length; i++) {
-        oDv.push(validBidRequests[i].placementCode);
+        oDv.push(validBidRequests[i].adUnitCode);
       }
       window.oDv = oDv;
       var scoresURL = SCORES_BASE_URL + clientID + '/' + optimeraHost + optimeraPathName + '.js';
@@ -43,30 +47,39 @@ export const spec = {
   /**
    * Unpack the response from the server into a list of bids.
    *
+   * Some required bid params are not needed for this so default
+   * values are used.
+   *
    * @param {*} serverResponse A successful response from the server.
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function (serverResponse, bidRequest) {
-    var scores = serverResponse.replace('window.oVa = ', '');
+    var scores = serverResponse.body.replace('window.oVa = ', '');
     scores = scores.replace(';', '');
     scores = JSON.parse(scores);
     var validBids = bidRequest.payload;
     var bidResponses = [];
     var dealId = '';
     for (var i = 0; i < validBids.length; i++) {
-      if (validBids[i].placementCode in scores && validBids[i].params.custom.clientID != undefined) {
-        dealId = scores[validBids[i].placementCode];
+      if (typeof validBids[i].params.custom.clientID != 'undefined') {
+        if (validBids[i].adUnitCode in scores) {
+          dealId = scores[validBids[i].adUnitCode];
+        }
+        var bidResponse = {
+          bidderCode: spec.code,
+          requestId: validBids[i].bidId,
+          ad: '<div></div>',
+          cpm: 0.01,
+          width: 0,
+          height: 0,
+          dealId: dealId,
+          ttl: 300,
+          creativeId: '1',
+          netRevenue: '0',
+          currency: 'USD'
+        };
+        bidResponses.push(bidResponse);
       }
-      var bidResponse = {
-        bidderCode: spec.code,
-        requestId: validBids[i].bidId,
-        ad: '<div></div>',
-        cpm: 0.01,
-        width: 0,
-        height: 0,
-        dealId: dealId
-      };
-      bidResponses.push(bidResponse);
     }
     return bidResponses;
   }

--- a/modules/optimeraBidAdapter.js
+++ b/modules/optimeraBidAdapter.js
@@ -1,0 +1,75 @@
+import {registerBidder} from 'src/adapters/bidderFactory';
+const BIDDER_CODE = 'optimera';
+const SCORES_BASE_URL = 'https://s3.amazonaws.com/elasticbeanstalk-us-east-1-397719490216/json/client/';
+
+export const spec = {
+  code: BIDDER_CODE,
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {bidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bidRequest) {
+    return !!(bidRequest.params.custom.clientID);
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests) {
+    var optimeraHost = window.location.host;
+    var optimeraPathName = window.location.pathname;
+    var timestamp = Math.round(new Date().getTime() / 1000);
+    var clientID = validBidRequests[0].params.custom.clientID;
+    var oDv = [];
+    if (clientID != undefined) {
+      oDv.push(clientID);
+      for (var i = 0; i < validBidRequests.length; i++) {
+        oDv.push(validBidRequests[i].placementCode);
+      }
+      window.oDv = oDv;
+      var scoresURL = SCORES_BASE_URL + clientID + '/' + optimeraHost + optimeraPathName + '.js';
+      return {
+        method: 'GET',
+        url: scoresURL,
+        payload: validBidRequests,
+        data: {'t': timestamp}
+      };
+    }
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    var scores = serverResponse.replace('window.oVa = ', '');
+    scores = scores.replace(';', '');
+    scores = JSON.parse(scores);
+    var validBids = bidRequest.payload;
+    var bidResponses = [];
+    var dealId = '';
+    for (var i = 0; i < validBids.length; i++) {
+      if (validBids[i].placementCode in scores && validBids[i].params.custom.clientID != undefined) {
+        dealId = scores[validBids[i].placementCode];
+      }
+      var bidResponse = {
+        bidderCode: spec.code,
+        requestId: validBids[i].bidId,
+        ad: '<div></div>',
+        cpm: 0.01,
+        width: 0,
+        height: 0,
+        dealId: dealId
+      };
+      bidResponses.push(bidResponse);
+    }
+    return bidResponses;
+  }
+}
+
+registerBidder(spec);

--- a/modules/optimeraBidAdapter.js
+++ b/modules/optimeraBidAdapter.js
@@ -60,7 +60,6 @@ export const spec = {
           dealId = scores[validBids[i].adUnitCode];
         }
         var bidResponse = {
-          bidderCode: spec.code,
           requestId: validBids[i].bidId,
           ad: '<div></div>',
           cpm: 0.01,

--- a/modules/optimeraBidAdapter.js
+++ b/modules/optimeraBidAdapter.js
@@ -27,14 +27,8 @@ export const spec = {
     var optimeraHost = window.location.host;
     var optimeraPathName = window.location.pathname;
     var timestamp = Math.round(new Date().getTime() / 1000);
-    var oDv = [];
     if (typeof validBidRequests[0].params.custom.clientID != 'undefined') {
       var clientID = validBidRequests[0].params.custom.clientID;
-      oDv.push(clientID);
-      for (var i = 0; i < validBidRequests.length; i++) {
-        oDv.push(validBidRequests[i].adUnitCode);
-      }
-      window.oDv = oDv;
       var scoresURL = SCORES_BASE_URL + clientID + '/' + optimeraHost + optimeraPathName + '.js';
       return {
         method: 'GET',

--- a/modules/optimeraBidAdapter.md
+++ b/modules/optimeraBidAdapter.md
@@ -1,0 +1,40 @@
+# Overview
+
+```
+Module Name: Optimera Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: kcandiotti@optimera.nyc
+```
+
+# Description
+
+Module that adds ad placement visibility scores for DFP.
+
+# Test Parameters
+```
+    var adUnits = [{
+                code: 'div-1',
+                sizes: [[300, 250], [300,600]],
+                bids: [
+                    {
+                        bidder: 'optimera',
+                        params: {
+                            custom:{
+                                clientID: '0'
+                            }
+                        }
+                    }]
+            },{
+                code: 'div-0',
+                sizes: [[728, 90]],
+                bids: [
+                    {
+                        bidder: 'optimera',
+                        params: {
+                            custom:{
+                                clientID: '0'
+                            }
+                        }
+                    }]
+            }];
+```

--- a/test/spec/modules/optimeraBidAdapter_spec.js
+++ b/test/spec/modules/optimeraBidAdapter_spec.js
@@ -19,7 +19,7 @@ describe('OptimeraAdapter', () => {
           'clientID': '0'
         }
       },
-      'adUnitCode': 'adunit-code',
+      'adUnitCode': 'div-0',
       'sizes': [[300, 250], [300, 600]],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
@@ -32,7 +32,7 @@ describe('OptimeraAdapter', () => {
   })
 
   describe('buildRequests', () => {
-    let validBidRequests = [
+    let bid = [
       {
         'adUnitCode': 'div-0',
         'auctionId': '1ab30503e03994',
@@ -40,29 +40,30 @@ describe('OptimeraAdapter', () => {
         'bidder': 'optimera',
         'bidderRequestId': '202be1ce3f6194',
         'params': {
-          'placementCode': '0',
-          'placementId': '104333943',
           'custom': {
-            'clientId': '0'
+            'clientID': '0'
           }
         }
       }
     ];
     it('buildRequests fires', () => {
-      var request = spec.buildRequests(validBidRequests);
+      let request = spec.buildRequests(bid);
+      expect(request).to.exist;
+      expect(request.method).to.equal('GET');
+      expect(request.payload).to.exist;
+      expect(request.data.t).to.exist;
     });
   })
 
   describe('interpretResponse', () => {
-    let serverResponse = 'window.oVa = {"div-0":["RB_K","728x90K"], "div-1":["RB_K","300x250K", "300x600K"], "timestamp":["RB_K","1507565666"]};';
+    let serverResponse = {};
+    serverResponse.body = 'window.oVa = {"div-0":["RB_K","728x90K"], "timestamp":["RB_K","1507565666"]};';
     var bidRequest = {
       'method': 'get',
       'payload': [
         {
           'bidder': 'optimera',
           'params': {
-            'placementId': '10433943',
-            'placementCode': '0',
             'custom': {
               'clientID': '0'
             }
@@ -74,7 +75,9 @@ describe('OptimeraAdapter', () => {
     }
     it('interpresResponse fires', () => {
       window.oDv = window.oDv || [];
-      var bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      let bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses[0].dealId[0]).to.equal('RB_K');
+      expect(bidResponses[0].dealId[1]).to.equal('728x90K');
     });
   });
 });

--- a/test/spec/modules/optimeraBidAdapter_spec.js
+++ b/test/spec/modules/optimeraBidAdapter_spec.js
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import { spec } from 'modules/optimeraBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('OptimeraAdapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  })
+
+  describe('isBidRequestValid', () => {
+    let bid = {
+      'bidder': 'optimera',
+      'params': {
+        'custom': {
+          'clientID': '0'
+        }
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    };
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+  })
+
+  describe('buildRequests', () => {
+    let validBidRequests = [
+      {
+        'adUnitCode': 'div-0',
+        'auctionId': '1ab30503e03994',
+        'bidId': '313e0afede8cdb',
+        'bidder': 'optimera',
+        'bidderRequestId': '202be1ce3f6194',
+        'params': {
+          'placementCode': '0',
+          'placementId': '104333943',
+          'custom': {
+            'clientId': '0'
+          }
+        }
+      }
+    ];
+    it('buildRequests fires', () => {
+      var request = spec.buildRequests(validBidRequests);
+    });
+  })
+
+  describe('interpretResponse', () => {
+    let serverResponse = 'window.oVa = {"div-0":["RB_K","728x90K"], "div-1":["RB_K","300x250K", "300x600K"], "timestamp":["RB_K","1507565666"]};';
+    var bidRequest = {
+      'method': 'get',
+      'payload': [
+        {
+          'bidder': 'optimera',
+          'params': {
+            'placementId': '10433943',
+            'placementCode': '0',
+            'custom': {
+              'clientID': '0'
+            }
+          },
+          'adUnitCode': 'div-0',
+          'bidId': '307440db8538ab'
+        }
+      ]
+    }
+    it('interpresResponse fires', () => {
+      window.oDv = window.oDv || [];
+      var bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter  

## Type of issue
Feature Request

## Description
Adding Optimera's bid adapter for public use. Optimera's technology allows publishers to target viewability data to automate viewability optimization for any line item or PMP. Optimera does not push bids but instead targeting data via the deal ID space.

test parameters for validating bids

- Optimera will pass targeting data via hb_deal_optimera, will never pass a size therefore 0x0, will never pass a price therefore 0.00. For example:
hb_deal_optimera=RB_K,300x250K,300x600K&hb_size_optimera=0x0&hb_pb_optimera=0.00&hb_adid_optimera=86a7b6905fe174&hb_bidder_optimera=optimera

```
{
  bidder: 'optimera',
  params: {
    custom: {
      clientId: '1234'
    }
  }
}
```
An external lib is needed and can be added to the site's footer:
```
<script src="https://s3.amazonaws.com/elasticbeanstalk-us-east-1-397719490216/external_json/oPS.js"></script>
```
contact email of the adapter’s maintainer
kcandiotti@optimera.nyc

- [x] official adapter submission

## Other information
Test Page:
http://optimera.elasticbeanstalk.com/prebidDemoPage.php
@kcandiotti

Relates to PR: https://github.com/prebid/Prebid.js/pull/1617

