### PR TITLE
Override s2s cookieseturl

### DIFF
--- a/integrationExamples/gpt/prebidServer_setCookieUrl_example.html
+++ b/integrationExamples/gpt/prebidServer_setCookieUrl_example.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style type="text/css">
+        nav a {
+            display: inline-block;
+            color: black;
+            padding: 0.5em;
+            text-align: center;
+            border-radius: 0.5em;
+            text-decoration: none;
+            border: 1px solid black;
+        }
+    </style>
+
+    <script>
+      var PREBID_TIMEOUT = 2000;
+
+      var adUnits = [
+        {
+          code: 'test-div',
+          sizes: [[728,90]],
+          bids: [
+            {
+              bidder: 'rubicon',
+              params: {
+                accountId: 1001,
+                siteId: 113932,
+                zoneId: 535510
+              }
+            }
+          ]
+        },
+        {
+          code: 'test-div2',
+          sizes: [[300,250]],
+          bids: [
+            {
+              bidder: 'rubicon',
+              params: {
+                accountId: 1001,
+                siteId: 113932,
+                zoneId: 535510
+              }
+            }
+          ]
+        }
+      ];
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+
+    </script>
+    <script type="text/javascript" src="../../build/dev/prebid.js" async></script>
+
+    <script>
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+      });
+
+      pbjs.que.push(function() {
+        pbjs.logging = true;
+        pbjs.setConfig({s2sConfig:{
+          // String (required): The account ID
+          // accountId: '0acfb8cd-48de-4102-b519-01d1898ab87e',
+          accountId: '1001',
+
+          // Boolean (required): Enables S2S - defaults to `false`.
+          enabled: true,
+
+          // Array[String] (required): List of bidder codes to enable for S2S.
+          // Note that these must have been included in the Prebid.js build
+          // from Step 2.
+          bidders: ['rubicon'],
+
+          // Number (optional): Timeout for bidders called via the S2S
+          // endpoint, in milliseconds. Default value is 1000.
+          timeout: 1000,
+
+          syncEndpoint: 'https://my-prebid-server.myhost/cookie_sync',
+
+          // String (optional): Adapter code for S2S. Defaults to 'prebidServer'.
+          adapter: 'prebidServer',
+
+          // String (optional): Will override the default endpoint for Prebid Server.
+          endpoint: 'https://my-prebid-server.myhost/auction',
+
+          // String (optional): Will override the default cookieSet endpoint for Prebid Server.
+          cookieSetUrl : 'https://my-prebid-server.myhost/cookieset/cs.js'
+        }});
+
+        pbjs.addAdUnits(adUnits);
+        pbjs.enableSendAllBids();
+        pbjs.requestBids({
+          bidsBackHandler: sendAdserverRequest
+        });
+      });
+
+      function sendAdserverRequest() {
+        if (pbjs.adserverRequestSent) return;
+        pbjs.adserverRequestSent = true;
+        googletag.cmd.push(function() {
+          pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        });
+      }
+
+      setTimeout(function() {
+        sendAdserverRequest();
+      }, PREBID_TIMEOUT);
+    </script>
+
+    <script>
+      (function () {
+        var gads = document.createElement('script');
+        gads.async = true;
+        gads.type = 'text/javascript';
+        var useSSL = 'https:' == document.location.protocol;
+        gads.src = (useSSL ? 'https:' : 'http:') +
+          '//www.googletagservices.com/tag/js/gpt.js';
+        var node = document.getElementsByTagName('script')[0];
+        node.parentNode.insertBefore(gads, node);
+      })();
+    </script>
+
+    <script>
+      googletag.cmd.push(function() {
+        googletag.defineSlot('/112115922/FL_PB_MedRect', [[728,90]], 'test-div').addService(googletag.pubads());
+        googletag.defineSlot('/112115922/FL_PB_MedRect', [[300,250]], 'test-div2').addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+    </script>
+</head>
+
+<body>
+
+<header>
+    <h1>Safari 3rd party set cookie workaround</h1>
+    <nav>
+        <a href="pages/page-one.html">site sub-page #1</a>
+        <a href="pages/page-two.html">site sub-page #2</a>
+    </nav>
+    <h2>Prebid.js S2S setCookieUrl Demo</h2>
+</header>
+<div id='test-div'>
+    <script>
+      googletag.cmd.push(function() { googletag.display('test-div'); });
+    </script>
+</div>
+<div id='test-div2'>
+    <script>
+      googletag.cmd.push(function() { googletag.display('test-div2'); });
+    </script>
+</div>
+</body>
+</html>

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -12,7 +12,6 @@ import { VIDEO } from 'src/mediaTypes';
 const getConfig = config.getConfig;
 
 const TYPE = S2S.SRC;
-const cookieSetUrl = 'https://acdn.adnxs.com/cookieset/cs.js';
 let _synced = false;
 
 /**
@@ -273,9 +272,9 @@ function PrebidServer() {
             });
         });
       }
-      if (result.status === 'no_cookie' && config.cookieSet) {
+      if (result.status === 'no_cookie' && config.cookieSet && config.cookieSetUrl) {
         // cookie sync
-        cookieSet(cookieSetUrl);
+        cookieSet(config.cookieSetUrl);
       }
     } catch (error) {
       utils.logError(error);

--- a/src/constants.json
+++ b/src/constants.json
@@ -58,6 +58,7 @@
     "SRC" : "s2s",
     "ADAPTER" : "prebidServer",
     "SYNC_ENDPOINT" : "https://prebid.adnxs.com/pbs/v1/cookie_sync",
-    "SYNCED_BIDDERS_KEY": "pbjsSyncs"
+    "SYNCED_BIDDERS_KEY": "pbjsSyncs",
+    "COOKIE_SET_URL": "https://acdn.adnxs.com/cookieset/cs.js"
   }
 }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -814,6 +814,7 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
  * @property {string} [adapter] adapter code to use for S2S
  * @property {string} [syncEndpoint] endpoint URL for syncing cookies
  * @property {boolean} [cookieSet] enables cookieSet functionality
+ * @property {string} [cookieSetUrl] override the default cookieSet endpoint
  * @alias module:pbjs.setS2SConfig
  */
 $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
@@ -835,6 +836,7 @@ $$PREBID_GLOBAL$$.setS2SConfig = function(options) {
     adapter: CONSTANTS.S2S.ADAPTER,
     syncEndpoint: CONSTANTS.S2S.SYNC_ENDPOINT,
     cookieSet: true,
+    cookieSetUrl: CONSTANTS.S2S.COOKIE_SET_URL,
     bidders: []
   }, options);
   adaptermanager.setS2SConfig(config);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -12,7 +12,8 @@ let CONFIG = {
   enabled: true,
   bidders: ['appnexus'],
   timeout: 1000,
-  endpoint: CONSTANTS.S2S.DEFAULT_ENDPOINT
+  endpoint: CONSTANTS.S2S.DEFAULT_ENDPOINT,
+  cookieSetUrl: CONSTANTS.S2S.COOKIE_SET_URL
 };
 
 const REQUEST = {


### PR DESCRIPTION
 
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature

## Description of change
Allows the s2s "cookieSetUrl" value to be overridden using setConfig.
```
setConfig({s2sConfig:{
  // String (optional): Will override the default cookieSet endpoint for Prebid Server.
  cookieSetUrl : 'https://my-prebid-server.myhost/cookieset/cs.js'
}})
```