### PR TITLE
Audience Network: Fix bid request validation for fullwidth

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -27,7 +27,7 @@ const isBidRequestValid = bid =>
   typeof bid.params.placementId === 'string' &&
   bid.params.placementId.length > 0 &&
   Array.isArray(bid.sizes) && bid.sizes.length > 0 &&
-  (isFullWidth(bid.params.format) ? bid.sizes.map(flattenSize).every(size => size === '300x250') : true) &&
+  (isFullWidth(bid.params.format) ? bid.sizes.map(flattenSize).some(size => size === '300x250') : true) &&
   (isValidNonSizedFormat(bid.params.format) || bid.sizes.map(flattenSize).some(isValidSize));
 
 /**

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -75,7 +75,7 @@ describe('AudienceNetwork adapter', () => {
     it('fullwidth', () => {
       expect(isBidRequestValid({
         bidder,
-        sizes: [[300, 250]],
+        sizes: [[300, 250], [336, 280]],
         params: {
           placementId,
           format: 'fullwidth'


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
#2203 implemented a restriction that ensures "fullwidth" bids are 300x250. In `isBidRequestValid`, it requires **every** size in bid must be 300x250. It should instead just check if some bid size is 300x250, just like existing validation for banners.

## Other information
Ping @lovell original PR author & @harpere previous reviewer