### PR TITLE
size mapping throws warning if mediaQuery missing

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,4 +1,5 @@
 import { config } from 'src/config';
+import { logWarn } from 'src/utils';
 import includes from 'core-js/library/fn/array/includes';
 
 let sizeConfig = [];
@@ -64,17 +65,20 @@ function evaluateSizeConfig(configs) {
   return configs.reduce((results, config) => {
     if (
       typeof config === 'object' &&
-      typeof config.mediaQuery === 'string' &&
-      matchMedia(config.mediaQuery).matches
+      typeof config.mediaQuery === 'string'
     ) {
-      if (Array.isArray(config.sizesSupported)) {
-        results.shouldFilter = true;
+      if (matchMedia(config.mediaQuery).matches) {
+        if (Array.isArray(config.sizesSupported)) {
+          results.shouldFilter = true;
+        }
+        ['labels', 'sizesSupported'].forEach(
+          type => (config[type] || []).forEach(
+            thing => results[type][thing] = true
+          )
+        );
       }
-      ['labels', 'sizesSupported'].forEach(
-        type => (config[type] || []).forEach(
-          thing => results[type][thing] = true
-        )
-      );
+    } else {
+      logWarn('sizeConfig rule missing required property "mediaQuery"');
     }
     return results;
   }, {

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -2,6 +2,9 @@ import { expect } from 'chai';
 import { resolveStatus, setSizeConfig } from 'src/sizeMapping';
 import includes from 'core-js/library/fn/array/includes';
 
+let utils = require('src/utils');
+let deepClone = utils.deepClone;
+
 describe('sizeMapping', () => {
   var testSizes = [[970, 90], [728, 90], [300, 250], [300, 100], [80, 80]];
 
@@ -68,6 +71,17 @@ describe('sizeMapping', () => {
   });
 
   describe('when handling sizes', () => {
+    it('should log a warning when mediaQuery property missing from sizeConfig', () => {
+      let errorConfig = deepClone(sizeConfig);
+
+      delete errorConfig[0].mediaQuery;
+
+      sandbox.stub(utils, 'logWarn');
+
+      resolveStatus(undefined, testSizes, errorConfig);
+      expect(utils.logWarn.firstCall.args[0]).to.match(/missing.+?mediaQuery/);
+    });
+
     it('when one mediaQuery block matches, it should filter the adUnit.sizes passed in', () => {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Added warning if `mediaQuery` is missing as discussed in issue #2043