### PR TITLE
added currency.defaultRates to use when currency file fails to load

### DIFF
--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -104,6 +104,31 @@ describe('currency', function () {
 
       expect(innerBid.cpm).to.equal('1.0000');
     });
+
+    it('uses default rates when currency file fails to load', () => {
+      setConfig({});
+
+      setConfig({
+        adServerCurrency: 'USD',
+        defaultRates: {
+          USD: {
+            JPY: 100
+          }
+        }
+      });
+
+      // default response is 404
+      fakeCurrencyFileServer.respond();
+
+      var bid = { cpm: 100, currency: 'JPY', bidder: 'rubicon' };
+      var innerBid;
+
+      addBidResponseHook('elementId', bid, function(adCodeId, bid) {
+      	innerBid = bid;
+      });
+
+      expect(innerBid.cpm).to.equal('1.0000');
+    });
   });
 
   describe('currency.addBidResponseDecorator bidResponseQueue', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
New config property added to currency that allows the setting of `defaultRates` that will be used only if the currency file fails to load.

e.g.
```javascript
pbjs.setConfig({
  "currency": {
    "adServerCurrency": "USD",
    "defaultRates": {
      "USD": {
        "JPY": 100
      }
    }
  }
});
```

## Other information
Related to #1843
