### PR TITLE
Update ReadPeak adapter (legacy)

### DIFF
--- a/modules/readpeakBidAdapter.js
+++ b/modules/readpeakBidAdapter.js
@@ -1,5 +1,7 @@
-import {logError, getTopWindowLocation} from 'src/utils';
+import {logError, getTopWindowLocation, replaceAuctionPrice} from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
+import { NATIVE } from 'src/mediaTypes';
 
 export const ENDPOINT = '//app.readpeak.com/header/prebid';
 
@@ -18,7 +20,7 @@ export const spec = {
 
   code: BIDDER_CODE,
 
-  supportedMediaTypes: ['native'],
+  supportedMediaTypes: [NATIVE],
 
   isBidRequestValid: bid => (
     !!(bid && bid.params && bid.params.publisherId && bid.nativeParams)
@@ -31,7 +33,14 @@ export const spec = {
       site: site(bidRequests),
       app: app(bidRequests),
       device: device(),
-      isPrebid: true,
+      cur: config.getConfig('currency') || ['USD'],
+      source: {
+        fd: 1,
+        tid: bidRequests[0].transactionId,
+        ext: {
+          prebid: $$PREBID_GLOBAL$$.version,
+        },
+      },
     }
 
     return {
@@ -70,7 +79,7 @@ function bidResponseAvailable(bidRequest, bidResponse) {
         creativeId: idToBidMap[id].crid,
         ttl: 300,
         netRevenue: true,
-        mediaType: 'native',
+        mediaType: NATIVE,
         currency: bidResponse.cur,
         native: nativeResponse(idToImpMap[id], idToBidMap[id]),
       };
@@ -93,7 +102,7 @@ function nativeImpression(slot) {
   if (slot.nativeParams) {
     const assets = [];
     addAsset(assets, titleAsset(1, slot.nativeParams.title, NATIVE_DEFAULTS.TITLE_LEN));
-    addAsset(assets, imageAsset(2, slot.nativeParams.image, 3, NATIVE_DEFAULTS.IMG_MIN, NATIVE_DEFAULTS.IMG_MIN));
+    addAsset(assets, imageAsset(2, slot.nativeParams.image, 3, slot.nativeParams.wmin || NATIVE_DEFAULTS.IMG_MIN, slot.nativeParams.hmin || NATIVE_DEFAULTS.IMG_MIN));
     addAsset(assets, dataAsset(3, slot.nativeParams.sponsoredBy, 1, NATIVE_DEFAULTS.SPONSORED_BY_LEN));
     addAsset(assets, dataAsset(4, slot.nativeParams.body, 2, NATIVE_DEFAULTS.DESCR_LEN));
     addAsset(assets, dataAsset(5, slot.nativeParams.cta, 12, NATIVE_DEFAULTS.CTA_LEN));
@@ -149,19 +158,29 @@ function dataAsset(id, params, type, defaultLen) {
 
 function site(bidderRequest) {
   const pubId = bidderRequest && bidderRequest.length > 0 ? bidderRequest[0].params.publisherId : '0';
+  const siteId = bidderRequest && bidderRequest.length > 0 ? bidderRequest[0].params.siteId : '0';
   const appParams = bidderRequest[0].params.app;
   if (!appParams) {
     return {
       publisher: {
         id: pubId.toString(),
+        domain: config.getConfig('publisherDomain'),
       },
-      id: pubId.toString(),
+      id: siteId ? siteId.toString() : pubId.toString(),
       ref: referrer(),
-      page: getTopWindowLocation().href,
+      page: config.getConfig('pageUrl') || getTopWindowLocation().href,
       domain: getTopWindowLocation().hostname
     }
   }
-  return null;
+  return undefined;
+}
+
+function referrer() {
+  try {
+    return window.top.document.referrer;
+  } catch (e) {
+    return document.referrer;
+  }
 }
 
 function app(bidderRequest) {
@@ -177,21 +196,14 @@ function app(bidderRequest) {
       domain: appParams.domain,
     }
   }
-  return null;
-}
-
-function referrer() {
-  try {
-    return window.top.document.referrer;
-  } catch (e) {
-    return document.referrer;
-  }
+  return undefined;
 }
 
 function device() {
   return {
     ua: navigator.userAgent,
     language: (navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage),
+    devicetype: 1
   };
 }
 
@@ -219,13 +231,19 @@ function nativeResponse(imp, bid) {
         keys.title = asset.title ? asset.title.text : keys.title;
         keys.body = asset.data && asset.id === 4 ? asset.data.value : keys.body;
         keys.sponsoredBy = asset.data && asset.id === 3 ? asset.data.value : keys.sponsoredBy;
-        keys.image = asset.img && asset.id === 2 ? asset.img.url : keys.image;
+        keys.image = asset.img && asset.id === 2 ? {
+          url: asset.img.url,
+          width: asset.img.w || 750,
+          height: asset.img.h || 500,
+        } : keys.image;
         keys.cta = asset.data && asset.id === 5 ? asset.data.value : keys.cta;
       });
       if (nativeAd.link) {
         keys.clickUrl = encodeURIComponent(nativeAd.link.url);
       }
-      keys.impressionTrackers = nativeAd.imptrackers;
+      const trackers = nativeAd.imptrackers || [];
+      trackers.unshift(replaceAuctionPrice(bid.burl, bid.price));
+      keys.impressionTrackers = trackers;
       return keys;
     }
   }

--- a/modules/readpeakBidAdapter.js
+++ b/modules/readpeakBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
         fd: 1,
         tid: bidRequests[0].transactionId,
         ext: {
-          prebid: $$PREBID_GLOBAL$$.version,
+          prebid: '$prebid.version$',
         },
       },
     }

--- a/modules/readpeakBidAdapter.js
+++ b/modules/readpeakBidAdapter.js
@@ -1,4 +1,4 @@
-import {logError, getTopWindowLocation, replaceAuctionPrice} from 'src/utils';
+import { logError, getTopWindowLocation, replaceAuctionPrice, getTopWindowReferrer } from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import { NATIVE } from 'src/mediaTypes';
@@ -167,20 +167,12 @@ function site(bidderRequest) {
         domain: config.getConfig('publisherDomain'),
       },
       id: siteId ? siteId.toString() : pubId.toString(),
-      ref: referrer(),
+      ref: getTopWindowReferrer(),
       page: config.getConfig('pageUrl') || getTopWindowLocation().href,
       domain: getTopWindowLocation().hostname
     }
   }
   return undefined;
-}
-
-function referrer() {
-  try {
-    return window.top.document.referrer;
-  } catch (e) {
-    return document.referrer;
-  }
 }
 
 function app(bidderRequest) {

--- a/modules/readpeakBidAdapter.md
+++ b/modules/readpeakBidAdapter.md
@@ -16,13 +16,14 @@ Please reach out to your account team or hello@readpeak.com for more information
 # Test Parameters
 ```javascript
     var adUnits = [{
-        code: 'test-native',
+        code: '/19968336/prebid_native_example_2',
         mediaTypes: { native: { type: 'image' } },
         bids: [{
             bidder: 'readpeak',
             params: {
                 bidfloor: 5.00,
-                publisherId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+                publisherId: 'test',
+                siteId: 'test'
             },
         }]
     }];

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -19,7 +19,8 @@ describe('ReadPeakAdapter', () => {
       },
       params: {
         bidfloor: 5.00,
-        publisherId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+        publisherId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+        siteId: '11bc5dd5-7421-4dd8-c926-40fa653bec77'
       },
       auctionId: '1d1a030790a475',
       bidId: '2ffb201a808da7',
@@ -64,8 +65,8 @@ describe('ReadPeakAdapter', () => {
               img: {
                 type: 3,
                 url: 'http://url.to/image',
-                w: 320,
-                h: 200,
+                w: 750,
+                h: 500,
               },
             }],
             link: {
@@ -98,7 +99,7 @@ describe('ReadPeakAdapter', () => {
           'publisher': {
             'id': '11bc5dd5-7421-4dd8-c926-40fa653bec76'
           },
-          'id': '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+          'id': '11bc5dd5-7421-4dd8-c926-40fa653bec77',
           'ref': '',
           'page': 'http://localhost:9876/?id=48509002',
           'domain': 'localhost'
@@ -152,15 +153,17 @@ describe('ReadPeakAdapter', () => {
       const request = spec.buildRequests([ bidRequest ]);
 
       const data = JSON.parse(request.data);
-      expect(data.isPrebid).to.equal(true);
+
+      expect(data.source.ext.prebid).to.equal($$PREBID_GLOBAL$$.version);
       expect(data.id).to.equal(bidRequest.bidderRequestId)
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
       expect(data.imp[0].bidfloorcur).to.equal('USD');
       expect(data.site).to.deep.equal({
         publisher: {
           id: bidRequest.params.publisherId,
+          domain: 'http://localhost:9876',
         },
-        id: bidRequest.params.publisherId,
+        id: bidRequest.params.siteId,
         ref: window.top.document.referrer,
         page: utils.getTopWindowLocation().href,
         domain: utils.getTopWindowLocation().hostname,
@@ -189,7 +192,7 @@ describe('ReadPeakAdapter', () => {
 
       expect(bidResponse.native.title).to.equal('Title')
       expect(bidResponse.native.body).to.equal('Description')
-      expect(bidResponse.native.image).to.equal('http://url.to/image')
+      expect(bidResponse.native.image).to.deep.equal({url: 'http://url.to/image', width: 750, height: 500})
       expect(bidResponse.native.clickUrl).to.equal('http%3A%2F%2Furl.to%2Ftarget')
       expect(bidResponse.native.impressionTrackers).to.contain('http://url.to/pixeltracker')
     });

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec, ENDPOINT } from 'modules/readpeakBidAdapter';
 import * as utils from 'src/utils';
+import { config } from 'src/config';
 
 describe('ReadPeakAdapter', () => {
   let bidRequest
@@ -161,7 +162,7 @@ describe('ReadPeakAdapter', () => {
       expect(data.site).to.deep.equal({
         publisher: {
           id: bidRequest.params.publisherId,
-          domain: 'http://localhost:9876',
+          domain: config.getConfig('publisherDomain'),
         },
         id: bidRequest.params.siteId,
         ref: window.top.document.referrer,

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -154,7 +154,7 @@ describe('ReadPeakAdapter', () => {
 
       const data = JSON.parse(request.data);
 
-      expect(data.source.ext.prebid).to.equal($$PREBID_GLOBAL$$.version);
+      expect(data.source.ext.prebid).to.equal('$prebid.version$');
       expect(data.id).to.equal(bidRequest.bidderRequestId)
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
       expect(data.imp[0].bidfloorcur).to.equal('USD');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

This is essentially the same PR as #2369 but for legacy branch and with one extra fix for tests. It seems that `config.getConfig('publisherDomain')` returns different value in legacy and master.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Updates to the ReadPeak adapter to match changes to the ReadPeak system as well as some minor refactoring to clean up the adapter and make it a better citizen in Prebid.

- contact email of the adapter’s maintainer
kurre.stahlberg@readpeak.com
