### PR TITLE
Fixes #2291 - user cust_params data lost with url option for dfpAdServerVideo module

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -70,7 +70,7 @@ export default function buildDfpVideoUrl(options) {
   if (options.url) {
     // when both `url` and `params` are given, parsed url will be overwriten
     // with any matching param components
-    urlComponents = parse(options.url);
+    urlComponents = parse(options.url, {noDecodeWholeURL: true});
 
     if (isEmpty(options.params)) {
       return buildUrlFromAdserverUrlComponents(urlComponents, bid);
@@ -126,7 +126,8 @@ function buildUrlFromAdserverUrlComponents(components, bid) {
   const customParams = Object.assign({},
     adserverTargeting,
   );
-  components.search.cust_params = encodeURIComponent(formatQS(customParams));
+  const encodedCustomParams = encodeURIComponent(formatQS(customParams));
+  components.search.cust_params = (components.search.cust_params) ? components.search.cust_params + '%26' + encodedCustomParams : encodedCustomParams;
 
   return buildUrl(components);
 }

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -130,6 +130,26 @@ describe('The DFP video support module', () => {
     expect(customParams).to.have.property('my_targeting', 'foo');
   });
 
+  it('should merge the user-provided cust-params with the default ones when using url object', () => {
+    const bidCopy = Object.assign({ }, bid);
+    bidCopy.adserverTargeting = {
+      hb_adid: 'ad_id',
+    };
+
+    const url = parse(buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bidCopy,
+      url: 'https://video.adserver.example/ads?sz=640x480&iu=/123/aduniturl&impl=s&cust_params=section%3dblog%26mykey%3dmyvalue'
+    }));
+
+    const queryObject = parseQS(url.query);
+    const customParams = parseQS('?' + decodeURIComponent(queryObject.cust_params));
+
+    expect(customParams).to.have.property('hb_adid', 'ad_id');
+    expect(customParams).to.have.property('section', 'blog');
+    expect(customParams).to.have.property('mykey', 'myvalue');
+  });
+
   it('should not overwrite an existing description_url for object input and cache disabled', () => {
     const bidCopy = Object.assign({}, bid);
     bidCopy.vastUrl = 'vastUrl.example';


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When user was attempting to pass their own `cust_params` data in a dfp video URL for the `dfpAdServerVideo` module, the module was dropping the original data and only setting the module's own data.

This fix preserves the original data and merges it with the module's data to make one unified encoded string for the `cust_params` field.  

Note - the `params` route for the module was handling the merge of the user's `cust_params` and the module's data fine; this issue only applied to the `url` route for the module.


## Other information
fix for issue #2291 
