### PR TITLE
Serverbid Legacy Bid Adapter: Added archon alias

### DIFF
--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -21,6 +21,9 @@ const CONFIG = {
   },
   'automatad': {
     'BASE_URI': 'https://e.serverbid.com/api/v2'
+  },
+  'archon': {
+    'BASE_URI': 'https://e.serverbid.com/api/v2'
   }
 };
 
@@ -29,7 +32,7 @@ let bidder = 'serverbid';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['connectad', 'onefiftytwo', 'insticator', 'adsparc', 'automatad'],
+  aliases: ['connectad', 'onefiftytwo', 'insticator', 'adsparc', 'automatad', 'archon'],
 
   /**
    * Determines whether or not the given bid request is valid.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
Adds the `archon` bidder alias to the Serverbid Bid Adapter, for the legacy branch.