### PR TITLE
add support to handle native js pixels for AN adapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -227,6 +227,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       clickUrl: nativeAd.link.url,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,
+      javascriptTrackers: nativeAd.javascript_trackers,
     };
     if (nativeAd.main_img) {
       bid['native'].image = {

--- a/src/native.js
+++ b/src/native.js
@@ -1,4 +1,4 @@
-import { deepAccess, getBidRequest, logError, triggerPixel } from './utils';
+import { deepAccess, getBidRequest, logError, triggerPixel, insertHtmlIntoIframe } from './utils';
 import includes from 'core-js/library/fn/array/includes';
 
 export const nativeAdapters = [];
@@ -145,6 +145,10 @@ export function fireNativeTrackers(message, adObject) {
     trackers = adObject['native'] && adObject['native'].clickTrackers;
   } else {
     trackers = adObject['native'] && adObject['native'].impressionTrackers;
+
+    if (adObject['native'] && adObject['native'].javascriptTrackers) {
+      insertHtmlIntoIframe(adObject['native'].javascriptTrackers);
+    }
   }
 
   (trackers || []).forEach(triggerPixel);

--- a/src/utils.js
+++ b/src/utils.js
@@ -515,6 +515,38 @@ exports.callBurl = function({ source, burl }) {
 };
 
 /**
+ * Inserts an empty iframe with the specified `html`, primarily used for tracking purposes
+ * (though could be for other purposes)
+ * @param {string} htmlCode snippet of HTML code used for tracking purposes
+ */
+exports.insertHtmlIntoIframe = function(htmlCode) {
+  if (!htmlCode) {
+    return;
+  }
+
+  let iframe = document.createElement('iframe');
+  iframe.id = exports.getUniqueIdentifierStr();
+  iframe.width = 0;
+  iframe.height = 0;
+  iframe.hspace = '0';
+  iframe.vspace = '0';
+  iframe.marginWidth = '0';
+  iframe.marginHeight = '0';
+  iframe.style.display = 'none';
+  iframe.style.height = '0px';
+  iframe.style.width = '0px';
+  iframe.scrolling = 'no';
+  iframe.frameBorder = '0';
+  iframe.allowtransparency = 'true';
+
+  exports.insertElement(iframe, document, 'body');
+
+  iframe.contentWindow.document.open();
+  iframe.contentWindow.document.write(htmlCode);
+  iframe.contentWindow.document.close();
+}
+
+/**
  * Inserts empty iframe with the specified `url` for cookie sync
  * @param  {string} url URL to be requested
  * @param  {string} encodeUri boolean if URL should be encoded before inserted. Defaults to true
@@ -566,7 +598,7 @@ exports.createTrackPixelIframeHtml = function (url, encodeUri = true, sandbox = 
       allowtransparency="true"
       marginheight="0" marginwidth="0"
       width="0" hspace="0" vspace="0" height="0"
-      style="height:0p;width:0p;display:none;"
+      style="height:0px;width:0px;display:none;"
       scrolling="no"
       src="${url}">
     </iframe>`;

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -11,18 +11,22 @@ const bid = {
     clickUrl: 'https://www.link.example',
     clickTrackers: ['https://tracker.example'],
     impressionTrackers: ['https://impression.example'],
+    javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>'
   }
 };
 
 describe('native.js', () => {
   let triggerPixelStub;
+  let insertHtmlIntoIframeStub;
 
   beforeEach(() => {
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
+    insertHtmlIntoIframeStub = sinon.stub(utils, 'insertHtmlIntoIframe');
   });
 
   afterEach(() => {
     utils.triggerPixel.restore();
+    utils.insertHtmlIntoIframe.restore();
   });
 
   it('gets native targeting keys', () => {
@@ -36,6 +40,7 @@ describe('native.js', () => {
     fireNativeTrackers({}, bid);
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
+    sinon.assert.calledWith(insertHtmlIntoIframeStub, bid.native.javascriptTrackers);
   });
 
   it('fires click trackers', () => {
@@ -91,6 +96,7 @@ describe('validate native', () => {
       },
       clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
       impressionTrackers: ['http://my.imp.tracker/url'],
+      javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>',
       title: 'This is an example Prebid Native creative'
     }
   };
@@ -114,6 +120,7 @@ describe('validate native', () => {
       },
       clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
       impressionTrackers: ['http://my.imp.tracker/url'],
+      javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>',
       title: 'This is an example Prebid Native creative'
     }
   };
@@ -137,6 +144,7 @@ describe('validate native', () => {
       },
       clickUrl: 'http://prebid.org/dev-docs/show-native-ads.html',
       impressionTrackers: ['http://my.imp.tracker/url'],
+      javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>',
       title: 'This is an example Prebid Native creative'
     }
   };


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added support to read the `javascript_trackers` field for AppNexus native creatives.  Added additional logic to handle the html script code from this field and render it onto the page along with the impression trackers.  The html code is stored into an iframe that's written onto the page in the body.

For any testing, use `placementId: '9880618'`.  Note you may have to refresh a few times to get the correct placement.