### PR TITLE
Update Adyoulike Adapter to prebid 1.0

### DIFF
--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -44,11 +44,16 @@ export const spec = {
       }, {}),
       PageRefreshed: getPageRefreshed()
     };
-    const payloadString = JSON.stringify(payload);
+    const data = JSON.stringify(payload);
+    const options = {
+      withCredentials: false
+    };
+
     return {
       method: 'POST',
       url: createEndpoint(dcHostname),
-      data: payloadString,
+      data,
+      options
     };
   },
   /**

--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -38,8 +38,8 @@ export const spec = {
         accumulator[bid.bidId] = {};
         accumulator[bid.bidId].PlacementID = bid.params.placement;
         accumulator[bid.bidId].TransactionID = bid.transactionId;
-        accumulator[bid.bidId].width = size.width;
-        accumulator[bid.bidId].height = size.height;
+        accumulator[bid.bidId].Width = size.width;
+        accumulator[bid.bidId].Height = size.height;
         return accumulator;
       }, {}),
       PageRefreshed: getPageRefreshed()

--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -1,0 +1,192 @@
+import * as utils from 'src/utils';
+import { format } from 'src/url';
+// import { config } from 'src/config';
+import { registerBidder } from 'src/adapters/bidderFactory';
+
+const VERSION = '1.0';
+const BIDDER_CODE = 'adyoulike';
+const DEFAULT_DC = 'hb-api';
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['ayl'], // short code
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    const sizes = getSize(bid.sizes);
+    if (!bid.params || !bid.params.placement || !sizes.width || !sizes.height) {
+      return false;
+    }
+    return true;
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {bidderRequest} - bidderRequest.bids[] is an array of AdUnits and bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (bidderRequest) {
+    let dcHostname = getHostname(bidderRequest);
+    const payload = {
+      Version: VERSION,
+      Bids: bidderRequest.reduce((accumulator, bid) => {
+        let size = getSize(bid.sizes);
+        accumulator[bid.bidId] = {};
+        accumulator[bid.bidId].PlacementID = bid.params.placement;
+        accumulator[bid.bidId].TransactionID = bid.transactionId;
+        accumulator[bid.bidId].width = size.width;
+        accumulator[bid.bidId].height = size.height;
+        return accumulator;
+      }, {}),
+      PageRefreshed: getPageRefreshed()
+    };
+    const payloadString = JSON.stringify(payload);
+    return {
+      method: 'POST',
+      url: createEndpoint(dcHostname),
+      data: payloadString,
+    };
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const bidResponses = [];
+    // For this adapter, serverResponse is a list
+    serverResponse.body.forEach(response => {
+      const bid = createBid(response);
+      if (bid) {
+        bidResponses.push(bid);
+      }
+    });
+    return bidResponses;
+  }
+}
+
+/* Get hostname from bids */
+function getHostname(bidderRequest) {
+  let dcHostname = bidderRequest.find(bid => bid.params.DC);
+  if (dcHostname) {
+    return ('-' + dcHostname.params.DC);
+  }
+  return '';
+}
+
+/* Get current page referrer url */
+function getReferrerUrl() {
+  let referer = '';
+  if (window.self !== window.top) {
+    try {
+      referer = window.top.document.referrer;
+    } catch (e) { }
+  } else {
+    referer = document.referrer;
+  }
+  return referer;
+}
+
+/* Get current page canonical url */
+function getCanonicalUrl() {
+  let link;
+  if (window.self !== window.top) {
+    try {
+      link = window.top.document.head.querySelector('link[rel="canonical"][href]');
+    } catch (e) { }
+  } else {
+    link = document.head.querySelector('link[rel="canonical"][href]');
+  }
+
+  if (link) {
+    return link.href;
+  }
+  return '';
+}
+
+/* Get information on page refresh */
+function getPageRefreshed() {
+  try {
+    if (performance && performance.navigation) {
+      return performance.navigation.type === performance.navigation.TYPE_RELOAD;
+    }
+  } catch (e) { }
+  return false;
+}
+
+/* Create endpoint url */
+function createEndpoint(host) {
+  return format({
+    protocol: (document.location.protocol === 'https:') ? 'https' : 'http',
+    host: `${DEFAULT_DC}${host}.omnitagjs.com`,
+    pathname: '/hb-api/prebid/v1',
+    search: createEndpointQS()
+  });
+}
+
+/* Create endpoint query string */
+function createEndpointQS() {
+  const qs = {};
+
+  const ref = getReferrerUrl();
+  if (ref) {
+    qs.RefererUrl = encodeURIComponent(ref);
+  }
+
+  const can = getCanonicalUrl();
+  if (can) {
+    qs.CanonicalUrl = encodeURIComponent(can);
+  }
+
+  return qs;
+}
+
+/* Get parsed size from request size */
+function getSize(requestSizes) {
+  const parsed = {};
+  const size = utils.parseSizesInput(requestSizes)[0];
+
+  if (typeof size !== 'string') {
+    return parsed;
+  }
+
+  const parsedSize = size.toUpperCase().split('X');
+  const width = parseInt(parsedSize[0], 10);
+  if (width) {
+    parsed.width = width;
+  }
+
+  const height = parseInt(parsedSize[1], 10);
+  if (height) {
+    parsed.height = height;
+  }
+
+  return parsed;
+}
+
+/* Create bid from response */
+function createBid(response) {
+  if (!response || !response.Ad) {
+    return
+  }
+
+  return {
+    requestId: response.BidID,
+    bidderCode: spec.code,
+    width: response.Width,
+    height: response.Height,
+    ad: response.Ad,
+    ttl: 3600,
+    creativeId: response.CreativeID,
+    cpm: response.Price,
+    netRevenue: true,
+    currency: 'USD'
+  };
+}
+
+registerBidder(spec);

--- a/modules/adyoulikeBidAdapter.md
+++ b/modules/adyoulikeBidAdapter.md
@@ -1,0 +1,29 @@
+# Overview
+
+Module Name: Adyoulike Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@adyoulike.com
+
+# Description
+
+Module that connects to Adyoulike demand sources.
+Banner formats are supported.
+
+# Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'test-div',
+               sizes: [[300, 250]],
+               bids: [
+                   {
+                       bidder: "adyoulike",
+                       params: {
+                           placement: 194f787b85c829fb8822cdaf1ae64435,
+                           DC: 'fra01', // Optional for set the data center name
+                       }
+                   }
+               ]
+           }
+       ];
+```

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -1,0 +1,300 @@
+import { expect } from 'chai';
+import { parse } from '../../../src/url';
+
+import { spec } from 'modules/adyoulikeBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('Adyoulike Adapter', () => {
+  const canonicalUrl = 'http://canonical.url/?t=%26';
+  const defaultDC = 'hb-api';
+  const bidderCode = 'adyoulike';
+  const bidRequestWithEmptyPlacement = [
+    {
+      'bidId': 'bid_id_0',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-0',
+      'params': {},
+      'sizes': '300x250'
+    }
+  ];
+  const bidRequestWithEmptySizes = {
+    'bidderCode': 'adyoulike',
+    'bids': [
+      {
+        'bidId': 'bid_id_0',
+        'bidder': 'adyoulike',
+        'placementCode': 'adunit/hb-0',
+        'params': {
+          'placement': 'placement_0'
+        },
+        'transactionId': 'bid_id_0_transaction_id'
+      }
+    ],
+  };
+
+  const bidRequestWithSinglePlacement = [
+    {
+      'bidId': 'bid_id_0',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-0',
+      'params': {
+        'placement': 'placement_0'
+      },
+      'sizes': '300x250',
+      'transactionId': 'bid_id_0_transaction_id'
+    }
+  ];
+
+  const bidRequestWithDCPlacement = [
+    {
+      'bidId': 'bid_id_0',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-0',
+      'params': {
+        'placement': 'placement_0',
+        'DC': 'fra01'
+      },
+      'sizes': '300x250',
+      'transactionId': 'bid_id_0_transaction_id'
+    }
+  ];
+
+  const bidRequestMultiPlacements = [
+    {
+      'bidId': 'bid_id_0',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-0',
+      'params': {
+        'placement': 'placement_0'
+      },
+      'sizes': '300x250',
+      'transactionId': 'bid_id_0_transaction_id'
+    },
+    {
+      'bidId': 'bid_id_1',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-1',
+      'params': {
+        'placement': 'placement_1'
+      },
+      'sizes': [[300, 600]],
+      'transactionId': 'bid_id_1_transaction_id'
+    },
+    {
+      'bidId': 'bid_id_2',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-2',
+      'params': {},
+      'sizes': '300x400',
+      'transactionId': 'bid_id_2_transaction_id'
+    },
+    {
+      'bidId': 'bid_id_3',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-3',
+      'params': {
+        'placement': 'placement_3'
+      },
+      'transactionId': 'bid_id_3_transaction_id'
+    }
+  ];
+
+  const responseWithEmptyPlacement = [
+    {
+      'Placement': 'placement_0'
+    }
+  ];
+  const responseWithSinglePlacement = [
+    {
+      'BidID': 'bid_id_0',
+      'Placement': 'placement_0',
+      'Ad': 'placement_0',
+      'Price': 0.5,
+      'Height': 300,
+      'Width': 300,
+    }
+  ];
+  const responseWithMultiplePlacements = [
+    {
+      'BidID': 'bid_id_0',
+      'Placement': 'placement_0',
+      'Ad': 'placement_0',
+      'Price': 0.5,
+      'Height': 300,
+      'Width': 300,
+    },
+    {
+      'BidID': 'bid_id_1',
+      'Placement': 'placement_1',
+      'Ad': 'placement_1',
+      'Price': 0.6,
+      'Height': 300,
+      'Width': 300,
+    }
+  ];
+  const adapter = newBidder(spec);
+
+  let getEndpoint = (dc = defaultDC) => `http://${dc}.omnitagjs.com/hb-api/prebid`;
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    let bid = {
+      'bidId': 'bid_id_1',
+      'bidder': 'adyoulike',
+      'placementCode': 'adunit/hb-1',
+      'params': {
+        'placement': 'placement_1'
+      },
+      'sizes': [[300, 600]],
+      'transactionId': 'bid_id_1_transaction_id'
+    };
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      delete bid.size;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'placement': 0
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', () => {
+    let canonicalQuery;
+
+    beforeEach(() => {
+      let canonical = document.createElement('link');
+      canonical.rel = 'canonical';
+      canonical.href = canonicalUrl;
+      canonicalQuery = sinon.stub(window.top.document.head, 'querySelector');
+      canonicalQuery.withArgs('link[rel="canonical"][href]').returns(canonical);
+    });
+
+    afterEach(() => {
+      canonicalQuery.restore();
+    });
+
+    it('sends bid request to endpoint with single placement', () => {
+      const request = spec.buildRequests(bidRequestWithSinglePlacement);
+      const payload = JSON.parse(request.data);
+
+      expect(request.url).to.contain(getEndpoint());
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
+
+      expect(payload.Version).to.equal('1.0');
+      expect(payload.Bids['bid_id_0'].PlacementID).to.be.equal('placement_0');
+      expect(payload.PageRefreshed).to.equal(false);
+      expect(payload.Bids['bid_id_0'].TransactionID).to.be.equal('bid_id_0_transaction_id');
+    });
+
+    it('sends bid request to endpoint with single placement without canonical', () => {
+      canonicalQuery.restore();
+      const request = spec.buildRequests(bidRequestWithSinglePlacement);
+      const payload = JSON.parse(request.data);
+
+      expect(request.url).to.contain(getEndpoint());
+      expect(request.method).to.equal('POST');
+
+      expect(request.url).to.not.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
+      expect(payload.Version).to.equal('1.0');
+      expect(payload.Bids['bid_id_0'].PlacementID).to.be.equal('placement_0');
+      expect(payload.PageRefreshed).to.equal(false);
+      expect(payload.Bids['bid_id_0'].TransactionID).to.be.equal('bid_id_0_transaction_id');
+    });
+
+    it('sends bid request to endpoint with multiple placements', () => {
+      const request = spec.buildRequests(bidRequestMultiPlacements);
+      const payload = JSON.parse(request.data);
+      expect(request.url).to.contain(getEndpoint());
+      expect(request.method).to.equal('POST');
+
+      expect(request.url).to.contains('CanonicalUrl=' + encodeURIComponent(canonicalUrl));
+
+      expect(payload.Version).to.equal('1.0');
+
+      expect(payload.Bids['bid_id_0'].PlacementID).to.be.equal('placement_0');
+      expect(payload.Bids['bid_id_1'].PlacementID).to.be.equal('placement_1');
+      expect(payload.Bids['bid_id_3'].PlacementID).to.be.equal('placement_3');
+
+      expect(payload.Bids['bid_id_0'].TransactionID).to.be.equal('bid_id_0_transaction_id');
+      expect(payload.Bids['bid_id_1'].TransactionID).to.be.equal('bid_id_1_transaction_id');
+      expect(payload.Bids['bid_id_3'].TransactionID).to.be.equal('bid_id_3_transaction_id');
+      expect(payload.PageRefreshed).to.equal(false);
+    });
+
+    it('sends bid request to endpoint setted by parameters', () => {
+      const request = spec.buildRequests(bidRequestWithDCPlacement);
+      const payload = JSON.parse(request.data);
+
+      expect(request.url).to.contain(getEndpoint(`${defaultDC}-fra01`));
+    });
+  });
+  //
+  describe('interpretResponse', () => {
+    let serverResponse;
+
+    beforeEach(() => {
+      serverResponse = {
+        body: {}
+      }
+    });
+
+    it('handles nobid responses', () => {
+      let response = [{
+        BidID: '123dfsdf',
+        Attempt: '32344fdse1',
+        Placement: '12df1'
+      }];
+      serverResponse.body = response;
+      let result = spec.interpretResponse(serverResponse, []);
+      expect(result).deep.equal([]);
+    });
+
+    it('receive reponse with single placement', () => {
+      serverResponse.body = responseWithSinglePlacement;
+      let result = spec.interpretResponse(serverResponse, bidRequestWithSinglePlacement);
+
+      expect(result.length).to.equal(1);
+      expect(result[0].cpm).to.equal(0.5);
+      expect(result[0].ad).to.equal('placement_0');
+      expect(result[0].width).to.equal(300);
+      expect(result[0].height).to.equal(300);
+    });
+
+    it('receive reponse with multiple placement', () => {
+      serverResponse.body = responseWithMultiplePlacements;
+      let result = spec.interpretResponse(serverResponse, bidRequestMultiPlacements);
+
+      expect(result.length).to.equal(2);
+
+      expect(result[0].bidderCode).to.equal(bidderCode);
+      expect(result[0].cpm).to.equal(0.5);
+      expect(result[0].ad).to.equal('placement_0');
+      expect(result[0].width).to.equal(300);
+      expect(result[0].height).to.equal(300);
+
+      expect(result[1].bidderCode).to.equal(bidderCode);
+      expect(result[1].cpm).to.equal(0.6);
+      expect(result[1].ad).to.equal('placement_1');
+      expect(result[1].width).to.equal(300);
+      expect(result[1].height).to.equal(300);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Version 1.0 of the Adyoulike Adapter, every mandatory params are the same as previous version

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
 bidder: 'adyoulike',
params: {
  placement: '194f787b85c829fb8822cdaf1ae64435'
  }
}
```
- jeremy.hernandez@adyoulike.com
- [x] official adapter submission

https://github.com/prebid/prebid.github.io/pull/633