### PR TITLE
add back stack trace to error logging

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -87,6 +87,7 @@ export const spec = {
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function(serverResponse, {bidderRequest}) {
+    utils.logError('foo', 'bar', {some: 'object'});
     serverResponse = serverResponse.body;
     const bids = [];
     if (!serverResponse || serverResponse.error) {

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -87,7 +87,6 @@ export const spec = {
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function(serverResponse, {bidderRequest}) {
-    utils.logError('foo', 'bar', {some: 'object'});
     serverResponse = serverResponse.body;
     const bids = [];
     if (!serverResponse || serverResponse.error) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -923,7 +923,7 @@ $$PREBID_GLOBAL$$.cmd.push = function(command) {
     try {
       command.call();
     } catch (e) {
-      utils.logError('Error processing command :' + e.message);
+      utils.logError('Error processing command :', e.message, e.stack);
     }
   } else {
     utils.logError('Commands written into $$PREBID_GLOBAL$$.cmd.push must be wrapped in a function');

--- a/src/utils.js
+++ b/src/utils.js
@@ -214,12 +214,11 @@ function hasConsoleLogger() {
   return (window.console && window.console.log);
 }
 
-exports.hasConsoleLogger = hasConsoleLogger;
+function hasConsoleError() {
+  return (window.console && window.console.error);
+}
 
-var errLogFn = (function (hasLogger) {
-  if (!hasLogger) return '';
-  return window.console.error ? 'error' : 'log';
-}(hasConsoleLogger()));
+exports.hasConsoleLogger = hasConsoleLogger;
 
 var debugTurnedOn = function () {
   if (config.getConfig('debug') === false && _loggingChecked === false) {
@@ -234,9 +233,9 @@ var debugTurnedOn = function () {
 exports.debugTurnedOn = debugTurnedOn;
 
 exports.logError = function (msg, code, exception) {
-  var errCode = code || 'ERROR';
-  if (debugTurnedOn() && hasConsoleLogger()) {
-    console[errLogFn](console, errCode + ': ' + msg, exception || '');
+  if (debugTurnedOn() && hasConsoleError()) {
+    window.console.error(msg, code || '', exception || '');
+    window.console.error.bind.apply(console, arguments);
   }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -232,10 +232,12 @@ var debugTurnedOn = function () {
 
 exports.debugTurnedOn = debugTurnedOn;
 
-exports.logError = function (msg, code, exception) {
+/**
+ * Wrapper to console.error. Takes N arguments to log the same as console.error.
+ */
+exports.logError = function () {
   if (debugTurnedOn() && hasConsoleError()) {
-    window.console.error(msg, code || '', exception || '');
-    window.console.error.bind.apply(console, arguments);
+    console.error.apply(console, arguments);
   }
 };
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Puts the stack trace back into the console.error logging so you can find originating line easier. 

Fixes #1313 
