### PR TITLE
Remove duplicate request id and fix empty response from getHighesCpmBids, getAdserverTargeting

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -60,7 +60,7 @@ export const spec = {
       const secure = isPageSecure || (utils.getBidIdParameter('secure', bid.params) ? 1 : 0);
 
       siteId = utils.getBidIdParameter('site_id', bid.params);
-      requestId = bid.requestId;
+      requestId = bid.auctionId;
 
       const format = convertSizes(bid.sizes);
 

--- a/modules/mobfoxBidAdapter.js
+++ b/modules/mobfoxBidAdapter.js
@@ -9,7 +9,7 @@ export const spec = {
   code: BIDDER_CODE,
   aliases: ['mf'], // short code
   isBidRequestValid: function (bid) {
-    return bid.params.s !== null && bid.params.s !== undefined && bid.requestId !== null && bid.requestId !== undefined;
+    return bid.params.s !== null && bid.params.s !== undefined;
   },
   buildRequests: function (validBidRequests) {
     if (validBidRequests.length > 1) {

--- a/src/auction.js
+++ b/src/auction.js
@@ -268,7 +268,6 @@ function getPreparedBidForAuction({adUnitCode, bid, bidRequests, auctionId}) {
 
   let bidObject = Object.assign({}, bid, {
     auctionId,
-    requestId: bidRequest.requestId,
     responseTimestamp: timestamp(),
     requestTimestamp: start,
     cpm: parseFloat(bid.cpm) || 0,

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,7 +1,7 @@
 /** @module pbjs */
 
 import { getGlobal } from './prebidGlobal';
-import { flatten, uniques, isGptPubadsDefined, adUnitsFilter } from './utils';
+import { flatten, uniques, isGptPubadsDefined, adUnitsFilter, removeRequestId } from './utils';
 import { videoAdUnit, videoBidder, hasNonVideoBidder } from './video';
 import { nativeAdUnit, nativeBidder, hasNonNativeBidder } from './native';
 import { listenMessagesFromCreative } from './secureCreatives';
@@ -113,7 +113,7 @@ $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCode = function(adUnitCode) {
 
 $$PREBID_GLOBAL$$.getAdserverTargeting = function (adUnitCode) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.getAdserverTargeting', arguments);
-  return targeting.getAllTargeting(adUnitCode);
+  return targeting.getAllTargeting(adUnitCode, auctionManager.getBidsReceived());
 };
 
 /**
@@ -127,16 +127,17 @@ $$PREBID_GLOBAL$$.getBidResponses = function () {
   const responses = auctionManager.getBidsReceived()
     .filter(adUnitsFilter.bind(this, auctionManager.getAdUnitCodes()));
 
-  // find the last requested id to get responses for most recent auction only
+  // find the last auction id to get responses for most recent auction only
   const currentAuctionId = responses && responses.length && responses[responses.length - 1].auctionId;
 
-  return responses.map(bid => bid.adUnitCode)
+  return responses
+    .map(bid => bid.adUnitCode)
     .filter(uniques).map(adUnitCode => responses
       .filter(bid => bid.auctionId === currentAuctionId && bid.adUnitCode === adUnitCode))
     .filter(bids => bids && bids[0] && bids[0].adUnitCode)
     .map(bids => {
       return {
-        [bids[0].adUnitCode]: { bids: bids }
+        [bids[0].adUnitCode]: { bids: bids.map(removeRequestId) }
       };
     })
     .reduce((a, b) => Object.assign(a, b), {});
@@ -152,7 +153,7 @@ $$PREBID_GLOBAL$$.getBidResponses = function () {
 $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode = function (adUnitCode) {
   const bids = auctionManager.getBidsReceived().filter(bid => bid.adUnitCode === adUnitCode);
   return {
-    bids: bids
+    bids: bids.map(removeRequestId)
   };
 };
 
@@ -528,7 +529,8 @@ $$PREBID_GLOBAL$$.aliasBidder = function (bidderCode, alias) {
  * @return {Array<AdapterBidResponse>} A list of bids that have won their respective auctions.
 */
 $$PREBID_GLOBAL$$.getAllWinningBids = function () {
-  return auctionManager.getAllWinningBids();
+  return auctionManager.getAllWinningBids()
+    .map(removeRequestId);
 };
 
 /**
@@ -539,7 +541,8 @@ $$PREBID_GLOBAL$$.getAllWinningBids = function () {
  * @return {Array} array containing highest cpm bid object(s)
  */
 $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
-  return targeting.getWinningBids(adUnitCode);
+  return targeting.getWinningBids(adUnitCode, auctionManager.getBidsReceived())
+    .map(removeRequestId);
 };
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -128,11 +128,11 @@ $$PREBID_GLOBAL$$.getBidResponses = function () {
     .filter(adUnitsFilter.bind(this, auctionManager.getAdUnitCodes()));
 
   // find the last requested id to get responses for most recent auction only
-  const currentRequestId = responses && responses.length && responses[responses.length - 1].requestId;
+  const currentAuctionId = responses && responses.length && responses[responses.length - 1].auctionId;
 
   return responses.map(bid => bid.adUnitCode)
     .filter(uniques).map(adUnitCode => responses
-      .filter(bid => bid.requestId === currentRequestId && bid.adUnitCode === adUnitCode))
+      .filter(bid => bid.auctionId === currentAuctionId && bid.adUnitCode === adUnitCode))
     .filter(bids => bids && bids[0] && bids[0].adUnitCode)
     .map(bids => {
       return {

--- a/src/utils.js
+++ b/src/utils.js
@@ -794,7 +794,7 @@ export function getBidderRequest(bidRequests, bidder, adUnitCode) {
   return find(bidRequests, request => {
     return request.bids
       .filter(bid => bid.bidder === bidder && bid.adUnitCode === adUnitCode).length > 0;
-  }) || { start: null, requestId: null };
+  }) || { start: null, auctionId: null };
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -845,3 +845,24 @@ export function unsupportedBidderMessage(adUnit, unSupportedBidders) {
     ${plural} won't fetch demand.
   `;
 }
+
+/**
+ * Delete property from object
+ * @param {Object} object 
+ * @param {string} prop
+ * @return {Object} object
+ */
+export function deletePropertyFromObject(object, prop) {
+  let result = Object.assign({}, object)
+  delete result[prop];
+  return result
+}
+
+/**
+ * Delete requestId from external bid object.
+ * @param {Object} bid
+ * @return {Object} bid
+ */
+export function removeRequestId(bid) {
+  return exports.deletePropertyFromObject(bid, 'requestId');
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -848,7 +848,7 @@ export function unsupportedBidderMessage(adUnit, unSupportedBidders) {
 
 /**
  * Delete property from object
- * @param {Object} object 
+ * @param {Object} object
  * @param {string} prop
  * @return {Object} object
  */

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -310,7 +310,7 @@ export function getBidResponses() {
       'pbHg': '0.11',
       'pbAg': '0.10',
       'size': '0x0',
-      'requestId': 123456,
+      'auctionId': 123456,
       'adserverTargeting': {
         'hb_bidder': 'triplelift',
         'hb_adid': '222bb26f9e8bd',
@@ -342,7 +342,7 @@ export function getBidResponses() {
       'pbAg': '10.00',
       'size': '300x250',
       'alwaysUseBid': true,
-      'requestId': 123456,
+      'auctionId': 123456,
       'adserverTargeting': {
         'hb_bidder': 'appnexus',
         'hb_adid': '233bcbee889d46d',
@@ -374,7 +374,7 @@ export function getBidResponses() {
       'pbAg': '10.00',
       'size': '728x90',
       'alwaysUseBid': true,
-      'requestId': 123456,
+      'auctionId': 123456,
       'adserverTargeting': {
         'hb_bidder': 'appnexus',
         'hb_adid': '24bd938435ec3fc',
@@ -405,7 +405,7 @@ export function getBidResponses() {
       'pbHg': '0.50',
       'pbAg': '0.50',
       'size': '300x250',
-      'requestId': 123456,
+      'auctionId': 123456,
       'adserverTargeting': {
         'hb_bidder': 'pagescience',
         'hb_adid': '25bedd4813632d7',
@@ -435,7 +435,7 @@ export function getBidResponses() {
       'pbHg': '0.17',
       'pbAg': '0.15',
       'size': '300x250',
-      'requestId': 654321,
+      'auctionId': 654321,
       'adserverTargeting': {
         'hb_bidder': 'brightcom',
         'hb_adid': '26e0795ab963896',
@@ -466,7 +466,7 @@ export function getBidResponses() {
       'pbHg': '0.50',
       'pbAg': '0.50',
       'size': '300x250',
-      'requestId': 654321,
+      'auctionId': 654321,
       'adserverTargeting': {
         'hb_bidder': 'brealtime',
         'hb_adid': '275bd666f5a5a5d',
@@ -498,7 +498,7 @@ export function getBidResponses() {
       'pbHg': '5.93',
       'pbAg': '5.90',
       'size': '300x250',
-      'requestId': 654321,
+      'auctionId': 654321,
       'adserverTargeting': {
         'hb_bidder': 'pubmatic',
         'hb_adid': '28f4039c636b6a7',
@@ -528,7 +528,7 @@ export function getBidResponses() {
       'pbHg': '2.74',
       'pbAg': '2.70',
       'size': '300x600',
-      'requestId': 654321,
+      'auctionId': 654321,
       'adserverTargeting': {
         'hb_bidder': 'rubicon',
         'hb_adid': '29019e2ab586a5a',
@@ -1032,7 +1032,7 @@ export function getBidResponsesFromAPI() {
           'pbHg': '0.17',
           'pbAg': '0.15',
           'size': '300x250',
-          'requestId': 654321,
+          'auctionId': 654321,
           'adserverTargeting': {
             'hb_bidder': 'brightcom',
             'hb_adid': '26e0795ab963896',
@@ -1063,7 +1063,7 @@ export function getBidResponsesFromAPI() {
           'pbHg': '0.50',
           'pbAg': '0.50',
           'size': '300x250',
-          'requestId': 654321,
+          'auctionId': 654321,
           'adserverTargeting': {
             'hb_bidder': 'brealtime',
             'hb_adid': '275bd666f5a5a5d',
@@ -1095,7 +1095,7 @@ export function getBidResponsesFromAPI() {
           'pbHg': '5.93',
           'pbAg': '5.90',
           'size': '300x250',
-          'requestId': 654321,
+          'auctionId': 654321,
           'adserverTargeting': {
             'hb_bidder': 'pubmatic',
             'hb_adid': '28f4039c636b6a7',
@@ -1125,7 +1125,7 @@ export function getBidResponsesFromAPI() {
           'pbHg': '2.74',
           'pbAg': '2.70',
           'size': '300x600',
-          'requestId': 654321,
+          'auctionId': 654321,
           'adserverTargeting': {
             'hb_bidder': 'rubicon',
             'hb_adid': '29019e2ab586a5a',

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -4,7 +4,7 @@ export function getBidRequests() {
   return [
     {
       'bidderCode': 'appnexus',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '2946b569352ef2',
       'bids': [
         {
@@ -26,7 +26,7 @@ export function getBidRequests() {
           ],
           'bidId': '392b5a6b05d648',
           'bidderRequestId': '2946b569352ef2',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'startTime': 1462918897462,
           'status': 1,
           'transactionId': 'fsafsa'
@@ -49,7 +49,7 @@ export function getBidRequests() {
           ],
           'bidId': '4dccdc37746135',
           'bidderRequestId': '2946b569352ef2',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'startTime': 1462918897463,
           'status': 1,
           'transactionId': 'fsafsa'
@@ -59,7 +59,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'pubmatic',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '5e1525bae3eb11',
       'bids': [
         {
@@ -81,7 +81,7 @@ export function getBidRequests() {
           ],
           'bidId': '6d11aa2d5b3659',
           'bidderRequestId': '5e1525bae3eb11',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'transactionId': 'fsafsa'
         }
       ],
@@ -89,7 +89,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'rubicon',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '8778750ee15a77',
       'bids': [
         {
@@ -130,7 +130,7 @@ export function getBidRequests() {
           ],
           'bidId': '96aff279720d39',
           'bidderRequestId': '8778750ee15a77',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'transactionId': 'fsafsa'
         }
       ],
@@ -138,7 +138,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'triplelift',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '107f5e6e98dcf09',
       'bids': [
         {
@@ -159,7 +159,7 @@ export function getBidRequests() {
           ],
           'bidId': '1144e2f0de84363',
           'bidderRequestId': '107f5e6e98dcf09',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'startTime': 1462918897477,
           'transactionId': 'fsafsa'
         }
@@ -168,7 +168,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'brightcom',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '12eeded736650b4',
       'bids': [
         {
@@ -189,7 +189,7 @@ export function getBidRequests() {
           ],
           'bidId': '135e89c039705da',
           'bidderRequestId': '12eeded736650b4',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'status': 1,
           'transactionId': 'fsafsa'
         }
@@ -198,7 +198,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'brealtime',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '167c4d79b615948',
       'bids': [
         {
@@ -219,7 +219,7 @@ export function getBidRequests() {
           ],
           'bidId': '17dd1d869bed44e',
           'bidderRequestId': '167c4d79b615948',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'startTime': 1462918897480,
           'status': 1,
           'transactionId': 'fsafsa'
@@ -229,7 +229,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'pagescience',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '18bed198c172a69',
       'bids': [
         {
@@ -250,7 +250,7 @@ export function getBidRequests() {
           ],
           'bidId': '192c8c1df0f5d1d',
           'bidderRequestId': '18bed198c172a69',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'startTime': 1462918897481,
           'status': 1,
           'transactionId': 'fsafsa'
@@ -260,7 +260,7 @@ export function getBidRequests() {
     },
     {
       'bidderCode': 'amazon',
-      'requestId': '1863e370099523',
+      'auctionId': '1863e370099523',
       'bidderRequestId': '20d0d30333715a7',
       'bids': [
         {
@@ -281,7 +281,7 @@ export function getBidRequests() {
           ],
           'bidId': '21ae8131ec04f6e',
           'bidderRequestId': '20d0d30333715a7',
-          'requestId': '1863e370099523',
+          'auctionId': '1863e370099523',
           'transactionId': 'fsafsa'
         }
       ],
@@ -609,7 +609,7 @@ export function getAdUnits() {
           ],
           'bidId': '3692954f816efc',
           'bidderRequestId': '2b1a75d5e826c4',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'appnexus',
@@ -630,7 +630,7 @@ export function getAdUnits() {
           ],
           'bidId': '68136e1c47023d',
           'bidderRequestId': '55e24a66bed717',
-          'requestId': '1ff753bd4ae5cb',
+          'auctionId': '1ff753bd4ae5cb',
           'startTime': 1463510220995,
           'status': 1
         }
@@ -667,7 +667,7 @@ export function getAdUnits() {
           ],
           'bidId': '7e5d6af25ed188',
           'bidderRequestId': '55e24a66bed717',
-          'requestId': '1ff753bd4ae5cb',
+          'auctionId': '1ff753bd4ae5cb',
           'startTime': 1463510220996
         },
         {
@@ -689,7 +689,7 @@ export function getAdUnits() {
           ],
           'bidId': '4448d80ac1374e',
           'bidderRequestId': '2b1a75d5e826c4',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'triplelift',
@@ -709,7 +709,7 @@ export function getAdUnits() {
           ],
           'bidId': '9514d586c52abf',
           'bidderRequestId': '8c4f03b838d7ee',
-          'requestId': '1ff753bd4ae5cb',
+          'auctionId': '1ff753bd4ae5cb',
           'startTime': 1463510220997
         },
         {
@@ -732,7 +732,7 @@ export function getAdUnits() {
           ],
           'bidId': '113079fed03f58c',
           'bidderRequestId': '1048e0df882e965',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'rubicon',
@@ -772,7 +772,7 @@ export function getAdUnits() {
           ],
           'bidId': '13c2c2a79d155ea',
           'bidderRequestId': '129e383ac549e5d',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'openx',
@@ -793,7 +793,7 @@ export function getAdUnits() {
           ],
           'bidId': '154f9cbf82df565',
           'bidderRequestId': '1448569c2453b84',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'pubmatic',
@@ -814,7 +814,7 @@ export function getAdUnits() {
           ],
           'bidId': '17f8c3a8fb13308',
           'bidderRequestId': '16095445eeb05e4',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'pagescience',
@@ -834,7 +834,7 @@ export function getAdUnits() {
           ],
           'bidId': '2074d5757675542',
           'bidderRequestId': '19883380ef5453a',
-          'requestId': '1ff753bd4ae5cb',
+          'auctionId': '1ff753bd4ae5cb',
           'startTime': 1463510221014
         },
         {
@@ -855,7 +855,7 @@ export function getAdUnits() {
           ],
           'bidId': '222b6ad5a9b835d',
           'bidderRequestId': '2163409fdf6f333',
-          'requestId': '1ff753bd4ae5cb',
+          'auctionId': '1ff753bd4ae5cb',
           'startTime': 1463510221015
         },
         {
@@ -878,7 +878,7 @@ export function getAdUnits() {
           ],
           'bidId': '2499961ab3f937a',
           'bidderRequestId': '23b57a2de4ae50b',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'adform',
@@ -900,7 +900,7 @@ export function getAdUnits() {
           ],
           'bidId': '26605265bf5e9c5',
           'bidderRequestId': '25a0902299c17d3',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'amazon',
@@ -920,7 +920,7 @@ export function getAdUnits() {
           ],
           'bidId': '2935d8f6764fe45',
           'bidderRequestId': '28afa21ca9246c1',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'aol',
@@ -941,7 +941,7 @@ export function getAdUnits() {
           ],
           'bidId': '31d1489681dc539',
           'bidderRequestId': '30bf32da9080fdd',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'sovrn',
@@ -961,7 +961,7 @@ export function getAdUnits() {
           ],
           'bidId': '33c1a8028d91563',
           'bidderRequestId': '324bcb47cfcf034',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'pulsepoint',
@@ -983,7 +983,7 @@ export function getAdUnits() {
           ],
           'bidId': '379219f0506a26f',
           'bidderRequestId': '360ec66bbb0719c',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         },
         {
           'bidder': 'brightcom',
@@ -1003,7 +1003,7 @@ export function getAdUnits() {
           ],
           'bidId': '395cfcf496e7d6d',
           'bidderRequestId': '38a776c7f001ea',
-          'requestId': '1ff753bd4ae5cb'
+          'auctionId': '1ff753bd4ae5cb'
         }
       ]
     }
@@ -1358,7 +1358,7 @@ export function getTargetingKeysBidLandscape() {
 export function getBidRequestedPayload() {
   return {
     'bidderCode': 'adequant',
-    'requestId': '150f361b202aa8',
+    'auctionId': '150f361b202aa8',
     'bidderRequestId': '2b193b7a6ff421',
     'bids': [
       {
@@ -1388,7 +1388,7 @@ export function getBidRequestedPayload() {
         ],
         'bidId': '39032dc5c7e834',
         'bidderRequestId': '2b193b7a6ff421',
-        'requestId': '150f361b202aa8'
+        'auctionId': '150f361b202aa8'
       }
     ],
     'start': 1465426155412

--- a/test/fixtures/video/bidRequest.json
+++ b/test/fixtures/video/bidRequest.json
@@ -16,11 +16,11 @@
       "sizes": [640,480],
       "bidId": "392b5a6b05d648",
       "bidderRequestId": "2946b569352ef2",
-      "requestId": "6172477f-987f-4523-a967-fa6d7a434ddf",
+      "auctionId": "6172477f-987f-4523-a967-fa6d7a434ddf",
       "startTime": 1462918897462
     }
   ],
-  "requestId": "6172477f-987f-4523-a967-fa6d7a434ddf",
+  "auctionId": "6172477f-987f-4523-a967-fa6d7a434ddf",
   "start": 1462918897460,
   "timeout": 5000
 }

--- a/test/fixtures/video/vastPayloadResponse.json
+++ b/test/fixtures/video/vastPayloadResponse.json
@@ -7,7 +7,7 @@
   "cpm": 0.1,
   "height": 480,
   "mediaType": "video",
-  "requestId": "6172477f-987f-4523-a967-fa6d7a434ddf",
+  "auctionId": "6172477f-987f-4523-a967-fa6d7a434ddf",
   "vastXml": "<VAST version=\"3.0\"></VAST>",
   "width": 640
 }

--- a/test/fixtures/video/vastUrlResponse.json
+++ b/test/fixtures/video/vastUrlResponse.json
@@ -7,7 +7,7 @@
   "cpm": 0.1,
   "height": 480,
   "mediaType": "video",
-  "requestId": "6172477f-987f-4523-a967-fa6d7a434ddf",
+  "auctionId": "6172477f-987f-4523-a967-fa6d7a434ddf",
   "vastUrl": "www.myVastUrl.com",
   "width": 640
 }

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -28,7 +28,7 @@ describe('33acrossBidAdapter:', function () {
           productId: PRODUCT_ID
         },
         adUnitCode: 'div-id',
-        requestId: 'r1',
+        auctionId: 'r1',
         sizes: [
           [ 300, 250 ],
           [ 728, 90 ]

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -18,7 +18,7 @@ describe('AdButler adapter', () => {
         placementCode: '/19968336/header-bid-tag-1',
         sizes: [[300, 250], [300, 600]],
         bidId: '23acc48ad47af5',
-        requestId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
+        auctionId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
         bidderRequestId: '1c56ad30b9b8ca8',
         transactionId: '92489f71-1bf2-49a0-adf9-000cea934729'
       }
@@ -63,7 +63,7 @@ describe('AdButler adapter', () => {
                 zoneID: '86133',
                 domain: 'servedbyadbutler.com.dan.test'
               },
-              requestId: '10b327aa396609',
+              auctionId: '10b327aa396609',
               placementCode: '/123456/header-bid-tag-1'
             }
           ],

--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -147,7 +147,7 @@ describe('', () => {
 
   const REQUEST = {
     bidderCode: 'adapter',
-    requestId: '5018eb39-f900-4370-b71e-3bb5b48d324f',
+    auctionId: '5018eb39-f900-4370-b71e-3bb5b48d324f',
     bidderRequestId: '1a6fc81528d0f6',
     bids: [{
       bidder: 'adapter',
@@ -157,7 +157,7 @@ describe('', () => {
       sizes: [[300, 250]],
       bidId: '208750227436c1',
       bidderRequestId: '1a6fc81528d0f6',
-      requestId: '5018eb39-f900-4370-b71e-3bb5b48d324f'
+      auctionId: '5018eb39-f900-4370-b71e-3bb5b48d324f'
     }],
     auctionStart: 1509369418387,
     timeout: 3000,
@@ -173,7 +173,7 @@ describe('', () => {
     mediaType: 'banner',
     cpm: 0.015,
     ad: '<!-- tag goes here -->',
-    requestId: '5018eb39-f900-4370-b71e-3bb5b48d324f',
+    auctionId: '5018eb39-f900-4370-b71e-3bb5b48d324f',
     responseTimestamp: 1509369418832,
     requestTimestamp: 1509369418389,
     bidder: 'adapter',

--- a/test/spec/modules/adxcgAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adxcgAnalyticsAdapter_spec.js
@@ -25,7 +25,7 @@ describe('adxcg analytics adapter', () => {
         publisherId: '42'
       };
       let bidRequest = {
-        requestId: 'requestIdData'
+        auctionId: 'requestIdData'
       };
       let bidResponse = {
         adId: 'adIdData',

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -54,14 +54,14 @@ let getNexagePostBidParams = () => {
 let getDefaultBidRequest = () => {
   return {
     bidderCode: 'aol',
-    requestId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+    auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
     bidderRequestId: '7101db09af0db2',
     start: new Date().getTime(),
     bids: [{
       bidder: 'aol',
       bidId: '84ab500420319d',
       bidderRequestId: '7101db09af0db2',
-      requestId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+      auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
       placementCode: 'foo',
       params: getMarketplaceBidParams()
     }]

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -22,7 +22,7 @@ describe('Conversant adapter tests', function() {
       sizes: [[300, 250]],
       bidId: 'bid000',
       bidderRequestId: '117d765b87bed38',
-      requestId: 'req000'
+      auctionId: 'req000'
     }, {
       bidder: 'conversant',
       params: {
@@ -34,7 +34,7 @@ describe('Conversant adapter tests', function() {
       sizes: [[468, 60]],
       bidId: 'bid001',
       bidderRequestId: '117d765b87bed38',
-      requestId: 'req000'
+      auctionId: 'req000'
     }, {
       bidder: 'conversant',
       params: {
@@ -48,7 +48,7 @@ describe('Conversant adapter tests', function() {
       sizes: [[300, 600], [160, 600]],
       bidId: 'bid002',
       bidderRequestId: '117d765b87bed38',
-      requestId: 'req000'
+      auctionId: 'req000'
     }, {
       bidder: 'conversant',
       params: {
@@ -68,7 +68,7 @@ describe('Conversant adapter tests', function() {
       sizes: [640, 480],
       bidId: 'bid003',
       bidderRequestId: '117d765b87bed38',
-      requestId: 'req000'
+      auctionId: 'req000'
     }];
 
   const bidResponses = {

--- a/test/spec/modules/fidelityBidAdapter_spec.js
+++ b/test/spec/modules/fidelityBidAdapter_spec.js
@@ -52,7 +52,7 @@ describe('FidelityAdapter', () => {
   describe('buildRequests', () => {
     let bidderRequest = {
       bidderCode: 'fidelity',
-      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       bidderRequestId: '178e34bad3658f',
       bids: [
         {
@@ -66,7 +66,7 @@ describe('FidelityAdapter', () => {
           sizes: [[300, 250], [320, 50]],
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
-          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+          auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         }
       ],

--- a/test/spec/modules/huddledmassesBidAdapter_spec.js
+++ b/test/spec/modules/huddledmassesBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('HuddledmassesAdapter', () => {
       placement_id: 0
     },
     placementCode: 'placementid_0',
-    requestId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
+    auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
     sizes: [[300, 250]],
     transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62'
   };

--- a/test/spec/modules/komoonaBidAdapter_spec.js
+++ b/test/spec/modules/komoonaBidAdapter_spec.js
@@ -16,7 +16,7 @@ describe('Komoona.com Adapter Tests', () => {
       ],
       bidId: '2faedf1095f815',
       bidderRequestId: '18065867f8ae39',
-      requestId: '529e1518-b872-45cf-807c-2d41dfa5bcd3'
+      auctionId: '529e1518-b872-45cf-807c-2d41dfa5bcd3'
     },
     {
       bidder: 'komoona',
@@ -32,7 +32,7 @@ describe('Komoona.com Adapter Tests', () => {
       ],
       bidId: '3c34e2367a3f59',
       bidderRequestId: '18065867f8ae39',
-      requestId: '529e1518-b872-45cf-807c-2d41dfa5bcd3'
+      auctionId: '529e1518-b872-45cf-807c-2d41dfa5bcd3'
     }];
 
   const bidsResponse = {

--- a/test/spec/modules/mobfoxBidAdapter_spec.js
+++ b/test/spec/modules/mobfoxBidAdapter_spec.js
@@ -14,7 +14,7 @@ describe('mobfox adapter tests', () => {
       imp_instl: 1 // optional - set to 1 if using interstitial otherwise delete or set to 0
     },
     placementCode: 'div-gpt-ad-1460505748561-0',
-    requestId: 'c241c810-18d9-4aa4-a62f-8c1980d8d36b',
+    auctionId: 'c241c810-18d9-4aa4-a62f-8c1980d8d36b',
     transactionId: '31f42cba-5920-4e47-adad-69c79d0d4fb4'
   }];
 
@@ -29,21 +29,7 @@ describe('mobfox adapter tests', () => {
         imp_instl: 1 // optional - set to 1 if using interstitial otherwise delete or set to 0
       },
       placementCode: 'div-gpt-ad-1460505748561-0',
-      requestId: 'c241c810-18d9-4aa4-a62f-8c1980d8d36b',
-      transactionId: '31f42cba-5920-4e47-adad-69c79d0d4fb4'
-    }];
-
-    let bidRequestInvalid2 = [{
-      code: 'div-gpt-ad-1460505748561-0',
-      sizes: [[320, 480], [300, 250], [300, 600]],
-      // Replace this object to test a new Adapter!
-      bidder: 'mobfox',
-      bidId: '5t5t5t5',
-      params: {
-        s: '267d72ac3f77a3f447b32cf7ebf20673', // required - The hash of your inventory to identify which app is making the request,
-        imp_instl: 1 // optional - set to 1 if using interstitial otherwise delete or set to 0
-      },
-      placementCode: 'div-gpt-ad-1460505748561-0',
+      auctionId: 'c241c810-18d9-4aa4-a62f-8c1980d8d36b',
       transactionId: '31f42cba-5920-4e47-adad-69c79d0d4fb4'
     }];
 
@@ -54,11 +40,6 @@ describe('mobfox adapter tests', () => {
 
     it('test valid MF request failed1', () => {
       let isValid = adapter.spec.isBidRequestValid(bidRequestInvalid1[0]);
-      expect(isValid).to.equal(false);
-    });
-
-    it('test valid MF request failed2', () => {
-      let isValid = adapter.spec.isBidRequestValid(bidRequestInvalid2[0]);
       expect(isValid).to.equal(false);
     });
   })

--- a/test/spec/modules/nanointeractiveBidAdapter_spec.js
+++ b/test/spec/modules/nanointeractiveBidAdapter_spec.js
@@ -32,7 +32,7 @@ describe('nanointeractive adapter tests', function () {
       sizes: SIZES,
       bidId: '24a1c9ec270973',
       bidderRequestId: '189135372acd55',
-      requestId: 'ac15bb68-4ef0-477f-93f4-de91c47f00a9'
+      auctionId: 'ac15bb68-4ef0-477f-93f4-de91c47f00a9'
     }
   }
 

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -17,7 +17,7 @@ describe('Quantcast adapter', () => {
     bidRequest = {
       bidder: 'quantcast',
       bidId: '2f7b179d443f14',
-      requestId: '595ffa73-d78a-46c9-b18e-f99548a5be6b',
+      auctionId: '595ffa73-d78a-46c9-b18e-f99548a5be6b',
       bidderRequestId: '1cc026909c24c8',
       placementCode: 'div-gpt-ad-1438287399331-0',
       params: {
@@ -74,7 +74,7 @@ describe('Quantcast adapter', () => {
       const bidRequest = {
         bidder: 'quantcast',
         bidId: '2f7b179d443f14',
-        requestId: '595ffa73-d78a-46c9-b18e-f99548a5be6b',
+        auctionId: '595ffa73-d78a-46c9-b18e-f99548a5be6b',
         bidderRequestId: '1cc026909c24c8',
         placementCode: 'div-gpt-ad-1438287399331-0',
         params: {

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -21,7 +21,6 @@ describe('ReadPeakAdapter', () => {
         bidfloor: 5.00,
         publisherId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
       },
-      auctionId: '1d1a030790a475',
       bidId: '2ffb201a808da7',
       bidderRequestId: '178e34bad3658f',
       auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -24,7 +24,7 @@ describe('ReadPeakAdapter', () => {
       auctionId: '1d1a030790a475',
       bidId: '2ffb201a808da7',
       bidderRequestId: '178e34bad3658f',
-      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
     }
     serverResponse = {

--- a/test/spec/modules/rtbdemandBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandBidAdapter_spec.js
@@ -52,7 +52,7 @@ describe('rtbdemandAdapter', () => {
   describe('buildRequests', () => {
     let bidderRequest = {
       bidderCode: 'rtbdemand',
-      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       bidderRequestId: '178e34bad3658f',
       bids: [
         {
@@ -66,7 +66,7 @@ describe('rtbdemandAdapter', () => {
           sizes: [[300, 250], [320, 50]],
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
-          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+          auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         },
         {
@@ -80,7 +80,7 @@ describe('rtbdemandAdapter', () => {
           sizes: [[728, 90], [320, 50]],
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
-          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+          auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         }
       ],

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -57,7 +57,7 @@ describe('the rubicon adapter', () => {
 
     bidderRequest = {
       bidderCode: 'rubicon',
-      requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+      auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       bidderRequestId: '178e34bad3658f',
       bids: [
         {
@@ -83,7 +83,7 @@ describe('the rubicon adapter', () => {
           sizes: [[300, 250], [320, 50]],
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
-          requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
+          auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         }
       ],

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -8,7 +8,7 @@ const SMARTSYNC_CALLBACK = 'serverbidCallBids';
 
 const REQUEST = {
   'bidderCode': 'serverbid',
-  'requestId': 'a4713c32-3762-4798-b342-4ab810ca770d',
+  'auctionId': 'a4713c32-3762-4798-b342-4ab810ca770d',
   'bidderRequestId': '109f2a181342a9',
   'bidRequest': [{
     'bidder': 'serverbid',
@@ -23,7 +23,7 @@ const REQUEST = {
     ],
     'bidId': '2b0f82502298c9',
     'bidderRequestId': '109f2a181342a9',
-    'requestId': 'a4713c32-3762-4798-b342-4ab810ca770d'
+    'auctionId': 'a4713c32-3762-4798-b342-4ab810ca770d'
   },
   {
     'bidder': 'serverbid',
@@ -38,7 +38,7 @@ const REQUEST = {
     ],
     'bidId': '123',
     'bidderRequestId': '109f2a181342a9',
-    'requestId': 'a4713c32-3762-4798-b342-4ab810ca770d'
+    'auctionId': 'a4713c32-3762-4798-b342-4ab810ca770d'
   }],
   'start': 1487883186070,
   'auctionStart': 1487883186069,
@@ -115,7 +115,7 @@ describe('Serverbid BidAdapter', () => {
         placementCode: 'header-bid-tag-1',
         sizes: [[300, 250], [300, 600]],
         bidId: '23acc48ad47af5',
-        requestId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
+        auctionId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
         bidderRequestId: '1c56ad30b9b8ca8',
         transactionId: '92489f71-1bf2-49a0-adf9-000cea934729'
       }

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -14,7 +14,7 @@ describe('UnderdogMedia adapter', () => {
         adUnitCode: '/19968336/header-bid-tag-1',
         sizes: [[300, 250], [300, 600], [728, 90], [160, 600], [320, 50]],
         bidId: '23acc48ad47af5',
-        requestId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
+        auctionId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
         bidderRequestId: '1c56ad30b9b8ca8',
         transactionId: '92489f71-1bf2-49a0-adf9-000cea934729'
       }
@@ -68,7 +68,7 @@ describe('UnderdogMedia adapter', () => {
             params: {
               siteId: '12143'
             },
-            requestId: '10b327aa396609',
+            auctionId: '10b327aa396609',
             adUnitCode: '/123456/header-bid-tag-1'
           }
         ];
@@ -86,7 +86,7 @@ describe('UnderdogMedia adapter', () => {
             params: {
               siteId: '12143'
             },
-            requestId: '10b327aa396609',
+            auctionId: '10b327aa396609',
             adUnitCode: '/123456/header-bid-tag-1'
           }
         ];

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -11,8 +11,7 @@ const validBidReq = {
   },
   sizes: [[300, 250], [300, 600]],
   bidId: '263be71e91dd9d',
-  requestId: '9ad1fa8d-2297-4660-a018-b39945054746',
-  auctionId: '1d1a030790a475'
+  auctionId: '9ad1fa8d-2297-4660-a018-b39945054746',
 };
 
 const invalidBidReq = {
@@ -22,7 +21,7 @@ const invalidBidReq = {
   },
   sizes: [[300, 250], [300, 600]],
   bidId: '263be71e91dd9d',
-  requestId: '9ad1fa8d-2297-4660-a018-b39945054746'
+  auctionId: '9ad1fa8d-2297-4660-a018-b39945054746'
 };
 
 const bidReq = [{
@@ -33,7 +32,7 @@ const bidReq = [{
   },
   sizes: [[300, 250], [300, 600]],
   bidId: '263be71e91dd9d',
-  requestId: '9ad1fa8d-2297-4660-a018-b39945054746',
+  auctionId: '9ad1fa8d-2297-4660-a018-b39945054746',
   auctionId: '1d1a030790a475'
 }];
 

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -32,8 +32,7 @@ const bidReq = [{
   },
   sizes: [[300, 250], [300, 600]],
   bidId: '263be71e91dd9d',
-  auctionId: '9ad1fa8d-2297-4660-a018-b39945054746',
-  auctionId: '1d1a030790a475'
+  auctionId: '9ad1fa8d-2297-4660-a018-b39945054746'
 }];
 
 const validBidRes = {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -45,7 +45,7 @@ describe('adapterManager tests', () => {
     it('should log an error if a bidder is used that does not exist', () => {
       let bidRequests = [{
         'bidderCode': 'appnexus',
-        'requestId': '1863e370099523',
+        'auctionId': '1863e370099523',
         'bidderRequestId': '2946b569352ef2',
         'tid': '34566b569352ef2',
         'bids': [
@@ -59,7 +59,7 @@ describe('adapterManager tests', () => {
             'sizes': [[728, 90], [970, 70]],
             'bidId': '392b5a6b05d648',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897462,
             'status': 1,
             'transactionId': 'fsafsa'
@@ -73,7 +73,7 @@ describe('adapterManager tests', () => {
             'sizes': [[300, 250], [300, 600]],
             'bidId': '4dccdc37746135',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897463,
             'status': 1,
             'transactionId': 'fsafsa'
@@ -122,7 +122,7 @@ describe('adapterManager tests', () => {
     it('invokes callBids on the S2S adapter', () => {
       let bidRequests = [{
         'bidderCode': 'appnexus',
-        'requestId': '1863e370099523',
+        'auctionId': '1863e370099523',
         'bidderRequestId': '2946b569352ef2',
         'tid': '34566b569352ef2',
         'src': 's2s',
@@ -159,7 +159,7 @@ describe('adapterManager tests', () => {
                 ],
                 'bidId': '68136e1c47023d',
                 'bidderRequestId': '55e24a66bed717',
-                'requestId': '1ff753bd4ae5cb',
+                'auctionId': '1ff753bd4ae5cb',
                 'startTime': 1463510220995,
                 'status': 1,
                 'bid_id': '378a8914450b334'
@@ -197,7 +197,7 @@ describe('adapterManager tests', () => {
                 ],
                 'bidId': '7e5d6af25ed188',
                 'bidderRequestId': '55e24a66bed717',
-                'requestId': '1ff753bd4ae5cb',
+                'auctionId': '1ff753bd4ae5cb',
                 'startTime': 1463510220996,
                 'bid_id': '387d9d9c32ca47c'
               }
@@ -224,7 +224,7 @@ describe('adapterManager tests', () => {
             ],
             'bidId': '392b5a6b05d648',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897462,
             'status': 1,
             'transactionId': 'fsafsa'
@@ -247,7 +247,7 @@ describe('adapterManager tests', () => {
             ],
             'bidId': '4dccdc37746135',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897463,
             'status': 1,
             'transactionId': 'fsafsa'
@@ -285,7 +285,7 @@ describe('adapterManager tests', () => {
 
       let bidRequests = [{
         'bidderCode': 'appnexus',
-        'requestId': '1863e370099523',
+        'auctionId': '1863e370099523',
         'bidderRequestId': '2946b569352ef2',
         'tid': '34566b569352ef2',
         'src': 's2s',
@@ -322,7 +322,7 @@ describe('adapterManager tests', () => {
                 ],
                 'bidId': '68136e1c47023d',
                 'bidderRequestId': '55e24a66bed717',
-                'requestId': '1ff753bd4ae5cb',
+                'auctionId': '1ff753bd4ae5cb',
                 'startTime': 1463510220995,
                 'status': 1,
                 'bid_id': '378a8914450b334'
@@ -360,7 +360,7 @@ describe('adapterManager tests', () => {
                 ],
                 'bidId': '7e5d6af25ed188',
                 'bidderRequestId': '55e24a66bed717',
-                'requestId': '1ff753bd4ae5cb',
+                'auctionId': '1ff753bd4ae5cb',
                 'startTime': 1463510220996,
                 'bid_id': '387d9d9c32ca47c'
               }
@@ -387,7 +387,7 @@ describe('adapterManager tests', () => {
             ],
             'bidId': '392b5a6b05d648',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897462,
             'status': 1,
             'transactionId': 'fsafsa'
@@ -410,7 +410,7 @@ describe('adapterManager tests', () => {
             ],
             'bidId': '4dccdc37746135',
             'bidderRequestId': '2946b569352ef2',
-            'requestId': '1863e370099523',
+            'auctionId': '1863e370099523',
             'startTime': 1462918897463,
             'status': 1,
             'transactionId': 'fsafsa'

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -11,7 +11,7 @@ const MOCK_BIDS_REQUEST = {
   bids: [
     {
       bidId: 1,
-      requestId: 'first-bid-id',
+      auctionId: 'first-bid-id',
       adUnitCode: 'mock/placement',
       params: {
         param: 5
@@ -19,7 +19,7 @@ const MOCK_BIDS_REQUEST = {
     },
     {
       bidId: 2,
-      requestId: 'second-bid-id',
+      auctionId: 'second-bid-id',
       adUnitCode: 'mock/placement2',
       params: {
         badParam: 6
@@ -609,7 +609,7 @@ describe('validate bid response: ', () => {
     let bidRequest = {
       bids: [{
         bidId: 1,
-        requestId: 'first-bid-id',
+        auctionId: 'first-bid-id',
         adUnitCode: 'mock/placement',
         params: {
           param: 5
@@ -646,7 +646,7 @@ describe('validate bid response: ', () => {
     let bidRequest = {
       bids: [{
         bidId: 1,
-        requestId: 'first-bid-id',
+        auctionId: 'first-bid-id',
         adUnitCode: 'mock/placement',
         params: {
           param: 5
@@ -682,7 +682,7 @@ describe('validate bid response: ', () => {
     let bidRequest = {
       bids: [{
         bidId: 1,
-        requestId: 'first-bid-id',
+        auctionId: 'first-bid-id',
         adUnitCode: 'mock/placement',
         params: {
           param: 5
@@ -717,7 +717,7 @@ describe('validate bid response: ', () => {
       bids: [{
         bidder: CODE,
         bidId: 1,
-        requestId: 'first-bid-id',
+        auctionId: 'first-bid-id',
         adUnitCode: 'mock/placement',
         params: {
           param: 5

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1443,7 +1443,7 @@ describe('Unit: Prebid Module', function () {
           'pbAg': '10.00',
           'size': '300x250',
           'alwaysUseBid': true,
-          'requestId': 123456,
+          'auctionId': 123456,
           'adserverTargeting': {
             'hb_bidder': 'appnexus',
             'hb_adid': '233bcbee889d46d',


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This PR has 3 changes
1) Since 1.0 we are using `auctionId` instead of `requestId` (https://github.com/prebid/Prebid.js/blob/legacy/src/adaptermanager.js#L191)
Update bidRequests in  core fixtures and modules 

2)  `requestId` and `adId` were same in external bid object. Hence removed `requestId` only from external bid object.

3) Also found a bug, pbjs public api `getHighesCpmBids`, `getAdserverTargeting` were returning empty results. In targeting we are filtering out bids which are already set and also checking bid expiry so when `pbjs.getHighestCpmBids` is called it will filter out the bid. 
