### PR TITLE
uncommenting utils_spec cookie tests, because no longer supporting IE…

### DIFF
--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -525,94 +525,89 @@ describe('Utils', function () {
     });
   });
 
-  /**
-   *  tests fail in IE10 because __lookupSetter__ and __lookupGetter__ are
-   *  not supported. See #1656. commenting out until they can be fixed.
-   *
-   *  describe('cookie support', function () {
-   *    // store original cookie getter and setter so we can reset later
-   *    var origCookieSetter = document.__lookupSetter__('cookie');
-   *    var origCookieGetter = document.__lookupGetter__('cookie');
-   *
-   *    // store original cookieEnabled getter and setter so we can reset later
-   *    var origCookieEnabledSetter = window.navigator.__lookupSetter__('cookieEnabled');
-   *    var origCookieEnabledGetter = window.navigator.__lookupGetter__('cookieEnabled');
-   *
-   *    // Replace the document cookie set function with the output of a custom function for testing
-   *    let setCookie = (v) => v;
-   *
-   *    beforeEach(() => {
-   *      // Redefine window.navigator.cookieEnabled such that you can set otherwise "read-only" values
-   *      Object.defineProperty(window.navigator, 'cookieEnabled', (function (_value) {
-   *        return {
-   *          get: function _get() {
-   *            return _value;
-   *          },
-   *          set: function _set(v) {
-   *            _value = v;
-   *          },
-   *          configurable: true
-   *        };
-   *      })(window.navigator.cookieEnabled));
-   *
-   *      // Reset the setCookie cookie function before each test
-   *      setCookie = (v) => v;
-   *      // Redefine the document.cookie object such that you can purposefully have it output nothing as if it is disabled
-   *      Object.defineProperty(window.document, 'cookie', (function (_value) {
-   *        return {
-   *          get: function _get() {
-   *            return _value;
-   *          },
-   *          set: function _set(v) {
-   *            _value = setCookie(v);
-   *          },
-   *          configurable: true
-   *        };
-   *      })(window.navigator.cookieEnabled));
-   *    });
-   *
-   *    afterEach(() => {
-   *      // redefine window.navigator.cookieEnabled to original getter and setter
-   *      Object.defineProperty(window.navigator, 'cookieEnabled', {
-   *        get: origCookieEnabledGetter,
-   *        set: origCookieEnabledSetter,
-   *        configurable: true
-   *      });
-   *      // redefine document.cookie to original getter and setter
-   *      Object.defineProperty(document, 'cookie', {
-   *        get: origCookieGetter,
-   *        set: origCookieSetter,
-   *        configurable: true
-   *      });
-   *    });
-   *
-   *    it('should be detected', function() {
-   *      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should be enabled by default');
-   *    });
-   *
-   *    it('should be not available', function() {
-   *      setCookie = () => '';
-   *      window.navigator.cookieEnabled = false;
-   *      window.document.cookie = '';
-   *      assert.equal(utils.cookiesAreEnabled(), false, 'Cookies should be disabled');
-   *    });
-   *
-   *    it('should be available', function() {
-   *      window.navigator.cookieEnabled = false;
-   *      window.document.cookie = 'key=value';
-   *      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should already be set');
-   *      window.navigator.cookieEnabled = false;
-   *      window.document.cookie = '';
-   *      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should settable');
-   *      setCookie = () => '';
-   *      window.navigator.cookieEnabled = true;
-   *      window.document.cookie = '';
-   *      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should be on via on window.navigator');
-   *      // Reset the setCookie
-   *      setCookie = (v) => v;
-   *    });
-   *  });
-  **/
+  describe('cookie support', function () {
+    // store original cookie getter and setter so we can reset later
+    var origCookieSetter = document.__lookupSetter__('cookie');
+    var origCookieGetter = document.__lookupGetter__('cookie');
+
+    // store original cookieEnabled getter and setter so we can reset later
+    var origCookieEnabledSetter = window.navigator.__lookupSetter__('cookieEnabled');
+    var origCookieEnabledGetter = window.navigator.__lookupGetter__('cookieEnabled');
+
+    // Replace the document cookie set function with the output of a custom function for testing
+    let setCookie = (v) => v;
+
+    beforeEach(() => {
+      // Redefine window.navigator.cookieEnabled such that you can set otherwise "read-only" values
+      Object.defineProperty(window.navigator, 'cookieEnabled', (function (_value) {
+        return {
+          get: function _get() {
+            return _value;
+          },
+          set: function _set(v) {
+            _value = v;
+          },
+          configurable: true
+        };
+      })(window.navigator.cookieEnabled));
+
+      // Reset the setCookie cookie function before each test
+      setCookie = (v) => v;
+      // Redefine the document.cookie object such that you can purposefully have it output nothing as if it is disabled
+      Object.defineProperty(window.document, 'cookie', (function (_value) {
+        return {
+          get: function _get() {
+            return _value;
+          },
+          set: function _set(v) {
+            _value = setCookie(v);
+          },
+          configurable: true
+        };
+      })(window.navigator.cookieEnabled));
+    });
+
+    afterEach(() => {
+      // redefine window.navigator.cookieEnabled to original getter and setter
+      Object.defineProperty(window.navigator, 'cookieEnabled', {
+        get: origCookieEnabledGetter,
+        set: origCookieEnabledSetter,
+        configurable: true
+      });
+      // redefine document.cookie to original getter and setter
+      Object.defineProperty(document, 'cookie', {
+        get: origCookieGetter,
+        set: origCookieSetter,
+        configurable: true
+      });
+    });
+
+    it('should be detected', function() {
+      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should be enabled by default');
+    });
+
+    it('should be not available', function() {
+      setCookie = () => '';
+      window.navigator.cookieEnabled = false;
+      window.document.cookie = '';
+      assert.equal(utils.cookiesAreEnabled(), false, 'Cookies should be disabled');
+    });
+
+    it('should be available', function() {
+      window.navigator.cookieEnabled = false;
+      window.document.cookie = 'key=value';
+      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should already be set');
+      window.navigator.cookieEnabled = false;
+      window.document.cookie = '';
+      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should settable');
+      setCookie = () => '';
+      window.navigator.cookieEnabled = true;
+      window.document.cookie = '';
+      assert.equal(utils.cookiesAreEnabled(), true, 'Cookies should be on via on window.navigator');
+      // Reset the setCookie
+      setCookie = (v) => v;
+    });
+  });
 
   describe('delayExecution', function () {
     it('should execute the core function after the correct number of calls', function () {


### PR DESCRIPTION
… 10, where they broke

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
Because Prebid is no longer supporting IE 10, uncommenting utils_spec cookie tests that had been failing in IE 10.
