### PR TITLE
remove hardcoded localhost port for tests

### DIFF
--- a/test/spec/modules/nanointeractiveBidAdapter_spec.js
+++ b/test/spec/modules/nanointeractiveBidAdapter_spec.js
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import * as utils from 'src/utils';
+
 import {
   ALG,
   BIDDER_CODE, CATEGORY, DATA_PARTNER_ID, DATA_PARTNER_PIXEL_ID, ENGINE_BASE_URL, NQ, NQ_NAME, SECURITY,
@@ -44,7 +46,7 @@ describe('nanointeractive adapter tests', function () {
     [NQ]: [SEARCH_QUERY, null],
     sizes: [WIDTH + 'x' + HEIGHT],
     bidId: '24a1c9ec270973',
-    cors: 'http://localhost:9876'
+    cors: 'http://localhost'
   };
 
   function getSingleBidResponse(isValid) {
@@ -84,10 +86,14 @@ describe('nanointeractive adapter tests', function () {
         expect(nanoBidAdapter.isBidRequestValid(getBid(false))).to.equal(false);
       });
       it('Test buildRequests()', function () {
+        let stub = sinon.stub(utils, 'getOrigin', () => 'http://localhost');
+
         let request = nanoBidAdapter.buildRequests([getBid(true)]);
         expect(request.method).to.equal('POST');
         expect(request.url).to.equal(ENGINE_BASE_URL);
         expect(request.data).to.equal(JSON.stringify([SINGlE_BID_REQUEST]));
+
+        stub.restore();
       });
       it('Test interpretResponse() length', function () {
         let bids = nanoBidAdapter.interpretResponse([getSingleBidResponse(true), getSingleBidResponse(false)]);

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -100,7 +100,7 @@ describe('ReadPeakAdapter', () => {
           },
           'id': '11bc5dd5-7421-4dd8-c926-40fa653bec76',
           'ref': '',
-          'page': 'http://localhost:9876/?id=48509002',
+          'page': 'http://localhost',
           'domain': 'localhost'
         },
         'app': null,


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixed some tests that make assertions on the expected localhost port.  The port can change depending on whether the defined port is already taken, which will cause the test suite to fail.  This resolves that issue.
