### PR TITLE
Remove unneeded lint exceptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,12 +21,9 @@ module.exports = {
     // See Issue #1111.
     "camelcase": "off",
     "eqeqeq": "off",
-    "no-control-regex": "off",
     "no-return-assign": "off",
     "no-throw-literal": "off",
     "no-undef": "off",
-    "no-use-before-define": "off",
     "no-useless-escape": "off",
-    "standard/no-callback-literal": "off",
   }
 };

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -29,13 +29,7 @@ module.exports = {
     "no-global-assign": "off",
     "no-path-concat": "off",
     "no-redeclare": "off",
-    "no-new-object": "off",
-    "no-array-constructor": "off",
     "node/no-deprecated-api": "off",
-    "no-cond-assign": "off",
-    "no-sequences": "off",
-    "no-eval": "off",
-    "no-new": "off",
     "no-return-assign": "off",
     "no-undef": "off",
     "no-unused-vars": "off",
@@ -43,7 +37,6 @@ module.exports = {
     "no-useless-escape": "off",
     "one-var": "off",
     "standard/array-bracket-even-spacing": "off",
-    "standard/no-callback-literal": "off",
     "standard/object-curly-even-spacing": "off"
   }
 };


### PR DESCRIPTION
## Type of change
- Maintenance

## Description of change
Some of the lint exceptions aren't needed anymore and can be removed without touching any code. Running `gulp lint` with these removed should result in 0 errors.

## Other information
Chipping away at #1206