### PR TITLE
Yieldbot Prebid.js 1.0 adapter

### DIFF
--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -12,137 +12,15 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 export const YieldbotAdapter = {
   _adapterLoaded: Date.now(),
   _navigationStart: 0,
-  /**
-   * @description Yieldbot adapter internal constants
-   * @constant
-   * @memberof module:YieldbotBidAdapter
-   * @property {string} VERSION Yieldbot adapter version string: <pre>'pbjs-{major}.{minor}.{patch}'</pre>
-   * @property {string} CURRENCY 3-letter ISO 4217 code defining the currency of the bid
-   * @property {boolean} NET_REVENUE Bid value is net or gross. True = Net
-   * @property {string} DEFAULT_REQUEST_URL_PREFIX Request Url prefix to use when ad server response has not provided availability zone specific prefix
-   * @property {string} REQUEST_API_VERSION Yieldbot request API Url path parameter
-   * @property {string} REQUEST_API_PATH_BID Yieldbot bid request API path component
-   * @property {string} REQUEST_API_PATH_CREATIVE Yieldbot ad markup request API path component
-   * @property {string} REQUEST_API_PATH_IMRESSION Yieldbot ad impression request API path component
-   * @property {string} REQUEST_PARAMS_TERMINATOR Yieldbot request query parameters termination character
-   * @property {number} USER_ID_TIMEOUT
-   * @property {number} VISIT_ID_TIMEOUT
-   * @property {number} SESSION_ID_TIMEOUT
-   * @property {object} IFRAME_TYPE the iFrame type in which a ad markup request is made
-   * @property {string} IFRAME_TYPE.NONE not in an iFrame
-   * @property {string} IFRAME_TYPE.SAME_ORIGIN in an iFrame with the same origin aka "friendly"
-   * @property {string} IFRAME_TYPE.CROSS_ORIGIN in an iFrame with a different origin aka "unfriendly"
-   * @property {object} REQUEST_PARAMS Request Url query parameter names
-   * @property {string} REQUEST_PARAMS.ADAPTER_VERSION The version of the YieldbotAdapter code. See [VERSION]{@link module:YieldbotBidAdapter.CONSTANTS}.
-   * @property {string} REQUEST_PARAMS.USER_ID First party user identifier
-   * @property {string} REQUEST_PARAMS.SESSION_ID Publisher site visit session identifier
-   * @property {string} REQUEST_PARAMS.PAGEVIEW_ID Page visit identifier
-   * @property {string} REQUEST_PARAMS.AD_REQUEST_ID Yieldbot ad request identifier
-   * @property {string} REQUEST_PARAMS.AD_REQUEST_SLOT Slot name for Yieldbot ad markup request e.g. <pre>&lt;slot name&gt;:&lt;width&gt;x&lt;height&gt;</pre>
-   * @property {string} REQUEST_PARAMS.PAGEVIEW_DEPTH Counter for page visits in a session
-   * @property {string} [REQUEST_PARAMS.LAST_PAGEVIEW_ID] Pageview identifier for the last pageview within the session TTL
-   * @property {string} REQUEST_PARAMS.BID_SLOT_NAME Yieldbot slot name to request bid for
-   * @property {string} REQUEST_PARAMS.BID_SLOT_SIZE Dimensions for the respective bid slot name
-   * @property {string} REQUEST_PARAMS.LOCATION The page visit location Url
-   * @property {string} REQUEST_PARAMS.REFERRER The referring page Url
-   * @property {string} REQUEST_PARAMS.SCREEN_DIMENSIONS User-agent screen dimensions
-   * @property {string} REQUEST_PARAMS.TIMEZONE_OFFSET Number of hours offset from UTC
-   * @property {string} REQUEST_PARAMS.LANGUAGE Language and locale of the user-agent
-   * @property {string} REQUEST_PARAMS.NAVIGATION_PLATFORM User-agent browsing platform
-   * @property {string} REQUEST_PARAMS.USER_AGENT User-Agent string
-   * @property {string} [REQUEST_PARAMS.LAST_PAGEVIEW_TIME] Time in milliseconds since the last page visit
-   * @property {string} REQUEST_PARAMS.NAVIGATION_START_TIME Performance timing navigationStart
-   * @property {string} REQUEST_PARAMS.ADAPTER_LOADED_TIME Adapter code interpreting started timestamp, in milliseconds since the UNIX epoch
-   * @property {string} REQUEST_PARAMS.BID_REQUEST_TIME Yieldbot bid request sent timestamp, in milliseconds since the UNIX epoch
-   * @property {string} REQUEST_PARAMS.BID_RESPONSE_TIME Yieldbot bid response processing started timestamp, in milliseconds since the UNIX epoch
-   * @property {string} REQUEST_PARAMS.AD_REQUEST_TIME Yieldbot ad creative request sent timestamp, in milliseconds since the UNIX epoch
-   * @property {string} REQUEST_PARAMS.AD_RENDER_TIME Yieldbot ad creative render started timestamp, in milliseconds since the UNIX epoch
-   * @property {string} REQUEST_PARAMS.AD_IMPRESSION_TIME Yieldbot ad impression rerquest sent  timestamp, in milliseconds since the UNIX epoch
-   * @property {string} [REQUEST_PARAMS.INTERSECTION_OBSERVER_AVAILABLE] Indicator that the user-agent supports the Intersection Observer API
-   * @property {string} [REQUEST_PARAMS.IFRAME_TYPE] Indicator to specify Yieldbot creative rendering occured in a same (<code>so</code>) or cross (<code>co</code>) origin iFrame
-   * @property {string} [REQUEST_PARAMS.BID_TYPE] Yieldbot bid request type: initial or refresh
-   * @property {string} REQUEST_PARAMS.CALLBACK Ad creative render callback
-   * @property {string} REQUEST_PARAMS.SESSION_BLOCKED Yieldbot ads blocked by user opt-out or suspicious activity detected during session
-   * @property {string} [REQUEST_PARAMS.ADAPTER_ERROR] Yieldbot error description parameter
-   * @property {string} [REQUEST_PARAMS.TERMINATOR] Yieldbot search parameters terminator
-   * @property {object} COOKIES Cookie name suffixes set by Yieldbot. See also <code>YieldbotAdapter._COOKIE_PREFIX</code>
-   * @property {string} COOKIES.SESSION_BLOCKED The user session is blocked for bids
-   * @property {string} COOKIES.SESSION_ID The user session identifier
-   * @property {string} COOKIES.PAGEVIEW_DEPTH The session pageview depth
-   * @property {string} COOKIES.USER_ID The Yieldbot first-party user identifier
-   * @property {string} COOKIES.LAST_PAGEVIEW_ID The last pageview identifier within the session TTL
-   * @property {string} COOKIES.PREVIOUS_VISIT The time in [ms] since the last visit within the session TTL
-   * @property {string} COOKIES.URL_PREFIX Geo/IP proximity request Url domain
-   * @TODO Document parameter optionality for properties
-   */
-  CONSTANTS: {
-    VERSION: 'pbjs-yb-1.0.0',
-    CURRENCY: 'USD',
-    NET_REVENUE: true,
-    DEFAULT_REQUEST_URL_PREFIX: '//i.yldbt.com/m/',
-    REQUEST_API_VERSION: '/v1',
-    REQUEST_API_PATH_BID: '/init',
-    REQUEST_API_PATH_CREATIVE: '/ad/creative.js',
-    REQUEST_API_PATH_IMPRESSION: '/ad/impression.gif',
-    REQUEST_PARAMS_TERMINATOR: '&e',
-    USER_ID_TIMEOUT: 2592000000,
-    VISIT_ID_TIMEOUT: 2592000000,
-    SESSION_ID_TIMEOUT: 180000,
-    IFRAME_TYPE: {
-      NONE: 'none',
-      SAME_ORIGIN: 'so',
-      CROSS_ORIGIN: 'co'
-    },
-    REQUEST_PARAMS: {
-      ADAPTER_VERSION: 'v',
-      USER_ID: 'vi',
-      SESSION_ID: 'si',
-      PAGEVIEW_ID: 'pvi',
-      AD_REQUEST_ID: 'ri',
-      AD_REQUEST_SLOT: 'slot',
-      PAGEVIEW_DEPTH: 'pvd',
-      LAST_PAGEVIEW_ID: 'lpvi',
-      BID_SLOT_NAME: 'sn',
-      BID_SLOT_SIZE: 'ssz',
-      LOCATION: 'lo',
-      REFERRER: 'r',
-      SCREEN_DIMENSIONS: 'sd',
-      TIMEZONE_OFFSET: 'to',
-      LANGUAGE: 'la',
-      NAVIGATOR_PLATFORM: 'np',
-      USER_AGENT: 'ua',
-      LAST_PAGEVIEW_TIME: 'lpv',
-      NAVIGATION_START_TIME: 'cts_ns',
-      ADAPTER_LOADED_TIME: 'cts_js',
-      BID_REQUEST_TIME: 'cts_ini',
-      BID_RESPONSE_TIME: 'cts_res',
-      AD_REQUEST_TIME: 'cts_ad',
-      AD_RENDER_TIME: 'cts_rend',
-      AD_IMPRESSION_TIME: 'cts_imp',
-      INTERSECTION_OBSERVER_AVAILABLE: 'ioa',
-      IFRAME_TYPE: 'it',
-      BID_TYPE: 'bt',
-      CALLBACK: 'cb',
-      MEDIA_TYPE: 'mtp',
-      SESSION_BLOCKED: 'sb',
-      ADAPTER_ERROR: 'apie',
-      TERMINATOR: 'e'
-    },
-    COOKIES: {
-      SESSION_BLOCKED: '__ybot_n',
-      SESSION_ID: '__ybot_si',
-      PAGEVIEW_DEPTH: '__ybot_pvd',
-      USER_ID: '__ybot_vi',
-      LAST_PAGEVIEW_ID: '__ybot_lpvi',
-      PREVIOUS_VISIT: '__ybot_v',
-      URL_PREFIX: '__ybot_c'
-    }
-  },
+  _version: 'pbjs-yb-0.0.1',
   _bidRequestCount: 0,
   _pageviewDepth: 0,
   _lastPageviewId: '',
   _sessionBlocked: false,
   _isInitialized: false,
+  _sessionTimeout: 180000,
+  _userTimeout: 2592000000,
+  _cookieLabels: ['n', 'u', 'si', 'pvd', 'lpv', 'lpvi', 'c'],
 
   initialize: function() {
     if (!this._isInitialized) {
@@ -150,6 +28,16 @@ export const YieldbotAdapter = {
       this._sessionBlocked = this.sessionBlocked;
       this._isInitialized = true;
     }
+  },
+
+  /**
+   * Adapter version
+   * <code>pbjs-yb-x.x.x</code>
+   * @returns {string} The adapter version string
+   * @memberof module:YieldbotBidAdapter
+   */
+  get version() {
+    return this._version;
   },
 
   /**
@@ -163,71 +51,71 @@ export const YieldbotAdapter = {
    * @private
    */
   get sessionBlocked() {
-    const cookieName = this.CONSTANTS.COOKIES.SESSION_BLOCKED;
+    const cookieName = '__ybotn';
     const cookieValue = this.getCookie(cookieName);
     const sessionBlocked = cookieValue ? parseInt(cookieValue, 10) || 0 : 0;
     if (sessionBlocked) {
-      this.setCookie(cookieName, 1, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      this.setCookie(cookieName, 1, this._sessionTimeout, '/');
     }
     this._sessionBlocked = !!sessionBlocked;
     return this._sessionBlocked;
   },
 
   set sessionBlocked(blockSession) {
-    const cookieName = this.CONSTANTS.COOKIES.SESSION_BLOCKED;
+    const cookieName = '__ybotn';
     const sessionBlocked = blockSession ? 1 : 0;
-    this.setCookie(cookieName, sessionBlocked, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    this.setCookie(cookieName, sessionBlocked, this._sessionTimeout, '/');
     return !!sessionBlocked;
   },
 
   get userId() {
-    const cookieName = this.CONSTANTS.COOKIES.USER_ID;
+    const cookieName = '__ybotu';
     let cookieValue = this.getCookie(cookieName);
     if (!cookieValue) {
       cookieValue = this.newId();
-      this.setCookie(cookieName, cookieValue, this.CONSTANTS.USER_ID_TIMEOUT, '/');
+      this.setCookie(cookieName, cookieValue, this._userTimeout, '/');
     }
     return cookieValue;
   },
 
   get sessionId() {
-    const cookieName = this.CONSTANTS.COOKIES.SESSION_ID;
+    const cookieName = '__ybotsi';
     let cookieValue = this.getCookie(cookieName);
     if (!cookieValue) {
       cookieValue = this.newId();
-      this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      this.setCookie(cookieName, cookieValue, this._sessionTimeout, '/');
     }
     return cookieValue;
   },
 
   get pageviewDepth() {
-    const cookieName = this.CONSTANTS.COOKIES.PAGEVIEW_DEPTH;
+    const cookieName = '__ybotpvd';
     let cookieValue = parseInt(this.getCookie(cookieName), 10) || 0;
     cookieValue++;
-    this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    this.setCookie(cookieName, cookieValue, this._sessionTimeout, '/');
     return cookieValue;
   },
 
   get lastPageviewId() {
-    const cookieName = this.CONSTANTS.COOKIES.LAST_PAGEVIEW_ID;
+    const cookieName = '__ybotlpvi';
     let cookieValue = this.getCookie(cookieName);
     return cookieValue || '';
   },
 
   set lastPageviewId(id) {
-    const cookieName = this.CONSTANTS.COOKIES.LAST_PAGEVIEW_ID;
-    return this.setCookie(cookieName, id, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    const cookieName = '__ybotlpvi';
+    return this.setCookie(cookieName, id, this._sessionTimeout, '/');
   },
 
   get lastPageviewTime() {
-    const cookieName = this.CONSTANTS.COOKIES.PREVIOUS_VISIT;
+    const cookieName = '__ybotlpv';
     let cookieValue = this.getCookie(cookieName);
     return cookieValue ? parseInt(cookieValue, 10) : 0;
   },
 
   set lastPageviewTime(ts) {
-    const cookieName = this.CONSTANTS.COOKIES.PREVIOUS_VISIT;
-    return this.setCookie(cookieName, ts, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    const cookieName = '__ybotlpv';
+    return this.setCookie(cookieName, ts, this._sessionTimeout, '/');
   },
 
   /**
@@ -237,14 +125,14 @@ export const YieldbotAdapter = {
    * @memberof module:YieldbotBidAdapter
    */
   urlPrefix: function(prefix) {
-    const cookieName = this.CONSTANTS.COOKIES.URL_PREFIX;
+    const cookieName = '__ybotc';
     const pIdx = prefix ? prefix.indexOf(':') : -1;
     const url = pIdx !== -1 ? document.location.protocol + prefix.substr(pIdx + 1) : null;
     let cookieValue = url || this.getCookie(cookieName);
     if (!cookieValue) {
-      cookieValue = this.CONSTANTS.DEFAULT_REQUEST_URL_PREFIX;
+      cookieValue = '//i.yldbt.com/m/';
     }
-    this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    this.setCookie(cookieName, cookieValue, this._sessionTimeout, '/');
     return cookieValue;
   },
 
@@ -309,22 +197,21 @@ export const YieldbotAdapter = {
       const searchParams = this.initBidRequestParams();
       this._bidRequestCount++;
 
-      const pageviewIdToMap = searchParams[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID];
+      const pageviewIdToMap = searchParams['pvi'];
 
       const yieldbotSlotParams = this.getSlotRequestParams(pageviewIdToMap, bidRequests);
 
-      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] =
-        yieldbotSlotParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] || '';
+      searchParams['sn'] =
+        yieldbotSlotParams['sn'] || '';
 
-      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] =
-        yieldbotSlotParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] || '';
+      searchParams['ssz'] =
+        yieldbotSlotParams['ssz'] || '';
 
       const bidUrl = this.urlPrefix() +
               yieldbotSlotParams.psn +
-              this.CONSTANTS.REQUEST_API_VERSION +
-              this.CONSTANTS.REQUEST_API_PATH_BID;
+              '/v1/init';
 
-      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_REQUEST_TIME] = Date.now();
+      searchParams['cts_ini'] = Date.now();
       requests.push({
         method: 'GET',
         url: bidUrl,
@@ -400,7 +287,7 @@ export const YieldbotAdapter = {
           const cpm = parseInt(bid.cpm, 10) / 100.0 || 0;
 
           const yieldbotSlotParams = bidRequest.yieldbotSlotParams || null;
-          const ybBidId = bidRequest.data[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID];
+          const ybBidId = bidRequest.data['pvi'];
           const paramKey = ybBidId +
                   ':' +
                   bid.slot +
@@ -417,9 +304,9 @@ export const YieldbotAdapter = {
             width: width,
             height: height,
             creativeId: tagObject.creativeId,
-            currency: this.CONSTANTS.CURRENCY,
-            netRevenue: this.CONSTANTS.NET_REVENUE,
-            ttl: this.CONSTANTS.SESSION_ID_TIMEOUT / 1000, // [s]
+            currency: 'USD',
+            netRevenue: true,
+            ttl: this._sessionTimeout / 1000, // [s]
             ad: tagObject.ad
           };
           bidResponses.push(bidResponse);
@@ -438,25 +325,24 @@ export const YieldbotAdapter = {
    */
   initAdRequestParams: function(adRequestId, bidRequest) {
     let commonSearchParams = {};
-    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_VERSION] = this.CONSTANTS.VERSION;
-    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.USER_ID] = bidRequest.data.vi || this.CONSTANTS.VERSION + '-vi';
-    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.SESSION_ID] = bidRequest.data.si || this.CONSTANTS.VERSION + '-si';
-    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID] = bidRequest.data.pvi || this.CONSTANTS.VERSION + '-pvi';
-    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.AD_REQUEST_ID] = adRequestId;
+    commonSearchParams['v'] = this._version;
+    commonSearchParams['vi'] = bidRequest.data.vi || this._version + '-vi';
+    commonSearchParams['si'] = bidRequest.data.si || this._version + '-si';
+    commonSearchParams['pvi'] = bidRequest.data.pvi || this._version + '-pvi';
+    commonSearchParams['ri'] = adRequestId;
     return commonSearchParams;
   },
 
   buildAdUrl: function(urlPrefix, publisherNumber, commonSearchParams, bid) {
     const searchParams = Object.assign({}, commonSearchParams);
-    searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_RESPONSE_TIME] = Date.now();
-    searchParams[this.CONSTANTS.REQUEST_PARAMS.AD_REQUEST_SLOT] = bid.slot + ':' + bid.size;
-    searchParams[this.CONSTANTS.REQUEST_PARAMS.INTERSECTION_OBSERVER_AVAILABLE] = this.intersectionObserverAvailable(window);
+    searchParams['cts_res'] = Date.now();
+    searchParams['slot'] = bid.slot + ':' + bid.size;
+    searchParams['ioa'] = this.intersectionObserverAvailable(window);
 
     const queryString = buildQueryString(searchParams) || '';
     const adUrl = urlPrefix +
             publisherNumber +
-            this.CONSTANTS.REQUEST_API_PATH_CREATIVE +
-            '?' +
+            '/ad/creative.js?' +
             queryString;
     return adUrl;
   },
@@ -466,8 +352,7 @@ export const YieldbotAdapter = {
     const queryString = buildQueryString(searchParams) || '';
     const impressionUrl = urlPrefix +
             publisherNumber +
-            this.CONSTANTS.REQUEST_API_PATH_IMPRESSION +
-            '?' +
+            '/ad/impression.gif?' +
             queryString;
     return impressionUrl;
   },
@@ -494,86 +379,8 @@ export const YieldbotAdapter = {
     const adUrl = this.buildAdUrl(urlPrefix, publisherNumber, commonSearchParams, bid);
     const impressionUrl = this.buildImpressionUrl(urlPrefix, publisherNumber, commonSearchParams);
 
-    let htmlMarkup = `<div id="ybot-${ybotAdRequestId}"></div>
-<script type="text/javascript">
-  var yieldbot = {
-    iframeType: function (win) {
-      var it = 'none';
-      while (win !== window.top) {
-        try {
-          win = win.parent;
-          var doc = win.document;
-          it = doc ? 'so' : 'co';
-        } catch (e) {
-          it = 'co';
-        }
-      }
-      return it;
-    },
-    '_render': function(data) {
-      try {
-        yieldbot['cts_rend_' + '${ybotAdRequestId}'] = Date.now();
-        var bodyHtml = data.html,
-        width = data.size[0] || 0,
-        height = data.size[1] || 0,
-        divEl = document.createElement('div');
-        divEl.style.width = width + 'px';
-        divEl.style.height = height + 'px';
-        divEl.className = 'ybot-creative creative-wrapper';
-
-        var containerEl = document.getElementById(data.wrapper_id || 'ybot-' + data.request_id);
-        containerEl.appendChild(divEl);
-
-        var iframeHtml = '<!DOCTYPE html><head><meta charset=utf-8><style>' +
-           data.style +
-           '</style></head><body>' +
-           data.html +
-           '</body>',
-        innerFrame = document.createElement('iframe');
-        innerFrame.width = width;
-        innerFrame.height = height;
-        innerFrame.scrolling = 'no';
-        innerFrame.marginWidth = '0';
-        innerFrame.marginHeight = '0';
-        innerFrame.frameBorder = '0';
-        innerFrame.style.border = '0px';
-        innerFrame.style['vertical-align'] = 'bottom';
-        innerFrame.id = 'ybot-' + data.request_id + '-iframe';
-        divEl.appendChild(innerFrame);
-        var innerFrameDoc = innerFrame.contentWindow.document;
-        innerFrameDoc.open();
-        innerFrameDoc.write(iframeHtml);
-        innerFrameDoc.close();
-
-        var image = new Image(1, 1);
-        image.onload = function () {};
-        var cts_rend = yieldbot['cts_rend_' + '${ybotAdRequestId}'] || 0;
-        image.src = '${impressionUrl}' + '&cts_imp=' + Date.now() + '&cts_rend=' + cts_rend + '&e';
-      } catch(err) {}
-    }
-  };
-</script>
-<script type="text/javascript">
-  var jsEl = document.createElement('script');
-  var src = '${adUrl}' + '&it=' + yieldbot.iframeType(window) + '&cts_ad=' + Date.now() + '&e';
-  jsEl.src = src;
-  var firstEl = document.getElementsByTagName('script')[0];
-  firstEl.parentNode.insertBefore(jsEl, firstEl);
-</script>`;
+    const htmlMarkup = `<div id="ybot-${ybotAdRequestId}"></div><script type="text/javascript">var yieldbot={iframeType:function(win){var it='none';while(win !== window.top){try{win=win.parent;var doc=win.document;it=doc?'so':'co';}catch(e){it='co';}}return it;},'_render':function(data){try{yieldbot['cts_rend_'+'${ybotAdRequestId}']=Date.now();var bodyHtml=data.html,width=data.size[0]||0,height=data.size[1]||0,divEl=document.createElement('div');divEl.style.width=width+'px';divEl.style.height=height+'px';divEl.className='ybot-creativecreative-wrapper';var containerEl=document.getElementById(data.wrapper_id||'ybot-'+data.request_id);containerEl.appendChild(divEl);var iframeHtml='<!DOCTYPE html><head><meta charset=utf-8><style>'+data.style+'</style></head><body>'+data.html+'</body>',innerFrame=document.createElement('iframe');innerFrame.width=width;innerFrame.height=height;innerFrame.scrolling='no';innerFrame.marginWidth='0';innerFrame.marginHeight='0';innerFrame.frameBorder='0';innerFrame.style.border='0px';innerFrame.style['vertical-align']='bottom';innerFrame.id='ybot-'+data.request_id+'-iframe';divEl.appendChild(innerFrame);var innerFrameDoc=innerFrame.contentWindow.document;innerFrameDoc.open();innerFrameDoc.write(iframeHtml);innerFrameDoc.close();var image=newImage(1,1);image.onload=function(){};var cts_rend=yieldbot['cts_rend_'+'${ybotAdRequestId}']||0;image.src='${impressionUrl}'+'&cts_imp='+Date.now()+'&cts_rend='+cts_rend+'&e';}catch(err){}}};</script><script type="text/javascript">var jsEl=document.createElement('script');var src='${adUrl}'+'&it='+yieldbot.iframeType(window)+'&cts_ad='+Date.now()+'&e';jsEl.src=src;var firstEl=document.getElementsByTagName('script')[0];firstEl.parentNode.insertBefore(jsEl,firstEl);</script>`;
     return { ad: htmlMarkup, creativeId: ybotAdRequestId };
-  },
-  iframeType: function (win) {
-    let it = this.CONSTANTS.IFRAME_TYPE.NONE;
-    while (win !== window.top) {
-      try {
-        win = win.parent;
-        const doc = win.document;
-        it = doc ? this.CONSTANTS.IFRAME_TYPE.SAME_ORIGIN : this.CONSTANTS.IFRAME_TYPE.CROSS_ORIGIN;
-      } catch (e) {
-        it = this.CONSTANTS.IFRAME_TYPE.CROSS_ORIGIN;
-      }
-    }
-    return it;
   },
 
   intersectionObserverAvailable: function (win) {
@@ -606,9 +413,9 @@ export const YieldbotAdapter = {
   initBidRequestParams: function() {
     const params = {};
 
-    params[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_LOADED_TIME] = this._adapterLoaded;
-    params[this.CONSTANTS.REQUEST_PARAMS.NAVIGATION_START_TIME] = this._navigationStart;
-    params[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_VERSION] = this.CONSTANTS.VERSION;
+    params['cts_js'] = this._adapterLoaded;
+    params['cts_ns'] = this._navigationStart;
+    params['v'] = this._version;
 
     const userId = this.userId;
     const sessionId = this.sessionId;
@@ -618,27 +425,27 @@ export const YieldbotAdapter = {
     const lastBidId = this.lastPageviewId;
     this.lastPageviewTime = currentBidTime;
     this.lastPageviewId = pageviewId;
-    params[this.CONSTANTS.REQUEST_PARAMS.USER_ID] = userId;
-    params[this.CONSTANTS.REQUEST_PARAMS.SESSION_ID] = sessionId;
-    params[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_DEPTH] = this._pageviewDepth;
-    params[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID] = pageviewId;
-    params[this.CONSTANTS.REQUEST_PARAMS.LAST_PAGEVIEW_TIME] = lastBidTime;
-    params[this.CONSTANTS.REQUEST_PARAMS.LAST_PAGEVIEW_ID] = lastBidId;
-    params[this.CONSTANTS.REQUEST_PARAMS.BID_TYPE] = this._bidRequestCount === 0 ? 'init' : 'refresh';
+    params['vi'] = userId;
+    params['si'] = sessionId;
+    params['pvd'] = this._pageviewDepth;
+    params['pvi'] = pageviewId;
+    params['lpv'] = lastBidTime;
+    params['lpvi'] = lastBidId;
+    params['bt'] = this._bidRequestCount === 0 ? 'init' : 'refresh';
 
-    params[this.CONSTANTS.REQUEST_PARAMS.USER_AGENT] = navigator.userAgent;
-    params[this.CONSTANTS.REQUEST_PARAMS.NAVIGATOR_PLATFORM] = navigator.platform;
-    params[this.CONSTANTS.REQUEST_PARAMS.LANGUAGE] =
+    params['ua'] = navigator.userAgent;
+    params['np'] = navigator.platform;
+    params['la'] =
       navigator.browserLanguage ? navigator.browserLanguage : navigator.language;
-    params[this.CONSTANTS.REQUEST_PARAMS.TIMEZONE_OFFSET] =
+    params['to'] =
       (new Date()).getTimezoneOffset() / 60;
-    params[this.CONSTANTS.REQUEST_PARAMS.SCREEN_DIMENSIONS] =
+    params['sd'] =
       window.screen.width + 'x' + window.screen.height;
 
-    params[this.CONSTANTS.REQUEST_PARAMS.LOCATION] = utils.getTopWindowUrl();
-    params[this.CONSTANTS.REQUEST_PARAMS.REFERRER] = utils.getTopWindowReferrer();
+    params['lo'] = utils.getTopWindowUrl();
+    params['r'] = utils.getTopWindowReferrer();
 
-    params[this.CONSTANTS.REQUEST_PARAMS.TERMINATOR] = '';
+    params['e'] = '';
 
     return params;
   },
@@ -715,8 +522,8 @@ export const YieldbotAdapter = {
         nm.push(slotName);
         sz.push(slotSizes.join('.'));
       }
-      params[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] = nm.join('|');
-      params[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] = sz.join('|');
+      params['sn'] = nm.join('|');
+      params['ssz'] = sz.join('|');
 
       params.bidIdMap = bidIdMap;
     } catch (err) {}
@@ -754,13 +561,12 @@ export const YieldbotAdapter = {
 
   /**
    * Clear all first-party cookies.
-   * See [CONSTANTS.COOKIES]{@link module:YieldbotBidAdapter.CONSTANTS}.
    */
   clearAllCookies: function() {
-    for (let label in this.CONSTANTS.COOKIES) {
-      if (this.CONSTANTS.COOKIES.hasOwnProperty(label)) {
-        this.deleteCookie(this.CONSTANTS.COOKIES[label]);
-      }
+    const labels = this._cookieLabels;
+    for (let idx = 0; idx < labels.length; idx++) {
+      const label = '__ybot' + labels[idx];
+      this.deleteCookie(label);
     }
   },
 

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -65,7 +65,6 @@ export const YieldbotAdapter = {
     const cookieName = '__ybotn';
     const sessionBlocked = blockSession ? 1 : 0;
     this.setCookie(cookieName, sessionBlocked, this._sessionTimeout, '/');
-    return !!sessionBlocked;
   },
 
   get userId() {
@@ -104,7 +103,7 @@ export const YieldbotAdapter = {
 
   set lastPageviewId(id) {
     const cookieName = '__ybotlpvi';
-    return this.setCookie(cookieName, id, this._sessionTimeout, '/');
+    this.setCookie(cookieName, id, this._sessionTimeout, '/');
   },
 
   get lastPageviewTime() {
@@ -115,7 +114,7 @@ export const YieldbotAdapter = {
 
   set lastPageviewTime(ts) {
     const cookieName = '__ybotlpv';
-    return this.setCookie(cookieName, ts, this._sessionTimeout, '/');
+    this.setCookie(cookieName, ts, this._sessionTimeout, '/');
   },
 
   /**

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -1,0 +1,806 @@
+import * as utils from 'src/utils';
+import { formatQS as buildQueryString } from '../src/url';
+import { registerBidder } from 'src/adapters/bidderFactory';
+
+/**
+ * @module {BidderSpec} YieldbotBidAdapter
+ * @description Adapter for requesting bids from Yieldbot
+ * @see BidderSpec
+ * @author [elljoh]{@link https://github.com/elljoh}
+ * @private
+ */
+export const YieldbotAdapter = {
+  _adapterLoaded: Date.now(),
+  _navigationStart: 0,
+  /**
+   * @description Yieldbot adapter internal constants
+   * @constant
+   * @memberof module:YieldbotBidAdapter
+   * @property {string} VERSION Yieldbot adapter version string: <pre>'pbjs-{major}.{minor}.{patch}'</pre>
+   * @property {string} CURRENCY 3-letter ISO 4217 code defining the currency of the bid
+   * @property {boolean} NET_REVENUE Bid value is net or gross. True = Net
+   * @property {string} DEFAULT_REQUEST_URL_PREFIX Request Url prefix to use when ad server response has not provided availability zone specific prefix
+   * @property {string} REQUEST_API_VERSION Yieldbot request API Url path parameter
+   * @property {string} REQUEST_API_PATH_BID Yieldbot bid request API path component
+   * @property {string} REQUEST_API_PATH_CREATIVE Yieldbot ad markup request API path component
+   * @property {string} REQUEST_API_PATH_IMRESSION Yieldbot ad impression request API path component
+   * @property {string} REQUEST_PARAMS_TERMINATOR Yieldbot request query parameters termination character
+   * @property {number} USER_ID_TIMEOUT
+   * @property {number} VISIT_ID_TIMEOUT
+   * @property {number} SESSION_ID_TIMEOUT
+   * @property {object} IFRAME_TYPE the iFrame type in which a ad markup request is made
+   * @property {string} IFRAME_TYPE.NONE not in an iFrame
+   * @property {string} IFRAME_TYPE.SAME_ORIGIN in an iFrame with the same origin aka "friendly"
+   * @property {string} IFRAME_TYPE.CROSS_ORIGIN in an iFrame with a different origin aka "unfriendly"
+   * @property {object} REQUEST_PARAMS Request Url query parameter names
+   * @property {string} REQUEST_PARAMS.ADAPTER_VERSION The version of the YieldbotAdapter code. See [VERSION]{@link module:YieldbotBidAdapter.CONSTANTS}.
+   * @property {string} REQUEST_PARAMS.USER_ID First party user identifier
+   * @property {string} REQUEST_PARAMS.SESSION_ID Publisher site visit session identifier
+   * @property {string} REQUEST_PARAMS.PAGEVIEW_ID Page visit identifier
+   * @property {string} REQUEST_PARAMS.AD_REQUEST_ID Yieldbot ad request identifier
+   * @property {string} REQUEST_PARAMS.AD_REQUEST_SLOT Slot name for Yieldbot ad markup request e.g. <pre>&lt;slot name&gt;:&lt;width&gt;x&lt;height&gt;</pre>
+   * @property {string} REQUEST_PARAMS.PAGEVIEW_DEPTH Counter for page visits in a session
+   * @property {string} [REQUEST_PARAMS.LAST_PAGEVIEW_ID] Pageview identifier for the last pageview within the session TTL
+   * @property {string} REQUEST_PARAMS.BID_SLOT_NAME Yieldbot slot name to request bid for
+   * @property {string} REQUEST_PARAMS.BID_SLOT_SIZE Dimensions for the respective bid slot name
+   * @property {string} REQUEST_PARAMS.LOCATION The page visit location Url
+   * @property {string} REQUEST_PARAMS.REFERRER The referring page Url
+   * @property {string} REQUEST_PARAMS.SCREEN_DIMENSIONS User-agent screen dimensions
+   * @property {string} REQUEST_PARAMS.TIMEZONE_OFFSET Number of hours offset from UTC
+   * @property {string} REQUEST_PARAMS.LANGUAGE Language and locale of the user-agent
+   * @property {string} REQUEST_PARAMS.NAVIGATION_PLATFORM User-agent browsing platform
+   * @property {string} REQUEST_PARAMS.USER_AGENT User-Agent string
+   * @property {string} [REQUEST_PARAMS.LAST_PAGEVIEW_TIME] Time in milliseconds since the last page visit
+   * @property {string} REQUEST_PARAMS.NAVIGATION_START_TIME Performance timing navigationStart
+   * @property {string} REQUEST_PARAMS.ADAPTER_LOADED_TIME Adapter code interpreting started timestamp, in milliseconds since the UNIX epoch
+   * @property {string} REQUEST_PARAMS.BID_REQUEST_TIME Yieldbot bid request sent timestamp, in milliseconds since the UNIX epoch
+   * @property {string} REQUEST_PARAMS.BID_RESPONSE_TIME Yieldbot bid response processing started timestamp, in milliseconds since the UNIX epoch
+   * @property {string} REQUEST_PARAMS.AD_REQUEST_TIME Yieldbot ad creative request sent timestamp, in milliseconds since the UNIX epoch
+   * @property {string} REQUEST_PARAMS.AD_RENDER_TIME Yieldbot ad creative render started timestamp, in milliseconds since the UNIX epoch
+   * @property {string} REQUEST_PARAMS.AD_IMPRESSION_TIME Yieldbot ad impression rerquest sent  timestamp, in milliseconds since the UNIX epoch
+   * @property {string} [REQUEST_PARAMS.INTERSECTION_OBSERVER_AVAILABLE] Indicator that the user-agent supports the Intersection Observer API
+   * @property {string} [REQUEST_PARAMS.IFRAME_TYPE] Indicator to specify Yieldbot creative rendering occured in a same (<code>so</code>) or cross (<code>co</code>) origin iFrame
+   * @property {string} [REQUEST_PARAMS.BID_TYPE] Yieldbot bid request type: initial or refresh
+   * @property {string} REQUEST_PARAMS.CALLBACK Ad creative render callback
+   * @property {string} REQUEST_PARAMS.SESSION_BLOCKED Yieldbot ads blocked by user opt-out or suspicious activity detected during session
+   * @property {string} [REQUEST_PARAMS.ADAPTER_ERROR] Yieldbot error description parameter
+   * @property {string} [REQUEST_PARAMS.TERMINATOR] Yieldbot search parameters terminator
+   * @property {object} COOKIES Cookie name suffixes set by Yieldbot. See also <code>YieldbotAdapter._COOKIE_PREFIX</code>
+   * @property {string} COOKIES.SESSION_BLOCKED The user session is blocked for bids
+   * @property {string} COOKIES.SESSION_ID The user session identifier
+   * @property {string} COOKIES.PAGEVIEW_DEPTH The session pageview depth
+   * @property {string} COOKIES.USER_ID The Yieldbot first-party user identifier
+   * @property {string} COOKIES.LAST_PAGEVIEW_ID The last pageview identifier within the session TTL
+   * @property {string} COOKIES.PREVIOUS_VISIT The time in [ms] since the last visit within the session TTL
+   * @property {string} COOKIES.URL_PREFIX Geo/IP proximity request Url domain
+   * @TODO Document parameter optionality for properties
+   */
+  CONSTANTS: {
+    VERSION: 'pbjs-yb-1.0.0',
+    CURRENCY: 'USD',
+    NET_REVENUE: true,
+    DEFAULT_REQUEST_URL_PREFIX: '//i.yldbt.com/m/',
+    REQUEST_API_VERSION: '/v1',
+    REQUEST_API_PATH_BID: '/init',
+    REQUEST_API_PATH_CREATIVE: '/ad/creative.js',
+    REQUEST_API_PATH_IMPRESSION: '/ad/impression.gif',
+    REQUEST_PARAMS_TERMINATOR: '&e',
+    USER_ID_TIMEOUT: 2592000000,
+    VISIT_ID_TIMEOUT: 2592000000,
+    SESSION_ID_TIMEOUT: 180000,
+    IFRAME_TYPE: {
+      NONE: 'none',
+      SAME_ORIGIN: 'so',
+      CROSS_ORIGIN: 'co'
+    },
+    REQUEST_PARAMS: {
+      ADAPTER_VERSION: 'v',
+      USER_ID: 'vi',
+      SESSION_ID: 'si',
+      PAGEVIEW_ID: 'pvi',
+      AD_REQUEST_ID: 'ri',
+      AD_REQUEST_SLOT: 'slot',
+      PAGEVIEW_DEPTH: 'pvd',
+      LAST_PAGEVIEW_ID: 'lpvi',
+      BID_SLOT_NAME: 'sn',
+      BID_SLOT_SIZE: 'ssz',
+      LOCATION: 'lo',
+      REFERRER: 'r',
+      SCREEN_DIMENSIONS: 'sd',
+      TIMEZONE_OFFSET: 'to',
+      LANGUAGE: 'la',
+      NAVIGATOR_PLATFORM: 'np',
+      USER_AGENT: 'ua',
+      LAST_PAGEVIEW_TIME: 'lpv',
+      NAVIGATION_START_TIME: 'cts_ns',
+      ADAPTER_LOADED_TIME: 'cts_js',
+      BID_REQUEST_TIME: 'cts_ini',
+      BID_RESPONSE_TIME: 'cts_res',
+      AD_REQUEST_TIME: 'cts_ad',
+      AD_RENDER_TIME: 'cts_rend',
+      AD_IMPRESSION_TIME: 'cts_imp',
+      INTERSECTION_OBSERVER_AVAILABLE: 'ioa',
+      IFRAME_TYPE: 'it',
+      BID_TYPE: 'bt',
+      CALLBACK: 'cb',
+      MEDIA_TYPE: 'mtp',
+      SESSION_BLOCKED: 'sb',
+      ADAPTER_ERROR: 'apie',
+      TERMINATOR: 'e'
+    },
+    COOKIES: {
+      SESSION_BLOCKED: '__ybot_n',
+      SESSION_ID: '__ybot_si',
+      PAGEVIEW_DEPTH: '__ybot_pvd',
+      USER_ID: '__ybot_vi',
+      LAST_PAGEVIEW_ID: '__ybot_lpvi',
+      PREVIOUS_VISIT: '__ybot_v',
+      URL_PREFIX: '__ybot_c'
+    }
+  },
+  _bidRequestCount: 0,
+  _pageviewDepth: 0,
+  _lastPageviewId: '',
+  _sessionBlocked: false,
+  _isInitialized: false,
+
+  initialize: function() {
+    if (!this._isInitialized) {
+      this._pageviewDepth = this.pageviewDepth;
+      this._sessionBlocked = this.sessionBlocked;
+      this._isInitialized = true;
+    }
+  },
+
+  /**
+   * Is the user session blocked by the Yieldbot adserver.<br>
+   * The Yieldbot adserver may return <code>"block_session": true</code> in a bid response.
+   * A session may be blocked for efficiency (i.e. Yieldbot has decided no to bid for the session),
+   * security and/or fraud detection.
+   * @returns {boolean}
+   * @readonly
+   * @memberof module:YieldbotBidAdapter
+   * @private
+   */
+  get sessionBlocked() {
+    const cookieName = this.CONSTANTS.COOKIES.SESSION_BLOCKED;
+    const cookieValue = this.getCookie(cookieName);
+    const sessionBlocked = cookieValue ? parseInt(cookieValue, 10) || 0 : 0;
+    if (sessionBlocked) {
+      this.setCookie(cookieName, 1, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    }
+    this._sessionBlocked = !!sessionBlocked;
+    return this._sessionBlocked;
+  },
+
+  set sessionBlocked(blockSession) {
+    const cookieName = this.CONSTANTS.COOKIES.SESSION_BLOCKED;
+    const sessionBlocked = blockSession ? 1 : 0;
+    this.setCookie(cookieName, sessionBlocked, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    return !!sessionBlocked;
+  },
+
+  get userId() {
+    const cookieName = this.CONSTANTS.COOKIES.USER_ID;
+    let cookieValue = this.getCookie(cookieName);
+    if (!cookieValue) {
+      cookieValue = this.newId();
+      this.setCookie(cookieName, cookieValue, this.CONSTANTS.USER_ID_TIMEOUT, '/');
+    }
+    return cookieValue;
+  },
+
+  get sessionId() {
+    const cookieName = this.CONSTANTS.COOKIES.SESSION_ID;
+    let cookieValue = this.getCookie(cookieName);
+    if (!cookieValue) {
+      cookieValue = this.newId();
+      this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    }
+    return cookieValue;
+  },
+
+  get pageviewDepth() {
+    const cookieName = this.CONSTANTS.COOKIES.PAGEVIEW_DEPTH;
+    let cookieValue = parseInt(this.getCookie(cookieName), 10) || 0;
+    cookieValue++;
+    this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    return cookieValue;
+  },
+
+  get lastPageviewId() {
+    const cookieName = this.CONSTANTS.COOKIES.LAST_PAGEVIEW_ID;
+    let cookieValue = this.getCookie(cookieName);
+    return cookieValue || '';
+  },
+
+  set lastPageviewId(id) {
+    const cookieName = this.CONSTANTS.COOKIES.LAST_PAGEVIEW_ID;
+    return this.setCookie(cookieName, id, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+  },
+
+  get lastPageviewTime() {
+    const cookieName = this.CONSTANTS.COOKIES.PREVIOUS_VISIT;
+    let cookieValue = this.getCookie(cookieName);
+    return cookieValue ? parseInt(cookieValue, 10) : 0;
+  },
+
+  set lastPageviewTime(ts) {
+    const cookieName = this.CONSTANTS.COOKIES.PREVIOUS_VISIT;
+    return this.setCookie(cookieName, ts, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+  },
+
+  /**
+   * Get/set the request base url used to form bid, ad markup and impression requests.
+   * @param {string} [prefix] the bidder request base url
+   * @returns {string} the request base Url string
+   * @memberof module:YieldbotBidAdapter
+   */
+  urlPrefix: function(prefix) {
+    const cookieName = this.CONSTANTS.COOKIES.URL_PREFIX;
+    let cookieValue = prefix || this.getCookie(cookieName);
+    if (!cookieValue) {
+      cookieValue = this.CONSTANTS.DEFAULT_REQUEST_URL_PREFIX;
+    }
+    this.setCookie(cookieName, cookieValue, this.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+    return cookieValue;
+  },
+
+  /**
+   * Bidder identifier code.
+   * @type {string}
+   * @constant
+   * @memberof module:YieldbotBidAdapter
+   */
+  get code() { return 'yieldbot'; },
+
+  /**
+   * A list of aliases which should also resolve to this bidder.
+   * @type {string[]}
+   * @constant
+   * @memberof module:YieldbotBidAdapter
+   */
+  get aliases() { return []; },
+
+  /**
+   * @property {MediaType[]} [supportedMediaTypes]: A list of Media Types which the adapter supports.
+   * @constant
+   * @memberof module:YieldbotBidAdapter
+   */
+  get supportedMediaTypes() { return ['banner']; },
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @returns {boolean} True if this is a valid bid, and false otherwise.
+   * @memberof module:YieldbotBidAdapter
+   */
+  isBidRequestValid: function(bid) {
+    let invalidSizeArray = false;
+    if (utils.isArray(bid.sizes)) {
+      const arr = bid.sizes.reduce((acc, cur) => acc.concat(cur), []).filter((item) => {
+        return !utils.isNumber(item);
+      });
+      invalidSizeArray = arr.length !== 0;
+    }
+    const ret = bid &&
+            bid.params &&
+            utils.isStr(bid.params.psn) &&
+            utils.isStr(bid.params.slot) &&
+            !invalidSizeArray &&
+            !!bid.params.psn &&
+      !!bid.params.slot;
+    return ret;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server.
+   * @return ServerRequest Info describing the request to the server.
+   * @memberof module:YieldbotBidAdapter
+   */
+  buildRequests: function(bidRequests) {
+    const requests = [];
+    if (!this._optOut && !this.sessionBlocked) {
+      const searchParams = this.initBidRequestParams();
+      this._bidRequestCount++;
+
+      const pageviewIdToMap = searchParams[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID];
+
+      const yieldbotSlotParams = this.getSlotRequestParams(pageviewIdToMap, bidRequests);
+
+      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] =
+        yieldbotSlotParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] || '';
+
+      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] =
+        yieldbotSlotParams[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] || '';
+
+      const bidUrl = this.urlPrefix() +
+              yieldbotSlotParams.psn +
+              this.CONSTANTS.REQUEST_API_VERSION +
+              this.CONSTANTS.REQUEST_API_PATH_BID;
+
+      searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_REQUEST_TIME] = Date.now();
+      requests.push({
+        method: 'GET',
+        url: bidUrl,
+        data: searchParams,
+        yieldbotSlotParams: yieldbotSlotParams,
+        options: {
+          withCredentials: true,
+          customHeaders: {
+            Accept: 'application/json'
+          }
+        }
+      });
+    }
+    return requests;
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   * @memberof module:YieldbotBidAdapter
+   */
+  getUserSyncs: function(syncOptions, serverResponses) {
+    const userSyncs = [];
+    if (syncOptions.pixelEnabled &&
+        serverResponses.length > 0 &&
+        serverResponses[0].body &&
+        serverResponses[0].body.user_syncs &&
+        utils.isArray(serverResponses[0].body.user_syncs)) {
+      const responseUserSyncs = serverResponses[0].body.user_syncs;
+      responseUserSyncs.forEach((pixel) => {
+        userSyncs.push({
+          type: 'image',
+          url: pixel
+        });
+      });
+    }
+    return userSyncs;
+  },
+
+  /**
+   * @typeDef {YieldbotBid} YieldbotBid
+   * @type {object}
+   * @property {string} slot Yieldbot config param slot
+   * @property {string} cpm Yieldbot bid quantity/label
+   * @property {string} size Slot dimensions of the form <code>&lt;width&gt;x&lt;height&gt;</code>
+   * @memberof module:YieldbotBidAdapter
+   */
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param {BidRequest} bidRequest Request object submitted which produced the response.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   * @memberof module:YieldbotBidAdapter
+   */
+  interpretResponse: function(serverResponse, bidRequest) {
+    const bidResponses = [];
+    const responseBody = serverResponse && serverResponse.body ? serverResponse.body : {};
+    this._optOut = responseBody.optout || false;
+    if (this._optOut) {
+      this.clearAllCookies();
+    }
+    if (!this._optOut && !this._sessionBlocked) {
+      const slotBids = responseBody.slots && responseBody.slots.length > 0 ? responseBody.slots : [];
+      slotBids.forEach((bid) => {
+        if (bid.slot && bid.size && bid.cpm) {
+          const sizeParts = bid.size ? bid.size.split('x') : [1, 1];
+          const width = sizeParts[0] || 1;
+          const height = sizeParts[1] || 1;
+          const cpm = parseInt(bid.cpm, 10) / 100.0 || 0;
+
+          const yieldbotSlotParams = bidRequest.yieldbotSlotParams || null;
+          const ybBidId = bidRequest.data[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID];
+          const paramKey = ybBidId +
+                  ':' +
+                  bid.slot +
+                  ':' +
+                  bid.size || '';
+          const bidIdMap = yieldbotSlotParams && yieldbotSlotParams.bidIdMap ? yieldbotSlotParams.bidIdMap : {};
+          const requestId = bidIdMap[paramKey] || '';
+
+          const urlPrefix = this.urlPrefix(responseBody.url_prefix);
+          const tagObject = this.buildAdCreativeTag(urlPrefix, bid, bidRequest);
+          const bidResponse = {
+            requestId: requestId,
+            cpm: cpm,
+            width: width,
+            height: height,
+            creativeId: tagObject.creativeId,
+            currency: this.CONSTANTS.CURRENCY,
+            netRevenue: this.CONSTANTS.NET_REVENUE,
+            ttl: this.CONSTANTS.SESSION_ID_TIMEOUT / 1000, // [s]
+            ad: tagObject.ad
+          };
+          bidResponses.push(bidResponse);
+        }
+      });
+    }
+    return bidResponses;
+  },
+
+  /**
+   * Initializes search parameters common to both ad request and impression Urls.
+   * @param {string} adRequestId Yieldbot ad request identifier
+   * @param {BidRequest} bidRequest The request that is the source of the impression
+   * @returns {object} Search parameter key/value pairs
+   * @memberof module:YieldbotBidAdapter
+   */
+  initAdRequestParams: function(adRequestId, bidRequest) {
+    let commonSearchParams = {};
+    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_VERSION] = this.CONSTANTS.VERSION;
+    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.USER_ID] = bidRequest.data.vi || this.CONSTANTS.VERSION + '-vi';
+    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.SESSION_ID] = bidRequest.data.si || this.CONSTANTS.VERSION + '-si';
+    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID] = bidRequest.data.pvi || this.CONSTANTS.VERSION + '-pvi';
+    commonSearchParams[this.CONSTANTS.REQUEST_PARAMS.AD_REQUEST_ID] = adRequestId;
+    return commonSearchParams;
+  },
+
+  buildAdUrl: function(urlPrefix, publisherNumber, commonSearchParams, bid) {
+    const searchParams = Object.assign({}, commonSearchParams);
+    searchParams[this.CONSTANTS.REQUEST_PARAMS.BID_RESPONSE_TIME] = Date.now();
+    searchParams[this.CONSTANTS.REQUEST_PARAMS.AD_REQUEST_SLOT] = bid.slot + ':' + bid.size;
+    searchParams[this.CONSTANTS.REQUEST_PARAMS.INTERSECTION_OBSERVER_AVAILABLE] = this.intersectionObserverAvailable(window);
+
+    const queryString = buildQueryString(searchParams) || '';
+    const adUrl = urlPrefix +
+            publisherNumber +
+            this.CONSTANTS.REQUEST_API_PATH_CREATIVE +
+            '?' +
+            queryString;
+    return adUrl;
+  },
+
+  buildImpressionUrl: function(urlPrefix, publisherNumber, commonSearchParams) {
+    const searchParams = Object.assign({}, commonSearchParams);
+    const queryString = buildQueryString(searchParams) || '';
+    const impressionUrl = urlPrefix +
+            publisherNumber +
+            this.CONSTANTS.REQUEST_API_PATH_IMPRESSION +
+            '?' +
+            queryString;
+    return impressionUrl;
+  },
+
+  /**
+   * Object with Yieldbot ad markup representation and unique creative identifier.
+   * @typeDef {TagObject} TagObject
+   * @type {object}
+   * @property {string} creativeId bidder specific creative identifier for tracking at the source
+   * @property {string} ad ad creative markup
+   * @memberof module:YieldbotBidAdapter
+   */
+  /**
+   * Builds the ad creative markup.
+   * @param {string} urlPrefix base url for Yieldbot requests
+   * @param {module:YieldbotBidAdapter.YieldbotBid} bid Bidder slot bid object
+   * @returns {module:YieldbotBidAdapter.TagObject}
+   * @memberof module:YieldbotBidAdapter
+   */
+  buildAdCreativeTag: function(urlPrefix, bid, bidRequest) {
+    const ybotAdRequestId = this.newId();
+    const commonSearchParams = this.initAdRequestParams(ybotAdRequestId, bidRequest);
+    const publisherNumber = bidRequest && bidRequest.yieldbotSlotParams ? bidRequest.yieldbotSlotParams.psn || '' : '';
+    const adUrl = this.buildAdUrl(urlPrefix, publisherNumber, commonSearchParams, bid);
+    const impressionUrl = this.buildImpressionUrl(urlPrefix, publisherNumber, commonSearchParams);
+
+    let htmlMarkup = `<div id="ybot-${ybotAdRequestId}"></div>
+<script type="text/javascript">
+  var yieldbot = {
+    iframeType: function (win) {
+      var it = 'none';
+      while (win !== window.top) {
+        try {
+          win = win.parent;
+          var doc = win.document;
+          it = doc ? 'so' : 'co';
+        } catch (e) {
+          it = 'co';
+        }
+      }
+      return it;
+    },
+    '_render': function(data) {
+      try {
+        yieldbot['cts_rend_' + '${ybotAdRequestId}'] = Date.now();
+        var bodyHtml = data.html,
+        width = data.size[0] || 0,
+        height = data.size[1] || 0,
+        divEl = document.createElement('div');
+        divEl.style.width = width + 'px';
+        divEl.style.height = height + 'px';
+        divEl.className = 'ybot-creative creative-wrapper';
+
+        var containerEl = document.getElementById(data.wrapper_id || 'ybot-' + data.request_id);
+        containerEl.appendChild(divEl);
+
+        var iframeHtml = '<!DOCTYPE html><head><meta charset=utf-8><style>' +
+           data.style +
+           '</style></head><body>' +
+           data.html +
+           '</body>',
+        innerFrame = document.createElement('iframe');
+        innerFrame.width = width;
+        innerFrame.height = height;
+        innerFrame.scrolling = 'no';
+        innerFrame.marginWidth = '0';
+        innerFrame.marginHeight = '0';
+        innerFrame.frameBorder = '0';
+        innerFrame.style.border = '0px';
+        innerFrame.style['vertical-align'] = 'bottom';
+        innerFrame.id = 'ybot-' + data.request_id + '-iframe';
+        divEl.appendChild(innerFrame);
+        var innerFrameDoc = innerFrame.contentWindow.document;
+        innerFrameDoc.open();
+        innerFrameDoc.write(iframeHtml);
+        innerFrameDoc.close();
+
+        var image = new Image(1, 1);
+        image.onload = function () {};
+        var cts_rend = yieldbot['cts_rend_' + '${ybotAdRequestId}'] || 0;
+        image.src = '${impressionUrl}' + '&cts_imp=' + Date.now() + '&cts_rend=' + cts_rend + '&e';
+      } catch(err) {}
+    }
+  };
+</script>
+<script type="text/javascript">
+  var jsEl = document.createElement('script');
+  var src = '${adUrl}' + '&it=' + yieldbot.iframeType(window) + '&cts_ad=' + Date.now() + '&e';
+  jsEl.src = src;
+  var firstEl = document.getElementsByTagName('script')[0];
+  firstEl.parentNode.insertBefore(jsEl, firstEl);
+</script>`;
+    return { ad: htmlMarkup, creativeId: ybotAdRequestId };
+  },
+  iframeType: function (win) {
+    let it = this.CONSTANTS.IFRAME_TYPE.NONE;
+    while (win !== window.top) {
+      try {
+        win = win.parent;
+        const doc = win.document;
+        it = doc ? this.CONSTANTS.IFRAME_TYPE.SAME_ORIGIN : this.CONSTANTS.IFRAME_TYPE.CROSS_ORIGIN;
+      } catch (e) {
+        it = this.CONSTANTS.IFRAME_TYPE.CROSS_ORIGIN;
+      }
+    }
+    return it;
+  },
+
+  intersectionObserverAvailable: function (win) {
+    /* Ref:
+     * https://github.com/w3c/IntersectionObserver/blob/gh-pages/polyfill/intersection-observer.js#L23-L25
+     */
+    return win &&
+      win.IntersectionObserver &&
+      win.IntersectionObserverEntry &&
+      win.IntersectionObserverEntry.prototype &&
+      'intersectionRatio' in win.IntersectionObserverEntry.prototype;
+  },
+
+  /**
+   * @typeDef {BidParams} BidParams
+   * @property {string} psn Yieldbot publisher customer number
+   * @property {object} searchParams bid request Url search parameters
+   * @property {object} searchParams.sn slot names
+   * @property {object} searchParams.szz slot sizes
+   * @memberof module:YieldbotBidAdapter
+   * @private
+   */
+  /**
+   * Builds the common Yieldbot bid request Url query parameters.<br>
+   * Slot bid related parameters are handled separately. The so-called common parameters
+   * here are request identifiers, page properties and user-agent attributes.
+   * @returns {object} query parameter key/value items
+   * @memberof module:YieldbotBidAdapter
+   */
+  initBidRequestParams: function() {
+    const params = {};
+
+    params[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_LOADED_TIME] = this._adapterLoaded;
+    params[this.CONSTANTS.REQUEST_PARAMS.NAVIGATION_START_TIME] = this._navigationStart;
+    params[this.CONSTANTS.REQUEST_PARAMS.ADAPTER_VERSION] = this.CONSTANTS.VERSION;
+
+    const userId = this.userId;
+    const sessionId = this.sessionId;
+    const pageviewId = this.newId();
+    const currentBidTime = Date.now();
+    const lastBidTime = this.lastPageviewTime;
+    const lastBidId = this.lastPageviewId;
+    this.lastPageviewTime = currentBidTime;
+    this.lastPageviewId = pageviewId;
+    params[this.CONSTANTS.REQUEST_PARAMS.USER_ID] = userId;
+    params[this.CONSTANTS.REQUEST_PARAMS.SESSION_ID] = sessionId;
+    params[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_DEPTH] = this._pageviewDepth;
+    params[this.CONSTANTS.REQUEST_PARAMS.PAGEVIEW_ID] = pageviewId;
+    params[this.CONSTANTS.REQUEST_PARAMS.LAST_PAGEVIEW_TIME] = lastBidTime;
+    params[this.CONSTANTS.REQUEST_PARAMS.LAST_PAGEVIEW_ID] = lastBidId;
+    params[this.CONSTANTS.REQUEST_PARAMS.BID_TYPE] = this._bidRequestCount === 0 ? 'init' : 'refresh';
+
+    params[this.CONSTANTS.REQUEST_PARAMS.USER_AGENT] = navigator.userAgent;
+    params[this.CONSTANTS.REQUEST_PARAMS.NAVIGATOR_PLATFORM] = navigator.platform;
+    params[this.CONSTANTS.REQUEST_PARAMS.LANGUAGE] =
+      navigator.browserLanguage ? navigator.browserLanguage : navigator.language;
+    params[this.CONSTANTS.REQUEST_PARAMS.TIMEZONE_OFFSET] =
+      (new Date()).getTimezoneOffset() / 60;
+    params[this.CONSTANTS.REQUEST_PARAMS.SCREEN_DIMENSIONS] =
+      window.screen.width + 'x' + window.screen.height;
+
+    params[this.CONSTANTS.REQUEST_PARAMS.LOCATION] = utils.getTopWindowUrl();
+    params[this.CONSTANTS.REQUEST_PARAMS.REFERRER] = utils.getTopWindowReferrer();
+
+    params[this.CONSTANTS.REQUEST_PARAMS.TERMINATOR] = '';
+
+    return params;
+  },
+
+  /**
+   * Bid mapping key to the Prebid internal bidRequestId<br>
+   * Format <code>{pageview id}:{slot name}:{width}x{height}</code>
+   * @typeDef {BidRequestKey} BidRequestKey
+   * @type {string}
+   * @example "jbgxsxqxyxvqm2oud7:leaderboard:728x90"
+   * @memberof module:YieldbotBidAdapter
+   */
+
+  /**
+   * Internal Yieldbot adapter bid and ad markup request state
+   * <br>
+   * When interpreting a server response, the associated requestId is lookeded up
+   * in this map when creating a {@link Bid} response object.
+   * @typeDef {BidRequestMapping} BidRequestMapping
+   * @type {object}
+   * @property {Object.<module:YieldbotBidAdapter.BidRequestKey, string>} {*} Yieldbot bid to requestId mapping item
+   * @memberof module:YieldbotBidAdapter
+   * @example
+   * {
+   *   "jbgxsxqxyxvqm2oud7:leaderboard:728x90": "2b7e31676ce17",
+   *   "jbgxsxqxyxvqm2oud7:medrec:300x250": "2b7e31676cd89",
+   *   "jcrvvd6eoileb8w8ko:medrec:300x250": "2b7e316788ca7"
+   * }
+   * @memberof module:YieldbotBidAdapter
+   */
+
+  /**
+   * Rationalized set of Yieldbot bids for adUnits and mapping to respective Prebid.js bidId.
+   * @typeDef {BidSlots} BidSlots
+   * @property {string} psn Yieldbot publisher site identifier taken from bidder params
+   * @property {string} sn slot names
+   * @property {string} szz slot sizes
+   * @property {module:YieldbotBidAdapter.BidRequestMapping} bidIdMap Yieldbot bid to Prebid bidId mapping
+   * @memberof module:YieldbotBidAdapter
+   */
+
+  /**
+   * Gets unique slot name and sizes for query parameters object
+   * @param {string} pageviewId The Yieldbot bid request identifier
+   * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server
+   * @returns {module:YieldbotBidAdapter.BidSlots} Yieldbot specific bid parameters and bid identifier mapping
+   * @memberof module:YieldbotBidAdapter
+   */
+  getSlotRequestParams: function(pageviewId, bidRequests) {
+    const params = {};
+    const bidIdMap = {};
+    bidRequests = bidRequests || [];
+    pageviewId = pageviewId || '';
+    try {
+      const slotBids = {};
+      bidRequests.forEach((bid) => {
+        params.psn = params.psn || bid.params.psn || '';
+        utils.parseSizesInput(bid.sizes).forEach(sz => {
+          const slotName = bid.params.slot;
+          if (sz && (!slotBids[slotName] || !slotBids[slotName].some(existingSize => existingSize === sz))) {
+            slotBids[slotName] = slotBids[slotName] || [];
+            slotBids[slotName].push(sz);
+            const paramKey = pageviewId + ':' + slotName + ':' + sz;
+            bidIdMap[paramKey] = bid.bidId;
+          }
+        });
+      });
+
+      const nm = [];
+      const sz = [];
+      for (let idx in slotBids) {
+        const slotName = idx;
+        const slotSizes = slotBids[idx];
+        nm.push(slotName);
+        sz.push(slotSizes.join('.'));
+      }
+      params[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_NAME] = nm.join('|');
+      params[this.CONSTANTS.REQUEST_PARAMS.BID_SLOT_SIZE] = sz.join('|');
+
+      params.bidIdMap = bidIdMap;
+    } catch (err) {}
+    return params;
+  },
+
+  getCookie: function(name) {
+    const cookies = document.cookie.split(';');
+    let value = null;
+    for (let idx = 0; idx < cookies.length; idx++) {
+      const item = cookies[idx].split('=');
+      const itemName = item[0].replace(/^\s+|\s+$/g, '');
+      if (itemName == name) {
+        value = item.length > 1 ? decodeURIComponent(item[1].replace(/^\s+|\s+$/g, '')) : null;
+        break;
+      }
+    }
+    return value;
+  },
+
+  setCookie: function(name, value, expireMillis, path, domain, secure) {
+    const expireTime = expireMillis ? new Date(Date.now() + expireMillis).toGMTString() : '';
+    const dataValue = encodeURIComponent(value);
+    const docLocation = path || '';
+    const pageDomain = domain || '';
+    const httpsOnly = secure ? ';secure' : '';
+
+    const cookieStr = `${name}=${dataValue};expires=${expireTime};path=${docLocation};domain=${pageDomain}${httpsOnly}`;
+    document.cookie = cookieStr;
+  },
+
+  deleteCookie: function(name, path, domain, secure) {
+    return this.setCookie(name, '', -1, path, domain, secure);
+  },
+
+  /**
+   * Clear all first-party cookies.
+   * See [CONSTANTS.COOKIES]{@link module:YieldbotBidAdapter.CONSTANTS}.
+   */
+  clearAllCookies: function() {
+    for (let label in this.CONSTANTS.COOKIES) {
+      if (this.CONSTANTS.COOKIES.hasOwnProperty(label)) {
+        this.deleteCookie(this.CONSTANTS.COOKIES[label]);
+      }
+    }
+  },
+
+  /**
+   * Generate a new Yieldbot format id<br>
+   * Base 36 and lowercase: <[ms] since epoch><[base36]{10}>
+   * @example "jbgxsyrlx9fxnr1hbl"
+   * @private
+   */
+  newId: function() {
+    return (+new Date()).toString(36) + 'xxxxxxxxxx'
+      .replace(/[x]/g, function() {
+        return (0 | Math.random() * 36).toString(36);
+      });
+  },
+
+  /**
+   * Create a delegate function with 'this' context of the YieldbotAdapter object.
+   * @param {object} instance Object for 'this' context in function apply
+   * @param {function} fn Function to execute in instance context
+   * @returns {function} the provided function bound to the instance context
+   * @memberof module:YieldbotBidAdapter
+   */
+  createDelegate: function(instance, fn) {
+    var outerArgs = Array.prototype.slice.call(arguments, 2);
+    return function() {
+      return fn.apply(instance, outerArgs.length > 0 ? Array.prototype.slice.call(arguments, 0).concat(outerArgs) : arguments);
+    };
+  }
+};
+
+YieldbotAdapter.initialize();
+
+export const spec = {
+  code: YieldbotAdapter.code,
+  aliases: YieldbotAdapter.aliases,
+  supportedMediaTypes: YieldbotAdapter.supportedMediaTypes,
+  isBidRequestValid: YieldbotAdapter.createDelegate(YieldbotAdapter, YieldbotAdapter.isBidRequestValid),
+  buildRequests: YieldbotAdapter.createDelegate(YieldbotAdapter, YieldbotAdapter.buildRequests),
+  interpretResponse: YieldbotAdapter.createDelegate(YieldbotAdapter, YieldbotAdapter.interpretResponse),
+  getUserSyncs: YieldbotAdapter.createDelegate(YieldbotAdapter, YieldbotAdapter.getUserSyncs)
+};
+
+YieldbotAdapter._navigationStart = Date.now();
+registerBidder(spec);

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -201,15 +201,10 @@ export const YieldbotAdapter = {
 
       const yieldbotSlotParams = this.getSlotRequestParams(pageviewIdToMap, bidRequests);
 
-      searchParams['sn'] =
-        yieldbotSlotParams['sn'] || '';
+      searchParams['sn'] = yieldbotSlotParams['sn'] || '';
+      searchParams['ssz'] = yieldbotSlotParams['ssz'] || '';
 
-      searchParams['ssz'] =
-        yieldbotSlotParams['ssz'] || '';
-
-      const bidUrl = this.urlPrefix() +
-              yieldbotSlotParams.psn +
-              '/v1/init';
+      const bidUrl = this.urlPrefix() + yieldbotSlotParams.psn + '/v1/init';
 
       searchParams['cts_ini'] = Date.now();
       requests.push({
@@ -288,11 +283,7 @@ export const YieldbotAdapter = {
 
           const yieldbotSlotParams = bidRequest.yieldbotSlotParams || null;
           const ybBidId = bidRequest.data['pvi'];
-          const paramKey = ybBidId +
-                  ':' +
-                  bid.slot +
-                  ':' +
-                  bid.size || '';
+          const paramKey = `${ybBidId}:${bid.slot}:${bid.size || ''}`;
           const bidIdMap = yieldbotSlotParams && yieldbotSlotParams.bidIdMap ? yieldbotSlotParams.bidIdMap : {};
           const requestId = bidIdMap[paramKey] || '';
 

--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -238,7 +238,9 @@ export const YieldbotAdapter = {
    */
   urlPrefix: function(prefix) {
     const cookieName = this.CONSTANTS.COOKIES.URL_PREFIX;
-    let cookieValue = prefix || this.getCookie(cookieName);
+    const pIdx = prefix ? prefix.indexOf(':') : -1;
+    const url = pIdx !== -1 ? document.location.protocol + prefix.substr(pIdx + 1) : null;
+    let cookieValue = url || this.getCookie(cookieName);
     if (!cookieValue) {
       cookieValue = this.CONSTANTS.DEFAULT_REQUEST_URL_PREFIX;
     }

--- a/modules/yieldbotBidAdapter.md
+++ b/modules/yieldbotBidAdapter.md
@@ -1,0 +1,143 @@
+# Overview
+
+```
+Module Name:  Yieldbot Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer:   pubops@yieldbot.com
+```
+
+# Description
+The Yieldbot Prebid.js bid adapter integrates Yieldbot demand to publisher inventory.
+
+# BaseAdapter Settings
+
+| Setting               | Value         |
+| :-------------------- | :------------ |
+| `supportedMediaTypes` | **banner**      |
+| `getUserSyncs`        | **image** pixel |
+| `ttl`                 | **180** [s]       |
+| `currency`            | **USD**       |
+
+# Parameters
+The following table lists parameters required for Yieldbot bidder configuration.
+See also [Test Parameters](#test-parameters) for an illustration of parameter usage.
+
+| Name    | Scope    | Description                                                         | Example         |
+| :------ | :------- | :------------------------------------------------------------------ | :-------------- |
+| `psn`   | required | The Yieldbot publisher account short name identifier                | "7b25"          |
+| `slot`  | required | The Yieldbot slot name associated to the publisher adUnit to bid on | "mobile_REC_2"  |
+
+## Example Bidder Configuration
+```javascript
+var adUnit0 = {
+    code: '/00000000/leaderboard',
+    mediaTypes: {
+        banner: {
+            sizes: [728, 90]
+        }
+    },
+    bids: [
+        {
+            bidder: 'yieldbot',
+            params: {
+                psn: '7b25',
+                slot: 'desktop_LB'
+            }
+        }
+    ]
+};
+```
+
+# Test Parameters
+For integration testing, the Yieldbot Platform can be set to always return a bid for requested slots.
+
+When Yieldbot testing mode is enabled, a cookie (`__ybot_test`) on the domain `.yldbt.com` tells the Yieldbot ad server to always return a bid. Each bid is associated to a static mock integration testing creative.
+
+- **Enable** integration testing mode:
+  - http://i.yldbt.com/integration/start
+- **Disable** integration testing mode:
+  - http://i.yldbt.com/integration/stop
+
+***Note:***
+
+- No ad serving metrics are impacted when integration testing mode is enabled.
+- The `__ybot_test` cookie expires in 24 hours.
+- It is good practice to click "Stop testing" when testing is complete, to return to normal ad delivery.
+
+For reference, the test bidder configuration below is included in the following manual test/example file [test/spec/e2e/gpt-examples/gpt_yieldbot.html](../test/spec/e2e/gpt-examples/gpt_yieldbot.html)
+- Replace the adUnit `code` values with your respective DFP adUnitCode.
+- ***Remember*** to **Enable** Yieldbot testing mode to force a bid to be returned.
+
+```javascript
+var adUnit0 = {
+   code: '/00000000/leaderboard',
+   mediaTypes: {
+       banner: {
+           sizes: [728, 90]
+       }
+   },
+   bids: [
+       {
+           bidder: 'yieldbot',
+           params: {
+               psn: '1234',
+               slot: 'leaderboard'
+           }
+       }
+   ]
+};
+
+var adUnit1 = {
+   code: '/00000000/medium-rectangle',
+   mediaTypes: {
+       banner: {
+           sizes: [[300, 250]]
+       }
+   },
+   bids: [
+       {
+           bidder: 'yieldbot',
+           params: {
+               psn: '1234',
+               slot: 'medrec'
+           }
+       }
+   ]
+};
+
+var adUnit2 = {
+   code: '/00000000/large-rectangle',
+   mediaTypes: {
+       banner: {
+           sizes: [[300, 600]]
+       }
+   },
+   bids: [
+       {
+           bidder: 'yieldbot',
+           params: {
+               psn: '1234',
+               slot: 'sidebar'
+           }
+       }
+   ]
+};
+
+var adUnit3 = {
+   code: '/00000000/skyscraper',
+   mediaTypes: {
+       banner: {
+           sizes: [[160, 600]]
+       }
+   },
+   bids: [
+       {
+           bidder: 'yieldbot',
+           params: {
+               psn: '1234',
+               slot: 'skyscraper'
+           }
+       }
+   ]
+};
+```

--- a/modules/yieldbotBidAdapter.md
+++ b/modules/yieldbotBidAdapter.md
@@ -141,3 +141,52 @@ var adUnit3 = {
    ]
 };
 ```
+
+# Yieldbot Query Parameters
+
+| Name | Description |
+| :--- | :---------- |
+| `apie` | Yieldbot error description parameter |
+| `bt` | Yieldbot bid request type: `initial` or `refresh` |
+| `cts_ad` | Yieldbot ad creative request sent timestamp, in milliseconds since the UNIX epoch |
+| `cts_imp` | Yieldbot ad impression request sent timestamp, in milliseconds since the UNIX epoch |
+| `cts_ini` | Yieldbot bid request sent timestamp, in milliseconds since the UNIX epoch |
+| `cts_js` | Adapter code interpreting started timestamp, in milliseconds since the UNIX epoch |
+| `cts_ns` | Performance timing navigationStart |
+| `cts_rend` | Yieldbot ad creative render started timestamp, in milliseconds since the UNIX epoch |
+| `cts_res` | Yieldbot bid response processing started timestamp, in milliseconds since the UNIX epoch |
+| `e` | Yieldbot search parameters terminator |
+| `ioa` | Indicator that the user-agent supports the Intersection Observer API |
+| `it` | Indicator to specify Yieldbot creative rendering occured in an iframe: same/cross origin (`so`)/(`co`) or top (`none`) |
+| `la` | Language and locale of the user-agent |
+| `lo` | The page visit location Url |
+| `lpv` | Time in milliseconds since the last page visit |
+| `lpvi` | Pageview identifier for the last pageview within the session TTL |
+| `np` | User-agent browsing platform |
+| `pvd` | Counter for page visits within a session |
+| `pvi` | Page visit identifier |
+| `r` | The referring page Url |
+| `ri` | Yieldbot ad request identifier |
+| `sb` | Yieldbot ads blocked by user opt-out or suspicious activity detected during session |
+| `sd` | User-agent screen dimensions |
+| `si` | Publisher site visit session identifier |
+| `slot` | Slot name for Yieldbot ad markup request e.g. `<slot name>:<width>x<height>` |
+| `sn` | Yieldbot bid slot names |
+| `ssz` | Dimensions for the respective bid slot names |
+| `to` | Number of hours offset from UTC |
+| `ua` | User-Agent string |
+| `v` | The version of the YieldbotAdapter |
+| `vi` | First party user identifier |
+
+
+# First-party Cookies
+
+| Name | Description |
+| :--- | :---------- |
+| `__ybotn` | The session is temporarily suspended from the ad server e.g. User-Agent, Geo location or suspicious activity |
+| `__ybotu` | The Yieldbot first-party user identifier |
+| `__ybotsi` | The user session identifier |
+| `__ybotpvd` | The session pageview depth |
+| `__ybotlpvi` | The last pageview identifier within the session |
+| `__ybotlpv` | The time in **[ms]** since the last visit within the session |
+| `__ybotc` | Geo/IP proximity location request Url |

--- a/test/spec/e2e/gpt-examples/gpt_yieldbot.html
+++ b/test/spec/e2e/gpt-examples/gpt_yieldbot.html
@@ -1,0 +1,241 @@
+<html>
+    <head>
+        <script>
+         (function () {
+             var d = document, pbs = d.createElement("script"), pro = d.location.protocal;
+             pbs.type = "text/javascript";
+             pbs.src = '/build/dev/prebid.js';
+             var target = document.getElementsByTagName("head")[0];
+             target.insertBefore(pbs, target.firstChild);
+         })();
+        </script>
+        <script>
+         (function () {
+             var gads = document.createElement('script');
+             gads.async = true;
+             gads.type = 'text/javascript';
+             var useSSL = 'https:' == document.location.protocol;
+             gads.src = (useSSL ? 'https:' : 'http:') +
+                        '//www.googletagservices.com/tag/js/gpt.js';
+             var node = document.getElementsByTagName('script')[0];
+             node.parentNode.insertBefore(gads, node);
+         })();
+        </script>
+
+        <script>
+         var googletag = googletag || {};
+         googletag.cmd = googletag.cmd || [];
+
+         var pbjs = pbjs || {};
+         pbjs.que = pbjs.que  || [];
+         var PREBID_TIMEOUT = 3000;
+
+         pbjs.que.push(function () {
+             var adUnit0 = {
+                 code: '/6355419/Travel/Europe/France/Paris',
+                 mediaTypes: {
+                     banner: {
+                         sizes: [728, 90]
+                     }
+                 },
+                 bids: [
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'leaderboard'
+                         }
+                     }
+                 ]
+             };
+
+             var adUnit1 = {
+                 code: '/6355419/Travel/Europe/France/Paris',
+                 mediaTypes: {
+                     banner: {
+                         sizes: [[300, 250]]
+                     }
+                 },
+                 bids: [
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'medrec'
+                         }
+                     }
+                 ]
+             };
+
+             var adUnit2 = {
+                 code: '/6355419/Travel/Europe/France/Paris',
+                 mediaTypes: {
+                     banner: {
+                         sizes: [[300, 600]]
+                     }
+                 },
+                 bids: [
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'sidebar'
+                         }
+                     }
+                 ]
+             };
+
+             var adUnit3 = {
+                 code: '/6355419/Travel/Europe/France/Paris',
+                 mediaTypes: {
+                     banner: {
+                         sizes: [[160, 600]]
+                     }
+                 },
+                 bids: [
+                     {
+                         bidder: 'yieldbot',
+                         params: {
+                             psn: '1234',
+                             slot: 'skyscraper'
+                         }
+                     }
+                 ]
+             };
+
+             pbjs.addAdUnits([adUnit0, adUnit1, adUnit2, adUnit3]);
+             const customGranularity = {
+                 'buckets': [{
+                     'min': 3,
+                     'max': 10,
+                     'increment': 1
+                 }]
+             };
+
+             pbjs.setConfig({
+                 priceGranularity: customGranularity,
+                 enableSendAllBids: false
+             })
+             pbjs.requestBids({
+                 bidsBackHandler: sendAdserverRequest
+             });
+         });
+
+         function sendAdserverRequest() {
+             if (pbjs.adserverRequestSent) {
+                 return;
+             }
+             pbjs.adserverRequestSent = true;
+             googletag.cmd.push(function() {
+                 pbjs.que.push(function() {
+                     pbjs.setTargetingForGPTAsync();
+                     googletag.pubads().refresh();
+                 });
+             });
+         }
+
+         setTimeout(function() {
+             sendAdserverRequest();
+         }, PREBID_TIMEOUT);
+
+        </script>
+
+        <script>
+         googletag.cmd.push(function () {
+             var slot0 = googletag.defineSlot('/6355419/Travel/Europe/France/Paris',
+                                               [[728, 90]],
+                                               'div-0')
+                                   .addService(googletag.pubads());
+             var slot1 = googletag.defineSlot('/6355419/Travel/Europe/France/Paris',
+                                               [[300, 250]],
+                                               'div-1')
+                                   .addService(googletag.pubads());
+             var slot2 = googletag.defineSlot('/6355419/Travel/Europe/France/Paris',
+                                               [[300, 600]],
+                                               'div-2')
+                                   .addService(googletag.pubads());
+             var slot3 = googletag.defineSlot('/6355419/Travel/Europe/France/Paris',
+                                              [[160, 600]],
+                                              'div-3')
+                                  .addService(googletag.pubads());
+
+             googletag.pubads().collapseEmptyDivs();
+             googletag.pubads().disableInitialLoad();
+             googletag.pubads().enableSingleRequest();
+             googletag.enableServices();
+
+         });
+
+         function refreshBids() {
+             var currentTime = new Date().getTime();
+             pbjs.que.push(function () {
+                 pbjs.requestBids({
+                     timeout: PREBID_TIMEOUT,
+                     bidsBackHandler: function () {
+                         callGPT();
+                     }
+                 });
+             });
+         }
+
+         function callGPT() {
+             pbjs.setTargetingForGPTAsync();
+             googletag.pubads().refresh();
+         }
+        </script>
+    </head>
+    <body>
+        <div>
+            <br>
+            <b>Yieldbot integration test mode:</b>
+
+            <ul>
+                <li><a href="http://i.yldbt.com/m/start-testing" target="_blank">START</a><em>  (i.e.force bids to be returned</em>)</li>
+                <li><a href="http://i.yldbt.com/m/stop-testing" target="_blank">STOP</a></li>
+            </ul>
+        </div>
+        <button onclick="refreshBids()">Refresh Bids</button>
+        <h2>Prebid.js Yieldbot Adapter Test</h2>
+        <div style="-moz-column-count: 2; -webkit-column-count: 2; column-count: 2;">
+            <div id='div-0'>
+                <script type='text/javascript'>
+                 googletag.cmd.push(function() {
+                     googletag.display('div-0');
+                 });
+                </script>
+            </div>
+            <p>Lorem ipsum dolor. Sit amet proin. Integer cursus mi mus curabitur euismod vel quos duis bibendum nec interdum porta dolor a viverra nisl fusce. Volutpat sit at. Donec nisl taciti. Eget eu lobortis. Excepteur diam orci lacus nibh pharetra. Justo neque maecenas. Viverra molestie dolor ante rutrum vivamus libero urna suscipit leo praesent ultricies. In dignissim qui ante bibendum in. Habitasse ac arcu non nulla augue. Felis lectus non tempus in aliquam. Sit porttitor nec. Sodales non sit eu duis.</p>
+            <div id='div-1'>
+                <script type='text/javascript'>
+                 googletag.cmd.push(function() {
+                     googletag.display('div-1');
+                 });
+                </script>
+            </div>
+            <p>Donec feugiat ornare a amet optio. Vitae sit sapien. Vitae nec justo. Fusce ac in semper ligula duis eget vel sit. Augue mauris sit. A adipisicing orci est augue dapibus ullamcorper faucibus fermentum. Et phasellus in tempus vivamus praesent. Nisl dui porttitor. Iaculis vulputate eros ut interdum eu. Lacus quis magna varius in quis. Congue erat porttitor sit eu vitae pharetra scelerisque nec. Dolor dui vel ut velit vestibulum. Lectus ullamcorper mi. Curabitur ipsum pellentesque sed erat est est sapien in tempor sodales viverra. Dui volutpat morbi eleifend fringilla quis. Neque erat erat. Rhoncus sed posuere. Dapibus fusce ut lacus mus est pede sed quisquam. Quis aliquam pellentesque. Wisi ac odio eu wisi amet ut ipsum a erat aliquam nunc.</p>
+            <p>Dis vitae penatibus. Mollis mauris bibendum. Porta orci amet dolor sed felis in neque per cursus molestie pellentesque. Quis accusamus vel sed dapibus orci congue ut eros. Nec faucibus inceptos. Hendrerit in eget nulla tellus lacinia. Fusce ut ut mattis.</p>
+            <p>Vivamus mauris metus. Ridiculus habitant lorem in nulla in quam eros ut. Libero aliquam platea. In enim consectetuer eget mattis accumsan aenean faucibus tincidunt. Amet donec vitae wisi pellentesque magna non lacinia qui. In erat in maecenas amet dui. Aliquam elit vel. Ligula sodales lacus. Nisl a purus. Pharetra velit porttitor vel vel non turpis viverra fringilla lorem arcu pellentesque sed aliquet nonummy quisque dapibus ullamcorper. Mollis ipsum nulla. Tempor tempus vitae. Luctus amet vel. Suspendisse sagittis vestibulum fusce eu.</p>
+            <p>Urna et felis bibendum felis sit vestibulum wisi pharetra quisque ac quis cursus suspendisse quisque aenean luctus curabitur. Eget nec leo. Mi placerat cras nulla et integer eget in sed. Non magni parturient. Egestas iaculis malesuada. Nec a duis. Pede condimentum ullamcorper. Augue arcu tellus. In velit in in duis odio dictum wisi proin quis eget sit. Felis tempus inceptos. Turpis risus eu. Mi vivamus consequat. Lectus dui imperdiet amet orci vehicula in vel pellentesque habitant suscipit aliquam. Proin porttitor vitae ultricies a in. Est duis pede. Tristique velit vestibulum odio sodales morbi magna ut vitae. Elementum imperdiet sodales ultrices tortor mollis vehicula lorem varius pellentesque mi ut sit turpis feugiat. In convallis urna. Justo aliquam sed quis scelerisque nonummy. Lobortis rhoncus ornare. Pellentesque leo quam at beatae in. Erat lorem tempus. Molestie faucibus a id mauris montes. Sed orci vulputate. Libero justo curabitur. Amet orci ante. Non felis est erat cras purus id at id nibh nunc facilisis amet metus sagittis pellentesque eros amet. Vitae sit nulla vitae wisi diam. Tincidunt ipsum eleifend semper tortor non. Tellus amet aliquet.</p>
+            <p>Dis vitae penatibus. Mollis mauris bibendum. Porta orci amet dolor sed felis in neque per cursus molestie pellentesque. Quis accusamus vel sed dapibus orci congue ut eros. Nec faucibus inceptos. Hendrerit in eget nulla tellus lacinia. Fusce ut ut mattis.</p>
+            <p>Vivamus mauris metus. Ridiculus habitant lorem in nulla in quam eros ut. Libero aliquam platea. In enim consectetuer eget mattis accumsan aenean faucibus tincidunt. Amet donec vitae wisi pellentesque magna non lacinia qui. In erat in maecenas amet dui. Aliquam elit vel. Ligula sodales lacus. Nisl a purus. Pharetra velit porttitor vel vel non turpis viverra fringilla lorem arcu pellentesque sed aliquet nonummy quisque dapibus ullamcorper. Mollis ipsum nulla. Tempor tempus vitae. Luctus amet vel. Suspendisse sagittis vestibulum fusce eu.</p>
+            <p>Urna et felis bibendum felis sit vestibulum wisi pharetra quisque ac quis cursus suspendisse quisque aenean luctus curabitur. Eget nec leo. Mi placerat cras nulla et integer eget in sed. Non magni parturient. Egestas iaculis malesuada. Nec a duis. Pede condimentum ullamcorper. Augue arcu tellus. In velit in in duis odio dictum wisi proin quis eget sit. Felis tempus inceptos. Turpis risus eu. Mi vivamus consequat. Lectus dui imperdiet amet orci vehicula in vel pellentesque habitant suscipit aliquam. Proin porttitor vitae ultricies a in. Est duis pede. Tristique velit vestibulum odio sodales morbi magna ut vitae. Elementum imperdiet sodales ultrices tortor mollis vehicula lorem varius pellentesque mi ut sit turpis feugiat. In convallis urna. Justo aliquam sed quis scelerisque nonummy. Lobortis rhoncus ornare. Pellentesque leo quam at beatae in. Erat lorem tempus. Molestie faucibus a id mauris montes. Sed orci vulputate. Libero justo curabitur. Amet orci ante. Non felis est erat cras purus id at id nibh nunc facilisis amet metus sagittis pellentesque eros amet. Vitae sit nulla vitae wisi diam. Tincidunt ipsum eleifend semper tortor non. Tellus amet aliquet.</p>
+            <div>
+                <div id='div-2' style='float:left;'>
+                    <script type='text/javascript'>
+                     googletag.cmd.push(function() {
+                         googletag.display('div-2');
+                     });
+                    </script>
+                </div>
+                <div id='div-3'>
+                    <script type='text/javascript'>
+                     googletag.cmd.push(function() {
+                         googletag.display('div-3');
+                     });
+                    </script>
+                </div>
+            </div>
+            <p>Dis vitae penatibus. Mollis mauris bibendum. Porta orci amet dolor sed felis in neque per cursus molestie pellentesque. Quis accusamus vel sed dapibus orci congue ut eros. Nec faucibus inceptos. Hendrerit in eget nulla tellus lacinia. Fusce ut ut mattis.</p>
+        </div>
+    </body>
+</html>

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -1132,22 +1132,15 @@ describe('Yieldbot Adapter Unit Tests', function() {
 
     const AUCTIONS = { FIRST: 0, SECOND: 1 };
     it('should build auction bids', function(done) {
-      const auctionBids = [];
+      let bidCount = 0;
       const bidResponseHandler = (event) => {
-        auctionBids.push(event);
-      };
-      const auctionEndHandler = (event) => {
-        try {
+        bidCount++;
+        if (bidCount === 4) {
           events.off('bidResponse', bidResponseHandler);
-          events.off('auctionEnd', auctionEndHandler);
-          expect(auctionBids.length, 'Auction bids').to.equal(4);
           done();
-        } catch (err) {
-          done(err);
         }
       };
       events.on('bidResponse', bidResponseHandler);
-      events.on('auctionEnd', auctionEndHandler);
 
       const firstAdUnits = FIXTURE_AD_UNITS;
       const firstAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
@@ -1167,8 +1160,7 @@ describe('Yieldbot Adapter Unit Tests', function() {
     });
 
     it('should provide multiple auctions with correct bid cpms', function(done) {
-      const auctionBids = [];
-      let auctionCount = 0;
+      let bidCount = 0;
       let firstAuctionId = '';
       let secondAuctionId = '';
       /*
@@ -1176,44 +1168,34 @@ describe('Yieldbot Adapter Unit Tests', function() {
        */
       const bidResponseHandler = (event) => {
         try {
-          const expr = `${event.adUnitCode}`;
           switch (true) {
-            case expr === '/00000000/leaderboard' && event.auctionId === firstAuctionId:
+            case event.adUnitCode === '/00000000/leaderboard' && event.auctionId === firstAuctionId:
               expect(event.cpm, 'leaderboard, first auction cpm').to.equal(8);
               break;
-            case expr === '/00000000/medrec' && event.auctionId === firstAuctionId:
+            case event.adUnitCode === '/00000000/medrec' && event.auctionId === firstAuctionId:
               expect(event.cpm, 'medrec, first auction cpm').to.equal(3);
               break;
-            case expr === '/00000000/multi-size' && event.auctionId === firstAuctionId:
+            case event.adUnitCode === '/00000000/multi-size' && event.auctionId === firstAuctionId:
               expect(event.cpm, 'multi-size, first auction cpm').to.equal(8);
               break;
-            case expr === '/00000000/skyscraper' && event.auctionId === firstAuctionId:
+            case event.adUnitCode === '/00000000/skyscraper' && event.auctionId === firstAuctionId:
               expect(event.cpm, 'skyscraper, first auction cpm').to.equal(3);
               break;
-            case expr === '/00000000/medrec' && event.auctionId === secondAuctionId:
+            case event.adUnitCode === '/00000000/medrec' && event.auctionId === secondAuctionId:
               expect(event.cpm, 'medrec, second auction cpm').to.equal(1.11);
               break;
-            case expr === '/00000000/multi-size' && event.auctionId === secondAuctionId:
+            case event.adUnitCode === '/00000000/multi-size' && event.auctionId === secondAuctionId:
               expect(event.cpm, 'multi-size, second auction cpm').to.equal(2.22);
               break;
-            case expr === '/00000000/skyscraper' && event.auctionId === secondAuctionId:
+            case event.adUnitCode === '/00000000/skyscraper' && event.auctionId === secondAuctionId:
               expect(event.cpm, 'skyscraper, second auction cpm').to.equal(3.33);
               break;
             default:
-              done(new Error(`Bid response to assert not found: ${expr}:${event.size}:${event.auctionId}, [${firstAuctionId}, ${secondAuctionId}]`));
+              done(new Error(`Bid response to assert not found: ${event.adUnitCode}:${event.size}:${event.auctionId}, [${firstAuctionId}, ${secondAuctionId}]`));
           }
-        } catch (err) {
-          done(err);
-        }
-        auctionBids.push(event);
-      };
-      const auctionEndHandler = (event) => {
-        try {
-          auctionCount++;
-          if (auctionCount === 2) {
+          bidCount++;
+          if (bidCount === 7) {
             events.off('bidResponse', bidResponseHandler);
-            events.off('auctionEnd', auctionEndHandler);
-            expect(auctionBids.length, 'Auction bids').to.equal(7);
             done();
           }
         } catch (err) {
@@ -1221,7 +1203,6 @@ describe('Yieldbot Adapter Unit Tests', function() {
         }
       };
       events.on('bidResponse', bidResponseHandler);
-      events.on('auctionEnd', auctionEndHandler);
 
       /*
        * First auction

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -1,0 +1,1305 @@
+import { expect } from 'chai';
+import find from 'core-js/library/fn/array/find';
+import { newBidder } from 'src/adapters/bidderFactory';
+import AdapterManager from 'src/adaptermanager';
+import { auctionManager } from 'src/auctionManager';
+import * as utils from 'src/utils';
+import * as urlUtils from 'src/url';
+import events from 'src/events';
+import { YieldbotAdapter, spec } from 'modules/yieldbotBidAdapter';
+
+before(function() {
+  YieldbotAdapter.clearAllCookies();
+});
+describe('Yieldbot Adapter Unit Tests', function() {
+  const ALL_SEARCH_PARAMS = ['apie', 'bt', 'cb', 'cts_ad', 'cts_imp', 'cts_ini', 'cts_js', 'cts_ns', 'cts_rend', 'cts_res', 'e', 'ioa', 'it', 'la', 'lo', 'lpv', 'lpvi', 'mtp', 'np', 'pvd', 'pvi', 'r', 'ri', 'sb', 'sd', 'si', 'slot', 'sn', 'ssz', 'to', 'ua', 'v', 'vi'];
+
+  const BID_LEADERBOARD_728x90 = {
+    bidder: 'yieldbot',
+    params: {
+      psn: '1234',
+      slot: 'leaderboard'
+    },
+    adUnitCode: '/0000000/leaderboard',
+    transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c19',
+    sizes: [728, 90],
+    bidId: '2240b2af6064bb',
+    bidderRequestId: '1e878e3676fb85',
+    auctionId: 'c9964bd5-f835-4c91-916e-00295819f932'
+  };
+
+  const BID_MEDREC_300x600 = {
+    bidder: 'yieldbot',
+    params: {
+      psn: '1234',
+      slot: 'medrec'
+    },
+    adUnitCode: '/0000000/side-bar',
+    transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c20',
+    sizes: [300, 600],
+    bidId: '332067957eaa33',
+    bidderRequestId: '1e878e3676fb85',
+    auctionId: 'c9964bd5-f835-4c91-916e-00295819f932'
+  };
+
+  const BID_MEDREC_300x250 = {
+    bidder: 'yieldbot',
+    params: {
+      psn: '1234',
+      slot: 'medrec'
+    },
+    adUnitCode: '/0000000/medrec',
+    transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c21',
+    sizes: [[300, 250]],
+    bidId: '49d7fe5c3a15ed',
+    bidderRequestId: '1e878e3676fb85',
+    auctionId: 'c9964bd5-f835-4c91-916e-00295819f932'
+  };
+
+  const BID_SKY160x600 = {
+    bidder: 'yieldbot',
+    params: {
+      psn: '1234',
+      slot: 'skyscraper'
+    },
+    adUnitCode: '/0000000/side-bar',
+    transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c21',
+    sizes: [160, 600],
+    bidId: '49d7fe5c3a16ee',
+    bidderRequestId: '1e878e3676fb85',
+    auctionId: 'c9964bd5-f835-4c91-916e-00295819f932'
+  };
+
+  const AD_UNITS = [
+    {
+      transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c19',
+      code: '/00000000/leaderboard',
+      sizes: [728, 90],
+      bids: [
+        {
+          bidder: 'yieldbot',
+          params: {
+            psn: '1234',
+            slot: 'leaderboard'
+          }
+        }
+      ]
+    },
+    {
+      transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c20',
+      code: '/00000000/medrec',
+      sizes: [[300, 250]],
+      bids: [
+        {
+          bidder: 'yieldbot',
+          params: {
+            psn: '1234',
+            slot: 'medrec'
+          }
+        }
+      ]
+    },
+    {
+      transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c21',
+      code: '/00000000/multi-size',
+      sizes: [[300, 600]],
+      bids: [
+        {
+          bidder: 'yieldbot',
+          params: {
+            psn: '1234',
+            slot: 'medrec'
+          }
+        }
+      ]
+    },
+    {
+      transactionId: '3bcca099-e22a-4e1e-ab60-365a74a87c22',
+      code: '/00000000/skyscraper',
+      sizes: [[160, 600]],
+      bids: [
+        {
+          bidder: 'yieldbot',
+          params: {
+            psn: '1234',
+            slot: 'skyscraper'
+          }
+        }
+      ]
+    }
+  ];
+
+  const INTERPRET_RESPONSE_BID_REQUEST = {
+    method: 'GET',
+    url: '//i.yldbt.com/m/1234/v1/init',
+    data: {
+      cts_js: 1518184900582,
+      cts_ns: 1518184900582,
+      v: 'pbjs-yb-1.0.0',
+      vi: 'jdg00eijgpvemqlz73',
+      si: 'jdg00eil9y4mcdo850',
+      pvd: 6,
+      pvi: 'jdg03ai5kp9k1rkheh',
+      lpv: 1518184868108,
+      lpvi: 'jdg02lfwmdx8n0ncgc',
+      bt: 'init',
+      ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36',
+      np: 'MacIntel',
+      la: 'en-US',
+      to: 5,
+      sd: '2560x1440',
+      lo: 'http://localhost:9999/test/spec/e2e/gpt-examples/gpt_yieldbot.html',
+      r: '',
+      e: '',
+      sn: 'leaderboard|medrec|medrec|skyscraper',
+      ssz: '728x90|300x250|300x600|160x600',
+      cts_ini: 1518184900591
+    },
+    yieldbotSlotParams: {
+      psn: '1234',
+      sn: 'leaderboard|medrec|medrec|skyscraper',
+      ssz: '728x90|300x250|300x600|160x600',
+      bidIdMap: {
+        'jdg03ai5kp9k1rkheh:leaderboard:728x90': '2240b2af6064bb',
+        'jdg03ai5kp9k1rkheh:medrec:300x250': '49d7fe5c3a15ed',
+        'jdg03ai5kp9k1rkheh:medrec:300x600': '332067957eaa33',
+        'jdg03ai5kp9k1rkheh:skyscraper:160x600': '49d7fe5c3a16ee'
+      }
+    },
+    options: {
+      withCredentials: true,
+      customHeaders: {
+        Accept: 'application/json'
+      }
+    }
+  };
+
+  const INTERPRET_RESPONSE_SERVER_RESPONSE = {
+    body: {
+      pvi: 'jdg03ai5kp9k1rkheh',
+      subdomain_iframe: 'ads-adseast-vpc',
+      url_prefix: 'http://ads-adseast-vpc.yldbt.com/m/',
+      slots: [
+        {
+          slot: 'leaderboard',
+          cpm: '800',
+          size: '728x90'
+        },
+        {
+          slot: 'medrec',
+          cpm: '300',
+          size: '300x250'
+        },
+        {
+          slot: 'medrec',
+          cpm: '800',
+          size: '300x600'
+        },
+        {
+          slot: 'skyscraper',
+          cpm: '300',
+          size: '160x600'
+        }
+      ],
+      user_syncs: [
+        'https://usersync.dd9693a32aa1.com/00000000.gif?p=a',
+        'https://usersync.3b19503b37d8.com/00000000.gif?p=b',
+        'https://usersync.5cb389d36d30.com/00000000.gif?p=c'
+      ]
+    },
+    headers: {}
+  };
+
+  let FIXTURE_AD_UNITS, FIXTURE_SERVER_RESPONSE, FIXTURE_BID_REQUEST, FIXTURE_BID_REQUESTS, FIXTURE_BIDS;
+  beforeEach(function() {
+    FIXTURE_AD_UNITS = utils.deepClone(AD_UNITS);
+    FIXTURE_BIDS = {
+      BID_LEADERBOARD_728x90: utils.deepClone(BID_LEADERBOARD_728x90),
+      BID_MEDREC_300x600: utils.deepClone(BID_MEDREC_300x600),
+      BID_MEDREC_300x250: utils.deepClone(BID_MEDREC_300x250),
+      BID_SKY160x600: utils.deepClone(BID_SKY160x600)
+    };
+
+    FIXTURE_BID_REQUEST = utils.deepClone(INTERPRET_RESPONSE_BID_REQUEST);
+    FIXTURE_SERVER_RESPONSE = utils.deepClone(INTERPRET_RESPONSE_SERVER_RESPONSE);
+    FIXTURE_BID_REQUESTS = [
+      FIXTURE_BIDS.BID_LEADERBOARD_728x90,
+      FIXTURE_BIDS.BID_MEDREC_300x600,
+      FIXTURE_BIDS.BID_MEDREC_300x250,
+      FIXTURE_BIDS.BID_SKY160x600
+    ];
+  });
+
+  afterEach(function() {
+    YieldbotAdapter._optOut = false;
+    YieldbotAdapter.clearAllCookies();
+  });
+
+  describe('Adapter exposes BidderSpec API', function() {
+    it('code', function() {
+      expect(spec.code).to.equal('yieldbot');
+    });
+    it('supportedMediaTypes', function() {
+      expect(spec.supportedMediaTypes).to.deep.equal(['banner']);
+    });
+    it('isBidRequestValid', function() {
+      expect(spec.isBidRequestValid).to.be.a('function');
+    });
+    it('buildRequests', function() {
+      expect(spec.buildRequests).to.be.a('function');
+    });
+    it('interpretResponse', function() {
+      expect(spec.interpretResponse).to.be.a('function');
+    });
+  });
+
+  describe('CONSTANTS.REQUEST_PARAMS', function() {
+    it('should have all request search params defined and no more', function() {
+      const requestParamsValues = utils.getKeys(YieldbotAdapter.CONSTANTS.REQUEST_PARAMS)
+        .map(key => utils.getValue(YieldbotAdapter.CONSTANTS.REQUEST_PARAMS, key));
+      expect(Object.values(requestParamsValues.sort())).to.deep.equal(ALL_SEARCH_PARAMS.sort());
+    });
+  });
+  describe('isBidRequestValid', function() {
+    let bid = {
+      bidder: 'yieldbot',
+      'params': {
+        psn: 'foo',
+        slot: 'bar'
+      },
+      sizes: [[300, 250], [300, 600]]
+    };
+
+    it('valid parameters', function() {
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo',
+          slot: 'bar'
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(true);
+    });
+
+    it('undefined parameters', function() {
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo'
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          slot: 'bar'
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+    });
+
+    it('falsey string parameters', function() {
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: '',
+          slot: 'bar'
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo',
+          slot: ''
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo',
+          slot: 0
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+    });
+
+    it('parameters type invalid', function() {
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo',
+          slot: 0
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: { name: 'foo' },
+          slot: 'bar'
+        },
+        sizes: [[300, 250], [300, 600]]
+      })).to.equal(false);
+    });
+
+    it('invalid sizes type', function() {
+      expect(spec.isBidRequestValid({
+        bidder: 'yieldbot',
+        'params': {
+          psn: 'foo',
+          slot: 'bar'
+        },
+        sizes: {}
+      })).to.equal(true);
+    });
+  });
+
+  describe('getSlotRequestParams', function() {
+    const EMPTY_SLOT_PARAMS = { sn: '', ssz: '', bidIdMap: {} };
+
+    it('should default to empty slot params', function() {
+      expect(YieldbotAdapter.getSlotRequestParams('')).to.deep.equal(EMPTY_SLOT_PARAMS);
+      expect(YieldbotAdapter.getSlotRequestParams()).to.deep.equal(EMPTY_SLOT_PARAMS);
+      expect(YieldbotAdapter.getSlotRequestParams('', [])).to.deep.equal(EMPTY_SLOT_PARAMS);
+      expect(YieldbotAdapter.getSlotRequestParams(0, [])).to.deep.equal(EMPTY_SLOT_PARAMS);
+    });
+
+    it('should build slot bid request parameters', function() {
+      const bidRequests = [
+        FIXTURE_BIDS.BID_LEADERBOARD_728x90,
+        FIXTURE_BIDS.BID_MEDREC_300x600,
+        FIXTURE_BIDS.BID_MEDREC_300x250
+      ];
+      const slotParams = YieldbotAdapter.getSlotRequestParams('f0e1d2c', bidRequests);
+
+      expect(slotParams.psn).to.equal('1234');
+      expect(slotParams.sn).to.equal('leaderboard|medrec');
+      expect(slotParams.ssz).to.equal('728x90|300x600.300x250');
+
+      let bidId = slotParams.bidIdMap['f0e1d2c:leaderboard:728x90'];
+      expect(bidId).to.equal('2240b2af6064bb');
+
+      bidId = slotParams.bidIdMap['f0e1d2c:medrec:300x250'];
+      expect(bidId).to.equal('49d7fe5c3a15ed');
+
+      bidId = slotParams.bidIdMap['f0e1d2c:medrec:300x600'];
+      expect(bidId).to.equal('332067957eaa33');
+    });
+
+    it('should build slot bid request parameters in order of bidRequests', function() {
+      const bidRequests = [
+        FIXTURE_BIDS.BID_MEDREC_300x600,
+        FIXTURE_BIDS.BID_LEADERBOARD_728x90,
+        FIXTURE_BIDS.BID_MEDREC_300x250
+      ];
+
+      const slotParams = YieldbotAdapter.getSlotRequestParams('f0e1d2c', bidRequests);
+
+      expect(slotParams.psn).to.equal('1234');
+      expect(slotParams.sn).to.equal('medrec|leaderboard');
+      expect(slotParams.ssz).to.equal('300x600.300x250|728x90');
+
+      let bidId = slotParams.bidIdMap['f0e1d2c:leaderboard:728x90'];
+      expect(bidId).to.equal('2240b2af6064bb');
+
+      bidId = slotParams.bidIdMap['f0e1d2c:medrec:300x250'];
+      expect(bidId).to.equal('49d7fe5c3a15ed');
+
+      bidId = slotParams.bidIdMap['f0e1d2c:medrec:300x600'];
+      expect(bidId).to.equal('332067957eaa33');
+    });
+
+    it('should exclude slot bid requests with malformed sizes', function() {
+      const bid = FIXTURE_BIDS.BID_MEDREC_300x250;
+      bid.sizes = ['300x250'];
+      const bidRequests = [bid, FIXTURE_BIDS.BID_LEADERBOARD_728x90];
+      const slotParams = YieldbotAdapter.getSlotRequestParams('affffffe', bidRequests);
+      expect(slotParams.psn).to.equal('1234');
+      expect(slotParams.sn).to.equal('leaderboard');
+      expect(slotParams.ssz).to.equal('728x90');
+    });
+  });
+
+  describe('getCookie', function() {
+    it('should return null if cookie name not found', function() {
+      const cookieName = YieldbotAdapter.newId();
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+  });
+
+  describe('setCookie', function() {
+    it('should set a root path first-party cookie with temporal expiry', function() {
+      const cookieName = YieldbotAdapter.newId();
+      const cookieValue = YieldbotAdapter.newId();
+
+      YieldbotAdapter.setCookie(cookieName, cookieValue, YieldbotAdapter.CONSTANTS.USER_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(cookieValue);
+
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should set a root path first-party cookie with session expiry', function() {
+      const cookieName = YieldbotAdapter.newId();
+      const cookieValue = YieldbotAdapter.newId();
+
+      YieldbotAdapter.setCookie(cookieName, cookieValue, null, '/');
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(cookieValue);
+
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should fail to set a cookie x-domain', function() {
+      const cookieName = YieldbotAdapter.newId();
+      const cookieValue = YieldbotAdapter.newId();
+
+      YieldbotAdapter.setCookie(cookieName, cookieValue, null, '/', `${cookieName}.com`);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+  });
+
+  describe('clearAllcookies', function() {
+    it('should delete all first-party cookies', function() {
+      let label, cookieName, cookieValue;
+      for (label in YieldbotAdapter.CONSTANTS.COOKIES) {
+        if (YieldbotAdapter.CONSTANTS.COOKIES.hasOwnProperty(label)) {
+          cookieName = YieldbotAdapter.CONSTANTS.COOKIES[label];
+          YieldbotAdapter.setCookie(cookieName, 1, YieldbotAdapter.CONSTANTS.USER_ID_TIMEOUT, '/');
+        }
+      };
+
+      for (label in YieldbotAdapter.CONSTANTS.COOKIES) {
+        if (YieldbotAdapter.CONSTANTS.COOKIES.hasOwnProperty(label)) {
+          cookieName = YieldbotAdapter.CONSTANTS.COOKIES[label];
+          cookieValue = YieldbotAdapter.getCookie(cookieName);
+          expect(!!cookieValue).to.equal(true);
+        }
+      };
+
+      YieldbotAdapter.clearAllCookies();
+
+      for (label in YieldbotAdapter.CONSTANTS.COOKIES) {
+        if (YieldbotAdapter.CONSTANTS.COOKIES.hasOwnProperty(label)) {
+          cookieName = YieldbotAdapter.CONSTANTS.COOKIES[label];
+          cookieValue = YieldbotAdapter.getCookie(cookieName);
+          expect(cookieValue).to.equal(null);
+        }
+      };
+    });
+  });
+
+  describe('sessionBlocked', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.SESSION_BLOCKED;
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should return true if cookie value is interpreted as non-zero', function() {
+      YieldbotAdapter.setCookie(cookieName, '1', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string "1"').to.equal(true);
+
+      YieldbotAdapter.setCookie(cookieName, '10.01', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string "10.01"').to.equal(true);
+
+      YieldbotAdapter.setCookie(cookieName, '-10.01', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string "-10.01"').to.equal(true);
+
+      YieldbotAdapter.setCookie(cookieName, 1, YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the number 1').to.equal(true);
+    });
+
+    it('should return false if cookie name not found', function() {
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+    });
+
+    it('should return false if cookie value is interpreted as zero', function() {
+      YieldbotAdapter.setCookie(cookieName, '0', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string "0"').to.equal(false);
+
+      YieldbotAdapter.setCookie(cookieName, '.01', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string ".01"').to.equal(false);
+
+      YieldbotAdapter.setCookie(cookieName, '-.9', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the string "-.9"').to.equal(false);
+
+      YieldbotAdapter.setCookie(cookieName, 0, YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked, 'cookie value: the number 0').to.equal(false);
+    });
+
+    it('should return false if cookie value source is a non-numeric string', function() {
+      YieldbotAdapter.setCookie(cookieName, 'true', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+    });
+
+    it('should return false if cookie value source is a boolean', function() {
+      YieldbotAdapter.setCookie(cookieName, true, YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+    });
+
+    it('should set sessionBlocked', function() {
+      YieldbotAdapter.sessionBlocked = true;
+      expect(YieldbotAdapter.sessionBlocked).to.equal(true);
+      YieldbotAdapter.sessionBlocked = false;
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+
+      YieldbotAdapter.sessionBlocked = 1;
+      expect(YieldbotAdapter.sessionBlocked).to.equal(true);
+      YieldbotAdapter.sessionBlocked = 0;
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+
+      YieldbotAdapter.sessionBlocked = '1';
+      expect(YieldbotAdapter.sessionBlocked).to.equal(true);
+      YieldbotAdapter.sessionBlocked = '';
+      expect(YieldbotAdapter.sessionBlocked).to.equal(false);
+    });
+  });
+
+  describe('userId', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.USER_ID;
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should set a user Id if cookie does not exist', function() {
+      const userId = YieldbotAdapter.userId;
+      expect(userId).to.match(/[0-9a-z]{18}/);
+    });
+
+    it('should return user Id if cookie exists', function() {
+      const expectedUserId = YieldbotAdapter.newId();
+      YieldbotAdapter.setCookie(cookieName, expectedUserId, YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      const userId = YieldbotAdapter.userId;
+      expect(userId).to.equal(expectedUserId);
+    });
+  });
+
+  describe('sessionId', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.SESSION_ID;
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should set a session Id if cookie does not exist', function() {
+      const sessionId = YieldbotAdapter.sessionId;
+      expect(sessionId).to.match(/[0-9a-z]{18}/);
+    });
+
+    it('should return session Id if cookie exists', function() {
+      const expectedSessionId = YieldbotAdapter.newId();
+      YieldbotAdapter.setCookie(cookieName, expectedSessionId, YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      const sessionId = YieldbotAdapter.sessionId;
+      expect(sessionId).to.equal(expectedSessionId);
+    });
+  });
+
+  describe('lastPageviewId', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.LAST_PAGEVIEW_ID;
+
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should return empty string if cookie does not exist', function() {
+      const lastBidId = YieldbotAdapter.lastPageviewId;
+      expect(lastBidId).to.equal('');
+    });
+
+    it('should set an id string', function() {
+      const id = YieldbotAdapter.newId();
+      YieldbotAdapter.lastPageviewId = id;
+      const lastBidId = YieldbotAdapter.lastPageviewId;
+      expect(lastBidId).to.equal(id);
+    });
+  });
+
+  describe('lastPageviewTime', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.PREVIOUS_VISIT;
+
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should return zero if cookie does not exist', function() {
+      const lastBidTime = YieldbotAdapter.lastPageviewTime;
+      expect(lastBidTime).to.equal(0);
+    });
+
+    it('should set a timestamp', function() {
+      const ts = Date.now();
+      YieldbotAdapter.lastPageviewTime = ts;
+      const lastBidTime = YieldbotAdapter.lastPageviewTime;
+      expect(lastBidTime).to.equal(ts);
+    });
+  });
+
+  describe('pageviewDepth', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.PAGEVIEW_DEPTH;
+
+    beforeEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+    });
+
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should return one (1) if cookie does not exist', function() {
+      const pageviewDepth = YieldbotAdapter.pageviewDepth;
+      expect(pageviewDepth).to.equal(1);
+    });
+
+    it('should increment the integer string for depth', function() {
+      let pageviewDepth = YieldbotAdapter.pageviewDepth;
+      expect(pageviewDepth).to.equal(1);
+
+      pageviewDepth = YieldbotAdapter.pageviewDepth;
+      expect(pageviewDepth).to.equal(2);
+    });
+  });
+
+  describe('urlPrefix', function() {
+    const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.URL_PREFIX;
+    afterEach(function() {
+      YieldbotAdapter.deleteCookie(cookieName);
+      expect(YieldbotAdapter.getCookie(cookieName)).to.equal(null);
+    });
+
+    it('should set the default prefix if cookie does not exist', function(done) {
+      const urlPrefix = YieldbotAdapter.urlPrefix();
+      expect(urlPrefix).to.equal(YieldbotAdapter.CONSTANTS.DEFAULT_REQUEST_URL_PREFIX);
+      done();
+    });
+
+    it('should return prefix if cookie exists', function() {
+      YieldbotAdapter.setCookie(cookieName, 'somePrefixUrl', YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT, '/');
+      const urlPrefix = YieldbotAdapter.urlPrefix();
+      expect(urlPrefix).to.equal('somePrefixUrl');
+    });
+
+    it('should reset prefix if default already set', function() {
+      const defaultUrlPrefix = YieldbotAdapter.urlPrefix();
+      expect(defaultUrlPrefix).to.equal(YieldbotAdapter.CONSTANTS.DEFAULT_REQUEST_URL_PREFIX);
+
+      let urlPrefix = YieldbotAdapter.urlPrefix('somePrefixUrl');
+      expect(urlPrefix, 'reset prefix').to.equal('somePrefixUrl');
+
+      urlPrefix = YieldbotAdapter.urlPrefix();
+      expect(urlPrefix, 'subsequent request').to.equal('somePrefixUrl');
+    });
+  });
+
+  describe('initBidRequestParams', function() {
+    it('should build common bid request state parameters', function() {
+      const params = YieldbotAdapter.initBidRequestParams(
+        [
+          {
+            'params': {
+              psn: '1234',
+              slot: 'medrec'
+            },
+            sizes: [[300, 250], [300, 600]]
+          }
+        ]
+      );
+
+      const expectedParamKeys = [
+        'v',
+        'vi',
+        'si',
+        'pvi',
+        'pvd',
+        'lpvi',
+        'bt',
+        'lo',
+        'r',
+        'sd',
+        'to',
+        'la',
+        'np',
+        'ua',
+        'lpv',
+        'cts_ns',
+        'cts_js',
+        'e'
+      ];
+
+      const missingKeys = [];
+      expectedParamKeys.forEach((item) => {
+        if (item in params === false) {
+          missingKeys.push(item);
+        }
+      });
+      const extraKeys = [];
+      Object.keys(params).forEach((item) => {
+        if (!find(expectedParamKeys, param => param === item)) {
+          extraKeys.push(item);
+        }
+      });
+
+      expect(
+        missingKeys.length,
+        `\nExpected: ${expectedParamKeys}\nMissing keys: ${JSON.stringify(missingKeys)}`)
+        .to.equal(0);
+      expect(
+        extraKeys.length,
+        `\nExpected: ${expectedParamKeys}\nExtra keys: ${JSON.stringify(extraKeys)}`)
+        .to.equal(0);
+    });
+  });
+
+  describe('buildRequests', function() {
+    it('should not return bid requests if optOut', function() {
+      YieldbotAdapter._optOut = true;
+      const requests = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS);
+      expect(requests.length).to.equal(0);
+    });
+
+    it('should not return bid requests if sessionBlocked', function() {
+      YieldbotAdapter.sessionBlocked = true;
+      const requests = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS);
+      expect(requests.length).to.equal(0);
+      YieldbotAdapter.sessionBlocked = false;
+    });
+
+    it('should re-enable requests when sessionBlocked expires', function() {
+      const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.SESSION_BLOCKED;
+      YieldbotAdapter.setCookie(
+        cookieName,
+        1,
+        YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT,
+        '/');
+      let requests = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS);
+      expect(requests.length).to.equal(0);
+      YieldbotAdapter.deleteCookie(cookieName);
+      requests = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS);
+      expect(requests.length).to.equal(1);
+    });
+
+    it('should return a single BidRequest object', function() {
+      const requests = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS);
+      expect(requests.length).to.equal(1);
+    });
+
+    it('should have expected server options', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      const expectedOptions = {
+        withCredentials: true,
+        customHeaders: {
+          Accept: 'application/json'
+        }
+      };
+      expect(request.options).to.eql(expectedOptions);
+    });
+
+    it('should be a GET request', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should have bid request specific params', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.data).to.not.equal(undefined);
+
+      const expectedParamKeys = [
+        'v',
+        'vi',
+        'si',
+        'pvi',
+        'pvd',
+        'lpvi',
+        'bt',
+        'lo',
+        'r',
+        'sd',
+        'to',
+        'la',
+        'np',
+        'ua',
+        'sn',
+        'ssz',
+        'lpv',
+        'cts_ns',
+        'cts_js',
+        'cts_ini',
+        'e'
+      ];
+
+      const missingKeys = [];
+      expectedParamKeys.forEach((item) => {
+        if (item in request.data === false) {
+          missingKeys.push(item);
+        }
+      });
+      const extraKeys = [];
+      Object.keys(request.data).forEach((item) => {
+        if (!find(expectedParamKeys, param => param === item)) {
+          extraKeys.push(item);
+        }
+      });
+
+      expect(
+        missingKeys.length,
+        `\nExpected: ${expectedParamKeys}\nMissing keys: ${JSON.stringify(missingKeys)}`)
+        .to.equal(0);
+      expect(
+        extraKeys.length,
+        `\nExpected: ${expectedParamKeys}\nExtra keys: ${JSON.stringify(extraKeys)}`)
+        .to.equal(0);
+    });
+
+    it('should have the correct bidUrl form', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      const bidUrl = '//i.yldbt.com/m/1234/v1/init';
+      expect(request.url).to.equal(bidUrl);
+    });
+
+    it('should set the bid request slot/bidId mapping', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.yieldbotSlotParams).to.not.equal(undefined);
+      expect(request.yieldbotSlotParams.bidIdMap).to.not.equal(undefined);
+
+      const map = {};
+      map[request.data.pvi + ':leaderboard:728x90'] = '2240b2af6064bb';
+      map[request.data.pvi + ':medrec:300x250'] = '49d7fe5c3a15ed';
+      map[request.data.pvi + ':medrec:300x600'] = '332067957eaa33';
+      map[request.data.pvi + ':skyscraper:160x600'] = '49d7fe5c3a16ee';
+      expect(request.yieldbotSlotParams.bidIdMap).to.eql(map);
+    });
+
+    it('should set the bid request publisher number', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.yieldbotSlotParams.psn).to.equal('1234');
+    });
+
+    it('should have unique slot name parameter', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.yieldbotSlotParams.sn).to.equal('leaderboard|medrec|skyscraper');
+    });
+
+    it('should have slot sizes parameter', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.yieldbotSlotParams.ssz).to.equal('728x90|300x600.300x250|160x600');
+    });
+
+    it('should use edge server Url prefix if set', function() {
+      const cookieName = YieldbotAdapter.CONSTANTS.COOKIES.URL_PREFIX;
+      YieldbotAdapter.setCookie(
+        cookieName,
+        'http://close.edge.adserver.com/',
+        YieldbotAdapter.CONSTANTS.SESSION_ID_TIMEOUT,
+        '/');
+
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      expect(request.url).to.match(/^http:\/\/close\.edge\.adserver\.com\//);
+    });
+
+    it('should be adapter loaded before navigation start time', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      const timeDiff = request.data.cts_ns - request.data.cts_js;
+      expect(timeDiff >= 0, 'adapter loaded < nav').to.equal(true);
+    });
+
+    it('should be navigation start before bid request time', function() {
+      const request = YieldbotAdapter.buildRequests(FIXTURE_BID_REQUESTS)[0];
+      const timeDiff = request.data.cts_ini - request.data.cts_ns;
+      expect(timeDiff >= 0, 'nav start < request').to.equal(true);
+    });
+  });
+
+  describe('interpretResponse', function() {
+    it('should not return Bids if optOut', function() {
+      YieldbotAdapter._optOut = true;
+      const responses = YieldbotAdapter.interpretResponse();
+      expect(responses.length).to.equal(0);
+    });
+
+    it('should not return Bids if no server response slot bids', function() {
+      FIXTURE_SERVER_RESPONSE.body.slots = [];
+      const responses = YieldbotAdapter.interpretResponse(FIXTURE_SERVER_RESPONSE, FIXTURE_BID_REQUEST);
+      expect(responses.length).to.equal(0);
+    });
+
+    it('should not include Bid if missing cpm', function() {
+      delete FIXTURE_SERVER_RESPONSE.body.slots[1].cpm;
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses.length).to.equal(3);
+    });
+
+    it('should not include Bid if missing size', function() {
+      delete FIXTURE_SERVER_RESPONSE.body.slots[2].size;
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses.length).to.equal(3);
+    });
+
+    it('should not include Bid if missing slot', function() {
+      delete FIXTURE_SERVER_RESPONSE.body.slots[3].slot;
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses.length).to.equal(3);
+    });
+
+    it('should have a valid creativeId', function() {
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses.length).to.equal(4);
+      responses.forEach((bid) => {
+        expect(bid.creativeId).to.match(/[0-9a-z]{18}/);
+        const containerDivId = 'ybot-' + bid.creativeId;
+        const re = new RegExp(containerDivId);
+        expect(re.test(bid.ad)).to.equal(true);
+      });
+    });
+
+    it('should specify Net revenue type for bid', function() {
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses[0].netRevenue).to.equal(true);
+    });
+
+    it('should specify USD currency for bid', function() {
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      expect(responses[1].currency).to.equal('USD');
+    });
+
+    it('should set edge server Url prefix', function() {
+      FIXTURE_SERVER_RESPONSE.body.url_prefix = 'http://close.edge.adserver.com/';
+      const responses = YieldbotAdapter.interpretResponse(
+        FIXTURE_SERVER_RESPONSE,
+        FIXTURE_BID_REQUEST
+      );
+      const edgeServerUrlPrefix = YieldbotAdapter.getCookie(YieldbotAdapter.CONSTANTS.COOKIES.URL_PREFIX);
+      expect(edgeServerUrlPrefix).to.match(/^http:\/\/close\.edge\.adserver\.com\//);
+      expect(responses[0].ad).to.match(/http:\/\/close\.edge\.adserver\.com\//);
+    });
+  });
+
+  describe('getUserSyncs', function() {
+    let responses;
+    beforeEach(function () {
+      responses = [FIXTURE_SERVER_RESPONSE];
+    });
+    it('should return empty Array when server response property missing', function() {
+      delete responses[0].body.user_syncs;
+      const userSyncs = YieldbotAdapter.getUserSyncs({ pixelEnabled: true }, responses);
+      expect(userSyncs.length).to.equal(0);
+    });
+
+    it('should return empty Array when server response property is empty', function() {
+      responses[0].body.user_syncs = [];
+      const userSyncs = YieldbotAdapter.getUserSyncs({ pixelEnabled: true }, responses);
+      expect(userSyncs.length).to.equal(0);
+    });
+
+    it('should return empty Array pixel disabled', function() {
+      const userSyncs = YieldbotAdapter.getUserSyncs({ pixelEnabled: false }, responses);
+      expect(userSyncs.length).to.equal(0);
+    });
+
+    it('should return empty Array pixel option not provided', function() {
+      const userSyncs = YieldbotAdapter.getUserSyncs({ pixelNotHere: true }, responses);
+      expect(userSyncs.length).to.equal(0);
+    });
+
+    it('should return image type pixels', function() {
+      const userSyncs = YieldbotAdapter.getUserSyncs({ pixelEnabled: true }, responses);
+      expect(userSyncs).to.eql(
+        [
+          { type: 'image', url: 'https://usersync.dd9693a32aa1.com/00000000.gif?p=a' },
+          { type: 'image', url: 'https://usersync.3b19503b37d8.com/00000000.gif?p=b' },
+          { type: 'image', url: 'https://usersync.5cb389d36d30.com/00000000.gif?p=c' }
+        ]
+      );
+    });
+  });
+
+  describe('Auction Behavior', function() {
+    AdapterManager.bidderRegistry['yieldbot'] = newBidder(spec);
+    let sandbox, server, xhr, fakeRequests;
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      server = sinon.fakeServer.create();
+      server.respondImmediately = true;
+
+      xhr = sinon.useFakeXMLHttpRequest();
+      fakeRequests = [];
+      xhr.onCreate = function (xhr) {
+        fakeRequests.push(xhr);
+      };
+      FIXTURE_SERVER_RESPONSE.user_syncs = [];
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+      YieldbotAdapter._bidRequestCount = 0;
+    });
+
+    function auctionDetails(auctionCount, adUnits, adUnitCodes, requestCb, done, quit) {
+      const cb = () => {
+        if (requestCb) {
+          try {
+            requestCb(fakeRequests[auctionCount]);
+            if (quit) {
+              done();
+            }
+          } catch (err) {
+            done(err);
+          }
+        }
+      };
+      return {
+        adUnits: adUnits,
+        adUnitCodes: adUnitCodes,
+        callback: cb
+      };
+    };
+
+    const AUCTIONS = { FIRST: 0, SECOND: 1 };
+    it('should build auction bids', function(done) {
+      const auctionBids = [];
+      const bidResponseHandler = (event) => {
+        auctionBids.push(event);
+      };
+      const auctionEndHandler = (event) => {
+        try {
+          events.off('bidResponse', bidResponseHandler);
+          events.off('auctionEnd', auctionEndHandler);
+          expect(auctionBids.length, 'Auction bids').to.equal(4);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      };
+      events.on('bidResponse', bidResponseHandler);
+      events.on('auctionEnd', auctionEndHandler);
+
+      const firstAdUnits = FIXTURE_AD_UNITS;
+      const firstAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
+      const firstAuction = auctionManager.createAuction(
+        auctionDetails(
+          AUCTIONS.FIRST,
+          firstAdUnits,
+          firstAdUnitCodes
+        )
+      );
+      firstAuction.callBids();
+      fakeRequests[AUCTIONS.FIRST].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(FIXTURE_SERVER_RESPONSE.body)
+      );
+    });
+
+    it('should provide multiple auctions with correct bid cpms', function(done) {
+      const auctionBids = [];
+      let auctionCount = 0;
+      let firstAuctionId = '';
+      let secondAuctionId = '';
+      /*
+       * 'bidResponse' event handler checks for respective adUnit auctions and bids
+       */
+      const bidResponseHandler = (event) => {
+        try {
+          const expr = `${event.adUnitCode}`;
+          switch (true) {
+            case expr === '/00000000/leaderboard' && event.auctionId === firstAuctionId:
+              expect(event.cpm, 'leaderboard, first auction cpm').to.equal(8);
+              break;
+            case expr === '/00000000/medrec' && event.auctionId === firstAuctionId:
+              expect(event.cpm, 'medrec, first auction cpm').to.equal(3);
+              break;
+            case expr === '/00000000/multi-size' && event.auctionId === firstAuctionId:
+              expect(event.cpm, 'multi-size, first auction cpm').to.equal(8);
+              break;
+            case expr === '/00000000/skyscraper' && event.auctionId === firstAuctionId:
+              expect(event.cpm, 'skyscraper, first auction cpm').to.equal(3);
+              break;
+            case expr === '/00000000/medrec' && event.auctionId === secondAuctionId:
+              expect(event.cpm, 'medrec, second auction cpm').to.equal(1.11);
+              break;
+            case expr === '/00000000/multi-size' && event.auctionId === secondAuctionId:
+              expect(event.cpm, 'multi-size, second auction cpm').to.equal(2.22);
+              break;
+            case expr === '/00000000/skyscraper' && event.auctionId === secondAuctionId:
+              expect(event.cpm, 'skyscraper, second auction cpm').to.equal(3.33);
+              break;
+            default:
+              done(new Error(`Bid response to assert not found: ${expr}:${event.size}:${event.auctionId}, [${firstAuctionId}, ${secondAuctionId}]`));
+          }
+        } catch (err) {
+          done(err);
+        }
+        auctionBids.push(event);
+      };
+      const auctionEndHandler = (event) => {
+        try {
+          auctionCount++;
+          if (auctionCount === 2) {
+            events.off('bidResponse', bidResponseHandler);
+            events.off('auctionEnd', auctionEndHandler);
+            expect(auctionBids.length, 'Auction bids').to.equal(7);
+            done();
+          }
+        } catch (err) {
+          done(err);
+        }
+      };
+      events.on('bidResponse', bidResponseHandler);
+      events.on('auctionEnd', auctionEndHandler);
+
+      /*
+       * First auction
+       */
+      const firstAdUnits = FIXTURE_AD_UNITS;
+      const firstAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
+      const firstAuction = auctionManager.createAuction(
+        auctionDetails(
+          AUCTIONS.FIRST,
+          firstAdUnits,
+          firstAdUnitCodes
+        )
+      );
+      firstAuctionId = firstAuction.getAuctionId();
+      firstAuction.callBids();
+      fakeRequests[AUCTIONS.FIRST].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(FIXTURE_SERVER_RESPONSE.body)
+      );
+
+      /*
+       * Second auction with different bid values and fewer slots
+       */
+      FIXTURE_AD_UNITS.shift();
+      const FIXTURE_SERVER_RESPONSE_2 = utils.deepClone(FIXTURE_SERVER_RESPONSE);
+      FIXTURE_SERVER_RESPONSE_2.user_syncs = [];
+      FIXTURE_SERVER_RESPONSE_2.body.slots.shift();
+      FIXTURE_SERVER_RESPONSE_2.body.slots.forEach((bid, idx) => { const num = idx + 1; bid.cpm = `${num}${num}${num}`; });
+      const secondAdUnits = FIXTURE_AD_UNITS;
+      const secondAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
+      const secondAuction = auctionManager.createAuction(
+        auctionDetails(
+          AUCTIONS.SECOND,
+          secondAdUnits,
+          secondAdUnitCodes
+        )
+      );
+
+      secondAuctionId = secondAuction.getAuctionId();
+      secondAuction.callBids();
+      fakeRequests[AUCTIONS.SECOND].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(FIXTURE_SERVER_RESPONSE_2.body)
+      );
+    });
+
+    it('should have refresh bid type after the first auction', function(done) {
+      const firstAdUnits = FIXTURE_AD_UNITS;
+      const firstAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
+      const firstAuction = auctionManager.createAuction(
+        auctionDetails(
+          AUCTIONS.FIRST,
+          firstAdUnits,
+          firstAdUnitCodes,
+          (request, done) => {
+            const url = urlUtils.parse(
+              request.url,
+              { noDecodeWholeURL: true }
+            );
+            const searchParams = url.search;
+            expect(searchParams.bt, 'First auction bid type').to.equal('init');
+          },
+          done,
+          false
+        )
+      );
+      firstAuction.callBids();
+      fakeRequests[AUCTIONS.FIRST].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(FIXTURE_SERVER_RESPONSE.body)
+      );
+
+      const secondAdUnits = FIXTURE_AD_UNITS;
+      const secondAdUnitCodes = FIXTURE_AD_UNITS.map(unit => unit.code);
+      const secondAuction = auctionManager.createAuction(
+        auctionDetails(
+          AUCTIONS.SECOND,
+          secondAdUnits,
+          secondAdUnitCodes,
+          (request) => {
+            const url = urlUtils.parse(
+              request.url,
+              { noDecodeWholeURL: true }
+            );
+            const searchParams = url.search;
+            expect(searchParams.bt, 'Second auction bid type').to.equal('refresh');
+          },
+          done,
+          true
+        )
+      );
+      secondAuction.callBids();
+      fakeRequests[AUCTIONS.SECOND].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(FIXTURE_SERVER_RESPONSE.body)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter
 - Parameters same as existing [prebid.github.io/dev-docs/bidders/yieldbot.md](https://github.com/prebid/prebid.github.io/blob/master/dev-docs/bidders/yieldbot.md)

## Description of change
Addition of the Yieldbot bidder adapter for the Prebid 1.0 release.

- test parameters for validating bids
```
{
  bidder: 'yieldbot',
  params: {
    psn: '1234',
    slot: 'medrec'
  }
}
```
- [John Ellis](mailto:jellis@yieldbot.com)
- [x] official adapter submission

## Parameters do not change
 - For reference, see [prebid.github.io/dev-docs/bidders/yieldbot.md](https://github.com/prebid/prebid.github.io/blob/master/dev-docs/bidders/yieldbot.md)
