### PR TITLE
Huddlemass unit test IE bug fix

### DIFF
--- a/modules/huddledmassesBidAdapter.js
+++ b/modules/huddledmassesBidAdapter.js
@@ -70,7 +70,7 @@ export const spec = {
     let request = {
       'deviceWidth': winTop.screen.width,
       'deviceHeight': winTop.screen.height,
-      'language': navigator ? navigator.language : '',
+      'language': (navigator && navigator.language) ? navigator.language : '',
       'secure': location.protocol === 'https:' ? 1 : 0,
       'host': location.host,
       'page': location.pathname,


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Unit test fix for IE10. 
`navigator.language` is not supported in IE10