### PR TITLE
ADSS-281 implement getUserSyncs and putting checks for empty ad serve…

### DIFF
--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -135,4 +135,26 @@ describe('gumgumAdapter', () => {
       expect(result.length).to.equal(0);
     });
   })
+  describe('getUserSyncs', () => {
+    const syncOptions = {
+      'iframeEnabled': 'true'
+    }
+    const response = {
+      'pxs': {
+        'scr': [
+          {
+            't': 'i',
+            'u': 'https://c.gumgum.com/images/pixel.gif'
+          },
+          {
+            't': 'f',
+            'u': 'https://www.nytimes.com/'
+          }
+        ]
+      }
+    }
+    let result = spec.getUserSyncs(syncOptions, [{ body: response }]);
+    expect(result[0].type).to.equal('image')
+    expect(result[1].type).to.equal('iframe')
+  })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding support for getUserSync

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- ajbruscantini@gmail.com
- [ ] official adapter submission

## Other information
@mxcoder 
