### PR TITLE
firing new adRenderFailed event when renderAd() fails

### DIFF
--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -13,6 +13,7 @@ const BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
 const BID_WON = CONSTANTS.EVENTS.BID_WON;
 const BID_ADJUSTMENT = CONSTANTS.EVENTS.BID_ADJUSTMENT;
 const SET_TARGETING = CONSTANTS.EVENTS.SET_TARGETING;
+const AD_RENDER_FAILED = CONSTANTS.EVENTS.AD_RENDER_FAILED;
 
 const LIBRARY = 'library';
 const ENDPOINT = 'endpoint';
@@ -105,6 +106,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
         [BID_ADJUSTMENT]: args => this.enqueue({ eventType: BID_ADJUSTMENT, args }),
         [SET_TARGETING]: args => this.enqueue({ eventType: SET_TARGETING, args }),
         [AUCTION_END]: args => this.enqueue({ eventType: AUCTION_END, args }),
+        [AD_RENDER_FAILED]: args => this.enqueue({ eventType: AD_RENDER_FAILED, args }),
         [AUCTION_INIT]: args => {
           args.config = config.options; // enableAnaltyics configuration object
           this.enqueue({ eventType: AUCTION_INIT, args });

--- a/src/constants.json
+++ b/src/constants.json
@@ -33,7 +33,15 @@
     "BID_WON": "bidWon",
     "SET_TARGETING": "setTargeting",
     "REQUEST_BIDS": "requestBids",
-    "ADD_AD_UNITS": "addAdUnits"
+    "ADD_AD_UNITS": "addAdUnits",
+    "AD_RENDER_FAILED" : "adRenderFailed"
+  },
+  "AD_RENDER_FAILED_REASON" : {
+    "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocuemnt",
+    "NO_AD": "noAd",
+    "EXCEPTION": "exception",
+    "CANNOT_FIND_AD": "cannotFindAd",
+    "MISSING_DOC_OR_ADID": "missingDocOrAdid"
   },
   "EVENT_ID_PATHS": {
     "bidWon": "adUnitCode"

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -197,6 +197,18 @@ $$PREBID_GLOBAL$$.setTargetingForAst = function() {
   events.emit(SET_TARGETING);
 };
 
+function emitAdRenderFail(reason, message, bid) {
+  const data = {};
+
+  data.reason = reason;
+  data.message = message;
+  if (data.bid) {
+    data.bid = bid;
+  }
+
+  utils.logError(message);
+  events.emit(AD_RENDER_FAILED, data);
+}
 /**
  * This function will render the ad (based on params) in the given iframe document passed through.
  * Note that doc SHOULD NOT be the parent document page as we can't doc.write() asynchronously
@@ -207,9 +219,7 @@ $$PREBID_GLOBAL$$.setTargetingForAst = function() {
 $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.renderAd', arguments);
   utils.logMessage('Calling renderAd with adId :' + id);
-  const error = {
-    status: false
-  };
+
   if (doc && id) {
     try {
       // lookup ad by ad Id
@@ -233,10 +243,8 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         if (renderer && renderer.url) {
           renderer.render(bid);
         } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
-          error.status = true;
-          error.bid = bid;
-          error.reason = PREVENT_WRITING_ON_MAIN_DOCUMENT;
-          error.message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
+          const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
+          emitAdRenderFail(PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid);
         } else if (ad) {
           doc.write(ad);
           doc.close();
@@ -252,30 +260,20 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           utils.insertElement(iframe, doc, 'body');
           setRenderSize(doc, width, height);
         } else {
-          error.status = true;
-          error.bid = bid;
-          error.reason = NO_AD;
-          error.message = `Error trying to write ad. No ad for bid response id: ${id}`;
+          const message = `Error trying to write ad. No ad for bid response id: ${id}`;
+          emitAdRenderFail(NO_AD, message, bid);
         }
       } else {
-        error.status = true;
-        error.reason = CANNOT_FIND_AD;
-        error.message = `Error trying to write ad. Cannot find ad by given id : ${id}`;
+        const message = `Error trying to write ad. Cannot find ad by given id : ${id}`;
+        emitAdRenderFail(CANNOT_FIND_AD, message);
       }
     } catch (e) {
-      error.status = true;
-      error.reason = EXCEPTION;
-      error.message = `Error trying to write ad Id :${id} to the page:${e.message}`;
+      const message = `Error trying to write ad Id :${id} to the page:${e.message}`;
+      emitAdRenderFail(EXCEPTION, message);
     }
   } else {
-    error.status = true;
-    error.reason = MISSING_DOC_OR_ADID;
-    error.message = `Error trying to write ad Id :${id} to the page. Missing document or adId`;
-  }
-  if (error.status === true) {
-    utils.logError(error.message);
-    delete error.status;
-    events.emit(AD_RENDER_FAILED, error);
+    const message = `Error trying to write ad Id :${id} to the page. Missing document or adId`;
+    emitAdRenderFail(MISSING_DOC_OR_ADID, message);
   }
 };
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -202,7 +202,7 @@ function emitAdRenderFail(reason, message, bid) {
 
   data.reason = reason;
   data.message = message;
-  if (data.bid) {
+  if (bid) {
     data.bid = bid;
   }
 

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -6,6 +6,8 @@ const BID_REQUESTED = CONSTANTS.EVENTS.BID_REQUESTED;
 const BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
 const BID_WON = CONSTANTS.EVENTS.BID_WON;
 const BID_TIMEOUT = CONSTANTS.EVENTS.BID_TIMEOUT;
+const AD_RENDER_FAILED = CONSTANTS.EVENTS.AD_RENDER_FAILED;
+
 const AnalyticsAdapter = require('src/AnalyticsAdapter').default;
 const config = {
   url: 'http://localhost:9999/src/adapters/analytics/libraries/example.js',
@@ -82,6 +84,17 @@ FEATURE: Analytics Adapters API
     it('SHOULD call global when a bidWon event occurs', () => {
       const eventType = BID_WON;
       const args = { more: 'info' };
+
+      adapter.enableAnalytics();
+      events.emit(eventType, args);
+
+      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
+      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+    });
+
+    it('SHOULD call global when a adRenderFailed event occurs', () => {
+      const eventType = AD_RENDER_FAILED;
+      const args = { call: 'adRenderFailed' };
 
       adapter.enableAnalytics();
       events.emit(eventType, args);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
This pull request resolves #2133 . If renderAd() fails for some reason, an event `adRenderFailed` is fired with data object which includes the error message and bid object if available. 
