### PR TITLE
use same adUnits copy for s2s in callBids that we made in makeBidRequ…

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -180,6 +180,7 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
         auctionId,
         bidderRequestId,
         tid,
+        adUnitsS2SCopy,
         bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': adUnitsS2SCopy, labels}),
         auctionStart: auctionStart,
         timeout: _s2sConfig.timeout,
@@ -227,9 +228,10 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
     let adaptersServerSide = _s2sConfig.bidders;
     const s2sAdapter = _bidderRegistry[_s2sConfig.adapter];
     let tid = serverBidRequests[0].tid;
+    let adUnitsS2SCopy = serverBidRequests[0].adUnitsS2SCopy;
 
     if (s2sAdapter) {
-      let s2sBidRequest = {tid, 'ad_units': getAdUnitCopyForPrebidServer(adUnits)};
+      let s2sBidRequest = {tid, 'ad_units': adUnitsS2SCopy};
       if (s2sBidRequest.ad_units.length) {
         let doneCbs = serverBidRequests.map(bidRequest => {
           bidRequest.doneCbCallCount = 0;

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -126,6 +126,84 @@ describe('adapterManager tests', () => {
         'bidderRequestId': '2946b569352ef2',
         'tid': '34566b569352ef2',
         'src': 's2s',
+        'adUnitsS2SCopy': [
+          {
+            'code': '/19968336/header-bid-tag1',
+            'sizes': [
+              {
+                'w': 728,
+                'h': 90
+              },
+              {
+                'w': 970,
+                'h': 90
+              }
+            ],
+            'bids': [
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'placementId': '543221',
+                  'test': 'me'
+                },
+                'placementCode': '/19968336/header-bid-tag1',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ],
+                  [
+                    970,
+                    90
+                  ]
+                ],
+                'bidId': '68136e1c47023d',
+                'bidderRequestId': '55e24a66bed717',
+                'requestId': '1ff753bd4ae5cb',
+                'startTime': 1463510220995,
+                'status': 1,
+                'bid_id': '378a8914450b334'
+              }
+            ]
+          },
+          {
+            'code': '/19968336/header-bid-tag-0',
+            'sizes': [
+              {
+                'w': 300,
+                'h': 250
+              },
+              {
+                'w': 300,
+                'h': 600
+              }
+            ],
+            'bids': [
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'placementId': '5324321'
+                },
+                'placementCode': '/19968336/header-bid-tag-0',
+                'sizes': [
+                  [
+                    300,
+                    250
+                  ],
+                  [
+                    300,
+                    600
+                  ]
+                ],
+                'bidId': '7e5d6af25ed188',
+                'bidderRequestId': '55e24a66bed717',
+                'requestId': '1ff753bd4ae5cb',
+                'startTime': 1463510220996,
+                'bid_id': '387d9d9c32ca47c'
+              }
+            ]
+          }
+        ],
         'bids': [
           {
             'bidder': 'appnexus',
@@ -211,6 +289,84 @@ describe('adapterManager tests', () => {
         'bidderRequestId': '2946b569352ef2',
         'tid': '34566b569352ef2',
         'src': 's2s',
+        'adUnitsS2SCopy': [
+          {
+            'code': '/19968336/header-bid-tag1',
+            'sizes': [
+              {
+                'w': 728,
+                'h': 90
+              },
+              {
+                'w': 970,
+                'h': 90
+              }
+            ],
+            'bids': [
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'placementId': '543221',
+                  'test': 'me'
+                },
+                'placementCode': '/19968336/header-bid-tag1',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ],
+                  [
+                    970,
+                    90
+                  ]
+                ],
+                'bidId': '68136e1c47023d',
+                'bidderRequestId': '55e24a66bed717',
+                'requestId': '1ff753bd4ae5cb',
+                'startTime': 1463510220995,
+                'status': 1,
+                'bid_id': '378a8914450b334'
+              }
+            ]
+          },
+          {
+            'code': '/19968336/header-bid-tag-0',
+            'sizes': [
+              {
+                'w': 300,
+                'h': 250
+              },
+              {
+                'w': 300,
+                'h': 600
+              }
+            ],
+            'bids': [
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'placementId': '5324321'
+                },
+                'placementCode': '/19968336/header-bid-tag-0',
+                'sizes': [
+                  [
+                    300,
+                    250
+                  ],
+                  [
+                    300,
+                    600
+                  ]
+                ],
+                'bidId': '7e5d6af25ed188',
+                'bidderRequestId': '55e24a66bed717',
+                'requestId': '1ff753bd4ae5cb',
+                'startTime': 1463510220996,
+                'bid_id': '387d9d9c32ca47c'
+              }
+            ]
+          }
+        ],
         'bids': [
           {
             'bidder': 'appnexus',


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
attaches results of first call to `getAdUnitCopyForPrebidServer` to bidRequests so that it can be used in `callBids`.  This allows the `bid_id`s to remain unchanged.