### PR TITLE
Adomik Analytics bugfix: use auctionId instead of requestId

### DIFF
--- a/modules/adomikAnalyticsAdapter.js
+++ b/modules/adomikAnalyticsAdapter.js
@@ -20,7 +20,7 @@ let adomikAdapter = Object.assign(adapter({}),
     track({ eventType, args }) {
       switch (eventType) {
         case auctionInit:
-          adomikAdapter.currentContext.id = args.requestId
+          adomikAdapter.currentContext.id = args.auctionId
           adomikAdapter.currentContext.timeout = args.timeout
           if (args.config.bidwonTimeout !== undefined && typeof args.config.bidwonTimeout === 'number') {
             bidwonTimeout = args.config.bidwonTimeout;

--- a/test/spec/modules/adomikAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adomikAnalyticsAdapter_spec.js
@@ -33,7 +33,7 @@ describe('Adomik Prebid Analytic', function () {
         height: 10,
         statusMessage: 'Bid available',
         adId: '1234',
-        requestId: '',
+        auctionId: '',
         responseTimestamp: 1496410856397,
         requestTimestamp: 1496410856295,
         cpm: 0.1,
@@ -58,7 +58,7 @@ describe('Adomik Prebid Analytic', function () {
       });
 
       // Step 1: Send init auction event
-      events.emit(constants.EVENTS.AUCTION_INIT, {config: initOptions, requestId: 'test-test-test', timeout: 3000});
+      events.emit(constants.EVENTS.AUCTION_INIT, {config: initOptions, auctionId: 'test-test-test', timeout: 3000});
 
       expect(adomikAnalytics.currentContext).to.deep.equal({
         uid: '123456',


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
In 1.0 we are using `auctionId` and not `requestId`

## Other information
@Yann-Pravo 
