### PR TITLE
+ fixed a minor bug in Optimatic Bid Adapter related to request property names

### DIFF
--- a/modules/optimaticBidAdapter.js
+++ b/modules/optimaticBidAdapter.js
@@ -75,8 +75,8 @@ function getData (bid) {
       bidfloor: bid.params.bidfloor,
       video: {
         mimes: ['video/mp4', 'video/ogg', 'video/webm', 'video/x-flv', 'application/javascript', 'application/x-shockwave-flash'],
-        width: size.width,
-        height: size.height
+        w: size.width,
+        h: size.height
       }
     }],
     site: {

--- a/test/spec/modules/optimaticBidAdapter_spec.js
+++ b/test/spec/modules/optimaticBidAdapter_spec.js
@@ -66,8 +66,8 @@ describe('OptimaticBidAdapter', () => {
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
       const [ width, height ] = bidRequest.sizes;
-      expect(data.imp[0].video.width).to.equal(width);
-      expect(data.imp[0].video.height).to.equal(height);
+      expect(data.imp[0].video.w).to.equal(width);
+      expect(data.imp[0].video.h).to.equal(height);
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
     });
 
@@ -77,8 +77,8 @@ describe('OptimaticBidAdapter', () => {
       bidRequest.sizes = [[ width, height ]];
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
-      expect(data.imp[0].video.width).to.equal(width);
-      expect(data.imp[0].video.height).to.equal(height);
+      expect(data.imp[0].video.w).to.equal(width);
+      expect(data.imp[0].video.h).to.equal(height);
     });
 
     it('must parse bid size from a string', () => {
@@ -87,16 +87,16 @@ describe('OptimaticBidAdapter', () => {
       bidRequest.sizes = `${width}x${height}`;
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
-      expect(data.imp[0].video.width).to.equal(width);
-      expect(data.imp[0].video.height).to.equal(height);
+      expect(data.imp[0].video.w).to.equal(width);
+      expect(data.imp[0].video.h).to.equal(height);
     });
 
     it('must handle an empty bid size', () => {
       bidRequest.sizes = [];
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
-      expect(data.imp[0].video.width).to.equal(undefined);
-      expect(data.imp[0].video.height).to.equal(undefined);
+      expect(data.imp[0].video.w).to.equal(undefined);
+      expect(data.imp[0].video.h).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
- updated endpoint request data property names (width to w, height to h) as required by the service

- contact email of the adapter’s maintainer
prebid@optimatic.com
- [x] official adapter submission
