### PR TITLE
updated sizeMapping to use sizeConfig and support labels

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -233,7 +233,7 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
       }
     });
   } else {
-    utils.logWarn('callBids executed with no bidRequests');
+    utils.logWarn('callBids executed with no bidRequests.  Were they filtered by labels or sizing?');
   }
 };
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -39,7 +39,6 @@ function getLabels(bidOrAdUnit, activeLabels) {
   return {labelAll: false, labels: bidOrAdUnit.labelAny, activeLabels};
 }
 
-
 function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
   return adUnits.reduce((result, adUnit) => {
     let {active, sizes: filteredAdUnitSizes} = resolveStatus(getLabels(adUnit, labels), adUnit.sizes);

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -19,14 +19,28 @@ let _s2sConfig = config.getConfig('s2sConfig');
 
 var _analyticsRegistry = {};
 
-function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
-  function getLabels(obj, requestLabels) {
-    if (obj.labelAll) {
-      return {labelAll: true, labels: obj.labelAll, requestLabels};
-    }
-    return {labelAll: false, labels: obj.labelAny, requestLabels};
-  }
+/**
+ * @typedef {object} LabelDescriptor
+ * @property {boolean} labelAll describes whether or not this object expects all labels to match, or any label to match
+ * @property {Array<string>} labels the labels listed on the bidder or adUnit
+ * @property {Array<string>} activeLabels the labels specified as being active by requestBids
+ */
 
+/**
+ * Returns object describing the status of labels on the adUnit or bidder along with labels passed into requestBids
+ * @param bidOrAdUnit the bidder or adUnit to get label info on
+ * @param activeLabels the labels passed to requestBids
+ * @returns {LabelDescriptor}
+ */
+function getLabels(bidOrAdUnit, activeLabels) {
+  if (bidOrAdUnit.labelAll) {
+    return {labelAll: true, labels: bidOrAdUnit.labelAll, activeLabels};
+  }
+  return {labelAll: false, labels: bidOrAdUnit.labelAny, activeLabels};
+}
+
+
+function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
   return adUnits.reduce((result, adUnit) => {
     let {active, sizes: filteredAdUnitSizes} = resolveStatus(getLabels(adUnit, labels), adUnit.sizes);
 

--- a/src/auction.js
+++ b/src/auction.js
@@ -82,8 +82,9 @@ events.on(CONSTANTS.EVENTS.BID_ADJUSTMENT, function (bid) {
   *
   * @returns {Auction} auction instance
   */
-export function newAuction({adUnits, adUnitCodes, callback, cbTimeout}) {
+export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) {
   let _adUnits = adUnits;
+  let _labels = labels;
   let _adUnitCodes = adUnitCodes;
   let _bidderRequests = [];
   let _bidsReceived = [];
@@ -346,7 +347,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout}) {
     };
     events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
 
-    let bidRequests = adaptermanager.makeBidRequests(_adUnits, _auctionStart, _auctionId, _timeout);
+    let bidRequests = adaptermanager.makeBidRequests(_adUnits, _auctionStart, _auctionId, _timeout, _labels);
     utils.logInfo(`Bids Requested for Auction with id: ${_auctionId}`, bidRequests);
     bidRequests.forEach(bidRequest => {
       addBidRequests(bidRequest);

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -60,8 +60,8 @@ export function newAuctionManager() {
       .filter(uniques);
   };
 
-  _public.createAuction = function({ adUnits, adUnitCodes, callback, cbTimeout }) {
-    const auction = newAuction({ adUnits, adUnitCodes, callback, cbTimeout })
+  _public.createAuction = function({ adUnits, adUnitCodes, callback, cbTimeout, labels }) {
+    const auction = newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels });
     _addAuction(auction);
     return auction;
   };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -296,9 +296,10 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
  * @param {number} requestOptions.timeout
  * @param {Array} requestOptions.adUnits
  * @param {Array} requestOptions.adUnitCodes
+ * @param {Array} requestOptions.labels
  * @alias module:pbjs.requestBids
  */
-$$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes } = {}) {
+$$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, adUnitCodes, labels } = {}) {
   events.emit('requestBids');
   const cbTimeout = timeout || config.getConfig('bidderTimeout');
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
@@ -346,7 +347,7 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     return;
   }
 
-  const auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout});
+  const auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout, labels});
   auction.callBids();
 };
 

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -26,12 +26,12 @@ config.getConfig('sizeConfig', config => setSizeConfig(config.sizeConfig));
  * Resolves the unique set of the union of all sizes and labels that are active from a SizeConfig.mediaQuery match
  * @param {Array<string>} labels Labels specified on adUnit or bidder
  * @param {boolean} labelAll if true, all labels must match to be enabled
- * @param {Array<string>} requestLabels Labels passed in through requestBids
+ * @param {Array<string>} activeLabels Labels passed in through requestBids
  * @param {Array<Array<number>>} sizes Sizes specified on adUnit
  * @param {Array<SizeConfig>} configs
  * @returns {{labels: Array<string>, sizes: Array<Array<number>>}}
  */
-export function resolveStatus({labels = [], labelAll = false, requestLabels = []} = {}, sizes = [], configs = sizeConfig) {
+export function resolveStatus({labels = [], labelAll = false, activeLabels = []} = {}, sizes = [], configs = sizeConfig) {
   let maps = evaluateSizeConfig(configs);
 
   let filteredSizes;
@@ -46,11 +46,11 @@ export function resolveStatus({labels = [], labelAll = false, requestLabels = []
       labels.length === 0 || (
         (!labelAll && (
           labels.some(label => maps.labels[label]) ||
-          labels.some(label => requestLabels.includes(label))
+          labels.some(label => activeLabels.includes(label))
         )) ||
         (labelAll && (
           labels.reduce((result, label) => !result ? result : (
-            maps.labels[label] || requestLabels.includes(label)
+            maps.labels[label] || activeLabels.includes(label)
           ), true)
         ))
       )

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,61 +1,84 @@
+import { config } from 'src/config';
+
+let sizeConfig = [];
+
 /**
- * @module sizeMapping
+ * @typedef {object} SizeConfig
+ *
+ * @property {string} [mediaQuery] A CSS media query string that will to be interpreted by window.matchMedia.  If the
+ *  media query matches then the this config will be active and sizesSupported will filter bid and adUnit sizes.  If
+ *  this property is not present then this SizeConfig will only be active if triggered manually by a call to
+ *  pbjs.setConfig({labels:['label']) specifying one of the labels present on this SizeConfig.
+ * @property {Array<Array>} sizesSupported The sizes to be accepted if this SizeConfig is enabled.
+ * @property {Array<string>} labels The active labels to match this SizeConfig to an adUnits and/or bidders.
  */
-import * as utils from './utils';
-let _win;
 
-function mapSizes(adUnit) {
-  if (!isSizeMappingValid(adUnit.sizeMapping)) {
-    return adUnit.sizes;
-  }
-  const width = getScreenWidth();
-  if (!width) {
-    // size not detected - get largest value set for desktop
-    const mapping = adUnit.sizeMapping.reduce((prev, curr) => {
-      return prev.minWidth < curr.minWidth ? curr : prev;
-    });
-    if (mapping.sizes && mapping.sizes.length) {
-      return mapping.sizes;
-    }
-    return adUnit.sizes;
-  }
-  let sizes = '';
-  const mapping = adUnit.sizeMapping.find(sizeMapping => {
-    return width >= sizeMapping.minWidth;
-  });
-  if (mapping && mapping.sizes && mapping.sizes.length) {
-    sizes = mapping.sizes;
-    utils.logMessage(`AdUnit : ${adUnit.code} resized based on device width to : ${sizes}`);
+/**
+ *
+ * @param {Array<SizeConfig>} config
+ */
+export function setSizeConfig(config) {
+  sizeConfig = config;
+}
+config.getConfig('sizeConfig', config => setSizeConfig(config.sizeConfig));
+
+/**
+ * Resolves the unique set of the union of all sizes and labels that are active from a SizeConfig.mediaQuery match
+ * @param {Array<string>} labels Labels specified on adUnit or bidder
+ * @param {boolean} labelAll if true, all labels must match to be enabled
+ * @param {Array<string>} requestLabels Labels passed in through requestBids
+ * @param {Array<Array<number>>} sizes Sizes specified on adUnit
+ * @param {Array<SizeConfig>} configs
+ * @returns {{labels: Array<string>, sizes: Array<Array<number>>}}
+ */
+export function resolveStatus({labels = [], labelAll = false, requestLabels = []} = {}, sizes = [], configs = sizeConfig) {
+  let maps = evaluateSizeConfig(configs);
+
+  let filteredSizes;
+  if (maps.shouldFilter) {
+    filteredSizes = sizes.filter(size => maps.sizesSupported[size]);
   } else {
-    utils.logMessage(`AdUnit : ${adUnit.code} not mapped to any sizes for device width. This request will be suppressed.`);
+    filteredSizes = sizes;
   }
-  return sizes;
+
+  return {
+    active: filteredSizes.length > 0 && (
+      labels.length === 0 || (
+        (!labelAll && (
+          labels.some(label => maps.labels[label]) ||
+          labels.some(label => requestLabels.includes(label))
+        )) ||
+        (labelAll && (
+          labels.reduce((result, label) => !result ? result : (
+            maps.labels[label] || requestLabels.includes(label)
+          ), true)
+        ))
+      )
+    ),
+    sizes: filteredSizes
+  };
 }
 
-function isSizeMappingValid(sizeMapping) {
-  if (utils.isArray(sizeMapping) && sizeMapping.length > 0) {
-    return true;
-  }
-  utils.logInfo('No size mapping defined');
-  return false;
+function evaluateSizeConfig(configs) {
+  return configs.reduce((results, config) => {
+    if (
+      typeof config === 'object' &&
+      typeof config.mediaQuery === 'string' &&
+      matchMedia(config.mediaQuery).matches
+    ) {
+      if (Array.isArray(config.sizesSupported)) {
+        results.shouldFilter = true;
+      }
+      ['labels', 'sizesSupported'].forEach(
+        type => (config[type] || []).forEach(
+          thing => results[type][thing] = true
+        )
+      );
+    }
+    return results;
+  }, {
+    labels: {},
+    sizesSupported: {},
+    shouldFilter: false
+  });
 }
-
-function getScreenWidth(win) {
-  var w = win || _win || window;
-  var d = w.document;
-
-  if (w.innerWidth) {
-    return w.innerWidth;
-  } else if (d.body.clientWidth) {
-    return d.body.clientWidth;
-  } else if (d.documentElement.clientWidth) {
-    return d.documentElement.clientWidth;
-  }
-  return 0;
-}
-
-function setWindow(win) {
-  _win = win;
-}
-
-export { mapSizes, getScreenWidth, setWindow };

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -1,123 +1,194 @@
 import { expect } from 'chai';
-import * as sizeMapping from 'src/sizeMapping';
+import { resolveStatus, setSizeConfig } from 'src/sizeMapping';
 
-var validAdUnit = {
-  'sizes': [300, 250],
-  'sizeMapping': [
-    {
-      'minWidth': 1024,
-      'sizes': [[300, 250], [728, 90]]
-    },
-    {
-      'minWidth': 480,
-      'sizes': [120, 60]
-    },
-    {
-      'minWidth': 0,
-      'sizes': [20, 20]
-    }
-  ]
-};
+describe('sizeMapping', () => {
+  var testSizes = [[970, 90], [728, 90], [300, 250], [300, 100], [80, 80]];
 
-var invalidAdUnit = {
-  'sizes': [300, 250],
-  'sizeMapping': {} // wrong type
-};
+  var sizeConfig = [{
+    'mediaQuery': '(min-width: 1200px)',
+    'sizesSupported': [
+      [970, 90],
+      [728, 90],
+      [300, 250]
+    ]
+  }, {
+    'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+    'sizesSupported': [
+      [728, 90],
+      [300, 250],
+      [300, 100]
+    ]
+  }, {
+    'mediaQuery': '(min-width: 0px) and (max-width: 767px)',
+    'sizesSupported': []
+  }];
 
-var invalidAdUnit2 = {
-  'sizes': [300, 250],
-  'sizeMapping': [{
-    foo: 'bar' // bad
-  }]
-};
+  var sizeConfigWithLabels = [{
+    'mediaQuery': '(min-width: 1200px)',
+    'labels': ['desktop']
+  }, {
+    'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+    'sizesSupported': [
+      [728, 90],
+      [300, 250]
+    ],
+    'labels': ['tablet', 'phone']
+  }, {
+    'mediaQuery': '(min-width: 0px) and (max-width: 767px)',
+    'sizesSupported': [
+      [300, 250],
+      [300, 100]
+    ],
+    'labels': ['phone']
+  }];
 
-let mockWindow = {};
+  let sandbox,
+    matchMediaOverride;
 
-function resetMockWindow() {
-  mockWindow = {
-    document: {
-      body: {
-        clientWidth: 1024
-      },
-      documentElement: {
-        clientWidth: 1024
+  beforeEach(() => {
+    setSizeConfig(sizeConfig);
+
+    sandbox = sinon.sandbox.create();
+
+    matchMediaOverride = {matches: false};
+
+    sandbox.stub(window, 'matchMedia', (...args) => {
+      if (typeof matchMediaOverride === 'function') {
+        return matchMediaOverride.apply(window, args);
       }
-    },
-    innerWidth: 1024
-  };
-}
-
-describe('sizeMapping', function() {
-  beforeEach(resetMockWindow);
-
-  it('minWidth should be inclusive', function() {
-    mockWindow.innerWidth = 1024;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
+      return matchMediaOverride;
+    });
   });
 
-  it('mapSizes 1029 width', function() {
-    mockWindow.innerWidth = 1029;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
-    expect(validAdUnit.sizes).to.deep.equal([300, 250]);
+  afterEach(() => {
+    setSizeConfig([]);
+
+    sandbox.restore();
   });
 
-  it('mapSizes 400 width', function() {
-    mockWindow.innerWidth = 400;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([20, 20]);
-    expect(validAdUnit.sizes).to.deep.equal([300, 250]);
+  describe('when handling sizes', () => {
+    it('when one mediaQuery block matches, it should filter the adUnit.sizes passed in', () => {
+      matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
+
+      let status = resolveStatus(undefined, testSizes, sizeConfig);
+
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: [[970, 90], [728, 90], [300, 250]]
+      })
+    });
+
+    it('when multiple mediaQuery block matches, it should filter a union of the matched sizesSupported', () => {
+      matchMediaOverride = (str) => [
+        '(min-width: 1200px)',
+        '(min-width: 768px) and (max-width: 1199px)'
+      ].includes(str) ? {matches: true} : {matches: false};
+
+      let status = resolveStatus(undefined, testSizes, sizeConfig);
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: [[970, 90], [728, 90], [300, 250], [300, 100]]
+      })
+    });
+
+    it('if no mediaQueries match, it should allow all sizes specified', () => {
+      matchMediaOverride = () => ({matches: false});
+
+      let status = resolveStatus(undefined, testSizes, sizeConfig);
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: testSizes
+      })
+    });
+
+    it('if a mediaQuery matches and has sizesSupported: [], it should filter all sizes', () => {
+      matchMediaOverride = (str) => str === '(min-width: 0px) and (max-width: 767px)' ? {matches: true} : {matches: false};
+
+      let status = resolveStatus(undefined, testSizes, sizeConfig);
+      expect(status).to.deep.equal({
+        active: false,
+        sizes: []
+      })
+    });
+
+    it('if a mediaQuery matches and no sizesSupported specified, it should not effect adUnit.sizes', () => {
+      matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
+
+      let status = resolveStatus(undefined, testSizes, sizeConfigWithLabels);
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: testSizes
+      })
+    });
   });
 
-  it('mapSizes - invalid adUnit - should return sizes', function() {
-    mockWindow.innerWidth = 1029;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(invalidAdUnit);
-    expect(sizes).to.deep.equal([300, 250]);
-    expect(invalidAdUnit.sizes).to.deep.equal([300, 250]);
+  describe('when handling labels', () => {
+    it('should activate/deactivate adUnits/bidders based on sizeConfig.labels', () => {
+      matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 
-    mockWindow.innerWidth = 400;
-    sizeMapping.setWindow(mockWindow);
-    sizes = sizeMapping.mapSizes(invalidAdUnit);
-    expect(sizes).to.deep.equal([300, 250]);
-    expect(invalidAdUnit.sizes).to.deep.equal([300, 250]);
-  });
+      let status = resolveStatus({
+        labels: ['desktop']
+      }, testSizes, sizeConfigWithLabels);
 
-  it('mapSizes - should return desktop (largest) sizes if screen width not detected', function() {
-    mockWindow.innerWidth = 0;
-    mockWindow.document.body.clientWidth = 0;
-    mockWindow.document.documentElement.clientWidth = 0;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(validAdUnit);
-    expect(sizes).to.deep.equal([[300, 250], [728, 90]]);
-    expect(validAdUnit.sizes).to.deep.equal([300, 250]);
-  });
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: testSizes
+      });
 
-  it('mapSizes - should return sizes if sizemapping improperly defined ', function() {
-    mockWindow.innerWidth = 0;
-    mockWindow.document.body.clientWidth = 0;
-    mockWindow.document.documentElement.clientWidth = 0;
-    sizeMapping.setWindow(mockWindow);
-    let sizes = sizeMapping.mapSizes(invalidAdUnit2);
-    expect(sizes).to.deep.equal([300, 250]);
-    expect(validAdUnit.sizes).to.deep.equal([300, 250]);
-  });
+      status = resolveStatus({
+        labels: ['tablet']
+      }, testSizes, sizeConfigWithLabels);
 
-  it('getScreenWidth', function() {
-    mockWindow.innerWidth = 900;
-    mockWindow.document.body.clientWidth = 900;
-    mockWindow.document.documentElement.clientWidth = 900;
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(900);
-  });
+      expect(status).to.deep.equal({
+        active: false,
+        sizes: testSizes
+      });
+    });
 
-  it('getScreenWidth - should return 0 if it cannot deteremine size', function() {
-    mockWindow.innerWidth = null;
-    mockWindow.document.body.clientWidth = null;
-    mockWindow.document.documentElement.clientWidth = null;
-    expect(sizeMapping.getScreenWidth(mockWindow)).to.equal(0);
+    it('should active/deactivate adUnits/bidders based on requestBids labels', () => {
+      let requestLabels = ['us-visitor', 'desktop', 'smart'];
+
+      let status = resolveStatus({
+        labels: ['uk-visitor'],
+        requestLabels
+      }, testSizes, sizeConfigWithLabels);
+
+      expect(status).to.deep.equal({
+        active: false,
+        sizes: testSizes
+      });
+
+      status = resolveStatus({
+        labels: ['us-visitor'],
+        requestLabels
+      }, testSizes, sizeConfigWithLabels);
+
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: testSizes
+      });
+
+      status = resolveStatus({
+        labels: ['us-visitor', 'tablet'],
+        labelAll: true,
+        requestLabels
+      }, testSizes, sizeConfigWithLabels);
+
+      expect(status).to.deep.equal({
+        active: false,
+        sizes: testSizes
+      });
+
+      status = resolveStatus({
+        labels: ['us-visitor', 'desktop'],
+        labelAll: true,
+        requestLabels
+      }, testSizes, sizeConfigWithLabels);
+
+      expect(status).to.deep.equal({
+        active: true,
+        sizes: testSizes
+      });
+    });
   });
 });

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -146,11 +146,11 @@ describe('sizeMapping', () => {
     });
 
     it('should active/deactivate adUnits/bidders based on requestBids labels', () => {
-      let requestLabels = ['us-visitor', 'desktop', 'smart'];
+      let activeLabels = ['us-visitor', 'desktop', 'smart'];
 
       let status = resolveStatus({
         labels: ['uk-visitor'],
-        requestLabels
+        activeLabels
       }, testSizes, sizeConfigWithLabels);
 
       expect(status).to.deep.equal({
@@ -160,7 +160,7 @@ describe('sizeMapping', () => {
 
       status = resolveStatus({
         labels: ['us-visitor'],
-        requestLabels
+        activeLabels
       }, testSizes, sizeConfigWithLabels);
 
       expect(status).to.deep.equal({
@@ -171,7 +171,7 @@ describe('sizeMapping', () => {
       status = resolveStatus({
         labels: ['us-visitor', 'tablet'],
         labelAll: true,
-        requestLabels
+        activeLabels
       }, testSizes, sizeConfigWithLabels);
 
       expect(status).to.deep.equal({
@@ -182,7 +182,7 @@ describe('sizeMapping', () => {
       status = resolveStatus({
         labels: ['us-visitor', 'desktop'],
         labelAll: true,
-        requestLabels
+        activeLabels
       }, testSizes, sizeConfigWithLabels);
 
       expect(status).to.deep.equal({

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -5,6 +5,7 @@ import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils';
 import { config } from 'src/config';
 import { registerBidder } from 'src/adapters/bidderFactory';
+import { setSizeConfig } from 'src/sizeMapping';
 var s2sTesting = require('../../../../modules/s2sTesting');
 
 const CONFIG = {
@@ -302,6 +303,120 @@ describe('adapterManager tests', () => {
         expect(AdapterManager.bidderRegistry).to.have.property(alias);
         expect(AdapterManager.videoAdapters).to.include(alias);
       });
+    });
+
+    describe('makeBidRequests', () => {
+      let adUnits;
+      beforeEach(() => {
+        adUnits = utils.cloneJson(getAdUnits()).map(adUnit => {
+          adUnit.bids = adUnit.bids.filter(bid => ['appnexus', 'rubicon'].includes(bid.bidder));
+          return adUnit;
+        })
+      });
+
+      describe('sizeMapping', () => {
+        beforeEach(() => {
+          sinon.stub(window, 'matchMedia', () => ({matches: true}));
+        });
+
+        afterEach(() => {
+          matchMedia.restore();
+          setSizeConfig([]);
+        });
+
+        it('should not filter bids w/ no labels', () => {
+          let bidRequests = AdapterManager.makeBidRequests(
+            adUnits,
+            Date.now(),
+            utils.getUniqueIdentifierStr(),
+            function callback() {},
+            []
+          );
+
+          expect(bidRequests.length).to.equal(2);
+          let rubiconBidRequests = bidRequests.find(bidRequest => bidRequest.bidderCode === 'rubicon');
+          expect(rubiconBidRequests.bids.length).to.equal(1);
+          expect(rubiconBidRequests.bids[0].sizes).to.deep.equal(adUnits.find(adUnit => adUnit.code === rubiconBidRequests.bids[0].adUnitCode).sizes);
+
+          let appnexusBidRequests = bidRequests.find(bidRequest => bidRequest.bidderCode === 'appnexus');
+          expect(appnexusBidRequests.bids.length).to.equal(2);
+          expect(appnexusBidRequests.bids[0].sizes).to.deep.equal(adUnits.find(adUnit => adUnit.code === appnexusBidRequests.bids[0].adUnitCode).sizes);
+          expect(appnexusBidRequests.bids[1].sizes).to.deep.equal(adUnits.find(adUnit => adUnit.code === appnexusBidRequests.bids[1].adUnitCode).sizes);
+        });
+
+        it('should filter sizes using size config', () => {
+          let validSizes = [
+            [728, 90],
+            [300, 250]
+          ];
+
+          let validSizeMap = validSizes.map(size => size.toString()).reduce((map, size) => {
+            map[size] = true;
+            return map;
+          }, {});
+
+          setSizeConfig([{
+            'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+            'sizesSupported': validSizes,
+            'labels': ['tablet', 'phone']
+          }]);
+
+          let bidRequests = AdapterManager.makeBidRequests(
+            adUnits,
+            Date.now(),
+            utils.getUniqueIdentifierStr(),
+            function callback() {},
+            []
+          );
+
+          // only valid sizes as specified in size config should show up in bidRequests
+          bidRequests.forEach(bidRequest => {
+            bidRequest.bids.forEach(bid => {
+              bid.sizes.forEach(size => {
+                expect(validSizeMap[size]).to.equal(true);
+              });
+            });
+          });
+
+          setSizeConfig([{
+            'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+            'sizesSupported': [],
+            'labels': ['tablet', 'phone']
+          }]);
+
+          bidRequests = AdapterManager.makeBidRequests(
+            adUnits,
+            Date.now(),
+            utils.getUniqueIdentifierStr(),
+            function callback() {},
+            []
+          );
+
+          // if no valid sizes, all bidders should be filtered out
+          expect(bidRequests.length).to.equal(0);
+        });
+
+        it('should filter adUnits/bidders based on applied labels', () => {
+          adUnits[0].labelAll = ['visitor-uk', 'mobile'];
+          adUnits[1].labelAny = ['visitor-uk', 'desktop'];
+          adUnits[1].bids[0].labelAny = ['mobile'];
+          adUnits[1].bids[1].labelAll = ['desktop'];
+
+          let bidRequests = AdapterManager.makeBidRequests(
+            adUnits,
+            Date.now(),
+            utils.getUniqueIdentifierStr(),
+            function callback() {},
+            ['visitor-uk', 'desktop']
+          );
+
+          // only one adUnit and one bid from that adUnit should make it through the applied labels above
+          expect(bidRequests.length).to.equal(1);
+          expect(bidRequests[0].bidderCode).to.equal('rubicon');
+          expect(bidRequests[0].bids.length).to.equal(1);
+          expect(bidRequests[0].bids[0].adUnitCode).to.equal(adUnits[1].code);
+        });
+      })
     });
   });
 });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -898,6 +898,7 @@ describe('Unit: Prebid Module', function () {
         adUnits = [{
           code: 'adUnit-code',
           mediaType: 'video',
+          sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexus', params: {placementId: 'id'}},
             {bidder: 'appnexusAst', params: {placementId: 'id'}}
@@ -933,6 +934,7 @@ describe('Unit: Prebid Module', function () {
         adUnits = [{
           code: 'adUnit-code',
           mediaType: 'video',
+          sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexusAst', params: {placementId: 'id'}}
           ]
@@ -967,6 +969,7 @@ describe('Unit: Prebid Module', function () {
         adUnits = [{
           code: 'adUnit-code',
           mediaType: 'native',
+          sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexus', params: {placementId: 'id'}},
             {bidder: 'appnexusAst', params: {placementId: 'id'}}
@@ -1017,6 +1020,7 @@ describe('Unit: Prebid Module', function () {
         adUnits = [{
           code: 'adUnit-code',
           nativeParams: {type: 'image'},
+          sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexusAst', params: {placementId: 'id'}}
           ]
@@ -1063,6 +1067,7 @@ describe('Unit: Prebid Module', function () {
         let adUnits = [{
           code: 'adUnit-code',
           nativeParams: {type: 'image'},
+          sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexusAst', params: {placementId: 'id'}}
           ]


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
### Labels
Labels can now be specified as a property on either an `adUnit` or on `adUnit.bids[]`.  The presence of a label will disable the adUnit or bidder unless a sizeConfig rule has matched and enabled the label or the label has been enabled manually through `pbjs.setConfig({labels:[]})`.  Defining labels on the adUnit look like the following:
```Javascript
pbjs.addAdUnits([{
  "code": "ad-slot-1",
  "sizes": [ [ 970,90 ], [ 728,90 ], [ 300,250 ], [ 300,100 ] ],
  "labelAll": ["visitor-uk", "category"] 
  "bids": [  // the full set of bids, not all of which are relevant on all devices
    {
      "bidder": "pulsepoint",
      "labelsAny": [ "desktop", "tablet" ], // flags this bid as relevant only on these screen sizes
      "params": {
        "cf": "728X90",
        "cp": 123456,
        "ct": 123456
      }
    },
    {
      "bidder": "pulsepoint",
      "labelAny": [ "desktop", "phone" ],
      "params": {
        "cf": "300x250",
        "cp": 123456,
        "ct": 123456
      }
    },
    {
      "bidder": "sovrn",
      "labelAny": [ "desktop", "tablet" ],
      "params": {
        "tagid": "123456"
      }
    },
    {
      "bidder": "sovrn",
      "labelAny": [ "phone" ],
      "params": {
        "tagid": "111111"
      }
    }
  ]
}];
```

### Size Configuration
To set size configuration rules, you can use `pbjs.setConfig` as follows
```Javascript
pbjs.setConfig({
  sizeConfig: [{
    'mediaQuery': '(min-width: 1200px)',
    'sizesSupported': [
      [970, 90],
      [728, 90],
      [300, 250]
    ],
    'labels': ['desktop']
  }, {
    'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
    'sizesSupported': [
      [728, 90],
      [300, 250]
    ],
    'labels': ['tablet', 'phone']
  }, {
    'mediaQuery': '(min-width: 0px)',
    'sizesSupported': [
      [300, 250],
      [300, 100]
    ],
    'labels': ['phone']
  }]
});
```
The sizeConfig configuration accepts an array of sizeConfig objects.  The `sizeConfig.mediaQuery` property allows media queries in the form described [here](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).  They are tested using the [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) API.  If the `sizeConfig.mediaQuery` rule matches, the listed `sizeConfig.labels` will be enabled and filtering will be performed on `adUnit.sizes` for the matching adUnits and/or bidders using the sizes listed in `sizeConfig.sizesSupported`.  If multiple rules match, the sizes will be filtered to the intersection of all matching rules' `sizeConfig.sizesSupported` arrays.  

## Manual Label Configuration
You can manually turn on labels by passing the labels to `pbjs.requestBids`
```Javascript
pbjs.requestBids({
  adUnits,
  labels: ['visitor-uk']
});
```
If an adUnit and/or adUnit.bids[] bidder has `labelsAny` or `labelsAll` defined they will be disabled by default.  Manually setting active labels using `pbjs.requestBids` labels can re-enable the selected adUnits and/or bidders.