### PR TITLE
New debugging functionality with bid overrides

### DIFF
--- a/src/debugging.js
+++ b/src/debugging.js
@@ -1,0 +1,89 @@
+
+import { config } from 'src/config';
+import { logMessage as utilsLogMessage, logWarn as utilsLogWarn } from 'src/utils';
+import { addBidResponse } from 'src/auction';
+
+const OVERRIDE_KEY = '$$PREBID_GLOBAL$$:bidderOverrides';
+
+export let boundHook;
+
+function logMessage(msg) {
+  utilsLogMessage('DEBUG: ' + msg);
+}
+
+function logWarn(msg) {
+  utilsLogWarn('DEBUG: ' + msg);
+}
+
+function enableOverrides(overrides, fromSession = false) {
+  config.setConfig({'debug': true});
+  logMessage(`bidder overrides enabled${fromSession ? ' from session' : ''}`);
+
+  if (boundHook) {
+    addBidResponse.removeHook(boundHook);
+  }
+
+  boundHook = addBidResponseHook.bind(null, overrides);
+  addBidResponse.addHook(boundHook, 5);
+}
+
+export function disableOverrides() {
+  if (boundHook) {
+    addBidResponse.removeHook(boundHook);
+    logMessage('bidder overrides disabled');
+  }
+}
+
+export function addBidResponseHook(overrides, adUnitCode, bid, next) {
+  if (Array.isArray(overrides.bidders) && overrides.bidders.indexOf(bid.bidderCode) === -1) {
+    logWarn(`bidder '${bid.bidderCode}' excluded from auction by bidder overrides`);
+    return;
+  }
+
+  if (Array.isArray(overrides.bids)) {
+    overrides.bids.forEach(overrideBid => {
+      if (overrideBid.bidder && overrideBid.bidder !== bid.bidderCode) {
+        return;
+      }
+      if (overrideBid.adUnitCode && overrideBid.adUnitCode !== adUnitCode) {
+        return;
+      }
+
+      bid = Object.assign({}, bid);
+
+      Object.keys(overrideBid).filter(key => ['bidder', 'adUnitCode'].indexOf(key) === -1).forEach((key) => {
+        let value = overrideBid[key];
+        logMessage(`bidder overrides changed '${adUnitCode}/${bid.bidderCode}' bid.${key} from '${bid[key]}' to '${value}'`);
+        bid[key] = value;
+      });
+    });
+  }
+
+  next(adUnitCode, bid);
+}
+
+export function getConfig(bidderOverrides) {
+  if (!bidderOverrides.enabled) {
+    disableOverrides();
+    try {
+      sessionStorage.removeItem(OVERRIDE_KEY);
+    } catch (e) {}
+  } else {
+    try {
+      sessionStorage.setItem(OVERRIDE_KEY, JSON.stringify(bidderOverrides));
+    } catch (e) {}
+    enableOverrides(bidderOverrides);
+  }
+}
+config.getConfig('bidderOverrides', ({bidderOverrides}) => getConfig(bidderOverrides));
+
+export function sessionLoader() {
+  let overrides;
+  try {
+    overrides = JSON.parse(sessionStorage.getItem(OVERRIDE_KEY));
+  } catch (e) {
+  }
+  if (overrides) {
+    enableOverrides(overrides, true);
+  }
+}

--- a/src/debugging.js
+++ b/src/debugging.js
@@ -3,7 +3,7 @@ import { config } from 'src/config';
 import { logMessage as utilsLogMessage, logWarn as utilsLogWarn } from 'src/utils';
 import { addBidResponse } from 'src/auction';
 
-const OVERRIDE_KEY = '$$PREBID_GLOBAL$$:bidderOverrides';
+const OVERRIDE_KEY = '$$PREBID_GLOBAL$$:debugging';
 
 export let boundHook;
 
@@ -62,20 +62,20 @@ export function addBidResponseHook(overrides, adUnitCode, bid, next) {
   next(adUnitCode, bid);
 }
 
-export function getConfig(bidderOverrides) {
-  if (!bidderOverrides.enabled) {
+export function getConfig(debugging) {
+  if (!debugging.enabled) {
     disableOverrides();
     try {
       sessionStorage.removeItem(OVERRIDE_KEY);
     } catch (e) {}
   } else {
     try {
-      sessionStorage.setItem(OVERRIDE_KEY, JSON.stringify(bidderOverrides));
+      sessionStorage.setItem(OVERRIDE_KEY, JSON.stringify(debugging));
     } catch (e) {}
-    enableOverrides(bidderOverrides);
+    enableOverrides(debugging);
   }
 }
-config.getConfig('bidderOverrides', ({bidderOverrides}) => getConfig(bidderOverrides));
+config.getConfig('debugging', ({debugging}) => getConfig(debugging));
 
 export function sessionLoader() {
   let overrides;

--- a/src/debugging.js
+++ b/src/debugging.js
@@ -66,11 +66,11 @@ export function getConfig(debugging) {
   if (!debugging.enabled) {
     disableOverrides();
     try {
-      sessionStorage.removeItem(OVERRIDE_KEY);
+      window.sessionStorage.removeItem(OVERRIDE_KEY);
     } catch (e) {}
   } else {
     try {
-      sessionStorage.setItem(OVERRIDE_KEY, JSON.stringify(debugging));
+      window.sessionStorage.setItem(OVERRIDE_KEY, JSON.stringify(debugging));
     } catch (e) {}
     enableOverrides(debugging);
   }
@@ -80,7 +80,7 @@ config.getConfig('debugging', ({debugging}) => getConfig(debugging));
 export function sessionLoader() {
   let overrides;
   try {
-    overrides = JSON.parse(sessionStorage.getItem(OVERRIDE_KEY));
+    overrides = JSON.parse(window.sessionStorage.getItem(OVERRIDE_KEY));
   } catch (e) {
   }
   if (overrides) {

--- a/src/hook.js
+++ b/src/hook.js
@@ -60,6 +60,9 @@ export function createHook(type, fn, hookName) {
     },
     removeHook: function(removeFn) {
       _hooks = _hooks.filter(hook => hook.fn === fn || hook.fn !== removeFn);
+    },
+    hasHook: function(fn) {
+      return _hooks.some(hook => hook.fn === fn);
     }
   };
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -9,6 +9,7 @@ import { config } from './config';
 import { auctionManager } from './auctionManager';
 import { targeting, getOldestBid, RENDERED, BID_TARGETING_SET } from './targeting';
 import { createHook } from 'src/hook';
+import { sessionLoader } from 'src/debugging';
 import includes from 'core-js/library/fn/array/includes';
 
 const $$PREBID_GLOBAL$$ = getGlobal();
@@ -26,6 +27,9 @@ const { PREVENT_WRITING_ON_MAIN_DOCUMENT, NO_AD, EXCEPTION, CANNOT_FIND_AD, MISS
 const eventValidators = {
   bidWon: checkDefinedPlacement
 };
+
+// initialize existing debugging sessions if present
+sessionLoader();
 
 /* Public vars */
 $$PREBID_GLOBAL$$.bidderSettings = $$PREBID_GLOBAL$$.bidderSettings || {};

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -1,0 +1,141 @@
+
+import { expect } from 'chai';
+import { sessionLoader, addBidResponseHook, getConfig, disableOverrides, boundHook } from 'src/debugging';
+import { addBidResponse } from 'src/auction';
+import { config } from 'src/config';
+
+describe('bid overrides', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('initialization', () => {
+    beforeEach(() => {
+      sandbox.stub(config, 'setConfig');
+      sandbox.stub(sessionStorage, 'setItem');
+      sandbox.stub(sessionStorage, 'removeItem');
+    });
+
+    afterEach(() => {
+      disableOverrides();
+    });
+
+    it('should happen when enabled with setConfig', () => {
+      getConfig({
+        enabled: true
+      });
+
+      expect(addBidResponse.hasHook(boundHook)).to.equal(true);
+    });
+
+    it('should happen when configuration found in sessionStorage', () => {
+      sandbox.stub(sessionStorage, 'getItem').returns('{"enabled": true}');
+
+      sessionLoader();
+      expect(addBidResponse.hasHook(boundHook)).to.equal(true);
+    });
+
+    it('should not throw if sessionStorage is inaccessible', () => {
+      sandbox.stub(sessionStorage, 'getItem').throws();
+
+      expect(() => {
+        sessionLoader();
+      }).not.to.throw();
+    });
+  });
+
+  describe('hook', () => {
+    let mockBids;
+    let bids;
+
+    beforeEach(() => {
+      let baseBid = {
+        'bidderCode': 'rubicon',
+        'width': 970,
+        'height': 250,
+        'statusMessage': 'Bid available',
+        'mediaType': 'banner',
+        'source': 'client',
+        'currency': 'USD',
+        'cpm': 0.5,
+        'ttl': 300,
+        'netRevenue': false,
+        'adUnitCode': '/19968336/header-bid-tag-0'
+      };
+      mockBids = [];
+      mockBids.push(baseBid);
+      mockBids.push(Object.assign({}, baseBid, {
+        bidderCode: 'appnexus'
+      }));
+
+      bids = [];
+    });
+
+    function run(overrides) {
+      mockBids.forEach(bid => {
+        addBidResponseHook(overrides, bid.adUnitCode, bid, (adUnitCode, bid) => {
+          bids.push(bid);
+        })
+      });
+    }
+
+    it('should allow us to exclude bidders', () => {
+      run({
+        enabled: true,
+        bidders: ['appnexus']
+      });
+
+      expect(bids.length).to.equal(1);
+      expect(bids[0].bidderCode).to.equal('appnexus');
+    });
+
+    it('should allow us to override all bids', () => {
+      run({
+        enabled: true,
+        bids: [{
+          cpm: 2
+        }]
+      });
+
+      expect(bids.length).to.equal(2);
+      expect(bids[0].cpm).to.equal(2);
+      expect(bids[1].cpm).to.equal(2);
+    });
+
+    it('should allow us to override bids by bidder', () => {
+      run({
+        enabled: true,
+        bids: [{
+          bidder: 'rubicon',
+          cpm: 2
+        }]
+      });
+
+      expect(bids.length).to.equal(2);
+      expect(bids[0].cpm).to.equal(2);
+      expect(bids[1].cpm).to.equal(0.5);
+    });
+
+    it('should allow us to override bids by adUnitCode', () => {
+      mockBids[1].adUnitCode = 'test';
+
+      run({
+        enabled: true,
+        bids: [{
+          adUnitCode: 'test',
+          cpm: 2
+        }]
+      });
+
+      expect(bids.length).to.equal(2);
+      expect(bids[0].cpm).to.equal(0.5);
+      expect(bids[1].cpm).to.equal(2);
+    });
+  });
+});

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -18,8 +18,8 @@ describe('bid overrides', () => {
   describe('initialization', () => {
     beforeEach(() => {
       sandbox.stub(config, 'setConfig');
-      sandbox.stub(sessionStorage, 'setItem');
-      sandbox.stub(sessionStorage, 'removeItem');
+      sandbox.stub(window.sessionStorage, 'setItem');
+      sandbox.stub(window.sessionStorage, 'removeItem');
     });
 
     afterEach(() => {
@@ -35,14 +35,14 @@ describe('bid overrides', () => {
     });
 
     it('should happen when configuration found in sessionStorage', () => {
-      sandbox.stub(sessionStorage, 'getItem').returns('{"enabled": true}');
+      sandbox.stub(window.sessionStorage, 'getItem').returns('{"enabled": true}');
 
       sessionLoader();
       expect(addBidResponse.hasHook(boundHook)).to.equal(true);
     });
 
     it('should not throw if sessionStorage is inaccessible', () => {
-      sandbox.stub(sessionStorage, 'getItem').throws();
+      sandbox.stub(window.sessionStorage, 'getItem').throws();
 
       expect(() => {
         sessionLoader();


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This feature adds the ability to override bid responses as they come in or to filter bidders for debugging purposes.  The debugging features, when enabled, will stay active for the duration of your session (until you close active tab) or until they are disabled with `pbjs.setConfig`.

Filtering bidders:
```
pbjs.setConfig({
  debugging: {
    enabled: true,
    bidders: ['appnexus', 'rubicon']
  }
});
```

Overwriting bid responses for all bidders:
```
pbjs.setConfig({
  debugging: {
    enabled: true,
    bids: [{
      cpm: 1.5
    }]
  }
});
```

Overwriting bid responses for a specific bidder and adUnit code (can use separately)
```
pbjs.setConfig({
  debugging: {
    enabled: true,
    bids: [{
      bidder: 'rubicon',
      adUnitCode: '/19968336/header-bid-tag-0',
      cpm: 1.5
    }]
  }
});
```

Disabling debugging
```
pbjs.setConfig({
  debugging: {
    enabled: false
  }
});
```

## Other information
Original description: https://gist.github.com/bretg/4880f9977a2e49e8a194b701b2e95b67

Using `pbjs.setConfig` and `sessionStorage` rather than url strings as encoding JSON for use in URLs is a cumbersome process.
