### PR TITLE
Add billing url (burl) support

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -376,6 +376,8 @@ const LEGACY_PROTOCOL = {
           bidObject.currency = (bidObj.currency) ? bidObj.currency : DEFAULT_S2S_CURRENCY;
           bidObject.netRevenue = (bidObj.netRevenue) ? bidObj.netRevenue : DEFAULT_S2S_NETREVENUE;
 
+          if (result.burl) { bidObject.burl = result.burl; }
+
           bids.push({ adUnit: bidObj.code, bid: bidObject });
         });
       }
@@ -505,6 +507,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.requestId = bid.id;
           bidObject.creative_id = bid.crid;
           bidObject.creativeId = bid.crid;
+          if (bid.burl) { bidObject.burl = bid.burl; }
 
           // TODO: Remove when prebid-server returns ttl, currency and netRevenue
           bidObject.ttl = (bid.ttl) ? bid.ttl : DEFAULT_S2S_TTL;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -234,6 +234,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           doc.write(ad);
           doc.close();
           setRenderSize(doc, width, height);
+          utils.callBurl(bid);
         } else if (adUrl) {
           const iframe = utils.createInvisibleIframe();
           iframe.height = height;
@@ -244,6 +245,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
 
           utils.insertElement(iframe, doc, 'body');
           setRenderSize(doc, width, height);
+          utils.callBurl(bid);
         } else {
           utils.logError('Error trying to write ad. No ad for bid response id: ' + id);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import { config } from './config';
 import clone from 'just-clone';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
-var CONSTANTS = require('./constants');
+const CONSTANTS = require('./constants');
 
 var _loggingChecked = false;
 
@@ -467,6 +467,12 @@ exports.insertElement = function(elm, doc, target) {
 exports.triggerPixel = function (url) {
   const img = new Image();
   img.src = url;
+};
+
+exports.callBurl = function({ source, burl }) {
+  if (source === CONSTANTS.S2S.SRC && burl) {
+    exports.triggerPixel(burl);
+  }
 };
 
 /**

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -680,6 +680,7 @@ describe('Unit: Prebid Module', function () {
     var spyLogError = null;
     var spyLogMessage = null;
     var inIframe = true;
+    let triggerPixelStub;
 
     function pushBidResponseToAuction(obj) {
       adResponse = Object.assign({
@@ -719,6 +720,7 @@ describe('Unit: Prebid Module', function () {
 
       inIframe = true;
       sinon.stub(utils, 'inIframe').callsFake(() => inIframe);
+      triggerPixelStub = sinon.stub(utils, 'triggerPixel');
     });
 
     afterEach(function () {
@@ -726,6 +728,7 @@ describe('Unit: Prebid Module', function () {
       utils.logError.restore();
       utils.logMessage.restore();
       utils.inIframe.restore();
+      utils.triggerPixel.restore();
     });
 
     it('should require doc and id params', function () {
@@ -809,6 +812,20 @@ describe('Unit: Prebid Module', function () {
       });
       $$PREBID_GLOBAL$$.renderAd(doc, bidId);
       assert.deepEqual($$PREBID_GLOBAL$$.getAllWinningBids()[0], adResponse);
+    });
+
+    it('fires billing url if present on s2s bid', () => {
+      const burl = 'http://www.example.com/burl';
+      pushBidResponseToAuction({
+        ad: '<div>ad</div>',
+        source: 's2s',
+        burl
+      });
+
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+
+      sinon.assert.calledOnce(triggerPixelStub);
+      sinon.assert.calledWith(triggerPixelStub, burl);
     });
   });
 


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Adds billing url support to prebidServer adapter. In OpenRTB, this field is called `burl`. Prebid will call this url for S2S bid responses after and if that bid is rendered. This does not include video bid support, which would follow a different rule according to the OpenRTB spec.