### PR TITLE
Option to use a configurable vendor preset for s2sConfig

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -35,8 +35,7 @@ config.setDefaults({
 const availVendorDefaults = {
   'appnexus': {
     adapter: 'prebidServer',
-    cookieSet: true,
-    cookieSetUrl: '//acdn.adnxs.com/cookieset/cs.js',
+    cookieSet: false,
     enabled: true,
     endpoint: '//prebid.adnxs.com/pbs/v1/auction',
     syncEndpoint: '//prebid.adnxs.com/pbs/v1/cookie_sync',
@@ -360,7 +359,7 @@ export function PrebidServer() {
           });
         }
       }
-      if (result.status === 'no_cookie' && typeof _s2sConfig.cookieSetUrl === 'string') {
+      if (result.status === 'no_cookie' && _s2sConfig.cookieSet && typeof _s2sConfig.cookieSetUrl === 'string') {
         // cookie sync
         cookieSet(_s2sConfig.cookieSetUrl);
       }

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -32,7 +32,7 @@ config.setDefaults({
 });
 
 // accountId and bidders params are not included here, should be configured by end-user
-const avail_vendor_defaults = {
+const availVendorDefaults = {
   'appnexus': {
     adapter: 'prebidServer',
     cookieSet: true,
@@ -42,7 +42,15 @@ const avail_vendor_defaults = {
     syncEndpoint: '//prebid.adnxs.com/pbs/v1/cookie_sync',
     timeout: 1000
   },
-  'rubicon': {}
+  'rubicon': {
+    adapter: 'prebidServer',
+    cookieSet: true,
+    cookieSetUrl: 'https://secure-assets.rubiconproject.com/utils/cookieset/cs.js',
+    enabled: true,
+    endpoint: 'https://prebid-server.rubiconproject.com/auction',
+    syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
+    timeout: 500
+  }
 };
 
 /**
@@ -59,13 +67,13 @@ const avail_vendor_defaults = {
  * @property {string} [cookieSetUrl] url for cookie set library, if passed then cookieSet is enabled
  */
 function setS2sConfig(options) {
-  if (options.default_vendor) {
-    let vendor = options.default_vendor
+  if (options.defaultVendor) {
+    let vendor = options.defaultVendor
 
-    if (avail_vendor_defaults.hasOwnProperty(vendor)) {
-      Object.keys(avail_vendor_defaults[vendor]).forEach(function(vendor_key) {
-        if (s2sDefaultConfig[vendor_key] === options[vendor_key]) {
-          options[vendor_key] = avail_vendor_defaults[vendor][vendor_key]
+    if (availVendorDefaults.hasOwnProperty(vendor)) {
+      Object.keys(availVendorDefaults[vendor]).forEach(function(vendorKey) {
+        if (s2sDefaultConfig[vendorKey] === options[vendorKey]) {
+          options[vendorKey] = availVendorDefaults[vendor][vendorKey]
         }
       });
     } else {

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -70,12 +70,6 @@ function setS2sConfig(options) {
     let vendor = options.defaultVendor;
     let optionKeys = Object.keys(options);
 
-    // adding these values to default config after the fact to mimic how they're added automatically via the setConfig code in pre1api.js
-    Object.assign(s2sDefaultConfig, {
-      endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
-      syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
-    });
-
     if (availVendorDefaults.hasOwnProperty(vendor)) {
       // vendor keys will be set if either: the key was not specified by user
       // or if the user did not set their own distinct value (ie using the system default) to override the vendor

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -44,10 +44,10 @@ const availVendorDefaults = {
   'rubicon': {
     adapter: 'prebidServer',
     cookieSet: true,
-    cookieSetUrl: 'https://secure-assets.rubiconproject.com/utils/cookieset/cs.js',
+    cookieSetUrl: '//secure-assets.rubiconproject.com/utils/cookieset/cs.js',
     enabled: true,
-    endpoint: 'https://prebid-server.rubiconproject.com/auction',
-    syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
+    endpoint: '//prebid-server.rubiconproject.com/auction',
+    syncEndpoint: '//prebid-server.rubiconproject.com/cookie_sync',
     timeout: 500
   }
 };
@@ -67,14 +67,21 @@ const availVendorDefaults = {
  */
 function setS2sConfig(options) {
   if (options.defaultVendor) {
-    let vendor = options.defaultVendor
-    let optionKeys = Object.keys(options)
+    let vendor = options.defaultVendor;
+    let optionKeys = Object.keys(options);
+
+    // adding these values to default config after the fact to mimic how they're added automatically via the setConfig code in pre1api.js
+    Object.assign(s2sDefaultConfig, {
+      endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
+      syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
+    });
+
     if (availVendorDefaults.hasOwnProperty(vendor)) {
       // vendor keys will be set if either: the key was not specified by user
       // or if the user did not set their own distinct value (ie using the system default) to override the vendor
       Object.keys(availVendorDefaults[vendor]).forEach(function(vendorKey) {
         if (s2sDefaultConfig[vendorKey] === options[vendorKey] || !includes(optionKeys, vendorKey)) {
-          options[vendorKey] = availVendorDefaults[vendor][vendorKey]
+          options[vendorKey] = availVendorDefaults[vendor][vendorKey];
         }
       });
     } else {

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -68,10 +68,12 @@ const availVendorDefaults = {
 function setS2sConfig(options) {
   if (options.defaultVendor) {
     let vendor = options.defaultVendor
-
+    let optionKeys = Object.keys(options)
     if (availVendorDefaults.hasOwnProperty(vendor)) {
+      // vendor keys will be set if either: the key was not specified by user
+      // or if the user did not set their own distinct value (ie using the system default) to override the vendor
       Object.keys(availVendorDefaults[vendor]).forEach(function(vendorKey) {
-        if (s2sDefaultConfig[vendorKey] === options[vendorKey]) {
+        if (s2sDefaultConfig[vendorKey] === options[vendorKey] || !includes(optionKeys, vendorKey)) {
           options[vendorKey] = availVendorDefaults[vendor][vendorKey]
         }
       });

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -43,8 +43,7 @@ const availVendorDefaults = {
   },
   'rubicon': {
     adapter: 'prebidServer',
-    cookieSet: true,
-    cookieSetUrl: '//secure-assets.rubiconproject.com/utils/cookieset/cs.js',
+    cookieSet: false,
     enabled: true,
     endpoint: '//prebid-server.rubiconproject.com/auction',
     syncEndpoint: '//prebid-server.rubiconproject.com/cookie_sync',

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -19,14 +19,31 @@ const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_NETREVENUE = true;
 
 let _s2sConfig;
+
+const s2sDefaultConfig = {
+  enabled: false,
+  timeout: 1000,
+  maxBids: 1,
+  adapter: 'prebidServer'
+};
+
 config.setDefaults({
-  's2sConfig': {
-    enabled: false,
-    timeout: 1000,
-    maxBids: 1,
-    adapter: 'prebidServer'
-  }
+  's2sConfig': s2sDefaultConfig
 });
+
+// accountId and bidders params are not included here, should be configured by end-user
+const avail_vendor_defaults = {
+  'appnexus': {
+    adapter: 'prebidServer',
+    cookieSet: true,
+    cookieSetUrl: '//acdn.adnxs.com/cookieset/cs.js',
+    enabled: true,
+    endpoint: '//prebid.adnxs.com/pbs/v1/auction',
+    syncEndpoint: '//prebid.adnxs.com/pbs/v1/cookie_sync',
+    timeout: 1000
+  },
+  'rubicon': {}
+};
 
 /**
  * Set config for server to server header bidding
@@ -42,6 +59,21 @@ config.setDefaults({
  * @property {string} [cookieSetUrl] url for cookie set library, if passed then cookieSet is enabled
  */
 function setS2sConfig(options) {
+  if (options.default_vendor) {
+    let vendor = options.default_vendor
+
+    if (avail_vendor_defaults.hasOwnProperty(vendor)) {
+      Object.keys(avail_vendor_defaults[vendor]).forEach(function(vendor_key) {
+        if (s2sDefaultConfig[vendor_key] === options[vendor_key]) {
+          options[vendor_key] = avail_vendor_defaults[vendor][vendor_key]
+        }
+      });
+    } else {
+      utils.logError('Incorrect or unavailable prebid server default vendor option: ' + vendor);
+      return false;
+    }
+  }
+
   let keys = Object.keys(options);
 
   if (['accountId', 'bidders', 'endpoint'].filter(key => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -539,8 +539,8 @@ describe('S2S Adapter', () => {
       expect(vendorConfig).to.have.property('accountId', 'abc');
       expect(vendorConfig).to.have.property('adapter', 'prebidServer');
       expect(vendorConfig.bidders).to.deep.equal(['rubicon']);
-      expect(vendorConfig.cookieSet).to.be.true;
-      expect(vendorConfig).to.have.property('cookieSetUrl', '//secure-assets.rubiconproject.com/utils/cookieset/cs.js');
+      expect(vendorConfig.cookieSet).to.be.false;
+      expect(vendorConfig.cookieSetUrl).to.be.undefined;
       expect(vendorConfig.enabled).to.be.true;
       expect(vendorConfig).to.have.property('endpoint', '//prebid-server.rubiconproject.com/auction');
       expect(vendorConfig).to.have.property('syncEndpoint', '//prebid-server.rubiconproject.com/cookie_sync');

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -480,18 +480,18 @@ describe('S2S Adapter', () => {
       const options = {
         accountId: '1',
         bidders: ['appnexus'],
-        default_vendor: 'mytest'
+        defaultVendor: 'mytest'
       };
 
       config.setConfig({ s2sConfig: options });
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should configure the s2sConfig object with vendor defaults unless specified by user', () => {
+    it('should configure the s2sConfig object with appnexus vendor defaults unless specified by user', () => {
       const options = {
         accountId: '123',
         bidders: ['appnexus'],
-        default_vendor: 'appnexus',
+        defaultVendor: 'appnexus',
         timeout: 750
       };
 
@@ -507,6 +507,29 @@ describe('S2S Adapter', () => {
       expect(vendorConfig.enabled).to.be.true;
       expect(vendorConfig).to.have.property('endpoint', '//prebid.adnxs.com/pbs/v1/auction');
       expect(vendorConfig).to.have.property('syncEndpoint', '//prebid.adnxs.com/pbs/v1/cookie_sync');
+      expect(vendorConfig).to.have.property('timeout', 750);
+    });
+
+    it('should configure the s2sConfig object with rubicon vendor defaults unless specified by user', () => {
+      const options = {
+        accountId: 'abc',
+        bidders: ['rubicon'],
+        defaultVendor: 'rubicon',
+        timeout: 750
+      };
+
+      config.setConfig({ s2sConfig: options });
+      sinon.assert.notCalled(logErrorSpy);
+
+      let vendorConfig = config.getConfig('s2sConfig');
+      expect(vendorConfig).to.have.property('accountId', 'abc');
+      expect(vendorConfig).to.have.property('adapter', 'prebidServer');
+      expect(vendorConfig.bidders).to.deep.equal(['rubicon']);
+      expect(vendorConfig.cookieSet).to.be.true;
+      expect(vendorConfig).to.have.property('cookieSetUrl', 'https://secure-assets.rubiconproject.com/utils/cookieset/cs.js');
+      expect(vendorConfig.enabled).to.be.true;
+      expect(vendorConfig).to.have.property('endpoint', 'https://prebid-server.rubiconproject.com/auction');
+      expect(vendorConfig).to.have.property('syncEndpoint', 'https://prebid-server.rubiconproject.com/cookie_sync');
       expect(vendorConfig).to.have.property('timeout', 750);
     });
   });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -475,5 +475,39 @@ describe('S2S Adapter', () => {
       config.setConfig({ s2sConfig: options });
       sinon.assert.calledOnce(logErrorSpy);
     });
+
+    it('should log error when vendor does not exist', () => {
+      const options = {
+        accountId: '1',
+        bidders: ['appnexus'],
+        vendor_default: 'mytest'
+      };
+
+      config.setConfig({ s2sConfig: options });
+      sinon.assert.calledOnce(logErrorSpy);
+    });
+
+    it('should configure the s2sConfig object with vendor defaults unless specified by user', () => {
+      const options = {
+        accountId: '123',
+        bidders: ['appnexus'],
+        default_vendor: 'appnexus',
+        timeout: 750
+      };
+
+      config.setConfig({ s2sConfig: options });
+      sinon.assert.notCalled(logErrorSpy);
+
+      let vendorConfig = config.getConfig('s2sConfig');
+      expect(vendorConfig).to.have.property('accountId', '123');
+      expect(vendorConfig).to.have.property('adapter', 'prebidServer');
+      expect(vendorConfig.bidders).to.deep.equal(['appnexus']);
+      expect(vendorConfig.cookieSet).to.be.true;
+      expect(vendorConfig).to.have.property('cookieSetUrl', '//acdn.adnxs.com/cookieset/cs.js');
+      expect(vendorConfig.enabled).to.be.true;
+      expect(vendorConfig).to.have.property('endpoint', '//prebid.adnxs.com/pbs/v1/auction');
+      expect(vendorConfig).to.have.property('syncEndpoint', '//prebid.adnxs.com/pbs/v1/cookie_sync');
+      expect(vendorConfig).to.have.property('timeout', 750);
+    });
   });
 });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -429,6 +429,7 @@ describe('S2S Adapter', () => {
     it('calls cookieSet cookie sync when no_cookie response && opted in', () => {
       server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
       let myConfig = Object.assign({
+        cookieSet: true,
         cookieSetUrl: 'https://acdn.adnxs.com/cookieset/cs.js'
       }, CONFIG);
 
@@ -450,7 +451,7 @@ describe('S2S Adapter', () => {
       utils.logError.restore();
     });
 
-    it('should log error when accountId is missing', () => {
+    it('should log an error when accountId is missing', () => {
       const options = {
         enabled: true,
         bidders: ['appnexus'],
@@ -463,7 +464,7 @@ describe('S2S Adapter', () => {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log error when bidders is missing', () => {
+    it('should log an error when bidders is missing', () => {
       const options = {
         accountId: '1',
         enabled: true,
@@ -476,7 +477,20 @@ describe('S2S Adapter', () => {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log error when vendor does not exist', () => {
+    it('should log an error when endpoint is missing', () => {
+      const options = {
+        accountId: '1',
+        bidders: ['appnexus'],
+        timeout: 1000,
+        enabled: true,
+        adapter: 'prebidServer'
+      };
+
+      config.setConfig({ s2sConfig: options});
+      sinon.assert.calledOnce(logErrorSpy);
+    });
+
+    it('should log an error when using an unknown vendor', () => {
       const options = {
         accountId: '1',
         bidders: ['appnexus'],
@@ -502,8 +516,8 @@ describe('S2S Adapter', () => {
       expect(vendorConfig).to.have.property('accountId', '123');
       expect(vendorConfig).to.have.property('adapter', 'prebidServer');
       expect(vendorConfig.bidders).to.deep.equal(['appnexus']);
-      expect(vendorConfig.cookieSet).to.be.true;
-      expect(vendorConfig).to.have.property('cookieSetUrl', '//acdn.adnxs.com/cookieset/cs.js');
+      expect(vendorConfig.cookieSet).to.be.false;
+      expect(vendorConfig.cookieSetUrl).to.be.undefined;
       expect(vendorConfig.enabled).to.be.true;
       expect(vendorConfig).to.have.property('endpoint', '//prebid.adnxs.com/pbs/v1/auction');
       expect(vendorConfig).to.have.property('syncEndpoint', '//prebid.adnxs.com/pbs/v1/cookie_sync');

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -540,10 +540,10 @@ describe('S2S Adapter', () => {
       expect(vendorConfig).to.have.property('adapter', 'prebidServer');
       expect(vendorConfig.bidders).to.deep.equal(['rubicon']);
       expect(vendorConfig.cookieSet).to.be.true;
-      expect(vendorConfig).to.have.property('cookieSetUrl', 'https://secure-assets.rubiconproject.com/utils/cookieset/cs.js');
+      expect(vendorConfig).to.have.property('cookieSetUrl', '//secure-assets.rubiconproject.com/utils/cookieset/cs.js');
       expect(vendorConfig.enabled).to.be.true;
-      expect(vendorConfig).to.have.property('endpoint', 'https://prebid-server.rubiconproject.com/auction');
-      expect(vendorConfig).to.have.property('syncEndpoint', 'https://prebid-server.rubiconproject.com/cookie_sync');
+      expect(vendorConfig).to.have.property('endpoint', '//prebid-server.rubiconproject.com/auction');
+      expect(vendorConfig).to.have.property('syncEndpoint', '//prebid-server.rubiconproject.com/cookie_sync');
       expect(vendorConfig).to.have.property('timeout', 750);
     });
   });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -480,7 +480,7 @@ describe('S2S Adapter', () => {
       const options = {
         accountId: '1',
         bidders: ['appnexus'],
-        vendor_default: 'mytest'
+        default_vendor: 'mytest'
       };
 
       config.setConfig({ s2sConfig: options });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
I have added support for end-users to optionally use a configurable pbs vendor preset in their `setConfig({s2sConfig: {...})` page code.  By using this `defaultVendor` option, the end-user won't have to specify a majority of the data-points that are generally needed for this object.

Below is an example usage:
```
pbjs.setConfig({
    "s2sConfig": {
        accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
        bidders: ['appnexus'],
        defaultVendor: 'appnexus'
    }
});
```
Two of the required s2sConfig attributes will still be expected to be supplied by the end-user; these are `accountId` and `bidders` (as depicted above).  All of the other commonly used attributes are configured under a vendor object and are invoked by using the `defaultVendor` attribute.  

While all these vendor settings will be automatically populated based on established defaults, end-users will still have the ability to override any individual vendor settings by simply including the attribute in their page-code (same as they would today).  

An example of this would look like:
```
pbjs.setConfig({
    "s2sConfig": {
        accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
        bidders: ['appnexus'],
        defaultVendor: 'appnexus',
        timeout: 500,
        cookieSet: false
    }
});
```

Of also note - the vendor settings are configured overwrite the normally assigned system default values for the s2sConfig (assuming there is no user override).  So ultimately s2sConfig settings are established in the following hierarchy:
User overrides > vendor settings > system defaults



For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/579