### PR TITLE
Add support for OpenRTB protocol and endpoint

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -418,34 +418,30 @@ const openRtb = {
     const bids = [];
 
     if (response.seatbid) {
-      response.seatbid.forEach(bidObj => {
-        let cpm = bidObj.bid[0].price;
-        let status;
-        if (cpm !== 0) {
-          status = STATUS.GOOD;
-        } else {
-          status = STATUS.NO_BID;
-        }
+      // a seatbid object contains a `bid` array and a `seat` string
+      response.seatbid.forEach(seatbid => {
+        (seatbid.bid || []).forEach(bid => {
+          const cpm = bid.price;
+          const status = cpm !== 0 ? STATUS.GOOD : STATUS.NO_BID;
+          let bidObject = bidfactory.createBid(status);
 
-        let bidObject = bidfactory.createBid(status);
+          bidObject.source = TYPE;
+          bidObject.creative_id = bid.crid;
+          bidObject.bidderCode = seatbid.seat;
+          bidObject.cpm = cpm;
+          bidObject.ad = bid.adm;
+          bidObject.width = bid.w;
+          bidObject.height = bid.h;
+          bidObject.requestId = bid.id;
+          bidObject.creativeId = bid.crid;
 
-        bidObject.source = TYPE;
-        bidObject.creative_id = bidObj.crid;
-        bidObject.bidderCode = bidObj.seat;
-        bidObject.cpm = cpm;
-        bidObject.ad = bidObj.bid[0].adm;
+          // TODO: Remove when prebid-server returns ttl, currency and netRevenue
+          bidObject.ttl = (bid.ttl) ? bid.ttl : DEFAULT_S2S_TTL;
+          bidObject.currency = (bid.currency) ? bid.currency : DEFAULT_S2S_CURRENCY;
+          bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 
-        bidObject.width = bidObj.bid[0].w;
-        bidObject.height = bidObj.bid[0].h;
-        bidObject.requestId = bidObj.bid[0].id;
-        bidObject.creativeId = bidObj.bid[0].crid;
-
-        // TODO: Remove when prebid-server returns ttl, currency and netRevenue
-        bidObject.ttl = (bidObj.ttl) ? bidObj.ttl : DEFAULT_S2S_TTL;
-        bidObject.currency = (bidObj.currency) ? bidObj.currency : DEFAULT_S2S_CURRENCY;
-        bidObject.netRevenue = (bidObj.netRevenue) ? bidObj.netRevenue : DEFAULT_S2S_NETREVENUE;
-
-        bids.push({ adUnit: bidObj.bid[0].impid, bid: bidObject });
+          bids.push({ adUnit: bid.impid, bid: bidObject });
+        });
       });
     }
 

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -334,7 +334,7 @@ const LEGACY_PROTOCOL = {
             } else if (bidObj.adm) {
               bidObject.ad = bidObj.adm;
             } else if (bidObj.nurl) {
-              bidObject.adUrl = bidObj.nurl
+              bidObject.adUrl = bidObj.nurl;
             }
           }
 
@@ -354,11 +354,6 @@ const LEGACY_PROTOCOL = {
 
           bids.push({ adUnit: bidObj.code, bid: bidObject });
         });
-      }
-
-      if (result.status === 'no_cookie' && _s2sConfig.cookieSet && typeof _s2sConfig.cookieSetUrl === 'string') {
-        // cookie sync
-        cookieSet(_s2sConfig.cookieSetUrl);
       }
     }
 
@@ -422,13 +417,23 @@ const OPEN_RTB_PROTOCOL = {
           let bidObject = bidfactory.createBid(status);
 
           bidObject.source = TYPE;
-          bidObject.creative_id = bid.crid;
           bidObject.bidderCode = seatbid.seat;
           bidObject.cpm = cpm;
-          bidObject.ad = bid.adm;
+
+          if (bid.adm && bid.nurl) {
+            bidObject.ad = bid.adm;
+            bidObject.ad += utils.createTrackPixelHtml(decodeURIComponent(bid.nurl));
+          } else if (bid.adm) {
+            bidObject.ad = bid.adm;
+          } else if (bid.nurl) {
+            bidObject.adUrl = bid.nurl;
+          }
+
           bidObject.width = bid.w;
           bidObject.height = bid.h;
+          if (bid.dealid) { bidObject.dealId = bid.dealid; }
           bidObject.requestId = bid.id;
+          bidObject.creative_id = bid.crid;
           bidObject.creativeId = bid.crid;
 
           // TODO: Remove when prebid-server returns ttl, currency and netRevenue
@@ -525,7 +530,7 @@ export function PrebidServer() {
         }
       });
 
-      if (result.status === 'no_cookie' && typeof _s2sConfig.cookieSetUrl === 'string') {
+      if (result.status === 'no_cookie' && _s2sConfig.cookieSet && typeof _s2sConfig.cookieSetUrl === 'string') {
         // cookie sync
         cookieSet(_s2sConfig.cookieSetUrl);
       }

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -396,15 +396,20 @@ const OPEN_RTB_PROTOCOL = {
       let banner;
       // default to banner if mediaTypes isn't defined
       if (utils.isEmpty(adUnit.mediaTypes)) {
-        const format = adUnit.sizes.map(size => ({ w: size.w, h: size.h }));
-        banner = {format};
+        const sizeObjects = adUnit.sizes.map(size => ({ w: size.w, h: size.h }));
+        banner = {format: sizeObjects};
       }
 
       const bannerParams = utils.deepAccess(adUnit, 'mediaTypes.banner');
       if (bannerParams && bannerParams.sizes) {
+        const sizes = utils.parseSizesInput(bannerParams.sizes);
+
         // get banner sizes in form [{ w: <int>, h: <int> }, ...]
-        const format = bannerParams.sizes.map(size => {
-          return { w: size[0], h: size[1] };
+        const format = sizes.map(size => {
+          const [ width, height ] = size.split('x');
+          const w = parseInt(width, 10);
+          const h = parseInt(height, 10);
+          return { w, h };
         });
 
         banner = {format};

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -433,6 +433,18 @@ const OPEN_RTB_PROTOCOL = {
       test: getConfig('debug') ? 1 : 0,
     };
 
+    ['app', 'device'].forEach(setting => {
+      let value = getConfig(setting);
+      if (typeof value === 'object') {
+        request[setting] = value;
+      }
+    });
+
+    const digiTrust = _getDigiTrustQueryParams();
+    if (digiTrust) {
+      request.user = { ext: { digitrust: digiTrust } };
+    }
+
     return request;
   },
 

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -252,6 +252,18 @@ function _getDigiTrustQueryParams() {
 const LEGACY_PROTOCOL = {
 
   buildRequest(s2sBidRequest, adUnits) {
+    // pbs expects an ad_unit.video attribute if the imp is video
+    adUnits.forEach(adUnit => {
+      const videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
+      if (videoMediaType) {
+        adUnit.video = Object.assign({}, videoMediaType);
+        delete adUnit.mediaTypes;
+        // default is assumed to be 'banner' so if there is a video type
+        // we assume video only until PBS can support multi-format auction
+        adUnit.media_types = [VIDEO];
+      }
+    });
+
     const request = {
       account_id: _s2sConfig.accountId,
       tid: s2sBidRequest.tid,
@@ -497,17 +509,6 @@ export function PrebidServer() {
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(s2sBidRequest, bidRequests, addBidResponse, done, ajax) {
     const adUnits = utils.deepClone(s2sBidRequest.ad_units);
-
-    adUnits.forEach(adUnit => {
-      const videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
-      if (videoMediaType) {
-        // pbs expects a ad_unit.video attribute if the imp is video
-        adUnit.video = Object.assign({}, videoMediaType);
-        delete adUnit.mediaTypes;
-        // default is assumed to be 'banner' so if there is a video type we assume video only until PBS can support multi format auction.
-        adUnit.media_types = [VIDEO];
-      }
-    });
 
     convertTypes(adUnits);
 

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -394,6 +394,12 @@ const OPEN_RTB_PROTOCOL = {
       });
 
       let banner;
+      // default to banner if mediaTypes isn't defined
+      if (utils.isEmpty(adUnit.mediaTypes)) {
+        const format = adUnit.sizes.map(size => ({ w: size.w, h: size.h }));
+        banner = {format};
+      }
+
       const bannerParams = utils.deepAccess(adUnit, 'mediaTypes.banner');
       if (bannerParams && bannerParams.sizes) {
         // get banner sizes in form [{ w: <int>, h: <int> }, ...]

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -386,15 +386,18 @@ const OPEN_RTB_PROTOCOL = {
       const bannerParams = utils.deepAccess(adUnit, 'mediaTypes.banner');
       if (bannerParams && bannerParams.sizes) {
         // get banner sizes in form [{ w: <int>, h: <int> }, ...]
-        const format = bannerParams.sizes.reduce((acc, size) =>
-          [...acc, { w: size[0], h: size[1] }], []);
+        const format = bannerParams.sizes.map(size => {
+          return { w: size[0], h: size[1] };
+        });
 
         banner = {format};
       }
 
       // get bidder params in form { <bidder code>: {...params} }
-      const ext = adUnit.bids.reduce((acc, bid) =>
-        Object.assign({}, acc, { [bid.bidder]: bid.params }), {});
+      const ext = adUnit.bids.reduce((acc, bid) => {
+        acc[bid.bidder] = bid.params;
+        return acc;
+      }, {});
 
       const imp = { id: adUnit.code, ext, secure: _s2sConfig.secure };
       if (banner) { imp.banner = banner; }
@@ -478,7 +481,10 @@ const OPEN_RTB_PROTOCOL = {
  */
 const protocolAdapter = () => {
   const OPEN_RTB_PATH = 'openrtb2/auction';
-  const isOpenRtb = _s2sConfig.endpoint.includes(OPEN_RTB_PATH);
+
+  const endpoint = (_s2sConfig && _s2sConfig.endpoint) || '';
+  const isOpenRtb = ~endpoint.indexOf(OPEN_RTB_PATH);
+
   return isOpenRtb ? OPEN_RTB_PROTOCOL : LEGACY_PROTOCOL;
 };
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -530,8 +530,9 @@ describe('S2S Adapter', () => {
 
       sinon.assert.calledOnce(addBidResponse);
       const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('bidderCode', 'appnexus');
       expect(response).to.have.property('statusMessage', 'Bid available');
+      expect(response).to.have.property('bidderCode', 'appnexus');
+      expect(response).to.have.property('adId', '123');
       expect(response).to.have.property('cpm', 0.5);
     });
   });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -36,6 +36,11 @@ const REQUEST = {
           'h': 600
         }
       ],
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[ 300, 250 ], [ 300, 300 ]]
+        }
+      },
       'transactionId': '4ef956ad-fd83-406d-bd35-e4bb786ab86c',
       'bids': [
         {
@@ -206,6 +211,45 @@ const RESPONSE_NO_PBS_COOKIE_ERROR = {
       'type': 'iframe'
     }
   }]
+};
+
+const RESPONSE_OPENRTB = {
+  'id': 'c7dcf14f',
+  'seatbid': [
+    {
+      'bid': [
+        {
+          'id': '8750901685062148',
+          'impid': '123',
+          'price': 0.5,
+          'adm': '<script src="http://lax1-ib.adnxs.com/ab?e=wqT_3QKgB6CgAwAAAwDWAAUBCJ7kvtMFEPft7JnIuImSdBj87IDv8q21rXcqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6Aw8ub8BDi-B0C-B0gCUNbLkw5Y4YBIYABokUB48NIEgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAsABA8gBAtABCdgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNTE3MjY5NTM0KTt1ZigncicsIDI5NjgxMTEwLDIeAPCckgKBAiFqRHF3RUFpNjBJY0VFTmJMa3c0WUFDRGhnRWd3QURnQVFBUkl2Z2RROHViOEJGZ0FZUF9fX184UGFBQndBWGdCZ0FFQmlBRUJrQUVCbUFFQm9BRUJxQUVEc0FFQXVRRXBpNGlEQUFEZ1A4RUJLWXVJZ3dBQTREX0pBVkx3MU5mdl9lMF8yUUVBQUFBQUFBRHdQLUFCQVBVQgUPKEpnQ0FLQUNBTFVDBRAETDAJCPBUTUFDQWNnQ0FkQUNBZGdDQWVBQ0FPZ0NBUGdDQUlBREFaQURBSmdEQWFnRHV0Q0hCTG9ERVdSbFptRjFiSFFqVEVGWU1Ub3pPRFk1mgI5IS1ndndfUTYEAfCENFlCSUlBUW9BRG9SWkdWbVlYVnNkQ05NUVZneE9qTTROamsu2ALoB-ACx9MB6gJHaHR0cDovL3ByZWJpZC5sb2NhbGhvc3Q6OTk5OS9pbnRlZ3JhdGlvbkV4YW1wbGVzL2dwdC9hcHBuZXh1cy10ZXN0Lmh0bWzyAhAKBkFEVl9JRBIGNCXTHPICEQoGQ1BHARM4BzE5Nzc5MzPyAhAKBUNQBRPwljg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2AMA4AMA6AMA-AMDgAQAkgQJL29wZW5ydGIymAQAogQMMjE2LjU1LjQ3Ljk0qAQAsgQMCAAQABgAIAAwADgAuAQAwAQAyAQA0gQRZGVmYXVsdCNMQVgxOjM4NjnaBAIIAeAEAPAE1suTDogFAZgFAKAF______8BA7ABqgUkYzdkY2YxNGYtZjliYS00Yzc3LWEzYjQtMjdmNmRmMzkwNjdmwAUAyQVpLhTwP9IFCQkJDFAAANgFAeAFAfAFAfoFBAgAEACQBgA.&s=f4dc8b6fa65845d08f0a87c145e12cb7d6288c2a&referrer=http%3A%2F%2Fprebid.localhost%3A9999%2FintegrationExamples%2Fgpt%2Fappnexus-test.html&pp=${AUCTION_PRICE}"></script>',
+          'adid': '29681110',
+          'adomain': [ 'appnexus.com' ],
+          'iurl': 'http://lax1-ib.adnxs.com/cr?id=2968111',
+          'cid': '958',
+          'crid': '2968111',
+          'w': 300,
+          'h': 250,
+          'ext': {
+            'prebid': { 'type': 'banner' },
+            'bidder': {
+              'appnexus': {
+                'brand_id': 1,
+                'auction_id': 3,
+                'bidder_id': 2
+              }
+            }
+          }
+        }
+      ],
+      'seat': 'appnexus'
+    },
+  ],
+  'ext': {
+    'responsetimemillis': {
+      'appnexus': 8,
+    }
+  }
 };
 
 describe('S2S Adapter', () => {
@@ -472,6 +516,23 @@ describe('S2S Adapter', () => {
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       server.respond();
       sinon.assert.calledOnce(cookie.cookieSet);
+    });
+
+    it('handles OpenRTB responses', () => {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig});
+
+      server.respondWith(JSON.stringify(RESPONSE_OPENRTB));
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      server.respond();
+
+      sinon.assert.calledOnce(addBidResponse);
+      const response = addBidResponse.firstCall.args[1];
+      expect(response).to.have.property('bidderCode', 'appnexus');
+      expect(response).to.have.property('statusMessage', 'Bid available');
+      expect(response).to.have.property('cpm', 0.5);
     });
   });
 


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Adds support to prebidServer adapter for working with the OpenRTB prebid-server endpoint. Enable support by configuring s2s to use an endpoint with the pattern `openrtb2/auction`:

```JavaScript
pbjs.setConfig({
  debug: true,
  s2sConfig: {
    accountId: '123',
    enabled: true,
    bidders: ['appnexus'],
    endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
  },
});
```

When `s2sConfig.endpoint` is not configured to this type of endpoint, prebidServer communicates with the configured endpoint using the existing s2s protocol.

## Other information
Fixes #2126