### PR TITLE
Clarify ad unit media filtering warning

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -384,13 +384,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   adUnits.filter(videoAdUnit).filter(hasNonVideoBidder).forEach(adUnit => {
     const nonVideoBidders = adUnit.bids
       .filter(bid => !videoBidder(bid))
-      .map(bid => bid.bidder)
-      .join(', ');
+      .map(bid => bid.bidder);
 
-    utils.logWarn(`
-      ${adUnit.code} is a 'video' ad unit that contains non-video bidder(s): ${nonVideoBidders}.
-      Those bidders won't fetch demand.
-    `);
+    utils.logWarn(utils.unsupportedBidderMessage(adUnit, nonVideoBidders));
     adUnit.bids = adUnit.bids.filter(videoBidder);
   });
 
@@ -398,13 +394,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
   adUnits.filter(nativeAdUnit).filter(hasNonNativeBidder).forEach(adUnit => {
     const nonNativeBidders = adUnit.bids
       .filter(bid => !nativeBidder(bid))
-      .map(bid => bid.bidder)
-      .join(', ');
+      .map(bid => bid.bidder);
 
-    utils.logWarn(`
-      ${adUnit.code} is a 'native' ad unit that contains non-native bidder(s): ${nonNativeBidders}.
-      Those bidders won't fetch demand.
-    `);
+    utils.logWarn(utils.unsupportedBidderMessage(adUnit, nonNativeBidders));
     adUnit.bids = adUnit.bids.filter(nativeBidder);
   });
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -401,9 +401,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
       .map(bid => bid.bidder)
       .join(', ');
 
-    utils.logError(`
-      ${adUnit.code} is a 'native' ad unit but contains non-native bidder(s) ${nonNativeBidders}.
-      No Prebid demand requests will be triggered for those bidders.
+    utils.logWarn(`
+      ${adUnit.code} is a 'native' ad unit that contains non-native bidder(s): ${nonNativeBidders}.
+      Those bidders won't fetch demand.
     `);
     adUnit.bids = adUnit.bids.filter(nativeBidder);
   });

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -387,9 +387,9 @@ $$PREBID_GLOBAL$$.requestBids = function ({ bidsBackHandler, timeout, adUnits, a
       .map(bid => bid.bidder)
       .join(', ');
 
-    utils.logError(`
-      ${adUnit.code} is a 'video' ad unit but contains non-video bidder(s) ${nonVideoBidders}.
-      No Prebid demand requests will be triggered for those bidders.
+    utils.logWarn(`
+      ${adUnit.code} is a 'video' ad unit that contains non-video bidder(s): ${nonVideoBidders}.
+      Those bidders won't fetch demand.
     `);
     adUnit.bids = adUnit.bids.filter(videoBidder);
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -793,3 +793,20 @@ export function isValidMediaTypes(mediaTypes) {
 
   return true;
 }
+
+/**
+ * Constructs warning message for when unsupported bidders are dropped from an adunit
+ * @param {Object} adUnit ad unit from which the bidder is being dropped
+ * @param {Array} unSupportedBidders arrary of bidder codes that are not compatible with the adUnit
+ * @return {string} warning message to display when condition is met
+ */
+export function unsupportedBidderMessage(adUnit, unSupportedBidders) {
+  const mediaType = adUnit.mediaType || Object.keys(adUnit.mediaTypes).join(', ');
+  const plural = unSupportedBidders.length === 1 ? 'This bidder' : 'These bidders';
+
+  return `
+    ${adUnit.code} is a ${mediaType} ad unit
+    containing bidders that don't support ${mediaType}: ${unSupportedBidders.join(', ')}.
+    ${plural} won't fetch demand.
+  `;
+}


### PR DESCRIPTION
## Type of change
- Maintenance 

## Description of change
When unsupported bidders are dropped from an ad unit of a media type they don't work with, use a warning instead of an error and reword message to clarify situation