### PR TITLE
change utils.js unit tests to fix browserstack errors

### DIFF
--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1,4 +1,5 @@
 import { getAdServerTargeting } from 'test/fixtures/fixtures';
+import { expect } from 'chai';
 
 var assert = require('assert');
 var utils = require('src/utils');
@@ -720,10 +721,10 @@ describe('Utils', function () {
       expect(topWindowLocation.href).to.equal('https://www.google.com/a/umich.edu/acs');
       expect(topWindowLocation.protocol).to.equal('https');
       expect(topWindowLocation.hostname).to.equal('www.google.com');
-      expect(topWindowLocation.port).to.equal(0);
+      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.hash).to.equal('');
       expect(topWindowLocation.search).to.equal('');
-      expect(topWindowLocation.host).to.equal('www.google.com');
+      expect(topWindowLocation.host).to.be.oneOf(['www.google.com', 'www.google.com:443']);
     });
 
     it('returns parsed referrer string if in iFrame but no ancestorOrigins', () => {
@@ -740,11 +741,11 @@ describe('Utils', function () {
       expect(topWindowLocation.href).to.equal('https://www.example.com/');
       expect(topWindowLocation.protocol).to.equal('https');
       expect(topWindowLocation.hostname).to.equal('www.example.com');
-      expect(topWindowLocation.port).to.equal(0);
+      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.pathname).to.equal('/');
       expect(topWindowLocation.hash).to.equal('');
       expect(topWindowLocation.search).to.equal('');
-      expect(topWindowLocation.host).to.equal('www.example.com');
+      expect(topWindowLocation.host).to.be.oneOf(['www.example.com', 'www.example.com:443']);
     });
   });
 });

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -721,9 +721,10 @@ describe('Utils', function () {
       expect(topWindowLocation.href).to.equal('https://www.google.com/a/umich.edu/acs');
       expect(topWindowLocation.protocol).to.equal('https');
       expect(topWindowLocation.hostname).to.equal('www.google.com');
-      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.hash).to.equal('');
       expect(topWindowLocation.search).to.equal('');
+      // note IE11 returns the default secure port, so we look for this alternate value as well in these tests
+      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.host).to.be.oneOf(['www.google.com', 'www.google.com:443']);
     });
 
@@ -741,10 +742,11 @@ describe('Utils', function () {
       expect(topWindowLocation.href).to.equal('https://www.example.com/');
       expect(topWindowLocation.protocol).to.equal('https');
       expect(topWindowLocation.hostname).to.equal('www.example.com');
-      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.pathname).to.equal('/');
       expect(topWindowLocation.hash).to.equal('');
       expect(topWindowLocation.search).to.equal('');
+      // note IE11 returns the default secure port, so we look for this alternate value as well in these tests
+      expect(topWindowLocation.port).to.be.oneOf([0, 443]);
       expect(topWindowLocation.host).to.be.oneOf(['www.example.com', 'www.example.com:443']);
     });
   });


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes
- [x] Other

## Description of change
This change fixes some issues we are seeing when running the browserstack tests.  In some browsers it seems the port value for these unit tests are either 0 or 443 (like IE and Chrome).  So we altered the unit tests to check for both.