### PR TITLE
add digitrust support to prebidserverBidAdapter

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -166,6 +166,23 @@ const paramTypes = {
   },
 };
 
+function _getDigiTrustQueryParams() {
+  function getDigiTrustId() {
+    let digiTrustUser = window.DigiTrust && (config.getConfig('digiTrustId') || window.DigiTrust.getUser({member: 'T9QSFKPDN9'}));
+    return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
+  }
+  let digiTrustId = getDigiTrustId();
+  // Verify there is an ID and this user has not opted out
+  if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) {
+    return null;
+  }
+  return {
+    id: digiTrustId.id,
+    keyv: digiTrustId.keyv,
+    pref: 0
+  };
+}
+
 /**
  * Bidder adapter for Prebid Server
  */
@@ -217,6 +234,12 @@ export function PrebidServer() {
       ad_units: adUnits.filter(hasSizes),
       is_debug: isDebug
     };
+
+    let digiTrust = _getDigiTrustQueryParams();
+
+    if (digiTrust) {
+      requestJson.digiTrust = digiTrust;
+    }
 
     // in case config.bidders contains invalid bidders, we only process those we sent requests for.
     const requestedBidders = requestJson.ad_units.map(adUnit => adUnit.bids.map(bid => bid.bidder).filter(utils.uniques)).reduce(utils.flatten).filter(utils.uniques);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -243,6 +243,41 @@ describe('S2S Adapter', () => {
       expect(requestBid.ad_units[0].bids[0].params.placementId).to.exist.and.to.be.a('number');
       expect(requestBid.ad_units[0].bids[0].params.member).to.exist.and.to.be.a('string');
     });
+
+    it('adds digitrust id if present and not optout', () => {
+      let digiTrustObj = {
+        success: true,
+        identity: {
+          privacy: {
+            optout: false
+          },
+          id: 'testId',
+          keyv: 'testKeyV'
+        }
+      };
+
+      window.DigiTrust = {
+        getUser: () => digiTrustObj
+      };
+
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      let requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.digiTrust).to.deep.equal({
+        id: digiTrustObj.identity.id,
+        keyv: digiTrustObj.identity.keyv,
+        pref: 0
+      });
+
+      digiTrustObj.identity.privacy.optout = true;
+
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      requestBid = JSON.parse(requests[1].requestBody);
+
+      expect(requestBid.digiTrust).to.not.exist;
+
+      delete window.DigiTrust;
+    });
   });
 
   describe('response handler', () => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -244,7 +244,7 @@ describe('S2S Adapter', () => {
       expect(requestBid.ad_units[0].bids[0].params.member).to.exist.and.to.be.a('string');
     });
 
-    it('adds digitrust id if present and not optout', () => {
+    it('adds digitrust id is present and user is not optout', () => {
       let digiTrustObj = {
         success: true,
         identity: {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added support for digitrust to prebidserverBidAdapter.  If the digitrust identity is detected, it will be sent to the prebid server as an extra parameter.