### PR TITLE
Expose native image-type asset dimensions on bid response object

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -213,7 +213,15 @@ function newBid(serverBid, rtbBid) {
       cta: nativeAd.ctatext,
       sponsoredBy: nativeAd.sponsored,
       image: nativeAd.main_img && nativeAd.main_img.url,
+      imageSize: {
+        height: nativeAd.main_img && nativeAd.main_img.height,
+        width: nativeAd.main_img && nativeAd.main_img.width,
+      },
       icon: nativeAd.icon && nativeAd.icon.url,
+      iconSize: {
+        height: nativeAd.icon && nativeAd.icon.height,
+        width: nativeAd.icon && nativeAd.icon.width,
+      },
       clickUrl: nativeAd.link.url,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -212,13 +212,13 @@ function newBid(serverBid, rtbBid) {
       body: nativeAd.desc,
       cta: nativeAd.ctatext,
       sponsoredBy: nativeAd.sponsored,
-      image: nativeAd.main_img && nativeAd.main_img.url,
-      imageSize: {
+      image: {
+        url: nativeAd.main_img && nativeAd.main_img.url,
         height: nativeAd.main_img && nativeAd.main_img.height,
         width: nativeAd.main_img && nativeAd.main_img.width,
       },
-      icon: nativeAd.icon && nativeAd.icon.url,
-      iconSize: {
+      icon: {
+        url: nativeAd.icon && nativeAd.icon.url,
         height: nativeAd.icon && nativeAd.icon.height,
         width: nativeAd.icon && nativeAd.icon.width,
       },

--- a/src/native.js
+++ b/src/native.js
@@ -146,7 +146,13 @@ export function getNativeTargeting(bid) {
 
   Object.keys(bid['native']).forEach(asset => {
     const key = NATIVE_KEYS[asset];
-    const value = bid['native'][asset];
+    let value = bid['native'][asset];
+
+    // native image-type assets can be a string or an object with a url prop
+    if (typeof value === 'object' && value.url) {
+      value = value.url;
+    }
+
     if (key) {
       keyValues[key] = value;
     }

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -423,7 +423,7 @@ describe('AppNexusAdapter', () => {
       expect(result[0].native.title).to.equal('Native Creative');
       expect(result[0].native.body).to.equal('Cool description great stuff');
       expect(result[0].native.cta).to.equal('Do it');
-      expect(result[0].native.image).to.equal('http://cdn.adnxs.com/img.png');
+      expect(result[0].native.image.url).to.equal('http://cdn.adnxs.com/img.png');
     });
   });
 });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Currently if a native bidder returns an image-type asset (`image` or `icon`), the url for that asset is set to the `image` or `icon` property on the bid response `native` object:

```JavaScript
// in a bidder adapter's interpretResponse function...
bid['native'] = {
  title: serverResponse['native'].title,
  image: serverResponse['native'].img.url,
  icon: serverResponse['native'].icon.url,
};
// ...
```

If a native bidder also provides a width and height associated with an image-type asset, the bidder can now set those dimensions on the native bid response object using an object instead of a string:

```JavaScript
bid['native'] = {
  title: serverResponse['native'].title,
  image: {
    url: serverResponse['native'].img.url,
    height: serverResponse['native'].img.height,
    width: serverResponse['native'].img.width,
  },
  icon: serverResponse['native'].icon.url,
};
```

As the above example shows, setting `native.image` or `native.icon` to a url string will continue to work. The targeting key `hb_native_image` will be set with the value of `image.url` if `image` is an object, or the value of `image` if `image` is a string (and likewise for `hb_native_icon` / `icon`).