### PR TITLE
Update renderAd to replace ${AUCTION_PRICE} in adUrl

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -289,7 +289,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         // emit 'bid won' event here
         events.emit(BID_WON, bid);
 
-        const { height, width, ad, mediaType, adUrl: url, renderer } = bid;
+        const { height, width, ad, mediaType, adUrl, renderer } = bid;
 
         if (renderer && renderer.url) {
           renderer.render(bid);
@@ -299,13 +299,13 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           doc.write(ad);
           doc.close();
           setRenderSize(doc, width, height);
-        } else if (url) {
+        } else if (adUrl) {
           const iframe = utils.createInvisibleIframe();
           iframe.height = height;
           iframe.width = width;
           iframe.style.display = 'inline';
           iframe.style.overflow = 'hidden';
-          iframe.src = url;
+          iframe.src = adUrl;
 
           utils.insertElement(iframe, doc, 'body');
           setRenderSize(doc, width, height);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -282,7 +282,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
       if (bid) {
         // replace macros according to openRTB with price paid = bid.cpm
         bid.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);
-        bid.url = utils.replaceAuctionPrice(bid.url, bid.cpm);
+        bid.adUrl = utils.replaceAuctionPrice(bid.adUrl, bid.cpm);
         // save winning bids
         $$PREBID_GLOBAL$$._winningBids.push(bid);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
This PR updates the `renderAd` function to replace `${AUCTION_PRICE}` in `adUrl`.

In addition to this, this PR uses `adUrl` for the `url` parameter to match with the key used in the bid object (if this should be removed or needs to be a separate PR, let me know)

## Other information
Associated Issue: #1794 
