### PR TITLE
fix mediaType being overwritten by undefined in rubicon bid adapter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -273,7 +273,6 @@ export const spec = {
         requestId: bidRequest.bidId,
         currency: 'USD',
         creativeId: ad.creative_id,
-        mediaType: ad.creative_type,
         cpm: ad.cpm || 0,
         dealId: ad.deal,
         ttl: 300, // 5 minutes
@@ -283,6 +282,10 @@ export const spec = {
           networkId: ad.network
         }
       };
+
+      if (ad.creative_type) {
+        bid.mediaType = ad.creative_type;
+      }
 
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Fixing bug where `ad.creative_type` is not returned and overwriting `bid.mediaType` with `undefined`.

## Other information
Related to #2064 