### PR TITLE
uppercase all keys for AST macros

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -193,9 +193,7 @@ export function newTargeting(auctionManager) {
         // setKeywords supports string and array as value
         if (utils.isStr(astTargeting[targetId][key]) || utils.isArray(astTargeting[targetId][key])) {
           let keywordsObj = {};
-          let input = 'hb_adid';
-          let nKey = (key.substring(0, input.length) === input) ? key.toUpperCase() : key;
-          keywordsObj[nKey] = astTargeting[targetId][key];
+          keywordsObj[key.toUpperCase()] = astTargeting[targetId][key];
           window.apntag.setKeywords(targetId, keywordsObj);
         }
       })

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1578,8 +1578,7 @@ describe('Unit: Prebid Module', function () {
       var expectedAdserverTargeting = bids[0].adserverTargeting;
       var newAdserverTargeting = {};
       for (var key in expectedAdserverTargeting) {
-        var nkey = (key === 'hb_adid') ? key.toUpperCase() : key;
-        newAdserverTargeting[nkey] = expectedAdserverTargeting[key];
+        newAdserverTargeting[key.toUpperCase()] = expectedAdserverTargeting[key];
       }
 
       targeting.setTargetingForAst();


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Macros for AST only work when they are in caps. This switches all keys set for AST to uppercase. 