### PR TITLE
load_pbjs_dfp_concurrently.html improvement (removed obsolete code)

### DIFF
--- a/integrationExamples/gpt/load_pbjs_dfp_concurrently.html
+++ b/integrationExamples/gpt/load_pbjs_dfp_concurrently.html
@@ -5,46 +5,37 @@
 * This is the optimized way of loading prebid.js. It loads both DFP and Prebid concurrently.
 * Publishers may wish to tweak the the MAX_RETRIES  and polling interval ms as desired to mitigate issue https://github.com/prebid/Prebid.js/issues/419
 */
-
+    
 //timeout to control how long bidders have to respond.
 var PREBID_TIMEOUT = 700;
-//how many times to attempt to load DFP if services have not been enabled
-var MAX_RETRIES = 20;
 
 var pbjs = pbjs || {};
 pbjs.que = pbjs.que || [];
-pbjs.retries = 0;
 var googletag = googletag || {};
 googletag.cmd = googletag.cmd || [];
 googletag.cmd.push(function () {
     googletag.pubads().disableInitialLoad();
 });
+
+// Load the Prebid Javascript Library Async. We recommend loading ASAP in page
+loadScript('//acdn.adnxs.com/prebid/not-for-prod/prebid.js');
+//load DFP async.
+loadScript('//www.googletagservices.com/tag/js/gpt.js');
+    
 /* initAdserver will be called either when all bids are back, or
    when the timeout is reached.
 */
 function initAdserver() {
   if (pbjs.initAdserverSet) return;
-
-  //we don't want to call DFP before it is ready
-  if(!googletag.pubadsReady && pbjs.retries <= MAX_RETRIES) {
-    setTimeout(initAdserver, 50); //poll ms can be adjusted as desired.
-    pbjs.retries++;
-    return;
-  }
+    
   googletag.cmd.push(function () {
     pbjs.que.push(function () {
       pbjs.setTargetingForGPTAsync();
+      googletag.pubads().refresh();
     });
-    googletag.pubads().refresh();
   });
   pbjs.initAdserverSet = true;
 }
-
-//load DFP async.
-loadScript('//www.googletagservices.com/tag/js/gpt.js');
-
-// Load the Prebid Javascript Library Async. We recommend loading ASAP in page
-loadScript('//acdn.adnxs.com/prebid/not-for-prod/prebid.js');
 
 /**
  * Loads the given script async
@@ -247,7 +238,6 @@ pbjs.que.push(function() {
   };
 
 });  //end push command
-
 
 </script>
 <script>

--- a/integrationExamples/gpt/load_pbjs_dfp_concurrently.html
+++ b/integrationExamples/gpt/load_pbjs_dfp_concurrently.html
@@ -27,6 +27,7 @@ loadScript('//www.googletagservices.com/tag/js/gpt.js');
 */
 function initAdserver() {
   if (pbjs.initAdserverSet) return;
+  pbjs.initAdserverSet = true;
     
   googletag.cmd.push(function () {
     pbjs.que.push(function () {
@@ -34,7 +35,6 @@ function initAdserver() {
       googletag.pubads().refresh();
     });
   });
-  pbjs.initAdserverSet = true;
 }
 
 /**


### PR DESCRIPTION
- prebid should be loaded as early as possible (gpt, too)
- removed googletag.pubadsReady check, this should be obsolete
- initAdserverSet should be set early on to avoid race conditions
- moved `googletag.pubads().refresh();` inside pbjs.que

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Unless I'm totally mistaken, the load_pbjs_dfp_concurrently.html example script is doing obsolete stuff.
I removed the obsolete googletag.pubadsReady check and loop including a few other smaller changes, see above.
