### PR TITLE
pass empty responses array for registerSyncs in prebidserverBidAdapter

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -345,7 +345,7 @@ export const spec = {
     let bidResponse = bidResponses[0];
 
     if (config.getConfig('aol.userSyncOn') === constants.EVENTS.BID_RESPONSE) {
-      if (!$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped && bidResponse.ext && bidResponse.ext.pixels) {
+      if (!$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped && bidResponse && bidResponse.ext && bidResponse.ext.pixels) {
         $$PREBID_GLOBAL$$.aolGlobals.pixelsDropped = true;
 
         return parsePixelItems(bidResponse.ext.pixels);

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -254,7 +254,7 @@ export function PrebidServer() {
         requestedBidders.forEach(bidder => {
           let clientAdapter = adaptermanager.getBidAdapter(bidder);
           if (clientAdapter && clientAdapter.registerSyncs) {
-            clientAdapter.registerSyncs();
+            clientAdapter.registerSyncs([]);
           }
         });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
prebidserverBidAdapter was not quite following the API for registerSyncs.  Added it to pass an empty array for server responses (since we don't have the original server responses like the client adapters have).  Also fixed AOL adapter from throwing errors if getUserSyncs called with no responses.