### PR TITLE
add support for latLong in rubicon adapter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -206,7 +206,8 @@ export const spec = {
         keywords,
         visitor,
         inventory,
-        userId
+        userId,
+        latLong: [latitude, longitude] = [],
       } = bidRequest.params;
 
       // defaults
@@ -230,7 +231,9 @@ export const spec = {
         'x_source.tid', bidRequest.transactionId,
         'p_screen_res', _getScreenResolution(),
         'kw', keywords,
-        'tk_user_key', userId
+        'tk_user_key', userId,
+        'p_geo.latitude', parseFloat(latitude).toFixed(4),
+        'p_geo.longitude', parseFloat(longitude).toFixed(4)
       ];
 
       if (gdprConsent) {
@@ -258,7 +261,7 @@ export const spec = {
 
       data = data.reduce(
         (memo, curr, index) =>
-          index % 2 === 0 && data[index + 1] !== undefined
+          index % 2 === 0 && data[index + 1] !== undefined && !isNaN(data[index + 1])
             ? memo + curr + '=' + encodeURIComponent(data[index + 1]) + '&' : memo,
         ''
       ).slice(0, -1); // remove trailing &
@@ -287,7 +290,7 @@ export const spec = {
    * @return {Bid[]} An array of bids which
    */
   interpretResponse: function (responseObj, {bidRequest}) {
-    responseObj = responseObj.body
+    responseObj = responseObj.body;
     let ads = responseObj.ads;
 
     // check overall response
@@ -470,6 +473,11 @@ var hasSynced = false;
 
 export function resetUserSync() {
   hasSynced = false;
+}
+
+function isNaN(value) {
+  // eslint-disable-next-line no-self-compare
+  return value !== value;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -171,7 +171,8 @@ describe('the rubicon adapter', () => {
               lastsearch: 'iphone'
             },
             position: 'atf',
-            referrer: 'localhost'
+            referrer: 'localhost',
+            latLong: [40.7608, '111.8910']
           },
           adUnitCode: '/19968336/header-bid-tag-0',
           code: 'div-1',
@@ -239,7 +240,9 @@ describe('the rubicon adapter', () => {
             'tg_v.lastsearch': 'iphone',
             'tg_i.rating': '5-star',
             'tg_i.prodtype': 'tech',
-            'rf': 'localhost'
+            'rf': 'localhost',
+            'p_geo.latitude': '40.7608',
+            'p_geo.longitude': '111.8910'
           };
 
           // test that all values above are both present and correct


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add the ability to pass latitude and longitude to rubicon adapter as new bidder param.
```
{
  bidder: 'rubicon',
  params: {
    latLong: [40.7608, 111.8910]
  }
}
```
## Other information
Corresponding documentation added here: https://github.com/prebid/prebid.github.io/pull/749
