### PR TITLE
[FEAT] add optional param to bridgewellBidAdapter

### DIFF
--- a/modules/bridgewellBidAdapter.js
+++ b/modules/bridgewellBidAdapter.js
@@ -15,7 +15,23 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function(bid) {
-    return bid && bid.params && !!bid.params.ChannelID;
+    let valid = false;
+    let typeOfCpmWeight;
+
+    if (bid && bid.params) {
+      if (bid.params.ChannelID) {
+        // cpmWeight is optinal parameter and should above than zero
+        typeOfCpmWeight = typeof bid.params.cpmWeight;
+        if (typeOfCpmWeight === 'undefined' ||
+          (typeOfCpmWeight === 'number' && bid.params.cpmWeight > 0)) {
+          valid = true;
+        } else {
+          valid = false;
+        }
+      }
+    }
+
+    return valid;
   },
 
   /**
@@ -82,7 +98,8 @@ export const spec = {
         }
 
         bidResponse.requestId = req.bidId;
-        bidResponse.cpm = matchedResponse.cpm;
+        bidResponse.requestId = req.bidId;
+        bidResponse.cpm = req.params.cpmWeight ? matchedResponse.cpm / req.params.cpmWeight : matchedResponse.cpm;
         bidResponse.width = matchedResponse.width;
         bidResponse.height = matchedResponse.height;
         bidResponse.ad = matchedResponse.ad;

--- a/modules/bridgewellBidAdapter.md
+++ b/modules/bridgewellBidAdapter.md
@@ -18,7 +18,7 @@ Module that connects to Bridgewell demand source to fetch bids.
                    {
                        bidder: 'bridgewell',
                        params: {
-                           ChannelID: 'CgUxMjMzOBIBNiIFcGVubnkqCQisAhD6ARoBOQ',
+                           ChannelID: 'CgUxMjMzOBIBNiIFcGVubnkqCQisAhD6ARoBOQ'
                        }
                    }
                ]
@@ -30,6 +30,7 @@ Module that connects to Bridgewell demand source to fetch bids.
                        bidder: 'bridgewell',
                        params: {
                            ChannelID: 'CgUxMjMzOBIBNiIGcGVubnkzKggI2AUQWhoBOQ',
+                           cpmWeight: 0.5
                        }
                    }
                ]

--- a/test/spec/modules/bridgewellBidAdapter_spec.js
+++ b/test/spec/modules/bridgewellBidAdapter_spec.js
@@ -37,6 +37,30 @@ describe('bridgewellBidAdapter', function () {
       'bidId': '42dbe3a7168a6a',
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',
+    },
+    {
+      'bidder': 'bridgewell',
+      'params': {
+        'ChannelID': 'CgUxMjMzOBIBNiIFcGVubnkqCQisAhD6ARoBOQ',
+        'cpmWeight': 0.5
+      },
+      'adUnitCode': 'adunit-code-1',
+      'sizes': [[300, 250]],
+      'bidId': '42dbe3a7168a6a',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    },
+    {
+      'bidder': 'bridgewell',
+      'params': {
+        'ChannelID': 'CgUxMjMzOBIBNiIGcGVubnkzKggI2AUQWhoBOQ',
+        'cpmWeight': -0.5
+      },
+      'adUnitCode': 'adunit-code-2',
+      'sizes': [[728, 90]],
+      'bidId': '3150ccb55da321',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
     }
   ];
   const adapter = newBidder(spec);
@@ -48,7 +72,7 @@ describe('bridgewellBidAdapter', function () {
   });
 
   describe('isBidRequestValid', () => {
-    let bid = {
+    let bidWithoutCpmWeight = {
       'bidder': 'bridgewell',
       'params': {
         'ChannelID': 'CLJgEAYYvxUiBXBlbm55KgkIrAIQ-gEaATk'
@@ -60,17 +84,62 @@ describe('bridgewellBidAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
+    let bidWithCorrectCpmWeight = {
+      'bidder': 'bridgewell',
+      'params': {
+        'ChannelID': 'CLJgEAYYvxUiBXBlbm55KgkIrAIQ-gEaATk',
+        'cpmWeight': 0.5
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    };
+
+    let bidWithUncorrectCpmWeight = {
+      'bidder': 'bridgewell',
+      'params': {
+        'ChannelID': 'CLJgEAYYvxUiBXBlbm55KgkIrAIQ-gEaATk',
+        'cpmWeight': -1.0
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    };
+
     it('should return true when required params found', () => {
-      expect(spec.isBidRequestValid(bid)).to.equal(true);
+      expect(spec.isBidRequestValid(bidWithoutCpmWeight)).to.equal(true);
+      expect(spec.isBidRequestValid(bidWithCorrectCpmWeight)).to.equal(true);
+      expect(spec.isBidRequestValid(bidWithUncorrectCpmWeight)).to.equal(false);
     });
 
     it('should return false when required params are not passed', () => {
-      let bid = Object.assign({}, bid);
-      delete bid.params;
-      bid.params = {
+      let bidWithoutCpmWeight = Object.assign({}, bidWithoutCpmWeight);
+      let bidWithCorrectCpmWeight = Object.assign({}, bidWithCorrectCpmWeight);
+      let bidWithUncorrectCpmWeight = Object.assign({}, bidWithUncorrectCpmWeight);
+
+      delete bidWithoutCpmWeight.params;
+      delete bidWithCorrectCpmWeight.params;
+      delete bidWithUncorrectCpmWeight.params;
+
+      bidWithoutCpmWeight.params = {
         'ChannelID': 0
       };
-      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bidWithCorrectCpmWeight.params = {
+        'ChannelID': 0
+      };
+
+      bidWithUncorrectCpmWeight.params = {
+        'ChannelID': 0
+      };
+
+      expect(spec.isBidRequestValid(bidWithoutCpmWeight)).to.equal(false);
+      expect(spec.isBidRequestValid(bidWithCorrectCpmWeight)).to.equal(false);
+      expect(spec.isBidRequestValid(bidWithUncorrectCpmWeight)).to.equal(false);
     });
   });
 
@@ -126,6 +195,26 @@ describe('bridgewellBidAdapter', function () {
       'width': 300,
       'height': 250,
       'ad': '<div>test 300x250</div>',
+      'ttl': 360,
+      'net_revenue': 'true',
+      'currency': 'NTD'
+    }, {
+      'id': '8f12c646-3b87-4326-a837-c2a76999f168',
+      'bidder_code': 'bridgewell',
+      'cpm': 5.0,
+      'width': 300,
+      'height': 250,
+      'ad': '<div>test 300x250</div>',
+      'ttl': 360,
+      'net_revenue': 'true',
+      'currency': 'NTD'
+    }, {
+      'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
+      'bidder_code': 'bridgewell',
+      'cpm': 5.0,
+      'width': 728,
+      'height': 90,
+      'ad': '<div>test 728x90</div>',
       'ttl': 360,
       'net_revenue': 'true',
       'currency': 'NTD'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
