### PR TITLE
added advertiserId and networkId for rubiconBidAdapter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -270,8 +270,10 @@ export const spec = {
         dealId: ad.deal,
         ttl: 300, // 5 minutes
         netRevenue: config.getConfig('rubicon.netRevenue') || false,
-        advertiserId: ad.advertiser,
-        networkId: ad.network
+        rubicon: {
+          advertiserId: ad.advertiser,
+          networkId: ad.network
+        }
       };
 
       if (bidRequest.mediaType === 'video') {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -269,8 +269,11 @@ export const spec = {
         cpm: ad.cpm || 0,
         dealId: ad.deal,
         ttl: 300, // 5 minutes
-        netRevenue: config.getConfig('rubicon.netRevenue') || false
+        netRevenue: config.getConfig('rubicon.netRevenue') || false,
+        advertiserId: ad.advertiser,
+        networkId: ad.network
       };
+
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -607,8 +607,8 @@ describe('the rubicon adapter', () => {
           expect(bids[0].cpm).to.equal(0.911);
           expect(bids[0].ttl).to.equal(300);
           expect(bids[0].netRevenue).to.equal(false);
-          expect(bids[0].advertiserId).to.equal(7);
-          expect(bids[0].networkId).to.equal(8);
+          expect(bids[0].rubicon.advertiserId).to.equal(7);
+          expect(bids[0].rubicon.networkId).to.equal(8);
           expect(bids[0].creativeId).to.equal('crid-9');
           expect(bids[0].currency).to.equal('USD');
           expect(bids[0].ad).to.contain(`alert('foo')`)
@@ -622,8 +622,8 @@ describe('the rubicon adapter', () => {
           expect(bids[1].cpm).to.equal(0.811);
           expect(bids[1].ttl).to.equal(300);
           expect(bids[1].netRevenue).to.equal(false);
-          expect(bids[1].advertiserId).to.equal(7);
-          expect(bids[1].networkId).to.equal(8);
+          expect(bids[1].rubicon.advertiserId).to.equal(7);
+          expect(bids[1].rubicon.networkId).to.equal(8);
           expect(bids[1].creativeId).to.equal('crid-9');
           expect(bids[1].currency).to.equal('USD');
           expect(bids[1].ad).to.contain(`alert('foo')`)

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -607,6 +607,8 @@ describe('the rubicon adapter', () => {
           expect(bids[0].cpm).to.equal(0.911);
           expect(bids[0].ttl).to.equal(300);
           expect(bids[0].netRevenue).to.equal(false);
+          expect(bids[0].advertiserId).to.equal(7);
+          expect(bids[0].networkId).to.equal(8);
           expect(bids[0].creativeId).to.equal('crid-9');
           expect(bids[0].currency).to.equal('USD');
           expect(bids[0].ad).to.contain(`alert('foo')`)
@@ -620,6 +622,8 @@ describe('the rubicon adapter', () => {
           expect(bids[1].cpm).to.equal(0.811);
           expect(bids[1].ttl).to.equal(300);
           expect(bids[1].netRevenue).to.equal(false);
+          expect(bids[1].advertiserId).to.equal(7);
+          expect(bids[1].networkId).to.equal(8);
           expect(bids[1].creativeId).to.equal('crid-9');
           expect(bids[1].currency).to.equal('USD');
           expect(bids[1].ad).to.contain(`alert('foo')`)


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added an `advertiserId` and `networkId` to rubicon bid response so these values can be picked up by analytics and others interested in this data.
