### PR TITLE
Add Oneplanetonly Bid Adapter

### DIFF
--- a/modules/oneplanetonlyBidAdapter.js
+++ b/modules/oneplanetonlyBidAdapter.js
@@ -1,0 +1,74 @@
+import * as utils from 'src/utils';
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
+
+const BIDDER_CODE = 'oneplanetonly';
+const EDNPOINT = '//show.oneplanetonly.com/prebid';
+
+function createEndpoint(siteId) {
+  return `${EDNPOINT}?siteId=${siteId}`;
+}
+
+function isBidRequestValid (bid) {
+  return !!(bid.params.siteId && bid.params.adUnitId);
+}
+
+function buildRequests(bidReqs) {
+  let firstBid = bidReqs[0] || {}
+  let siteId = utils.getBidIdParameter('siteId', firstBid.params)
+  let adUnits = bidReqs.map((bid) => {
+    return {
+      id: utils.getBidIdParameter('adUnitId', bid.params),
+      bidId: bid.bidId,
+      sizes: utils.parseSizesInput(bid.sizes),
+    };
+  });
+
+  const bidRequest = {
+    id: firstBid.auctionId,
+    transactionId: firstBid.transactionId,
+    currency: config.getConfig('currency.adServerCurrency'),
+    timeout: config.getConfig('bidderTimeout'),
+    siteId,
+    domain: utils.getTopWindowLocation().hostname,
+    page: config.getConfig('pageUrl') || utils.getTopWindowUrl(),
+    referrer: utils.getTopWindowReferrer(),
+    adUnits,
+  };
+
+  return {
+    method: 'POST',
+    url: createEndpoint(siteId),
+    data: bidRequest,
+    options: {contentType: 'application/json', withCredentials: true}
+  };
+}
+
+function interpretResponse(serverResponse, request) {
+  if (!serverResponse.body.length) {
+    return [];
+  }
+  return serverResponse.body.map((bid) => {
+    return {
+      requestId: bid.requestId,
+      cpm: bid.cpm,
+      width: bid.width,
+      height: bid.height,
+      creativeId: bid.creativeId,
+      currency: bid.currency,
+      netRevenue: true,
+      ad: bid.ad,
+      ttl: bid.ttl
+    };
+  });
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['opo'], // short code
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse
+}
+
+registerBidder(spec);

--- a/modules/oneplanetonlyBidAdapter.js
+++ b/modules/oneplanetonlyBidAdapter.js
@@ -26,6 +26,8 @@ function buildRequests(bidReqs) {
 
   const bidRequest = {
     id: firstBid.auctionId,
+    ver: 1,
+    prebidVer: `$prebid.version$`,
     transactionId: firstBid.transactionId,
     currency: config.getConfig('currency.adServerCurrency'),
     timeout: config.getConfig('bidderTimeout'),
@@ -45,10 +47,10 @@ function buildRequests(bidReqs) {
 }
 
 function interpretResponse(serverResponse, request) {
-  if (!serverResponse.body.length) {
+  if (!serverResponse.body.bids) {
     return [];
   }
-  return serverResponse.body.map((bid) => {
+  return serverResponse.body.bids.map((bid) => {
     return {
       requestId: bid.requestId,
       cpm: bid.cpm,

--- a/modules/oneplanetonlyBidAdapter.md
+++ b/modules/oneplanetonlyBidAdapter.md
@@ -1,0 +1,50 @@
+# Overview
+
+```
+Module Name: OnePlanetOnly Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: vitaly@oneplanetonly.com
+```
+
+# Description
+
+Module that connects to OnePlanetOnly's demand sources
+
+# Test Parameters
+```
+    var adUnits = [
+        {
+            code: 'desktop-banner-ad-div',
+            mediaTypes: {
+                banner: {
+                    sizes: [[300, 250], [300, 600]],
+                }
+            },
+            bids: [
+                {
+                    bidder: 'oneplanetonly',
+                    params: {
+                        siteId: '5',
+                        adUnitId: '5-4587544'
+                    }
+                }
+            ]
+        },{
+            code: 'mobile-banner-ad-div',
+            mediaTypes: {
+                banner: {
+                    sizes: [[320, 50], [320, 100]],
+                }
+            },
+            bids: [
+                {
+                    bidder: "oneplanetonly",
+                    params: {
+                        siteId: '5',
+                        adUnitId: '5-81037880'
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/oneplanetonlyBidAdapter_spec.js
+++ b/test/spec/modules/oneplanetonlyBidAdapter_spec.js
@@ -43,7 +43,8 @@ describe('OnePlanetOnlyAdapter', () => {
     it('Returns valid data if array of bids is valid', () => {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
-      expect(data).to.have.all.keys('id', 'transactionId', 'currency', 'timeout', 'siteId', 'domain', 'page', 'referrer', 'adUnits');
+      expect(data).to.have.all.keys('id', 'ver', 'prebidVer', 'transactionId', 'currency', 'timeout', 'siteId',
+        'domain', 'page', 'referrer', 'adUnits');
 
       let adUnit = data.adUnits[0];
       expect(adUnit).to.have.keys('id', 'bidId', 'sizes');
@@ -60,16 +61,18 @@ describe('OnePlanetOnlyAdapter', () => {
   describe('interpretResponse', () => {
     it('Should interpret banner response', () => {
       const serverResponse = {
-        body: [{
-          requestId: '51ef8751f9aead',
-          cpm: 0.4,
-          width: 300,
-          height: 250,
-          creativeId: '2',
-          currency: 'USD',
-          ad: 'Test',
-          ttl: 120,
-        }]
+        body: {
+          bids: [{
+            requestId: '51ef8751f9aead',
+            cpm: 0.4,
+            width: 300,
+            height: 250,
+            creativeId: '2',
+            currency: 'USD',
+            ad: 'Test',
+            ttl: 120,
+          }]
+        }
       };
       let bannerResponses = spec.interpretResponse(serverResponse);
       expect(bannerResponses).to.be.an('array').that.is.not.empty;

--- a/test/spec/modules/oneplanetonlyBidAdapter_spec.js
+++ b/test/spec/modules/oneplanetonlyBidAdapter_spec.js
@@ -1,0 +1,97 @@
+import {expect} from 'chai';
+import {spec} from '../../../modules/oneplanetonlyBidAdapter';
+
+describe('OnePlanetOnlyAdapter', () => {
+  let bid = {
+    bidId: '51ef8751f9aead',
+    bidder: 'oneplanetonly',
+    params: {
+      siteId: '5',
+      adUnitId: '5-4587544',
+    },
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    transactionId: 'd7b773de-ceaa-484d-89ca-d9f51b8d61ec',
+    sizes: [[300, 250], [300, 600]],
+    bidderRequestId: '418b37f85e772c',
+    auctionId: '18fd8b8b0bd757'
+  };
+
+  describe('isBidRequestValid', () => {
+    it('Should return true if there are params.siteId and params.adUnitId parameters present', () => {
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+    it('Should return false if at least one of parameters is not present', () => {
+      delete bid.params.adUnitId;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+  });
+
+  describe('buildRequests', () => {
+    let serverRequest = spec.buildRequests([bid]);
+    it('Creates a ServerRequest object with method, URL and data', () => {
+      expect(serverRequest).to.exist;
+      expect(serverRequest.method).to.exist;
+      expect(serverRequest.url).to.exist;
+      expect(serverRequest.data).to.exist;
+    });
+    it('Returns POST method', () => {
+      expect(serverRequest.method).to.equal('POST');
+    });
+    it('Returns valid URL', () => {
+      expect(serverRequest.url).to.equal('//show.oneplanetonly.com/prebid?siteId=5');
+    });
+    it('Returns valid data if array of bids is valid', () => {
+      let data = serverRequest.data;
+      expect(data).to.be.an('object');
+      expect(data).to.have.all.keys('id', 'transactionId', 'currency', 'timeout', 'siteId', 'domain', 'page', 'referrer', 'adUnits');
+
+      let adUnit = data.adUnits[0];
+      expect(adUnit).to.have.keys('id', 'bidId', 'sizes');
+      expect(adUnit.id).to.equal('5-4587544');
+      expect(adUnit.bidId).to.equal('51ef8751f9aead');
+      expect(adUnit.sizes).to.have.members(['300x250', '300x600']);
+    });
+    it('Returns empty data if no valid requests are passed', () => {
+      serverRequest = spec.buildRequests([]);
+      let data = serverRequest.data;
+      expect(data.adUnits).to.be.an('array').that.is.empty;
+    });
+  });
+  describe('interpretResponse', () => {
+    it('Should interpret banner response', () => {
+      const serverResponse = {
+        body: [{
+          requestId: '51ef8751f9aead',
+          cpm: 0.4,
+          width: 300,
+          height: 250,
+          creativeId: '2',
+          currency: 'USD',
+          ad: 'Test',
+          ttl: 120,
+        }]
+      };
+      let bannerResponses = spec.interpretResponse(serverResponse);
+      expect(bannerResponses).to.be.an('array').that.is.not.empty;
+      let bidObject = bannerResponses[0];
+      expect(bidObject).to.have.all.keys('requestId', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId',
+        'netRevenue', 'currency');
+      expect(bidObject.requestId).to.equal('51ef8751f9aead');
+      expect(bidObject.cpm).to.equal(0.4);
+      expect(bidObject.width).to.equal(300);
+      expect(bidObject.height).to.equal(250);
+      expect(bidObject.ad).to.equal('Test');
+      expect(bidObject.ttl).to.equal(120);
+      expect(bidObject.creativeId).to.equal('2');
+      expect(bidObject.netRevenue).to.be.true;
+      expect(bidObject.currency).to.equal('USD');
+    });
+    it('Should return an empty array if invalid response is passed', () => {
+      const invalid = {
+        body: {}
+      };
+      let serverResponses = spec.interpretResponse(invalid);
+      expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
New bidder adapter from oneplanetonly

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'oneplanetonly',
    params: {
      siteId: '5',
      adUnitId: '5-4587544'
    }
}
```

- vitaly@oneplanetonly.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- https://github.com/prebid/prebid.github.io/pull/671
