### PR TITLE
fix bug where hooked functions w/ no hooks weren't ran immediately

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -68,7 +68,7 @@ export function createHook(type, fn, hookName) {
   }
 
   function hookedFn(...args) {
-    if (_hooks.length === 0) {
+    if (_hooks.length === 1 && _hooks[0].fn === fn) {
       return fn.apply(this, args);
     }
     return types[type].apply(this, args);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
I had put this shortcut for running hooked functions immediately if they didn't have any additional hooks applied, however it wasn't working correctly because a hooked function w/ no hooks has a length of 1 (the hooked function itself), not 0.

This removes one extra func invocation for non-hooked functions, so a slight performance increase and improves debuggability.
