### PR TITLE
Added adUnitCode to bidRequest for pre-1.0

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -207,6 +207,10 @@ export function newBidder(spec) {
       const bidRequestMap = {};
       validBidRequests.forEach(bid => {
         bidRequestMap[bid.bidId] = bid;
+        // Delete this once we are 1.0
+        if (!bid.adUnitCode) {
+          bid.adUnitCode = bid.placementCode
+        }
       });
 
       let requests = spec.buildRequests(validBidRequests, bidderRequest);


### PR DESCRIPTION
## Type of change
- [x] Bugfix


## Description of change
In 1.0 we updated all occurrences of `placementCode` to `adUnitCode` since both are same. A bug was created for 1.0 adapters who wanted to use `bidRequest.placementCode` in their adapter. 

So to support both pre-1.0 and 1.0 added `adUnitCode` in bidderFactory. Adapters can now use `adUnitCode` in their adapters and maintain compatibility for both versions.


## Other information
@snapwich #1776 
