### PR TITLE
Update Unruly Adapter to ensure Prebid.js 1.x compatibility

### DIFF
--- a/integrationExamples/gpt/unruly_example.html
+++ b/integrationExamples/gpt/unruly_example.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- Prebid Config Section START -->
+    <!-- Make sure this is inserted before your GPT tag -->
+    <script>
+    var PREBID_TIMEOUT = 3000;
+
+    var adUnits = [{
+        code: 'ad-slot',
+        sizes: [[728, 90], [300, 250]],
+        mediaType: 'video',
+        bids: [{
+            bidder: 'unruly',
+            params: {
+                targetingUUID: '6f15e139-5f18-49a1-b52f-87e5e69ee65e',
+                siteId: 1081534
+            }
+        }
+        ]
+    }];
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    (function() {
+        var pbjsEl = document.createElement("script");
+        pbjsEl.type = "text/javascript";
+        pbjsEl.async = true;
+        pbjsEl.src = '/build/dev/prebid.js';
+        var pbjsTargetEl = document.getElementsByTagName("head")[0];
+        pbjsTargetEl.insertBefore(pbjsEl, pbjsTargetEl.firstChild);
+    })();
+
+    </script>
+    <!-- Prebid Config Section END -->
+
+    <!-- Prebid Boilerplate Section START. No Need to Edit. -->
+    <script>
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function() {
+          googletag.pubads().disableInitialLoad();
+      });
+
+
+      pbjs.que.push(function() {
+          pbjs.addAdUnits(adUnits);
+          pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest
+            });
+            pbjs.setConfig({
+                "currency": {
+                    "adServerCurrency": "USD",
+                }
+            });
+        });
+
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent)
+                return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function () {
+                pbjs.que.push(function () {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+        ;
+
+        setTimeout(function () {
+            sendAdserverRequest();
+        }, PREBID_TIMEOUT);
+
+    </script>
+    <!-- Prebid Boilerplate Section END -->
+
+    <script>
+      (function () {
+          var gads = document.createElement('script');
+          gads.async = true;
+          gads.type = 'text/javascript';
+          var useSSL = 'https:' == document.location.protocol;
+          gads.src = (useSSL ? 'https:' : 'http:') +
+                  '//www.googletagservices.com/tag/js/gpt.js';
+          var node = document.getElementsByTagName('script')[0];
+          node.parentNode.insertBefore(gads, node);
+      })();
+    </script>
+
+    <script>
+      googletag.cmd.push(function () {
+          googletag.defineSlot('/19968336/header-bid-tag1', [[728, 90], [300, 250]], 'ad-slot').addService(googletag.pubads());
+          googletag.pubads().enableSingleRequest();
+          googletag.enableServices();
+      });
+    </script>
+
+    <style>
+        body {
+           margin: 0;
+           padding: 0;
+        }
+    </style>
+    <title>test</title>
+</head>
+
+<body>
+<div id='ad-slot'>
+    <script type='text/javascript'>
+        googletag.cmd.push(function() { googletag.display('ad-slot'); });
+    </script>
+</div>
+
+</body>
+</html>

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -1,119 +1,100 @@
-import { ajax } from 'src/ajax'
-import bidfactory from 'src/bidfactory'
-import bidmanager from 'src/bidmanager'
 import * as utils from 'src/utils'
-import { STATUS } from 'src/constants'
 import { Renderer } from 'src/Renderer'
-import adaptermanager from 'src/adaptermanager'
+import { registerBidder } from 'src/adapters/bidderFactory'
+import { VIDEO } from 'src/mediaTypes'
 
-function createRenderHandler({ bidResponseBid, rendererConfig }) {
-  function createApi() {
-    parent.window.unruly['native'].prebid = parent.window.unruly['native'].prebid || {}
-    parent.window.unruly['native'].prebid.uq = parent.window.unruly['native'].prebid.uq || []
-
-    return {
-      render(bidResponseBid) {
-        parent.window.unruly['native'].prebid.uq.push(['render', bidResponseBid])
-      },
-      onLoaded(bidResponseBid) {}
-    }
-  }
-
-  parent.window.unruly = parent.window.unruly || {}
-  parent.window.unruly['native'] = parent.window.unruly['native'] || {}
-  parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || rendererConfig.siteId
-
-  const api = createApi()
-  return {
-    render() {
-      api.render(bidResponseBid)
-    },
-    onRendererLoad() {
-      api.onLoaded(bidResponseBid)
-    }
-  }
+function configureUniversalTag (exchangeRenderer) {
+  parent.window.unruly = parent.window.unruly || {};
+  parent.window.unruly['native'] = parent.window.unruly['native'] || {};
+  parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || exchangeRenderer.siteId
 }
 
-function createBidResponseHandler(bidRequestBids) {
-  return {
-    onBidResponse(responseBody) {
-      try {
-        const exchangeResponse = JSON.parse(responseBody)
-        exchangeResponse.bids.forEach((exchangeBid) => {
-          const bidResponseBid = bidfactory.createBid(exchangeBid.ext.statusCode, exchangeBid)
-
-          Object.assign(
-            bidResponseBid,
-            exchangeBid
-          )
-
-          if (exchangeBid.ext.renderer) {
-            const rendererParams = exchangeBid.ext.renderer
-            const renderHandler = createRenderHandler({
-              bidResponseBid,
-              rendererConfig: rendererParams.config
-            })
-
-            bidResponseBid.renderer = Renderer.install(
-              Object.assign(
-                {},
-                rendererParams,
-                { callback: () => renderHandler.onRendererLoad() }
-              )
-            )
-            bidResponseBid.renderer.setRender(() => renderHandler.render())
-          }
-
-          bidmanager.addBidResponse(exchangeBid.ext.placementCode, bidResponseBid)
-        })
-      } catch (error) {
-        utils.logError(error);
-        bidRequestBids.forEach(bidRequestBid => {
-          const bidResponseBid = bidfactory.createBid(STATUS.NO_BID)
-          bidmanager.addBidResponse(bidRequestBid.placementCode, bidResponseBid)
-        })
-      }
-    }
-  }
+function configureRendererQueue () {
+  parent.window.unruly['native'].prebid = parent.window.unruly['native'].prebid || {};
+  parent.window.unruly['native'].prebid.uq = parent.window.unruly['native'].prebid.uq || []
 }
 
-function UnrulyAdapter() {
-  const adapter = {
-    exchangeUrl: 'https://targeting.unrulymedia.com/prebid',
-    callBids({ bids: bidRequestBids }) {
-      if (!bidRequestBids || bidRequestBids.length === 0) {
-        return
-      }
-
-      const videoMediaType = utils.deepAccess(bidRequestBids[0], 'mediaTypes.video')
-      const context = utils.deepAccess(bidRequestBids[0], 'mediaTypes.video.context')
-      if (videoMediaType && context !== 'outstream') {
-        return
-      }
-
-      const payload = {
-        bidRequests: bidRequestBids
-      }
-
-      const bidResponseHandler = createBidResponseHandler(bidRequestBids)
-
-      ajax(
-        adapter.exchangeUrl,
-        bidResponseHandler.onBidResponse,
-        JSON.stringify(payload),
-        {
-          contentType: 'application/json',
-          withCredentials: true
-        }
-      )
-    }
-  }
-
-  return adapter
+function notifyRenderer (bidResponseBid) {
+  parent.window.unruly['native'].prebid.uq.push(['render', bidResponseBid])
 }
 
-adaptermanager.registerBidAdapter(new UnrulyAdapter(), 'unruly', {
-  supportedMediaTypes: ['video']
+const serverResponseToBid = (bid, rendererInstance) => ({
+  requestId: bid.bidId,
+  cpm: bid.cpm,
+  width: bid.width,
+  height: bid.height,
+  vastUrl: bid.vastUrl,
+  netRevenue: true,
+  creativeId: bid.bidId,
+  ttl: 360,
+  currency: 'USD',
+  renderer: rendererInstance
 });
 
-module.exports = UnrulyAdapter
+const buildPrebidResponseAndInstallRenderer = bids =>
+  bids
+    .filter(serverBid => !!utils.deepAccess(serverBid, 'ext.renderer'))
+    .map(serverBid => {
+      const exchangeRenderer = utils.deepAccess(serverBid, 'ext.renderer');
+      configureUniversalTag(exchangeRenderer);
+      configureRendererQueue();
+
+      const rendererInstance = Renderer.install(Object.assign({}, exchangeRenderer, { callback: () => {} }));
+      return { rendererInstance, serverBid }
+    })
+    .map(
+      ({rendererInstance, serverBid}) => {
+        const prebidBid = serverResponseToBid(serverBid, rendererInstance);
+
+        const rendererConfig = Object.assign(
+          {},
+          prebidBid,
+          {
+            renderer: rendererInstance,
+            adUnitCode: serverBid.ext.placementCode
+          }
+        );
+
+        rendererInstance.setRender(() => { notifyRenderer(rendererConfig) });
+
+        return prebidBid
+      }
+    );
+
+export const adapter = {
+  code: 'unruly',
+  supportedMediaTypes: [ VIDEO ],
+  isBidRequestValid: function(bid) {
+    if (!bid) return false;
+
+    const context = utils.deepAccess(bid, 'mediaTypes.video.context');
+
+    return bid.mediaType === 'video' || context === 'outstream';
+  },
+
+  buildRequests: function(validBidRequests) {
+    const url = 'https://targeting.unrulymedia.com/prebid';
+    const method = 'POST';
+    const data = { bidRequests: validBidRequests };
+    const options = { contentType: 'application/json' };
+
+    return {
+      url,
+      method,
+      data,
+      options,
+    };
+  },
+
+  interpretResponse: function(serverResponse = {}) {
+    const serverResponseBody = serverResponse.body;
+    const noBidsResponse = [];
+    const isInvalidResponse = !serverResponseBody || !serverResponseBody.bids;
+
+    return isInvalidResponse
+      ? noBidsResponse
+      : buildPrebidResponseAndInstallRenderer(serverResponseBody.bids);
+  }
+};
+
+registerBidder(adapter);

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -1,47 +1,18 @@
 /* globals describe, it, beforeEach, afterEach, sinon */
 import { expect } from 'chai'
-import bidfactory from 'src/bidfactory'
-import bidmanager from 'src/bidmanager'
 import * as utils from 'src/utils'
 import { STATUS } from 'src/constants'
+import { VIDEO } from 'src/mediaTypes'
 import { Renderer } from 'src/Renderer'
-import createUnrulyAdapter from 'modules/unrulyBidAdapter'
+import { adapter } from 'modules/unrulyBidAdapter'
 
 describe('UnrulyAdapter', () => {
-  function createBidRequestBid({ placementCode }) {
-    return {
-      'bidder': 'unruly',
-      'params': {
-        'uuid': '74544e00-d43b-4f3a-a799-69d22ce979ce',
-        'siteId': 794599,
-        'placementId': '5768085'
-      },
-      'placementCode': placementCode,
-      'mediaTypes': { video: { context: 'outstream' } },
-      'transactionId': '62890707-3770-497c-a3b8-d905a2d0cb98',
-      'sizes': [
-        640,
-        480
-      ],
-      'bidId': '23b86d8f6335ce',
-      'bidderRequestId': '1d5b7474eb5416',
-      'requestId': '406fe12b-fa3b-4bd3-b3c8-043951b4dac1'
-    }
-  }
-
-  function createParams(...bids) {
-    return {
-      'bidderCode': 'unruly',
-      'requestId': '406fe12b-fa3b-4bd3-b3c8-043951b4dac1',
-      'bidderRequestId': '1d5b7474eb5416',
-      'bids': bids,
-      'start': 1495794517251,
-      'auctionStart': 1495794517250,
-      'timeout': 3000
-    }
-  }
-
-  function createOutStreamExchangeBid({ placementCode, statusCode = 1 }) {
+  function createOutStreamExchangeBid({
+    placementCode = 'placement2',
+    statusCode = 1,
+    bidId = 'foo',
+    vastUrl = 'https://targeting.unrulymedia.com/in_article?uuid=74544e00-d43b-4f3a-a799-69d22ce979ce&supported_mime_type=application/javascript&supported_mime_type=video/mp4&tj=%7B%22site%22%3A%7B%22lang%22%3A%22en-GB%22%2C%22ref%22%3A%22%22%2C%22page%22%3A%22http%3A%2F%2Fdemo.unrulymedia.com%2FinArticle%2Finarticle_nypost_upbeat%2Ftravel_magazines.html%22%2C%22domain%22%3A%22demo.unrulymedia.com%22%7D%2C%22user%22%3A%7B%22profile%22%3A%7B%22quantcast%22%3A%7B%22segments%22%3A%5B%7B%22id%22%3A%22D%22%7D%2C%7B%22id%22%3A%22T%22%7D%5D%7D%7D%7D%7D&video_width=618&video_height=347'
+  }) {
     return {
       'ext': {
         'statusCode': statusCode,
@@ -55,224 +26,168 @@ describe('UnrulyAdapter', () => {
       'cpm': 20,
       'bidderCode': 'unruly',
       'width': 323,
-      'vastUrl': 'https://targeting.unrulymedia.com/in_article?uuid=74544e00-d43b-4f3a-a799-69d22ce979ce&supported_mime_type=application/javascript&supported_mime_type=video/mp4&tj=%7B%22site%22%3A%7B%22lang%22%3A%22en-GB%22%2C%22ref%22%3A%22%22%2C%22page%22%3A%22http%3A%2F%2Fdemo.unrulymedia.com%2FinArticle%2Finarticle_nypost_upbeat%2Ftravel_magazines.html%22%2C%22domain%22%3A%22demo.unrulymedia.com%22%7D%2C%22user%22%3A%7B%22profile%22%3A%7B%22quantcast%22%3A%7B%22segments%22%3A%5B%7B%22id%22%3A%22D%22%7D%2C%7B%22id%22%3A%22T%22%7D%5D%7D%7D%7D%7D&video_width=618&video_height=347',
-      'bidId': 'foo',
+      'vastUrl': vastUrl,
+      'bidId': bidId,
       'height': 323
     }
   }
 
-  function createInStreamExchangeBid({ placementCode, statusCode = 1 }) {
-    return {
-      'ext': {
-        'statusCode': statusCode,
-        'placementCode': placementCode
-      },
-      'cpm': 20,
-      'bidderCode': 'unruly',
-      'width': 323,
-      'vastUrl': 'https://targeting.unrulymedia.com/in_article?uuid=74544e00-d43b-4f3a-a799-69d22ce979ce&supported_mime_type=application/javascript&supported_mime_type=video/mp4&tj=%7B%22site%22%3A%7B%22lang%22%3A%22en-GB%22%2C%22ref%22%3A%22%22%2C%22page%22%3A%22http%3A%2F%2Fdemo.unrulymedia.com%2FinArticle%2Finarticle_nypost_upbeat%2Ftravel_magazines.html%22%2C%22domain%22%3A%22demo.unrulymedia.com%22%7D%2C%22user%22%3A%7B%22profile%22%3A%7B%22quantcast%22%3A%7B%22segments%22%3A%5B%7B%22id%22%3A%22D%22%7D%2C%7B%22id%22%3A%22T%22%7D%5D%7D%7D%7D%7D&video_width=618&video_height=347',
-      'bidId': 'foo',
-      'height': 323
-    }
-  }
+  const createExchangeResponse = (...bids) => ({
+    body: { bids }
+  });
 
-  function createExchangeResponse(...bids) {
-    return {
-      'bids': bids
-    }
-  }
-
-  let adapter
-  let server
-  let sandbox
-  let fakeRenderer
+  let sandbox;
+  let fakeRenderer;
 
   beforeEach(() => {
-    adapter = createUnrulyAdapter()
-    adapter.exchangeUrl = 'http://localhost:9000/prebid'
-
-    sandbox = sinon.sandbox.create()
-    sandbox.stub(bidmanager, 'addBidResponse')
-    sandbox.stub(bidfactory, 'createBid')
-    sandbox.stub(utils, 'logError')
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(utils, 'logError');
+    sandbox.stub(Renderer, 'install');
 
     fakeRenderer = {
       setRender: sinon.stub()
-    }
-
-    sandbox.stub(Renderer, 'install')
+    };
     Renderer.install.returns(fakeRenderer)
-
-    server = sinon.fakeServer.create()
-  })
+  });
 
   afterEach(() => {
-    sandbox.restore()
-    server.restore()
+    sandbox.restore();
     delete parent.window.unruly
-  })
+  });
 
-  describe('callBids', () => {
-    it('exists and is a function', () => {
-      expect(adapter.callBids).to.exist.and.to.be.a('function')
+  it('should expose Unruly Bidder code', () => {
+    expect(adapter.code).to.equal('unruly')
+  });
+
+  it('should contain the VIDEO mediaType', function () {
+    expect(adapter.supportedMediaTypes).to.deep.equal([ VIDEO ])
+  });
+
+  describe('isBidRequestValid', () => {
+    it('should be a function', () => {
+      expect(typeof adapter.isBidRequestValid).to.equal('function')
+    });
+
+    it('should return false if bid is falsey', () => {
+      expect(adapter.isBidRequestValid()).to.be.false;
+    });
+
+    it('should return true if bid.mediaType is "video"', () => {
+      const mockBid = { mediaType: 'video' };
+
+      expect(adapter.isBidRequestValid(mockBid)).to.be.true;
+    });
+
+    it('should return true if bid.mediaTypes.video.context is "outstream"', () => {
+      const mockBid = {
+        mediaTypes: {
+          video: {
+            context: 'outstream'
+          }
+        }
+      };
+
+      expect(adapter.isBidRequestValid(mockBid)).to.be.true;
+    });
+  });
+
+  describe('buildRequests', () => {
+    it('should be a function', () => {
+      expect(typeof adapter.buildRequests).to.equal('function');
+    });
+    it('should return an object', () => {
+      const mockBidRequests = ['mockBid'];
+      expect(typeof adapter.buildRequests(mockBidRequests)).to.equal('object')
+    });
+    it('should return a server request with a valid exchange url', () => {
+      const mockBidRequests = ['mockBid'];
+      expect(adapter.buildRequests(mockBidRequests).url).to.equal('https://targeting.unrulymedia.com/prebid')
+    });
+    it('should return a server request with method === POST', () => {
+      const mockBidRequests = ['mockBid'];
+      expect(adapter.buildRequests(mockBidRequests).method).to.equal('POST');
+    });
+    it('should ensure contentType is `application/json`', function () {
+      const mockBidRequests = ['mockBid'];
+      expect(adapter.buildRequests(mockBidRequests).options).to.deep.equal({
+        contentType: 'application/json'
+      });
+    });
+    it('should return a server request with valid payload', () => {
+      const mockBidRequests = ['mockBid'];
+      expect(adapter.buildRequests(mockBidRequests).data).to.deep.equal({bidRequests: mockBidRequests})
     })
+  });
 
-    it('requires bids to make request', () => {
-      adapter.callBids({})
-      expect(server.requests).to.be.empty
+  describe('interpretResponse', () => {
+    it('should be a function', () => {
+      expect(typeof adapter.interpretResponse).to.equal('function');
+    });
+    it('should return empty array when serverResponse is undefined', () => {
+      expect(adapter.interpretResponse()).to.deep.equal([]);
+    });
+    it('should return empty array when  serverResponse has no bids', () => {
+      const mockServerResponse = { body: { bids: [] } };
+      expect(adapter.interpretResponse(mockServerResponse)).to.deep.equal([])
+    });
+    it('should return array of bids when receive a successful response from server', () => {
+      const mockExchangeBid = createOutStreamExchangeBid({placementCode: 'video1', bidId: 'mockBidId'});
+      const mockServerResponse = createExchangeResponse(mockExchangeBid);
+      expect(adapter.interpretResponse(mockServerResponse)).to.deep.equal([
+        {
+          requestId: 'mockBidId',
+          cpm: 20,
+          width: 323,
+          height: 323,
+          vastUrl: 'https://targeting.unrulymedia.com/in_article?uuid=74544e00-d43b-4f3a-a799-69d22ce979ce&supported_mime_type=application/javascript&supported_mime_type=video/mp4&tj=%7B%22site%22%3A%7B%22lang%22%3A%22en-GB%22%2C%22ref%22%3A%22%22%2C%22page%22%3A%22http%3A%2F%2Fdemo.unrulymedia.com%2FinArticle%2Finarticle_nypost_upbeat%2Ftravel_magazines.html%22%2C%22domain%22%3A%22demo.unrulymedia.com%22%7D%2C%22user%22%3A%7B%22profile%22%3A%7B%22quantcast%22%3A%7B%22segments%22%3A%5B%7B%22id%22%3A%22D%22%7D%2C%7B%22id%22%3A%22T%22%7D%5D%7D%7D%7D%7D&video_width=618&video_height=347',
+          netRevenue: true,
+          creativeId: 'mockBidId',
+          ttl: 360,
+          currency: 'USD',
+          renderer: fakeRenderer
+        }
+      ])
+    });
+
+    it('should initialize and set the renderer', () => {
+      expect(Renderer.install).not.to.have.been.called;
+      expect(fakeRenderer.setRender).not.to.have.been.called;
+
+      const mockReturnedBid = createOutStreamExchangeBid({placementCode: 'video1', bidId: 'mockBidId'});
+      const mockRenderer = { url: 'value: mockRendererURL' };
+      mockReturnedBid.ext.renderer = mockRenderer;
+      const mockServerResponse = createExchangeResponse(mockReturnedBid);
+
+      adapter.interpretResponse(mockServerResponse);
+
+      expect(Renderer.install).to.have.been.calledOnce;
+      sinon.assert.calledWithExactly(
+        Renderer.install,
+        Object.assign({}, mockRenderer, {callback: sinon.match.func})
+      );
+
+      sinon.assert.calledOnce(fakeRenderer.setRender);
+      sinon.assert.calledWithExactly(fakeRenderer.setRender, sinon.match.func)
+    });
+
+    it('bid is placed on the bid queue when render is called', () => {
+      const exchangeBid = createOutStreamExchangeBid({ placementCode: 'video', vastUrl: 'value: vastUrl' });
+      const exchangeResponse = createExchangeResponse(exchangeBid);
+
+      adapter.interpretResponse(exchangeResponse);
+
+      sinon.assert.calledOnce(fakeRenderer.setRender);
+      fakeRenderer.setRender.firstCall.args[0]();
+
+      expect(window.top).to.have.deep.property('unruly.native.prebid.uq');
+
+      const uq = window.top.unruly.native.prebid.uq;
+      const sentRendererConfig = uq[0][1];
+
+      expect(uq[0][0]).to.equal('render');
+      expect(sentRendererConfig.vastUrl).to.equal('value: vastUrl');
+      expect(sentRendererConfig.renderer).to.equal(fakeRenderer);
+      expect(sentRendererConfig.adUnitCode).to.equal('video')
     })
-
-    it('requires at least one bid to make request', () => {
-      adapter.callBids({ bids: [] })
-      expect(server.requests).to.be.empty
-    })
-
-    it('passes bids through to exchange', () => {
-      const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-
-      adapter.callBids(params)
-
-      expect(server.requests).to.have.length(1)
-      expect(server.requests[0].url).to.equal('http://localhost:9000/prebid')
-
-      const requestBody = JSON.parse(server.requests[0].requestBody)
-      expect(requestBody).to.deep.equal({
-        'bidRequests': params.bids
-      })
-    })
-
-    it('creates a bid response using status code from exchange for each bid and passes in the exchange response', () => {
-      const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-
-      const exchangeBid1 = createOutStreamExchangeBid({ placementCode: 'placement1' })
-      const exchangeBid2 = createOutStreamExchangeBid({ placementCode: 'placement2', statusCode: 2 })
-      const exchangeResponse = createExchangeResponse(exchangeBid1, exchangeBid2)
-
-      server.respondWith(JSON.stringify(exchangeResponse))
-      bidfactory.createBid.returns({})
-
-      adapter.callBids(params)
-      server.respond()
-
-      sinon.assert.calledTwice(bidfactory.createBid)
-      sinon.assert.calledWith(bidfactory.createBid, exchangeBid1.ext.statusCode, exchangeResponse.bids[0])
-      sinon.assert.calledWith(bidfactory.createBid, exchangeBid2.ext.statusCode, exchangeResponse.bids[1])
-    })
-
-    it('adds the bid response to the bid manager', () => {
-      const fakeBid = {}
-
-      const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-      const exchangeBid = createOutStreamExchangeBid({ placementCode: 'placement1' })
-      const exchangeResponse = createExchangeResponse(exchangeBid)
-
-      server.respondWith(JSON.stringify(exchangeResponse))
-      bidfactory.createBid.withArgs(exchangeBid.ext.statusCode).returns(fakeBid)
-
-      adapter.callBids(params)
-      server.respond()
-
-      sinon.assert.calledOnce(bidmanager.addBidResponse)
-      sinon.assert.calledWith(bidmanager.addBidResponse, exchangeBid.ext.placementCode, fakeBid)
-    })
-
-    describe('on invalid exchange response', () => {
-      it('should create NO_BID response for each bid request bid', () => {
-        const bidRequestBid1 = createBidRequestBid({ placementCode: 'placement1' })
-        const bidRequestBid2 = createBidRequestBid({ placementCode: 'placement2' })
-        const params = createParams(bidRequestBid1, bidRequestBid2)
-        const expectedBid = { 'some': 'props' }
-
-        server.respondWith('this is not json')
-        bidfactory.createBid.withArgs(STATUS.NO_BID).returns(expectedBid)
-
-        adapter.callBids(params)
-        server.respond()
-
-        sinon.assert.calledOnce(utils.logError)
-        sinon.assert.calledTwice(bidmanager.addBidResponse)
-        sinon.assert.calledWith(bidmanager.addBidResponse, bidRequestBid1.placementCode, expectedBid)
-        sinon.assert.calledWith(bidmanager.addBidResponse, bidRequestBid2.placementCode, expectedBid)
-      })
-    })
-
-    describe('InStream', () => {
-      it('merges bid response defaults', () => {
-        const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-
-        const fakeBidDefaults = { some: 'default' }
-        const fakeBid = Object.assign({}, fakeBidDefaults)
-
-        const exchangeBid = createInStreamExchangeBid({ placementCode: 'placement1' })
-        const exchangeResponse = createExchangeResponse(exchangeBid)
-        server.respondWith(JSON.stringify(exchangeResponse))
-
-        bidfactory.createBid.withArgs(exchangeBid.ext.statusCode).returns(fakeBid)
-
-        adapter.callBids(params)
-        server.respond()
-
-        sinon.assert.notCalled(Renderer.install)
-        expect(fakeBid).to.deep.equal(Object.assign(
-          {},
-          fakeBidDefaults,
-          exchangeBid
-        ))
-      })
-    })
-
-    describe('OutStream', () => {
-      it('merges bid response defaults with exchange bid and renderer', () => {
-        const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-
-        const fakeBidDefaults = { some: 'default' }
-        const fakeBid = Object.assign({}, fakeBidDefaults)
-
-        const exchangeBid = createOutStreamExchangeBid({ placementCode: 'placement1' })
-        const exchangeResponse = createExchangeResponse(exchangeBid)
-        server.respondWith(JSON.stringify(exchangeResponse))
-
-        bidfactory.createBid.withArgs(exchangeBid.ext.statusCode).returns(fakeBid)
-
-        const fakeRenderer = {}
-        Renderer.install.withArgs(Object.assign(
-          {},
-          exchangeBid.ext.renderer,
-          { callback: sinon.match.func }
-        )).returns(fakeRenderer)
-
-        adapter.callBids(params)
-        server.respond()
-
-        expect(fakeBid).to.deep.equal(Object.assign(
-          {},
-          fakeBidDefaults,
-          exchangeBid,
-          { renderer: fakeRenderer }
-        ))
-      })
-
-      it('bid is placed on the bid queue when render is called', () => {
-        const params = createParams(createBidRequestBid({ placementCode: 'placement1' }))
-
-        const fakeBidDefaults = { some: 'default' }
-        const fakeBid = Object.assign({}, fakeBidDefaults)
-
-        const exchangeBid = createOutStreamExchangeBid({ placementCode: 'placement1' })
-        const exchangeResponse = createExchangeResponse(exchangeBid)
-        server.respondWith(JSON.stringify(exchangeResponse))
-
-        bidfactory.createBid.withArgs(exchangeBid.ext.statusCode).returns(fakeBid)
-
-        adapter.callBids(params)
-        server.respond()
-
-        sinon.assert.calledOnce(fakeRenderer.setRender)
-        fakeRenderer.setRender.firstCall.args[0]()
-
-        expect(window.top).to.have.deep.property('unruly.native.prebid.uq');
-        expect(window.top.unruly.native.prebid.uq).to.deep.equal([['render', fakeBid]])
-      })
-    })
-  })
-})
+  });
+});


### PR DESCRIPTION
## Type of change
- [ x ] Refactoring (no functional changes, no api changes)

## Description of change

- Refactored our old adapter to be compatible with 1.0.0 and 0.34.x (legacy) builds.
- Added an example test page

- **maintainer:** prodev@unrulygroup.com
- test parameters for validating bids:

       // Same as before, pasting for convenience
       // Check /integrationExamples/gpt/unruly_example.html for a complete integration example
       // Test params
       {
           bidder: 'unruly',
           params: {
               targetingUUID: '6f15e139-5f18-49a1-b52f-87e5e69ee65e',
               siteId: 1081534
           }
       }
       // Also, please ensure mediaType === 'video'