### PR TITLE
pin gulp-connect at non-broken version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-clean": "^0.3.2",
     "gulp-concat": "^2.6.0",
-    "gulp-connect": "^5.0.0",
+    "gulp-connect": "5.0.0",
     "gulp-documentation": "^3.2.1",
     "gulp-eslint": "^4.0.0",
     "gulp-footer": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,7 +3770,7 @@ gulp-concat@^2.6.0:
     through2 "^2.0.0"
     vinyl "^2.0.0"
 
-gulp-connect@^5.0.0:
+gulp-connect@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gulp-connect/-/gulp-connect-5.0.0.tgz#f2fdf306ae911468368c2285f2d782f13eddaf4e"
   dependencies:


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The latest version of gulp-connect pushed to the npm registry [is broken](https://github.com/AveVlad/gulp-connect/issues/241) and breaks our build.  I suggest we just pin it to a good version since its a dev tool and we really don't require the updates.
