### PR TITLE
Support setting outstream renderer options

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -206,7 +206,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     if (rtbBid.renderer_url) {
       const rendererOptions = utils.deepAccess(
         bidderRequest.bids[0],
-        'mediaTypes.video.rendererOptions'
+        'renderer.options'
       );
 
       Object.assign(bid, {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -123,7 +123,7 @@ export const spec = {
   }
 }
 
-function newRenderer(adUnitCode, rtbBid, rendererOptions) {
+function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
   const renderer = Renderer.install({
     id: rtbBid.renderer_id,
     url: rtbBid.renderer_url,
@@ -204,8 +204,11 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     });
     // This supports Outstream Video
     if (rtbBid.renderer_url) {
-      // TODO get appnexus params properly
-      const rendererOptions = bidderRequest.bids[0].params.video.rendererOptions;
+      const rendererOptions = utils.deepAccess(
+        bidderRequest.bids[0],
+        'mediaTypes.video.rendererOptions'
+      );
+
       Object.assign(bid, {
         adResponse: serverBid,
         renderer: newRenderer(bid.adUnitCode, rtbBid, rendererOptions)

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -127,10 +127,7 @@ function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
   const renderer = Renderer.install({
     id: rtbBid.renderer_id,
     url: rtbBid.renderer_url,
-    config: Object.assign({},
-      { adText: `AppNexus Outstream Video Ad via Prebid.js` },
-      rendererOptions,
-    ),
+    config: rendererOptions,
     loaded: false,
   });
 

--- a/src/auction.js
+++ b/src/auction.js
@@ -287,7 +287,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidRequest, auctionId}) {
   const adUnitRenderer =
     bidRequest.bids && bidRequest.bids[0] && bidRequest.bids[0].renderer;
 
-  if (adUnitRenderer) {
+  if (adUnitRenderer && adUnitRenderer.url) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });
     bidObject.renderer.setRender(adUnitRenderer.render);
   }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/appnexusBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
+import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
 
@@ -392,7 +393,7 @@ describe('AppNexusAdapter', () => {
     });
 
     it('handles native responses', () => {
-      let response1 = Object.assign({}, response);
+      let response1 = deepClone(response);
       response1.tags[0].ads[0].ad_type = 'native';
       response1.tags[0].ads[0].rtb.native = {
         'title': 'Native Creative',
@@ -423,6 +424,29 @@ describe('AppNexusAdapter', () => {
       expect(result[0].native.body).to.equal('Cool description great stuff');
       expect(result[0].native.cta).to.equal('Do it');
       expect(result[0].native.image.url).to.equal('http://cdn.adnxs.com/img.png');
+    });
+
+    it('supports configuring outstream renderers', () => {
+      const outstreamResponse = deepClone(response);
+      outstreamResponse.tags[0].ads[0].rtb.video = {};
+      outstreamResponse.tags[0].ads[0].renderer_url = 'renderer.js';
+
+      const bidderRequest = {
+        bids: [{
+          mediaTypes: {
+            video: {
+              rendererOptions: {
+                adText: 'configured'
+              }
+            }
+          }
+        }]
+      };
+
+      const result = spec.interpretResponse({ body: outstreamResponse }, {bidderRequest});
+      expect(result[0].renderer.config).to.deep.equal(
+        bidderRequest.bids[0].mediaTypes.video.rendererOptions
+      );
     });
   });
 });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -433,11 +433,9 @@ describe('AppNexusAdapter', () => {
 
       const bidderRequest = {
         bids: [{
-          mediaTypes: {
-            video: {
-              rendererOptions: {
-                adText: 'configured'
-              }
+          renderer: {
+            options: {
+              adText: 'configured'
             }
           }
         }]
@@ -445,7 +443,7 @@ describe('AppNexusAdapter', () => {
 
       const result = spec.interpretResponse({ body: outstreamResponse }, {bidderRequest});
       expect(result[0].renderer.config).to.deep.equal(
-        bidderRequest.bids[0].mediaTypes.video.rendererOptions
+        bidderRequest.bids[0].renderer.options
       );
     });
   });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Adds support to the appnexus adapter for setting outstream renderer options with the `renderer.options` object. Any properties in this object will be used to configure the renderer that is used to display outstream video

_Example_
```JavaScript
pbjs.addAdUnits({
  code: 'video1',
  sizes: [ 640, 480 ],
  mediaTypes: {
    video: { context: 'outstream' }
  },
  renderer: {
    options: {
        adText: 'Outstream Video Ad',
    },
  },
  bids: [
    {
      bidder: 'appnexus',
      params: { placementId: '5768085' }
    }
  ]
});
```

## Other information
Resolves #1700