### PR TITLE
Fixes #2276 - video.playerSize and Size Mapping not working together

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -240,6 +240,11 @@ exports.checkBidRequestSizes = (adUnits) => {
       if (video.playerSize) {
         if (Array.isArray(video.playerSize) && video.playerSize.length === 1 && video.playerSize.every(isArrayOfNums)) {
           adUnit.sizes = video.playerSize;
+        } else if (isArrayOfNums(video.playerSize)) {
+          let newPlayerSize = [];
+          newPlayerSize.push(video.playerSize);
+          utils.logInfo(`Transforming video.playerSize from ${video.playerSize} to ${newPlayerSize} so it's in the proper format.`);
+          adUnit.sizes = video.playerSize = newPlayerSize;
         } else {
           utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.');
           delete adUnit.mediaTypes.video.playerSize;

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -215,7 +215,12 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
 };
 
 exports.checkBidRequestSizes = (adUnits) => {
-  Array.prototype.forEach.call(adUnits, adUnit => {
+  function isArrayOfNums(val) {
+    return Array.isArray(val) && val.length === 2 && utils.isInteger(val[0]) && utils.isInteger(val[1]);
+  }
+
+  // Array.prototype.forEach.call(adUnits, adUnit => {
+  adUnits.forEach((adUnit) => {
     if (adUnit.sizes) {
       utils.logWarn('Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).');
     }
@@ -234,10 +239,10 @@ exports.checkBidRequestSizes = (adUnits) => {
     if (mediaTypes && mediaTypes.video) {
       const video = mediaTypes.video;
       if (video.playerSize) {
-        if (Array.isArray(video.playerSize) && video.playerSize.length === 2 && utils.isInteger(video.playerSize[0]) && utils.isInteger(video.playerSize[1])) {
+        if (Array.isArray(video.playerSize) && video.playerSize.length === 1 && video.playerSize.every(isArrayOfNums)) {
           adUnit.sizes = video.playerSize;
         } else {
-          utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [640, 480]. Removing invalid mediaTypes.video.playerSize property from request.');
+          utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.');
           delete adUnit.mediaTypes.video.playerSize;
         }
       }

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -219,7 +219,6 @@ exports.checkBidRequestSizes = (adUnits) => {
     return Array.isArray(val) && val.length === 2 && utils.isInteger(val[0]) && utils.isInteger(val[1]);
   }
 
-  // Array.prototype.forEach.call(adUnits, adUnit => {
   adUnits.forEach((adUnit) => {
     if (adUnit.sizes) {
       utils.logWarn('Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).');

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -857,9 +857,14 @@ describe('adapterManager tests', () => {
 
   describe('isValidBidRequest', () => {
     describe('positive tests for validating bid request', () => {
-      beforeEach(() => {});
+      beforeEach(() => {
+        sinon.stub(utils, 'logInfo');
+      });
 
-      afterEach(() => {});
+      afterEach(() => {
+        utils.logInfo.restore();
+      });
+
       it('should maintain adUnit structure and adUnits.sizes is replaced', () => {
         let fullAdUnit = [{
           sizes: [[300, 250], [300, 600]],
@@ -929,6 +934,20 @@ describe('adapterManager tests', () => {
         result = checkBidRequestSizes(mixedAdUnit);
         expect(result[0].sizes).to.deep.equal([[400, 350]]);
         expect(result[0].mediaTypes.video).to.exist;
+
+        let altVideoPlayerSize = [{
+          sizes: [[600, 600]],
+          mediaTypes: {
+            video: {
+              playerSize: [640, 480]
+            }
+          }
+        }];
+        result = checkBidRequestSizes(altVideoPlayerSize);
+        expect(result[0].sizes).to.deep.equal([[640, 480]]);
+        expect(result[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
+        expect(result[0].mediaTypes.video).to.exist;
+        sinon.assert.calledOnce(utils.logInfo);
       });
     });
 
@@ -978,20 +997,6 @@ describe('adapterManager tests', () => {
           }
         }];
         result = checkBidRequestSizes(badVideo2);
-        expect(result[0].sizes).to.deep.equal([[600, 600]]);
-        expect(result[0].mediaTypes.video.playerSize).to.be.undefined;
-        expect(result[0].mediaTypes.video).to.exist;
-        sinon.assert.called(utils.logError);
-
-        let badVideo3 = [{
-          sizes: [[600, 600]],
-          mediaTypes: {
-            video: {
-              playerSize: [640, 480]
-            }
-          }
-        }];
-        result = checkBidRequestSizes(badVideo3);
         expect(result[0].sizes).to.deep.equal([[600, 600]]);
         expect(result[0].mediaTypes.video.playerSize).to.be.undefined;
         expect(result[0].mediaTypes.video).to.exist;

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -860,7 +860,7 @@ describe('adapterManager tests', () => {
       beforeEach(() => {});
 
       afterEach(() => {});
-      it('should main adUnit structure and adUnits.sizes is replaced', () => {
+      it('should maintain adUnit structure and adUnits.sizes is replaced', () => {
         let fullAdUnit = [{
           sizes: [[300, 250], [300, 600]],
           mediaTypes: {
@@ -868,7 +868,7 @@ describe('adapterManager tests', () => {
               sizes: [[300, 250]]
             },
             video: {
-              playerSize: [640, 480]
+              playerSize: [[640, 480]]
             },
             native: {
               image: {
@@ -882,8 +882,8 @@ describe('adapterManager tests', () => {
           }
         }];
         let result = checkBidRequestSizes(fullAdUnit);
-        expect(result[0].sizes).to.deep.equal([640, 480]);
-        expect(result[0].mediaTypes.video.playerSize).to.deep.equal([640, 480]);
+        expect(result[0].sizes).to.deep.equal([[640, 480]]);
+        expect(result[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
         expect(result[0].mediaTypes.native.image.sizes).to.deep.equal([150, 150]);
         expect(result[0].mediaTypes.native.icon.sizes).to.deep.equal([75, 75]);
         expect(result[0].mediaTypes.native.image.aspect_ratios).to.deep.equal([140, 140]);
@@ -916,7 +916,7 @@ describe('adapterManager tests', () => {
           mediaTypes: {
             video: {
               context: 'outstream',
-              playerSize: [400, 350]
+              playerSize: [[400, 350]]
             },
             native: {
               image: {
@@ -927,7 +927,7 @@ describe('adapterManager tests', () => {
           }
         }];
         result = checkBidRequestSizes(mixedAdUnit);
-        expect(result[0].sizes).to.deep.equal([400, 350]);
+        expect(result[0].sizes).to.deep.equal([[400, 350]]);
         expect(result[0].mediaTypes.video).to.exist;
       });
     });
@@ -959,7 +959,7 @@ describe('adapterManager tests', () => {
           sizes: [[600, 600]],
           mediaTypes: {
             video: {
-              playerSize: '600x400'
+              playerSize: ['600x400']
             }
           }
         }];
@@ -973,7 +973,7 @@ describe('adapterManager tests', () => {
           sizes: [[600, 600]],
           mediaTypes: {
             video: {
-              playerSize: ['300', '200']
+              playerSize: [['300', '200']]
             }
           }
         }];
@@ -987,7 +987,7 @@ describe('adapterManager tests', () => {
           sizes: [[600, 600]],
           mediaTypes: {
             video: {
-              playerSize: [[640, 480]]
+              playerSize: [640, 480]
             }
           }
         }];


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently, using Size Mapping functionality with a video adUnit that specifies `mediaTypes.video.playerSize` would not pass the `sizeMapping.js` validation checks causing the ad unit to not be included in the `bidRequest` object.  

As a quick recap, the validation check in the sizeMapping (located here https://github.com/prebid/Prebid.js/blob/master/src/sizeMapping.js#L41) does the following:
- uses a list of arrayed sizes (ie `[[300, 250], [300, 600]]`) as a list of acceptable sizes (this is derived from the matching mediaQuery params).
- It reads the adUnit's size params and cross checks that array against the mediaQuery list of sizes
- if it finds a match, the size passes the filter
- otherwise if no sizes are matched, the bid doesn't get added to the request

Because the filtering operates on a list of arrayed sizes, the adUnits.sizes has to use the same format.  Otherwise, the filter would treat the single array of sizes ie `[300, 250]` as two integers and the size wouldn't pass the check.

To meet this requirement, I changed the `adUnits.mediaTypes.video.playerSize` field to accept either format (ie `[[640, 480]]` or `[640, 480]`) but it will automatically format the latter syntax into the former.

A note - while the `playerSize` field will expect an array of an array, there should only 1 set of sizes in the field.  The changes in the `checkBidRequestSizes()` function check for this exact type of setup.


## Other information
fixes issue reported in #2276 