### PR TITLE
native is reserved keyword, use bracket/quotes to reference property

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -403,7 +403,7 @@ export function getKeyValueTargetingPairs(bidderCode, custBidObj) {
   }
 
   // set native key value targeting
-  if (custBidObj.native) {
+  if (custBidObj['native']) {
     keyValues = Object.assign({}, keyValues, getNativeTargeting(custBidObj));
   }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Port of 6cf71d0 to 1.0. 'native' is a reserved keyword, and its use as a property breaks some tools.  Use ['native'] to safely refer to it.

## Other information
#1984 