### PR TITLE
just remove require.ensure entirely

### DIFF
--- a/plugins/RequireEnsureWithoutJsonp.js
+++ b/plugins/RequireEnsureWithoutJsonp.js
@@ -15,14 +15,7 @@ function RequireEnsureWithoutJsonp() {}
 RequireEnsureWithoutJsonp.prototype.apply = function(compiler) {
   compiler.plugin('compilation', function(compilation) {
     compilation.mainTemplate.plugin('require-ensure', function(_, chunk, hash) {
-      return (
-`
-if(installedChunks[chunkId] === 0)
-  return callback.call(null, __webpack_require__);
-else
-  console.error('webpack chunk not found and jsonp disabled');
-`
-      ).trim();
+      return '';
     });
   });
 };


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
After discussion in #1177 it looks like the require.ensure replacement code path is never being run anyways; so rather than try to fail nicely we can probably just remove it.  It's getting out of date w/ webpack updates anyways, so even if the fail-nice code ran it would probably throw an error.
