### PR TITLE
Update Lifestreet adapter to 1.0

### DIFF
--- a/modules/lifestreetBidAdapter.js
+++ b/modules/lifestreetBidAdapter.js
@@ -1,0 +1,149 @@
+import * as utils from 'src/utils';
+import {registerBidder} from 'src/adapters/bidderFactory';
+import { BANNER, VIDEO } from 'src/mediaTypes';
+
+const BIDDER_CODE = 'lifestreet';
+const ADAPTER_VERSION = 'prebidJS-2.0';
+
+const urlTemplate = template`//ads.lfstmedia.com/gate/${'adapter'}/${'slot'}?adkey=${'adkey'}&ad_size=${'ad_size'}&__location=${'location'}&__referrer=${'referrer'}&__wn=${'wn'}&__sf=${'sf'}&__fif=${'fif'}&__if=${'if'}&__stamp=${'stamp'}&__pp=1&__hb=1&_prebid_json=1&__gz=1&deferred_format=vast_2_0,vast_3_0&__hbver=${'hbver'}`;
+
+/**
+ * Creates a bid requests for a given bid.
+ *
+ * @param {BidRequest} bid The bid params to use for formatting a request
+ */
+function formatBidRequest(bid) {
+  let url = urlTemplate({
+    adapter: 'prebid',
+    slot: bid.params.slot,
+    adkey: bid.params.adkey,
+    ad_size: bid.params.ad_size,
+    location: encodeURIComponent(utils.getTopWindowLocation()),
+    referrer: encodeURIComponent(utils.getTopWindowReferrer()),
+    wn: boolToString(/fb_http/i.test(window.name)),
+    sf: boolToString(window['sfAPI'] || window['$sf']),
+    fif: boolToString(window['inDapIF'] === true),
+    if: boolToString(window !== window.top),
+    stamp: new Date().getTime(),
+    hbver: ADAPTER_VERSION
+  });
+
+  return {
+    method: 'GET',
+    url: url,
+    bidId: bid.bidId
+  };
+}
+
+/**
+ * A helper function to form URL from the template
+ */
+function template(strings, ...keys) {
+  return function(...values) {
+    let dict = values[values.length - 1] || {};
+    let result = [strings[0]];
+    keys.forEach(function(key, i) {
+      let value = isInteger(key) ? values[key] : dict[key];
+      result.push(value, strings[i + 1]);
+    });
+    return result.join('');
+  };
+}
+
+/**
+ * A helper function for template to generate string from boolean
+ */
+function boolToString(value) {
+  return value ? '1' : '0';
+}
+
+/**
+ * A helper function for template
+ */
+function isInteger(value) {
+  return typeof value === 'number' &&
+    isFinite(value) && Math.floor(value) === value;
+}
+
+/**
+ * Validates response from Lifestreet AD server
+ */
+function isResponseValid(response) {
+  return !/^\s*\{\s*"advertisementAvailable"\s*:\s*false/i.test(response.content) &&
+    response.content.indexOf('<VAST version="2.0"></VAST>') === -1 && (typeof response.cpm !== 'undefined') &&
+    response.status === 1;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['lsm'], // short code
+  supportedMediaTypes: [BANNER, VIDEO], // Lifestreet supports banner and video media types
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+  */
+  isBidRequestValid: function(bid) {
+    return !!(bid.params.slot && bid.params.adkey && bid.params.ad_size);
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+  */
+  buildRequests: function(validBidRequests) {
+    return validBidRequests.map(bid => {
+      return formatBidRequest(bid)
+    });
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+  */
+  interpretResponse: function(serverResponse, bidRequest) {
+    const bidResponses = [];
+    let response = serverResponse.body;
+    if (!isResponseValid(response)) {
+      return bidResponses;
+    }
+
+    const bidResponse = {
+      requestId: bidRequest.bidId,
+      cpm: response.cpm,
+      width: response.width,
+      height: response.height,
+      creativeId: response.creativeId,
+      currency: response.currency ? response.currency : 'USD',
+      netRevenue: response.netRevenue ? response.netRevenue : true,
+      ttl: response.ttl ? response.ttl : 86400
+    };
+
+    if (response.hasOwnProperty('dealId')) {
+      bidResponse.dealId = response.dealId;
+    }
+
+    if (response.content_type.indexOf('vast') > -1) {
+      if (typeof response.vastUrl !== 'undefined') {
+        bidResponse.vastUrl = response.vastUrl;
+      } else {
+        bidResponse.vastXml = response.content;
+      }
+      bidResponse.mediaType = VIDEO;
+    } else {
+      bidResponse.ad = response.content;
+      bidResponse.mediaType = BANNER;
+    }
+
+    bidResponses.push(bidResponse);
+    return bidResponses;
+  }
+};
+
+registerBidder(spec);

--- a/modules/lifestreetBidAdapter.md
+++ b/modules/lifestreetBidAdapter.md
@@ -1,0 +1,47 @@
+# Overview
+
+Module Name: Lifestreet Bid Adapter
+
+Module Type: Lifestreet Adapter
+
+Maintainer: hb.tech@lifestreet.com
+
+# Description
+
+Module that connects to Lifestreet's demand sources
+
+# Test Parameters
+```javascript
+    var adUnits = [
+        // Banner adUnit
+        {
+            code: 'test-ad',
+            sizes: [[160, 600]],
+            bids: [
+                {
+                    bidder: 'lifestreet',
+                    params: {
+                        slot: 'slot166704',
+                        adkey: '78c',
+                        ad_size: '160x600'
+                    }
+                }
+            ]
+        },
+        // Video instream adUnit
+        {
+            code: 'test-video-ad',
+            sizes: [[640, 480]],
+            bids: [
+                {
+                    bidder: 'lifestreet',
+                    params: {
+                        slot: 'slot1227631',
+                        adkey: 'a98',
+                        ad_size: '640x480'
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/lifestreetBidAdapter_spec.js
+++ b/test/spec/modules/lifestreetBidAdapter_spec.js
@@ -1,0 +1,181 @@
+import {expect} from 'chai';
+import * as utils from 'src/utils';
+import {spec} from 'modules/lifestreetBidAdapter';
+import {config} from 'src/config';
+
+let getDefaultBidRequest = () => {
+  return {
+    bidderCode: 'lifestreet',
+    auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+    bidderRequestId: '7101db09af0dg2',
+    start: new Date().getTime(),
+    bids: [{
+      bidder: 'lifestreet',
+      bidId: '84ab500420329d',
+      bidderRequestId: '7101db09af0dg2',
+      auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+      placementCode: 'foo',
+      params: getBidParams()
+    }]
+  };
+};
+
+let getVASTAd = () => {
+  return `<VAST version="3.0">
+    <Ad>
+      <Wrapper>
+        <AdSystem>Lifestreet wrapper</AdSystem>
+        <VASTAdTagURI><![CDATA[http://lifestreet.com]]></VASTAdTagURI>
+        <Impression></Impression>
+        <Creatives></Creatives>
+      </Wrapper>
+    </Ad>
+  </VAST>`;
+};
+
+let getBidParams = () => {
+  return {
+    slot: 'slot166704',
+    adkey: '78c',
+    ad_size: '160x600'
+  };
+};
+
+let getDefaultBidResponse = (isBanner, noBid = 0) => {
+  let noBidContent = isBanner ? '{"advertisementAvailable": false}' : '<VAST version="2.0"></VAST>';
+  let content = isBanner ? '<script>logConsole(\'hello\')</script>' : getVASTAd();
+  return {
+    status: noBid ? 0 : 1,
+    cpm: 1.0,
+    width: 160,
+    height: 600,
+    creativeId: 'test',
+    dealId: 'test',
+    content: noBid ? noBidContent : content,
+    content_type: isBanner ? 'display' : 'vast_2_0'
+  };
+};
+
+describe('LifestreetAdapter', () => {
+  const LIFESTREET_URL = '//ads.lfstmedia.com/gate/';
+  const ADAPTER_VERSION = 'prebidJS-2.0';
+
+  describe('buildRequests()', () => {
+    it('method exists and is a function', () => {
+      expect(spec.buildRequests).to.exist.and.to.be.a('function');
+    });
+
+    it('should not return request when no bids are present', () => {
+      let [request] = spec.buildRequests([]);
+      expect(request).to.be.empty;
+    });
+
+    let bidRequest = getDefaultBidRequest();
+    let [request] = spec.buildRequests(bidRequest.bids);
+    it('should return request for Lifestreet endpoint', () => {
+      expect(request.url).to.contain(LIFESTREET_URL);
+    });
+
+    it('should use json adapter', () => {
+      expect(request.url).to.contain('/prebid/');
+    });
+
+    it('should contain slot', () => {
+      expect(request.url).to.contain('slot166704');
+    });
+    it('should contain adkey', () => {
+      expect(request.url).to.contain('adkey=78c');
+    });
+    it('should contain ad_size', () => {
+      expect(request.url).to.contain('ad_size=160x600');
+    });
+
+    it('should contain location and rferrer paramters', () => {
+      expect(request.url).to.contain('__location=');
+      expect(request.url).to.contain('__referrer=');
+    });
+    it('should contain info parameters', () => {
+      expect(request.url).to.contain('__wn=');
+      expect(request.url).to.contain('__sf=');
+      expect(request.url).to.contain('__fif=');
+      expect(request.url).to.contain('__if=');
+      expect(request.url).to.contain('__stamp=');
+      expect(request.url).to.contain('__pp=');
+    });
+
+    it('should contain HB enabled', () => {
+      expect(request.url).to.contain('__hb=1');
+    });
+    it('should include gzip', () => {
+      expect(request.url).to.contain('__gz=1');
+    });
+
+    it('should contain the right version of adapter', () => {
+      expect(request.url).to.contain('__hbver=' + ADAPTER_VERSION);
+    });
+  });
+  describe('interpretResponse()', () => {
+    it('should return formatted bid response with required properties', () => {
+      let bidRequest = getDefaultBidRequest().bids[0];
+      let bidResponse = { body: getDefaultBidResponse(true) };
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+      expect(formattedBidResponse).to.deep.equal([{
+        requestId: bidRequest.bidId,
+        cpm: 1.0,
+        width: 160,
+        height: 600,
+        ad: '<script>logConsole(\'hello\')</script>',
+        creativeId: 'test',
+        currency: 'USD',
+        dealId: 'test',
+        netRevenue: true,
+        ttl: 86400,
+        mediaType: 'banner'
+      }]);
+    });
+    it('should return formatted VAST bid response with required properties', () => {
+      let bidRequest = getDefaultBidRequest().bids[0];
+      let bidResponse = { body: getDefaultBidResponse(false) };
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+      expect(formattedBidResponse).to.deep.equal([{
+        requestId: bidRequest.bidId,
+        cpm: 1.0,
+        width: 160,
+        height: 600,
+        vastXml: getVASTAd(),
+        creativeId: 'test',
+        currency: 'USD',
+        dealId: 'test',
+        netRevenue: true,
+        ttl: 86400,
+        mediaType: 'video'
+      }]);
+    });
+    it('should return formatted VAST bid response with vastUrl', () => {
+      let bidRequest = getDefaultBidRequest().bids[0];
+      let bidResponse = { body: getDefaultBidResponse(false) };
+      bidResponse.body.vastUrl = 'http://lifestreet.com'; // set vastUrl
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+      expect(formattedBidResponse).to.deep.equal([{
+        requestId: bidRequest.bidId,
+        cpm: 1.0,
+        width: 160,
+        height: 600,
+        vastUrl: 'http://lifestreet.com',
+        creativeId: 'test',
+        currency: 'USD',
+        dealId: 'test',
+        netRevenue: true,
+        ttl: 86400,
+        mediaType: 'video'
+      }]);
+    });
+
+    it('should return no-bid', () => {
+      let bidRequest = getDefaultBidRequest().bids[0];
+      let bidResponse = { body: getDefaultBidResponse(true, true) };
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+      expect(formattedBidResponse).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
- [x] New bidder adapter

Added Lifestreet bid adapter.

- test parameters for validating display bids
```
{
  bidder: 'lifestreet',
  params: {
    slot: 'slot166704',
    adkey: '78c',
    ad_size: '160x600'
  }
}
```
- test parameters for validating video bids
```
{
  bidder: 'lifestreet',
  params: {
    slot: 'slot1227631',
    adkey: 'a98',
    ad_size: '640x480'
  }
}
```

- contact email of the adapter’s maintainer
hb.tech@lifestreet.com or dmitry.vodianyk@lifestreet.com
- [x] official adapter submission
