### PR TITLE
Adding onRenderFail in Adapter Spec

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -437,3 +437,19 @@ exports.getBidAdapter = function(bidder) {
 exports.setS2STestingModule = function (module) {
   s2sTestingModule = module;
 };
+
+exports.callRenderFailBidder = function(bid) {
+  const bidder = bid.bidderCode || '';
+  try {
+    const adapter = _bidderRegistry[bidder];
+    const spec = adapter.getSpec();
+    if (spec && spec.onRenderFail && typeof spec.onRenderFail === 'function') {
+      utils.logInfo(`Invoking ${bidder}.onRenderFail`);
+      spec.onRenderFail(bid);
+    }
+  } catch (e) {
+    if (bidder !== '') {
+      utils.logWarn(`Error calling onTimeout of ${bidder}`);
+    }
+  }
+}

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -204,6 +204,7 @@ function emitAdRenderFail(reason, message, bid) {
   data.message = message;
   if (bid) {
     data.bid = bid;
+    adaptermanager.callRenderFailBidder(bid);
   }
 
   utils.logError(message);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
This adds a function `onRenderFail` to bidder spec, letting bidders to subscribe when their Ad Fails to render.

Payload received to this function is same as Bid object.

PR on  [prebid.github.io](https://github.com/prebid/prebid.github.io/) will be added soon 

## Other information
This resolves #2303 
