### PR TITLE
Serverbid Bid Adapter: getUserSyncs and new adsizes

### DIFF
--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -156,7 +156,7 @@ export const spec = {
       } else {
         return [{
           type: 'iframe',
-          url: '//s.zkcdn.net/ss/' + siteId + '.js'
+          url: '//s.zkcdn.net/ss/' + siteId + '.html'
         }];
       }
     } else {

--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -24,6 +24,9 @@ const CONFIG = {
   }
 };
 
+let siteId = 0;
+let bidder = 'serverbid';
+
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['connectad', 'onefiftytwo', 'insticator', 'adsparc', 'automatad'],
@@ -61,6 +64,10 @@ export const spec = {
     }
 
     let ENDPOINT_URL;
+
+    // These variables are used in creating the user sync URL.
+    siteId = validBidRequests[0].params.siteId;
+    bidder = validBidRequests[0].params.bidder;
 
     const data = Object.assign({
       placements: [],
@@ -140,7 +147,21 @@ export const spec = {
   },
 
   getUserSyncs: function(syncOptions) {
-    return [];
+    if (syncOptions.iframeEnabled) {
+      if (bidder === 'connectad') {
+        return [{
+          type: 'iframe',
+          url: '//cdn.connectad.io/connectmyusers.php'
+        }];
+      } else {
+        return [{
+          type: 'iframe',
+          url: '//s.zkcdn.net/ss/' + siteId + '.js'
+        }];
+      }
+    } else {
+      utils.logWarn(bidder + ': Please enable iframe based user syncing.');
+    }
   }
 };
 
@@ -185,6 +206,9 @@ sizeMap[429] = '486x60';
 sizeMap[374] = '700x500';
 sizeMap[934] = '300x1050';
 sizeMap[1578] = '320x100';
+sizeMap[331] = '320x250';
+sizeMap[3301] = '320x267';
+sizeMap[2730] = '728x250';
 
 function getSize(sizes) {
   const result = [];

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -245,10 +245,10 @@ describe('Serverbid BidAdapter', () => {
       expect(opts).to.be.empty;
     });
 
-    it('should always return empty array', () => {
+    it('should return a sync url if iframe syncs are enabled', () => {
       let opts = spec.getUserSyncs(syncOptions);
 
-      expect(opts).to.be.empty;
+      expect(opts.length).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds return values for `getUserSyncs` to let publishers sync through Prebid and a few new ad sizes.
