### PR TITLE
Update conversant adapter to include ttl and netRevenue for Prebid 1.0

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -5,7 +5,7 @@ import { VIDEO } from 'src/mediaTypes';
 const BIDDER_CODE = 'conversant';
 const URL = '//media.msg.dotomi.com/s2s/header/24';
 const SYNC_URL = '//media.msg.dotomi.com/w/user.sync';
-const VERSION = '2.2.0';
+const VERSION = '2.2.1';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -75,7 +75,10 @@ export const spec = {
       copyOptProperty(bid.params, 'tag_id', imp, 'tagid');
 
       if (isVideoRequest(bid)) {
-        const video = {format: format};
+        const video = {
+          w: format[0].w,
+          h: format[0].h
+        };
 
         copyOptProperty(bid.params, 'position', video, 'pos');
         copyOptProperty(bid.params, 'mimes', video);
@@ -141,17 +144,16 @@ export const spec = {
               requestId: conversantBid.impid,
               currency: serverResponse.cur || 'USD',
               cpm: responseCPM,
-              creativeId: conversantBid.crid || ''
+              creativeId: conversantBid.crid || '',
+              ttl: 300,
+              netRevenue: true
             };
 
             if (request.video) {
               bid.vastUrl = responseAd;
               bid.mediaType = 'video';
-
-              if (request.video.format.length >= 1) {
-                bid.width = request.video.format[0].w;
-                bid.height = request.video.format[0].h;
-              }
+              bid.width = request.video.w;
+              bid.height = request.video.h;
             } else {
               bid.ad = responseAd + '<img src="' + responseNurl + '" />';
               bid.width = conversantBid.w;

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -205,8 +205,8 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[3]).to.not.have.property('tagid');
     expect(payload.imp[3]).to.have.property('video');
     expect(payload.imp[3].video).to.not.have.property('pos');
-    expect(payload.imp[3].video).to.have.property('format');
-    expect(payload.imp[3].video.format).to.deep.equal([{w: 640, h: 480}]);
+    expect(payload.imp[3].video).to.have.property('w', 640);
+    expect(payload.imp[3].video).to.have.property('h', 480);
     expect(payload.imp[3].video).to.have.property('mimes');
     expect(payload.imp[3].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
     expect(payload.imp[3].video).to.have.property('protocols');
@@ -243,6 +243,8 @@ describe('Conversant adapter tests', function() {
     expect(bid).to.have.property('width', 300);
     expect(bid).to.have.property('height', 250);
     expect(bid).to.have.property('ad', 'markup000<img src="notify000" />');
+    expect(bid).to.have.property('ttl', 300);
+    expect(bid).to.have.property('netRevenue', true);
 
     // There is no bid001 because cpm is $0
 
@@ -254,6 +256,8 @@ describe('Conversant adapter tests', function() {
     expect(bid).to.have.property('width', 300);
     expect(bid).to.have.property('height', 600);
     expect(bid).to.have.property('ad', 'markup002<img src="notify002" />');
+    expect(bid).to.have.property('ttl', 300);
+    expect(bid).to.have.property('netRevenue', true);
 
     bid = response[2];
     expect(bid).to.have.property('requestId', 'bid003');
@@ -264,6 +268,8 @@ describe('Conversant adapter tests', function() {
     expect(bid).to.have.property('height', 480);
     expect(bid).to.have.property('vastUrl', 'markup003');
     expect(bid).to.have.property('mediaType', 'video');
+    expect(bid).to.have.property('ttl', 300);
+    expect(bid).to.have.property('netRevenue', true);
   });
 
   it('Verify handling of bad responses', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

- Add ttl and netRevenue to bids
- (minor) video bids should only use w and h instead of format


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- pyang@conversantmedia.com
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
