### PR TITLE
Re-implemented RhythmOne audit beacon in prebid 1.0 interface

### DIFF
--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -11,6 +11,68 @@ function RhythmOneBidAdapter() {
     return true;
   };
 
+  this.getUserSyncs = function (syncOptions) {
+    let slots = [];
+    let placementIds = [];
+
+    for (let k in slotsToBids) {
+      slots.push(k);
+      placementIds.push(getFirstParam('placementId', [slotsToBids[k]]));
+    }
+
+    let data = {
+      doc_version: 1,
+      doc_type: 'Prebid Audit',
+      placement_id: placementIds.join(',').replace(/[,]+/g, ',').replace(/^,|,$/g, '')
+    };
+    let w = typeof (window) !== 'undefined' ? window : {document: {location: {href: ''}}};
+    let ao = w.document.location.ancestorOrigins;
+    let q = [];
+    let u = '//hbevents.1rx.io/audit?';
+
+    if (ao && ao.length > 0) {
+      data.ancestor_origins = ao[ao.length - 1];
+    }
+
+    data.popped = w.opener !== null ? 1 : 0;
+    data.framed = w.top === w ? 0 : 1;
+
+    try {
+      data.url = w.top.document.location.href.toString();
+    } catch (ex) {
+      data.url = w.document.location.href.toString();
+    }
+
+    try {
+      let prebid_instance = w.$$PREBID_GLOBAL$$;
+      data.prebid_version = prebid_instance.version;
+      data.prebid_timeout = prebid_instance.cbTimeout || config.getConfig('bidderTimeout');
+    } catch (ex) { }
+
+    data.response_ms = Date.now() - loadStart;
+    data.placement_codes = slots.join(',');
+    data.bidder_version = version;
+
+    for (let k in data) {
+      q.push(encodeURIComponent(k) + '=' + encodeURIComponent((typeof data[k] === 'object' ? JSON.stringify(data[k]) : data[k])));
+    }
+
+    q.sort();
+
+    if (syncOptions.pixelEnabled) {
+      return [{
+        type: 'image',
+        url: u + q.join('&')
+      }];
+    } else {
+      if (typeof (Image) !== 'undefined') {
+        let i = new Image();
+        i.src = u + q.join('&');
+      }
+      return [];
+    }
+  };
+
   function getFirstParam(key, validBidRequests) {
     for (let i = 0; i < validBidRequests.length; i++) {
       if (validBidRequests[i].params && validBidRequests[i].params[key]) {
@@ -22,6 +84,7 @@ function RhythmOneBidAdapter() {
   let slotsToBids = {};
   let that = this;
   let version = '1.0.0.0';
+  let loadStart = Date.now();
 
   this.buildRequests = function (BRs) {
     let fallbackPlacementId = getFirstParam('placementId', BRs);
@@ -29,13 +92,14 @@ function RhythmOneBidAdapter() {
       return [];
     }
 
+    loadStart = Date.now();
     slotsToBids = {};
 
     let query = [];
     let w = (typeof window !== 'undefined' ? window : {});
 
-    function p(k, v) {
-      if (v instanceof Array) { v = v.join(','); }
+    function p(k, v, d) {
+      if (v instanceof Array) { v = v.join((d || ',')); }
       if (typeof v !== 'undefined') { query.push(encodeURIComponent(k) + '=' + encodeURIComponent(v)); }
     }
 
@@ -98,8 +162,7 @@ function RhythmOneBidAdapter() {
             if ((new w.ActiveXObject('ShockwaveFlash.ShockwaveFlash'))) {
               return 1;
             }
-          } catch (e) {
-          }
+          } catch (e) { }
         }
 
         return 0;
@@ -186,12 +249,14 @@ function RhythmOneBidAdapter() {
 
       if (bidRequest.mediaTypes && bidRequest.mediaTypes.video) {
         bidResponse.vastUrl = bid.nurl;
+        bidResponse.mediaType = 'video';
         bidResponse.ttl = 10000;
       } else {
         bidResponse.ad = bid.adm;
       }
       bids.push(bidResponse);
     }
+
     return bids;
   };
 }

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -44,9 +44,8 @@ function RhythmOneBidAdapter() {
     }
 
     try {
-      let prebid_instance = w.$$PREBID_GLOBAL$$;
-      data.prebid_version = prebid_instance.version;
-      data.prebid_timeout = prebid_instance.cbTimeout || config.getConfig('bidderTimeout');
+      data.prebid_version = '$prebid.version$';
+      data.prebid_timeout = config.getConfig('bidderTimeout');
     } catch (ex) { }
 
     data.response_ms = Date.now() - loadStart;

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -63,12 +63,6 @@ function RhythmOneBidAdapter() {
         type: 'image',
         url: u + q.join('&')
       }];
-    } else {
-      if (typeof (Image) !== 'undefined') {
-        let i = new Image();
-        i.src = u + q.join('&');
-      }
-      return [];
     }
   };
 

--- a/test/spec/modules/rhythmoneBidAdapter_spec.js
+++ b/test/spec/modules/rhythmoneBidAdapter_spec.js
@@ -2,6 +2,16 @@ import {spec} from '../../../modules/rhythmoneBidAdapter';
 var assert = require('assert');
 
 describe('rhythmone adapter tests', function () {
+  describe('auditBeacon', function() {
+    var z = spec;
+    var beaconURL = z.getUserSyncs({pixelEnabled: true})[0];
+
+    it('should contain the correct path', function() {
+      var u = '//hbevents.1rx.io/audit?'
+      assert.equal(beaconURL.url.substring(0, u.length), u);
+    });
+  });
+
   describe('rhythmoneResponse', function () {
     var z = spec;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Re-implemented our fraud audit beacon in the 1.0 adapter.  This beacon was present in the previous versions of rhythm one's bidder, but was removed for the sake of expediting the 1.0 version changes.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
    {
      bidder: 'rhythmone',
      params: 
      { 
        placementId: '411806',
        endpoint: "//tag.1rx.io/rmp/72721/0/mvo?z=1r" // only required for testing.  this api guarantees no 204 responses
      }
    }
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->