### PR TITLE
Separate bids & won calls

### DIFF
--- a/modules/adomikAnalyticsAdapter.js
+++ b/modules/adomikAnalyticsAdapter.js
@@ -1,8 +1,7 @@
 import adapter from 'src/AnalyticsAdapter';
 import CONSTANTS from 'src/constants.json';
 import adaptermanager from 'src/adaptermanager';
-import find from 'core-js/library/fn/array/find';
-import findIndex from 'core-js/library/fn/array/find-index';
+import { logInfo } from 'src/utils';
 
 // Events used in adomik analytics adapter
 const auctionInit = CONSTANTS.EVENTS.AUCTION_INIT;
@@ -12,19 +11,14 @@ const bidResponse = CONSTANTS.EVENTS.BID_RESPONSE;
 const bidWon = CONSTANTS.EVENTS.BID_WON;
 const bidTimeout = CONSTANTS.EVENTS.BID_TIMEOUT;
 
-let bidwonTimeout = 1000;
-
 let adomikAdapter = Object.assign(adapter({}),
   {
     // Track every event needed
     track({ eventType, args }) {
       switch (eventType) {
         case auctionInit:
+          adomikAdapter.initializeBucketEvents()
           adomikAdapter.currentContext.id = args.auctionId
-          adomikAdapter.currentContext.timeout = args.timeout
-          if (args.config.bidwonTimeout !== undefined && typeof args.config.bidwonTimeout === 'number') {
-            bidwonTimeout = args.config.bidwonTimeout;
-          }
           break;
 
         case bidTimeout:
@@ -39,12 +33,9 @@ let adomikAdapter = Object.assign(adapter({}),
           break;
 
         case bidWon:
-          adomikAdapter.bucketEvents.push({
-            type: 'winner',
-            event: {
-              id: args.adId,
-              placementCode: args.adUnitCode
-            }
+          adomikAdapter.sendWonEvent({
+            id: args.adId,
+            placementCode: args.adUnitCode
           });
           break;
 
@@ -61,16 +52,18 @@ let adomikAdapter = Object.assign(adapter({}),
           break;
 
         case auctionEnd:
-          setTimeout(() => {
-            if (adomikAdapter.bucketEvents.length > 0) {
-              adomikAdapter.sendTypedEvent();
-            }
-          }, bidwonTimeout);
+          if (adomikAdapter.bucketEvents.length > 0) {
+            adomikAdapter.sendTypedEvent();
+          }
           break;
       }
     }
   }
 );
+
+adomikAdapter.initializeBucketEvents = function() {
+  adomikAdapter.bucketEvents = [];
+}
 
 adomikAdapter.sendTypedEvent = function() {
   const groupedTypedEvents = adomikAdapter.buildTypedEvents();
@@ -78,7 +71,6 @@ adomikAdapter.sendTypedEvent = function() {
   const bulkEvents = {
     uid: adomikAdapter.currentContext.uid,
     ahbaid: adomikAdapter.currentContext.id,
-    timeout: adomikAdapter.currentContext.timeout,
     hostname: window.location.hostname,
     eventsByPlacementCode: groupedTypedEvents.map(function(typedEventsByType) {
       let sizes = [];
@@ -108,8 +100,11 @@ adomikAdapter.sendTypedEvent = function() {
     })
   };
 
+  const stringBulkEvents = JSON.stringify(bulkEvents)
+  logInfo('Events sent to adomik prebid analytic ' + stringBulkEvents);
+
   // Encode object in base64
-  const encodedBuf = window.btoa(JSON.stringify(bulkEvents));
+  const encodedBuf = window.btoa(stringBulkEvents);
 
   // Create final url and split it in 1600 characters max (+endpoint length)
   const encodedUri = encodeURIComponent(encodedBuf);
@@ -121,6 +116,17 @@ adomikAdapter.sendTypedEvent = function() {
     img.src = 'https://' + adomikAdapter.currentContext.url + '/?q=' + partUrl;
   })
 };
+
+adomikAdapter.sendWonEvent = function (wonEvent) {
+  const stringWonEvent = JSON.stringify(wonEvent)
+  logInfo('Won event sent to adomik prebid analytic ' + wonEvent);
+
+  // Encode object in base64
+  const encodedBuf = window.btoa(stringWonEvent);
+  const encodedUri = encodeURIComponent(encodedBuf);
+  const img = new Image(1, 1);
+  img.src = `https://${adomikAdapter.currentContext.url}/?q=${encodedUri}&id=${adomikAdapter.currentContext.id}&won=true`
+}
 
 adomikAdapter.buildBidResponse = function (bid) {
   return {
@@ -140,7 +146,7 @@ adomikAdapter.buildBidResponse = function (bid) {
 
 adomikAdapter.sizeUtils = {
   sizeAlreadyExists: (sizes, typedEventSize) => {
-    return find(sizes, (size) => size.height === typedEventSize.height && size.width === typedEventSize.width);
+    return sizes.find((size) => size.height === typedEventSize.height && size.width === typedEventSize.width);
   },
   formatSize: (typedEventSize) => {
     return {
@@ -161,7 +167,7 @@ adomikAdapter.buildTypedEvents = function () {
   const groupedTypedEvents = [];
   adomikAdapter.bucketEvents.forEach(function(typedEvent, i) {
     const [placementCode, type] = [typedEvent.event.placementCode, typedEvent.type];
-    let existTypedEvent = findIndex(groupedTypedEvents, (groupedTypedEvent) => groupedTypedEvent.placementCode === placementCode);
+    let existTypedEvent = groupedTypedEvents.findIndex((groupedTypedEvent) => groupedTypedEvent.placementCode === placementCode);
 
     if (existTypedEvent === -1) {
       groupedTypedEvents.push({
@@ -181,23 +187,20 @@ adomikAdapter.buildTypedEvents = function () {
   return groupedTypedEvents;
 }
 
-// Initialize adomik object
-adomikAdapter.currentContext = {};
-adomikAdapter.bucketEvents = [];
-
 adomikAdapter.adapterEnableAnalytics = adomikAdapter.enableAnalytics;
 
 adomikAdapter.enableAnalytics = function (config) {
+  adomikAdapter.currentContext = {};
+
   const initOptions = config.options;
   if (initOptions) {
     adomikAdapter.currentContext = {
       uid: initOptions.id,
       url: initOptions.url,
-      debug: initOptions.debug,
       id: '',
       timeouted: false,
-      timeout: 0,
     }
+    logInfo('Adomik Analytics enabled with config', initOptions);
     adomikAdapter.adapterEnableAnalytics(config);
   }
 };

--- a/modules/adomikAnalyticsAdapter.js
+++ b/modules/adomikAnalyticsAdapter.js
@@ -2,6 +2,8 @@ import adapter from 'src/AnalyticsAdapter';
 import CONSTANTS from 'src/constants.json';
 import adaptermanager from 'src/adaptermanager';
 import { logInfo } from 'src/utils';
+import find from 'core-js/library/fn/array/find';
+import findIndex from 'core-js/library/fn/array/find-index';
 
 // Events used in adomik analytics adapter
 const auctionInit = CONSTANTS.EVENTS.AUCTION_INIT;
@@ -146,7 +148,7 @@ adomikAdapter.buildBidResponse = function (bid) {
 
 adomikAdapter.sizeUtils = {
   sizeAlreadyExists: (sizes, typedEventSize) => {
-    return sizes.find((size) => size.height === typedEventSize.height && size.width === typedEventSize.width);
+    return find(sizes, (size) => size.height === typedEventSize.height && size.width === typedEventSize.width);
   },
   formatSize: (typedEventSize) => {
     return {
@@ -167,7 +169,7 @@ adomikAdapter.buildTypedEvents = function () {
   const groupedTypedEvents = [];
   adomikAdapter.bucketEvents.forEach(function(typedEvent, i) {
     const [placementCode, type] = [typedEvent.event.placementCode, typedEvent.type];
-    let existTypedEvent = groupedTypedEvents.findIndex((groupedTypedEvent) => groupedTypedEvent.placementCode === placementCode);
+    let existTypedEvent = findIndex(groupedTypedEvents, (groupedTypedEvent) => groupedTypedEvent.placementCode === placementCode);
 
     if (existTypedEvent === -1) {
       groupedTypedEvents.push({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Don't wait for won event anymore, but send it separately
