### PR TITLE
Emit array of objects from BID_TIMEOUT event

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -88,7 +88,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
   let _bidderRequests = [];
   let _bidsReceived = [];
   let _auctionStart;
-  let _auctionId = utils.getUniqueIdentifierStr();
+  let _auctionId = utils.generateUUID();
   let _auctionStatus;
   let _callback = callback;
   let _timer;

--- a/src/auction.js
+++ b/src/auction.js
@@ -146,7 +146,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
    * @property {string} bidId The id representing the bid
    * @property {string} bidder The string name of the bidder
    * @property {string} adUnitCode The code used to uniquely identify the ad unit on the publisher's page
-   * @property {string} requestId The UUID representing the bid request
+   * @property {string} auctionId The id representing the auction
    * @return {Array<TimedOutBid>} List of bids that Prebid hasn't received a response for
    */
   function getTimedOutBids() {
@@ -168,7 +168,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
         bidId: bid.bidId,
         bidder: bid.bidder,
         adUnitCode: bid.adUnitCode,
-        requestId: bid.requestId,
+        auctionId: bid.auctionId,
       }));
 
     return timedOutBids;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -850,7 +850,7 @@ describe('Unit: Prebid Module', function () {
         };
 
         $$PREBID_GLOBAL$$.requestBids(requestObj);
-        let re = new RegExp('^Auction [0-9A-Za-z]+ timedOut$');
+        let re = new RegExp('^Auction [a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12} timedOut$');
         clock.tick(requestObj.timeout - 1);
         assert.ok(logMessageSpy.neverCalledWith(sinon.match(re)), 'executeCallback not called');
 


### PR DESCRIPTION
## Type of change
- Other

## Description of change
Changes the data payload emitted from the `BID_TIMEOUT` event from an array of bidder codes strings, to an array of objects containing the bid id, bidder code, ad unit code, and auction id (this is equivalent to `requestId` in pre-1.0) for each timed out bid.

Before
```JavaScript
["bidderOne", "bidderTwo"]
```

After
```JavaScript
[
  {
    "bidId": "2baa51527bd015",
    "bidder": "bidderOne",
    "adUnitCode": "/19968336/header-bid-tag-0",
    "auctionId": "66529d4c-8998-47c2-ab3e-5b953490b98f"
  },
  {
    "bidId": "6fe3b4c2c23092",
    "bidder": "bidderTwo",
    "adUnitCode": "/19968336/header-bid-tag-0",
    "auctionId": "66529d4c-8998-47c2-ab3e-5b953490b98f"
  }
]
```

## Other information
Closes #844 