### PR TITLE
Update Sonobi Bidder Adapter For Prebid 1.x

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -1,0 +1,137 @@
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { getTopWindowLocation, parseSizesInput } from 'src/utils';
+import * as utils from '../src/utils';
+
+const BIDDER_CODE = 'sonobi';
+const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
+
+export const spec = {
+  code: BIDDER_CODE,
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid - The bid params to validate.
+   * @return {boolean} True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: bid => !!(bid.params && (bid.params.ad_unit || bid.params.placement_id) && (bid.params.sizes || bid.sizes)),
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests - an array of bids
+   * @return {object} ServerRequest - Info describing the request to the server.
+   */
+  buildRequests: (validBidRequests) => {
+    const bids = validBidRequests.map(bid => {
+      let slotIdentifier = _validateSlot(bid)
+      if (/^[\/]?[\d]+[[\/].+[\/]?]?$/.test(slotIdentifier)) {
+        slotIdentifier = slotIdentifier.charAt(0) === '/' ? slotIdentifier : '/' + slotIdentifier
+        return {
+          [`${slotIdentifier}|${bid.bidId}`]: `${_validateSize(bid)}${_validateFloor(bid)}`
+        }
+      } else if (/^[0-9a-fA-F]{20}$/.test(slotIdentifier) && slotIdentifier.length === 20) {
+        return {
+          [bid.bidId]: `${slotIdentifier}|${_validateSize(bid)}${_validateFloor(bid)}`
+        }
+      } else {
+        utils.logError(`The ad unit code or Sonobi Placement id for slot ${bid.bidId} is invalid`);
+      }
+    });
+
+    const payload = {
+      'key_maker': JSON.stringify(Object.assign({}, ...bids)),
+      'ref': getTopWindowLocation().host,
+      's': utils.generateUUID(),
+    };
+
+    return {
+      method: 'GET',
+      url: STR_ENDPOINT,
+      withCredentials: true,
+      data: payload
+    };
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: (serverResponse) => {
+    const bidResponse = serverResponse.body;
+    const bidsReturned = [];
+
+    if (Object.keys(bidResponse.slots).length === 0) {
+      return bidsReturned;
+    }
+
+    Object.keys(bidResponse.slots).forEach(slot => {
+      const bid = bidResponse.slots[slot];
+
+      if (bid.sbi_aid && bid.sbi_mouse && bid.sbi_size) {
+        const bids = {
+          requestId: slot.split('|').slice(-1)[0],
+          cpm: Number(bid.sbi_mouse),
+          width: Number(bid.sbi_size.split('x')[0]) || 1,
+          height: Number(bid.sbi_size.split('x')[1]) || 1,
+          ad: _creative(bidResponse.sbi_dc, bid.sbi_aid),
+          ttl: 500,
+          creativeId: bid.sbi_aid,
+          netRevenue: true,
+          currency: 'USD',
+        };
+
+        if (bid.sbi_dozer) {
+          bids.dealId = bid.sbi_dozer;
+        }
+
+        bidsReturned.push(bids);
+      }
+    });
+    return bidsReturned;
+  },
+  /**
+   * Register User Sync.
+   */
+  getUserSyncs: (syncOptions, serverResponses) => {
+    const syncs = [];
+    if (syncOptions.pixelEnabled && serverResponses[0].body.sbi_px) {
+      serverResponses[0].body.sbi_px.forEach(pixel => {
+        syncs.push({
+          type: pixel.type,
+          url: pixel.url
+        });
+      });
+    }
+    return syncs;
+  }
+}
+
+function _validateSize (bid) {
+  if (bid.params.sizes) {
+    return parseSizesInput(bid.params.sizes).join(',');
+  }
+  return parseSizesInput(bid.sizes).join(',');
+}
+
+function _validateSlot (bid) {
+  if (bid.params.ad_unit) {
+    return bid.params.ad_unit;
+  }
+  return bid.params.placement_id;
+}
+
+function _validateFloor (bid) {
+  if (bid.params.floor) {
+    return `|f=${bid.params.floor}`;
+  }
+  return '';
+}
+
+function _creative (sbi_dc, sbi_aid) {
+  const src = 'https://' + sbi_dc + 'apex.go.sonobi.com/sbi.js?aid=' + sbi_aid + '&as=null';
+  return '<script type="text/javascript" src="' + src + '"></script>';
+}
+
+registerBidder(spec);

--- a/modules/sonobiBidAdapter.md
+++ b/modules/sonobiBidAdapter.md
@@ -1,0 +1,32 @@
+# Overview
+
+```
+Module Name: Sonobi Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: apex.prebid@sonobi.com
+```
+
+# Description
+
+Module that connects to Sonobi's demand sources.
+
+# Test Parameters
+```
+  var adUnits = [
+    {
+      code: 'adUnit_af',
+      sizes: [[300, 250], [300, 600]],  // a display size
+      bids: [
+        {
+            bidder: 'sonobi',
+            params: {
+                ad_unit: '/7780971/sparks_prebid_MR',
+                placement_id: '1a2b3c4d5e6f1a2b3c4d', // ad_unit and placement_id are mutually exclusive
+                sizes: [[300, 250], [300, 600]],
+                floor: 1 // optional
+            }
+        }
+      ]
+    }
+  ];
+```

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -1,0 +1,229 @@
+import { expect } from 'chai'
+import { spec } from 'modules/sonobiBidAdapter'
+import { newBidder } from 'src/adapters/bidderFactory'
+
+describe('SonobiBidAdapter', () => {
+  const adapter = newBidder(spec)
+
+  describe('.code', () => {
+    it('should return a bidder code of sonobi', () => {
+      expect(spec.code).to.equal('sonobi')
+    })
+  })
+
+  describe('inherited functions', () => {
+    it('should exist and be a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function')
+    })
+  })
+
+  describe('.isBidRequestValid', () => {
+    let bid = {
+      'bidder': 'sonobi',
+      'params': {
+        'ad_unit': '/7780971/sparks_prebid_MR',
+        'sizes': [[300, 250], [300, 600]],
+        'floor': '1'
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    }
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    })
+
+    it('should return true when bid.params.placement_id and bid.params.sizes are found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      delete bid.sizes
+      bid.params = {
+        'placement_id': '1a2b3c4d5e6f1a2b3c4d',
+        'sizes': [[300, 250], [300, 600]],
+      }
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    })
+
+    it('should return true when bid.params.placement_id and bid.sizes are found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      bid.sizes = [[300, 250], [300, 600]]
+      bid.params = {
+        'placement_id': '1a2b3c4d5e6f1a2b3c4d',
+      }
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    })
+
+    it('should return true when bid.params.ad_unit and bid.params.sizes are found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      delete bid.sizes
+      bid.params = {
+        'ad_unit': '/7780971/sparks_prebid_MR',
+        'sizes': [[300, 250], [300, 600]],
+      }
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    })
+
+    it('should return true when bid.params.ad_unit and bid.sizes are found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      bid.sizes = [[300, 250], [300, 600]]
+      bid.params = {
+        'ad_unit': '/7780971/sparks_prebid_MR',
+      }
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    })
+
+    it('should return false when no params are found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      expect(spec.isBidRequestValid(bid)).to.equal(false)
+    })
+
+    it('should return false when bid.params.placement_id and bid.params.ad_unit are not found', () => {
+      let bid = Object.assign({}, bid)
+      delete bid.params
+      bid.params = {
+        'placement_id': 0,
+        'ad_unit': 0,
+        'sizes': [[300, 250], [300, 600]],
+      }
+      expect(spec.isBidRequestValid(bid)).to.equal(false)
+    })
+  })
+
+  describe('.buildRequests', () => {
+    let bidRequest = [{
+      'bidder': 'sonobi',
+      'params': {
+        'placement_id': '1a2b3c4d5e6f1a2b3c4d',
+        'sizes': [[300, 250], [300, 600]],
+        'floor': '1.25',
+      },
+      'adUnitCode': 'adunit-code-1',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1f',
+    },
+    {
+      'bidder': 'sonobi',
+      'params': {
+        'ad_unit': '/7780971/sparks_prebid_LB',
+        'sizes': [[300, 250], [300, 600]],
+      },
+      'adUnitCode': 'adunit-code-2',
+      'sizes': [[120, 600], [300, 600], [160, 600]],
+      'bidId': '30b31c1838de1e',
+    }];
+
+    let keyMakerData = {
+      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25',
+      '/7780971/sparks_prebid_LB|30b31c1838de1e': '300x250,300x600',
+    };
+
+    it('should return a properly formatted request', () => {
+      const bidRequests = spec.buildRequests(bidRequest)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.key_maker).to.deep.equal(JSON.stringify(keyMakerData))
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+    })
+  })
+
+  describe('.interpretResponse', () => {
+    let bidResponse = {
+      'body': {
+        'slots': {
+          '/7780971/sparks_prebid_LB|30b31c1838de1d': {
+            'sbi_size': '300x600',
+            'sbi_apoc': 'remnant',
+            'sbi_aid': '30292e432662bd5f86d90774b944b039',
+            'sbi_mouse': 1.07,
+          },
+          '30b31c1838de1f': {
+            'sbi_size': '300x250',
+            'sbi_apoc': 'remnant',
+            'sbi_aid': '30292e432662bd5f86d90774b944b038',
+            'sbi_mouse': 1.25,
+            'sbi_dozer': 'dozerkey',
+          },
+          '30b31c1838de1e': {},
+        },
+        'sbi_dc': 'mco-1-',
+        'sbi_px': [{
+          'code': 'so',
+          'delay': 0,
+          'url': 'https://example.com/pixel.png',
+          'type': 'image'
+        }],
+        'sbi_suid': 'af99f47a-e7b1-4791-ab32-34952d87c5a0',
+      }
+    };
+
+    let prebidResponse = [{
+      'requestId': '30b31c1838de1d',
+      'cpm': 1.07,
+      'width': 300,
+      'height': 600,
+      'ad': '<script type="text/javascript" src="https://mco-1-apex.go.sonobi.com/sbi.js?aid=30292e432662bd5f86d90774b944b039&as=null"></script>',
+      'ttl': 500,
+      'creativeId': '30292e432662bd5f86d90774b944b039',
+      'netRevenue': true,
+      'currency': 'USD'
+    }, {
+      'requestId': '30b31c1838de1f',
+      'cpm': 1.25,
+      'width': 300,
+      'height': 250,
+      'ad': '<script type="text/javascript" src="https://mco-1-apex.go.sonobi.com/sbi.js?aid=30292e432662bd5f86d90774b944b038&as=null"></script>',
+      'ttl': 500,
+      'creativeId': '30292e432662bd5f86d90774b944b038',
+      'netRevenue': true,
+      'currency': 'USD',
+      'dealId': 'dozerkey'
+    }];
+
+    it('should map bidResponse to prebidResponse', () => {
+      const response = spec.interpretResponse(bidResponse);
+      expect(response).to.deep.equal(prebidResponse);
+    })
+  })
+
+  describe('.getUserSyncs', () => {
+    let bidResponse = [{
+      'body': {
+        'sbi_px': [{
+          'code': 'so',
+          'delay': 0,
+          'url': 'https://pixel-test',
+          'type': 'image'
+        }]
+      }
+    }];
+
+    it('should return one sync pixel', () => {
+      expect(spec.getUserSyncs({ pixelEnabled: true }, bidResponse)).to.deep.equal([{
+        type: 'image',
+        url: 'https://pixel-test'
+      }]);
+    })
+
+    it('should return an empty array when sync is enabled but no sync pixel returned', () => {
+      const pixel = Object.assign({}, bidResponse);
+      delete pixel[0].body.sbi_px;
+      expect(spec.getUserSyncs({ pixelEnabled: true }, bidResponse)).to.have.length(0);
+    })
+
+    it('should return an empty array', () => {
+      expect(spec.getUserSyncs({ pixelEnabled: false }, bidResponse)).to.have.length(0);
+    })
+  })
+})


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Update Sonobi Bid Adapter For Prebid 1.x

- test parameters for validating bids
```
{
  bidder: "sonobi",
  params: {
    ad_unit: "/7780971/sparks_prebid_MR",
    sizes: [[300, 250], [300, 600]],
  }
}
```

- contact email of the adapter’s maintainer apex.prebid@sonobi.com
- [x] official adapter submission

## Other information
