### PR TITLE
Change clone function to make deep copies

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -130,7 +130,7 @@ function PrebidServer() {
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
     const isDebug = !!getConfig('debug');
-    const adUnits = utils.clone(bidRequest.ad_units);
+    const adUnits = utils.deepClone(bidRequest.ad_units);
     adUnits.forEach(adUnit => {
       let videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
       if (videoMediaType) {

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -130,7 +130,7 @@ function PrebidServer() {
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(bidRequest) {
     const isDebug = !!getConfig('debug');
-    const adUnits = utils.cloneJson(bidRequest.ad_units);
+    const adUnits = utils.clone(bidRequest.ad_units);
     adUnits.forEach(adUnit => {
       let videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
       if (videoMediaType) {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "dependencies": {
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
-    "gulp-sourcemaps": "^2.6.0"
+    "gulp-sourcemaps": "^2.6.0",
+    "just-clone": "^1.0.2"
   }
 }

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -118,7 +118,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
     bidderCodes = bidderCodes.filter((elm) => {
       return !adaptersServerSide.includes(elm) || clientTestAdapters.includes(elm);
     });
-    let adUnitsS2SCopy = utils.cloneJson(adUnits);
+    let adUnitsS2SCopy = utils.clone(adUnits);
 
     // filter out client side bids
     adUnitsS2SCopy.forEach((adUnit) => {
@@ -169,7 +169,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
 
   let _bidderRequests = [];
   // client side adapters
-  let adUnitsClientCopy = utils.cloneJson(adUnits);
+  let adUnitsClientCopy = utils.clone(adUnits);
   // filter out s2s bids
   adUnitsClientCopy.forEach((adUnit) => {
     adUnit.bids = adUnit.bids.filter((bid) => {

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -118,7 +118,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
     bidderCodes = bidderCodes.filter((elm) => {
       return !adaptersServerSide.includes(elm) || clientTestAdapters.includes(elm);
     });
-    let adUnitsS2SCopy = utils.clone(adUnits);
+    let adUnitsS2SCopy = utils.deepClone(adUnits);
 
     // filter out client side bids
     adUnitsS2SCopy.forEach((adUnit) => {
@@ -169,7 +169,7 @@ exports.callBids = ({adUnits, cbTimeout}) => {
 
   let _bidderRequests = [];
   // client side adapters
-  let adUnitsClientCopy = utils.clone(adUnits);
+  let adUnitsClientCopy = utils.deepClone(adUnits);
   // filter out s2s bids
   adUnitsClientCopy.forEach((adUnit) => {
     adUnit.bids = adUnit.bids.filter((bid) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import { config } from './config';
-import cloneDeep from 'just-clone';
+import clone from 'just-clone';
 var CONSTANTS = require('./constants');
 
 var _loggingChecked = false;
@@ -644,8 +644,8 @@ export function isSrcdocSupported(doc) {
     'srcdoc' in doc.defaultView.frameElement && !/firefox/i.test(navigator.userAgent);
 }
 
-export function clone(obj) {
-  return cloneDeep(obj);
+export function deepClone(obj) {
+  return clone(obj);
 }
 
 export function inIframe() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { config } from './config';
+import cloneDeep from 'just-clone';
 var CONSTANTS = require('./constants');
 
 var _loggingChecked = false;
@@ -643,8 +644,8 @@ export function isSrcdocSupported(doc) {
     'srcdoc' in doc.defaultView.frameElement && !/firefox/i.test(navigator.userAgent);
 }
 
-export function cloneJson(obj) {
-  return JSON.parse(JSON.stringify(obj));
+export function clone(obj) {
+  return cloneDeep(obj);
 }
 
 export function inIframe() {

--- a/test/spec/modules/carambolaBidAdapter_spec.js
+++ b/test/spec/modules/carambolaBidAdapter_spec.js
@@ -41,7 +41,7 @@ describe('carambolaAdapter', function () {
   beforeEach(() => adapter = new CarambolaAdapter());
 
   function createBidderRequest({bids, params} = {}) {
-    var bidderRequest = utils.cloneJson(DEFAULT_BIDDER_REQUEST);
+    var bidderRequest = utils.clone(DEFAULT_BIDDER_REQUEST);
     if (bids && Array.isArray(bids)) {
       bidderRequest.bids = bids;
     }

--- a/test/spec/modules/carambolaBidAdapter_spec.js
+++ b/test/spec/modules/carambolaBidAdapter_spec.js
@@ -41,7 +41,7 @@ describe('carambolaAdapter', function () {
   beforeEach(() => adapter = new CarambolaAdapter());
 
   function createBidderRequest({bids, params} = {}) {
-    var bidderRequest = utils.clone(DEFAULT_BIDDER_REQUEST);
+    var bidderRequest = utils.deepClone(DEFAULT_BIDDER_REQUEST);
     if (bids && Array.isArray(bids)) {
       bidderRequest.bids = bids;
     }

--- a/test/spec/modules/lifestreetBidAdapter_spec.js
+++ b/test/spec/modules/lifestreetBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {clone} from 'src/utils';
+import {deepClone} from 'src/utils';
 import adloader from 'src/adloader';
 import bidmanager from 'src/bidmanager';
 import LifestreetAdapter from 'modules/lifestreetBidAdapter';
@@ -44,7 +44,7 @@ describe('LifestreetAdapter', () => {
 
       beforeEach(() => {
         tagRequests = [];
-        request = clone(BIDDER_REQUEST);
+        request = deepClone(BIDDER_REQUEST);
         sinon.stub(adloader, 'loadScript', (url, callback) => {
           tagRequests.push(url);
           callback();

--- a/test/spec/modules/lifestreetBidAdapter_spec.js
+++ b/test/spec/modules/lifestreetBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {cloneJson} from 'src/utils';
+import {clone} from 'src/utils';
 import adloader from 'src/adloader';
 import bidmanager from 'src/bidmanager';
 import LifestreetAdapter from 'modules/lifestreetBidAdapter';
@@ -44,7 +44,7 @@ describe('LifestreetAdapter', () => {
 
       beforeEach(() => {
         tagRequests = [];
-        request = cloneJson(BIDDER_REQUEST);
+        request = clone(BIDDER_REQUEST);
         sinon.stub(adloader, 'loadScript', (url, callback) => {
           tagRequests.push(url);
           callback();

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import YieldbotAdapter from 'modules/yieldbotBidAdapter';
 import bidManager from 'src/bidmanager';
 import adLoader from 'src/adloader';
-import {clone} from 'src/utils';
+import {deepClone} from 'src/utils';
 
 const bidderRequest = {
   bidderCode: 'yieldbot',
@@ -132,7 +132,7 @@ function setupTest(testRequest, force = false) {
   bidManagerStub = sandbox.stub(bidManager, 'addBidResponse');
 
   const ybAdapter = new YieldbotAdapter();
-  let request = testRequest || clone(bidderRequest);
+  let request = testRequest || deepClone(bidderRequest);
   if ((this && !this.currentTest.parent.title.match(localSetupTestRegex)) || force === MAKE_BID_REQUEST) {
     ybAdapter.callBids(request);
     mockYieldbotBidRequest();
@@ -369,7 +369,7 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard');
 
       const refreshBids = localRequest.bids.filter((object) => { return object.placementCode === '/4294967296/adunit1'; });
-      let refreshRequest = clone(localRequest);
+      let refreshRequest = deepClone(localRequest);
       refreshRequest.bids = refreshBids;
       expect(refreshRequest.bids.length).to.equal(1);
 

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import YieldbotAdapter from 'modules/yieldbotBidAdapter';
 import bidManager from 'src/bidmanager';
 import adLoader from 'src/adloader';
-import {cloneJson} from 'src/utils';
+import {clone} from 'src/utils';
 
 const bidderRequest = {
   bidderCode: 'yieldbot',
@@ -132,7 +132,7 @@ function setupTest(testRequest, force = false) {
   bidManagerStub = sandbox.stub(bidManager, 'addBidResponse');
 
   const ybAdapter = new YieldbotAdapter();
-  let request = testRequest || cloneJson(bidderRequest);
+  let request = testRequest || clone(bidderRequest);
   if ((this && !this.currentTest.parent.title.match(localSetupTestRegex)) || force === MAKE_BID_REQUEST) {
     ybAdapter.callBids(request);
     mockYieldbotBidRequest();
@@ -369,7 +369,7 @@ describe('Yieldbot adapter tests', function() {
       sinon.assert.calledWith(yieldbotLibStub.defineSlot, 'leaderboard');
 
       const refreshBids = localRequest.bids.filter((object) => { return object.placementCode === '/4294967296/adunit1'; });
-      let refreshRequest = cloneJson(localRequest);
+      let refreshRequest = clone(localRequest);
       refreshRequest.bids = refreshBids;
       expect(refreshRequest.bids.length).to.equal(1);
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -690,4 +690,25 @@ describe('Utils', function () {
       });
     });
   });
+
+  describe('clone', () => {
+    it('deep copies objects', () => {
+      const adUnit = [{
+        code: 'swan',
+        mediaTypes: {video: {context: 'outstream'}},
+        renderer: {
+          render: bid => player.render(bid),
+          url: '/video/renderer.js'
+        },
+        bids: [{
+          bidder: 'dharmaInitiative',
+          params: { placementId: '481516', }
+        }],
+      }];
+
+      const adUnitCopy = utils.clone(adUnit);
+      expect(adUnitCopy[0].renderer.url).to.be.a('string');
+      expect(adUnitCopy[0].renderer.render).to.be.a('function');
+    });
+  });
 });

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -691,7 +691,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('clone', () => {
+  describe('deepClone', () => {
     it('deep copies objects', () => {
       const adUnit = [{
         code: 'swan',
@@ -706,7 +706,7 @@ describe('Utils', function () {
         }],
       }];
 
-      const adUnitCopy = utils.clone(adUnit);
+      const adUnitCopy = utils.deepClone(adUnit);
       expect(adUnitCopy[0].renderer.url).to.be.a('string');
       expect(adUnitCopy[0].renderer.render).to.be.a('function');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3819,6 +3819,12 @@ gulp-if@^2.0.2:
     ternary-stream "^2.0.1"
     through2 "^2.0.1"
 
+gulp-js-escape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-js-escape/-/gulp-js-escape-1.0.1.tgz#1cd445fbd009e0da76959a03a7f49b3566aff868"
+  dependencies:
+    through2 "^0.6.3"
+
 gulp-match@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/gulp-match/-/gulp-match-1.0.3.tgz#91c7c0d7f29becd6606d57d80a7f8776a87aba8e"
@@ -4836,6 +4842,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-clone@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/just-clone/-/just-clone-1.0.2.tgz#bfb3faef65aa12a316058712945c326fd8f01434"
 
 karma-babel-preprocessor@^6.0.1:
   version "6.0.1"
@@ -8029,7 +8039,7 @@ through2@^0.5.0:
     readable-stream "~1.0.17"
     xtend "~3.0.0"
 
-through2@^0.6.0, through2@^0.6.1, through2@^0.6.5:
+through2@^0.6.0, through2@^0.6.1, through2@^0.6.3, through2@^0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   dependencies:


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Changes `utils.cloneJson` to perform a deep copy. This resolves situations where functions on objects were not being copied by the utility. The utility function was also renamed to reflect the fact that it now does a full clone rather than parsing by JSON, which drops functions.

## Other information
Uses [`just-clone`](https://github.com/angus-c/just/tree/master/packages/collection-clone) library, which adds ~176 bytes to the production build

Fixes #1869 
Fixes #1878