### PR TITLE
Update Criteo bid adapter to Prebid 1.x

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -33,9 +33,14 @@ export const spec = {
     let url;
     let data;
 
-    // If publisher tag not already loaded try to get it from fast bid else load it
-    if (typeof Criteo === 'undefined' && !tryGetCriteoFastBid()) {
-      loadScript(PUBLISHER_TAG_URL);
+    // If publisher tag not already loaded try to get it from fast bid
+    if (typeof Criteo === 'undefined') {
+      tryGetCriteoFastBid();
+
+      // Reload publisher tag after prebid timeout to ensure fast bid is up to date
+      setTimeout(() => {
+        loadScript(PUBLISHER_TAG_URL);
+      }, bidderRequest.timeout);
     }
 
     if (typeof Criteo !== 'undefined') {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -264,6 +264,13 @@ function registerEventHandlers() {
       });
   });
 
+  events.on(EVENTS.SET_TARGETING, () => {
+    const adapters = Criteo.PubTag.Adapters.Prebid.GetAllAdapters();
+    for (const k in adapters) {
+      adapters[k].handleSetTargeting();
+    }
+  });
+
   registeredEvents = true;
 }
 

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -35,7 +35,8 @@ export const spec = {
 
     // If publisher tag not already loaded try to get it from fast bid
     if (!publisherTagAvailable()) {
-      window.Criteo = { usePrebidEvents: false };
+      window.Criteo = window.Criteo || {};
+      window.Criteo.usePrebidEvents = false;
 
       tryGetCriteoFastBid();
 

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -59,7 +59,9 @@ export const spec = {
   interpretResponse: (response, request) => {
     if (typeof Criteo !== 'undefined') {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request);
-      return adapter.interpretResponse(response.body, request);
+      if (adapter) {
+        return adapter.interpretResponse(response.body, request);
+      }
     }
 
     const bids = [];

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -48,7 +48,7 @@ export const spec = {
       data = buildCdbRequest(context, bidRequests);
     }
 
-    return { method: 'POST', url, data };
+    return { method: 'POST', url, data, bidRequests };
   },
 
   /**
@@ -58,8 +58,8 @@ export const spec = {
    */
   interpretResponse: (response, request) => {
     if (typeof Criteo !== 'undefined') {
-      const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request.data);
-      return adapter.interpretResponse(response.body);
+      const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request);
+      return adapter.interpretResponse(response.body, request);
     }
 
     const bids = [];

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -48,7 +48,7 @@ export const spec = {
         const bid = {
           requestId: slot.impid,
           cpm: slot.cpm,
-          // currency: 'USD', // FIXME: should return currency from CDB
+          currency: slot.currency,
           netRevenue: true,
           ad: slot.creative,
           width: slot.width,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -83,7 +83,7 @@ export const spec = {
 
     if (body && body.slots && utils.isArray(body.slots)) {
       body.slots.forEach(slot => {
-        const bidRequest = request.bidRequests.find(b => b.adUnitCode === slot.impid);
+        const bidRequest = request.bidRequests.find(b => b.adUnitCode === slot.impid && b.params.zoneId === slot.zoneid);
         const bidId = bidRequest.bidId;
         const bid = {
           requestId: bidId,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -64,17 +64,19 @@ export const spec = {
    * @return {Bid[]}
    */
   interpretResponse: (response, request) => {
+    const body = response.body || response;
+
     if (typeof Criteo !== 'undefined' && Criteo.PubTag) {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request);
       if (adapter) {
-        return adapter.interpretResponse(response.body, request);
+        return adapter.interpretResponse(body, request);
       }
     }
 
     const bids = [];
 
-    if (response.body && response.body.slots && utils.isArray(response.body.slots)) {
-      response.body.slots.forEach(slot => {
+    if (body && body.slots && utils.isArray(body.slots)) {
+      body.slots.forEach(slot => {
         const bid = {
           requestId: slot.impid,
           cpm: slot.cpm,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { parse } from 'src/url';
 import * as utils from 'src/utils';
 
-const ADAPTER_VERSION = 5;
+const ADAPTER_VERSION = 7;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -83,7 +83,7 @@ export const spec = {
 
     if (body && body.slots && utils.isArray(body.slots)) {
       body.slots.forEach(slot => {
-        const bidRequest = request.bidRequests.find(b => b.adUnitCode === slot.impid && b.params.zoneId === slot.zoneid);
+        const bidRequest = request.bidRequests.find(b => b.adUnitCode === slot.impid && (!b.params.zoneId || parseInt(b.params.zoneId) === slot.zoneid));
         const bidId = bidRequest.bidId;
         const bid = {
           requestId: bidId,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { parse } from 'src/url';
 import * as utils from 'src/utils';
 
-const ADAPTER_VERSION = 4;
+const ADAPTER_VERSION = 5;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -49,7 +49,7 @@ export const spec = {
           requestId: slot.impid,
           cpm: slot.cpm,
           // currency: 'USD', // FIXME: should return currency from CDB
-          // netRevenue: true, // FIXME: are bids net or gross?
+          netRevenue: true,
           ad: slot.creative,
           width: slot.width,
           height: slot.height,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -78,19 +78,20 @@ export const spec = {
 
     if (body && body.slots && utils.isArray(body.slots)) {
       body.slots.forEach(slot => {
+        const bidRequest = request.bidRequests.find(b => b.adUnitCode === slot.impid);
+        const bidId = bidRequest.bidId;
         const bid = {
-          requestId: slot.impid,
+          requestId: bidId,
           cpm: slot.cpm,
           currency: slot.currency,
           netRevenue: true,
           ttl: slot.ttl || 60,
-          creativeId: slot.impid,
+          creativeId: bidId,
           width: slot.width,
           height: slot.height,
         }
         if (slot.native) {
-          const bidRequest = request.bidRequests.find(b => b.bidId === slot.impid);
-          bid.ad = createNativeAd(slot.impid, slot.native, bidRequest.params.nativeCallback);
+          bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
         } else {
           bid.ad = slot.creative;
         }
@@ -170,7 +171,7 @@ function buildCdbRequest(context, bidRequests) {
     slots: bidRequests.map(bidRequest => {
       networkId = bidRequest.params.networkId || networkId;
       const slot = {
-        impid: bidRequest.bidId,
+        impid: bidRequest.adUnitCode,
         transactionid: bidRequest.transactionId,
         auctionId: bidRequest.auctionId,
         sizes: bidRequest.sizes.map(size => size[0] + 'x' + size[1]),

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -72,6 +72,8 @@ export const spec = {
           currency: slot.currency,
           netRevenue: true,
           ad: slot.creative,
+          ttl: slot.ttl || 60,
+          creativeId: slot.impid,
           width: slot.width,
           height: slot.height,
         }

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -191,7 +191,7 @@ function createNativeAd(id, payload, callback) {
   // from the parent window (doesn't work with safeframes)
   return `<script type="text/javascript">
     var win = window;
-    for (const i = 0; i < 10; ++i) {
+    for (var i = 0; i < 10; ++i) {
       win = win.parent;
       if (win.criteo_prebid_native_slots) {
         var responseSlot = win.criteo_prebid_native_slots["${id}"];

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -248,6 +248,8 @@ function registerEventHandlers() {
     return;
   }
 
+  registeredEvents = true;
+
   events.on(EVENTS.BID_WON, (bid) => {
     if (bid.bidderCode === 'criteo') {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(bid.auctionId);
@@ -270,8 +272,6 @@ function registerEventHandlers() {
       adapters[k].handleSetTargeting();
     }
   });
-
-  registeredEvents = true;
 }
 
 registerBidder(spec);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -40,7 +40,7 @@ export const spec = {
 
       tryGetCriteoFastBid();
 
-      // Reload publisher tag after prebid timeout to ensure fast bid is up to date
+      // Reload the PublisherTag after the timeout to ensure FastBid is up-to-date and tracking done properly
       setTimeout(() => {
         loadScript(PUBLISHER_TAG_URL);
       }, bidderRequest.timeout);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -19,7 +19,7 @@ export const spec = {
    * @return {boolean}
    */
   isBidRequestValid: bid => (
-    !!(bid && bid.params && bid.params.zoneId)
+    !!(bid && bid.params && (bid.params.zoneId || bid.params.networkId))
   ),
 
   /**
@@ -124,10 +124,12 @@ function buildCdbRequest(context, bidRequests) {
       networkId = bidRequest.params.networkId || networkId;
       const slot = {
         impid: bidRequest.bidId,
-        zoneid: bidRequest.params.zoneId,
         transactionid: bidRequest.transactionId,
         sizes: bidRequest.sizes.map(size => size[0] + 'x' + size[1]),
       };
+      if (bidRequest.params.zoneId) {
+        slot.zoneid = bidRequest.params.zoneId;
+      }
       if (bidRequest.params.publisherSubId) {
         slot.publishersubid = bidRequest.params.publisherSubId;
       }

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,0 +1,143 @@
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { parse } from 'src/url';
+import * as utils from 'src/utils';
+
+const BIDDER_CODE = 'criteo';
+const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
+const PROFILE_ID = 207;
+const ADAPTER_VERSION = 2;
+const INTEGRATION_MODES = {
+  'amp': 1,
+};
+
+/** @type {BidderSpec} */
+export const spec = {
+  code: BIDDER_CODE,
+
+  /**
+   * @param {object} bid
+   * @return {boolean}
+   */
+  isBidRequestValid: bid => (
+    !!(bid && bid.params && bid.params.zoneId)
+  ),
+
+  /**
+   * @param {BidRequest[]} bidRequests
+   * @return {ServerRequest}
+   */
+  buildRequests: bidRequests => {
+    const context = buildContext(bidRequests);
+    return {
+      method: 'POST',
+      url: buildCdbUrl(context),
+      data: buildCdbRequest(context, bidRequests),
+    };
+  },
+
+  /**
+   * @param {*} response
+   * @param {ServerRequest} request
+   * @return {Bid[]}
+   */
+  interpretResponse: (response, request) => {
+    const bids = [];
+
+    if (response.slots && utils.isArray(response.slots)) {
+      response.slots.forEach(slot => {
+        const bid = {
+          requestId: slot.impid,
+          cpm: slot.cpm,
+          // currency: 'USD', // FIXME: should return currency from CDB
+          // netRevenue: true, // FIXME: are bids net or gross?
+          ad: slot.creative,
+          width: slot.width,
+          height: slot.height,
+        }
+        bids.push(bid);
+      });
+    }
+
+    return bids;
+  },
+};
+
+/**
+ * @param {BidRequest[]} bidRequests
+ * @return {CriteoContext}
+ */
+function buildContext(bidRequests) {
+  const url = utils.getTopWindowUrl();
+  const queryString = parse(url).search;
+
+  const context = {
+    url: url,
+    debug: queryString['pbt_debug'] === '1',
+    noLog: queryString['pbt_nolog'] === '1',
+    integrationMode: undefined,
+  };
+
+  bidRequests.forEach(bidRequest => {
+    if (bidRequest.params.integrationMode) {
+      context.integrationMode = bidRequest.params.integrationMode;
+    }
+  })
+
+  return context;
+}
+
+/**
+ * @param {CriteoContext} context
+ * @return {string}
+ */
+function buildCdbUrl(context) {
+  let url = CDB_ENDPOINT;
+  url += '?profileId=' + PROFILE_ID;
+  url += '&av=' + String(ADAPTER_VERSION);
+  url += '&cb=' + String(Math.floor(Math.random() * 99999999999));
+
+  if (context.integrationMode in INTEGRATION_MODES) {
+    url += '&im=' + INTEGRATION_MODES[context.integrationMode];
+  }
+  if (context.debug) {
+    url += '&debug=1';
+  }
+  if (context.noLog) {
+    url += '&nolog=1';
+  }
+
+  return url;
+}
+
+/**
+ * @param {CriteoContext} context
+ * @param {BidRequest[]} bidRequests
+ * @return {*}
+ */
+function buildCdbRequest(context, bidRequests) {
+  let networkId;
+  const request = {
+    publisher: {
+      url: context.url,
+    },
+    slots: bidRequests.map(bidRequest => {
+      networkId = bidRequest.params.networkId || networkId;
+      const slot = {
+        impid: bidRequest.bidId,
+        zoneid: bidRequest.params.zoneId,
+        transactionid: bidRequest.transactionId,
+        sizes: bidRequest.sizes.map(size => size[0] + 'x' + size[1]),
+      };
+      if (bidRequest.params.publisherSubId) {
+        slot.publishersubid = bidRequest.params.publisherSubId;
+      }
+      return slot;
+    }),
+  };
+  if (networkId) {
+    request.publisher.networkid = networkId;
+  }
+  return request;
+}
+
+registerBidder(spec);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { parse } from 'src/url';
 import * as utils from 'src/utils';
 
-const ADAPTER_VERSION = 2;
+const ADAPTER_VERSION = 3;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
 const INTEGRATION_MODES = {
@@ -34,7 +34,9 @@ export const spec = {
     let data;
 
     // If publisher tag not already loaded try to get it from fast bid
-    if (typeof Criteo === 'undefined') {
+    if (typeof Criteo === 'undefined' || !Criteo.PubTag) {
+      window.Criteo = { usePrebidEvents: false };
+
       tryGetCriteoFastBid();
 
       // Reload publisher tag after prebid timeout to ensure fast bid is up to date
@@ -43,7 +45,7 @@ export const spec = {
       }, bidderRequest.timeout);
     }
 
-    if (typeof Criteo !== 'undefined') {
+    if (typeof Criteo !== 'undefined' && Criteo.PubTag) {
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest);
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
@@ -62,7 +64,7 @@ export const spec = {
    * @return {Bid[]}
    */
   interpretResponse: (response, request) => {
-    if (typeof Criteo !== 'undefined') {
+    if (typeof Criteo !== 'undefined' && Criteo.PubTag) {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request);
       if (adapter) {
         return adapter.interpretResponse(response.body, request);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -222,17 +222,16 @@ function createNativeAd(id, payload, callback) {
  * @return {boolean}
  */
 function tryGetCriteoFastBid() {
-  let success = false;
   try {
     const fastBid = localStorage.getItem('criteo_fast_bid');
     if (fastBid !== null) {
       eval(fastBid); // eslint-disable-line no-eval
-      success = true;
+      return true;
     }
   } catch (e) {
     // Unable to get fast bid
   }
-  return success;
+  return false;
 }
 
 registerBidder(spec);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -34,7 +34,7 @@ export const spec = {
     let data;
 
     // If publisher tag not already loaded try to get it from fast bid
-    if (typeof Criteo === 'undefined' || !Criteo.PubTag) {
+    if (!publisherTagAvailable()) {
       window.Criteo = { usePrebidEvents: false };
 
       tryGetCriteoFastBid();
@@ -45,7 +45,7 @@ export const spec = {
       }, bidderRequest.timeout);
     }
 
-    if (typeof Criteo !== 'undefined' && Criteo.PubTag) {
+    if (publisherTagAvailable()) {
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest);
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
@@ -66,7 +66,7 @@ export const spec = {
   interpretResponse: (response, request) => {
     const body = response.body || response;
 
-    if (typeof Criteo !== 'undefined' && Criteo.PubTag) {
+    if (publisherTagAvailable()) {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(request);
       if (adapter) {
         return adapter.interpretResponse(body, request);
@@ -100,6 +100,13 @@ export const spec = {
     return bids;
   },
 };
+
+/**
+ * @return {boolean}
+ */
+function publisherTagAvailable() {
+  return typeof Criteo !== 'undefined' && Criteo.PubTag && Criteo.PubTag.Adapters && Criteo.PubTag.Adapters.Prebid;
+}
 
 /**
  * @param {BidRequest[]} bidRequests

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -110,6 +110,16 @@ export const spec = {
 
     return bids;
   },
+
+  /**
+   * @param {TimedOutBid} timeoutData
+   */
+  onTimeout: (timeoutData) => {
+    if (publisherTagAvailable()) {
+      const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(timeoutData.auctionId);
+      adapter.handleBidTimeout();
+    }
+  },
 };
 
 /**
@@ -259,15 +269,6 @@ function registerEventHandlers() {
       const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(bid.auctionId);
       adapter.handleBidWon(bid);
     }
-  });
-
-  events.on(EVENTS.BID_TIMEOUT, (timedOutBidders) => {
-    timedOutBidders
-      .filter(bidder => bidder.bidder === 'criteo')
-      .map(bidder => {
-        const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(bidder.auctionId);
-        adapter.handleBidTimeout();
-      });
   });
 
   events.on(EVENTS.SET_TARGETING, () => {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -13,6 +13,8 @@ const INTEGRATION_MODES = {
   'amp': 1,
 };
 const PROFILE_ID = 207;
+
+// Unminified source code can be found in: https://github.com/Prebid-org/prebid-js-external-js-criteo/blob/master/dist/prod.js
 const PUBLISHER_TAG_URL = '//static.criteo.net/js/ld/publishertag.prebid.js';
 
 /** @type {BidderSpec} */

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,4 +1,4 @@
-import { loadScript } from 'src/adloader';
+import { loadExternalScript } from 'src/adloader';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { EVENTS } from 'src/constants';
 import { parse } from 'src/url';
@@ -47,7 +47,7 @@ export const spec = {
 
       // Reload the PublisherTag after the timeout to ensure FastBid is up-to-date and tracking done properly
       setTimeout(() => {
-        loadScript(PUBLISHER_TAG_URL);
+        loadExternalScript(PUBLISHER_TAG_URL, BIDDER_CODE);
       }, bidderRequest.timeout);
     }
 

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -63,7 +63,9 @@ export const spec = {
       data = buildCdbRequest(context, bidRequests);
     }
 
-    return { method: 'POST', url, data, bidRequests };
+    if (data) {
+      return { method: 'POST', url, data, bidRequests };
+    }
   },
 
   /**

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,10 +1,7 @@
 import { loadExternalScript } from 'src/adloader';
 import { registerBidder } from 'src/adapters/bidderFactory';
-import { EVENTS } from 'src/constants';
 import { parse } from 'src/url';
 import * as utils from 'src/utils';
-
-var events = require('src/events');
 
 const ADAPTER_VERSION = 4;
 const BIDDER_CODE = 'criteo';
@@ -56,8 +53,6 @@ export const spec = {
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest);
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
-
-      registerEventHandlers();
     } else {
       const context = buildContext(bidRequests);
       url = buildCdbUrl(context);
@@ -262,30 +257,6 @@ function tryGetCriteoFastBid() {
     // Unable to get fast bid
   }
   return false;
-}
-
-// Register events to know when Criteo won the bid or timeouted
-let registeredEvents = false;
-function registerEventHandlers() {
-  if (registeredEvents) {
-    return;
-  }
-
-  registeredEvents = true;
-
-  events.on(EVENTS.BID_WON, (bid) => {
-    if (bid.bidderCode === 'criteo') {
-      const adapter = Criteo.PubTag.Adapters.Prebid.GetAdapter(bid.auctionId);
-      adapter.handleBidWon(bid);
-    }
-  });
-
-  events.on(EVENTS.SET_TARGETING, () => {
-    const adapters = Criteo.PubTag.Adapters.Prebid.GetAllAdapters();
-    for (const k in adapters) {
-      adapters[k].handleSetTargeting();
-    }
-  });
 }
 
 registerBidder(spec);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -9,6 +9,7 @@ var events = require('src/events');
 const ADAPTER_VERSION = 4;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
+const CRITEO_VENDOR_ID = 91;
 const INTEGRATION_MODES = {
   'amp': 1,
 };
@@ -60,7 +61,7 @@ export const spec = {
     } else {
       const context = buildContext(bidRequests);
       url = buildCdbUrl(context);
-      data = buildCdbRequest(context, bidRequests);
+      data = buildCdbRequest(context, bidRequests, bidderRequest);
     }
 
     if (data) {
@@ -181,7 +182,7 @@ function buildCdbUrl(context) {
  * @param {BidRequest[]} bidRequests
  * @return {*}
  */
-function buildCdbRequest(context, bidRequests) {
+function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
   const request = {
     publisher: {
@@ -209,6 +210,14 @@ function buildCdbRequest(context, bidRequests) {
   };
   if (networkId) {
     request.publisher.networkid = networkId;
+  }
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    request.gdprConsent = {
+      gdprApplies: !!(bidderRequest.gdprConsent.gdprApplies),
+      consentData: bidderRequest.gdprConsent.consentString,
+      consentGiven: !!(bidderRequest.gdprConsent.vendorData && bidderRequest.gdprConsent.vendorData.vendorConsents &&
+        bidderRequest.gdprConsent.vendorData.vendorConsents[ CRITEO_VENDOR_ID.toString(10) ]),
+    };
   }
   return request;
 }

--- a/modules/criteoBidAdapter.md
+++ b/modules/criteoBidAdapter.md
@@ -1,0 +1,27 @@
+# Overview
+
+Module Name: Criteo Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: pi-direct@criteo.com
+
+# Description
+
+Module that connects to Criteo's demand sources.
+
+# Test Parameters
+```
+    var adUnits = [
+        {
+            code: 'banner-ad-div',
+            sizes: [[300, 250], [728, 90]],
+            bids: [
+                {
+                    bidder: 'criteo',
+                    params: {
+                        zoneId: 497747
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -61,10 +61,11 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
       expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
-      expect(ortbRequest.slots).to.have.lengthOf(2);
+      expect(ortbRequest.slots).to.have.lengthOf(1);
       expect(ortbRequest.slots[0].impid).to.equal('bid-123');
       expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
       expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
@@ -85,8 +86,9 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
       expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
       expect(ortbRequest.publisher.networkid).to.equal(456);
       expect(ortbRequest.slots).to.have.lengthOf(1);
@@ -119,8 +121,9 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
       expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
       expect(ortbRequest.publisher.networkid).to.equal(456);
       expect(ortbRequest.slots).to.have.lengthOf(2);
@@ -145,13 +148,15 @@ describe('The Criteo bidding adapter', () => {
 
     it('should properly parse a bid response', () => {
       const response = {
-        slots: [{
-          impid: 'test-requestId',
-          cpm: 1.23,
-          ad: 'test-ad',
-          width: 728,
-          height: 90,
-        }],
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            cpm: 1.23,
+            creative: 'test-ad',
+            width: 728,
+            height: 90,
+          }],
+        },
       };
       const bids = spec.interpretResponse(response, null);
       expect(bids).to.have.lengthOf(1);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -179,7 +179,7 @@ describe('The Criteo bidding adapter', () => {
       expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response', () => {
+    it('should properly parse a bid response with a networkId', () => {
       const response = {
         body: {
           slots: [{
@@ -195,6 +195,71 @@ describe('The Criteo bidding adapter', () => {
         bidRequests: [{
           adUnitCode: 'test-requestId',
           bidId: 'test-bidId',
+          params: {
+            networkId: 456,
+          }
+        }]
+      };
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('test-bidId');
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+    });
+
+    it('should properly parse a bid responsewith with a zoneId', () => {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            cpm: 1.23,
+            creative: 'test-ad',
+            width: 728,
+            height: 90,
+            zoneid: 123,
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: 123,
+          },
+        }]
+      };
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('test-bidId');
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+    });
+
+    it('should properly parse a bid responsewith with a zoneId passed as a string', () => {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            cpm: 1.23,
+            creative: 'test-ad',
+            width: 728,
+            height: 90,
+            zoneid: 123,
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: '123',
+          },
         }]
       };
       const bids = spec.interpretResponse(response, request);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1,0 +1,164 @@
+import { expect } from 'chai';
+import { spec } from 'modules/criteoBidAdapter';
+import * as utils from 'src/utils';
+
+describe('The Criteo bidding adapter', () => {
+  describe('isBidRequestValid', () => {
+    it('should return false when given an invalid bid', () => {
+      const bid = {
+        bidder: 'criteo',
+      };
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(false);
+    });
+
+    it('should return true when given a zoneId bid', () => {
+      const bid = {
+        bidder: 'criteo',
+        params: {
+          zoneId: 123,
+        },
+      };
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(true);
+    });
+
+    it('should return true when given a networkId bid', () => {
+      const bid = {
+        bidder: 'criteo',
+        params: {
+          networkId: 456,
+        },
+      };
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(true);
+    });
+
+    it('should return true when given a mixed bid with both a zoneId and a networkId', () => {
+      const bid = {
+        bidder: 'criteo',
+        params: {
+          zoneId: 123,
+          networkId: 456,
+        },
+      };
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(true);
+    });
+  });
+
+  describe('buildRequests', () => {
+    it('should properly build a zoneId request', () => {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          bidId: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests);
+      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.method).to.equal('POST');
+      expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
+      expect(ortbRequest.slots).to.have.lengthOf(2);
+      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
+      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
+      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
+      expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
+      expect(ortbRequest.slots[0].zoneid).to.equal(123);
+    });
+
+    it('should properly build a networkId request', () => {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          bidId: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[300, 250], [728, 90]],
+          params: {
+            networkId: 456,
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests);
+      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.method).to.equal('POST');
+      expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
+      expect(ortbRequest.publisher.networkid).to.equal(456);
+      expect(ortbRequest.slots).to.have.lengthOf(1);
+      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
+      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
+      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(2);
+      expect(ortbRequest.slots[0].sizes[0]).to.equal('300x250');
+      expect(ortbRequest.slots[0].sizes[1]).to.equal('728x90');
+    });
+
+    it('should properly build a mixed request', () => {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          bidId: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          params: {
+            zoneId: 123,
+          },
+        },
+        {
+          bidder: 'criteo',
+          bidId: 'bid-234',
+          transactionId: 'transaction-234',
+          sizes: [[300, 250], [728, 90]],
+          params: {
+            networkId: 456,
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests);
+      expect(request.url).to.equal('//bidder.criteo.com/cdb');
+      expect(request.method).to.equal('POST');
+      expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
+      expect(ortbRequest.publisher.networkid).to.equal(456);
+      expect(ortbRequest.slots).to.have.lengthOf(2);
+      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
+      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
+      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
+      expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
+      expect(ortbRequest.slots[1].impid).to.equal('bid-234');
+      expect(ortbRequest.slots[1].transactionid).to.equal('transaction-234');
+      expect(ortbRequest.slots[1].sizes).to.have.lengthOf(2);
+      expect(ortbRequest.slots[1].sizes[0]).to.equal('300x250');
+      expect(ortbRequest.slots[1].sizes[1]).to.equal('728x90');
+    });
+  });
+
+  describe('interpretResponse', () => {
+    it('should return an empty array when parsing a no bid response', () => {
+      const response = {};
+      const bids = spec.interpretResponse(response, null);
+      expect(bids).to.have.lengthOf(0);
+    });
+
+    it('should properly parse a bid response', () => {
+      const response = {
+        slots: [{
+          impid: 'test-requestId',
+          cpm: 1.23,
+          ad: 'test-ad',
+          width: 728,
+          height: 90,
+        }],
+      };
+      const bids = spec.interpretResponse(response, null);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+    });
+  });
+});

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -48,11 +48,13 @@ describe('The Criteo bidding adapter', () => {
   });
 
   describe('buildRequests', () => {
+    const bidderRequest = { timeout: 3000 };
+
     it('should properly build a zoneId request', () => {
       const bidRequests = [
         {
           bidder: 'criteo',
-          bidId: 'bid-123',
+          adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
           sizes: [[728, 90]],
           params: {
@@ -60,8 +62,8 @@ describe('The Criteo bidding adapter', () => {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
@@ -77,7 +79,7 @@ describe('The Criteo bidding adapter', () => {
       const bidRequests = [
         {
           bidder: 'criteo',
-          bidId: 'bid-123',
+          adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
           sizes: [[300, 250], [728, 90]],
           params: {
@@ -85,8 +87,8 @@ describe('The Criteo bidding adapter', () => {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
@@ -103,7 +105,7 @@ describe('The Criteo bidding adapter', () => {
       const bidRequests = [
         {
           bidder: 'criteo',
-          bidId: 'bid-123',
+          adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
           sizes: [[728, 90]],
           params: {
@@ -112,7 +114,7 @@ describe('The Criteo bidding adapter', () => {
         },
         {
           bidder: 'criteo',
-          bidId: 'bid-234',
+          adUnitCode: 'bid-234',
           transactionId: 'transaction-234',
           sizes: [[300, 250], [728, 90]],
           params: {
@@ -120,8 +122,8 @@ describe('The Criteo bidding adapter', () => {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=2&cb=\d/);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
@@ -142,7 +144,8 @@ describe('The Criteo bidding adapter', () => {
   describe('interpretResponse', () => {
     it('should return an empty array when parsing a no bid response', () => {
       const response = {};
-      const bids = spec.interpretResponse(response, null);
+      const request = { bidRequests: [] };
+      const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(0);
     });
 
@@ -158,8 +161,15 @@ describe('The Criteo bidding adapter', () => {
           }],
         },
       };
-      const bids = spec.interpretResponse(response, null);
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+        }]
+      };
+      const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('test-bidId');
       expect(bids[0].cpm).to.equal(1.23);
       expect(bids[0].ad).to.equal('test-ad');
       expect(bids[0].width).to.equal(728);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -48,7 +48,17 @@ describe('The Criteo bidding adapter', () => {
   });
 
   describe('buildRequests', () => {
-    const bidderRequest = { timeout: 3000 };
+    const bidderRequest = { timeout: 3000,
+      gdprConsent: {
+        gdprApplies: 1,
+        consentString: 'concentDataString',
+        vendorData: {
+          vendorConsents: {
+            '1': 1
+          },
+        },
+      },
+    };
 
     it('should properly build a zoneId request', () => {
       const bidRequests = [
@@ -73,9 +83,24 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
       expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
       expect(ortbRequest.slots[0].zoneid).to.equal(123);
+      expect(ortbRequest.gdprConsent.consentData).to.equal('concentDataString');
+      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(true);
+      expect(ortbRequest.gdprConsent.consentGiven).to.equal(true);
     });
 
     it('should properly build a networkId request', () => {
+      const bidderRequest = {
+        timeout: 3000,
+        gdprConsent: {
+          gdprApplies: 0,
+          consentString: undefined,
+          vendorData: {
+            vendorConsents: {
+              '1': 0
+            },
+          },
+        },
+      };
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -99,9 +124,13 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[0].sizes).to.have.lengthOf(2);
       expect(ortbRequest.slots[0].sizes[0]).to.equal('300x250');
       expect(ortbRequest.slots[0].sizes[1]).to.equal('728x90');
+      expect(ortbRequest.gdprConsent.consentData).to.equal(undefined);
+      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(false);
+      expect(ortbRequest.gdprConsent.consentGiven).to.equal(false);
     });
 
     it('should properly build a mixed request', () => {
+      const bidderRequest = { timeout: 3000 };
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -138,6 +167,7 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[1].sizes).to.have.lengthOf(2);
       expect(ortbRequest.slots[1].sizes[0]).to.equal('300x250');
       expect(ortbRequest.slots[1].sizes[1]).to.equal('728x90');
+      expect(ortbRequest.gdprConsent).to.equal(undefined);
     });
   });
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -54,7 +54,7 @@ describe('The Criteo bidding adapter', () => {
         consentString: 'concentDataString',
         vendorData: {
           vendorConsents: {
-            '1': 1
+            '91': 1
           },
         },
       },


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter
- [x] Official adapter submission

## Description of change
- Test parameters for validating bids
```
{
    code: '...',
    sizes: [[300, 250], [728, 90]],
    bids: [{
        bidder: 'criteo',
        params: {
            zoneId: 497747
        }
    }]
}
```
- Adapter maintainers: pi-direct@criteo.com, n.faure@criteo.com, a.hubert@criteo.com
- The bidders params documentation [already exists](https://github.com/prebid/prebid.github.io/blob/master/dev-docs/bidders/criteo.md) and does not require an update as the params didn't change

## Other information
- The old Prebid 0.x adapter can be found [here](https://github.com/prebid/Prebid.js/blob/legacy/modules/criteoBidAdapter.js) on the legacy branch
