### PR TITLE
Add LockerDome legacy bid adapter

### DIFF
--- a/modules/lockerdomeBidAdapter.js
+++ b/modules/lockerdomeBidAdapter.js
@@ -1,0 +1,50 @@
+import * as utils from 'src/utils';
+import {BANNER} from 'src/mediaTypes';
+import {registerBidder} from 'src/adapters/bidderFactory';
+
+export const spec = {
+  code: 'lockerdome',
+  supportedMediaTypes: [BANNER],
+  isBidRequestValid: function(bid) {
+    return !!bid.params.adUnitId;
+  },
+  buildRequests: function(bidRequests) {
+    const adUnitBidRequests = bidRequests.map(function (bid) {
+      return {
+        requestId: bid.bidId,
+        adUnitId: utils.getBidIdParameter('adUnitId', bid.params),
+        sizes: bid.sizes
+      }
+    });
+    const payload = {
+      bidRequests: adUnitBidRequests,
+      url: utils.getTopWindowLocation().href,
+      referrer: utils.getTopWindowReferrer()
+    };
+    const payloadString = JSON.stringify(payload);
+    return {
+      method: 'POST',
+      url: 'https://lockerdome.com/ladbid/prebid',
+      data: payloadString
+    };
+  },
+  interpretResponse: function(serverResponse, bidRequest) {
+    if (!serverResponse || !serverResponse.body || !serverResponse.body.bids) {
+      return [];
+    }
+    return serverResponse.body.bids.map(function(bid) {
+      return {
+        requestId: bid.requestId,
+        cpm: bid.cpm,
+        width: bid.width,
+        height: bid.height,
+        creativeId: bid.creativeId,
+        currency: bid.currency,
+        netRevenue: bid.netRevenue,
+        ad: bid.ad,
+        ttl: bid.ttl
+      };
+    });
+  },
+}
+registerBidder(spec);

--- a/modules/lockerdomeBidAdapter.md
+++ b/modules/lockerdomeBidAdapter.md
@@ -1,0 +1,29 @@
+# Overview
+
+```
+Module Name: LockerDome Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: bidding@lockerdome.com
+```
+
+#Description
+Connects to LockerDome Ad Server for bids.
+
+# Test Parameters
+```
+var adUnits = [{
+    code: 'ad-div',
+    sizes: [[300, 250]],
+    mediaTypes: {
+        banner: {
+            sizes: [[300, 250]]
+        }
+    },
+    bids: [{
+        bidder: 'lockerdome',
+        params: {
+            adUnitId: 10809467961050726
+        }
+    }]
+}];
+```

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -1,0 +1,142 @@
+import { expect } from 'chai';
+import { spec } from '../../../modules/lockerdomeBidAdapter';
+import * as utils from 'src/utils';
+
+describe('LockerDomeAdapter', () => {
+  const bidRequests = [{
+    bidder: 'lockerdome',
+    params: {
+      adUnitId: 10809467961050726
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    adUnitCode: 'ad-1',
+    transactionId: 'b55e97d7-792c-46be-95a5-3df40b115734',
+    sizes: [[300, 250]],
+    bidId: '2652ca954bce9',
+    bidderRequestId: '14a54fade69854',
+    auctionId: 'd4c83108-615d-4c2c-9384-dac9ffd4fd72'
+  }, {
+    bidder: 'lockerdome',
+    params: {
+      adUnitId: 9434769725128806
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 600]]
+      }
+    },
+    adUnitCode: 'ad-2',
+    transactionId: '73459f05-c482-4706-b2b7-72e6f6264ce6',
+    sizes: [[300, 600]],
+    bidId: '4510f2834773ce',
+    bidderRequestId: '14a54fade69854',
+    auctionId: 'd4c83108-615d-4c2c-9384-dac9ffd4fd72'
+  }];
+
+  describe('isBidRequestValid', () => {
+    it('should return true if the adUnitId parameter is present', () => {
+      expect(spec.isBidRequestValid(bidRequests[0])).to.be.true;
+      expect(spec.isBidRequestValid(bidRequests[1])).to.be.true;
+    });
+    it('should return false if the adUnitId parameter is not present', () => {
+      let bidRequest = utils.deepClone(bidRequests[0]);
+      delete bidRequest.params.adUnitId;
+      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+    });
+  });
+
+  describe('buildRequests', () => {
+    it('should generate a valid single POST request for multiple bid requests', () => {
+      const request = spec.buildRequests(bidRequests);
+      expect(request.method).to.equal('POST');
+      // TODO: Update to production URL
+      expect(request.url).to.equal('https://lockerdome.com/ladbid/prebid');
+      expect(request.data).to.exist;
+
+      const requestData = JSON.parse(request.data);
+
+      expect(requestData.url).to.equal(utils.getTopWindowLocation().href);
+      expect(requestData.referrer).to.equal(utils.getTopWindowReferrer());
+
+      const bids = requestData.bidRequests;
+      expect(bids).to.have.lengthOf(2);
+
+      expect(bids[0].requestId).to.equal('2652ca954bce9');
+      expect(bids[0].adUnitId).to.equal(10809467961050726);
+      expect(bids[0].sizes).to.have.lengthOf(1);
+      expect(bids[0].sizes[0][0]).to.equal(300);
+      expect(bids[0].sizes[0][1]).to.equal(250);
+
+      expect(bids[1].requestId).to.equal('4510f2834773ce');
+      expect(bids[1].adUnitId).to.equal(9434769725128806);
+      expect(bids[1].sizes).to.have.lengthOf(1);
+      expect(bids[1].sizes[0][0]).to.equal(300);
+      expect(bids[1].sizes[0][1]).to.equal(600);
+    });
+  });
+
+  describe('interpretResponse', () => {
+    it('should return an empty array if an invalid response is passed', () => {
+      const interpretedResponse = spec.interpretResponse({ body: {} });
+      expect(interpretedResponse).to.be.an('array').that.is.empty;
+    });
+
+    it('should return valid response when passed valid server response', () => {
+      const serverResponse = {
+        body: {
+          bids: [{
+            requestId: '2652ca954bce9',
+            cpm: 1.00,
+            width: 300,
+            height: 250,
+            creativeId: '12345',
+            currency: 'USD',
+            netRevenue: true,
+            ad: '<!-- AD 1 CREATIVE -->',
+            ttl: 300
+          },
+          {
+            requestId: '4510f2834773ce',
+            cpm: 1.10,
+            width: 300,
+            height: 600,
+            creativeId: '45678',
+            currency: 'USD',
+            netRevenue: true,
+            ad: '<!-- AD 2 CREATIVE -->',
+            ttl: 300
+          }]
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests);
+      const interpretedResponse = spec.interpretResponse(serverResponse, request);
+
+      expect(interpretedResponse).to.have.lengthOf(2);
+
+      expect(interpretedResponse[0].requestId).to.equal(serverResponse.body.bids[0].requestId);
+      expect(interpretedResponse[0].cpm).to.equal(serverResponse.body.bids[0].cpm);
+      expect(interpretedResponse[0].width).to.equal(serverResponse.body.bids[0].width);
+      expect(interpretedResponse[0].height).to.equal(serverResponse.body.bids[0].height);
+      expect(interpretedResponse[0].creativeId).to.equal(serverResponse.body.bids[0].creativeId);
+      expect(interpretedResponse[0].currency).to.equal(serverResponse.body.bids[0].currency);
+      expect(interpretedResponse[0].netRevenue).to.equal(serverResponse.body.bids[0].netRevenue);
+      expect(interpretedResponse[0].ad).to.equal(serverResponse.body.bids[0].ad);
+      expect(interpretedResponse[0].ttl).to.equal(serverResponse.body.bids[0].ttl);
+
+      expect(interpretedResponse[1].requestId).to.equal(serverResponse.body.bids[1].requestId);
+      expect(interpretedResponse[1].cpm).to.equal(serverResponse.body.bids[1].cpm);
+      expect(interpretedResponse[1].width).to.equal(serverResponse.body.bids[1].width);
+      expect(interpretedResponse[1].height).to.equal(serverResponse.body.bids[1].height);
+      expect(interpretedResponse[1].creativeId).to.equal(serverResponse.body.bids[1].creativeId);
+      expect(interpretedResponse[1].currency).to.equal(serverResponse.body.bids[1].currency);
+      expect(interpretedResponse[1].netRevenue).to.equal(serverResponse.body.bids[1].netRevenue);
+      expect(interpretedResponse[1].ad).to.equal(serverResponse.body.bids[1].ad);
+      expect(interpretedResponse[1].ttl).to.equal(serverResponse.body.bids[1].ttl);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [X] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- test parameters for validating bids
```
{
        bidder: 'lockerdome',
        params: {
            adUnitId: 10809467961050726
        }
}
```

- contact email of the adapter’s maintainer bidding@lockerdome.com
- [X] official adapter submission

- A link to a PR on the docs repo - https://github.com/prebid/prebid.github.io/pull/738

## Other Information

Same changes as 1.0 adapter pull request https://github.com/prebid/Prebid.js/pull/2477
