### PR TITLE
Update rubicon adapter with new properties and 1.0 changes

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1,10 +1,8 @@
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
 
-// use deferred function call since version isn't defined yet at this point
-function getIntegration() {
-  return 'pbjs_lite_' + $$PREBID_GLOBAL$$.version;
-}
+const INTEGRATION = 'pbjs_lite_v$prebid.version$';
 
 function isSecure() {
   return location.protocol === 'https:';
@@ -113,7 +111,7 @@ export const spec = {
           page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
           resolution: _getScreenResolution(),
           account_id: params.accountId,
-          integration: getIntegration(),
+          integration: INTEGRATION,
           timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
           stash_creatives: true,
           ae_pass_through_parameters: params.video.aeParams,
@@ -126,8 +124,8 @@ export const spec = {
           zone_id: params.zoneId,
           position: params.position || 'btf',
           floor: parseFloat(params.floor) > 0.01 ? params.floor : 0.01,
-          element_id: bidRequest.placementCode,
-          name: bidRequest.placementCode,
+          element_id: bidRequest.adUnitCode,
+          name: bidRequest.adUnitCode,
           language: params.video.language,
           width: size[0],
           height: size[1],
@@ -187,7 +185,7 @@ export const spec = {
         'p_pos', position,
         'rp_floor', floor,
         'rp_secure', isSecure() ? '1' : '0',
-        'tk_flint', getIntegration(),
+        'tk_flint', INTEGRATION,
         'tid', bidRequest.transactionId,
         'p_screen_res', _getScreenResolution(),
         'kw', keywords,
@@ -239,7 +237,7 @@ export const spec = {
 
     // video ads array is wrapped in an object
     if (typeof bidRequest === 'object' && bidRequest.mediaType === 'video' && typeof ads === 'object') {
-      ads = ads[bidRequest.placementCode];
+      ads = ads[bidRequest.adUnitCode];
     }
 
     // check the ad response
@@ -258,9 +256,11 @@ export const spec = {
       let bid = {
         requestId: bidRequest.bidId,
         currency: 'USD',
-        creative_id: ad.creative_id,
+        creativeId: ad.creative_id,
         cpm: ad.cpm || 0,
-        dealId: ad.deal
+        dealId: ad.deal,
+        ttl: 300, // 5 minutes
+        netRevenue: config.getConfig('rubicon.netRevenue') || false
       };
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
@@ -278,7 +278,7 @@ export const spec = {
         .reduce((memo, item) => {
           memo[item.key] = item.values[0];
           return memo;
-        }, {'rpfl_elemid': bidRequest.placementCode});
+        }, {'rpfl_elemid': bidRequest.adUnitCode});
 
       bids.push(bid);
 
@@ -306,7 +306,7 @@ function _getScreenResolution() {
 
 function _getDigiTrustQueryParams() {
   function getDigiTrustId() {
-    let digiTrustUser = window.DigiTrust && ($$PREBID_GLOBAL$$.getConfig('digiTrustId') || window.DigiTrust.getUser({member: 'T9QSFKPDN9'}));
+    let digiTrustUser = window.DigiTrust && (config.getConfig('digiTrustId') || window.DigiTrust.getUser({member: 'T9QSFKPDN9'}));
     return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
   }
   let digiTrustId = getDigiTrustId();

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -259,7 +259,6 @@ export const spec = {
         requestId: bidRequest.bidId,
         currency: 'USD',
         creative_id: ad.creative_id,
-        bidderCode: spec.code,
         cpm: ad.cpm || 0,
         dealId: ad.deal
       };

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -610,7 +610,6 @@ describe('the rubicon adapter', () => {
 
           expect(bids).to.be.lengthOf(2);
 
-          expect(bids[0].bidderCode).to.equal('rubicon');
           expect(bids[0].width).to.equal(320);
           expect(bids[0].height).to.equal(50);
           expect(bids[0].cpm).to.equal(0.911);
@@ -622,7 +621,6 @@ describe('the rubicon adapter', () => {
           expect(bids[0].rubiconTargeting.rpfl_elemid).to.equal('/19968336/header-bid-tag-0');
           expect(bids[0].rubiconTargeting.rpfl_14062).to.equal('43_tier_all_test');
 
-          expect(bids[1].bidderCode).to.equal('rubicon');
           expect(bids[1].width).to.equal(300);
           expect(bids[1].height).to.equal(250);
           expect(bids[1].cpm).to.equal(0.811);
@@ -758,7 +756,6 @@ describe('the rubicon adapter', () => {
 
           expect(bids).to.be.lengthOf(1);
 
-          expect(bids[0].bidderCode).to.equal('rubicon');
           expect(bids[0].creative_id).to.equal('crid-999999');
           expect(bids[0].cpm).to.equal(1);
           expect(bids[0].descriptionUrl).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { spec, masSizeOrdering, resetUserSync } from 'modules/rubiconBidAdapter'
 import { parse as parseQuery } from 'querystring';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { userSync } from 'src/userSync';
+import { config } from 'src/config';
 
 var CONSTANTS = require('src/constants.json');
 
@@ -78,7 +79,7 @@ describe('the rubicon adapter', () => {
             position: 'atf',
             referrer: 'localhost'
           },
-          placementCode: '/19968336/header-bid-tag-0',
+          adUnitCode: '/19968336/header-bid-tag-0',
           sizes: [[300, 250], [320, 50]],
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
@@ -312,16 +313,14 @@ describe('the rubicon adapter', () => {
             window.DigiTrust = {
               getUser: sandbox.spy()
             };
-            origGetConfig = window.$$PREBID_GLOBAL$$.getConfig;
           });
 
           afterEach(() => {
             delete window.DigiTrust;
-            window.$$PREBID_GLOBAL$$.getConfig = origGetConfig;
           });
 
           it('should send digiTrustId config params', () => {
-            sandbox.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
+            sandbox.stub(config, 'getConfig', (key) => {
               var config = {
                 digiTrustId: {
                   success: true,
@@ -354,7 +353,7 @@ describe('the rubicon adapter', () => {
           });
 
           it('should not send digiTrustId config params due to optout', () => {
-            sandbox.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
+            sandbox.stub(config, 'getConfig', (key) => {
               var config = {
                 digiTrustId: {
                   success: true,
@@ -383,7 +382,7 @@ describe('the rubicon adapter', () => {
           });
 
           it('should not send digiTrustId config params due to failure', () => {
-            sandbox.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
+            sandbox.stub(config, 'getConfig', (key) => {
               var config = {
                 digiTrustId: {
                   success: false,
@@ -412,7 +411,7 @@ describe('the rubicon adapter', () => {
           });
 
           it('should not send digiTrustId config params if they do not exist', () => {
-            sandbox.stub(window.$$PREBID_GLOBAL$$, 'getConfig', (key) => {
+            sandbox.stub(config, 'getConfig', (key) => {
               var config = {};
               return config[key];
             });
@@ -473,8 +472,8 @@ describe('the rubicon adapter', () => {
           expect(slot.zone_id).to.equal('335918');
           expect(slot.position).to.equal('atf');
           expect(slot.floor).to.equal(0.01);
-          expect(slot.element_id).to.equal(bidderRequest.bids[0].placementCode);
-          expect(slot.name).to.equal(bidderRequest.bids[0].placementCode);
+          expect(slot.element_id).to.equal(bidderRequest.bids[0].adUnitCode);
+          expect(slot.name).to.equal(bidderRequest.bids[0].adUnitCode);
           expect(slot.language).to.equal('en');
           expect(slot.width).to.equal(640);
           expect(slot.height).to.equal(320);
@@ -613,7 +612,9 @@ describe('the rubicon adapter', () => {
           expect(bids[0].width).to.equal(320);
           expect(bids[0].height).to.equal(50);
           expect(bids[0].cpm).to.equal(0.911);
-          expect(bids[0].creative_id).to.equal('crid-9');
+          expect(bids[0].ttl).to.equal(300);
+          expect(bids[0].netRevenue).to.equal(false);
+          expect(bids[0].creativeId).to.equal('crid-9');
           expect(bids[0].currency).to.equal('USD');
           expect(bids[0].ad).to.contain(`alert('foo')`)
             .and.to.contain(`<html>`)
@@ -624,7 +625,9 @@ describe('the rubicon adapter', () => {
           expect(bids[1].width).to.equal(300);
           expect(bids[1].height).to.equal(250);
           expect(bids[1].cpm).to.equal(0.811);
-          expect(bids[1].creative_id).to.equal('crid-9');
+          expect(bids[1].ttl).to.equal(300);
+          expect(bids[1].netRevenue).to.equal(false);
+          expect(bids[1].creativeId).to.equal('crid-9');
           expect(bids[1].currency).to.equal('USD');
           expect(bids[1].ad).to.contain(`alert('foo')`)
             .and.to.contain(`<html>`)
@@ -756,8 +759,10 @@ describe('the rubicon adapter', () => {
 
           expect(bids).to.be.lengthOf(1);
 
-          expect(bids[0].creative_id).to.equal('crid-999999');
+          expect(bids[0].creativeId).to.equal('crid-999999');
           expect(bids[0].cpm).to.equal(1);
+          expect(bids[0].ttl).to.equal(300);
+          expect(bids[0].netRevenue).to.equal(false);
           expect(bids[0].descriptionUrl).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');
           expect(bids[0].vastUrl).to.equal(
             'https://fastlane-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml'


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
I updated the Rubicon adapter to use `adUnitCode` for 1.0 compliance.  However, from testing it looks like pre-1.0 has no bid.adUnitCod even though glancing at appnexus adapter it looks like it expects it.  What is the desired implementation here to be both pre-1.0 and 1.0 compatible?  Right now I just implemented both...
