### PR TITLE
GDPR - add consent information to PBS cookie_sync request

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -115,7 +115,7 @@ function queueSync(bidderCodes, gdprConsent) {
   }
   _synced = true;
 
-  let payload = {
+  const payload = {
     uuid: utils.generateUUID(),
     bidders: bidderCodes
   };
@@ -684,7 +684,8 @@ export function PrebidServer() {
       .filter(utils.uniques);
 
     if (_s2sConfig && _s2sConfig.syncEndpoint) {
-      queueSync(_s2sConfig.bidders, bidRequests[0].gdprConsent);
+      let consent = (Array.isArray(bidRequests) && bidRequests.length > 0) ? bidRequests[0].gdprConsent : undefined;
+      queueSync(_s2sConfig.bidders, consent);
     }
 
     const request = protocolAdapter().buildRequest(s2sBidRequest, bidRequests, adUnitsWithSizes);

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -96,36 +96,56 @@ function setS2sConfig(options) {
   }
 
   _s2sConfig = options;
-  if (options.syncEndpoint) {
-    queueSync(options.bidders);
-  }
 }
 getConfig('s2sConfig', ({s2sConfig}) => setS2sConfig(s2sConfig));
 
 /**
+ * resets the _synced variable back to false, primiarily used for testing purposes
+*/
+export function resetSyncedStatus() {
+  _synced = false;
+}
+
+/**
  * @param  {Array} bidderCodes list of bidders to request user syncs for.
  */
-function queueSync(bidderCodes) {
+function queueSync(bidderCodes, gdprConsent) {
   if (_synced) {
     return;
   }
   _synced = true;
-  const payload = JSON.stringify({
+
+  let payload = {
     uuid: utils.generateUUID(),
     bidders: bidderCodes
-  });
-  ajax(_s2sConfig.syncEndpoint, (response) => {
-    try {
-      response = JSON.parse(response);
-      response.bidder_status.forEach(bidder => doBidderSync(bidder.usersync.type, bidder.usersync.url, bidder.bidder));
-    } catch (e) {
-      utils.logError(e);
+  };
+
+  if (gdprConsent) {
+    // only populate gdpr field if we know CMP returned consent information (ie didn't timeout or have an error)
+    if (gdprConsent.consentString) {
+      payload.gdpr = (gdprConsent.gdprApplies) ? 1 : 0;
     }
-  },
-  payload, {
-    contentType: 'text/plain',
-    withCredentials: true
-  });
+    // attempt to populate gdpr_consent if we know gdprApplies or it may apply
+    if (gdprConsent.gdprApplies !== false) {
+      payload.gdpr_consent = gdprConsent.consentString;
+    }
+  }
+  const jsonPayload = JSON.stringify(payload);
+
+  ajax(_s2sConfig.syncEndpoint,
+    (response) => {
+      try {
+        response = JSON.parse(response);
+        response.bidder_status.forEach(bidder => doBidderSync(bidder.usersync.type, bidder.usersync.url, bidder.bidder));
+      } catch (e) {
+        utils.logError(e);
+      }
+    },
+    jsonPayload,
+    {
+      contentType: 'text/plain',
+      withCredentials: true
+    });
 }
 
 /**
@@ -348,9 +368,6 @@ const LEGACY_PROTOCOL = {
     if (result.status === 'OK' || result.status === 'no_cookie') {
       if (result.bidder_status) {
         result.bidder_status.forEach(bidder => {
-          if (bidder.no_cookie) {
-            doBidderSync(bidder.usersync.type, bidder.usersync.url, bidder.bidder);
-          }
           if (bidder.error) {
             utils.logWarn(`Prebid Server returned error: '${bidder.error}' for ${bidder.bidder}`);
           }
@@ -665,6 +682,10 @@ export function PrebidServer() {
       .map(adUnit => adUnit.bids.map(bid => bid.bidder).filter(utils.uniques))
       .reduce(utils.flatten)
       .filter(utils.uniques);
+
+    if (_s2sConfig && _s2sConfig.syncEndpoint) {
+      queueSync(_s2sConfig.bidders, bidRequests[0].gdprConsent);
+    }
 
     const request = protocolAdapter().buildRequest(s2sBidRequest, bidRequests, adUnitsWithSizes);
     const requestJson = JSON.stringify(request);


### PR DESCRIPTION

## Type of change
- [x] Feature


## Description of change
Addresses the issue raised in https://github.com/prebid/Prebid.js/issues/2516

Adds support to pass the consent information into the prebidServer cookie sync request.
We also removed an additional sync attempt made in the response as this was deemed redundant.