### PR TITLE
Update stalebot labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,8 +7,9 @@ exemptLabels:
   - pinned
   - security
   - bug
+  - feature
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
## Type of change
- Maintenance / GitHub

## Description of change
- Adds `feature` to exempt labels
- Changes stale label from `wontfix` to `stale`