### PR TITLE
Add `usePaymentRule` param to AN bidders

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -248,6 +248,7 @@ function bidToTag(bid) {
     tag.code = bid.params.invCode;
   }
   tag.allow_smaller_sizes = bid.params.allowSmallerSizes || false;
+  tag.use_pmt_rule = bid.params.usePaymentRule || false
   tag.prebid = true;
   tag.disable_psa = true;
   if (bid.params.reserve) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -44,12 +44,15 @@ AppNexusAdapter = function AppNexusAdapter() {
     var query = utils.getBidIdParameter('query', bid.params);
     var referrer = utils.getBidIdParameter('referrer', bid.params);
     var altReferrer = utils.getBidIdParameter('alt_referrer', bid.params);
+    let usePaymentRule = utils.getBidIdParameter('usePaymentRule', bid.params);
     var jptCall = '//ib.adnxs.com/jpt?';
 
     jptCall = utils.tryAppendQueryString(jptCall, 'callback', '$$PREBID_GLOBAL$$.handleAnCB');
     jptCall = utils.tryAppendQueryString(jptCall, 'callback_uid', callbackId);
     jptCall = utils.tryAppendQueryString(jptCall, 'psa', '0');
     jptCall = utils.tryAppendQueryString(jptCall, 'id', placementId);
+    jptCall = utils.tryAppendQueryString(jptCall, 'use_pmt_rule', usePaymentRule);
+
     if (member) {
       jptCall = utils.tryAppendQueryString(jptCall, 'member', member);
     } else if (memberId) {
@@ -106,6 +109,7 @@ AppNexusAdapter = function AppNexusAdapter() {
     delete paramsCopy.referrer;
     delete paramsCopy.alt_referrer;
     delete paramsCopy.member;
+    delete paramsCopy.usePaymentRule;
 
     // get the reminder
     var queryParams = utils.parseQueryStringParameters(paramsCopy);

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -244,6 +244,23 @@ describe('AppNexusAdapter', () => {
         'value': ['123']
       }]);
     });
+
+    it('should should add payment rules to the request', () => {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394',
+            usePaymentRule: true
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].use_pmt_rule).to.equal(true);
+    });
   })
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Resolves RAD-1790 - adds a `usePaymentRule` boolean value to params. 

```
{
  bidder: 'appnexus',
  params: {
    usePaymentRule : true
  }
}
```