### PR TITLE
Drop non-video bidders from video ad units

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -383,7 +383,7 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   // for video-enabled adUnits, only request bids if all bidders support video
   const invalidVideoAdUnits = adUnits.filter(videoAdUnit).filter(hasNonVideoBidder);
   invalidVideoAdUnits.forEach(adUnit => {
-    utils.logError(`adUnit ${adUnit.code} has 'mediaType' set to 'video' but contains a bidder that doesn't support video. No Prebid demand requests will be triggered for this adUnit.`);
+    utils.logError(`adUnit ${adUnit.code} is of type 'video' but contains a bidder that doesn't support video. No Prebid demand requests will be triggered for this adUnit.`);
     for (let i = 0; i < adUnits.length; i++) {
       if (adUnits[i].code === adUnit.code) { adUnits.splice(i, 1); }
     }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -2,7 +2,7 @@
 
 import { getGlobal } from './prebidGlobal';
 import { flatten, uniques, isGptPubadsDefined, adUnitsFilter } from './utils';
-import { videoAdUnit, hasNonVideoBidder } from './video';
+import { videoAdUnit, videoBidder, hasNonVideoBidder } from './video';
 import { nativeAdUnit, nativeBidder, hasNonNativeBidder } from './native';
 import './polyfill';
 import { parse as parseURL, format as formatURL } from './url';
@@ -380,13 +380,18 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
     adUnitCodes = adUnits && adUnits.map(unit => unit.code);
   }
 
-  // for video-enabled adUnits, only request bids if all bidders support video
-  const invalidVideoAdUnits = adUnits.filter(videoAdUnit).filter(hasNonVideoBidder);
-  invalidVideoAdUnits.forEach(adUnit => {
-    utils.logError(`adUnit ${adUnit.code} is of type 'video' but contains a bidder that doesn't support video. No Prebid demand requests will be triggered for this adUnit.`);
-    for (let i = 0; i < adUnits.length; i++) {
-      if (adUnits[i].code === adUnit.code) { adUnits.splice(i, 1); }
-    }
+  // for video-enabled adUnits, only request bids for bidders that support video
+  adUnits.filter(videoAdUnit).filter(hasNonVideoBidder).forEach(adUnit => {
+    const nonVideoBidders = adUnit.bids
+      .filter(bid => !videoBidder(bid))
+      .map(bid => bid.bidder)
+      .join(', ');
+
+    utils.logError(`
+      ${adUnit.code} is a 'video' ad unit but contains non-video bidder(s) ${nonVideoBidders}.
+      No Prebid demand requests will be triggered for those bidders.
+    `);
+    adUnit.bids = adUnit.bids.filter(videoBidder);
   });
 
   // for native-enabled adUnits, only request bids for bidders that support native
@@ -396,7 +401,10 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
       .map(bid => bid.bidder)
       .join(', ');
 
-    utils.logError(`adUnit ${adUnit.code} has 'mediaType' set to 'native' but contains non-native bidder(s) ${nonNativeBidders}. No Prebid demand requests will be triggered for those bidders.`);
+    utils.logError(`
+      ${adUnit.code} is a 'native' ad unit but contains non-native bidder(s) ${nonNativeBidders}.
+      No Prebid demand requests will be triggered for those bidders.
+    `);
     adUnit.bids = adUnit.bids.filter(nativeBidder);
   });
 

--- a/src/video.js
+++ b/src/video.js
@@ -8,7 +8,11 @@ const OUTSTREAM = 'outstream';
 /**
  * Helper functions for working with video-enabled adUnits
  */
-export const videoAdUnit = adUnit => adUnit.mediaType === VIDEO_MEDIA_TYPE;
+export const videoAdUnit = adUnit => {
+  const mediaTypes = deepAccess(adUnit, 'mediaTypes.video');
+  return !!mediaTypes || adUnit.mediaType === VIDEO_MEDIA_TYPE;
+};
+
 const nonVideoBidder = bid => !videoAdapters.includes(bid.bidder);
 export const hasNonVideoBidder = adUnit =>
   adUnit.bids.filter(nonVideoBidder).length;

--- a/src/video.js
+++ b/src/video.js
@@ -9,13 +9,13 @@ const OUTSTREAM = 'outstream';
  * Helper functions for working with video-enabled adUnits
  */
 export const videoAdUnit = adUnit => {
+  const mediaType = adUnit.mediaType === VIDEO_MEDIA_TYPE;
   const mediaTypes = deepAccess(adUnit, 'mediaTypes.video');
-  return !!mediaTypes || adUnit.mediaType === VIDEO_MEDIA_TYPE;
+  return mediaType || mediaTypes;
 };
-
-const nonVideoBidder = bid => !videoAdapters.includes(bid.bidder);
+export const videoBidder = bid => videoAdapters.includes(bid.bidder);
 export const hasNonVideoBidder = adUnit =>
-  adUnit.bids.filter(nonVideoBidder).length;
+  adUnit.bids.filter(bid => !videoBidder(bid)).length;
 
 /**
  * @typedef {object} VideoBid

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -779,7 +779,7 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.callBids.restore();
     });
 
-    it('should not callBids if a video adUnit has non-video bidders', () => {
+    it('should only request video bidders on video adunits', () => {
       sinon.spy(adaptermanager, 'callBids');
       const videoAdaptersBackup = adaptermanager.videoAdapters;
       adaptermanager.videoAdapters = ['appnexusAst'];
@@ -793,13 +793,17 @@ describe('Unit: Prebid Module', function () {
       }];
 
       $$PREBID_GLOBAL$$.requestBids({adUnits});
-      sinon.assert.notCalled(adaptermanager.callBids);
+      sinon.assert.calledOnce(adaptermanager.callBids);
+
+      const spyArgs = adaptermanager.callBids.getCall(0);
+      const biddersCalled = spyArgs.args[0].adUnits[0].bids;
+      expect(biddersCalled.length).to.equal(1);
 
       adaptermanager.callBids.restore();
       adaptermanager.videoAdapters = videoAdaptersBackup;
     });
 
-    it('should not callBids if a video adUnit defined with mediaTypes has non-video bidders', () => {
+    it('should only request video bidders on video adunits configured with mediaTypes', () => {
       sinon.spy(adaptermanager, 'callBids');
       const videoAdaptersBackup = adaptermanager.videoAdapters;
       adaptermanager.videoAdapters = ['appnexusAst'];
@@ -813,7 +817,11 @@ describe('Unit: Prebid Module', function () {
       }];
 
       $$PREBID_GLOBAL$$.requestBids({adUnits});
-      sinon.assert.notCalled(adaptermanager.callBids);
+      sinon.assert.calledOnce(adaptermanager.callBids);
+
+      const spyArgs = adaptermanager.callBids.getCall(0);
+      const biddersCalled = spyArgs.args[0].adUnits[0].bids;
+      expect(biddersCalled.length).to.equal(1);
 
       adaptermanager.callBids.restore();
       adaptermanager.videoAdapters = videoAdaptersBackup;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -799,6 +799,26 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.videoAdapters = videoAdaptersBackup;
     });
 
+    it('should not callBids if a video adUnit defined with mediaTypes has non-video bidders', () => {
+      sinon.spy(adaptermanager, 'callBids');
+      const videoAdaptersBackup = adaptermanager.videoAdapters;
+      adaptermanager.videoAdapters = ['appnexusAst'];
+      const adUnits = [{
+        code: 'adUnit-code',
+        mediaTypes: {video: {context: 'instream'}},
+        bids: [
+          {bidder: 'appnexus', params: {placementId: 'id'}},
+          {bidder: 'appnexusAst', params: {placementId: 'id'}}
+        ]
+      }];
+
+      $$PREBID_GLOBAL$$.requestBids({adUnits});
+      sinon.assert.notCalled(adaptermanager.callBids);
+
+      adaptermanager.callBids.restore();
+      adaptermanager.videoAdapters = videoAdaptersBackup;
+    });
+
     it('should callBids if a video adUnit has all video bidders', () => {
       sinon.spy(adaptermanager, 'callBids');
       const videoAdaptersBackup = adaptermanager.videoAdapters;


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Ad units with `mediaType: 'video'` that included non-video bidders were preventing calls to all bidders in the ad unit, even if that included video bidders. This change drops non-video bidders and still calls valid video bidders rather than dropping the ad unit entirely. Works for ad units configured with `mediaTypes: 'video'` or 1.0-compatible `meidaTypes: {video: {}}`

In this example ad unit, on master `appnexusAst` will not get called because `fakeBidder` is not a video bidder, or even real for that matter. With this PR `appnexusAst` gets called.

```JavaScript
pbjs.addAdUnits({
  code: '/19968336/prebid_video_adunit',
  sizes: [640,480],
  mediaType: 'video',
  // or mediaTypes: { video: {context: 'instream'} },
  bids: [

    {
      bidder: 'appnexusAst',
      params: {
        placementId: '9333431',
        video: { skippable: true, playback_method: ['auto_play_sound_off'] }
      }
    },

    {
      bidder: 'fakeBidder',
      params: { tag: 'stopHammerTime' }
    },

  ]
});
```

## Other information
Fixes #1137