### PR TITLE
Support aliases in prebidServer

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -8,7 +8,6 @@ import adaptermanager from 'src/adaptermanager';
 import { config } from 'src/config';
 import { VIDEO } from 'src/mediaTypes';
 import { isValid } from 'src/adapters/bidderFactory';
-import { spec as appnexus } from 'modules/appnexusBidAdapter';
 import includes from 'core-js/library/fn/array/includes';
 
 const getConfig = config.getConfig;
@@ -215,10 +214,7 @@ function convertTypes(adUnits) {
   adUnits.forEach(adUnit => {
     adUnit.bids.forEach(bid => {
       // aliases use the base bidder's paramTypes
-      const bidder = includes(appnexus.aliases, bid.bidder)
-        ? appnexus.code
-        : bid.bidder;
-
+      const bidder = adaptermanager.aliasRegistry[bid.bidder] || bid.bidder;
       const types = paramTypes[bidder] || [];
 
       Object.keys(types).forEach(key => {
@@ -414,9 +410,9 @@ const OPEN_RTB_PROTOCOL = {
         const key = `${adUnit.code}${bid.bidder}`;
         this.bidMap[key] = bid;
 
-        // check for and store valid appnexus aliases to add to the request
-        if (includes(appnexus.aliases, bid.bidder)) {
-          aliases[bid.bidder] = appnexus.code;
+        // check for and store valid aliases to add to the request
+        if (adaptermanager.aliasRegistry[bid.bidder]) {
+          aliases[bid.bidder] = adaptermanager.aliasRegistry[bid.bidder];
         }
       });
 

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -15,6 +15,7 @@ let s2sTestingModule; // store s2sTesting module if it's loaded
 
 var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;
+exports.aliasRegistry = {};
 
 let _s2sConfig = {};
 config.getConfig('s2sConfig', config => {
@@ -383,6 +384,7 @@ exports.aliasBidAdapter = function (bidderCode, alias) {
         } else {
           let spec = bidAdaptor.getSpec();
           newAdapter = newBidder(Object.assign({}, spec, { code: alias }));
+          exports.aliasRegistry[alias] = bidderCode;
         }
         this.registerBidAdapter(newAdapter, alias, {
           supportedMediaTypes

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -139,6 +139,7 @@ export function registerBidder(spec) {
   putBidder(spec);
   if (Array.isArray(spec.aliases)) {
     spec.aliases.forEach(alias => {
+      adaptermanager.aliasRegistry[alias] = spec.code;
       putBidder(Object.assign({}, spec, { code: alias }));
     });
   }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -480,6 +480,36 @@ describe('S2S Adapter', () => {
         }
       });
     });
+
+    it('adds dynamic aliases to request', () => {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig});
+
+      const alias = 'foobar';
+      const aliasBidder = {
+        bidder: alias,
+        params: { placementId: '123456' }
+      };
+
+      const request = Object.assign({}, REQUEST);
+      request.ad_units[0].bids = [aliasBidder];
+
+      // TODO: stub this
+      $$PREBID_GLOBAL$$.aliasBidder('appnexus', alias);
+      adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
+
+      const requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          aliases: {
+            [alias]: 'appnexus'
+          }
+        }
+      });
+    });
   });
 
   describe('response handler', () => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -453,6 +453,33 @@ describe('S2S Adapter', () => {
       expect(requestBid.site.publisher).to.exist.and.to.be.a('object');
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
     });
+
+    it('adds appnexus aliases to request', () => {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig});
+
+      const aliasBidder = {
+        bidder: 'brealtime',
+        params: { placementId: '123456' }
+      };
+
+      const request = Object.assign({}, REQUEST);
+      request.ad_units[0].bids = [aliasBidder];
+
+      adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
+
+      const requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          aliases: {
+            brealtime: 'appnexus'
+          }
+        }
+      });
+    });
   });
 
   describe('response handler', () => {


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Supports calling bider adapter aliases with prebidServer adapter (OpenRTB endpoint only). In a prebid setup, add a known alias to the `s2sConfig.bidders` array, and that will take part in the s2s auction.

**Example config - known alias**
```JavaScript
pbjs.setConfig({
  s2sConfig: {
    enabled: true,
    accountId: '123-456',
    endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
    bidders: ['appnexus', 'brealtime'],
  },
});

// brealtime and appnexusAst are both aliases of appnexus
// appnexus and brealtime will take part in the s2s auction since they are listed in s2sConfig.bidders
// appnexusAst will be run client-side
pbjs.addAdUnits({
    // ...
    bids: [
      {
        bidder: 'appnexus',
        params: { placementId: '123' }
      },
      {
        bidder: 'brealtime',
        params: { placementId: '123' }
      },
      {
        bidder: 'appnexusAst',
        params: { placementId: '456' }
      },
    ],
   // ...
  });
```

**Example config - dynamic alias**
```JavaScript
pbjs.aliasBidder('appnexus', 'newAlias');

pbjs.setConfig({
  s2sConfig: {
    enabled: true,
    accountId: '123-456',
    endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
    bidders: ['newAlias'],
  },
});

// newAlias will take part in s2s auction
pbjs.addAdUnits({
    // ...
    bids: [
      {
        bidder: 'newAlias',
        params: { placementId: '123' }
      },
    ],
   // ...
  });
```