### PR TITLE
Improve calls to addBidToAuction and tryAddVideoBid

### DIFF
--- a/src/bidmanager.js
+++ b/src/bidmanager.js
@@ -88,9 +88,9 @@ exports.addBidResponse = createHook('asyncSeries', function (adUnitCode, bid) {
     prepareBidForAuction();
 
     if (bid.mediaType === 'video') {
-      tryAddVideoBid(bid);
+      tryAddVideoBid();
     } else {
-      addBidToAuction(bid);
+      addBidToAuction();
       doCallbacksIfNeeded();
     }
   }
@@ -232,7 +232,7 @@ exports.addBidResponse = createHook('asyncSeries', function (adUnitCode, bid) {
   }
 
   // Video bids may fail if the cache is down, or there's trouble on the network.
-  function tryAddVideoBid(bid) {
+  function tryAddVideoBid() {
     if (config.getConfig('usePrebidCache')) {
       store([bid], function(error, cacheIds) {
         if (error) {
@@ -242,12 +242,12 @@ exports.addBidResponse = createHook('asyncSeries', function (adUnitCode, bid) {
           if (!bid.vastUrl) {
             bid.vastUrl = getCacheUrl(bid.videoCacheKey);
           }
-          addBidToAuction(bid);
+          addBidToAuction();
         }
         doCallbacksIfNeeded();
       });
     } else {
-      addBidToAuction(bid);
+      addBidToAuction();
       doCallbacksIfNeeded();
     }
   }


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
addBidToAuction does not take any parameters, but calls to addBidToAuction are passing in the bid object. This patch modifies calls to reflect the fact that addBidToAuction uses the bid object from the closure instead of taking a parameter. It also modified calls to tryAddVideoBid to use the same convention.
