### PR TITLE
AOL adapter: Fixed broken user matching in iframes

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -1,7 +1,7 @@
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
-import constants from 'src/constants.json';
+import { EVENTS, STATUS } from 'src/constants.json';
 
 const AOL_BIDDERS_CODES = {
   AOL: 'aol',
@@ -180,55 +180,6 @@ function _buildOneMobileGetUrl(bid) {
   return nexageApi;
 }
 
-function _parseBidResponse(response, bidRequest) {
-  let bidData;
-
-  try {
-    bidData = response.seatbid[0].bid[0];
-  } catch (e) {
-    return;
-  }
-
-  let cpm;
-
-  if (bidData.ext && bidData.ext.encp) {
-    cpm = bidData.ext.encp;
-  } else {
-    cpm = bidData.price;
-
-    if (cpm === null || isNaN(cpm)) {
-      utils.logError('Invalid price in bid response', AOL_BIDDERS_CODES.AOL, bid);
-      return;
-    }
-  }
-
-  let ad = bidData.adm;
-  if (response.ext && response.ext.pixels) {
-    if (config.getConfig('aol.userSyncOn') !== constants.EVENTS.BID_RESPONSE) {
-      let formattedPixels = response.ext.pixels.replace(/<\/?script( type=('|")text\/javascript('|")|)?>/g, '');
-
-      ad += '<script>if(!parent.$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped){' +
-        'parent.$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped=true;' + formattedPixels +
-        '}</script>';
-    }
-  }
-
-  return {
-    bidderCode: bidRequest.bidderCode,
-    requestId: bidRequest.bidId,
-    ad: ad,
-    cpm: cpm,
-    width: bidData.w,
-    height: bidData.h,
-    creativeId: bidData.crid,
-    pubapiId: response.id,
-    currency: response.cur,
-    dealId: bidData.dealid,
-    netRevenue: true,
-    ttl: bidRequest.ttl
-  };
-}
-
 function _isMarketplaceBidder(bidder) {
   return bidder === AOL_BIDDERS_CODES.AOL || bidder === AOL_BIDDERS_CODES.ONEDISPLAY;
 }
@@ -311,20 +262,6 @@ function formatBidRequest(endpointCode, bid) {
   return bidRequest;
 }
 
-function interpretResponse({body}, bidRequest) {
-  showCpmAdjustmentWarning();
-
-  if (!body) {
-    utils.logError('Empty bid response', bidRequest.bidderCode, body);
-  } else {
-    let bid = _parseBidResponse(body, bidRequest);
-
-    if (bid) {
-      return bid;
-    }
-  }
-}
-
 export const spec = {
   code: AOL_BIDDERS_CODES.AOL,
   aliases: [AOL_BIDDERS_CODES.ONEMOBILE, AOL_BIDDERS_CODES.ONEDISPLAY],
@@ -340,12 +277,78 @@ export const spec = {
       }
     });
   },
-  interpretResponse: interpretResponse,
+  interpretResponse: function ({body}, bidRequest) {
+    showCpmAdjustmentWarning();
+
+    if (!body) {
+      utils.logError('Empty bid response', bidRequest.bidderCode, body);
+    } else {
+      let bid = this._parseBidResponse(body, bidRequest);
+
+      if (bid) {
+        return bid;
+      }
+    }
+  },
+  _formatPixels: function (pixels) {
+    let formattedPixels = pixels.replace(/<\/?script( type=('|")text\/javascript('|")|)?>/g, '');
+
+    return '<script>var w=window,prebid;' +
+      'for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
+      'if(prebid && prebid.aolGlobals && !prebid.aolGlobals.pixelsDropped){' +
+      'try{prebid.aolGlobals.pixelsDropped=true;' + formattedPixels + 'break;}' +
+      'catch(e){continue;}' +
+      '}}</script>';
+  },
+  _parseBidResponse: function (response, bidRequest) {
+    let bidData;
+
+    try {
+      bidData = response.seatbid[0].bid[0];
+    } catch (e) {
+      return;
+    }
+
+    let cpm;
+
+    if (bidData.ext && bidData.ext.encp) {
+      cpm = bidData.ext.encp;
+    } else {
+      cpm = bidData.price;
+
+      if (cpm === null || isNaN(cpm)) {
+        utils.logError('Invalid price in bid response', AOL_BIDDERS_CODES.AOL, bid);
+        return;
+      }
+    }
+
+    let ad = bidData.adm;
+    if (response.ext && response.ext.pixels) {
+      if (config.getConfig('aol.userSyncOn') !== EVENTS.BID_RESPONSE) {
+        ad += this._formatPixels(response.ext.pixels);
+      }
+    }
+
+    return {
+      bidderCode: bidRequest.bidderCode,
+      requestId: bidRequest.bidId,
+      ad: ad,
+      cpm: cpm,
+      width: bidData.w,
+      height: bidData.h,
+      creativeId: bidData.crid,
+      pubapiId: response.id,
+      currency: response.cur,
+      dealId: bidData.dealid,
+      netRevenue: true,
+      ttl: bidRequest.ttl
+    };
+  },
   getUserSyncs: function(options, bidResponses) {
     let bidResponse = bidResponses[0];
 
-    if (config.getConfig('aol.userSyncOn') === constants.EVENTS.BID_RESPONSE) {
-      if (!$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped && bidResponse && bidResponse.ext && bidResponse.ext.pixels) {
+    if (config.getConfig('aol.userSyncOn') === EVENTS.BID_RESPONSE) {
+      if (!$$PREBID_GLOBAL$$.aolGlobals.pixelsDropped && bidResponse.ext && bidResponse.ext.pixels) {
         $$PREBID_GLOBAL$$.aolGlobals.pixelsDropped = true;
 
         return parsePixelItems(bidResponse.ext.pixels);

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -1,7 +1,7 @@
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
-import { EVENTS, STATUS } from 'src/constants.json';
+import { EVENTS } from 'src/constants.json';
 
 const AOL_BIDDERS_CODES = {
   AOL: 'aol',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
When the creative is serving out of an iframe within a DFP iframe "pbjs" context is not available on the creative level. It causes an error and breaks user matching. Added a loop to search in windows stack for "pbjs".
