### PR TITLE
Smart: User sync

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -87,6 +87,24 @@ export const spec = {
       console.log('Error while parsing smart server response');
     }
     return bidResponses;
+  },
+  /**
+   * User syncs.
+   *
+   * @param {*} syncOptions Publisher prebid configuration.
+   * @param {*} serverResponses A successful response from the server.
+   * @return {Syncs[]} An array of syncs that should be executed.
+   */
+  getUserSyncs: function (syncOptions, serverResponses) {
+    const syncs = []
+    var serverResponses
+    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+      syncs.push({
+        type: 'iframe',
+        url: serverResponses[0].body.cSyncUrl
+      });
+    }
+    return syncs;
   }
 }
 registerBidder(spec);

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -84,7 +84,7 @@ export const spec = {
         bidResponses.push(bidResponse);
       }
     } catch (error) {
-      console.log('Error while parsing smart server response');
+      utils.logError('Error while parsing smart server response', error);
     }
     return bidResponses;
   },
@@ -97,7 +97,6 @@ export const spec = {
    */
   getUserSyncs: function (syncOptions, serverResponses) {
     const syncs = []
-    var serverResponses
     if (syncOptions.iframeEnabled && serverResponses.length > 0) {
       syncs.push({
         type: 'iframe',

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -107,6 +107,8 @@ describe('Smart bid adapter tests', () => {
     expect(bid.ttl).to.equal(300);
     expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
     expect(bid.referrer).to.equal(utils.getTopWindowUrl());
+
+    expect(function() { spec.interpretResponse(BID_RESPONSE, {data : 'invalid Json'}) }).to.not.throw();
   });
 
   it('Verifies bidder code', () => {

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -5,9 +5,6 @@ import {
   spec
 } from 'modules/smartadserverBidAdapter';
 import {
-  getTopWindowLocation
-} from 'src/utils';
-import {
   newBidder
 } from 'src/adapters/bidderFactory';
 import {
@@ -15,7 +12,7 @@ import {
 } from 'src/config';
 import * as utils from 'src/utils';
 
-describe('Smart ad server bid adapter tests', () => {
+describe('Smart bid adapter tests', () => {
   var DEFAULT_PARAMS = [{
     adUnitCode: 'sas_42',
     bidId: 'abcd1234',
@@ -63,7 +60,8 @@ describe('Smart ad server bid adapter tests', () => {
       isNetCpm: true,
       ttl: 300,
       adUrl: 'http://awesome.fake.url',
-      ad: '< --- awesome script --- >'
+      ad: '< --- awesome script --- >',
+      cSyncUrl: 'http://awesome.fake.csync.url'
     }
   };
 
@@ -151,7 +149,16 @@ describe('Smart ad server bid adapter tests', () => {
     })).to.equal(false);
   });
 
-  it('Verifies sync options', () => {
-    expect(spec.getUserSyncs).to.be.undefined;
+  it('Verifies user sync', () => {
+    var syncs = spec.getUserSyncs({iframeEnabled: true}, [BID_RESPONSE]);
+    expect(syncs).to.have.lengthOf(1);
+    expect(syncs[0].type).to.equal('iframe');
+    expect(syncs[0].url).to.equal('http://awesome.fake.csync.url');
+
+    syncs = spec.getUserSyncs({iframeEnabled: false}, [BID_RESPONSE]);
+    expect(syncs).to.have.lengthOf(0);
+
+    syncs = spec.getUserSyncs({iframeEnabled: true}, []);
+    expect(syncs).to.have.lengthOf(0);
   });
 });

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -108,7 +108,7 @@ describe('Smart bid adapter tests', () => {
     expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
     expect(bid.referrer).to.equal(utils.getTopWindowUrl());
 
-    expect(function() { spec.interpretResponse(BID_RESPONSE, {data : 'invalid Json'}) }).to.not.throw();
+    expect(function() { spec.interpretResponse(BID_RESPONSE, {data: 'invalid Json'}) }).to.not.throw();
   });
 
   it('Verifies bidder code', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR includes an implementation of the user synchronization feature for Smart's Prebid adapter. Smart is only supporting an IFRAME user synchronization.

Please use the following test parameters:
```
          {
            code: 'div-gpt-ad-1460505748561-0',
            sizes: [[300, 250]],  // a display size
            bids: [{
              bidder: "smart",
              params: {
                domain: 'http://ww251.smartadserver.com',
                siteId: 207435,
                pageId: 896536,
                formatId: 62913
              }
            }]
          }
```

and configuration:

```
          pbjs.setConfig({
            userSync: {
                iframeEnabled: true
          }});
```

As a result Smart's adapter should call the following user synchronization mechanism: _csync.smartadserver.com/rtb/csync/CookieSyncV.html_

This PR also includes a minor change in error logging.