### PR TITLE
Smart: GDPR support

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -22,9 +22,10 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {validBidRequests[]} - an array of bids
+   * @param {bidderRequest} - bidder request object
    * @return ServerRequest Info describing the request to the server.
    */
-  buildRequests: function (validBidRequests) {
+  buildRequests: function (validBidRequests, bidderRequest) {
     // use bidderRequest.bids[] to get bidder-dependent request info
 
     // if your bidder supports multiple currencies, use config.getConfig(currency)
@@ -54,9 +55,9 @@ export const spec = {
         prebidVersion: '$prebid.version$',
       };
 
-      if (bid.gdprConsent) {
-        payload.gdpr_consent = bid.gdprConsent.consentString;
-        payload.gdpr = bid.gdprConsent.gdprApplies; // we're handling the undefined case server side
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+        payload.gdpr = bidderRequest.gdprConsent.gdprApplies; // we're handling the undefined case server side
       }
 
       var payloadString = JSON.stringify(payload);

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -52,7 +52,7 @@ export const spec = {
         transactionId: bid.transactionId,
         timeout: config.getConfig('bidderTimeout'),
         bidId: bid.bidId,
-        prebidVersion: '$prebid.version$',
+        prebidVersion: '$prebid.version$'
       };
 
       if (bidderRequest && bidderRequest.gdprConsent) {

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -51,8 +51,14 @@ export const spec = {
         transactionId: bid.transactionId,
         timeout: config.getConfig('bidderTimeout'),
         bidId: bid.bidId,
-        prebidVersion: '$prebid.version$'
+        prebidVersion: '$prebid.version$',
       };
+
+      if(bid.gdprConsent) {
+        payload.gdpr_consent = bid.gdprConsent.consentString;
+        payload.gdpr = bid.gdprConsent.gdprApplies; //we're handling the undefined case server side
+      }
+
       var payloadString = JSON.stringify(payload);
       return {
         method: 'POST',

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -56,7 +56,7 @@ export const spec = {
 
       if (bid.gdprConsent) {
         payload.gdpr_consent = bid.gdprConsent.consentString;
-        payload.gdpr = bid.gdprConsent.gdprApplies; //we're handling the undefined case server side
+        payload.gdpr = bid.gdprConsent.gdprApplies; // we're handling the undefined case server side
       }
 
       var payloadString = JSON.stringify(payload);

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -54,7 +54,7 @@ export const spec = {
         prebidVersion: '$prebid.version$',
       };
 
-      if(bid.gdprConsent) {
+      if (bid.gdprConsent) {
         payload.gdpr_consent = bid.gdprConsent.consentString;
         payload.gdpr = bid.gdprConsent.gdprApplies; //we're handling the undefined case server side
       }

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -55,48 +55,6 @@ describe('Smart bid adapter tests', () => {
     requestId: 'efgh5678'
   }];
 
-  // Default params without optional and with GPDR
-  var DEFAULT_PARAMS_WO_OPTIONAL_GDPR = [{
-    adUnitCode: 'sas_42',
-    bidId: 'abcd1234',
-    sizes: [
-      [300, 250],
-      [300, 200]
-    ],
-    bidder: 'smartadserver',
-    params: {
-      domain: 'http://prg.smartadserver.com',
-      siteId: '1234',
-      pageId: '5678',
-      formatId: '90'
-    },
-    requestId: 'efgh5678',
-    gdprConsent: {
-      consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A==',
-      gdprApplies: true
-    }
-  }];
-
-  var DEFAULT_PARAMS_WO_OPTIONAL_GDPR_WITHOUT_GDPRAPPLIES = [{
-    adUnitCode: 'sas_42',
-    bidId: 'abcd1234',
-    sizes: [
-      [300, 250],
-      [300, 200]
-    ],
-    bidder: 'smartadserver',
-    params: {
-      domain: 'http://prg.smartadserver.com',
-      siteId: '1234',
-      pageId: '5678',
-      formatId: '90'
-    },
-    requestId: 'efgh5678',
-    gdprConsent: {
-      consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A=='
-    }
-  }];
-
   var BID_RESPONSE = {
     body: {
       cpm: 12,
@@ -153,7 +111,12 @@ describe('Smart bid adapter tests', () => {
         allowAuctionWithoutConsent: true
       }
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL_GDPR);
+    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+      gdprConsent: {
+        consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A==',
+        gdprApplies: true
+      }
+    });
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.have.property('gdpr').and.to.equal(true);
     expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
@@ -171,7 +134,11 @@ describe('Smart bid adapter tests', () => {
         allowAuctionWithoutConsent: true
       }
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL_GDPR_WITHOUT_GDPRAPPLIES);
+    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+      gdprConsent: {
+        consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A=='
+      }
+    });
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.not.have.property('gdpr');
     expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
@@ -194,7 +161,11 @@ describe('Smart bid adapter tests', () => {
     expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
     expect(bid.referrer).to.equal(utils.getTopWindowUrl());
 
-    expect(function () { spec.interpretResponse(BID_RESPONSE, { data: 'invalid Json' }) }).to.not.throw();
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
   });
 
   it('Verifies bidder code', () => {
@@ -265,15 +236,21 @@ describe('Smart bid adapter tests', () => {
   });
 
   it('Verifies user sync', () => {
-    var syncs = spec.getUserSyncs({ iframeEnabled: true }, [BID_RESPONSE]);
+    var syncs = spec.getUserSyncs({
+      iframeEnabled: true
+    }, [BID_RESPONSE]);
     expect(syncs).to.have.lengthOf(1);
     expect(syncs[0].type).to.equal('iframe');
     expect(syncs[0].url).to.equal('http://awesome.fake.csync.url');
 
-    syncs = spec.getUserSyncs({ iframeEnabled: false }, [BID_RESPONSE]);
+    syncs = spec.getUserSyncs({
+      iframeEnabled: false
+    }, [BID_RESPONSE]);
     expect(syncs).to.have.lengthOf(0);
 
-    syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+    syncs = spec.getUserSyncs({
+      iframeEnabled: true
+    }, []);
     expect(syncs).to.have.lengthOf(0);
   });
 });

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -55,6 +55,48 @@ describe('Smart bid adapter tests', () => {
     requestId: 'efgh5678'
   }];
 
+  // Default params without optional and with GPDR
+  var DEFAULT_PARAMS_WO_OPTIONAL_GDPR = [{
+    adUnitCode: 'sas_42',
+    bidId: 'abcd1234',
+    sizes: [
+      [300, 250],
+      [300, 200]
+    ],
+    bidder: 'smartadserver',
+    params: {
+      domain: 'http://prg.smartadserver.com',
+      siteId: '1234',
+      pageId: '5678',
+      formatId: '90'
+    },
+    requestId: 'efgh5678',
+    gdprConsent: {
+      consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A==',
+      gdprApplies: true
+    }
+  }];
+
+  var DEFAULT_PARAMS_WO_OPTIONAL_GDPR_WITHOUT_GDPRAPPLIES = [{
+    adUnitCode: 'sas_42',
+    bidId: 'abcd1234',
+    sizes: [
+      [300, 250],
+      [300, 200]
+    ],
+    bidder: 'smartadserver',
+    params: {
+      domain: 'http://prg.smartadserver.com',
+      siteId: '1234',
+      pageId: '5678',
+      formatId: '90'
+    },
+    requestId: 'efgh5678',
+    gdprConsent: {
+      consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A=='
+    }
+  }];
+
   var BID_RESPONSE = {
     body: {
       cpm: 12,
@@ -98,6 +140,42 @@ describe('Smart bid adapter tests', () => {
     expect(requestContent).to.have.property('appname').and.to.equal('Mozilla');
     expect(requestContent).to.have.property('ckid').and.to.equal(42);
   });
+
+  it('Verify build request with GDPR', () => {
+    config.setConfig({
+      'currency': {
+        'adServerCurrency': 'EUR'
+      },
+      consentManagement: {
+        cmp: 'iab',
+        consentRequired: true,
+        timeout: 1000,
+        allowAuctionWithoutConsent: true
+      }
+    });
+    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL_GDPR);
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent).to.have.property('gdpr').and.to.equal(true);
+    expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
+  });  
+
+  it('Verify build request with GDPR without gdprApplies', () => {
+    config.setConfig({
+      'currency': {
+        'adServerCurrency': 'EUR'
+      },
+      consentManagement: {
+        cmp: 'iab',
+        consentRequired: true,
+        timeout: 1000,
+        allowAuctionWithoutConsent: true
+      }
+    });
+    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL_GDPR_WITHOUT_GDPRAPPLIES);
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent).to.not.have.property('gdpr');
+    expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
+  });  
 
   it('Verify parse response', () => {
     const request = spec.buildRequests(DEFAULT_PARAMS);

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -157,7 +157,7 @@ describe('Smart bid adapter tests', () => {
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.have.property('gdpr').and.to.equal(true);
     expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
-  });  
+  });
 
   it('Verify build request with GDPR without gdprApplies', () => {
     config.setConfig({
@@ -175,7 +175,7 @@ describe('Smart bid adapter tests', () => {
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.not.have.property('gdpr');
     expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
-  });  
+  });
 
   it('Verify parse response', () => {
     const request = spec.buildRequests(DEFAULT_PARAMS);
@@ -194,7 +194,7 @@ describe('Smart bid adapter tests', () => {
     expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
     expect(bid.referrer).to.equal(utils.getTopWindowUrl());
 
-    expect(function() { spec.interpretResponse(BID_RESPONSE, {data: 'invalid Json'}) }).to.not.throw();
+    expect(function () { spec.interpretResponse(BID_RESPONSE, { data: 'invalid Json' }) }).to.not.throw();
   });
 
   it('Verifies bidder code', () => {
@@ -265,15 +265,15 @@ describe('Smart bid adapter tests', () => {
   });
 
   it('Verifies user sync', () => {
-    var syncs = spec.getUserSyncs({iframeEnabled: true}, [BID_RESPONSE]);
+    var syncs = spec.getUserSyncs({ iframeEnabled: true }, [BID_RESPONSE]);
     expect(syncs).to.have.lengthOf(1);
     expect(syncs[0].type).to.equal('iframe');
     expect(syncs[0].url).to.equal('http://awesome.fake.csync.url');
 
-    syncs = spec.getUserSyncs({iframeEnabled: false}, [BID_RESPONSE]);
+    syncs = spec.getUserSyncs({ iframeEnabled: false }, [BID_RESPONSE]);
     expect(syncs).to.have.lengthOf(0);
 
-    syncs = spec.getUserSyncs({iframeEnabled: true}, []);
+    syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
     expect(syncs).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding GDPR support to Smart's prebid adapter.

Please use the following test parameters:
```
          {
            code: 'div-gpt-ad-1460505748561-0',
            sizes: [[300, 250]],  // a display size
            bids: [{
              bidder: "smart",
              params: {
                domain: 'http://ww251.smartadserver.com',
                siteId: 207435,
                pageId: 896536,
                formatId: 62913
              }
            }]
          }
```
As a result Smart's adapter should send acquired GDPR params in the POST message.
