### PR TITLE
added missing dfpAdServerVideo.js dfp vast tag generation uri compone…

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -152,7 +152,7 @@ function getCustParams(bid, options) {
     adserverTargeting,
     { hb_uuid: bid && bid.videoCacheKey },
     // hb_uuid will be deprecated and replaced by hb_cache_id
-    {hb_cache_id: bid && bid.videoCacheKey},
+    { hb_cache_id: bid && bid.videoCacheKey },
     optCustParams,
   );
   return encodeURIComponent(formatQS(customParams));

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -80,7 +80,7 @@ export default function buildDfpVideoUrl(options) {
   const derivedParams = {
     correlator: Date.now(),
     sz: parseSizesInput(adUnit.sizes).join('|'),
-    url: location.href,
+    url: encodeURIComponent(location.href),
   };
   const encodedCustomParams = getCustParams(bid, options);
 

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -22,7 +22,7 @@ export const isBidExpired = (bid) => (bid.responseTimestamp + bid.ttl * 1000 + T
 const isUnusedBid = (bid) => bid && ((bid.status && !includes([BID_TARGETING_SET, RENDERED], bid.status)) || !bid.status);
 
 // If two bids are found for same adUnitCode, we will use the latest one to take part in auction
-// This can happen in case of concurrent autions
+// This can happen in case of concurrent auctions
 export const getOldestBid = function(bid, i, arr) {
   let oldestBid = true;
   arr.forEach((val, j) => {
@@ -175,7 +175,6 @@ export function newTargeting(auctionManager) {
 
   function getBidsReceived() {
     return auctionManager.getBidsReceived()
-      .filter(isUnusedBid)
       .filter(exports.isBidExpired)
       .filter(getOldestBid)
     ;

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -175,6 +175,7 @@ export function newTargeting(auctionManager) {
 
   function getBidsReceived() {
     return auctionManager.getBidsReceived()
+      .filter(isUnusedBid)
       .filter(exports.isBidExpired)
       .filter(getOldestBid)
     ;


### PR DESCRIPTION
- [x] Bugfix

DFP urls built from sites containing special chars and or get params them self were invalid and causing dfp internal server errors.