### PR TITLE
[RE-OPEN] Update to sovrn custom params as well as site object construction

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
       imp: sovrnImps,
       site: {
         domain: window.location.host,
-        page: window.location.pathname + location.search + location.hash
+        page: window.location.host + window.location.pathname + location.search + location.hash
       }
     };
     if (iv) sovrnBidReq.iv = iv;

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -28,7 +28,7 @@ export const spec = {
       sovrnImps.push({
         id: bid.bidId,
         banner: { w: 1, h: 1 },
-        tagid: utils.getBidIdParameter('tagid', bid.params),
+        tagid: String(utils.getBidIdParameter('tagid', bid.params)),
         bidfloor: utils.getBidIdParameter('bidfloor', bid.params)
       });
       iv = iv || utils.getBidIdParameter('iv', bid.params);

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -23,6 +23,7 @@ export const spec = {
    */
   buildRequests: function(bidReqs) {
     let sovrnImps = [];
+    let iv;
     utils._each(bidReqs, function (bid) {
       sovrnImps.push({
         id: bid.bidId,
@@ -30,6 +31,7 @@ export const spec = {
         tagid: utils.getBidIdParameter('tagid', bid.params),
         bidfloor: utils.getBidIdParameter('bidfloor', bid.params)
       });
+      iv = iv || utils.getBidIdParameter('iv', bid.params);
     });
     const sovrnBidReq = {
       id: utils.getUniqueIdentifierStr(),
@@ -39,6 +41,7 @@ export const spec = {
         page: window.location.pathname + location.search + location.hash
       }
     };
+    if (iv) sovrnBidReq.iv = iv;
     return {
       method: 'POST',
       url: `//ap.lijit.com/rtb/bid?src=${REPO_AND_VERSION}`,

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -83,6 +83,26 @@ describe('sovrnBidAdapter', function() {
 
       expect(request.data).to.contain('"iv":"vet"')
     })
+
+    it('converts tagid to string', () => {
+      const ivBidRequests = [{
+        'bidder': 'sovrn',
+        'params': {
+          'tagid': 403370,
+          'iv': 'vet'
+        },
+        'adUnitCode': 'adunit-code',
+        'sizes': [
+          [300, 250]
+        ],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475'
+      }];
+      const request = spec.buildRequests(ivBidRequests);
+
+      expect(request.data).to.contain('"tagid":"403370"')
+    })
   });
 
   describe('interpretResponse', () => {

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -63,6 +63,26 @@ describe('sovrnBidAdapter', function() {
     it('attaches source and version to endpoint URL as query params', () => {
       expect(request.url).to.equal(ENDPOINT)
     });
+
+    it('sends \'iv\' as query param if present', () => {
+      const ivBidRequests = [{
+        'bidder': 'sovrn',
+        'params': {
+          'tagid': '403370',
+          'iv': 'vet'
+        },
+        'adUnitCode': 'adunit-code',
+        'sizes': [
+          [300, 250]
+        ],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475'
+      }];
+      const request = spec.buildRequests(ivBidRequests);
+
+      expect(request.data).to.contain('"iv":"vet"')
+    })
   });
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Sovrn internally uses a custom param called 'iv' to log ad refresh events, this change is to send the parameter through prebid auctions as well. Also included is a minor update in setting the `page` field of the `site` object of a bid request to align with the OpenRTB 2.5 spec.

NOTE: This is the same update made by https://github.com/prebid/Prebid.js/pull/2149 in the master branch, but done for the legacy adapter.

@harpere 

- contact email of the adapter’s maintainer: aprakash@sovrn.com
