### PR TITLE
Fix ad-rendering with client-side cached advertisements

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,7 +1,7 @@
 /** @module pbjs */
 
 import { getGlobal } from './prebidGlobal';
-import { flatten, uniques, isGptPubadsDefined, adUnitsFilter, removeRequestId } from './utils';
+import { flatten, uniques, isGptPubadsDefined, getHighestCpm, adUnitsFilter, removeRequestId } from './utils';
 import { listenMessagesFromCreative } from './secureCreatives';
 import { userSync } from 'src/userSync.js';
 import { loadScript } from './adloader';
@@ -208,9 +208,20 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
   utils.logMessage('Calling renderAd with adId :' + id);
   if (doc && id) {
     try {
-      // lookup ad by ad Id
-      const bid = auctionManager.findBidByAdId(id);
+      // lookup ads by ad Id
+      const bids = (id + '').split(',')
+        .map(adId => auctionManager.findBidByAdId(adId))
+        .filter(bid => bid);
+
+      // get the highest earning ad
+      let bid;
+      if (bids.length) {
+        bid = bids.length > 1 ? bids.reduce(getHighestCpm) : bids[0];
+      }
+
       if (bid) {
+        utils.logMessage('Rendering ad with adId :' + bid.adId);
+
         bid.status = RENDERED;
         // replace macros according to openRTB with price paid = bid.cpm
         bid.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Changed the renderAd function to support multiple adIds that can be returned by the ad-server (ex. DFP). 

Fixes ad-rendering with client-side cached advertisements.

### Before
```
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_format_appnexus value: banner
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_source_appnexus value: client
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_size_appnexus value: 300x250
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_adid_appnexus value: 4fd87aed1b83d,10c8b8b14b81e02
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_bidder_appnexus value: appnexus
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_pb_appnexus value: 0.12,0.15
MESSAGE: Emitting event for: setTargeting
INFO: Invoking pbjs.renderAd : params :  Arguments(2) [document, "4fd87aed1b83d,10c8b8b14b81e02", callee: (...), Symbol(Symbol.iterator): ƒ]
MESSAGE: Calling renderAd with adId :4fd87aed1b83d,10c8b8b14b81e02
Error trying to write ad. **Cannot find ad by given id : 4fd87aed1b83d,10c8b8b14b81e02**
```

### After
```
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_format_appnexus value: banner
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_source_appnexus value: client
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_size_appnexus value: 300x250
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_adid_appnexus value: 12b6b63afd05064,18abcced141fd96
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_bidder_appnexus value: appnexus
MESSAGE: Attempting to set key value for slot: CP-300x250-ATF key: hb_pb_appnexus value: 0.17
MESSAGE: Emitting event for: setTargeting
INFO: Invoking pbjs.renderAd : params :  Arguments(2) [document, "12b6b63afd05064,18abcced141fd96", callee: (...), Symbol(Symbol.iterator): ƒ]
MESSAGE: Calling renderAd with adId :12b6b63afd05064,18abcced141fd96
MESSAGE: Rendering ad with adId :18abcced141fd96
MESSAGE: Emitting event for: bidWon
```

## Other information
Issue: https://github.com/prebid/Prebid.js/issues/2225