### PR TITLE
Fix for TrustX Legacy adapter

### DIFF
--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -37,11 +37,13 @@ export const spec = {
     const bidsMap = {};
     const bids = validBidRequests || [];
     let priceType = 'net';
+    let reqId;
 
     bids.forEach(bid => {
       if (bid.params.priceType === 'gross') {
         priceType = 'gross';
       }
+      reqId = bid.bidderRequestId;
       if (!bidsMap[bid.params.uid]) {
         bidsMap[bid.params.uid] = [bid];
         auids.push(bid.params.uid);
@@ -54,6 +56,7 @@ export const spec = {
       u: utils.getTopWindowUrl(),
       pt: priceType,
       auids: auids.join(','),
+      r: reqId
     };
 
     return {

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -82,6 +82,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '43');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
     it('auids must not be duplicated', () => {
@@ -91,6 +92,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '43,45');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
     it('pt parameter must be "gross" if params.priceType === "gross"', () => {
@@ -101,6 +103,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'gross');
       expect(payload).to.have.property('auids', '43,45');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
       delete bidRequests[1].params.priceType;
     });
 
@@ -112,6 +115,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '43,45');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
       delete bidRequests[1].params.priceType;
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Parameter "r" was added to HB request as cache buster in order to avoid caching header bids.
We need this version reviewed and merged in order to migrate our pubs who are using the legacy prebid version

- paul@trustx.org
- [x] official adapter submission