### PR TITLE
Get GPT Size Mapped Slot Sizes

### DIFF
--- a/modules/express.js
+++ b/modules/express.js
@@ -75,7 +75,7 @@ $$PREBID_GLOBAL$$.express = function(adUnits = $$PREBID_GLOBAL$$.adUnits) {
 
         if (adUnit) {
           gptSlotCache[elemId] = gptSlot; // store by elementId
-          adUnit.sizes = adUnit.sizes || mapGptSlotSizes(gptSlot.getSizes());
+          adUnit.sizes = adUnit.sizes || mapGptSlotSizes(gptSlot.getSizes(window.innerWidth, window.innerHeight));
           adUnits.push(adUnit);
           gptSlots.splice(i, 1);
         }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Depending on monitor width and height, an ad slot may support a variety of sizes. This update returns only the sizes a GPT Slot supports for a given monitor width and height.

SLOT.getSizes(monitorWidth, monitorHeight)