### PR TITLE
add hb_cache_id for legacy version

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -88,6 +88,8 @@ export default function buildDfpVideoUrl(options) {
   const customParams = Object.assign({},
     adserverTargeting,
     { hb_uuid: bid && bid.videoCacheKey },
+    // hb_uuid should be deprecated and replaced by hb_cache_id
+    {hb_cache_id: bid && bid.videoCacheKey},
     options.params.cust_params);
 
   const queryParams = Object.assign({},

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -105,6 +105,7 @@ describe('The DFP video support module', () => {
 
     expect(customParams).to.have.property('hb_adid', 'ad_id');
     expect(customParams).to.have.property('hb_uuid', bid.videoCacheKey);
+    expect(customParams).to.have.property('hb_cache_id', bid.videoCacheKey);
   });
 
   it('should merge the user-provided cust_params with the default ones', () => {


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
add hb_cache_id for legacy version, hb_uuid should be deprecated and replaced by hb_cache_id