### PR TITLE
1298 fix fbf0840

### DIFF
--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -453,6 +453,7 @@ describe('auctionmanager.js', function () {
     let auction;
     let ajaxStub;
     const BIDDER_CODE = 'sampleBidder';
+    const BIDDER_CODE1 = 'sampleBidder1';
     let makeRequestsStub;
     let bids = [{
       'ad': 'creative',
@@ -641,57 +642,6 @@ describe('auctionmanager.js', function () {
         auction.callBids();
         const addedBid = auction.getBidsReceived().pop();
         assert.equal(addedBid.renderer.url, 'renderer.js');
-      });
-    });
-
-    describe('with auction timeout 20', () => {
-      let auction;
-      let adUnits;
-      let adUnitCodes;
-      let createAuctionStub;
-      let spec;
-      let getBidderRequestStub;
-      let eventsEmitSpy;
-
-      beforeEach(() => {
-        adUnits = [{
-          code: 'adUnit-code',
-          bids: [
-            {bidder: BIDDER_CODE, params: {placementId: 'id'}},
-          ]
-        }];
-        adUnitCodes = ['adUnit-code'];
-        auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: 20});
-        createAuctionStub = sinon.stub(auctionModule, 'newAuction');
-        createAuctionStub.returns(auction);
-        getBidderRequestStub = sinon.stub(utils, 'getBidderRequest');
-
-        let newBidRequest = Object.assign({}, bidRequests[0], {'start': 1000});
-        getBidderRequestStub.returns(newBidRequest);
-
-        spec = {
-          code: BIDDER_CODE,
-          isBidRequestValid: sinon.stub(),
-          buildRequests: sinon.stub(),
-          interpretResponse: sinon.stub(),
-          getUserSyncs: sinon.stub()
-        };
-        eventsEmitSpy = sinon.spy(events, 'emit');
-      });
-
-      afterEach(() => {
-        auctionModule.newAuction.restore();
-        utils.getBidderRequest.restore();
-        events.emit.restore();
-      });
-
-      it('should emit BID_TIMEOUT for timed out bids', () => {
-        registerBidder(spec);
-        spec.buildRequests.returns([{'id': 123, 'method': 'POST'}]);
-        spec.isBidRequestValid.returns(true);
-        spec.interpretResponse.returns(bids);
-        auction.callBids();
-        assert.ok(eventsEmitSpy.calledWith(CONSTANTS.EVENTS.BID_TIMEOUT), 'emitted events BID_TIMEOUT');
       });
     });
   });


### PR DESCRIPTION
This is a work in progress, I was hoping to get some feedback on the tests.

## Type of change
- [x] Bugfix

## Description of change
This is a port of fbf0840 to 1.0. 

The calling order for addBidToAuction and doCallbacksIfNeeded is not consistent. This patch moves most of the calls to doCallbacks into addBidToAuction to make sure it is used consistently.

There is a problem with one of the tests though. A side effect of this change is that the bid that triggers the timeout is added to the bids received list. This seems appropriate to me since if you've waited for and  received the bid, it doesn't make sense to throw it away because of timing. However, if that bid is the last bid that prebid was waiting for, the timeout event is not triggered. The test case that I removed in this patch expects that any bid received after the timeout window will trigger the timeout event. 

It seems like a fix could be to just add a second bidder so that the triggering bid is not the last bid expected. I tried modifying the test to do that, but ran into a lot of issues getting the test framework to bend to my will. I can bang on it some more, but I thought I'd see if anyone who knows the test system better could help.

As more of a general question, have you all thought about working on the test framework to make it easier to use? There is a lot of duplicated code and partially mocked objects, which makes it confusing to work with. It'd be nice if it were easier to get a standard mocked request / response, and the test could modify it as needed. 

The current situation is frustrating and there are times that I don't even submit bugfix patches because the tests are so brittle and difficult to change, like I spend 10x time on wrangling tests vs the actual bugfix. Anyway just my 2c, /rant. Would you all be open to patches to refactor the tests?