### PR TITLE
consentManagement - add support for safeframe workflow

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -108,6 +108,35 @@ exports.transformAdServerTargetingObj = function (targeting) {
 };
 
 /**
+ * Read an adUnit object and return the sizes used in an [[728, 90]] format (even if they had [728, 90] defined)
+ * Preference is given to the `adUnit.mediaTypes.banner.sizes` object over the `adUnit.sizes`
+ * @param {object} adUnit one adUnit object from the normal list of adUnits
+ * @returns {array[array[number]]} array of arrays containing numeric sizes
+ */
+export function getAdUnitSizes(adUnit) {
+  if (!adUnit) {
+    return;
+  }
+
+  let sizes = [];
+  if (adUnit.mediaTypes && adUnit.mediaTypes.banner && Array.isArray(adUnit.mediaTypes.banner.sizes)) {
+    let bannerSizes = adUnit.mediaTypes.banner.sizes;
+    if (Array.isArray(bannerSizes[0])) {
+      sizes = bannerSizes;
+    } else {
+      sizes.push(bannerSizes);
+    }
+  } else if (Array.isArray(adUnit.sizes)) {
+    if (Array.isArray(adUnit.sizes[0])) {
+      sizes = adUnit.sizes;
+    } else {
+      sizes.push(adUnit.sizes);
+    }
+  }
+  return sizes;
+}
+
+/**
  * Parse a GPT-Style general size Array like `[[300, 250]]` or `"300x250,970x90"` into an array of sizes `["300x250"]` or '['300x250', '970x90']'
  * @param  {array[array|number]} sizeObj Input array or double array [300,250] or [[300,250], [728,90]]
  * @return {array[string]}  Array of strings like `["300x250"]` or `["300x250", "728x90"]`

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -789,4 +789,32 @@ describe('Utils', function () {
       expect(test2).to.equal(var2);
     });
   });
+
+  describe('getAdUnitSizes', () => {
+    it('returns an empty response when adUnits is undefined', () => {
+      let sizes = utils.getAdUnitSizes();
+      expect(sizes).to.be.undefined;
+    });
+
+    it('returns an empty array when invalid data is present in adUnit object', () => {
+      let sizes = utils.getAdUnitSizes({ sizes: 300 });
+      expect(sizes).to.deep.equal([]);
+    });
+
+    it('retuns an array of arrays when reading from adUnit.sizes', () => {
+      let sizes = utils.getAdUnitSizes({ sizes: [300, 250] });
+      expect(sizes).to.deep.equal([[300, 250]]);
+
+      sizes = utils.getAdUnitSizes({ sizes: [[300, 250], [300, 600]] });
+      expect(sizes).to.deep.equal([[300, 250], [300, 600]]);
+    });
+
+    it('returns an array of arrays when reading from adUnit.mediaTypes.banner.sizes', () => {
+      let sizes = utils.getAdUnitSizes({ mediaTypes: { banner: { sizes: [300, 250] } } });
+      expect(sizes).to.deep.equal([[300, 250]]);
+
+      sizes = utils.getAdUnitSizes({ mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } } });
+      expect(sizes).to.deep.equal([[300, 250], [300, 600]]);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature


## Description of change
This PR adds support for the safeframe workflow that's described in the 1.1 CMP spec for the consentManagement module.

See link [here](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/CMP%20JS%20API%20v1.1%20Final.md#safeframe) for details from the spec.

Also added new method in utils to read the `adUnits` object to grab the sizes from either `adUnit.mediaTypes.banner.sizes` or `adUnit.sizes`.  We use the first `adUnits` object's dimensions as part of the safeframe register function.