### PR TITLE
Allow specific gptSlot targeting in setTargetingForGPTAsync

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -213,7 +213,7 @@ $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode = function (adUnitCode) {
  * @param {(string|string[])} adUnit a single `adUnit.code` or multiple.
  * @alias module:pbjs.setTargetingForGPTAsync
  */
-$$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit) {
+$$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit, gptSlot) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.setTargetingForGPTAsync', arguments);
   if (!isGptPubadsDefined()) {
     utils.logError('window.googletag is not defined on the page');
@@ -227,7 +227,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit) {
   targeting.resetPresetTargeting(adUnit);
 
   // now set new targeting keys
-  targeting.setTargeting(targetingSet);
+  targeting.setTargeting(targetingSet, gptSlot);
 
   // emit event
   events.emit(SET_TARGETING);

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -48,10 +48,10 @@ targeting.getAllTargeting = function(adUnitCode) {
   return targeting;
 };
 
-targeting.setTargeting = function(targetingConfig) {
+targeting.setTargeting = function(targetingConfig, gptSlot) {
   window.googletag.pubads().getSlots().forEach(slot => {
     targetingConfig.filter(targeting => Object.keys(targeting)[0] === slot.getAdUnitPath() ||
-      Object.keys(targeting)[0] === slot.getSlotElementId())
+      Object.keys(targeting)[0] === slot.getSlotElementId() || (gptSlot && gptSlot.getSlotElementId() === slot.getSlotElementId()))
       .forEach(targeting => targeting[Object.keys(targeting)[0]]
         .forEach(key => {
           key[Object.keys(key)[0]]


### PR DESCRIPTION
## Type of change
- [x] Bug
- [x] Feature 

## Description of change
We use the following flow:

We start a auction as early as possible. Without knowing where in the feed we're gonna place it. So depending on the outcome of the auction and how long it took we might inject it into a placement defined further down the page in order to now burn views above the fold.

The current semantics of setTargeting requires that we shall know a head of time what gptSlot the targeting should apply for because its looking into the auction object.

But allowing us to pass in an explicit gptSlot into the function we can allow the targeting to explicitly use this slot when setting targeting

We use this in order not to place ads above fold and insert them to a better position instead of everything just being very static.
