### PR TITLE
RockYou Adapter: Added RockYou Adapter supporting Prebid 1.0

### DIFF
--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -1,0 +1,357 @@
+import * as utils from 'src/utils';
+import { Renderer } from 'src/Renderer';
+import { BANNER, VIDEO } from 'src/mediaTypes';
+import { registerBidder } from 'src/adapters/bidderFactory';
+
+const BIDDER_CODE = 'rockyou';
+
+const BASE_REQUEST_PATH = 'https://tas.rockyou.net/servlet/rotator/';
+const IFRAME_SYNC_URL = 'https://prebid.tex-sync.rockyou.net/usersync2/tas';
+const VAST_PLAYER_LOCATION = 'https://rya-static.rockyou.com/rya/js/PreBidPlayer.js';
+export const ROTATION_ZONE = 'openrtbprod';
+
+let isBidRequestValid = (bid) => {
+  return !!bid.params && !!bid.params.placementId;
+};
+
+/**
+* The RockYou Ad Serving system currently only accepts one placementId
+* per Ad request. For this reason, the first placementId indicated
+* will be chosen as the predominant placementId for this request.
+*/
+let determineOptimalPlacementId = (bidRequest) => {
+  return bidRequest.params.placementId;
+}
+
+let determineOptimalRequestId = (bidRequest) => {
+  return bidRequest.bidId;
+}
+
+let buildSiteComponent = (bidRequest) => {
+  let topLocation = utils.getTopWindowLocation();
+
+  let site = {
+    domain: topLocation.hostname,
+    page: topLocation.href,
+    ref: topLocation.origin
+  };
+
+  return site;
+}
+
+let buildDeviceComponent = (bidRequest) => {
+  let device = {
+    js: 1,
+    language: ('language' in navigator) ? navigator.language : null
+  };
+
+  return device;
+};
+
+let extractValidSize = (bidRequest) => {
+  let width = null;
+  let height = null;
+
+  if (!utils.isEmpty(bidRequest.sizes)) {
+    // Currently only the first size is utilized
+    let firstSize = bidRequest.sizes[0];
+    width = firstSize[0];
+    height = firstSize[1];
+  }
+
+  return {
+    w: width,
+    h: height
+  };
+};
+
+let generateVideoComponent = (bidRequest) => {
+  let impSize = extractValidSize(bidRequest);
+
+  return {
+    w: impSize.w,
+    h: impSize.h
+  }
+}
+
+let generateBannerComponent = (bidRequest) => {
+  let impSize = extractValidSize(bidRequest);
+
+  return {
+    w: impSize.w,
+    h: impSize.h
+  }
+}
+
+let generateImpBody = (bidRequest) => {
+  let mediaTypes = bidRequest.mediaTypes;
+
+  let banner = null;
+  let video = null;
+
+  // Assume banner if the mediatype is not included
+  if (mediaTypes && mediaTypes.video) {
+    video = generateVideoComponent(bidRequest);
+  } else {
+    banner = generateBannerComponent(bidRequest);
+  }
+
+  return {
+    id: bidRequest.index,
+    banner: banner,
+    video: video
+  };
+}
+
+let generatePayload = (bidRequests) => {
+  // Generate the expected OpenRTB payload
+
+  let rootBidRequest = bidRequests[0];
+
+  let index = 1;
+  bidRequests.forEach((bidRequest) => {
+    bidRequest.index = index;
+    index += 1;
+  })
+
+  let payload = {
+    id: determineOptimalRequestId(rootBidRequest),
+    site: buildSiteComponent(rootBidRequest),
+    device: buildDeviceComponent(rootBidRequest),
+    imp: bidRequests.map(generateImpBody)
+  };
+
+  return JSON.stringify(payload);
+};
+
+let overridableProperties = (request) => {
+  let rendererLocation = VAST_PLAYER_LOCATION;
+  let baseRequestPath = BASE_REQUEST_PATH;
+  let rotationZone = ROTATION_ZONE;
+
+  if (!utils.isEmpty(request.rendererOverride)) {
+    rendererLocation = request.rendererOverride;
+  }
+
+  if (request.params) {
+    if (!utils.isEmpty(request.params.baseRequestPath)) {
+      baseRequestPath = request.params.baseRequestPath;
+    }
+
+    if (!utils.isEmpty(request.params.rotationZone)) {
+      rotationZone = request.params.rotationZone;
+    }
+  }
+
+  return {
+    rendererLocation,
+    baseRequestPath,
+    rotationZone
+  }
+}
+
+let buildRequests = (validBidRequests, requestRoot) => {
+  const requestType = 'POST';
+
+  let requestUrl = null;
+  let requestPayload = null;
+  let mediaTypes = null;
+  let adUnitCode = null;
+  let rendererOverride = null;
+
+  // Due to the nature of how URLs are generated, there must
+  // be at least one bid request present for this to function
+  // correctly
+  if (!utils.isEmpty(validBidRequests)) {
+    let headBidRequest = validBidRequests[0];
+
+    let serverLocations = overridableProperties(headBidRequest);
+
+    // requestUrl is the full endpoint w/ relevant adspot paramters
+    let placementId = determineOptimalPlacementId(headBidRequest);
+    requestUrl = `${serverLocations.baseRequestPath}${placementId}/0/vo?z=${serverLocations.rotationZone}`;
+
+    // requestPayload is the POST body JSON for the OpenRtb request
+    requestPayload = generatePayload(validBidRequests);
+
+    mediaTypes = headBidRequest.mediaTypes;
+    adUnitCode = headBidRequest.adUnitCode;
+    rendererOverride = headBidRequest.rendererOverride;
+  }
+  const result = {
+    method: requestType,
+    type: requestType,
+    url: requestUrl,
+    data: requestPayload,
+    mediaTypes,
+    requestId: requestRoot.bidderRequestId,
+    adUnitCode,
+    rendererOverride
+  };
+
+  return result;
+};
+
+let outstreamRender = (bid) => {
+  // push to render queue because player may not be loaded yet
+  bid.renderer.push(() => {
+    let adUnitCode = bid.renderer.config.adUnitCode;
+
+    try {
+      RockYouVastPlayer.render(adUnitCode, bid, playerCallbacks(bid.renderer));
+    } catch (pbe) {
+      utils.logError(pbe);
+    }
+  });
+}
+
+let rockYouEventTranslation = (rockYouEvent) => {
+  let translated;
+  switch (rockYouEvent) {
+    case 'LOAD':
+      translated = 'loaded';
+      break;
+    case 'IMPRESSION':
+      translated = 'impression';
+      break;
+    case 'COMPLETE':
+    case 'ERROR':
+      translated = 'ended'
+      break;
+  }
+
+  return translated;
+}
+
+let playerCallbacks = (renderer) => (id, eventName) => {
+  eventName = rockYouEventTranslation(eventName);
+
+  if (eventName) {
+    renderer.handleVideoEvent({ id, eventName });
+  }
+};
+
+let generateRenderer = (bid, adUnitCode, rendererLocation) => {
+  let renderer = Renderer.install({
+    url: rendererLocation,
+    config: {
+      adText: `RockYou Outstream Video Ad`,
+      adUnitCode: adUnitCode
+    },
+    id: bid.id
+  });
+
+  bid.renderer = renderer;
+
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    utils.logWarn('Prebid Error calling setRender on renderer', err);
+  }
+
+  renderer.setEventHandlers({
+    impression: () => utils.logMessage('RockYou outstream video impression event'),
+    loaded: () => utils.logMessage('RockYou outstream video loaded event'),
+    ended: () => {
+      utils.logMessage('RockYou outstream renderer video event');
+      document.querySelector(`#${adUnitCode}`).style.display = 'none';
+    }
+  });
+
+  return renderer;
+};
+
+let interpretResponse = (serverResponse, request) => {
+  let responses = [];
+
+  if (serverResponse.body) {
+    let responseBody = serverResponse.body;
+
+    if (responseBody != null) {
+      let seatBids = responseBody.seatbid;
+
+      if (!(utils.isEmpty(seatBids) ||
+            utils.isEmpty(seatBids[0].bid))) {
+        let bid = seatBids[0].bid[0];
+
+        // handle any values that may end up undefined
+        let nullify = (value) => typeof value === 'undefined' ? null : value;
+
+        let ttl = null;
+        if (bid.ext) {
+          ttl = nullify(bid.ext.ttl);
+        }
+
+        let bidWidth = nullify(bid.w);
+        let bidHeight = nullify(bid.h);
+
+        let bannerCreative = null;
+        let videoXml = null;
+        let mediaType = null;
+        let renderer = null;
+
+        if (request.mediaTypes && request.mediaTypes.video) {
+          videoXml = bid.adm;
+          mediaType = VIDEO;
+
+          let serversideLocations = overridableProperties(request);
+
+          renderer = generateRenderer(bid, request.adUnitCode, serversideLocations.rendererLocation);
+        } else {
+          bannerCreative = bid.adm;
+        }
+
+        let response = {
+          requestId: responseBody.id,
+          cpm: bid.price,
+          width: bidWidth,
+          height: bidHeight,
+          ad: bannerCreative,
+          ttl: ttl,
+          creativeId: bid.adid,
+          netRevenue: true,
+          currency: responseBody.cur,
+          vastUrl: null,
+          vastXml: videoXml,
+          dealId: null,
+          mediaType: mediaType,
+          renderer: renderer
+        };
+
+        responses.push(response);
+      }
+    }
+  }
+
+  return responses;
+};
+
+let getUserSyncs = (syncOptions, serverResponses) => {
+  const syncs = []
+
+  if (syncOptions.iframeEnabled) {
+    syncs.push({
+      type: 'iframe',
+      url: IFRAME_SYNC_URL
+    });
+  }
+
+  return syncs;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['ry'],
+  isBidRequestValid: isBidRequestValid,
+  buildRequests: buildRequests,
+  interpretResponse: interpretResponse,
+  getUserSyncs: getUserSyncs,
+  supportedMediaTypes: [BANNER, VIDEO]
+};
+
+export const internals = {
+  playerCallbacks,
+  generateRenderer
+}
+
+registerBidder(spec);

--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -53,10 +53,16 @@ let extractValidSize = (bidRequest) => {
   let height = null;
 
   if (!utils.isEmpty(bidRequest.sizes)) {
-    // Currently only the first size is utilized
-    let firstSize = bidRequest.sizes[0];
-    width = firstSize[0];
-    height = firstSize[1];
+    // Ensure the size array is normalized
+    let conformingSize = utils.parseSizesInput(bidRequest.sizes);
+
+    if (!utils.isEmpty(conformingSize) && conformingSize[0] != null) {
+      // Currently only the first size is utilized
+      let splitSizes = conformingSize[0].split('x');
+
+      width = parseInt(splitSizes[0]);
+      height = parseInt(splitSizes[1]);
+    }
   }
 
   return {

--- a/modules/rockyouBidAdapter.md
+++ b/modules/rockyouBidAdapter.md
@@ -1,0 +1,57 @@
+# Overview
+
+```
+Module Name: RockYou Bidder Adapter  
+Module Type: Bidder Adapter  
+Maintainer: prebid.adapter@rockyou.com  
+```
+
+# Description
+
+Connects to the RockYou exchange for bids.
+
+The RockYou bid adapter supports Banner and Video.
+
+For publishers who wish to be set up on the RockYou Ad Network, please contact
+publishers@rockyou.com.
+
+RockYou user syncing requires the `userSync.iframeEnabled` property be set to `true`.
+
+# Test PARAMETERS
+```
+var adUnits = [
+
+  // Banner adUnit
+  {
+    code: 'banner-div',
+    sizes: [[720, 480]],
+
+    // Replace this object to test a new Adapter!
+    bids: [{
+          bidder: 'rockyou',
+          params: {
+            placementId: '4322'
+          }
+        }]
+  },
+
+  // Video (outstream)
+  {
+    code: 'video-outstream',
+    sizes: [[720, 480]],
+
+    mediaType: 'video',
+    mediaTypes: {
+      video: {
+        context: 'outstream'
+      }
+    },
+    bids: [{
+      bidder: 'rockyou',
+      params: {
+        placementId: '4307'
+      }
+    }]
+  }
+]
+```

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -1,7 +1,5 @@
 import { expect } from 'chai';
-import chai from 'chai';
 import { spec, internals } from 'modules/rockyouBidAdapter';
-import { ROTATION_ZONE } from 'modules/rockyouBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
 describe('RockYouAdapter', () => {
@@ -364,9 +362,9 @@ describe('RockYouAdapter', () => {
 
       let validCallbacks = ['LOAD', 'IMPRESSION', 'COMPLETE', 'ERROR'];
 
-      for (event in validCallbacks) {
-        callbacks('n/a', validCallbacks[event]);
-      }
+      validCallbacks.forEach(event => {
+        callbacks('n/a', event);
+      });
 
       let callbackKeys = Object.keys(tally);
       expect(callbackKeys.length).to.equal(3);

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -140,6 +140,60 @@ describe('RockYouAdapter', () => {
       expect(bannerData.h).to.equal(50);
     });
 
+    it('generates a banner request using a singular adSize instead of an array', () => {
+      // clone the sample for stability
+      let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
+      localBidRequest.sizes = [320, 50];
+      localBidRequest.mediaTypes = { banner: {} };
+
+      let result = spec.buildRequests([localBidRequest], {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+
+      let imps = payload.imp;
+
+      let firstImp = imps[0];
+
+      expect(firstImp.banner).to.not.be.null;
+
+      let bannerData = firstImp.banner;
+
+      expect(bannerData.w).to.equal(320);
+      expect(bannerData.h).to.equal(50);
+    });
+
+    it('fails gracefully on an invalid size', () => {
+      // clone the sample for stability
+      let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
+      localBidRequest.sizes = ['x', 'w'];
+      localBidRequest.mediaTypes = { banner: {} };
+
+      let result = spec.buildRequests([localBidRequest], {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+
+      let imps = payload.imp;
+
+      let firstImp = imps[0];
+
+      expect(firstImp.banner).to.not.be.null;
+
+      let bannerData = firstImp.banner;
+
+      expect(bannerData.w).to.equal(null);
+      expect(bannerData.h).to.equal(null);
+    });
+
     it('generates a video request as expected', () => {
       // clone the sample for stability
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -1,0 +1,403 @@
+import { expect } from 'chai';
+import chai from 'chai';
+import { spec, internals } from 'modules/rockyouBidAdapter';
+import { ROTATION_ZONE } from 'modules/rockyouBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('RockYouAdapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('bid validator', () => {
+    it('rejects a bid that is missing the placementId', () => {
+      let testBid = {};
+      expect(spec.isBidRequestValid(testBid)).to.be.false;
+    });
+
+    it('accepts a bid with all the expected parameters', () => {
+      let testBid = {
+        params: {
+          placementId: 'f39ba81609'
+        }
+      };
+
+      expect(spec.isBidRequestValid(testBid)).to.be.true;
+    });
+  });
+
+  describe('request builder', () => {
+    // Taken from the docs, so used as much as is valid
+    const sampleBidRequest = {
+      'bidder': 'tests',
+      'bidId': '51ef8751f9aead',
+      'params': {
+        'cId': '59ac1da80784890004047d89',
+        'placementId': 'ZZZPLACEMENTZZZ'
+      },
+      'adUnitCode': 'div-gpt-ad-1460505748561-0',
+      'transactionId': 'd7b773de-ceaa-484d-89ca-d9f51b8d61ec',
+      'sizes': [[320, 50], [300, 250], [300, 600]],
+      'bidderRequestId': '418b37f85e772c',
+      'auctionId': '18fd8b8b0bd757'
+    };
+
+    it('successfully generates a URL', () => {
+      const placementId = 'ZZZPLACEMENTZZZ';
+
+      let bidRequests = [
+        {
+          'params': {
+            'placementId': placementId
+          }
+        }
+      ];
+
+      let result = spec.buildRequests(bidRequests, {
+        bidderRequestId: 'sample'
+      });
+
+      expect(result.url).to.not.be.undefined;
+      expect(result.url).to.not.be.null;
+
+      expect(result.url).to.include('/servlet/rotator/' + placementId + '/0/vo?z=')
+    });
+
+    it('uses the bidId id as the openRtb request ID', () => {
+      const bidId = '51ef8751f9aead';
+
+      let bidRequests = [
+        sampleBidRequest
+      ];
+
+      let result = spec.buildRequests(bidRequests, {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+      expect(payload.id).to.equal(bidId);
+    });
+
+    it('generates the device payload as expected', () => {
+      let bidRequests = [
+        sampleBidRequest
+      ];
+
+      let result = spec.buildRequests(bidRequests, {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+      let userData = payload.user;
+
+      expect(userData).to.not.be.null;
+    });
+
+    it('generates multiple imp bodies', () => {
+      let bidRequests = [
+        sampleBidRequest,
+        sampleBidRequest
+      ];
+
+      let result = spec.buildRequests(bidRequests, {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+      expect(payload.imp).to.not.be.null;
+      expect(payload.imp.length).to.equal(2);
+    });
+
+    it('generates a banner request as expected', () => {
+      // clone the sample for stability
+      let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
+
+      localBidRequest.mediaTypes = { banner: {} };
+
+      let result = spec.buildRequests([localBidRequest], {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+
+      let imps = payload.imp;
+
+      let firstImp = imps[0];
+
+      expect(firstImp.banner).to.not.be.null;
+
+      let bannerData = firstImp.banner;
+
+      expect(bannerData.w).to.equal(320);
+      expect(bannerData.h).to.equal(50);
+    });
+
+    it('generates a video request as expected', () => {
+      // clone the sample for stability
+      let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
+
+      localBidRequest.mediaTypes = { video: {} };
+
+      let result = spec.buildRequests([localBidRequest], {
+        bidderRequestId: 'sample'
+      });
+
+      // Double encoded JSON
+      let payload = JSON.parse(result.data);
+
+      expect(payload).to.not.be.null;
+
+      let imps = payload.imp;
+
+      let firstImp = imps[0];
+
+      expect(firstImp.video).to.not.be.null;
+
+      let videoData = firstImp.video;
+
+      expect(videoData.w).to.equal(320);
+      expect(videoData.h).to.equal(50);
+    });
+
+    it('propagates the mediaTypes object in the built request', () => {
+      let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
+
+      localBidRequest.mediaTypes = { video: {} };
+
+      let result = spec.buildRequests([localBidRequest], {
+        bidderRequestId: 'sample'
+      });
+
+      let mediaTypes = result.mediaTypes;
+
+      expect(mediaTypes).to.not.be.null;
+      expect(mediaTypes).to.not.be.undefined;
+      expect(mediaTypes.video).to.not.be.null;
+      expect(mediaTypes.video).to.not.be.undefined;
+    });
+  });
+
+  describe('response interpreter', () => {
+    it('returns an empty array when no bids present', () => {
+      // an empty JSON body indicates no ad was found
+
+      let result = spec.interpretResponse({ body: '' }, {})
+
+      expect(result).to.eql([]);
+    });
+
+    it('gracefully fails when a non-JSON body is present', () => {
+      let result = spec.interpretResponse({ body: 'THIS IS NOT <JSON/>' }, {})
+
+      expect(result).to.eql([]);
+    });
+
+    it('returns a valid bid response on sucessful banner request', () => {
+      let incomingRequestId = 'XXtestingXX';
+      let responsePrice = 3.14
+
+      let responseCreative = '<style>\n    body {\n        margin:0px;\n        padding:0px\n    }\n    #RyImgContainer {\n        width:100%;\n        height:100%;\n        position:absolute;\n        background-image: url(\"http://robertwlaschintest.rockyou.com/images/banners/adhawk3_test_728x90.png\");\n        background-size: contain;\n        background-repeat: no-repeat;\n        background-position: center;\n    }\n</style>\n<a href=\"http://tas-qa.rockyou.com/servlet/rotator/273/0/ch?ajkey=V1290DDF4BAJ-573J8400I2011AC181011I276I274QI219QQP0G00G0I2741274D66E000001010000G0PH101H36W8c21bab0e2DW476682DW44d8f2DW4908a2DX1263e094c09197H24X24AC181011AC18101134440BC2H44W7XU01v042DW8659e0a222DW4d04a2DW446612DW4bca22DX12cca633a0680e00G0G01FFG0H84W4http3A2F2FW5https25334125324625W52Fwww2EW9w3schools2EW3com25W62Fhtml25W72Ftryit2EW3asp25X103Ffilename25X153Dtryhtml_basic05\" target=\"_blank\">\n    <div id=\"RyImgContainer\"></div>\n</a><script src=\"http://tas-qa.rockyou.com/servlet/rotator/273/0/impr?ajkey=V1290DDF4BAJ-573J8400I2011AC181011I276I274QI219QQP0G00G0I2741274D66E000001010000G0PH101H36W8c21bab0e2DW476682DW44d8f2DW4908a2DX1263e094c09197H24X24AC181011AC18101134440BC2H44W7XU01v042DW8659e0a222DW4d04a2DW446612DW4bca22DX12cca633a0680e00G0G01FFG0H84W4http3A2F2FW5https25334125324625W52Fwww2EW9w3schools2EW3com25W62Fhtml25W72Ftryit2EW3asp25X103Ffilename25X153Dtryhtml_basic05&obid=${AUCTION_PRICE}\" type=\"text/javascript\"></script>';
+
+      let responseCreativeId = '274';
+      let responseCurrency = 'USD';
+
+      let responseWidth = 300;
+      let responseHeight = 250;
+      let responseTtl = 213;
+
+      let sampleResponse = {
+        id: '66043f5ca44ecd8f8769093b1615b2d9',
+        seatbid: [
+          {
+            bid: [
+              {
+                id: 'c21bab0e-7668-4d8f-908a-63e094c09197',
+                impid: '1',
+                price: responsePrice,
+                adid: responseCreativeId,
+                adm: responseCreative,
+                adomain: [
+                  'www.rockyouteststudios.com'
+                ],
+                cid: '274',
+                attr: [],
+                w: responseWidth,
+                h: responseHeight,
+                ext: {
+                  ttl: responseTtl
+                }
+              }
+            ],
+            seat: '201',
+            group: 0
+          }
+        ],
+        bidid: 'c21bab0e-7668-4d8f-908a-63e094c09197',
+        cur: responseCurrency
+      };
+
+      let sampleRequest = {
+        bidId: incomingRequestId,
+        mediaTypes: { banner: {} },
+        requestId: incomingRequestId
+      };
+
+      let result = spec.interpretResponse(
+        {
+          body: sampleResponse
+        },
+        sampleRequest
+      );
+
+      expect(result.length).to.equal(1);
+
+      let processedBid = result[0];
+
+      // expect(processedBid.requestId).to.equal(incomingRequestId);
+      expect(processedBid.cpm).to.equal(responsePrice);
+      expect(processedBid.width).to.equal(responseWidth);
+      expect(processedBid.height).to.equal(responseHeight);
+      expect(processedBid.ad).to.equal(responseCreative);
+      expect(processedBid.ttl).to.equal(responseTtl);
+      expect(processedBid.creativeId).to.equal(responseCreativeId);
+      expect(processedBid.netRevenue).to.equal(true);
+      expect(processedBid.currency).to.equal(responseCurrency);
+    });
+
+    it('returns an valid bid response on sucessful video request', () => {
+      let incomingRequestId = 'XXtesting-275XX';
+      let responsePrice = 6
+
+      let responseCreative = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VAST version=\"2.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"vast.xsd\">\n    <Ad id=\"01-1101011\">\n        <InLine>\n            <AdSystem version=\"2.0\">Mediatastic</AdSystem>\n            <Impression><![CDATA[https://tas-qa.rockyou.com/servlet/rotator/278/0/impr?ajkey=V1213221C05J-573J8400I2011329C6717J1556I270QI238QQP0G00G0I270127CF0B71G5302EW30061G3302E300001011000G0PH101H36W8a8ae0b482DW4a8db2DW442202DW4ba0c2DX127458f452b1f5H24X24329C6717329C6717448F69C5G0101109G9W9unwrapperG01FFG0G05C]]></Impression><Creatives>\n                <Creative>\n                    <Linear>\n                        <MediaFiles>\n                            <MediaFile delivery=\"progressive\" height=\"3\" type=\"video/mp4\" width=\"4\"><![CDATA[https://cdnrockyou-a.akamaihd.net/apps/socialvideoads/ads/mobiletest/kitchenscramble_15s.mp4]]></MediaFile>\n                        </MediaFiles>\n                        <Duration><![CDATA[00:00:15]]></Duration>\n                        <TrackingEvents/>\n                        <VideoClicks>\n                            <ClickThrough><![CDATA[https://www.facebook.com/KitchenScramble]]></ClickThrough>\n                        <ClickTracking><![CDATA[https://tas-qa.rockyou.com/servlet/rotator/278/0/ch?ajkey=V1213221C05J-573J8400I2011329C6717J1556I270QI238QQP0G00G0I270127CF0B71G5302EW30061G3302E300001011000G0PH101H36W8a8ae0b482DW4a8db2DW442202DW4ba0c2DX127458f452b1f5H24X24329C6717329C6717448F69C5G0101109G9W9unwrapperG01FFG0G05C]]></ClickTracking></VideoClicks>\n                    </Linear>\n                </Creative>\n            </Creatives>\n        </InLine>\n    </Ad>\n</VAST>';
+
+      let responseCreativeId = '1556';
+      let responseCurrency = 'USD';
+
+      let responseWidth = 284;
+      let responseHeight = 285;
+      let responseTtl = 286;
+
+      let sampleResponse = {
+        id: '1234567890',
+        seatbid: [
+          {
+            bid: [
+              {
+                id: 'a8ae0b48-a8db-4220-ba0c-7458f452b1f5',
+                impid: '1',
+                price: responsePrice,
+                adid: responseCreativeId,
+                adm: responseCreative,
+                cid: '270',
+                attr: [],
+                w: responseWidth,
+                h: responseHeight,
+                ext: {
+                  ttl: responseTtl
+                }
+              }
+            ],
+            seat: '201',
+            group: 0
+          }
+        ],
+        bidid: 'a8ae0b48-a8db-4220-ba0c-7458f452b1f5',
+        cur: 'USD'
+      };
+
+      let sampleRequest = {
+        bidId: incomingRequestId,
+        mediaTypes: {
+          video: {
+          }
+        },
+        requestId: incomingRequestId
+      };
+
+      let result = spec.interpretResponse(
+        {
+          body: sampleResponse
+        },
+        sampleRequest
+      );
+
+      expect(result.length).to.equal(1);
+
+      let processedBid = result[0];
+
+      // expect(processedBid.requestId).to.equal(incomingRequestId);
+      expect(processedBid.cpm).to.equal(responsePrice);
+      expect(processedBid.width).to.equal(responseWidth);
+      expect(processedBid.height).to.equal(responseHeight);
+      expect(processedBid.ad).to.equal(null);
+      expect(processedBid.ttl).to.equal(responseTtl);
+      expect(processedBid.creativeId).to.equal(responseCreativeId);
+      expect(processedBid.netRevenue).to.equal(true);
+      expect(processedBid.currency).to.equal(responseCurrency);
+      expect(processedBid.vastXml).to.equal(responseCreative);
+    });
+
+    it('generates event callbacks as expected', () => {
+      let tally = {};
+      let renderer = {
+        handleVideoEvent: (eventObject) => {
+          let eventName = eventObject.eventName;
+          if (tally[eventName]) {
+            tally[eventName] = tally[eventName] + 1;
+          } else {
+            tally[eventName] = 1;
+          }
+        }
+      };
+
+      let callbacks = internals.playerCallbacks(renderer);
+
+      let validCallbacks = ['LOAD', 'IMPRESSION', 'COMPLETE', 'ERROR'];
+
+      for (event in validCallbacks) {
+        callbacks('n/a', validCallbacks[event]);
+      }
+
+      let callbackKeys = Object.keys(tally);
+      expect(callbackKeys.length).to.equal(3);
+      expect(tally['loaded']).to.equal(1);
+      expect(tally['impression']).to.equal(1);
+      expect(tally['ended']).to.equal(2);
+    });
+
+    it('generates a renderer that will hide on complete', () => {
+      let elementName = 'test_element_id';
+      let selector = `#${elementName}`;
+
+      let mockElement = {
+        style: {
+          display: 'some'
+        }
+      };
+
+      document.querySelector = (name) => {
+        if (name === selector) {
+          return mockElement;
+        } else {
+          return null;
+        }
+      };
+
+      let renderer = internals.generateRenderer({}, elementName);
+
+      renderer.handlers['ended']();
+
+      expect(mockElement.style.display).to.equal('none');
+    })
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
 
- [ X ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
Created a new bidder adapter for RockYou.

<!-- For new bidder adapters, please provide the following -->
- Test parameters for validating bids without vast player:
```
{
  bidder: 'rockyou',
  params: {
    placementId: '4322'
  }
}
```

- Test parameters for validating bids requiring vast player (this assumes that `mediaTypes: { video: {}}` is set in the adUnit):
```
{
  bidder: 'rockyou',
  params: {
    placementId: '4307'
  }
}
```

- prebid.adapter@rockyou.com
- [ X ] official adapter submission
