### PR TITLE
Remove deprecated method reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,6 @@ When you are adding code to Prebid.js, or modifying code that isn't covered by a
   - _Assert_: check that the expected results have occurred
     - e.g., use Chai assertions to check that the expected output is equal to the actual output
 - Test the public interface, not the internal implementation
-- If using global `pbjs` data structures in your test, take care to not completely overwrite them with your own data as that may affect other tests relying on those structures, e.g.:
-    - **OK**: `pbjs._bidsRequested.push(bidderRequestObject);`
-    - **NOT OK**: `pbjs._bidsRequested = [bidderRequestObject];`
 - If you need to check `adloader.loadScript` in a test, use a `stub` rather than a `spy`. `spy`s trigger a network call which can result in a `script error` and cause unrelated unit tests to fail. `stub`s will let you gather information about the `adloader.loadScript` call without affecting external resources
 - When writing tests you may use ES2015 syntax if desired
 


### PR DESCRIPTION
## Type of change
- Documentation

## Description of change
Removing reference to method that's no longer in 1.x

## Other information
Resolves #1856 
