### PR TITLE
XDomainRequest.send exception fix

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -98,7 +98,11 @@ export function ajaxBuilder(timeout = 3000) {
         }
         x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
       }
-      x.send(method === 'POST' && data);
+      if (method === 'POST' && data) {
+        x.send(data);
+      } else {
+        x.send();
+      }
     } catch (error) {
       utils.logError('xhr construction', error);
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Unwind one-liner function call to make parameters passing logic for  XDomainRequest( or XMLHttpRequest).send more explicit as at the moment it passes **false** for GET method and it causes an exception for XDomainRequest on IE9.

<!-- Describe the change proposed in this pull request -->

## Other information
#1941