### PR TITLE
Only send OpenX BO beacon once per page load

### DIFF
--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {spec} from 'modules/openxBidAdapter';
+import {spec, resetBoPixel} from 'modules/openxBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 import {userSync} from 'src/userSync';
 import * as utils from 'src/utils';
@@ -586,6 +586,7 @@ describe('OpenxAdapter', () => {
       });
 
       it('should register a beacon', () => {
+        resetBoPixel();
         spec.interpretResponse({body: bidResponse}, bidRequest);
         sinon.assert.calledWith(userSync.registerSync, 'image', 'openx', sinon.match(new RegExp(`\/\/openx-d\.openx\.net.*\/bo\?.*ts=${adUnitOverride.ts}`)));
       });
@@ -882,6 +883,7 @@ describe('OpenxAdapter', () => {
     });
 
     it('should register a beacon', () => {
+      resetBoPixel();
       spec.interpretResponse({body: bidResponse}, bidRequestsWithMediaTypes);
       sinon.assert.calledWith(userSync.registerSync, 'image', 'openx', sinon.match(/^\/\/test-colo\.com/))
       sinon.assert.calledWith(userSync.registerSync, 'image', 'openx', sinon.match(/ph=test-ph/));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Currently the beacon is sent for each ad unit, which is unnecessary and eats up pixel quota.


