### PR TITLE
add cleanup and proper stubbing for legacy analytics

### DIFF
--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -1,9 +1,10 @@
 import analyticsAdapter, {ExpiringQueue, getUmtSource, storage} from 'modules/adkernelAdnAnalyticsAdapter';
 import {expect} from 'chai';
 import adaptermanager from 'src/adaptermanager';
-import * as events from 'src/events';
 import * as ajax from 'src/ajax';
 import CONSTANTS from 'src/constants.json';
+
+const events = require('../../../src/events');
 
 const DIRECT = {
   source: '(direct)',
@@ -41,6 +42,7 @@ describe('', () => {
 
   after(() => {
     sandbox.restore();
+    analyticsAdapter.disableAnalytics();
   });
 
   describe('UTM source parser', () => {
@@ -189,6 +191,16 @@ describe('', () => {
     before(() => {
       ajaxStub = sandbox.stub(ajax, 'ajax');
       timer = sandbox.useFakeTimers(0);
+    });
+
+    beforeEach(() => {
+      sandbox.stub(events, 'getEvents', () => {
+        return [];
+      });
+    });
+
+    afterEach(() => {
+      events.getEvents.restore();
     });
 
     it('should be configurable', () => {

--- a/test/spec/modules/adxcgAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adxcgAnalyticsAdapter_spec.js
@@ -8,22 +8,34 @@ describe('adxcg analytics adapter', () => {
   let xhr;
   let requests;
 
+  let initOptions = {
+    publisherId: '42'
+  };
+
+  adaptermanager.registerAnalyticsAdapter({
+    code: 'adxcg',
+    adapter: adxcgAnalyticsAdapter
+  });
+
   beforeEach(() => {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
     xhr.onCreate = request => requests.push(request);
+    sinon.stub(events, 'getEvents', () => []);
+    adaptermanager.enableAnalytics({
+      provider: 'adxcg',
+      options: initOptions
+    });
   });
 
   afterEach(() => {
+    adxcgAnalyticsAdapter.disableAnalytics();
     xhr.restore();
   });
 
   describe('track', () => {
     it('builds and sends auction data', () => {
       let auctionTimestamp = 42;
-      let initOptions = {
-        publisherId: '42'
-      };
       let bidRequest = {
         requestId: 'requestIdData'
       };
@@ -31,16 +43,6 @@ describe('adxcg analytics adapter', () => {
         adId: 'adIdData',
         ad: 'adContent'
       };
-
-      adaptermanager.registerAnalyticsAdapter({
-        code: 'adxcg',
-        adapter: adxcgAnalyticsAdapter
-      });
-
-      adaptermanager.enableAnalytics({
-        provider: 'adxcg',
-        options: initOptions
-      });
 
       events.emit(constants.EVENTS.AUCTION_INIT, {
         timestamp: auctionTimestamp

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -4,7 +4,26 @@ let adaptermanager = require('src/adaptermanager');
 let constants = require('src/constants.json');
 
 describe('PubWise Prebid Analytics', function () {
+  let xhr;
+
+  before(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+  });
+
+  after(() => {
+    xhr.restore();
+    pubwiseAnalytics.disableAnalytics();
+  });
+
   describe('enableAnalytics', function () {
+    beforeEach(() => {
+      sinon.stub(events, 'getEvents', () => []);
+    });
+
+    afterEach(() => {
+      events.getEvents.restore();
+    });
+
     it('should catch all events', function () {
       sinon.spy(pubwiseAnalytics, 'track');
 

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -5,13 +5,24 @@ let adaptermanager = require('src/adaptermanager');
 let constants = require('src/constants.json');
 
 describe('Roxot Prebid Analytic', function () {
+  let xhr;
+  before(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+  })
+  after(() => {
+    roxotAnalytic.disableAnalytics();
+    xhr.restore();
+  });
+
   describe('enableAnalytics', function () {
     beforeEach(() => {
       sinon.spy(roxotAnalytic, 'track');
+      sinon.stub(events, 'getEvents', () => []);
     });
 
     afterEach(() => {
       roxotAnalytic.track.restore();
+      events.getEvents.restore();
     });
     it('should catch all events', function () {
       adaptermanager.registerAnalyticsAdapter({


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This is an effort to apply a lot of the analytics test fixes I made in `master` to the `legacy` branch.  Most of the fixes are around making sure the analytics test suites properly stub and clean up events in their test suites.  A failure to do so is what I think accounts for many of the errors as seen in #2382
