### PR TITLE
Beachfront adapter support for sizes defined in mediaTypes

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -121,7 +121,10 @@ function outstreamRender(bid) {
 }
 
 function getSizes(bid) {
-  return utils.parseSizesInput(bid.sizes).map(size => {
+  let sizes = (isVideoBid(bid)
+    ? utils.deepAccess(bid, 'mediaTypes.video.playerSize')
+    : utils.deepAccess(bid, 'mediaTypes.banner.sizes')) || bid.sizes;
+  return utils.parseSizesInput(sizes).map(size => {
     let [ width, height ] = size.split('x');
     return {
       w: parseInt(width, 10) || undefined,

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -15,10 +15,10 @@ Module that connects to Beachfront's demand sources
     var adUnits = [
         {
             code: 'test-video',
-            sizes: [[640, 360]],
             mediaTypes: {
                 video: {
-                    context: 'instream'
+                    context: 'instream',
+                    playerSize: [ 640, 360 ]
                 }
             },
             bids: [
@@ -28,14 +28,18 @@ Module that connects to Beachfront's demand sources
                         bidfloor: 0.01,
                         appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
                         video: {
-                            mimes: ['video/mp4', 'application/javascript']
+                            mimes: [ 'video/mp4', 'application/javascript' ]
                         }
                     }
                 }
             ]
         }, {
             code: 'test-banner',
-            sizes: [300, 250],
+            mediaTypes: {
+                banner: {
+                    sizes: [ 300, 250 ]
+                }
+            },
             bids: [
                 {
                     bidder: 'beachfront',

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -14,7 +14,6 @@ describe('BeachfrontAdapter', () => {
           appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
         },
         adUnitCode: 'div-gpt-ad-1460505748561-0',
-        sizes: [ 300, 250 ],
         bidId: '25186806a41eab',
         bidderRequestId: '15bdd8d4a0ebaf',
         auctionId: 'f17d62d0-e3e3-48d0-9f73-cb4ea358a309'
@@ -25,7 +24,6 @@ describe('BeachfrontAdapter', () => {
           appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
         },
         adUnitCode: 'div-gpt-ad-1460505748561-1',
-        sizes: [ 300, 600 ],
         bidId: '365088ee6d649d',
         bidderRequestId: '15bdd8d4a0ebaf',
         auctionId: 'f17d62d0-e3e3-48d0-9f73-cb4ea358a309'
@@ -86,11 +84,16 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('should attach request data', () => {
+        const width = 640;
+        const height = 480;
         const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = { video: {} };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
-        const [ width, height ] = bidRequest.sizes;
         const topLocation = utils.getTopWindowLocation();
         expect(data.isPrebid).to.equal(true);
         expect(data.appId).to.equal(bidRequest.params.appId);
@@ -107,8 +110,11 @@ describe('BeachfrontAdapter', () => {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = [[ width, height ]];
-        bidRequest.mediaTypes = { video: {} };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [[ width, height ]]
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
@@ -118,8 +124,11 @@ describe('BeachfrontAdapter', () => {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = `${width}x${height}`;
-        bidRequest.mediaTypes = { video: {} };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: `${width}x${height}`
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
@@ -127,11 +136,25 @@ describe('BeachfrontAdapter', () => {
 
       it('must handle an empty bid size', () => {
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = [];
-        bidRequest.mediaTypes = { video: {} };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: []
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.imp[0].video).to.deep.contain({ w: undefined, h: undefined });
+      });
+
+      it('must fall back to the size on the bid object', () => {
+        const width = 640;
+        const height = 480;
+        const bidRequest = bidRequests[0];
+        bidRequest.sizes = [ width, height ];
+        bidRequest.mediaTypes = { video: {} };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
       });
 
       it('must override video targeting params', () => {
@@ -163,11 +186,16 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('should attach request data', () => {
+        const width = 300;
+        const height = 250;
         const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.mediaTypes = {
+          banner: {
+            sizes: [ width, height ]
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
-        const [ width, height ] = bidRequest.sizes;
         const topLocation = utils.getTopWindowLocation();
         expect(data.slots).to.deep.equal([
           {
@@ -184,11 +212,14 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('must parse bid size from a nested array', () => {
-        const width = 640;
-        const height = 480;
+        const width = 300;
+        const height = 250;
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = [[ width, height ]];
-        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.mediaTypes = {
+          banner: {
+            sizes: [[ width, height ]]
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.slots[0].sizes).to.deep.equal([
@@ -197,11 +228,14 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('must parse bid size from a string', () => {
-        const width = 640;
-        const height = 480;
+        const width = 300;
+        const height = 250;
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = `${width}x${height}`;
-        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.mediaTypes = {
+          banner: {
+            sizes: `${width}x${height}`
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.slots[0].sizes).to.deep.equal([
@@ -211,11 +245,25 @@ describe('BeachfrontAdapter', () => {
 
       it('must handle an empty bid size', () => {
         const bidRequest = bidRequests[0];
-        bidRequest.sizes = [];
-        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.mediaTypes = {
+          banner: {
+            sizes: []
+          }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.slots[0].sizes).to.deep.equal([]);
+      });
+
+      it('must fall back to the size on the bid object', () => {
+        const width = 300;
+        const height = 250;
+        const bidRequest = bidRequests[0];
+        bidRequest.sizes = [ width, height ];
+        bidRequest.mediaTypes = { banner: {} };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.slots[0].sizes).to.deep.contain({ w: width, h: height });
       });
     });
   });
@@ -250,15 +298,20 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('should return a valid video bid response', () => {
+        const width = 640;
+        const height = 480;
         const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = { video: {} };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
           cmpId: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
-        const [ width, height ] = bidRequest.sizes;
         expect(bidResponse).to.deep.equal({
           requestId: bidRequest.bidId,
           bidderCode: spec.code,
@@ -277,7 +330,11 @@ describe('BeachfrontAdapter', () => {
 
       it('should return a renderer for outstream video bids', () => {
         const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = { video: { context: 'outstream' } };
+        bidRequest.mediaTypes = {
+          video: {
+            context: 'outstream'
+          }
+        };
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
@@ -307,10 +364,16 @@ describe('BeachfrontAdapter', () => {
       });
 
       it('should return valid banner bid responses', () => {
-        bidRequests[0].mediaTypes = { banner: {} };
-        bidRequests[0].sizes = [[ 300, 250 ], [ 728, 90 ]];
-        bidRequests[1].mediaTypes = { banner: {} };
-        bidRequests[1].sizes = [[ 300, 600 ], [ 200, 200 ]];
+        bidRequests[0].mediaTypes = {
+          banner: {
+            sizes: [[ 300, 250 ], [ 728, 90 ]]
+          }
+        };
+        bidRequests[1].mediaTypes = {
+          banner: {
+            sizes: [[ 300, 600 ], [ 200, 200 ]]
+          }
+        };
         const serverResponse = [{
           slot: bidRequests[0].adUnitCode,
           adm: '<div id="44851937"></div>',


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This adds support for sizes defined in `mediaTypes.video.playerSize` and `mediaTypes.banner.sizes` because "Usage of adUnits.sizes will eventually be deprecated." The adapter will still use `adUnits.sizes` as a fallback.