### PR TITLE
omit app and device if not present rather than send false

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -210,8 +210,6 @@ export function PrebidServer() {
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(s2sBidRequest, bidRequests, addBidResponse, done, ajax) {
     const isDebug = !!getConfig('debug');
-    const app = !!getConfig('app');
-    const device = !!getConfig('device');
     const adUnits = utils.deepClone(s2sBidRequest.ad_units);
     adUnits.forEach(adUnit => {
       let videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
@@ -239,13 +237,13 @@ export function PrebidServer() {
 
     let digiTrust = _getDigiTrustQueryParams();
 
-    if (device) {
-      requestJson.device = device;
-    }
-
-    if (app) {
-      requestJson.app = app;
-    }
+    // grab some global config and pass it along
+    ['app', 'device'].forEach(setting => {
+      let value = getConfig(setting);
+      if (typeof value === 'object') {
+        requestJson[setting] = value;
+      }
+    });
 
     if (digiTrust) {
       requestJson.digiTrust = digiTrust;

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -234,12 +234,18 @@ export function PrebidServer() {
       url: utils.getTopWindowUrl(),
       prebid_version: '$prebid.version$',
       ad_units: adUnits.filter(hasSizes),
-      is_debug: isDebug,
-      device: device,
-      app: app
+      is_debug: isDebug
     };
 
     let digiTrust = _getDigiTrustQueryParams();
+
+    if (device) {
+      requestJson.device = device;
+    }
+
+    if (app) {
+      requestJson.app = app;
+    }
 
     if (digiTrust) {
       requestJson.digiTrust = digiTrust;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Prebid server does not expect a `false` value for `app` or `device` so we need to omit them if they are not set.