### PR TITLE
add support for video bids to use an impression tracking URL 

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -200,6 +200,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       width: rtbBid.rtb.video.player_width,
       height: rtbBid.rtb.video.player_height,
       vastUrl: rtbBid.rtb.video.asset_url,
+      vastImpUrl: rtbBid.notify_url,
       ttl: 3600
     });
     // This supports Outstream Video

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -32,18 +32,20 @@ import { config } from '../src/config';
  * Function which wraps a URI that serves VAST XML, so that it can be loaded.
  *
  * @param {string} uri The URI where the VAST content can be found.
+ * @param {string} impUrl An impression tracker URL for the delivery of the video ad
  * @return A VAST URL which loads XML from the given URI.
  */
-function wrapURI(uri) {
+function wrapURI(uri, impUrl) {
   // Technically, this is vulnerable to cross-script injection by sketchy vastUrl bids.
   // We could make sure it's a valid URI... but since we're loading VAST XML from the
   // URL they provide anyway, that's probably not a big deal.
+  let vastImp = (impUrl) ? `<![CDATA[${impUrl}]]>` : ``;
   return `<VAST version="3.0">
     <Ad>
       <Wrapper>
         <AdSystem>prebid.org wrapper</AdSystem>
         <VASTAdTagURI><![CDATA[${uri}]]></VASTAdTagURI>
-        <Impression></Impression>
+        <Impression>${vastImp}</Impression>
         <Creatives></Creatives>
       </Wrapper>
     </Ad>
@@ -57,7 +59,7 @@ function wrapURI(uri) {
  * @param {CacheableBid} bid
  */
 function toStorageRequest(bid) {
-  const vastValue = bid.vastXml ? bid.vastXml : wrapURI(bid.vastUrl);
+  const vastValue = bid.vastXml ? bid.vastXml : wrapURI(bid.vastUrl, bid.vastImpUrl);
   return {
     type: 'xml',
     value: vastValue

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -412,6 +412,7 @@ describe('AppNexusAdapter', () => {
           'ads': [{
             'ad_type': 'video',
             'cpm': 0.500000,
+            'notify_url': 'imptracker.com',
             'rtb': {
               'video': {
                 'content': '<!-- Creative -->'
@@ -424,6 +425,7 @@ describe('AppNexusAdapter', () => {
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0]).to.have.property('vastUrl');
+      expect(result[0]).to.have.property('vastImpUrl');
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -101,7 +101,7 @@ describe('The video cache', () => {
       assertRequestMade({ vastUrl: 'my-mock-url.com' }, expectedValue)
     });
 
-    it('should make the expected request when store() is called on an ad with a vastUrl and vastImpUrl', () => {
+    it('should make the expected request when store() is called on an ad with a vastUrl and a vastImpUrl', () => {
       const expectedValue = `<VAST version="3.0">
     <Ad>
       <Wrapper>

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -101,6 +101,20 @@ describe('The video cache', () => {
       assertRequestMade({ vastUrl: 'my-mock-url.com' }, expectedValue)
     });
 
+    it('should make the expected request when store() is called on an ad with a vastUrl and vastImpUrl', () => {
+      const expectedValue = `<VAST version="3.0">
+    <Ad>
+      <Wrapper>
+        <AdSystem>prebid.org wrapper</AdSystem>
+        <VASTAdTagURI><![CDATA[my-mock-url.com]]></VASTAdTagURI>
+        <Impression><![CDATA[imptracker.com]]></Impression>
+        <Creatives></Creatives>
+      </Wrapper>
+    </Ad>
+  </VAST>`;
+      assertRequestMade({ vastUrl: 'my-mock-url.com', vastImpUrl: 'imptracker.com' }, expectedValue)
+    });
+
     it('should make the expected request when store() is called on an ad with vastXml', () => {
       const vastXml = '<VAST version="3.0"></VAST>';
       assertRequestMade({ vastXml: vastXml }, vastXml);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds support for adapters to populate the impression element of the VAST wrapper XML that gets generated by the `videoCache` module for an instream video bid response.  

When interpreting the bid response, an adapter could set the corresponding imp URL to the new `bid.vastImpUrl` field.  This field would be read by the `videoCache` module when it's storing the bid in prebid cache, and if present the URL gets automatically added into the VAST wrapper.  By adding it to the wrapper, the URL would only be executed when the video player was parsing the XML to load the video ad.

The `appnexusBidAdapter` was updated to use this new functionality, by reading/using the URL stored in the `notify_url` field of the AN video response.

Docs PR https://github.com/prebid/prebid.github.io/pull/699