### PR TITLE
must explicitly list pre1api for it to be included in build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,12 +71,17 @@ function nodeBundle(modules) {
   });
 }
 
+// these modules must be explicitly listed in --modules to be included in the build, won't be part of "all" modules
+var explicitModules = [
+  'pre1api'
+];
+
 function bundle(dev, moduleArr) {
   var modules = moduleArr || helpers.getArgModules(),
       allModules = helpers.getModuleNames(modules);
 
   if(modules.length === 0) {
-    modules = allModules;
+    modules = allModules.filter(module => !explicitModules.includes(module));
   } else {
     var diff = _.difference(modules, allModules);
     if(diff.length !== 0) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When building prebid you can specify which modules to include using the `--modules=...` arg.  If you don't specify any modules then all modules are included.  This can cause issues for people not expecting modules like `pre1api` to be included, which changes the prebid API.  This adds a fix that makes sure for `pre1api` to be included you must specifically list it in `--modules=...`.  
