### PR TITLE
Do client-side user syncs when using the OpenRTB endpoint

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -150,6 +150,20 @@ function doBidderSync(type, url, bidder) {
 }
 
 /**
+ * Do client-side syncs for bidders.
+ *
+ * @param {Array} bidders a list of bidder names
+ */
+function doClientSideSyncs(bidders) {
+  bidders.forEach(bidder => {
+    let clientAdapter = adaptermanager.getBidAdapter(bidder);
+    if (clientAdapter && clientAdapter.registerSyncs) {
+      clientAdapter.registerSyncs([]);
+    }
+  });
+}
+
+/**
  * Try to convert a value to a type.
  * If it can't be done, the value will be returned.
  *
@@ -337,14 +351,6 @@ const LEGACY_PROTOCOL = {
           }
         });
       }
-
-      // do client-side syncs if available
-      requestedBidders.forEach(bidder => {
-        let clientAdapter = adaptermanager.getBidAdapter(bidder);
-        if (clientAdapter && clientAdapter.registerSyncs) {
-          clientAdapter.registerSyncs([]);
-        }
-      });
 
       if (result.bids) {
         result.bids.forEach(bidObj => {
@@ -645,6 +651,7 @@ export function PrebidServer() {
     }
 
     done();
+    doClientSideSyncs(requestedBidders);
   }
 
   return Object.assign(this, {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -703,6 +703,26 @@ describe('S2S Adapter', () => {
       adapterManager.getBidAdapter.restore();
     });
 
+    it('registers client user syncs when using OpenRTB endpoint', () => {
+      let rubiconAdapter = {
+        registerSyncs: sinon.spy()
+      };
+      sinon.stub(adapterManager, 'getBidAdapter').returns(rubiconAdapter);
+
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig});
+
+      server.respondWith(JSON.stringify(RESPONSE_OPENRTB));
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      server.respond();
+
+      sinon.assert.calledOnce(rubiconAdapter.registerSyncs);
+
+      adapterManager.getBidAdapter.restore();
+    });
+
     it('registers bid responses when server requests cookie sync', () => {
       server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Currently prebid only does client-side user syncs when using the legacy endpoint. This change adds that functionality to the OpenRTB endpoint. See https://github.com/prebid/Prebid.js/issues/2355 for details.

