### PR TITLE
Updates to legacy appnexusAst adapter for buyerMemberId and outstream config

### DIFF
--- a/modules/appnexusAstBidAdapter.js
+++ b/modules/appnexusAstBidAdapter.js
@@ -124,7 +124,6 @@ function newRenderer(adUnitCode, rtbBid) {
   const renderer = Renderer.install({
     id: rtbBid.renderer_id,
     url: rtbBid.renderer_url,
-    config: { adText: `AppNexus Outstream Video Ad via Prebid.js` },
     loaded: false,
   });
 
@@ -185,7 +184,10 @@ function newBid(serverBid, rtbBid) {
     dealId: rtbBid.deal_id,
     currency: 'USD',
     netRevenue: true,
-    ttl: 300
+    ttl: 300,
+    appnexus: {
+      buyerMemberId: rtbBid.buyer_member_id
+    }
   };
 
   if (rtbBid.rtb.video) {

--- a/test/spec/modules/appnexusAstBidAdapter_spec.js
+++ b/test/spec/modules/appnexusAstBidAdapter_spec.js
@@ -345,7 +345,10 @@ describe('AppNexusAdapter', () => {
           'mediaType': 'banner',
           'currency': 'USD',
           'ttl': 300,
-          'netRevenue': true
+          'netRevenue': true,
+          'appnexus': {
+            'buyerMemberId': 958
+          }
         }
       ];
       let bidderRequest;


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
- Added buyerMemberId to appnexusAst adapter so clients can distinguish between direct and RTB demand.
- Removed hard-coded outstream renderer config which was overriding server-side renderer config. The ANOutstreamVideo renderer automatically reads in the server-side config which is available on the `bid.adResponse` object.

## Other information
This pull request introduces the same buyerMemberId to the legacy branch that was pulled to the master branch with https://github.com/prebid/Prebid.js/pull/2161