### PR TITLE
Allow explicit timeout for ajax request

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -82,8 +82,8 @@ export function ajax(url, callback, data, options = {}) {
     }
 
     x.open(method, url);
-    // IE needs timoeut to be set after open - see #1410
-    x.timeout = _timeout;
+    // IE needs timeout to be set after open - see #1410
+    x.timeout = options.timeout || _timeout;
 
     if (!useXDomainRequest) {
       if (options.withCredentials) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change

As it was noticed in #1718, in case of strict auction timeout value some analytics information might be lost. This pull request proposes an optional **options.timeout** parameter for ajax function to avoid such limitation.