### PR TITLE
fix legacy sizes in prebidserverAdapter

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -442,7 +442,7 @@ const OPEN_RTB_PROTOCOL = {
       let banner;
       // default to banner if mediaTypes isn't defined
       if (utils.isEmpty(adUnit.mediaTypes)) {
-        const sizeObjects = adUnit.sizes.map(size => ({ w: size.w, h: size.h }));
+        const sizeObjects = adUnit.sizes.map(size => ({ w: size[0], h: size[1] }));
         banner = {format: sizeObjects};
       }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Our QA noticed errors with prebidServer legacy endpoint in the new 1.7.0 release related to #2332, it appears a spot was missed that was expecting the old transformed sizes.  This fixes that bug.