### PR TITLE
update JSDoc comment. Remove trailing space and fix type

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -794,10 +794,10 @@ export function getBidderRequest(bidRequests, bidder, adUnitCode) {
 }
 
 /**
- * Returns the origin 
+ * Returns the origin
  */
 export function getOrigin() {
-  // IE10 does not have this propery. https://gist.github.com/hbogs/7908703
+  // IE10 does not have this property. https://gist.github.com/hbogs/7908703
   if (!window.location.origin) {
     return window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
   } else {


### PR DESCRIPTION
Remove trailing white space as tests fail when performing the lint step which causes builds to fail.

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Updating JSDoc comment. Fixed typo while I was there.