### PR TITLE
Fix TypeError condition when bid is empty

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -64,9 +64,11 @@ export default function buildDfpVideoUrl(options) {
     url: location.href,
   };
 
+  const adserverTargeting = (bid && bid.adserverTargeting) || {};
+
   const customParams = Object.assign({},
-    bid.adserverTargeting,
-    { hb_uuid: bid.videoCacheKey },
+    adserverTargeting,
+    { hb_uuid: bid && bid.videoCacheKey },
     options.params.cust_params);
 
   const queryParams = Object.assign({},

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -91,4 +91,13 @@ describe('The DFP video support module', () => {
     expect(customParams).to.have.property('hb_adid', 'ad_id');
     expect(customParams).to.have.property('my_targeting', 'foo');
   });
+
+  it('should work with nobid responses', () => {
+    const url = buildDfpVideoUrl({
+      adUnit: adUnit,
+      params: { 'iu': 'my/adUnit' }
+    });
+
+    expect(url).to.be.a('string');
+  });
 });


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Fixes case where the `bid` object in `buildDfpVideoUrl` was empty, causing a `TypeError` and content video not to play.

## Other information
Fixes #1688 
