### PR TITLE
Remove config setting from Optimatic adapter

### DIFF
--- a/modules/optimaticBidAdapter.js
+++ b/modules/optimaticBidAdapter.js
@@ -1,5 +1,4 @@
 import * as utils from 'src/utils';
-import { config } from 'src/config';
 import { registerBidder } from 'src/adapters/bidderFactory';
 export const ENDPOINT = '//mg-bid.optimatic.com/adrequest/';
 

--- a/modules/optimaticBidAdapter.js
+++ b/modules/optimaticBidAdapter.js
@@ -97,5 +97,4 @@ function getData (bid) {
   };
 }
 
-config.setConfig({ usePrebidCache: true });
 registerBidder(spec);


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change.
Setting config values in adapter is not allowed. This can be done via `pbjs.setConfig` method on page.
Removed config setting from Optimatic adapter

## Other information
@optimatic58 
