### PR TITLE
Fix path to analytics src directory in build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ var jsEscape = require('gulp-js-escape');
 var prebid = require('./package.json');
 var dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
 var banner = '/* <%= prebid.name %> v<%= prebid.version %>\n' + dateString + ' */\n';
-var analyticsDirectory = '../analytics';
+var analyticsDirectory = './src/adapters/analytics';
 var port = 9999;
 
 // Tasks


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Bugfix
- [x] Build related changes

## Description of change
The `analyticsDirectory` path defined in the gulpfile appears to be incorrect. I've updated this to reflect the directory structure found within the repo:

`src/adapters/analytics`

This was stopping me from running my build.

## Other information

See related historical issue here: https://github.com/prebid/Prebid.js/issues/1185
