### PR TITLE
33Across Adapter (legacy): Fixing bugs found during beta test

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -3,7 +3,7 @@ const utils = require('../src/utils');
 
 const BIDDER_CODE = '33across';
 const END_POINT = 'https://ssc.33across.com/api/v1/hb';
-const SYNC_ENDPOINT = 'https://de.tynt.com/deb/v2?m=xch';
+const SYNC_ENDPOINT = 'https://de.tynt.com/deb/v2?m=xch&rt=html';
 
 // All this assumes that only one bid is ever returned by ttx
 function _createBidResponse(response) {
@@ -15,7 +15,7 @@ function _createBidResponse(response) {
     height: response.seatbid[0].bid[0].h,
     ad: response.seatbid[0].bid[0].adm,
     ttl: response.seatbid[0].bid[0].ttl || 60,
-    creativeId: response.seatbid[0].bid[0].ext.rp.advid,
+    creativeId: response.seatbid[0].bid[0].crid,
     currency: response.cur,
     netRevenue: true
   }
@@ -45,10 +45,14 @@ function _createServerRequest(bidRequest) {
   // Go ahead send the bidId in request to 33exchange so it's kept track of in the bid response and
   // therefore in ad targetting process
   ttxRequest.id = bidRequest.bidId;
+  // Finally, set the openRTB 'test' param if this is to be a test bid
+  if (params.test === 1) {
+    ttxRequest.test = 1;
+  }
 
   const options = {
     contentType: 'application/json',
-    withCredentials: false
+    withCredentials: true
   };
 
   if (bidRequest.params.customHeaders) {

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -145,7 +145,7 @@ describe('33acrossBidAdapter:', function () {
         data: JSON.stringify(ttxRequest),
         options: {
           contentType: 'application/json',
-          withCredentials: false
+          withCredentials: true
         }
       }
       const builtServerRequests = buildRequests(this.bidRequests);
@@ -198,7 +198,7 @@ describe('33acrossBidAdapter:', function () {
         data: JSON.stringify(ttxRequest),
         options: {
           contentType: 'application/json',
-          withCredentials: false,
+          withCredentials: true,
           customHeaders: {
             foo: 'bar'
           }
@@ -227,14 +227,10 @@ describe('33acrossBidAdapter:', function () {
               bid: [{
                 id: '1',
                 adm: '<html><h3>I am an ad</h3></html>',
-                ext: {
-                  rp: {
-                    advid: 1
-                  }
-                },
                 h: 250,
                 w: 300,
-                price: 0.0938
+                price: 0.0938,
+                crid: '23455'
               }]
             }
           ]
@@ -248,7 +244,7 @@ describe('33acrossBidAdapter:', function () {
           height: 250,
           ad: '<html><h3>I am an ad</h3></html>',
           ttl: 60,
-          creativeId: 1,
+          creativeId: '23455',
           currency: 'USD',
           netRevenue: true
         }
@@ -281,26 +277,18 @@ describe('33acrossBidAdapter:', function () {
               bid: [{
                 id: '1',
                 adm: '<html><h3>I am an ad</h3></html>',
-                ext: {
-                  rp: {
-                    advid: 1
-                  }
-                },
                 h: 250,
                 w: 300,
-                price: 0.0940
+                price: 0.0940,
+                crid: 1
               },
               {
                 id: '2',
                 adm: '<html><h3>I am an ad</h3></html>',
-                ext: {
-                  rp: {
-                    advid: 2
-                  }
-                },
                 h: 250,
                 w: 300,
-                price: 0.0938
+                price: 0.0938,
+                crid: 2
               }
               ]
             },
@@ -308,14 +296,10 @@ describe('33acrossBidAdapter:', function () {
               bid: [{
                 id: '3',
                 adm: '<html><h3>I am an ad</h3></html>',
-                ext: {
-                  rp: {
-                    advid: 3
-                  }
-                },
                 h: 250,
                 w: 300,
-                price: 0.0938
+                price: 0.0938,
+                crid: 3
               }]
             }
           ]
@@ -361,14 +345,14 @@ describe('33acrossBidAdapter:', function () {
           params: {
             site: { id: 'id1' },
             productId: 'p1',
-            syncUrl: 'https://staging-de.tynt.com/deb/v2?m=xch'
+            syncUrl: 'https://foo.com/v2?m=xch'
           }
         },
         {
           params: {
             site: { id: 'id2' },
             productId: 'p1',
-            syncUrl: 'https://staging-de.tynt.com/deb/v2?m=xch'
+            syncUrl: 'https://foo.com/v2?m=xch'
           }
         }
       ];
@@ -376,22 +360,22 @@ describe('33acrossBidAdapter:', function () {
       this.syncs = [
         {
           type: 'iframe',
-          url: 'https://de.tynt.com/deb/v2?m=xch&id=id1'
+          url: 'https://de.tynt.com/deb/v2?m=xch&rt=html&id=id1'
         },
         {
           type: 'iframe',
-          url: 'https://de.tynt.com/deb/v2?m=xch&id=id2'
+          url: 'https://de.tynt.com/deb/v2?m=xch&rt=html&id=id2'
         },
       ];
 
       this.testSyncs = [
         {
           type: 'iframe',
-          url: 'https://staging-de.tynt.com/deb/v2?m=xch&id=id1'
+          url: 'https://foo.com/v2?m=xch&id=id1'
         },
         {
           type: 'iframe',
-          url: 'https://staging-de.tynt.com/deb/v2?m=xch&id=id2'
+          url: 'https://foo.com/v2?m=xch&id=id2'
         },
       ];
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- Infer creativeId from `crid` which is the correct source
- Send cookie withCredentials in order to userSync properly

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
aparna.hegde@33across.com

