### PR TITLE
emitEvent method accessible from the global pbjs object

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -469,8 +469,7 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
 $$PREBID_GLOBAL$$.emitEvent = function (event) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.emitEvent', arguments);
   
-  var args = slice.call(arguments, 1);
-  events.emit(event, args);
+  events.emit.apply(this, arguments);
 };
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -467,7 +467,7 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
  */
 $$PREBID_GLOBAL$$.emitEvent = function (event) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.emitEvent', arguments);
-  
+
   events.emit.apply(this, arguments);
 };
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -22,7 +22,6 @@ var bidfactory = require('./bidfactory');
 var events = require('./events');
 var adserver = require('./adserver.js');
 var targeting = require('./targeting.js');
-var slice = Array.prototype.slice;
 const { syncUsers, triggerUserSyncs } = userSync;
 
 /* private variables */

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -22,6 +22,7 @@ var bidfactory = require('./bidfactory');
 var events = require('./events');
 var adserver = require('./adserver.js');
 var targeting = require('./targeting.js');
+var slice = Array.prototype.slice;
 const { syncUsers, triggerUserSyncs } = userSync;
 
 /* private variables */
@@ -459,6 +460,17 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
   }
   // emit event
   events.emit(ADD_AD_UNITS);
+};
+
+/**
+ * @param {string} event the name of the event
+ * @alias module:pbjs.emitEvent
+ */
+$$PREBID_GLOBAL$$.emitEvent = function (event) {
+  utils.logInfo('Invoking $$PREBID_GLOBAL$$.emitEvent', arguments);
+  
+  var args = slice.call(arguments, 1);
+  events.emit(event, args);
 };
 
 /**

--- a/test/spec/api_spec.js
+++ b/test/spec/api_spec.js
@@ -82,5 +82,9 @@ describe('Publisher API', function () {
     it('should have function $$PREBID_GLOBAL$$.getAllWinningBids', function () {
       assert.isFunction($$PREBID_GLOBAL$$.getAllWinningBids);
     });
+
+    it('should have function $$PREBID_GLOBAL$$.emitEvent', function () {
+      assert.isFunction($$PREBID_GLOBAL$$.emitEvent);
+    });
   });
 });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1110,10 +1110,12 @@ describe('Unit: Prebid Module', function () {
 
   describe('emit', () => {
     it('should call events.emit with valid parameters', () => {
-      const bid = $$PREBID_GLOBAL$$.createBid(0);
+      const adUnitCode = '/19968336/header-bid-tag-0';
+      const result = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+      const bids = getBidResponses().filter(bid => bid.adUnitCode === adUnitCode);
       const spyEventsEmit = sinon.spy(events, 'emit');
-      $$PREBID_GLOBAL$$.emitEvent(CONSTANTS.EVENTS.BID_WON, bid);
-      assert.ok(spyEventsEmit.calledWith('bidWon', bid));
+      $$PREBID_GLOBAL$$.emitEvent(CONSTANTS.EVENTS.BID_WON, bids[0]);
+      assert.ok(spyEventsEmit.calledWith('bidWon', bids[0]));
       events.emit.restore();
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1065,15 +1065,6 @@ describe('Unit: Prebid Module', function () {
     });
   });
   
-  describe('emitEvent', () => {
-    it('should call events.emit with valid parameters', () => {
-      var spyEventsEmit = sinon.spy(events, 'emit');
-      $$PREBID_GLOBAL$$.emitEvent('bidWon', Function);
-      assert.ok(spyEventsEmit.calledWith('bidWon', Function));
-      events.emit.restore();
-    });
-  });
-
   describe('onEvent', () => {
     it('should log an error when handler is not a function', () => {
       var spyLogError = sinon.spy(utils, 'logError');
@@ -1118,6 +1109,14 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('emit', () => {
+    it('should call events.emit with valid parameters', () => {
+      const bid = $$PREBID_GLOBAL$$.createBid(0);
+      const spyEventsEmit = sinon.spy(events, 'emit');
+      $$PREBID_GLOBAL$$.emitEvent(CONSTANTS.EVENTS.BID_WON, bid);
+      assert.ok(spyEventsEmit.calledWith('bidWon', bid));
+      events.emit.restore();
+    });
+
     it('should be able to emit event without arguments', () => {
       var spyEventsEmit = sinon.spy(events, 'emit');
       events.emit(CONSTANTS.EVENTS.AUCTION_END);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1064,6 +1064,15 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.callBids.restore();
     });
   });
+  
+  describe('emitEvent', () => {
+    it('should call events.emit with valid parameters', () => {
+      var spyEventsEmit = sinon.spy(events, 'emit');
+      $$PREBID_GLOBAL$$.emitEvent('bidWon', Function);
+      assert.ok(spyEventsEmit.calledWith('bidWon', Function));
+      events.emit.restore();
+    });
+  });
 
   describe('onEvent', () => {
     it('should log an error when handler is not a function', () => {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1064,7 +1064,7 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.callBids.restore();
     });
   });
-  
+
   describe('onEvent', () => {
     it('should log an error when handler is not a function', () => {
       var spyLogError = sinon.spy(utils, 'logError');


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
As part of our internal prebid integration, we manually elect a winning bid (due to custom blacklists and floors) and we customize how ads are rendered (e.g. for skins, interstitials...) so we don't call renderAd. Thus, analytics modules don't register the bidWon event.
This proposal solves this problem by allowing us to emit any event from the gobal pbjs object. If required, it could also be tweaked to only allow the bidWon (and others?) event to be "manually" emitted.