### PR TITLE
multiformat size validation checks

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -216,20 +216,24 @@ function newBid(serverBid, rtbBid) {
       body: nativeAd.desc,
       cta: nativeAd.ctatext,
       sponsoredBy: nativeAd.sponsored,
-      image: {
-        url: nativeAd.main_img && nativeAd.main_img.url,
-        height: nativeAd.main_img && nativeAd.main_img.height,
-        width: nativeAd.main_img && nativeAd.main_img.width,
-      },
-      icon: {
-        url: nativeAd.icon && nativeAd.icon.url,
-        height: nativeAd.icon && nativeAd.icon.height,
-        width: nativeAd.icon && nativeAd.icon.width,
-      },
       clickUrl: nativeAd.link.url,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,
     };
+    if (nativeAd.main_img) {
+      bid['native'].image = {
+        url: nativeAd.main_img.url,
+        height: nativeAd.main_img.height,
+        width: nativeAd.main_img.width,
+      };
+    }
+    if (nativeAd.icon) {
+      bid['native'].icon = {
+        url: nativeAd.icon.url,
+        height: nativeAd.icon.height,
+        width: nativeAd.icon.width,
+      };
+    }
   } else {
     Object.assign(bid, {
       width: rtbBid.rtb.banner.width,

--- a/src/native.js
+++ b/src/native.js
@@ -85,6 +85,18 @@ export function nativeBidIsValid(bid, bidRequests) {
     return false;
   }
 
+  if (deepAccess(bid, 'native.image')) {
+    if (!deepAccess(bid, 'native.image.height') || !deepAccess(bid, 'native.image.width')) {
+      return false;
+    }
+  }
+
+  if (deepAccess(bid, 'native.icon')) {
+    if (!deepAccess(bid, 'native.icon.height') || !deepAccess(bid, 'native.icon.width')) {
+      return false;
+    }
+  }
+
   const requestedAssets = bidRequest.nativeParams;
   if (!requestedAssets) {
     return true;

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { fireNativeTrackers, getNativeTargeting } from 'src/native';
+import { fireNativeTrackers, getNativeTargeting, nativeBidIsValid } from 'src/native';
 const utils = require('src/utils');
 
 const bid = {
@@ -42,5 +42,115 @@ describe('native.js', () => {
     fireNativeTrackers({ action: 'click' }, bid);
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
+  });
+});
+
+describe('validate native', () => {
+  let bidReq = [{
+    bids: [{
+      bidderCode: 'test_bidder',
+      bidId: 'test_bid_id',
+      mediaTypes: {
+        native: {
+          title: {
+            required: true,
+          },
+          body: {
+            required: true,
+          },
+          image: {
+            required: true,
+            sizes: [150, 50],
+            aspect_ratios: [150, 50]
+          },
+          icon: {
+            required: true,
+            sizes: [50, 50]
+          },
+        }
+      }
+    }]
+  }];
+
+  let validBid = {
+    adId: 'test_bid_id',
+    adUnitCode: '123/prebid_native_adunit',
+    bidder: 'test_bidder',
+    native: {
+      body: 'This is a Prebid Native Creative. There are many like it, but this one is mine.',
+      clickTrackers: ['http://my.click.tracker/url'],
+      icon: {
+        url: 'http://my.image.file/ad_image.jpg',
+        height: 75,
+        width: 75
+      },
+      image: {
+        url: 'http://my.icon.file/ad_icon.jpg',
+        height: 2250,
+        width: 3000
+      },
+      clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
+      impressionTrackers: ['http://my.imp.tracker/url'],
+      title: 'This is an example Prebid Native creative'
+    }
+  };
+
+  let noIconDimBid = {
+    adId: 'test_bid_id',
+    adUnitCode: '123/prebid_native_adunit',
+    bidder: 'test_bidder',
+    native: {
+      body: 'This is a Prebid Native Creative. There are many like it, but this one is mine.',
+      clickTrackers: ['http://my.click.tracker/url'],
+      icon: {
+        url: 'http://my.image.file/ad_image.jpg',
+        height: 0,
+        width: 0
+      },
+      image: {
+        url: 'http://my.icon.file/ad_icon.jpg',
+        height: 2250,
+        width: 3000
+      },
+      clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
+      impressionTrackers: ['http://my.imp.tracker/url'],
+      title: 'This is an example Prebid Native creative'
+    }
+  };
+
+  let noImgDimBid = {
+    adId: 'test_bid_id',
+    adUnitCode: '123/prebid_native_adunit',
+    bidder: 'test_bidder',
+    native: {
+      body: 'This is a Prebid Native Creative. There are many like it, but this one is mine.',
+      clickTrackers: ['http://my.click.tracker/url'],
+      icon: {
+        url: 'http://my.image.file/ad_image.jpg',
+        height: 75,
+        width: 75
+      },
+      image: {
+        url: 'http://my.icon.file/ad_icon.jpg',
+        height: 0,
+        width: 0
+      },
+      clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
+      impressionTrackers: ['http://my.imp.tracker/url'],
+      title: 'This is an example Prebid Native creative'
+    }
+  };
+
+  beforeEach(() => {});
+
+  afterEach(() => {});
+
+  it('should reject bid if no image sizes are defined', () => {
+    let result = nativeBidIsValid(validBid, bidReq);
+    expect(result).to.be.true;
+    result = nativeBidIsValid(noIconDimBid, bidReq);
+    expect(result).to.be.false;
+    result = nativeBidIsValid(noImgDimBid, bidReq);
+    expect(result).to.be.false;
   });
 });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import AdapterManager from 'src/adaptermanager';
+import { checkBidRequestSizes } from 'src/adaptermanager';
 import { getAdUnits } from 'test/fixtures/fixtures';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils';
@@ -814,6 +815,193 @@ describe('adapterManager tests', () => {
           expect(bidRequests[0].bids[0].adUnitCode).to.equal(adUnits[1].code);
         });
       })
+    });
+  });
+
+  describe('isValidBidRequest', () => {
+    describe('positive tests for validating bid request', () => {
+      beforeEach(() => {});
+
+      afterEach(() => {});
+      it('should main adUnit structure and adUnits.sizes is replaced', () => {
+        let fullAdUnit = [{
+          sizes: [[300, 250], [300, 600]],
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250]]
+            },
+            video: {
+              playerSize: [640, 480]
+            },
+            native: {
+              image: {
+                sizes: [150, 150],
+                aspect_ratios: [140, 140]
+              },
+              icon: {
+                sizes: [75, 75]
+              }
+            }
+          }
+        }];
+        let result = checkBidRequestSizes(fullAdUnit);
+        expect(result[0].sizes).to.deep.equal([640, 480]);
+        expect(result[0].mediaTypes.video.playerSize).to.deep.equal([640, 480]);
+        expect(result[0].mediaTypes.native.image.sizes).to.deep.equal([150, 150]);
+        expect(result[0].mediaTypes.native.icon.sizes).to.deep.equal([75, 75]);
+        expect(result[0].mediaTypes.native.image.aspect_ratios).to.deep.equal([140, 140]);
+
+        let noOptnlFieldAdUnit = [{
+          sizes: [[300, 250], [300, 600]],
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250]]
+            },
+            video: {
+              context: 'outstream'
+            },
+            native: {
+              image: {
+                required: true
+              },
+              icon: {
+                required: true
+              }
+            }
+          }
+        }];
+        result = checkBidRequestSizes(noOptnlFieldAdUnit);
+        expect(result[0].sizes).to.deep.equal([[300, 250]]);
+        expect(result[0].mediaTypes.video).to.exist;
+
+        let mixedAdUnit = [{
+          sizes: [[300, 250], [300, 600]],
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [400, 350]
+            },
+            native: {
+              image: {
+                aspect_ratios: [200, 150],
+                required: true
+              }
+            }
+          }
+        }];
+        result = checkBidRequestSizes(mixedAdUnit);
+        expect(result[0].sizes).to.deep.equal([400, 350]);
+        expect(result[0].mediaTypes.video).to.exist;
+      });
+    });
+
+    describe('negative tests for validating bid requests', () => {
+      beforeEach(() => {
+        sinon.stub(utils, 'logError');
+      });
+
+      afterEach(() => {
+        utils.logError.restore();
+      });
+
+      it('should throw error message and delete an object/property', () => {
+        let badBanner = [{
+          sizes: [[300, 250], [300, 600]],
+          mediaTypes: {
+            banner: {
+              name: 'test'
+            }
+          }
+        }];
+        let result = checkBidRequestSizes(badBanner);
+        expect(result[0].sizes).to.deep.equal([[300, 250], [300, 600]]);
+        expect(result[0].mediaTypes.banner).to.be.undefined;
+        sinon.assert.called(utils.logError);
+
+        let badVideo1 = [{
+          sizes: [[600, 600]],
+          mediaTypes: {
+            video: {
+              playerSize: '600x400'
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badVideo1);
+        expect(result[0].sizes).to.deep.equal([[600, 600]]);
+        expect(result[0].mediaTypes.video.playerSize).to.be.undefined;
+        expect(result[0].mediaTypes.video).to.exist;
+        sinon.assert.called(utils.logError);
+
+        let badVideo2 = [{
+          sizes: [[600, 600]],
+          mediaTypes: {
+            video: {
+              playerSize: ['300', '200']
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badVideo2);
+        expect(result[0].sizes).to.deep.equal([[600, 600]]);
+        expect(result[0].mediaTypes.video.playerSize).to.be.undefined;
+        expect(result[0].mediaTypes.video).to.exist;
+        sinon.assert.called(utils.logError);
+
+        let badVideo3 = [{
+          sizes: [[600, 600]],
+          mediaTypes: {
+            video: {
+              playerSize: [[640, 480]]
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badVideo3);
+        expect(result[0].sizes).to.deep.equal([[600, 600]]);
+        expect(result[0].mediaTypes.video.playerSize).to.be.undefined;
+        expect(result[0].mediaTypes.video).to.exist;
+        sinon.assert.called(utils.logError);
+
+        let badNativeImgSize = [{
+          mediaTypes: {
+            native: {
+              image: {
+                sizes: '300x250'
+              }
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badNativeImgSize);
+        expect(result[0].mediaTypes.native.image.sizes).to.be.undefined;
+        expect(result[0].mediaTypes.native.image).to.exist;
+        sinon.assert.called(utils.logError);
+
+        let badNativeImgAspRat = [{
+          mediaTypes: {
+            native: {
+              image: {
+                aspect_ratios: '300x250'
+              }
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badNativeImgAspRat);
+        expect(result[0].mediaTypes.native.image.aspect_ratios).to.be.undefined;
+        expect(result[0].mediaTypes.native.image).to.exist;
+        sinon.assert.called(utils.logError);
+
+        let badNativeIcon = [{
+          mediaTypes: {
+            native: {
+              icon: {
+                sizes: '300x250'
+              }
+            }
+          }
+        }];
+        result = checkBidRequestSizes(badNativeIcon);
+        expect(result[0].mediaTypes.native.icon.sizes).to.be.undefined;
+        expect(result[0].mediaTypes.native.icon).to.exist;
+        sinon.assert.called(utils.logError);
+      });
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add new checks to validate/support declaring size attributes within the mediaType.banner|video|native objects and using these values in place of the `adUnits.sizes` value.  Summary of changes/expected usage (for testing) for each mediaType is listed below:

- `mediaTypes.banner.sizes` accepts an array of sizes (either `[300, 250]` or `[[300, 250],[300, 600]]`).  If the `mediaTypes.banner` object is present, but sizes is left out - the `banner` object gets rejected and is removed from the request.  At this point, the request would fall back to original behavior (where it assumes a request with no mediaTypes object is a banner); note it will use the `adUnits.sizes` value in this case.  As an additional note - banner width/height sizes must be defined within the bid response object.  This validation already exists within the bidderFactory.js file, so no additional changes were made in support of this requirement.

- `mediaTypes.video.playerSize` accepts a single array for the WxH of the player (ie `[640, 480]`).  This is an optional field for the `mediaTypes.video` object, but when it's declared it can **only** contain one size.  If this setting is present, this size will replace the original `adUnits.sizes` to ensure the player ignores the original value.  If the playerSize is misconfigured, we will reject the `mediaTypes.video.playerSize` attribute from the request (the rest of the `video` object remains).  We are not validating video bid response to have a defined width/height.

- `mediaTypes.native.image.sizes` and/or `mediaTypes.native.image.aspect_ratios` each accept an array of sizes (either single or multiple like banner).  Either of these attributes can be present, both can be present, or neither can be present within the `mediaTypes.native.image` object.  If they are present, we are simply validating they are using an array declaration.  If they are not configured correctly, then the `mediaTypes.native.image.sizes|aspect_ratios` attribute is removed from the request (the rest of the `native.image` object remains).  

- `mediaTypes.native.icon.sizes` can accept an array of sizes (either single or multiple).  This is an optional field.  The same logic done for the `mediaTypes.native.image` applies here as well.  

- For both `mediaTypes.native.image` and `mediaTypes.native.icon` objects, we are validating the bid response has a corresponding defined height/width (if the image/icon objects exists).  If the dimensions are not present in the supplied object, the bid is rejected.  Currently the value in `adUnits.sizes` is supplied in the request, but it's basically ignored in the subsequent bid response.  This functionality hasn't been altered.

- Added a deprecation warning message when the `adUnits.sizes` field is defined/used in the original request object.  The message currently states:
Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).

## Other information
RAD-1954 and related sub-tasks for original requirements.

  