### PR TITLE
Remove 'supported' from analytics adapter info

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -635,7 +635,7 @@ $$PREBID_GLOBAL$$.loadScript = function (tagSrc, callback, useCache) {
  * For usage, see [Integrate with the Prebid Analytics
  * API](http://prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html).
  *
- * For a list of supported analytics adapters, see [Analytics for
+ * For a list of analytics adapters, see [Analytics for
  * Prebid](http://prebid.org/overview/analytics.html).
  * @param  {Object} config
  * @param {string} config.provider The name of the provider, e.g., `"ga"` for Google Analytics.


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other

## Description of change

Removing term "supported" from JSDoc - Prebid.org doesn't endorse or support any particular adapter, per our [analytics overview docs](http://prebid.org/overview/analytics.html).