### PR TITLE
Add adapter for Invibes (0.34)

### DIFF
--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -1,0 +1,142 @@
+﻿var utils = require('src/utils.js');
+var bidfactory = require('src/bidfactory.js');
+var bidmanager = require('src/bidmanager.js');
+var adaptermanager = require('src/adaptermanager');
+
+const CONSTANTS = {
+  BIDDER_CODE: 'invibes',
+  BID_ENDPOINT: '//k.r66net.com/GetLink'
+}
+/**
+ * Adapter for requesting bids from Invibes.
+ *
+ * @returns {{callBids: _callBids}}
+ * @constructor
+ */
+const InvibesAdapter = function InvibesAdapter() {
+  var bids;
+  let iframe;
+
+  var _iv_bid_placementIds = [];
+  var _iv_bid_adContainerId;
+  var _iv_custom_endpoint;
+  var _iv_login_id;
+
+  function _callBids(params) {
+    bids = params.bids;
+
+    if (!bids || bids.length == 0) {
+      utils.logInfo('Invibes Adapter - no bids requested');
+      return;
+    } else if (bids.length > 1) {
+      utils.logInfo('Invibes Adapter - multiple bids requested. Will match to first configured placementId');
+    }
+
+    for (var i = 0; i < bids.length; i++) {
+      var bid = bids[i];
+
+      _iv_bid_placementIds.push(bid.params.placementId);
+      _iv_bid_adContainerId = _iv_bid_adContainerId || bid.params.adContainerId;
+      _iv_custom_endpoint = _iv_custom_endpoint || bid.params.customEndpoint;
+      _iv_login_id = _iv_login_id || bid.params.loginId;
+    }
+
+    _getBids();
+  }
+
+  function _getBids() {
+    iframe = utils.createInvisibleIframe();
+    var elToAppend = document.getElementsByTagName('head')[0];
+    elToAppend.insertBefore(iframe, elToAppend.firstChild);
+    var iframeDoc = utils.getIframeDocument(iframe);
+    iframeDoc.write(_createRequestContent());
+    iframeDoc.close();
+  }
+
+  function _createRequestContent() {
+    var bidParams = encodeURIComponent(JSON.stringify({
+      placementIds: _iv_bid_placementIds
+    }));
+    var getlinkEndpoint = _iv_custom_endpoint || CONSTANTS.BID_ENDPOINT;
+    var url = getlinkEndpoint + '?bidParams=' + bidParams;
+    var content = utils.createContentToExecuteExtScriptInFriendlyFrame(url);
+
+    var scripts = 'window.invibes = window.invibes || {};' +
+      'window.invibes.iv_bidParams = "%%IV_BID_PARAMS%%";' +
+      'window.invibes.iv_adContainerId = "%%IV_AD_CONTAINER_ID%%";' +
+      'window.invibes.iv_loginId = "%%IV_LOGIN_ID%%";' +
+      'window.invibes.iv_async_callback_fn = window.parent.$$PREBID_GLOBAL$$.handleInvibesCallback;';
+    var map = {};
+    map.IV_BID_PARAMS = bidParams;
+    map.IV_AD_CONTAINER_ID = _iv_bid_adContainerId;
+    map.IV_LOGIN_ID = _iv_login_id;
+    scripts = utils.replaceTokenInString(scripts, map, '%%');
+    content = content.replace('<!--PRE_SCRIPT_TAG_MACRO-->', '<script>' + scripts + '</script>');
+
+    return content;
+  }
+
+  $$PREBID_GLOBAL$$.handleInvibesCallback = function(biddingResponse) {
+    if (!biddingResponse) {
+      utils.logInfo('Invibes Adapter - Bid response is empty');
+      return;
+    }
+
+    if (!bids || bids.length == 0) {
+      utils.logInfo('Invibes Adapter - No bids requested');
+      return;
+    }
+
+    var bid;
+    var placementFound = false;
+
+    for (var i = 0; i < bids.length; i++) {
+      bid = bids[i].params;
+      if (bid.placementId == biddingResponse.placementId) {
+        var adResponse;
+        placementFound = true;
+
+        if (biddingResponse.bidstatus === '1') {
+          adResponse = bidfactory.createBid(1);
+          adResponse.bidderCode = CONSTANTS.BIDDER_CODE;
+          adResponse.cpm = Number(biddingResponse.bid);
+
+          if (bids[i].sizes != null && bids[i].sizes.length > 0) {
+            adResponse.width = bids[i].sizes[0][0];
+            adResponse.height = bids[i].sizes[0][1];
+          }
+
+          adResponse.width = biddingResponse.width || adResponse.width;
+          adResponse.height = biddingResponse.height || adResponse.height;
+
+          // html code
+          adResponse.ad = unescape(biddingResponse.creative_tag);
+          if (biddingResponse.tracking_url !== null && biddingResponse.tracking_url !== undefined) {
+            adResponse.ad += utils.createTrackPixelIframeHtml(decodeURIComponent(biddingResponse.tracking_url));
+          }
+          // put placement here
+          bidmanager.addBidResponse(bids[i].placementCode, adResponse);
+        } else {
+          // Indicate an ad was not returned
+          adResponse = bidfactory.createBid(2);
+          adResponse.bidderCode = CONSTANTS.BIDDER_CODE;
+          bidmanager.addBidResponse(bids[i].placementCode, adResponse);
+        }
+
+        break;
+      }
+    }
+
+    if (!placementFound) {
+      utils.logInfo('Invibes Adapter - Incorrect placement id. The expected request was for placementId: ' + biddingResponse.placementId);
+    }
+  };
+
+  return {
+    callBids: _callBids
+  };
+}
+
+adaptermanager.registerBidAdapter(new InvibesAdapter(), CONSTANTS.BIDDER_CODE);
+
+module.exports = InvibesAdapter;

--- a/modules/invibesBidAdapter.md
+++ b/modules/invibesBidAdapter.md
@@ -1,0 +1,29 @@
+# Overview
+
+**Module Name**: Invibes Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**: system_operations@invibes.com
+
+# Description
+
+Module that connects to Invibes demand sources
+
+# Test Parameters
+```
+    var adUnits = [
+      {
+        code: 'test-div',
+        sizes: [[300, 250]],
+        bids: [
+          {
+            bidder: 'invibes',
+            params: {
+              placementId: '11595052',
+              adContainerId: 'pb-if-312312',
+			  loginId: '5qCteKJl0wfiyQ5DEplh'
+            }
+          }
+        ]
+      }
+    ];
+```

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -19,7 +19,7 @@ let getDefaultBidRequest = () => {
       placementCode: 'test-div',
       params: {
         placementId: '1234567',
-        customEndpoint: '//static.videostepstage.com/scripts/testPrebidEndpoint.js'
+        customEndpoint: 'https://static.r66net.com/bid/testEndpoint.js'
       }
     }]
   };

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -1,0 +1,127 @@
+import {
+  expect
+} from 'chai';
+import * as utils from 'src/utils';
+import InvibesAdapter from 'modules/invibesBidAdapter';
+import bidmanager from 'src/bidmanager';
+
+let getDefaultBidRequest = () => {
+  return {
+    bidderCode: 'invibes',
+    requestId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+    bidderRequestId: '7101db09af0db2',
+    start: new Date().getTime(),
+    bids: [{
+      bidder: 'invibes',
+      bidId: '84ab500420319d',
+      bidderRequestId: '7101db09af0db2',
+      requestId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+      placementCode: 'test-div',
+      params: {
+        placementId: '1234567',
+        customEndpoint: '//static.videostepstage.com/scripts/testPrebidEndpoint.js'
+      }
+    }]
+  };
+};
+
+describe('InvibesAdapter', () => {
+  let adapter;
+
+  function createBidderRequest({
+    bids,
+    params
+  } = {}) {
+    var bidderRequest = getDefaultBidRequest();
+    if (bids && Array.isArray(bids)) {
+      bidderRequest.bids = bids;
+    }
+    if (params) {
+      bidderRequest.bids.forEach(bid => bid.params = params);
+    }
+    return bidderRequest;
+  }
+
+  beforeEach(() => adapter = new InvibesAdapter());
+
+  describe('callBids()', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+
+    describe('bid request', () => {
+      beforeEach(() => {
+        sinon.stub(utils, 'createContentToExecuteExtScriptInFriendlyFrame', function() {
+          return '';
+        });
+      });
+
+      afterEach(() => {
+        utils.createContentToExecuteExtScriptInFriendlyFrame.restore();
+      });
+
+      it('requires parameters to be made', () => {
+        adapter.callBids({});
+        utils.createContentToExecuteExtScriptInFriendlyFrame.calledOnce.should.be.false;
+      });
+
+      it('valid placement test creative', () => {
+        var bidRequest = createBidderRequest();
+        adapter.callBids(bidRequest);
+        var callURL = utils.createContentToExecuteExtScriptInFriendlyFrame.getCall(0).args[0];
+        expect(bidRequest.bids[0].params.placementId).to.equal('1234567');
+        expect(callURL).to.contain('placementIds');
+      });
+    });
+
+    describe('#handleInvibesCallback: ', () => {
+      beforeEach(() => {
+        sinon.stub(utils, 'createContentToExecuteExtScriptInFriendlyFrame', function() {
+          return '';
+        });
+        sinon.stub(bidmanager, 'addBidResponse');
+      });
+
+      afterEach(() => {
+        utils.createContentToExecuteExtScriptInFriendlyFrame.restore();
+        bidmanager.addBidResponse.restore();
+      });
+
+      it('exists and is a function', () => {
+        expect($$PREBID_GLOBAL$$.handleInvibesCallback).to.exist.and.to.be.a('function');
+      });
+
+      it('empty response, arguments not passed', () => {
+        adapter.callBids(createBidderRequest());
+        $$PREBID_GLOBAL$$.handleInvibesCallback();
+        expect(bidmanager.addBidResponse.callCount).to.equal(0);
+      });
+
+      it('not empty response', () => {
+        adapter.callBids(createBidderRequest());
+        $$PREBID_GLOBAL$$.handleInvibesCallback({
+          bidstatus: '1',
+          bid: 0.01,
+          placementId: '1234567'
+        });
+        sinon.assert.called(bidmanager.addBidResponse);
+        expect(bidmanager.addBidResponse.firstCall.args[0]).to.equal('test-div');
+        var theBid = bidmanager.addBidResponse.firstCall.args[1];
+        expect(theBid.bidderCode).to.equal('invibes');
+        expect(theBid.cpm).to.equal(0.01);
+      });
+
+      it('not empty response but invalid status', () => {
+        adapter.callBids(createBidderRequest());
+        $$PREBID_GLOBAL$$.handleInvibesCallback({
+          bidstatus: '0',
+          placementId: '1234567'
+        });
+        sinon.assert.called(bidmanager.addBidResponse);
+        expect(bidmanager.addBidResponse.firstCall.args[0]).to.equal('test-div');
+        var theBid = bidmanager.addBidResponse.firstCall.args[1];
+        expect(theBid.bidderCode).to.equal('invibes');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
Added adapter for requesting bids from Invibes for Prebid 0.34

- test parameters for validating bids
```
{
  bidder: 'invibes',
  params: {
    placementId: '1234567',
    customEndpoint: 'https://static.r66net.com/bid/testEndpoint.js'
   }
}
```
- contact email of the adapter’s maintainer: system_operations@invibes.com
- [x] official adapter submission

## Other information
Please allow inclusion of our adapter for the legacy 0.34 version of prebid. The Publishers we are collaborating with are currently requiring this version. We intend to provide a new adapter as soon as possible for version 1.0, according to the adapter conventions
