### PR TITLE
fixes #2229 - Edge cookie string form

### DIFF
--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -535,13 +535,13 @@ export const YieldbotAdapter = {
   },
 
   setCookie: function(name, value, expireMillis, path, domain, secure) {
-    const expireTime = expireMillis ? new Date(Date.now() + expireMillis).toGMTString() : '';
     const dataValue = encodeURIComponent(value);
-    const docLocation = path || '';
-    const pageDomain = domain || '';
-    const httpsOnly = secure ? ';secure' : '';
+    const cookieStr = name + '=' + dataValue +
+            (expireMillis ? ';expires=' + new Date(Date.now() + expireMillis).toGMTString() : '') +
+            (path ? ';path=' + path : '') +
+            (domain ? ';domain=' + domain : '') +
+            (secure ? ';secure' : '');
 
-    const cookieStr = `${name}=${dataValue};expires=${expireTime};path=${docLocation};domain=${pageDomain}${httpsOnly}`;
     document.cookie = cookieStr;
   },
 


### PR DESCRIPTION
Fixes #2229 

## Type of change
- [x] Bugfix

## Description of change
Microsoft Edge is not tolerant of `document.cookie` string components with empty values.

This pull changes `YieldbotBidAdapter.setCookie()` to prevent including empty values for string components:
 - `;expires=`
 - `;path=`
 - `;domain=`
