### PR TITLE
Pass the adUnit array when emitting SET_TARGETING

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -230,7 +230,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit) {
   targeting.setTargeting(targetingSet);
 
   // emit event
-  events.emit(SET_TARGETING);
+  events.emit(SET_TARGETING, adUnit);
 };
 
 /**


### PR DESCRIPTION
We use this in our analytics adapter very useful to have as args

- [x] Feature

## Description of change

Since the auction process is detached from the DFP rendering process aka when does a call against DFP happen we find it very useful in our analytics adapter to have which ad unit's or all are getting invoked