### PR TITLE
Fix skipped test

### DIFF
--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -82,12 +82,12 @@ describe('Publisher API _ AdUnits', function () {
       assert.strictEqual(bids2[1].params.placementId, '827326', 'adUnit2 bids2 params.placementId');
     });
 
-    it('both add unit should contains a transactionid.'), function() {
-      assert.exist(adUnit1.transationId)
-      assert.exist(adUnit2.transationId)
+    it('both add unit should contains a transactionId', function() {
+      assert.isString(adUnit1.transactionId);
+      assert.isString(adUnit2.transactionId);
 
-      assert.strictEqual(false, adUnit1.transationId === adUnit2.transationId)
-    }
+      assert.strictEqual(false, adUnit1.transactionId === adUnit2.transactionId);
+    });
 
     it('the second adUnits value should be same with the adUnits that is added by $$PREBID_GLOBAL$$.addAdUnits();', function () {
       assert.strictEqual(adUnit2.code, '/1996833/slot-2', 'adUnit2 code');


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
A test was being skipped due to incorrect parenthesis placement. It was also failing due to incorrect property naming. This runs the test and updates it to pass. Also updated to use `isString` because `exists` was causing `TypeError: assert.exists is not a function` for some reason, even though this assertion is in the Chai docs. After this PR is merged there should no longer be any skipped tests.