### PR TITLE
Fix video bids from multi-response array triggering callback early

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -173,13 +173,16 @@ export function newBidder(spec) {
       // register any required usersync pixels.
       const responses = [];
       function afterAllResponses(bids) {
-        const videoBid = bids && bids[0] && bids[0].mediaType && bids[0].mediaType === 'video';
+        const bidsArray = bids ? (bids[0] ? bids : [bids]) : [];
+
+        const videoBid = bidsArray.some(bid => bid.mediaType === 'video');
         const cacheEnabled = config.getConfig('cache.url');
 
         // video bids with cache enabled need to be cached first before they are considered done
         if (!(videoBid && cacheEnabled)) {
           done();
         }
+
         registerSyncs(responses);
       }
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -801,5 +801,30 @@ describe('auctionmanager.js', function () {
       config.getConfig.restore();
       store.store.restore();
     });
+
+    it('runs auction after video responses with multiple bid objects have been cached', () => {
+      sinon.stub(store, 'store').callsArgWith(1, null, [{ uuid: 123 }]);
+      sinon.stub(config, 'getConfig').withArgs('cache.url').returns('cache-url');
+
+      const bidsCopy = [
+        Object.assign({}, bids[0], { mediaType: 'video' }),
+        Object.assign({}, bids[0], { mediaType: 'banner' }),
+      ];
+      const bids1Copy = [
+        Object.assign({}, bids1[0], { mediaType: 'video' }),
+        Object.assign({}, bids1[0], { mediaType: 'video' }),
+      ];
+
+      spec.interpretResponse.returns(bidsCopy);
+      spec1.interpretResponse.returns(bids1Copy);
+
+      auction.callBids();
+
+      assert.equal(auction.getBidsReceived().length, 4);
+      assert.equal(auction.getAuctionStatus(), 'completed');
+
+      config.getConfig.restore();
+      store.store.restore();
+    });
   });
 });


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Fixes case not covered by #2017, where a video bid response is not the first object in a bid response array.

## Other information
Tested using setup described in https://github.com/prebid/Prebid.js/issues/2022#issuecomment-369763645. On master, a bid response comes after `auctionEnd`. With this PR all bid responses are added, then `auctionEnd` fires.