### PR TITLE
Update Yieldlab adapter and add official maintainer

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -67,7 +67,7 @@ export const spec = {
           width: sizes[0],
           height: sizes[1],
           creativeId: '' + matchedBid.id,
-          dealId: matchedBid.did,
+          dealId: matchedBid.pid,
           currency: CURRENCY_CODE,
           netRevenue: true,
           ttl: BID_RESPONSE_TTL_SEC,

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: true,
+          netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.accountId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}"></script>`

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -13,7 +13,7 @@ export const spec = {
   supportedMediaTypes: [VIDEO, BANNER],
 
   isBidRequestValid: function (bid) {
-    if (bid && bid.params && bid.params.placementId && bid.params.adSize) {
+    if (bid && bid.params && bid.params.adslotId && bid.params.adSize) {
       return true
     }
     return false
@@ -25,18 +25,18 @@ export const spec = {
    * @returns {{method: string, url: string}}
    */
   buildRequests: function (validBidRequests) {
-    const placementIds = []
+    const adslotIds = []
     const timestamp = Date.now()
 
     utils._each(validBidRequests, function (bid) {
-      placementIds.push(bid.params.placementId)
+      adslotIds.push(bid.params.adslotId)
     })
 
-    const placements = placementIds.join(',')
+    const adslots = adslotIds.join(',')
 
     return {
       method: 'GET',
-      url: `${ENDPOINT}/yp/${placements}?ts=${timestamp}&json=true`,
+      url: `${ENDPOINT}/yp/${adslots}?ts=${timestamp}&json=true`,
       validBidRequests: validBidRequests
     }
   },
@@ -56,7 +56,7 @@ export const spec = {
       }
 
       let matchedBid = find(serverResponse.body, function (bidResponse) {
-        return bidRequest.params.placementId == bidResponse.id
+        return bidRequest.params.adslotId == bidResponse.id
       })
 
       if (matchedBid) {
@@ -72,11 +72,11 @@ export const spec = {
           netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
-          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.accountId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}"></script>`
+          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}"></script>`
         }
         if (isVideo(bidRequest)) {
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.accountId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}`
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}`
         }
 
         bidResponses.push(bidResponse)

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -76,7 +76,7 @@ export const spec = {
         }
         if (isVideo(bidRequest)) {
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.accountId}/1x1?ts=${timestamp}`
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.accountId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}`
         }
 
         bidResponses.push(bidResponse)

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -5,7 +5,7 @@ import { VIDEO, BANNER } from 'src/mediaTypes'
 
 const ENDPOINT = 'https://ad.yieldlab.net'
 const BIDDER_CODE = 'yieldlab'
-const BID_RESPONSE_TTL_SEC = 600
+const BID_RESPONSE_TTL_SEC = 300
 const CURRENCY_CODE = 'EUR'
 
 export const spec = {

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -14,19 +14,19 @@ Module that connects to Yieldlab's demand sources
 ```
     var adUnits = [
            {
-               code: "test1",
-               sizes: [[800, 250]]
+               code: "banner",
+               sizes: [[728, 90]],
                bids: [{
                    bidder: "yieldlab",
                    params: {
-                       placement: "4206978",
-                       accountId: "2358365",
-                       adSize: "800x250"
+                       placement: "5220336",
+                       accountId: "1381604",
+                       adSize: "728x90"
                    }
                }]
            }, {
-               code: "test2",
-               sizes: [[1, 1]],
+               code: "video",
+               sizes: [[640, 480]],
                mediaTypes: {
                    video: {
                        context: "instream"
@@ -35,9 +35,9 @@ Module that connects to Yieldlab's demand sources
                bids: [{
                    bidder: "yieldlab",
                    params: {
-                       placementId: "4207034",
-                       accountId: "2358365",
-                       adSize: "1x1"
+                       placementId: "5220339",
+                       accountId: "1381604",
+                       adSize: "640x480"
                    }
                }]
            }

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -19,8 +19,8 @@ Module that connects to Yieldlab's demand sources
                bids: [{
                    bidder: "yieldlab",
                    params: {
-                       placement: "5220336",
-                       accountId: "1381604",
+                       adslotId: "5220336",
+                       supplyId: "1381604",
                        adSize: "728x90"
                    }
                }]
@@ -35,8 +35,8 @@ Module that connects to Yieldlab's demand sources
                bids: [{
                    bidder: "yieldlab",
                    params: {
-                       placementId: "5220339",
-                       accountId: "1381604",
+                       adslotId: "5220339",
+                       supplyId: "1381604",
                        adSize: "640x480"
                    }
                }]

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name: Yieldlab Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: api@platform-lunar.com
+Maintainer: solutions@yieldlab.de
 ```
 
 # Description

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -5,15 +5,15 @@ import { newBidder } from 'src/adapters/bidderFactory'
 const REQUEST = {
   'bidder': 'yieldlab',
   'params': {
-    'placementId': '1111',
-    'accountId': '2222',
-    'adSize': '800x250'
+    'adslotId': '1111',
+    'supplyId': '2222',
+    'adSize': '728x90'
   },
   'bidderRequestId': '143346cf0f1731',
   'auctionId': '2e41f65424c87c',
   'adUnitCode': 'adunit-code',
   'bidId': '2d925f27f5079f',
-  'sizes': [1, 1]
+  'sizes': [728, 90]
 }
 
 const RESPONSE = {
@@ -37,9 +37,9 @@ describe('yieldlabBidAdapter', () => {
     it('should return true when required params found', () => {
       const request = {
         'params': {
-          'placementId': '1111',
-          'accountId': '2222',
-          'adSize': '800x250'
+          'adslotId': '1111',
+          'supplyId': '2222',
+          'adSize': '728x90'
         }
       }
       expect(spec.isBidRequestValid(request)).to.equal(true)
@@ -78,15 +78,15 @@ describe('yieldlabBidAdapter', () => {
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
-      expect(result[0].width).to.equal(800)
-      expect(result[0].height).to.equal(250)
+      expect(result[0].width).to.equal(728)
+      expect(result[0].height).to.equal(90)
       expect(result[0].creativeId).to.equal('1111')
       expect(result[0].dealId).to.equal(undefined)
       expect(result[0].currency).to.equal('EUR')
-      expect(result[0].netRevenue).to.equal(true)
-      expect(result[0].ttl).to.equal(600)
+      expect(result[0].netRevenue).to.equal(false)
+      expect(result[0].ttl).to.equal(300)
       expect(result[0].referrer).to.equal('')
-      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/800x250?ts=')
+      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
     })
 
     it('should add vastUrl when type is video', () => {
@@ -105,7 +105,7 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
       expect(result[0].mediaType).to.equal('video')
-      expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/1x1?ts=')
+      expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
     })
   })
 })

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -21,7 +21,8 @@ const RESPONSE = {
   curl: 'https://www.yieldlab.de',
   format: 0,
   id: 1111,
-  price: 1
+  price: 1,
+  pid: 2222
 }
 
 describe('yieldlabBidAdapter', () => {
@@ -81,7 +82,7 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].width).to.equal(728)
       expect(result[0].height).to.equal(90)
       expect(result[0].creativeId).to.equal('1111')
-      expect(result[0].dealId).to.equal(undefined)
+      expect(result[0].dealId).to.equal(2222)
       expect(result[0].currency).to.equal('EUR')
       expect(result[0].netRevenue).to.equal(false)
       expect(result[0].ttl).to.equal(300)


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Official update from Yieldlab. Many thanks to our friends from Platform Lunar for the work on the adapter.

Bugfixes:
- TTL was wrong. Should be 5 minutes
- Identifier used for dealId was wrong
- netRevenue should be "false"
- Video adsize should be set dynamically

Other:
- Changed params to the actual naming used by Yieldlab to avoid confusion from customers. Corresponding Pull Request to the documentation: https://github.com/prebid/prebid.github.io/pull/651
- Updated maintainer to be Yieldlab
  
- contact email of the adapter’s maintainer: solutions@yieldlab.de
- [x] official adapter submission