### PR TITLE
fix getPreparedBidForAuction to look for renderer on correct bid

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -298,8 +298,8 @@ function getPreparedBidForAuction({adUnitCode, bid, bidRequest, auctionId}) {
   events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bidObject);
 
   // a publisher-defined renderer can be used to render bids
-  const adUnitRenderer =
-    bidRequest.bids && bidRequest.bids[0] && bidRequest.bids[0].renderer;
+  const bidReq = bidRequest.bids && bidRequest.bids.find(bid => bid.adUnitCode == adUnitCode);
+  const adUnitRenderer = bidReq && bidReq.renderer;
 
   if (adUnitRenderer && adUnitRenderer.url) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -643,6 +643,35 @@ describe('auctionmanager.js', function () {
         const addedBid = auction.getBidsReceived().pop();
         assert.equal(addedBid.renderer.url, 'renderer.js');
       });
+
+      it('bid for a regular unit and a video unit', function() {
+        let renderer = {
+          url: 'renderer.js',
+          render: (bid) => bid
+        };
+
+        // make sure that if the renderer is only on the second ad unit, prebid
+        // still correctly uses it
+        let bid = mockBid();
+        let bidRequests = [mockBidRequest(bid)];
+
+        bidRequests[0].bids[1] = Object.assign({
+          renderer,
+          bidId: utils.getUniqueIdentifierStr()
+        }, bidRequests[0].bids[0]);
+        bidRequests[0].bids[0].adUnitCode = ADUNIT_CODE1;
+
+        makeRequestsStub.returns(bidRequests);
+
+        // this should correspond with the second bid in the bidReq because of the ad unit code
+        bid.mediaType = 'video-outstream';
+        spec.interpretResponse.returns(bid);
+
+        auction.callBids();
+
+        const addedBid = auction.getBidsReceived().find(bid => bid.adUnitCode == ADUNIT_CODE);
+        assert.equal(addedBid.renderer.url, 'renderer.js');
+      });
     });
 
     describe('when auction timeout is 20', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
getPreparedBidForAuction was just looking on the first bid in the bidder request regardless of whether or not it was for the given ad unit. This modifies the function to get the renderer off the correct bid request.

Also just as an aside, this file is not very consistent in variable naming with respect to bidderRequests vs. bidRequests. It's also confusing that they are so similarly named -- what do you all think about renaming bidderRequest to be bidRequestSet or bidRequestGroup or something like that? Or maybe auctionBids? Anyway just a thought.