### PR TITLE
S2s defaults fix in serverbidServerBidAdapter

### DIFF
--- a/modules/serverbidServerBidAdapter.js
+++ b/modules/serverbidServerBidAdapter.js
@@ -10,13 +10,8 @@ const getConfig = config.getConfig;
 const REQUIRED_S2S_CONFIG_KEYS = ['siteId', 'networkId', 'bidders', 'endpoint'];
 
 let _s2sConfig;
-config.setDefaults({
-  's2sConfig': {
-    enabled: false,
-    timeout: 1000,
-    adapter: 'serverbidServer'
-  }
-});
+
+const bidder = 'serverbidServer';
 
 var ServerBidServerAdapter;
 ServerBidServerAdapter = function ServerBidServerAdapter() {
@@ -61,6 +56,8 @@ ServerBidServerAdapter = function ServerBidServerAdapter() {
   sizeMap[43] = '300x600';
 
   function setS2sConfig(options) {
+    if (options.adapter != bidder) return;
+
     let contains = (xs, x) => xs.indexOf(x) > -1;
     let userConfig = Object.keys(options);
 
@@ -231,6 +228,6 @@ ServerBidServerAdapter.createNew = function() {
   return new ServerBidServerAdapter();
 };
 
-adaptermanager.registerBidAdapter(new ServerBidServerAdapter(), 'serverbidServer');
+adaptermanager.registerBidAdapter(new ServerBidServerAdapter(), bidder);
 
 module.exports = ServerBidServerAdapter;

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,6 +1,6 @@
 /** @module adaptermanger */
 
-import { flatten, getBidderCodes, getDefinedParams, shuffle } from './utils';
+import { flatten, getBidderCodes, getDefinedParams, shuffle, timestamp } from './utils';
 import { resolveStatus } from './sizeMapping';
 import { processNativeAdUnitParams, nativeAdapters } from './native';
 import { newBidder } from './adapters/bidderFactory';
@@ -234,6 +234,7 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
       let s2sBidRequest = {tid, 'ad_units': adUnitsS2SCopy};
       if (s2sBidRequest.ad_units.length) {
         let doneCbs = serverBidRequests.map(bidRequest => {
+          bidRequest.start = timestamp();
           bidRequest.doneCbCallCount = 0;
           return doneCb(bidRequest.bidderRequestId)
         });
@@ -265,7 +266,7 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
 
   // handle client adapter requests
   clientBidRequests.forEach(bidRequest => {
-    bidRequest.start = new Date().getTime();
+    bidRequest.start = timestamp();
     // TODO : Do we check for bid in pool from here and skip calling adapter again ?
     const adapter = _bidderRegistry[bidRequest.bidderCode];
     if (adapter) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixed 3 issues
1) only prebidServerBidAdapter can set s2sConfig defaults. So removed the default setting from serverbidServerBidAdapter.js

2) s2sConfig subscriber in serverbidServerBidAdapter is doing some validation checks.  These check should only be done if this adapter is in use.

3) s2s Requests did not have start time when calling for bids.

