### PR TITLE
Add BrightRoll bid adapter

### DIFF
--- a/modules/brightrollBidAdapter.js
+++ b/modules/brightrollBidAdapter.js
@@ -1,0 +1,72 @@
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import adaptermanager from 'src/adaptermanager';
+import * as utils from 'src/utils';
+import {STATUS} from 'src/constants';
+import {ajax} from 'src/ajax';
+
+const BRIGHTROLL_BIDDER_CODE = 'brightroll';
+
+const BrightRollBidAdapter = function BrightRollBidAdapter() {
+  let _protocol = (window.location.protocol === 'https:' ? 'https' : 'http') + '://';
+  function buildBidRequest(params) {
+    let provider = params.publisher;
+    let slot = params.slot;
+    let prebid = '&prebid=1';
+    let cacheBuster = '&n=' + new Date().getTime();
+    let isTest = params.test ? '&test=1' : '';
+    return `${_protocol}pmp.ybp.yahoo.com/bid/${provider}/adslot/${slot}/?${prebid}${isTest}${cacheBuster}`
+  }
+
+  function _callBids(params) {
+    let bids = params.bids || [];
+
+    bids.forEach((bid) => {
+      try {
+        ajax(buildBidRequest(bid.params), bidCallback, undefined, { withCredentials: false });
+      } catch (err) {
+        utils.logError('Error sending brightroll request for ad slot ' + bid.slot, null, err);
+      }
+
+      function bidCallback(responseText) {
+        try {
+          utils.logMessage('XHR callback function called for ad slot: ' + bid.slot);
+          handleResponse(responseText, bid);
+        } catch (err) {
+          if (typeof err === 'string') {
+            utils.logWarn(`${err} when processing brightroll response for ad slot ${bid.slot}`);
+          } else {
+            utils.logError('Error processing brightroll response for ad slot ' + bid.slot, null, err);
+          }
+          // indicate that there is no bid for this placement
+          let badBid = bidfactory.createBid(STATUS.NO_BID, bid);
+          badBid.bidderCode = bid.bidder;
+          badBid.error = err;
+          bidmanager.addBidResponse(bid.slot, badBid);
+        }
+      }
+
+      function handleResponse(responseText, bidRequest) {
+        let ad = JSON.parse(responseText);
+        if (!ad.requestId) { // no bid
+          throw 'NoBid';
+        }
+
+        let bid = bidfactory.createBid(STATUS.GOOD, bidRequest);
+        bid.creative_id = ad.creativeId;
+        bid.bidderCode = BRIGHTROLL_BIDDER_CODE;
+        bid.cpm = ad.cpm || 0;
+        bid.ad = `<html><script type="text/javascript" src="${ad.adm}"></script><html>`;
+        bid.width = ad.width;
+        bid.height = ad.height;
+        bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      }
+    });
+  }
+  return {
+    callBids: _callBids
+  };
+};
+
+adaptermanager.registerBidAdapter(new BrightRollBidAdapter(), BRIGHTROLL_BIDDER_CODE);
+module.exports = BrightRollBidAdapter;

--- a/modules/brightrollBidAdapter.js
+++ b/modules/brightrollBidAdapter.js
@@ -9,13 +9,14 @@ const BRIGHTROLL_BIDDER_CODE = 'brightroll';
 
 const BrightRollBidAdapter = function BrightRollBidAdapter() {
   let _protocol = (window.location.protocol === 'https:' ? 'https' : 'http') + '://';
+  let _host = 'pmp.ybp.yahoo.com';
   function buildBidRequest(params) {
     let provider = params.publisher;
     let slot = params.slot;
     let prebid = '&prebid=1';
     let cacheBuster = '&n=' + new Date().getTime();
     let isTest = params.test ? '&test=1' : '';
-    return `${_protocol}pmp.ybp.yahoo.com/bid/${provider}/adslot/${slot}/?${prebid}${isTest}${cacheBuster}`
+    return `${_protocol}${_host}/bid/${provider}/adslot/${slot}/?${prebid}${isTest}${cacheBuster}`
   }
 
   function _callBids(params) {

--- a/modules/brightrollBidAdapter.md
+++ b/modules/brightrollBidAdapter.md
@@ -1,0 +1,29 @@
+# Overview
+
+```
+Module Name:  BrightRoll Bidder Adapter
+Module Type:  Bidder Adapter
+Maintainer: mingsi@oath.com
+```
+
+# Description
+
+Connects to BrightRoll DSP+ for bids.
+
+BrightRoll bid adapter requires setup and approval from the DSP+ team. Please reach out to your account team for more information
+
+# Test Parameters
+```
+  var adUnits = [{
+    code: 'banner-ad-div',
+    sizes: [300, 250],
+    bids: [{
+    bidder: 'brightroll',
+      params: { 
+        publisher: '33across',
+        slot: 1,
+        test: true
+      }
+    }]
+  }];
+```

--- a/test/spec/modules/brightrollBidAdapter_spec.js
+++ b/test/spec/modules/brightrollBidAdapter_spec.js
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import Adapter from 'modules/brightrollBidAdapter';
+import adapterManager from 'src/adaptermanager';
+import bidManager from 'src/bidmanager';
+import CONSTANTS from 'src/constants.json';
+
+describe('brightroll adapter tests', function () {
+  let sandbox;
+  const adUnit = {
+    code: 'brightroll',
+    sizes: [[300, 250]],
+    bids: [{
+      bidder: 'brightroll',
+      params: {
+        test: true,
+        publisher: 'testPub',
+        slot: 1
+      }
+    }]
+  };
+
+  const response = {
+    requestId: 8119236875707151596,
+    cpm: 1.5,
+    adm: 'https://pr.ybp.yahoo.com/ab/secure/true/imp/grpThhPoq9w/wp/',
+    width: 300,
+    height: 250,
+    creativeId: '1001',
+    currency: 'USD'
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('brightroll callBids validation', () => {
+    let bids,
+      server;
+
+    beforeEach(() => {
+      bids = [];
+      server = sinon.fakeServer.create();
+
+      sandbox.stub(bidManager, 'addBidResponse', (elemId, bid) => {
+        bids.push(bid);
+      });
+    });
+
+    afterEach(() => {
+      server.restore();
+    });
+
+    let adapter = adapterManager.bidderRegistry['brightroll'];
+
+    it('Valid bid-request', () => {
+      sandbox.stub(adapter, 'callBids');
+      adapterManager.callBids({
+        adUnits: [clone(adUnit)]
+      });
+
+      let bidderRequest = adapter.callBids.getCall(0).args[0];
+
+      expect(bidderRequest).to.have.property('bids')
+        .that.is.an('array')
+        .with.lengthOf(1);
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .to.have.property('bidder', 'brightroll');
+
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('sizes')
+        .that.is.an('array')
+        .with.lengthOf(1)
+        .that.deep.equals(adUnit.sizes);
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('params')
+        .to.have.property('publisher', 'testPub');
+      expect(bidderRequest).to.have.deep.property('bids[0]')
+        .with.property('params')
+        .to.have.property('slot', 1);
+    });
+
+    it('Valid bid-response', () => {
+      server.respondWith(JSON.stringify(
+        response
+      ));
+      adapterManager.callBids({
+        adUnits: [clone(adUnit)]
+      });
+      server.respond();
+
+      expect(bids).to.be.lengthOf(1);
+      expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.GOOD);
+      expect(bids[0].bidderCode).to.equal('brightroll');
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].cpm).to.equal(1.5);
+    });
+
+    it('No Bid', () => {
+      server.respondWith('()');
+      adapterManager.callBids({
+        adUnits: [clone(adUnit)]
+      });
+      server.respond();
+      expect(bids).to.be.lengthOf(1);
+      expect(bids[0].getStatusCode()).to.equal(CONSTANTS.STATUS.NO_BID);
+    });
+  });
+});
+
+function clone(obj) {
+  try {
+    return JSON.parse(JSON.stringify(obj));
+  } catch (e) {
+    return {};
+  }
+}


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'brightroll',
  params: {
    test: true,
    publisher: '33across',
    slot: 1
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer  mingsi@oath.com
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
