### PR TITLE
Adding 152media as alias

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -29,7 +29,7 @@ const SOURCE = 'pbjs';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['appnexusAst', 'brealtime', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm'],
+  aliases: ['appnexusAst', 'brealtime', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm', '152media'],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   /**


### PR DESCRIPTION

## Type of change
- [ ] Other

## Description of change
Adding 152media network as an alias to Apnnexus AST 

- contact email of the adapter’s maintainer alejo@152media.com
- [ ] official adapter submission
