### PR TITLE
Update auctionId parameter to be requestId

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -37,7 +37,7 @@ function AdformAdapter() {
 
     request.unshift('//' + globalParams[0][1] + '/adx/?rp=4');
 
-    request.push('auctionId=' + encodeURIComponent(params.bidderRequestId));
+    request.push('auctionId=' + params.requestId);
     for (i = 1, l = globalParams.length; i < l; i++) {
       _key = globalParams[i][0];
       _value = globalParams[i][1];

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -29,7 +29,7 @@ describe('Adform adapter', () => {
       assert.equal(_query.tid, 145);
       assert.equal(_query.rp, 4);
       assert.equal(_query.fd, 1);
-      assert.equal(_query.auctionId, '1a2b3c');
+      assert.equal(_query.auctionId, '4db6ddaa-ec86-459e-99aa-f7ffe940c473');
       assert.equal(_query.url, encodeURIComponent('some// there'));
     });
 
@@ -119,6 +119,7 @@ describe('Adform adapter', () => {
     sandbox.stub(adLoader, 'loadScript');
     _adformAdapter.callBids({
       bidderRequestId: '1a2b3c',
+      requestId: '4db6ddaa-ec86-459e-99aa-f7ffe940c473',
       bids: [
         {
           bidId: 'abc',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
RequestId must be used as auctionId.

- contact email of the adapter’s maintainer
Scope.FL.Scripts@adform.com
- [x] official adapter submission


## Other information
Changing value of parameter, which was introduced in this [`PR`].(https://github.com/prebid/Prebid.js/pull/1888)