### PR TITLE
updated adxcg analytics adapter for prebid 1.0 (#1824)

### DIFF
--- a/modules/adxcgAnalyticsAdapter.js
+++ b/modules/adxcgAnalyticsAdapter.js
@@ -1,12 +1,13 @@
 import {ajax} from 'src/ajax';
 import adapter from 'src/AnalyticsAdapter';
 import adaptermanager from 'src/adaptermanager';
+import CONSTANTS from 'src/constants.json';
 import * as url from 'src/url';
 import * as utils from 'src/utils';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
-const adxcgAnalyticsVersion = 'v1.04';
+const adxcgAnalyticsVersion = 'v1.05';
 
 let initOptions;
 let auctionTimestamp;
@@ -22,23 +23,23 @@ var adxcgAnalyticsAdapter = Object.assign(adapter(
   }), {
   track({eventType, args}) {
     if (typeof args !== 'undefined') {
-      if (eventType === 'bidTimeout') {
-        events.bidTimeout = args;
-      } else if (eventType === 'auctionInit') {
+      if (eventType === CONSTANTS.EVENTS.BID_TIMEOUT) {
+        events.bidTimeout = [...new Set(args.map(item => item.bidder))];
+      } else if (eventType === CONSTANTS.EVENTS.AUCTION_INIT) {
         events.auctionInit = args;
         auctionTimestamp = args.timestamp;
-      } else if (eventType === 'bidRequested') {
+      } else if (eventType === CONSTANTS.EVENTS.BID_REQUESTED) {
         events.bidRequests.push(args);
-      } else if (eventType === 'bidResponse') {
+      } else if (eventType === CONSTANTS.EVENTS.BID_RESPONSE) {
         events.bidResponses.push(mapBidResponse(args));
-      } else if (eventType === 'bidWon') {
+      } else if (eventType === CONSTANTS.EVENTS.BID_WON) {
         send({
           bidWon: mapBidResponse(args)
         });
       }
     }
 
-    if (eventType === 'auctionEnd') {
+    if (eventType === CONSTANTS.EVENTS.AUCTION_END) {
       send(events);
     }
   }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X ] Other  - #1824 

## Description of change
Change to keep format of BID_TIMEOUT event in same format as before change in #1824

- info@adxcg.com   contact email of the adapter’s maintainer
- [x ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
