### PR TITLE
deprecate loadScript and add loadExternalScript

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -1,7 +1,35 @@
 var utils = require('./utils');
 let _requestCache = {};
 
-// add a script tag to the page, used to add /jpt call to page
+/**
+ * Loads external javascript. Can only be used if external JS is approved by Prebid. See https://github.com/prebid/prebid-js-external-js-template#policy
+ * @param {string} url the url to load
+ * @param {string} moduleCode bidderCode or module code of the module requesting this resource
+ */
+exports.loadExternalScript = function(url, moduleCode) {
+  if (!moduleCode || !url) {
+    utils.logError('cannot load external script without url and moduleCode');
+    return;
+  }
+  utils.logWarn(`module ${moduleCode} is loading external JavaScript`);
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.async = true;
+
+  script.src = url;
+
+  // add the new script tag to the page
+  const target = document.head || document.body;
+  if (target) {
+    target.appendChild(script);
+  }
+};
+
+/**
+ *
+ * @deprecated
+ * Do not use this function. Will be removed in the next release. If external resources are required, use #loadExternalScript instead.
+ */
 exports.loadScript = function (tagSrc, callback, cacheRequest) {
   // var noop = () => {};
   //

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -474,7 +474,7 @@ $$PREBID_GLOBAL$$.createBid = function (statusCode) {
 };
 
 /**
- * Wrapper to adloader.loadScript
+ * @deprecated this function will be removed in the next release. Prebid has deprected external JS loading.
  * @param  {string} tagSrc [description]
  * @param  {Function} callback [description]
  * @alias module:pbjs.loadScript


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Use of adLoader.loadScript is deprecated as of prebid 1.x however it was not removed. Adding a deprecated tag here + adding lightweight function to just load a script. 