### PR TITLE
Update legacy appnexusAstBidAdapter with buyerMemberIds and outstream renderer changes

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -125,7 +125,6 @@ function newRenderer(adUnitCode, rtbBid) {
   const renderer = Renderer.install({
     id: rtbBid.renderer_id,
     url: rtbBid.renderer_url,
-    config: { adText: `AppNexus Outstream Video Ad via Prebid.js` },
     loaded: false,
   });
 
@@ -186,7 +185,10 @@ function newBid(serverBid, rtbBid) {
     dealId: rtbBid.deal_id,
     currency: 'USD',
     netRevenue: true,
-    ttl: 300
+    ttl: 300,
+    appnexus: {
+      buyerMemberId: rtbBid.buyer_member_id
+    }
   };
 
   if (rtbBid.rtb.video) {

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -321,7 +321,10 @@ describe('AppNexusAdapter', () => {
           'mediaType': 'banner',
           'currency': 'USD',
           'ttl': 300,
-          'netRevenue': true
+          'netRevenue': true,
+          'appnexus': {
+            'buyerMemberId': 958
+          }
         }
       ];
       let bidderRequest;


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
- Added buyerMemberId to legacy appnexusAstBidAdapter bids so that clients can distinguish between managed and RTB demand
- Removed hard-coded outstream renderer config which would override any server-side renderer config