### PR TITLE
Audience Network: add 'cb' and 'pbv' query params

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -4,7 +4,7 @@
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import { formatQS } from 'src/url';
-import { getTopWindowUrl } from 'src/utils';
+import { generateUUID, getTopWindowUrl, isSafariBrowser } from 'src/utils';
 import findIndex from 'core-js/library/fn/array/find-index';
 import includes from 'core-js/library/fn/array/includes';
 
@@ -15,6 +15,7 @@ const url = 'https://an.facebook.com/v2/placementbid.json';
 const supportedMediaTypes = ['banner', 'video'];
 const netRevenue = true;
 const hb_bidder = 'fan';
+const pbv = '$prebid.version$';
 
 /**
  * Does this bid request contain valid parameters?
@@ -164,11 +165,15 @@ const buildRequests = bids => {
     adformats,
     testmode,
     pageurl,
-    sdk
+    sdk,
+    pbv
   };
   const video = findIndex(adformats, isVideo);
   if (video !== -1) {
     [search.playerwidth, search.playerheight] = expandSize(sizes[video]);
+  }
+  if (isSafariBrowser()) {
+    search.cb = generateUUID();
   }
   const data = formatQS(search);
 

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -18,6 +18,7 @@ const placementId = 'test-placement-id';
 const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
+const pbv = '$prebid.version$';
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
@@ -128,7 +129,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web'
+        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web&pbv=${pbv}`
       }]);
     });
 
@@ -147,7 +148,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['640x480'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=&sdk[]=&playerwidth=640&playerheight=480'
+        data: `placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=&sdk[]=&pbv=${pbv}&playerwidth=640&playerheight=480`
       }]);
     });
 
@@ -166,7 +167,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['728x90'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=native&testmode=false&pageurl=&sdk[]=5.5.web'
+        data: `placementids[]=test-placement-id&adformats[]=native&testmode=false&pageurl=&sdk[]=5.5.web&pbv=${pbv}`
       }]);
     });
 
@@ -185,8 +186,28 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=fullwidth&testmode=false&pageurl=&sdk[]=5.5.web'
+        data: `placementids[]=test-placement-id&adformats[]=fullwidth&testmode=false&pageurl=&sdk[]=5.5.web&pbv=${pbv}`
       }]);
+    });
+
+    it('can build URL on Safari that includes a cachebuster param', () => {
+      const { userAgent } = navigator;
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'safari',
+        writable: true
+      });
+
+      expect(buildRequests([{
+        bidder,
+        bidId: requestId,
+        sizes: [[300, 250]],
+        params: { placementId }
+      }])[0].data).to.contain('&cb=');
+
+      Object.defineProperty(navigator, 'userAgent', {
+        value: userAgent,
+        writable: false
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

Hello, this PR adds a couple of query parameters to an Audience Network bid request.

* `cb` is for a Safari-only "cachebuster" to fix #2199
* `pbv` is for the Prebid version to aid with debugging

A new unit test is provided for the conditional `cb` parameter and a few existing unit test expectations were updated to match the new behaviour. Branch coverage for this adaptor remains at 100%.

This work was commissioned and paid for by Facebook.
