### PR TITLE
Rubicon Adapter GDPR Update for gdprApplies flag

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -134,6 +134,9 @@ export const spec = {
 
       page_url = bidRequest.params.secure ? page_url.replace(/^http:/i, 'https:') : page_url;
 
+      // GDPR reference, for use by 'banner' and 'video'
+      const gdprConsent = bidderRequest.gdprConsent;
+
       if (spec.hasVideoMediaType(bidRequest)) {
         let params = bidRequest.params;
         let size = parseSizes(bidRequest);
@@ -178,9 +181,12 @@ export const spec = {
 
         data.slots.push(slotData);
 
-        if (bidderRequest && bidderRequest.gdprConsent) {
-          data.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
-          data.gdpr_consent = bidderRequest.gdprConsent.consentString;
+        if (gdprConsent) {
+          // add 'gdpr' only if 'gdprApplies' is defined
+          if (typeof gdprConsent.gdprApplies === 'boolean') {
+            data.gdpr = Number(gdprConsent.gdprApplies);
+          }
+          data.gdpr_consent = gdprConsent.consentString;
         }
 
         return {
@@ -228,13 +234,12 @@ export const spec = {
         'tk_user_key', userId
       ];
 
-      // add GDPR properties if enabled
-      if (config.getConfig('consentManagement') &&
-        bidderRequest && bidderRequest.gdprConsent && typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') {
-        data.push(
-          'gdpr', bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
-          'gdpr_consent', bidderRequest.gdprConsent.consentString
-        );
+      if (gdprConsent) {
+        // add 'gdpr' only if 'gdprApplies' is defined
+        if (typeof gdprConsent.gdprApplies === 'boolean') {
+          data.push('gdpr', Number(gdprConsent.gdprApplies));
+        }
+        data.push('gdpr_consent', gdprConsent.consentString);
       }
 
       if (visitor !== null && typeof visitor === 'object') {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -178,9 +178,9 @@ export const spec = {
 
         data.slots.push(slotData);
 
-        if (bidderRequest && bidRequest.gdprConsent) {
-          data.gdpr = bidRequest.gdprConsent.consentRequired ? 1 : 0;
-          data.gdpr_consent = bidRequest.gdprConsent.consentString;
+        if (bidderRequest && bidderRequest.gdprConsent) {
+          data.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+          data.gdpr_consent = bidderRequest.gdprConsent.consentString;
         }
 
         return {
@@ -229,15 +229,12 @@ export const spec = {
       ];
 
       // add GDPR properties if enabled
-      if (config.getConfig('consentManagement')) {
-        if (bidRequest.gdprConsent && typeof bidRequest.gdprConsent === 'object') {
-          if (typeof bidRequest.gdprConsent.consentRequired === 'boolean') {
-            data.push(
-              'gdpr', bidRequest.gdprConsent.consentRequired ? 1 : 0,
-              'gdpr_consent', bidRequest.gdprConsent.consentString
-            );
-          }
-        }
+      if (config.getConfig('consentManagement') &&
+        bidderRequest && bidderRequest.gdprConsent && typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') {
+        data.push(
+          'gdpr', bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+          'gdpr_consent', bidderRequest.gdprConsent.consentString
+        );
       }
 
       if (visitor !== null && typeof visitor === 'object') {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -228,6 +228,18 @@ export const spec = {
         'tk_user_key', userId
       ];
 
+      // add GDPR properties if enabled
+      if (config.getConfig('consentManagement')) {
+        if (bidRequest.gdprConsent && typeof bidRequest.gdprConsent === 'object') {
+          if (typeof bidRequest.gdprConsent.consentRequired === 'boolean') {
+            data.push(
+              'gdpr', bidRequest.gdprConsent.consentRequired ? 1 : 0,
+              'gdpr_consent', bidRequest.gdprConsent.consentString
+            );
+          }
+        }
+      }
+
       if (visitor !== null && typeof visitor === 'object') {
         utils._each(visitor, (item, key) => data.push(`tg_v.${key}`, item));
       }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -15,20 +15,22 @@ describe('the rubicon adapter', () => {
   let sandbox,
     bidderRequest;
 
-  function createVideoBidderRequest() {
-    let bid = bidderRequest.bids[0];
+  function addConsentManagement() {
+    bidderRequest.gdprConsent = {
+      'consentString': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+      'gdprApplies': true
+    }
+  }
 
+  function createVideoBidderRequest() {
+    addConsentManagement();
+
+    let bid = bidderRequest.bids[0];
     bid.mediaTypes = {
       video: {
         context: 'instream'
       }
     };
-
-    bid.gdprConsent = {
-      'consentString': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
-      'consentRequired': true
-    };
-
     bid.params.video = {
       'language': 'en',
       'p_aso.video.ext.skip': true,
@@ -44,14 +46,11 @@ describe('the rubicon adapter', () => {
   }
 
   function createLegacyVideoBidderRequest() {
-    let bid = bidderRequest.bids[0];
+    addConsentManagement();
 
+    let bid = bidderRequest.bids[0];
     // Legacy property (Prebid <1.0)
     bid.mediaType = 'video';
-    bid.gdprConsent = {
-      'consentString': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
-      'consentRequired': true
-    };
     bid.params.video = {
       'language': 'en',
       'p_aso.video.ext.skip': true,
@@ -147,10 +146,6 @@ describe('the rubicon adapter', () => {
       bids: [
         {
           bidder: 'rubicon',
-          gdprConsent: {
-            'consentString': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
-            'consentRequired': true
-          },
           params: {
             accountId: '14062',
             siteId: '70608',
@@ -541,6 +536,8 @@ describe('the rubicon adapter', () => {
         });
 
         it('should send GDPR params when enabled', () => {
+          addConsentManagement();
+
           sandbox.stub(config, 'getConfig').callsFake((key) => {
             var config = {
               consentManagement: {
@@ -586,7 +583,7 @@ describe('the rubicon adapter', () => {
           });
         });
 
-        it('should not send GDPR params if bidRequest does not pass gdprConsent', () => {
+        it('should not send GDPR params if gdprConsent is not set in config', () => {
           sandbox.stub(config, 'getConfig').callsFake((key) => {
             var config = {
               consentManagement: {
@@ -597,9 +594,6 @@ describe('the rubicon adapter', () => {
             };
             return config[key];
           });
-
-          // Remove gdprConsent from bidRequest
-          delete bidderRequest.bids[0].gdprConsent;
 
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let data = parseQuery(request.data);


### PR DESCRIPTION
Rubicon Adapter GDPR: change to support gdprApplies flag

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Other

## Description of change

Added support for both the v1.0 callback (just consentData) and the 1.1 callback object.

## Other information
[HB-2543](https://jira.rubiconproject.com/browse/HB-2543)