### PR TITLE
convert AN bid params to underscore formatting for pbs

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -469,6 +469,16 @@ const OPEN_RTB_PROTOCOL = {
 
       // get bidder params in form { <bidder code>: {...params} }
       const ext = adUnit.bids.reduce((acc, bid) => {
+        // convert all AppNexus keys to underscore format for pbs
+        if (bid.bidder === 'appnexus') {
+          Object.keys(bid.params).forEach(paramKey => {
+            let convertedKey = utils.convertCamelToUnderscore(paramKey);
+            if (convertedKey !== paramKey) {
+              bid.params[convertedKey] = bid.params[paramKey];
+              delete bid.params[paramKey];
+            }
+          });
+        }
         acc[bid.bidder] = bid.params;
         return acc;
       }, {});

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -469,6 +469,7 @@ const OPEN_RTB_PROTOCOL = {
 
       // get bidder params in form { <bidder code>: {...params} }
       const ext = adUnit.bids.reduce((acc, bid) => {
+        // TODO: move this bidder specific out to a more ideal location (submodule?); issue# pending
         // convert all AppNexus keys to underscore format for pbs
         if (bid.bidder === 'appnexus') {
           Object.keys(bid.params).forEach(paramKey => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -949,3 +949,11 @@ export function isInteger(value) {
     return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
   }
 }
+
+/**
+ * Converts a string value in camel-case to underscore eg 'placementId' becomes 'placement_id'
+ * @param {string} value string value to convert
+ */
+export function convertCamelToUnderscore(value) {
+  return value.replace(/(?:^|\.?)([A-Z])/g, function (x, y) { return '_' + y.toLowerCase() }).replace(/^_/, '');
+}

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -559,7 +559,6 @@ describe('S2S Adapter', () => {
 
       const myRequest = utils.deepClone(REQUEST);
 
-      debugger;//eslint-disable-line
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       const requestBid = JSON.parse(requests[0].requestBody);
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -505,7 +505,7 @@ describe('S2S Adapter', () => {
         params: { placementId: '123456' }
       };
 
-      const request = Object.assign({}, REQUEST);
+      const request = utils.deepClone(REQUEST);
       request.ad_units[0].bids = [aliasBidder];
 
       adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
@@ -533,7 +533,7 @@ describe('S2S Adapter', () => {
         params: { placementId: '123456' }
       };
 
-      const request = Object.assign({}, REQUEST);
+      const request = utils.deepClone(REQUEST);
       request.ad_units[0].bids = [aliasBidder];
 
       // TODO: stub this
@@ -549,6 +549,23 @@ describe('S2S Adapter', () => {
           }
         }
       });
+    });
+
+    it('converts appnexus params to underscore syntax', () => {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig});
+
+      const myRequest = utils.deepClone(REQUEST);
+
+      debugger;//eslint-disable-line
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      const requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.imp[0].ext.appnexus).to.exist;
+      expect(requestBid.imp[0].ext.appnexus.placement_id).to.exist.and.to.equal(10433394);
+      expect(requestBid.imp[0].ext.appnexus.member).to.exist;
     });
   });
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -750,4 +750,16 @@ describe('Utils', function () {
       expect(topWindowLocation.host).to.be.oneOf(['www.example.com', 'www.example.com:443']);
     });
   });
+
+  describe('convertCamelToUnderscore', () => {
+    it('returns converted string value using underscore syntax instead of camelCase', () => {
+      let var1 = 'placementIdTest';
+      let test1 = utils.convertCamelToUnderscore(var1);
+      expect(test1).to.equal('placement_id_test');
+
+      let var2 = 'my_test_value';
+      let test2 = utils.convertCamelToUnderscore(var2);
+      expect(test2).to.equal(var2);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)


## Description of change
Currently the AppNexus bid params are being passed in their normal camel-case format to PBS in the openrtb request.  This is not the correct format for PBS, which expects an underscore syntax.

This change automatically converts the AppNexus `bid.params` to the underscore syntax (if they need it) and removes the old camel-case keys so the data in the openrtb `request.imp.ext.appenxus` field is formatted properly.