### PR TITLE
Bug fix to populate userSync default values

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -1,6 +1,16 @@
 import * as utils from 'src/utils';
 import { config } from 'src/config';
 
+// Set userSync default values
+config.setDefaults({
+  'userSync': {
+    syncEnabled: true,
+    pixelEnabled: true,
+    syncsPerBidder: 5,
+    syncDelay: 3000
+  }
+});
+
 /**
  * Factory function which creates a new UserSyncPool.
  *

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -6,6 +6,7 @@ const utils = require('src/utils');
 
 let getConfig;
 let setConfig;
+let setDefaults;
 
 describe('config API', () => {
   let logErrorSpy;
@@ -13,6 +14,7 @@ describe('config API', () => {
     const config = newConfig();
     getConfig = config.getConfig;
     setConfig = config.setConfig;
+    setDefaults = config.setDefaults;
     logErrorSpy = sinon.spy(utils, 'logError');
   });
 
@@ -86,12 +88,14 @@ describe('config API', () => {
   });
 
   it('gets default userSync config', () => {
-    expect(getConfig('userSync')).to.eql({
+    const DEFAULT_USERSYNC = {
       syncEnabled: true,
       pixelEnabled: true,
       syncsPerBidder: 5,
       syncDelay: 3000
-    });
+    };
+    setDefaults({'userSync': DEFAULT_USERSYNC});
+    expect(getConfig('userSync')).to.eql(DEFAULT_USERSYNC);
   });
 
   it('has subscribe functionality for adding listeners to config updates', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This PR fixes #1883 
It also includes `config.setDefaults` added by @snapwich in [Prebid Server Adapter committ](https://github.com/prebid/Prebid.js/pull/1846/commits/09089febaee1d1d6fd36b70c8623d9d535720ba1)
