### PR TITLE
fix mediaType being overwritten by undefined in rubicon bid adapter 

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -268,12 +268,16 @@ export const spec = {
         requestId: bidRequest.bidId,
         currency: 'USD',
         creativeId: ad.creative_id,
-        mediaType: ad.creative_type,
         cpm: ad.cpm || 0,
         dealId: ad.deal,
         ttl: 300, // 5 minutes
         netRevenue: config.getConfig('rubicon.netRevenue') || false
       };
+
+      if (ad.creative_type) {
+        bid.mediaType = ad.creative_type;
+      }
+
       if (bidRequest.mediaType === 'video') {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;


### PR DESCRIPTION
(cherry picked from commit f7ee794)

## Type of change
- [x] Bugfix

## Description of change
Cherry-pick of bug fix to rubicon adapter in master branch to this legacy branch.