### PR TITLE
OpenX adapter: Make mediaType default to banner when none is specified

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -30,8 +30,15 @@ export const spec = {
     let requests = [];
     let bannerRequests = [];
     let videoRequests = [];
-    let bannerBids = bids.filter(function(bid) { return bid.mediaType === BANNER; });
-    let videoBids = bids.filter(function(bid) { return bid.mediaType === VIDEO; });
+    let bannerBids = [];
+    let videoBids = [];
+    bids.forEach(function (bid) {
+      if (bid.mediaType === VIDEO) {
+        videoBids.push(bid);
+      } else {
+        bannerBids.push(bid);
+      }
+    });
 
     // build banner requests
     if (bannerBids.length !== 0) {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -73,6 +73,18 @@ describe('OpenxAdapter', () => {
   });
 
   describe('buildRequests for banner ads', () => {
+    let bidRequestsWithNoMediaType = [{
+      'bidder': 'openx',
+      'params': {
+        'unit': '12345678',
+        'delDomain': 'test-del-domain'
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    }];
     let bidRequests = [{
       'bidder': 'openx',
       'params': {
@@ -86,6 +98,12 @@ describe('OpenxAdapter', () => {
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',
     }];
+
+    it('should send bid request to openx url via GET, even without mediaType specified', () => {
+      const request = spec.buildRequests(bidRequestsWithNoMediaType);
+      expect(request[0].url).to.equal('//' + bidRequests[0].params.delDomain + URLBASE);
+      expect(request[0].method).to.equal('GET');
+    });
 
     it('should send bid request to openx url via GET', () => {
       const request = spec.buildRequests(bidRequests);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

Make mediaType default to BANNER when there is no mediaType specified