### PR TITLE
Fixes issue #2327 - getBidLandScapeTargeting not using adUnitCode argument

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -328,7 +328,11 @@ export function newTargeting(auctionManager) {
     });
     // populate targeting keys for the remaining bids
     return bids.map(bid => {
-      if (bid.adserverTargeting) {
+      if (
+        bid.adserverTargeting && adUnitCodes &&
+        ((utils.isArray(adUnitCodes) && adUnitCodes.includes(bid.adUnitCode)) ||
+        (typeof adUnitCodes === 'string' && bid.adUnitCode === adUnitCodes))
+      ) {
         return {
           [bid.adUnitCode]: getTargetingMap(bid, standardKeys.filter(
             key => typeof bid.adserverTargeting[key] !== 'undefined')

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -330,7 +330,7 @@ export function newTargeting(auctionManager) {
     return bids.map(bid => {
       if (
         bid.adserverTargeting && adUnitCodes &&
-        ((utils.isArray(adUnitCodes) && adUnitCodes.includes(bid.adUnitCode)) ||
+        ((utils.isArray(adUnitCodes) && includes(adUnitCodes, bid.adUnitCode)) ||
         (typeof adUnitCodes === 'string' && bid.adUnitCode === adUnitCodes))
       ) {
         return {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -66,6 +66,36 @@ const bid2 = {
   'ttl': 300
 };
 
+const bid3 = {
+  'bidderCode': 'rubicon',
+  'width': '300',
+  'height': '600',
+  'statusMessage': 'Bid available',
+  'adId': '48747745',
+  'cpm': 0.75,
+  'ad': 'markup',
+  'ad_id': '3163950',
+  'sizeId': '15',
+  'requestTimestamp': 1454535718610,
+  'responseTimestamp': 1454535724863,
+  'timeToRespond': 123,
+  'pbLg': '0.75',
+  'pbMg': '0.75',
+  'pbHg': '0.75',
+  'adUnitCode': '/123456/header-bid-tag-1',
+  'bidder': 'rubicon',
+  'size': '300x600',
+  'adserverTargeting': {
+    'hb_bidder': 'rubicon',
+    'hb_adid': '48747745',
+    'hb_pb': '0.75',
+    'foobar': '300x600'
+  },
+  'netRevenue': true,
+  'currency': 'USD',
+  'ttl': 300
+};
+
 describe('targeting tests', () => {
   describe('getAllTargeting', () => {
     let amBidsReceivedStub;
@@ -75,7 +105,7 @@ describe('targeting tests', () => {
     beforeEach(() => {
       $$PREBID_GLOBAL$$._sendAllBids = false;
       amBidsReceivedStub = sinon.stub(auctionManager, 'getBidsReceived').callsFake(function() {
-        return [bid1, bid2];
+        return [bid1, bid2, bid3];
       });
       amGetAdUnitsStub = sinon.stub(auctionManager, 'getAdUnitCodes').callsFake(function() {
         return ['/123456/header-bid-tag-0'];
@@ -92,9 +122,14 @@ describe('targeting tests', () => {
     it('selects the top bid when _sendAllBids true', () => {
       config.setConfig({ enableSendAllBids: true });
       let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+
+      // we should only get the targeting data for the one requested adunit
+      expect(Object.keys(targeting).length).to.equal(1);
+
       let sendAllBidCpm = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf('hb_pb_') != -1)
       // we shouldn't get more than 1 key for hb_pb_${bidder}
       expect(sendAllBidCpm.length).to.equal(1);
+
       // expect the winning CPM to be equal to the sendAllBidCPM
       expect(targeting['/123456/header-bid-tag-0']['hb_pb_rubicon']).to.deep.equal(targeting['/123456/header-bid-tag-0']['hb_pb']);
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Previously the `getBidLandScapeTargeting` function accepted an `adUnitCodes` argument, but it was never directly used inside the actual function.  It's purpose was meant to provide the specific bids that match adUnitCode(s) (this param could be either a string or a list of strings).  

This fix introduces the proper logic to use this argument.  So now if a publisher wanted to apply the targeting data for a specific ad unit from their page code (as noted in the original issue), they could call (`pbjs.setTargetingForGPTAsync('div-gpt-ad-1438287399331-0');`) and it would only process that ad unit's data.

## Other information
Fixes issue #2327 
