### PR TITLE
fix issue #2315 sizeMapping not working with s2s requests

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -275,6 +275,8 @@ const LEGACY_PROTOCOL = {
   buildRequest(s2sBidRequest, adUnits) {
     // pbs expects an ad_unit.video attribute if the imp is video
     adUnits.forEach(adUnit => {
+      adUnit.sizes = adUnit.sizesS2S;
+      delete adUnit.sizesS2S;
       const videoMediaType = utils.deepAccess(adUnit, 'mediaTypes.video');
       if (videoMediaType) {
         adUnit.video = Object.assign({}, videoMediaType);

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -113,7 +113,7 @@ function getAdUnitCopyForPrebidServer(adUnits) {
   let adUnitsCopy = utils.deepClone(adUnits);
 
   adUnitsCopy.forEach((adUnit) => {
-    adUnit.sizes = transformHeightWidth(adUnit);
+    adUnit.sizesS2S = transformHeightWidth(adUnit);
 
     // filter out client side bids
     adUnit.bids = adUnit.bids.filter((bid) => {
@@ -281,6 +281,17 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
     const s2sAdapter = _bidderRegistry[_s2sConfig.adapter];
     let tid = serverBidRequests[0].tid;
     let adUnitsS2SCopy = serverBidRequests[0].adUnitsS2SCopy;
+    adUnitsS2SCopy.forEach((adUnitCopy) => {
+      let validBids = adUnitCopy.bids.filter((bid) => {
+        return serverBidRequests.find(request => {
+          return request.bidderCode === bid.bidder &&
+          request.bids.find((reqBid) => reqBid.adUnitCode === adUnitCopy.code);
+        });
+      });
+      adUnitCopy.bids = validBids;
+    });
+
+    adUnitsS2SCopy = adUnitsS2SCopy.filter(adUnitCopy => adUnitCopy.bids.length > 0);
 
     if (s2sAdapter) {
       let s2sBidRequest = {tid, 'ad_units': adUnitsS2SCopy};


### PR DESCRIPTION
## Type of change
- [x] Bugfix


## Description of change
This PR addresses the issue reported in #2315 and a subsequent issue found during testing.  

The issue with the sizeMapping functionality was due to the `adUnit.sizes` being transformed from a list of integer sizes (ie `[[300, 250], [300, 600]]` to a list of objects (ie `[{w: 300, h: 250}, {w: 300, h: 600}]`).  The sizeMapping code expected a list of integer sizes, not the object format sizes - so it never passed the filtering check properly.

The fix places the remapped object sizes to a different variable (`adUnit.sizesS2S`) temporarily so the original sizes are kept in the right format for the sizeMapping check.  Later in the prebidServer adapter, the reassigned sizes are placed properly under the adUnit.sizes so it use the correct format for prebid server.

During testing for this fix, a subsequent issue was observed and fixed.  In this issue, a bidder that was rejected by the sizeMapping still had the opportunity to participate in the pbs auction and could win the bid.  This is due to the fact that the sizeMapping functionality filters out the invalid `adUnit` bidders and simply doesn't include them in the bids objects that are made in the request object.  The sizeMapping functionality doesn't directly edit/remove the invalid bidders from the `adUnits`.  This indirectly causes the issue, since the the actual request object made for the pbs request is built separately from the client-side request and it uses the `adUnits` unmodified object.

The fix for this issue is to introduce a filter that removes any bidders from the `adUnits` object if there is no corresponding `bid` in the bidder's client-side request for that `adUnit`.  It performs a two stage check, first against the `adUnit.code` with the `request.bid.adUnitCode` (in case the same bidder is in multiple adUnits) and second against the `adUnit.bid.bidder` with the `request.bidderCode`.  


## Other information
Fixes issue #2315 
