### PR TITLE
Fix lqpd unit test failure

### DIFF
--- a/modules/lkqdBidAdapter.js
+++ b/modules/lkqdBidAdapter.js
@@ -173,7 +173,7 @@ function interpretResponse(serverResponse, bidRequest) {
             bidResponse.requestId = bidRequest.data.bidId;
             bidResponse.bidderCode = BIDDER_CODE;
             bidResponse.ad = '';
-            bidResponse.cpm = parseFloat(sspXml.getElementsByTagName('Pricing')[0].innerHTML);
+            bidResponse.cpm = parseFloat(sspXml.getElementsByTagName('Pricing')[0].textContent);
             bidResponse.width = bidRequest.data.bidWidth;
             bidResponse.height = bidRequest.data.bidHeight;
             bidResponse.ttl = BID_TTL_DEFAULT;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Travis detected unit failures in IE11, Safari 8, Mobile Safari 8 
https://travis-ci.org/prebid/Prebid.js/builds/365619585

innerHTML property did not exist so it was returning undefined in older browsers. This helped https://stackoverflow.com/questions/21311299/nodevalue-vs-innerhtml-and-textcontent-how-to-choose 
