### PR TITLE
Randomize pbjs global name when testing

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -1,7 +1,7 @@
 // This configures Karma, describing how to run the tests and where to output code coverage reports.
 //
 // For more information, see http://karma-runner.github.io/1.0/config/configuration-file.html
-
+process.env.test = true;
 var _ = require('lodash');
 var webpackConf = require('./webpack.conf');
 var path = require('path')

--- a/test/spec/modules/s2sTesting_spec.js
+++ b/test/spec/modules/s2sTesting_spec.js
@@ -312,15 +312,15 @@ describe('s2sTesting', function () {
     const AST = CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING;
 
     function checkTargeting(bidder) {
-      var targeting = window.pbjs.bidderSettings[bidder][AST];
+      var targeting = window.$$PREBID_GLOBAL$$.bidderSettings[bidder][AST];
       var srcTargeting = targeting[targeting.length - 1];
       expect(srcTargeting.key).to.equal(`hb_source_${bidder}`);
       expect(srcTargeting.val).to.be.a('function');
-      expect(window.pbjs.bidderSettings[bidder].alwaysUseBid).to.be.true;
+      expect(window.$$PREBID_GLOBAL$$.bidderSettings[bidder].alwaysUseBid).to.be.true;
     }
 
     function checkNoTargeting(bidder) {
-      var bs = window.pbjs.bidderSettings;
+      var bs = window.$$PREBID_GLOBAL$$.bidderSettings;
       var targeting = bs[bidder] && bs[bidder][AST];
       if (!targeting) {
         expect(targeting).to.be.undefined;
@@ -332,22 +332,22 @@ describe('s2sTesting', function () {
     }
 
     function checkTargetingVal(bidResponse, expectedVal) {
-      var targeting = window.pbjs.bidderSettings[bidResponse.bidderCode][AST];
+      var targeting = window.$$PREBID_GLOBAL$$.bidderSettings[bidResponse.bidderCode][AST];
       var targetingFunc = targeting[targeting.length - 1].val;
       expect(targetingFunc(bidResponse)).to.equal(expectedVal);
     }
 
     beforeEach(() => {
       // set bidderSettings
-      window.pbjs.bidderSettings = {};
+      window.$$PREBID_GLOBAL$$.bidderSettings = {};
     });
 
     it('should not set hb_source_<bidder> unless testing is on and includeSourceKvp is set', () => {
       config.setConfig({s2sConfig: {bidders: ['rubicon', 'appnexus']}});
-      expect(window.pbjs.bidderSettings).to.eql({});
+      expect(window.$$PREBID_GLOBAL$$.bidderSettings).to.eql({});
 
       config.setConfig({s2sConfig: {bidders: ['rubicon', 'appnexus'], testing: true}});
-      expect(window.pbjs.bidderSettings).to.eql({});
+      expect(window.$$PREBID_GLOBAL$$.bidderSettings).to.eql({});
 
       config.setConfig({s2sConfig: {
         bidders: ['rubicon', 'appnexus'],
@@ -357,7 +357,7 @@ describe('s2sTesting', function () {
           appnexus: {bidSource: {server: 1}}
         }
       }});
-      expect(window.pbjs.bidderSettings).to.eql({});
+      expect(window.$$PREBID_GLOBAL$$.bidderSettings).to.eql({});
 
       config.setConfig({s2sConfig: {
         bidders: ['rubicon', 'appnexus'],
@@ -367,7 +367,7 @@ describe('s2sTesting', function () {
           appnexus: {includeSourceKvp: true}
         }
       }});
-      expect(window.pbjs.bidderSettings).to.eql({});
+      expect(window.$$PREBID_GLOBAL$$.bidderSettings).to.eql({});
     });
 
     it('should set hb_source_<bidder> if includeSourceKvp is set', () => {

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -10,6 +10,8 @@ var neverBundle = [
   'AnalyticsAdapter.js'
 ];
 
+var prebidGlobalName = process.env.test ? 'pbjs_' + Math.floor(Math.random() * 10000) : prebid.globalVarName;
+
 module.exports = {
   devtool: 'source-map',
   resolve: {
@@ -77,7 +79,7 @@ module.exports = {
             {
               pattern: /\$\$PREBID_GLOBAL\$\$/g,
               replacement: function (match, p1, offset, string) {
-                return prebid.globalVarName;
+                return prebidGlobalName;
               }
             }
           ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

It seems that adapter tests routinely hard-code `pbjs` instead of using `$$PREBID_GLOBAL$$`.  I suppose things will change with prebid-1.0, but meanwhile this change forces those tests to break by randomizing the global name when testing.

There is probably a cleaner way to do this, but I also didn't want to do a bigger refactor given the plans to move away from using `$$PREBID_GLOBAL$$`.  

## References
#1786
#1666