### PR TITLE
send rp_secure to frank for video bids in legacy

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -117,16 +117,16 @@ export const spec = {
       if (spec.hasVideoMediaType(bidRequest)) {
         let params = bidRequest.params;
         let size = parseSizes(bidRequest);
-        let page_rf = !params.referrer ? utils.getTopWindowUrl() : params.referrer;
 
         let data = {
-          page_url: params.secure ? page_rf.replace(/^http:/i, 'https:') : page_rf,
+          page_url: !params.referrer ? utils.getTopWindowUrl() : params.referrer,
           resolution: _getScreenResolution(),
           account_id: params.accountId,
           integration: INTEGRATION,
           timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart + TIMEOUT_BUFFER),
           stash_creatives: true,
           ae_pass_through_parameters: params.video.aeParams,
+          rp_secure: params.secure !== false,
           slots: []
         };
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -54,6 +54,7 @@ describe('the rubicon adapter', () => {
         'p_aso.video.ext.skipdelay': '15'
       }
     };
+    bid.params.secure = false;
   }
 
   function createVideoBidderRequestNoVideo() {
@@ -532,6 +533,7 @@ describe('the rubicon adapter', () => {
           expect(post).to.have.property('timeout').that.is.a('number');
           expect(post.timeout < 5000).to.equal(true);
           expect(post.stash_creatives).to.equal(true);
+          expect(post.rp_secure).to.equal(false);
 
           expect(post).to.have.property('ae_pass_through_parameters');
           expect(post.ae_pass_through_parameters)
@@ -592,6 +594,7 @@ describe('the rubicon adapter', () => {
           expect(post).to.have.property('timeout').that.is.a('number');
           expect(post.timeout < 5000).to.equal(true);
           expect(post.stash_creatives).to.equal(true);
+          expect(post.rp_secure).to.equal(true);
 
           expect(post).to.have.property('ae_pass_through_parameters');
           expect(post.ae_pass_through_parameters)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
In rubiconBidAdapter, send secure info to Frank for video bids