### PR TITLE
if cache markup is not enabled, set it to the default value 0

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -288,7 +288,7 @@ const LEGACY_PROTOCOL = {
       max_bids: _s2sConfig.maxBids,
       timeout_millis: _s2sConfig.timeout,
       secure: _s2sConfig.secure,
-      cache_markup: _s2sConfig.cacheMarkup == 1 || _s2sConfig.cacheMarkup == 2 ? _s2sConfig.cacheMarkup : 0,
+      cache_markup: _s2sConfig.cacheMarkup === 1 || _s2sConfig.cacheMarkup === 2 ? _s2sConfig.cacheMarkup : 0,
       url: utils.getTopWindowUrl(),
       prebid_version: '$prebid.version$',
       ad_units: adUnits,

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -288,7 +288,7 @@ const LEGACY_PROTOCOL = {
       max_bids: _s2sConfig.maxBids,
       timeout_millis: _s2sConfig.timeout,
       secure: _s2sConfig.secure,
-      cache_markup: _s2sConfig.cacheMarkup,
+      cache_markup: _s2sConfig.cacheMarkup == 1 || _s2sConfig.cacheMarkup == 2 ? _s2sConfig.cacheMarkup : 0,
       url: utils.getTopWindowUrl(),
       prebid_version: '$prebid.version$',
       ad_units: adUnits,

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -12,6 +12,7 @@ let CONFIG = {
   enabled: true,
   bidders: ['appnexus'],
   timeout: 1000,
+  cacheMarkup: 2,
   endpoint: 'https://prebid.adnxs.com/pbs/v1/auction'
 };
 
@@ -357,8 +358,19 @@ describe('S2S Adapter', () => {
       config.setConfig({s2sConfig: CONFIG});
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       const requestBid = JSON.parse(requests[0].requestBody);
+      expect(requestBid).to.have.property('cache_markup', 2);
       expect(requestBid.ad_units[0].bids[0].params.placementId).to.exist.and.to.be.a('number');
       expect(requestBid.ad_units[0].bids[0].params.member).to.exist.and.to.be.a('string');
+    });
+
+    it('sets invalid cacheMarkup value to 0', () => {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        cacheMarkup: 999
+      });
+      config.setConfig({s2sConfig: s2sConfig});
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      const requestBid = JSON.parse(requests[0].requestBody);
+      expect(requestBid).to.have.property('cache_markup', 0);
     });
 
     it('adds digitrust id is present and user is not optout', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Parse cacheMarkup into the expected values (1 for Mobile App, 2 for Web), and if it is unsuccessful, defaults to 0