### PR TITLE
Update appnexusBidAdapter so clients can distinguish between managed and RTB bids

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -191,7 +191,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     netRevenue: true,
     ttl: 300,
     appnexus: {
-        buyerMemberId: rtbBid.buyer_member_id
+      buyerMemberId: rtbBid.buyer_member_id
     }
   };
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -185,12 +185,14 @@ function newBid(serverBid, rtbBid, bidderRequest) {
   const bid = {
     requestId: serverBid.uuid,
     cpm: rtbBid.cpm,
-    buyerMemberId: rtbBid.buyer_member_id,
     creativeId: rtbBid.creative_id,
     dealId: rtbBid.deal_id,
     currency: 'USD',
     netRevenue: true,
-    ttl: 300
+    ttl: 300,
+    appnexus: {
+        buyerMemberId: rtbBid.buyer_member_id
+    }
   };
 
   if (rtbBid.rtb.video) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -185,6 +185,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
   const bid = {
     requestId: serverBid.uuid,
     cpm: rtbBid.cpm,
+    buyerMemberId: rtbBid.buyer_member_id,
     creativeId: rtbBid.creative_id,
     dealId: rtbBid.deal_id,
     currency: 'USD',

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -371,7 +371,6 @@ describe('AppNexusAdapter', () => {
           'requestId': '3db3773286ee59',
           'cpm': 0.5,
           'creativeId': 29681110,
-          'buyerMemberId': 958,
           'dealId': undefined,
           'width': 300,
           'height': 250,
@@ -379,7 +378,10 @@ describe('AppNexusAdapter', () => {
           'mediaType': 'banner',
           'currency': 'USD',
           'ttl': 300,
-          'netRevenue': true
+          'netRevenue': true,
+          'appnexus': {
+            'buyerMemberId': 958
+          }
         }
       ];
       let bidderRequest;

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -371,6 +371,7 @@ describe('AppNexusAdapter', () => {
           'requestId': '3db3773286ee59',
           'cpm': 0.5,
           'creativeId': 29681110,
+          'buyerMemberId': 958,
           'dealId': undefined,
           'width': 300,
           'height': 250,


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Added buyerMemberId to appnexusBidAdapter bids so that clients can distinguish between managed and RTB demand