### PR TITLE
Legacy Rubicon Adapter add mediatypes support

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
 
     if (spec.hasVideoMediaType(bid)) {
       // support instream only
-      if (utils.deepAccess(bid, `mediaTypes.${VIDEO}`) && utils.deepAccess(bid, `mediaTypes.${VIDEO}.context`) !== 'instream' || typeof params.video !== 'object' || !params.video.size_id) {
+      if ((utils.deepAccess(bid, `mediaTypes.${VIDEO}`) && utils.deepAccess(bid, `mediaTypes.${VIDEO}.context`) !== 'instream') || typeof params.video !== 'object' || !params.video.size_id) {
         return false;
       }
     }
@@ -114,7 +114,7 @@ export const spec = {
     return bidRequests.map(bidRequest => {
       bidRequest.startTime = new Date().getTime();
 
-      if (bidRequest.mediaType === 'video') {
+      if (spec.hasVideoMediaType(bidRequest)) {
         let params = bidRequest.params;
         let size = parseSizes(bidRequest);
         let page_rf = !params.referrer ? utils.getTopWindowUrl() : params.referrer;
@@ -289,7 +289,7 @@ export const spec = {
         bid.mediaType = ad.creative_type;
       }
 
-      if (bidRequest.mediaType === 'video') {
+      if (ad.creative_type === VIDEO) {
         bid.width = bidRequest.params.video.playerWidth;
         bid.height = bidRequest.params.video.playerHeight;
         bid.vastUrl = ad.creative_depot_url;
@@ -362,10 +362,9 @@ function _renderCreative(script, impId) {
 
 function parseSizes(bid) {
   let params = bid.params;
-
   if (spec.hasVideoMediaType(bid)) {
     let size = [];
-    if (typeof params.video === 'object' && params.video.playerWidth && params.video.playerHeight)
+    if (typeof params.video === 'object' && params.video.playerWidth && params.video.playerHeight) {
       size = [
         params.video.playerWidth,
         params.video.playerHeight

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -16,6 +16,31 @@ describe('the rubicon adapter', () => {
 
   function createVideoBidderRequest() {
     let bid = bidderRequest.bids[0];
+
+    bid.mediaTypes = {
+      video: {
+        context: 'instream'
+      }
+    };
+
+    bid.params.video = {
+      'language': 'en',
+      'p_aso.video.ext.skip': true,
+      'p_aso.video.ext.skipdelay': 15,
+      'playerHeight': 320,
+      'playerWidth': 640,
+      'size_id': 201,
+      'aeParams': {
+        'p_aso.video.ext.skip': '1',
+        'p_aso.video.ext.skipdelay': '15'
+      }
+    };
+  }
+
+  function createLegacyVideoBidderRequest() {
+    let bid = bidderRequest.bids[0];
+
+    // Legacy property (Prebid <1.0)
     bid.mediaType = 'video';
     bid.params.video = {
       'language': 'en',
@@ -33,11 +58,61 @@ describe('the rubicon adapter', () => {
 
   function createVideoBidderRequestNoVideo() {
     let bid = bidderRequest.bids[0];
+    bid.mediaTypes = {
+      video: {
+        context: 'instream'
+      },
+    };
+    bid.params.video = '';
+  }
+
+  function createLegacyVideoBidderRequestNoVideo() {
+    let bid = bidderRequest.bids[0];
     bid.mediaType = 'video';
     bid.params.video = '';
   }
 
+  function createVideoBidderRequestOutstream() {
+    let bid = bidderRequest.bids[0];
+    bid.mediaTypes = {
+      video: {
+        context: 'outstream'
+      },
+    };
+    bid.params.video = {
+      'language': 'en',
+      'p_aso.video.ext.skip': true,
+      'p_aso.video.ext.skipdelay': 15,
+      'playerHeight': 320,
+      'playerWidth': 640,
+      'size_id': 201,
+      'aeParams': {
+        'p_aso.video.ext.skip': '1',
+        'p_aso.video.ext.skipdelay': '15'
+      }
+    };
+  }
+
   function createVideoBidderRequestNoPlayer() {
+    let bid = bidderRequest.bids[0];
+    bid.mediaTypes = {
+      video: {
+        context: 'instream'
+      },
+    };
+    bid.params.video = {
+      'language': 'en',
+      'p_aso.video.ext.skip': true,
+      'p_aso.video.ext.skipdelay': 15,
+      'size_id': 201,
+      'aeParams': {
+        'p_aso.video.ext.skip': '1',
+        'p_aso.video.ext.skipdelay': '15'
+      }
+    };
+  }
+
+  function createLegacyVideoBidderRequestNoPlayer() {
     let bid = bidderRequest.bids[0];
     bid.mediaType = 'video';
     bid.params.video = {
@@ -433,12 +508,72 @@ describe('the rubicon adapter', () => {
       });
 
       describe('for video requests', () => {
+        it('should make a well-formed video request with legacy mediaType config', () => {
+          createLegacyVideoBidderRequest();
+
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
+
+          let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+          let post = request.data;
+
+          let url = request.url;
+
+          expect(url).to.equal('//fastlane-adv.rubiconproject.com/v1/auction/video');
+
+          expect(post).to.have.property('page_url').that.is.a('string');
+          expect(post.resolution).to.match(/\d+x\d+/);
+          expect(post.account_id).to.equal('14062');
+          expect(post.integration).to.equal(INTEGRATION);
+          expect(post).to.have.property('timeout').that.is.a('number');
+          expect(post.timeout < 5000).to.equal(true);
+          expect(post.stash_creatives).to.equal(true);
+
+          expect(post).to.have.property('ae_pass_through_parameters');
+          expect(post.ae_pass_through_parameters)
+            .to.have.property('p_aso.video.ext.skip')
+            .that.equals('1');
+          expect(post.ae_pass_through_parameters)
+            .to.have.property('p_aso.video.ext.skipdelay')
+            .that.equals('15');
+
+          expect(post).to.have.property('slots')
+            .with.length.of(1);
+
+          let slot = post.slots[0];
+
+          expect(slot.site_id).to.equal('70608');
+          expect(slot.zone_id).to.equal('335918');
+          expect(slot.position).to.equal('atf');
+          expect(slot.floor).to.equal(0.01);
+          expect(slot.element_id).to.equal(bidderRequest.bids[0].adUnitCode);
+          expect(slot.name).to.equal(bidderRequest.bids[0].adUnitCode);
+          expect(slot.language).to.equal('en');
+          expect(slot.width).to.equal(640);
+          expect(slot.height).to.equal(320);
+          expect(slot.size_id).to.equal(201);
+
+          expect(slot).to.have.property('inventory').that.is.an('object');
+          expect(slot.inventory).to.have.property('rating').that.equals('5-star');
+          expect(slot.inventory).to.have.property('prodtype').that.equals('tech');
+
+          expect(slot).to.have.property('keywords')
+            .that.is.an('array')
+            .of.length(3)
+            .that.deep.equals(['a', 'b', 'c']);
+
+          expect(slot).to.have.property('visitor').that.is.an('object');
+          expect(slot.visitor).to.have.property('ucat').that.equals('new');
+          expect(slot.visitor).to.have.property('lastsearch').that.equals('iphone');
+        });
+
         it('should make a well-formed video request', () => {
           createVideoBidderRequest();
 
-          sandbox.stub(Date, 'now', () =>
-            bidderRequest.auctionStart + 100
-          );
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
 
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let post = request.data;
@@ -496,9 +631,9 @@ describe('the rubicon adapter', () => {
         it('should allow a floor price override', () => {
           createVideoBidderRequest();
 
-          sandbox.stub(Date, 'now', () =>
-            bidderRequest.auctionStart + 100
-          );
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
 
           var floorBidderRequest = clone(bidderRequest);
 
@@ -513,32 +648,117 @@ describe('the rubicon adapter', () => {
           expect(floor).to.equal(3.25);
         });
 
-        it('should not validate bid request when no video object is passed in', () => {
+        it('should not validate bid request when a invalid video object is passed in', () => {
           createVideoBidderRequestNoVideo();
-          sandbox.stub(Date, 'now', () =>
-            bidderRequest.auctionStart + 100
-          );
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
 
-          var floorBidderRequest = clone(bidderRequest);
+          const bidRequestCopy = clone(bidderRequest.bids[0]);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
-          let result = spec.isBidRequestValid(floorBidderRequest.bids[0]);
+          bidRequestCopy.params.video = {};
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
-          expect(result).to.equal(false);
+          bidRequestCopy.params.video = undefined;
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+
+          bidRequestCopy.params.video = 123;
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+
+          bidRequestCopy.params.video = { size_id: '' };
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+
+          delete bidRequestCopy.params.video;
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+        });
+
+        it('should not validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
+          createLegacyVideoBidderRequestNoVideo();
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
+
+          const bidderRequestCopy = clone(bidderRequest);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+
+          bidderRequestCopy.bids[0].params.video = {};
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+
+          bidderRequestCopy.bids[0].params.video = undefined;
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+
+          bidderRequestCopy.bids[0].params.video = NaN;
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+
+          delete bidderRequestCopy.bids[0].params.video;
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+        });
+
+        it('should not validate bid request when video is outstream', () => {
+          createVideoBidderRequestOutstream();
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
+
+          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
         });
 
         it('should get size from bid.sizes too', () => {
           createVideoBidderRequestNoPlayer();
-          sandbox.stub(Date, 'now', () =>
-            bidderRequest.auctionStart + 100
-          );
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
 
-          var floorBidderRequest = clone(bidderRequest);
+          const bidRequestCopy = clone(bidderRequest);
 
-          let [request] = spec.buildRequests(floorBidderRequest.bids, floorBidderRequest);
-          let post = request.data;
+          let [request] = spec.buildRequests(bidRequestCopy.bids, bidRequestCopy);
 
-          expect(post.slots[0].width).to.equal(300);
-          expect(post.slots[0].height).to.equal(250);
+          expect(request.data.slots[0].width).to.equal(300);
+          expect(request.data.slots[0].height).to.equal(250);
+        });
+
+        it('should get size from bid.sizes too with legacy config mediaType', () => {
+          createLegacyVideoBidderRequestNoPlayer();
+          sandbox.stub(Date, 'now', () => {
+            return bidderRequest.auctionStart + 100
+          });
+
+          const bidRequestCopy = clone(bidderRequest);
+
+          let [request] = spec.buildRequests(bidRequestCopy.bids, bidRequestCopy);
+
+          expect(request.data.slots[0].width).to.equal(300);
+          expect(request.data.slots[0].height).to.equal(250);
+        });
+      });
+
+      describe('hasVideoMediaType', () => {
+        it('should return true if mediaType is true', () => {
+          createVideoBidderRequest();
+          const legacyVideoTypeBidRequest = spec.hasVideoMediaType(bidderRequest.bids[0]);
+          expect(legacyVideoTypeBidRequest).is.equal(true);
+        });
+
+        it('should return false if bidRequest.mediaType is not equal to video', () => {
+          expect(spec.hasVideoMediaType({
+            mediaType: 'banner'
+          })).is.equal(false);
+        });
+
+        it('should return false if bidRequest.mediaType is not defined', () => {
+          expect(spec.hasVideoMediaType({})).is.equal(false);
+        });
+
+        it('should return true if bidRequest.mediaTypes.video object exists', () => {
+          expect(spec.hasVideoMediaType({
+            mediaTypes: {
+              video: {
+                context: 'outstream',
+                playerSize: [300, 250]
+              }
+            }
+          })).is.equal(true);
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Other

## Description of change
Update to Rubicon Adapter for mediaTypes support

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'rubicon',
  mediaTypes: {
    video: {
      context: 'instream',
    }
  }
  params: {
    accountId: 1001,
    siteId: 113932,
    zoneId: 535510,
    video: {
      language: 'en',
      'p_aso.video.ext.skip': true,
      'p_aso.video.ext.skipdelay': 15,
      playerHeight: 320,
      playerWidth: 640,
      size_id: 201,
      aeParams: {
        'p_aso.video.ext.skip': '1',
        'p_aso.video.ext.skipdelay': '15'
      }
    }
  }
}
```