### PR TITLE
Remove description url

### DIFF
--- a/modules/admixerBidAdapter.js
+++ b/modules/admixerBidAdapter.js
@@ -62,7 +62,6 @@ var AdmixerAdapter = function AdmixerAdapter() {
       if (bid.vastUrl) {
         bidObject.mediaType = 'video';
         bidObject.vastUrl = bid.vastUrl;
-        bidObject.descriptionUrl = bid.vastUrl;
       } else {
         bidObject.ad = bid.ad;
       }

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -102,7 +102,6 @@ export const spec = {
           bid.ad = serverResponseOneItem.ad;
         } else if (serverResponseOneItem.vastUrl) {
           bid.vastUrl = serverResponseOneItem.vastUrl;
-          bid.descriptionUrl = serverResponseOneItem.vastUrl;
           bid.mediaType = 'video';
         } else if (serverResponseOneItem.nativeResponse) {
           bid.mediaType = 'native';

--- a/modules/aerservBidAdapter.js
+++ b/modules/aerservBidAdapter.js
@@ -33,7 +33,6 @@ const AerServAdapter = function AerServAdapter() {
       bid.height = response.h;
       if (bidRequest.mediaType === 'video') {
         bid.vastUrl = response.vastUrl;
-        bid.descriptionUrl = response.vastUrl;
         bid.mediaType = 'video';
       } else {
         bid.ad = response.adm;

--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -193,7 +193,6 @@ function newBid(serverBid, rtbBid) {
       width: rtbBid.rtb.video.player_width,
       height: rtbBid.rtb.video.player_height,
       vastUrl: rtbBid.rtb.video.asset_url,
-      descriptionUrl: rtbBid.rtb.video.asset_url,
       ttl: 3600
     });
     // This supports Outstream Video

--- a/modules/indexExchangeBidAdapter.js
+++ b/modules/indexExchangeBidAdapter.js
@@ -907,7 +907,6 @@ var IndexExchangeAdapter = function IndexExchangeAdapter() {
           bid.width = cygnusRequest.video.w;
           bid.height = cygnusRequest.video.h;
           bid.vastUrl = cygnusBid.ext.vasturl;
-          bid.descriptionUrl = cygnusBid.ext.vasturl;
           bid.mediaType = 'video';
 
           bidmanager.addBidResponse(prebidRequest.placementCode, bid);

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -273,7 +273,6 @@ export const spec = {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;
         bid.vastUrl = ad.creative_depot_url;
-        bid.descriptionUrl = ad.impression_id;
         bid.impression_id = ad.impression_id;
       } else {
         bid.ad = _renderCreative(ad.script, ad.impression_id);

--- a/modules/vertamediaBidAdapter.js
+++ b/modules/vertamediaBidAdapter.js
@@ -105,7 +105,6 @@ function getSize(requestSizes) {
 function createBid(bidResponse) {
   return {
     requestId: bidResponse.requestId,
-    descriptionUrl: bidResponse.url,
     creativeId: bidResponse.cmpId,
     vastUrl: bidResponse.vastUrl,
     height: bidResponse.height,

--- a/src/adserver.js
+++ b/src/adserver.js
@@ -31,7 +31,7 @@ exports.dfpAdserver = function (options, urlComponents) {
   adserver.appendQueryParams = function() {
     var bid = adserver.getWinningBidByCode();
     if (bid) {
-      this.urlComponents.search.description_url = encodeURIComponent(bid.descriptionUrl);
+      this.urlComponents.search.description_url = encodeURIComponent(bid.vastUrl);
       this.urlComponents.search.cust_params = getCustomParams(bid.adserverTargeting);
       this.urlComponents.search.correlator = Date.now();
     }

--- a/test/spec/modules/adxcgBidAdapter_spec.js
+++ b/test/spec/modules/adxcgBidAdapter_spec.js
@@ -218,7 +218,6 @@ describe('AdxcgAdapter', () => {
       expect(result[0].creativeId).to.equal(42);
       expect(result[0].cpm).to.equal(0.45);
       expect(result[0].vastUrl).to.equal('vastContentUrl');
-      expect(result[0].descriptionUrl).to.equal('vastContentUrl');
       expect(result[0].currency).to.equal('USD');
       expect(result[0].netRevenue).to.equal(true);
       expect(result[0].ttl).to.equal(300);

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -388,7 +388,6 @@ describe('AppNexusAdapter', () => {
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0]).to.have.property('vastUrl');
-      expect(result[0]).to.have.property('descriptionUrl');
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 

--- a/test/spec/modules/indexExchangeBidAdapter_video_spec.js
+++ b/test/spec/modules/indexExchangeBidAdapter_video_spec.js
@@ -8,7 +8,7 @@ const PREBID_REQUEST = { 'bidderCode': 'indexExchange', 'requestId': '6f4cb846-1
 
 const CYGNUS_REQUEST_R_PARAM = { 'id': '16940e979c42d4', 'imp': [{ 'id': '2f4e1cc0f992f2', 'ext': { 'siteID': 6, 'sid': 'pr_1_1_s' }, 'video': { 'protocols': [2, 5, 3, 6], 'maxduration': 15, 'minduration': 0, 'startdelay': 0, 'linearity': 1, 'mimes': ['video/mp4', 'video/webm'], 'w': 640, 'h': 480 } }], 'site': { 'page': 'http://localhost:9876/' }};
 
-const PREBID_RESPONSE = { 'bidderCode': 'indexExchange', 'width': 640, 'height': 480, 'statusMessage': 'Bid available', 'adId': '2f4e1cc0f992f2', 'code': 'indexExchange', 'cpm': 10, 'vastUrl': 'http://vast.url', 'descriptionUrl': 'http://vast.url' };
+const PREBID_RESPONSE = { 'bidderCode': 'indexExchange', 'width': 640, 'height': 480, 'statusMessage': 'Bid available', 'adId': '2f4e1cc0f992f2', 'code': 'indexExchange', 'cpm': 10, 'vastUrl': 'http://vast.url' };
 
 const CYGNUS_RESPONSE = { 'seatbid': [{ 'bid': [{ 'crid': '1', 'adomain': ['vastdsp.com'], 'adid': '1', 'impid': '2f4e1cc0f992f2', 'cid': '1', 'id': '1', 'ext': { 'vasturl': 'http://vast.url', 'errorurl': 'http://error.url', 'dspid': 1, 'pricelevel': '_1000', 'advbrandid': 75, 'advbrand': 'Nacho Momma' } }], 'seat': '1' }], 'cur': 'USD', 'id': '16940e979c42d4' };
 
@@ -944,7 +944,6 @@ describe('indexExchange adapter - Video', () => {
           expect(response).to.have.property('statusMessage', PREBID_RESPONSE.statusMessage);
           expect(response).to.have.property('cpm', PREBID_RESPONSE.cpm);
           expect(response).to.have.property('vastUrl', PREBID_RESPONSE.vastUrl);
-          expect(response).to.have.property('descriptionUrl', PREBID_RESPONSE.descriptionUrl);
           expect(response).to.have.property('width', PREBID_RESPONSE.width);
           expect(response).to.have.property('height', PREBID_RESPONSE.height);
         });

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -763,7 +763,6 @@ describe('the rubicon adapter', () => {
           expect(bids[0].cpm).to.equal(1);
           expect(bids[0].ttl).to.equal(300);
           expect(bids[0].netRevenue).to.equal(false);
-          expect(bids[0].descriptionUrl).to.equal('a40fe16e-d08d-46a9-869d-2e1573599e0c');
           expect(bids[0].vastUrl).to.equal(
             'https://fastlane-adv.rubiconproject.com/v1/creative/a40fe16e-d08d-46a9-869d-2e1573599e0c.xml'
           );

--- a/test/spec/modules/vertamediaBidAdapter_spec.js
+++ b/test/spec/modules/vertamediaBidAdapter_spec.js
@@ -19,7 +19,6 @@ const serverResponse = {
   'source': {'aid': 12345, 'pubId': 54321},
   'bids': [{
     'vastUrl': 'http://rtb.vertamedia.com/vast/?adid=44F2AEB9BFC881B3',
-    'descriptionUrl': '44F2AEB9BFC881B3',
     'requestId': '2e41f65424c87c',
     'url': '44F2AEB9BFC881B3',
     'creative_id': 342516,
@@ -86,7 +85,6 @@ describe('vertamediaBidAdapter', () => {
       const result = spec.interpretResponse({body: serverResponse}, {bidderRequest});
       const eq = [{
         vastUrl: 'http://rtb.vertamedia.com/vast/?adid=44F2AEB9BFC881B3',
-        descriptionUrl: '44F2AEB9BFC881B3',
         requestId: '2e41f65424c87c',
         creativeId: 342516,
         mediaType: 'video',

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1608,7 +1608,6 @@ describe('Unit: Prebid Module', function () {
           'creative_id': 29681110,
           'cpm': 10,
           'vastUrl': 'http://www.simplevideoad.com/',
-          'descriptionUrl': 'http://www.simplevideoad.com/',
           'responseTimestamp': 1462919239340,
           'requestTimestamp': 1462919238919,
           'bidder': 'appnexus',


### PR DESCRIPTION
## Type of change
- Maintenance

## Description of change
Video bidders no longer need to set a `descriptionUrl`, as they only need to return video content in the form of `vastUrl` or `vastXml`. This PR removes that field from video bid response objects. If Prebid needs to set a value for `description_url` in the DFP-specific case, it does so based on the value of either `vastUrl` or `vastXml` returned by the relevant bidder.