### PR TITLE
PBS set nurl for video.

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -488,6 +488,7 @@ const OPEN_RTB_PROTOCOL = {
           if (utils.deepAccess(bid, 'ext.prebid.type') === VIDEO) {
             bidObject.mediaType = VIDEO;
             if (bid.adm) { bidObject.vastXml = bid.adm; }
+            if (bid.nurl) { bidObject.vastUrl = bid.nurl; }
           } else { // banner
             if (bid.adm && bid.nurl) {
               bidObject.ad = bid.adm;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
One line change to set bidObject.vastUrl from bid.nurl.

Fixes #2243