### PR TITLE
Rubicon Adapter - Multiple media types bug fix

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -91,12 +91,12 @@ export const spec = {
 
     // Log warning if context is 'outstream', is not currently supported
     if (utils.deepAccess(bid, `mediaTypes.${VIDEO}.context`) === 'outstream') {
-      utils.logWarn('Warning: outstream video is not supported yet');
+      utils.logWarn('Warning: outstream video for Rubicon Client Adapter is not supported yet');
     }
 
     // Invalid bid, if mediaTypes contains both 'banner' and 'video'
     if (spec.hasVideoMediaType(bid) && typeof utils.deepAccess(bid, `mediaTypes.${BANNER}`) !== 'undefined') {
-      utils.logWarn('Warning: video and banner mediaTypes defined for bid; the banner definition is ignored');
+      utils.logWarn('Warning: instream video and banner requested for same ad unit, continuing with video instream request');
     }
 
     let parsedSizes = parseSizes(bid);

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1,7 +1,7 @@
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
-import {BANNER, VIDEO} from 'src/mediaTypes'
+import { BANNER, VIDEO } from 'src/mediaTypes';
 
 const INTEGRATION = 'pbjs_lite_v$prebid.version$';
 

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1,7 +1,7 @@
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
-import {BANNER, NATIVE, VIDEO} from 'src/mediaTypes'
+import {BANNER, VIDEO} from 'src/mediaTypes'
 
 const INTEGRATION = 'pbjs_lite_v$prebid.version$';
 
@@ -250,8 +250,8 @@ export const spec = {
    * @returns {boolean}
    */
   hasVideoMediaType: function(bidRequest) {
-    return (typeof utils.deepAccess(bidRequest, 'params.video.size_id') !== 'undefined'
-      && (bidRequest.mediaType === VIDEO || utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}.context`) === 'instream'));
+    return (typeof utils.deepAccess(bidRequest, 'params.video.size_id') !== 'undefined' &&
+      (bidRequest.mediaType === VIDEO || utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}.context`) === 'instream'));
   },
   /**
    * @param {*} responseObj

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -94,11 +94,17 @@ export const spec = {
       utils.logWarn('Warning: outstream video for Rubicon Client Adapter is not supported yet');
     }
 
-    // Invalid bid, if mediaTypes contains both 'banner' and 'video'
+    // Log warning if mediaTypes contains both 'banner' and 'video'
     if (spec.hasVideoMediaType(bid) && typeof utils.deepAccess(bid, `mediaTypes.${BANNER}`) !== 'undefined') {
       utils.logWarn('Warning: instream video and banner requested for same ad unit, continuing with video instream request');
     }
 
+    // Bid is invalid if legacy video is set but params video is missing size_id
+    if (bid.mediaType === 'video' && typeof utils.deepAccess(bid, 'params.video.size_id') === 'undefined') {
+      return false;
+    }
+
+    // Bid is invalid if mediaTypes video is invalid and a mediaTypes banner property is not defined
     if (bid.mediaTypes && !spec.hasVideoMediaType(bid) && typeof bid.mediaTypes.banner === 'undefined') {
       return false;
     }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -99,6 +99,10 @@ export const spec = {
       utils.logWarn('Warning: instream video and banner requested for same ad unit, continuing with video instream request');
     }
 
+    if (bid.mediaTypes && !spec.hasVideoMediaType(bid) && typeof bid.mediaTypes.banner === 'undefined') {
+      return false;
+    }
+
     let parsedSizes = parseSizes(bid);
     if (parsedSizes.length < 1) {
       return false;

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -712,7 +712,7 @@ describe('the rubicon adapter', () => {
           expect(floor).to.equal(3.25);
         });
 
-        it('should noy validate bid request when a invalid video object and no banner object is passed in', () => {
+        it('should not validate bid request when a invalid video object and no banner object is passed in', () => {
           createVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -712,29 +712,29 @@ describe('the rubicon adapter', () => {
           expect(floor).to.equal(3.25);
         });
 
-        it('should validate bid request when a invalid video object is passed in', () => {
+        it('should noy validate bid request when a invalid video object and no banner object is passed in', () => {
           createVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
           const bidRequestCopy = clone(bidderRequest.bids[0]);
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
           bidRequestCopy.params.video = {};
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
           bidRequestCopy.params.video = undefined;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
           bidRequestCopy.params.video = 123;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
-          bidRequestCopy.params.video = { size_id: '' };
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          bidRequestCopy.params.video = { size_id: undefined };
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
 
           delete bidRequestCopy.params.video;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
         });
 
         it('should validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
@@ -759,13 +759,13 @@ describe('the rubicon adapter', () => {
           expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
         });
 
-        it('should validate bid request when video is outstream', () => {
+        it('should not validate bid request when video is outstream', () => {
           createVideoBidderRequestOutstream();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
-          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
         });
 
         it('should get size from bid.sizes too', () => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -712,60 +712,60 @@ describe('the rubicon adapter', () => {
           expect(floor).to.equal(3.25);
         });
 
-        it('should not validate bid request when a invalid video object is passed in', () => {
+        it('should validate bid request when a invalid video object is passed in', () => {
           createVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
           const bidRequestCopy = clone(bidderRequest.bids[0]);
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
 
           bidRequestCopy.params.video = {};
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
 
           bidRequestCopy.params.video = undefined;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
 
           bidRequestCopy.params.video = 123;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
 
           bidRequestCopy.params.video = { size_id: '' };
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
 
           delete bidRequestCopy.params.video;
-          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
+          expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(true);
         });
 
-        it('should not validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
+        it('should validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
           createLegacyVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
           const bidderRequestCopy = clone(bidderRequest);
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
 
           bidderRequestCopy.bids[0].params.video = {};
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
 
           bidderRequestCopy.bids[0].params.video = undefined;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
 
           bidderRequestCopy.bids[0].params.video = NaN;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
 
           delete bidderRequestCopy.bids[0].params.video;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
         });
 
-        it('should not validate bid request when video is outstream', () => {
+        it('should validate bid request when video is outstream', () => {
           createVideoBidderRequestOutstream();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
-          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
+          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(true);
         });
 
         it('should get size from bid.sizes too', () => {
@@ -798,10 +798,20 @@ describe('the rubicon adapter', () => {
       });
 
       describe('hasVideoMediaType', () => {
-        it('should return true if mediaType is true', () => {
+        it('should return true if mediaType is video and size_id is set', () => {
           createVideoBidderRequest();
           const legacyVideoTypeBidRequest = spec.hasVideoMediaType(bidderRequest.bids[0]);
           expect(legacyVideoTypeBidRequest).is.equal(true);
+        });
+
+        it('should return false if mediaType is video and size_id is not defined', () => {
+          expect(spec.hasVideoMediaType({
+            bid:99,
+            mediaType: 'video',
+            params: {
+              video: {}
+            }
+          })).is.equal(false);
         });
 
         it('should return false if bidRequest.mediaType is not equal to video', () => {
@@ -814,15 +824,32 @@ describe('the rubicon adapter', () => {
           expect(spec.hasVideoMediaType({})).is.equal(false);
         });
 
-        it('should return true if bidRequest.mediaTypes.video object exists', () => {
+        it('should return true if bidRequest.mediaTypes.video.context is instream and size_id is defined', () => {
           expect(spec.hasVideoMediaType({
             mediaTypes: {
               video: {
-                context: 'outstream',
-                playerSize: [300, 250]
+                context: 'instream'
+              }
+            },
+            params: {
+              video: {
+                size_id: 7
               }
             }
           })).is.equal(true);
+        });
+
+        it('should return false if bidRequest.mediaTypes.video.context is instream but size_id is not defined', () => {
+          expect(spec.hasVideoMediaType({
+            mediaTypes: {
+              video: {
+                context: 'instream'
+              }
+            },
+            params: {
+              video: {}
+            }
+          })).is.equal(false);
         });
       });
     });

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -719,14 +719,14 @@ describe('the rubicon adapter', () => {
                 context: 'instream'
               },
               banner: {
-                sizes: [[300,250]]
+                sizes: [[300, 250]]
               }
             },
             params: {
               accountId: 1001,
               video: {}
             },
-            sizes: [[300,250]]
+            sizes: [[300, 250]]
           }
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -712,6 +712,28 @@ describe('the rubicon adapter', () => {
           expect(floor).to.equal(3.25);
         });
 
+        it('should validate bid request with invalid video if a mediaTypes banner property is defined', () => {
+          const bidRequest = {
+            mediaTypes: {
+              video: {
+                context: 'instream'
+              },
+              banner: {
+                sizes: [[300,250]]
+              }
+            },
+            params: {
+              accountId: 1001,
+              video: {}
+            },
+            sizes: [[300,250]]
+          }
+          sandbox.stub(Date, 'now').callsFake(() =>
+            bidderRequest.auctionStart + 100
+          );
+          expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+        });
+
         it('should not validate bid request when a invalid video object and no banner object is passed in', () => {
           createVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
@@ -737,26 +759,26 @@ describe('the rubicon adapter', () => {
           expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
         });
 
-        it('should validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
+        it('should not validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
           createLegacyVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
 
           const bidderRequestCopy = clone(bidderRequest);
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
 
           bidderRequestCopy.bids[0].params.video = {};
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
 
           bidderRequestCopy.bids[0].params.video = undefined;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
 
           bidderRequestCopy.bids[0].params.video = NaN;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
 
           delete bidderRequestCopy.bids[0].params.video;
-          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(true);
+          expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
         });
 
         it('should not validate bid request when video is outstream', () => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -806,7 +806,7 @@ describe('the rubicon adapter', () => {
 
         it('should return false if mediaType is video and size_id is not defined', () => {
           expect(spec.hasVideoMediaType({
-            bid:99,
+            bid: 99,
             mediaType: 'video',
             params: {
               video: {}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Rubicon Bid Adapter not handling multiple mediaTypes correctly

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    code: 'test_div_1',
    sizes: [[728, 90], [300, 250], [300, 600]],
    mediaTypes: {
    "video":
    {"context": "outstream"},
    "banner":
    {"sizes": [[728, 90], [300, 250], [300, 600], [160, 600]]},
    "native": {}},
    bids:
        [
            {
                "bidder": "rubicon",
                "params": {
                    "accountId": 1001,
                    "siteId": 113932,
                    "zoneId": 535510
                }
            },
            {
                "bidder": "appnexus",
                "params": {
                    "placementId": "10433394",
                    "video": {
                        "playback_method": [
                            "auto_play_sound_off"
                        ],
                        "skippable": true
                    }
                }
            }
        ]
}
```

## Other information
https://jira.rubiconproject.com/browse/HB-2441