### PR TITLE
use b64EncodeUnicode to encode strings with unicode chars in them

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -48,7 +48,7 @@ function generateAd(body, req) {
   return `
     <div data-str-native-key="${req.data.placement_key}" data-stx-response-name="${strRespId}">
     </div>
-    <script>var ${strRespId} = "${btoa(JSON.stringify(body))}"</script>
+    <script>var ${strRespId} = "${b64EncodeUnicode(JSON.stringify(body))}"</script>
     <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>
     <script>
     (function() {
@@ -65,6 +65,15 @@ function generateAd(body, req) {
       }
     })()
     </script>`;
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
+function b64EncodeUnicode(str) {
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+      function toSolidBytes(match, p1) {
+        return String.fromCharCode('0x' + p1);
+      }));
 }
 
 registerBidder(sharethroughAdapterSpec);

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -40,14 +40,22 @@ const bidderResponse = {
       'cpm': 12.34,
       'creative': {
         'deal_id': 'aDealId',
-        'creative_key': 'aCreativeId'
+        'creative_key': 'aCreativeId',
+        'title': '✓ à la mode'
       }
     }],
     'stxUserId': ''
   },
   header: { get: (header) => header }
 };
-
+// Mirrors the one in modules/sharethroughBidAdapter.js as the function is unexported
+const b64EncodeUnicode = (str) => {
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+      function toSolidBytes(match, p1) {
+        return String.fromCharCode('0x' + p1);
+      }));
+}
 describe('sharethrough adapter spec', () => {
   describe('.code', () => {
     it('should return a bidder code of sharethrough', () => {
@@ -111,8 +119,10 @@ describe('sharethrough adapter spec', () => {
 
     it('correctly sends back a sfp script tag', () => {
       const adMarkup = spec.interpretResponse(bidderResponse, prebidRequest[0])[0].ad;
-      const resp = btoa(JSON.stringify(bidderResponse));
+      let resp = null;
 
+      expect(() => btoa(JSON.stringify(bidderResponse))).to.throw();
+      expect(() => resp = b64EncodeUnicode(JSON.stringify(bidderResponse))).not.to.throw();
       expect(adMarkup).to.match(
         /data-str-native-key="pKey" data-stx-response-name=\"str_response_bidId\"/);
       expect(!!adMarkup.indexOf(resp)).to.eql(true);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Fixes uses cases where `btoa` is used on a Unicode string and blows up. We're using the Mozilla solution found here: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Apologies, this was originally opened against only `legacy`, but should have been for both `legacy` and `master`.