### PR TITLE
Kumma Adapter: size parameter is not mandatory anymore

### DIFF
--- a/modules/kummaBidAdapter.js
+++ b/modules/kummaBidAdapter.js
@@ -76,7 +76,7 @@ function impression(slot) {
   };
 }
 function banner(slot) {
-  const size = parseSizesInput(slot.sizes)[0].split('x') || slot.params.size.toUpperCase().split('X');
+  const size = parseSizesInput(slot.sizes)[0].split('x');
   const width = parseInt(size[0]);
   const height = parseInt(size[1]);
   return {

--- a/modules/kummaBidAdapter.js
+++ b/modules/kummaBidAdapter.js
@@ -1,5 +1,5 @@
 
-import {logError, getTopWindowLocation, getTopWindowReferrer} from 'src/utils';
+import {logError, getTopWindowLocation, getTopWindowReferrer, parseSizesInput} from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 export const spec = {
@@ -76,7 +76,7 @@ function impression(slot) {
   };
 }
 function banner(slot) {
-  const size = slot.params.size.toUpperCase().split('X');
+  const size = parseSizesInput(slot.sizes)[0].split('x') || slot.params.size.toUpperCase().split('X');
   const width = parseInt(size[0]);
   const height = parseInt(size[1]);
   return {

--- a/modules/kummaBidAdapter.md
+++ b/modules/kummaBidAdapter.md
@@ -19,9 +19,9 @@ Please use ```kumma``` as the bidder code.
           params: { 
             pubId: '55879', // required
             siteId: '26047', // required
-            size: '300X250', // required
-            placementId: '123',
-            bidFloor: '0.001'
+            size: '300X250', // optional
+            placementId: '123', // optional
+            bidFloor: '0.001' // optional
           }
       }]
     }];

--- a/modules/kummaBidAdapter.md
+++ b/modules/kummaBidAdapter.md
@@ -19,7 +19,6 @@ Please use ```kumma``` as the bidder code.
           params: { 
             pubId: '55879', // required
             siteId: '26047', // required
-            size: '300X250', // optional
             placementId: '123', // optional
             bidFloor: '0.001' // optional
           }

--- a/test/spec/modules/kummaBidAdapter_spec.js
+++ b/test/spec/modules/kummaBidAdapter_spec.js
@@ -11,7 +11,6 @@ describe('Kumma Adapter Tests', () => {
       pubId: '55879',
       siteId: '26047',
       placementId: '123',
-      size: '300x250',
       bidFloor: '0.001'
     }
   }, {

--- a/test/spec/modules/kummaBidAdapter_spec.js
+++ b/test/spec/modules/kummaBidAdapter_spec.js
@@ -21,8 +21,7 @@ describe('Kumma Adapter Tests', () => {
     params: {
       pubId: '55879',
       siteId: '26047',
-      placementId: '456',
-      size: '250x250'
+      placementId: '456'
     }
   }];
   it('Verify build request', () => {


### PR DESCRIPTION

## Type of change


- [ X] Feature


## Description of change
Size parameter is not mandatory anymore for Kumma adapter


- contact email of the adapter’s maintainer
yehonatan@kumma.com
- [ ] official adapter submission


