### PR TITLE
Adkernel adapters compatibility issues

### DIFF
--- a/modules/adkernelAdnAnalyticsAdapter.js
+++ b/modules/adkernelAdnAnalyticsAdapter.js
@@ -123,7 +123,7 @@ function trackAuctionInit() {
 
 function trackBidRequest(args) {
   return args.bids.map(bid =>
-    createHbEvent(args.bidderCode, ADK_HB_EVENTS.BID_REQUEST, bid.placementCode));
+    createHbEvent(args.bidderCode, ADK_HB_EVENTS.BID_REQUEST, bid.adUnitCode));
 }
 
 function trackBidResponse(args) {

--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from 'src/utils';
 import {registerBidder} from 'src/adapters/bidderFactory';
-import { BANNER, VIDEO } from 'src/mediaTypes';
+import {BANNER, VIDEO} from 'src/mediaTypes';
 import includes from 'core-js/library/fn/array/includes';
 
 const DEFAULT_ADKERNEL_DSP_DOMAIN = 'tag.adkernel.com';
@@ -14,15 +14,21 @@ function isRtbDebugEnabled() {
 }
 
 function buildImp(bidRequest) {
-  const sizes = bidRequest.sizes;
   let imp = {
     id: bidRequest.bidId,
-    tagid: bidRequest.placementCode
+    tagid: bidRequest.adUnitCode
   };
-  if (bidRequest.mediaType === 'video' || utils.deepAccess(bidRequest, 'mediaTypes.video')) {
+  if (bidRequest.mediaType === BANNER || utils.deepAccess(bidRequest, `mediaTypes.banner`) ||
+    (bidRequest.mediaTypes === undefined && bidRequest.mediaType === undefined)) {
+    let sizes = canonicalizeSizesArray(utils.deepAccess(bidRequest, `mediaTypes.banner.sizes`) || bidRequest.sizes);
+    imp.banner = {
+      format: utils.parseSizesInput(sizes)
+    }
+  } else if (bidRequest.mediaType === VIDEO || utils.deepAccess(bidRequest, `mediaTypes.video`)) {
+    let size = utils.deepAccess(bidRequest, `mediaTypes.video.playerSize`) || canonicalizeSizesArray(bidRequest.sizes)[0];
     imp.video = {
-      w: sizes[0],
-      h: sizes[1],
+      w: size[0],
+      h: size[1],
       mimes: DEFAULT_MIMES,
       protocols: DEFAULT_PROTOCOLS,
       api: DEFAULT_APIS
@@ -32,12 +38,20 @@ function buildImp(bidRequest) {
         .filter(param => includes(VIDEO_TARGETING, param))
         .forEach(param => imp.video[param] = bidRequest.params.video[param]);
     }
-  } else {
-    imp.banner = {
-      format: utils.parseSizesInput(bidRequest.sizes)
-    };
   }
   return imp;
+}
+
+/**
+ * Convert input array of sizes to canonical form Array[Array[Number]]
+ * @param sizes
+ * @return Array[Array[Number]]
+ */
+function canonicalizeSizesArray(sizes) {
+  if (sizes.length === 2 && !utils.isArray(sizes[0])) {
+    return [sizes];
+  }
+  return sizes;
 }
 
 function buildRequestParams(auctionId, transactionId, tags) {
@@ -131,15 +145,10 @@ export const spec = {
     if (!syncOptions.iframeEnabled || !serverResponses || serverResponses.length === 0) {
       return [];
     }
-    return serverResponses.filter(rps => 'syncpages' in rps.body)
+    return serverResponses.filter(rps => rps.body && rps.body.syncpages)
       .map(rsp => rsp.body.syncpages)
       .reduce((a, b) => a.concat(b), [])
-      .map(sync_url => {
-        return {
-          type: 'iframe',
-          url: sync_url
-        }
-      });
+      .map(sync_url => ({type: 'iframe', url: sync_url}));
   }
 };
 

--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -154,7 +154,7 @@ describe('', () => {
     bids: [{
       bidder: 'adapter',
       params: {},
-      placementCode: 'container-1',
+      adUnitCode: 'container-1',
       transactionId: 'de90df62-7fd0-4fbc-8787-92d133a7dc06',
       sizes: [[300, 250]],
       bidId: '208750227436c1',

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -11,7 +11,7 @@ describe('AdkernelAdn adapter', () => {
       params: {
         pubId: 1
       },
-      placementCode: 'ad-unit-1',
+      adUnitCode: 'ad-unit-1',
       sizes: [[300, 250], [300, 200]]
     },
     bid2_pub1 = {
@@ -22,8 +22,8 @@ describe('AdkernelAdn adapter', () => {
       params: {
         pubId: 1
       },
-      placementCode: 'ad-unit-2',
-      sizes: [[300, 250]]
+      adUnitCode: 'ad-unit-2',
+      sizes: [300, 250]
     },
     bid1_pub2 = {
       bidder: 'adkernelAdn',
@@ -34,7 +34,7 @@ describe('AdkernelAdn adapter', () => {
         pubId: 7,
         host: 'dps-test.com'
       },
-      placementCode: 'ad-unit-2',
+      adUnitCode: 'ad-unit-2',
       sizes: [[728, 90]]
     }, bid_video1 = {
       bidder: 'adkernelAdn',
@@ -43,7 +43,7 @@ describe('AdkernelAdn adapter', () => {
       bidId: 'bidid_4',
       mediaType: 'video',
       sizes: [640, 300],
-      placementCode: 'video_wrapper',
+      adUnitCode: 'video_wrapper',
       params: {
         pubId: 7,
         video: {
@@ -57,9 +57,14 @@ describe('AdkernelAdn adapter', () => {
       transactionId: 'transact3',
       bidderRequestId: 'req1',
       bidId: 'bidid_5',
-      mediaTypes: {video: {context: 'instream'}},
-      sizes: [640, 300],
-      placementCode: 'video_wrapper2',
+      mediaTypes: {
+        video: {
+          playerSize: [1920, 1080],
+          context: 'instream'
+        }
+      },
+
+      adUnitCode: 'video_wrapper2',
       params: {
         pubId: 7,
         video: {
@@ -178,6 +183,12 @@ describe('AdkernelAdn adapter', () => {
       expect(tagRequest.imp[0]).to.have.property('tagid', 'video_wrapper');
       expect(tagRequest.imp[1]).to.have.property('tagid', 'video_wrapper2');
     });
+    it('should have size', () => {
+      expect(tagRequest.imp[0].video).to.have.property('w', 640);
+      expect(tagRequest.imp[0].video).to.have.property('h', 300);
+      expect(tagRequest.imp[1].video).to.have.property('w', 1920);
+      expect(tagRequest.imp[1].video).to.have.property('h', 1080);
+    });
   });
 
   describe('requests routing', () => {
@@ -249,6 +260,10 @@ describe('AdkernelAdn adapter', () => {
       let request = spec.buildRequests([bid1_pub1])[0];
       let resp = spec.interpretResponse({body: usersyncOnlyResponse}, request);
       expect(resp).to.have.length(0);
+    });
+    it('shouldn\' fail in empty response', () => {
+      let syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: ''}]);
+      expect(syncs).to.have.length(0);
     });
   });
 });

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -7,37 +7,37 @@ describe('Adkernel adapter', () => {
       bidder: 'adkernel',
       bidId: 'Bid_01',
       params: {zoneId: 1, host: 'rtb.adkernel.com'},
-      placementCode: 'ad-unit-1',
+      adUnitCode: 'ad-unit-1',
       sizes: [[300, 250], [300, 200]]
     }, bid2_zone2 = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 2, host: 'rtb.adkernel.com'},
-      placementCode: 'ad-unit-2',
+      adUnitCode: 'ad-unit-2',
       sizes: [[728, 90]]
     }, bid3_host2 = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 1, host: 'rtb-private.adkernel.com'},
-      placementCode: 'ad-unit-2',
+      adUnitCode: 'ad-unit-2',
       sizes: [[728, 90]]
     }, bid_without_zone = {
       bidder: 'adkernel',
       bidId: 'Bid_W',
       params: {host: 'rtb-private.adkernel.com'},
-      placementCode: 'ad-unit-1',
+      adUnitCode: 'ad-unit-1',
       sizes: [[728, 90]]
     }, bid_without_host = {
       bidder: 'adkernel',
       bidId: 'Bid_W',
       params: {zoneId: 1},
-      placementCode: 'ad-unit-1',
+      adUnitCode: 'ad-unit-1',
       sizes: [[728, 90]]
     }, bid_with_wrong_zoneId = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 'wrong id', host: 'rtb.adkernel.com'},
-      placementCode: 'ad-unit-2',
+      adUnitCode: 'ad-unit-2',
       sizes: [[728, 90]]
     }, bid_video = {
       bidder: 'adkernel',
@@ -51,7 +51,7 @@ describe('Adkernel adapter', () => {
           mimes: ['video/mp4', 'video/webm', 'video/x-flv']
         }
       },
-      placementCode: 'ad-unit-1'
+      adUnitCode: 'ad-unit-1'
     };
 
   const bidResponse1 = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change
Fixes for adkernel, adkernelAdn and analytics adkernelAdn adapters:

- Use adUnitCode instead of obsolete placementCode
- Complete mediaType config support
- Single banner size notation support
- Fixed empty user-sync response parsing

- [x] official adapter submission