### PR TITLE
Changing default currency file to https

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -5,7 +5,7 @@ import * as utils from 'src/utils';
 import { config } from 'src/config';
 import { hooks } from 'src/hook.js';
 
-const DEFAULT_CURRENCY_RATE_URL = 'http://currency.prebid.org/latest.json';
+const DEFAULT_CURRENCY_RATE_URL = 'https://currency.prebid.org/latest.json';
 const CURRENCY_RATE_PRECISION = 4;
 
 var bidResponseQueue = [];


### PR DESCRIPTION
## Type of change
- [ X ] Other

## Description of change
Got a request to make the currency file be able to detect whether it's being called from an HTTP or HTTPS context instead of forcing pubs to define the HTTPS url.

I propose simplifying this request and just using HTTPS all the time rather than using protocol-neutral or sniffing for protocol.

The drawback would be the extra TLS handshake for HTTP pages. If that's a concern, we can fall back to one of the other approaches.
