### PR TITLE
Add multi-format ad unit support to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -1,5 +1,4 @@
 import * as utils from 'src/utils';
-import { deepAccess } from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { Renderer } from 'src/Renderer';
 import { VIDEO, BANNER } from 'src/mediaTypes';
@@ -58,7 +57,7 @@ export const spec = {
       }
       let sizes = getVideoSizes(bidRequest);
       let firstSize = getFirstSize(sizes);
-      let context = deepAccess(bidRequest, 'mediaTypes.video.context');
+      let context = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
       return {
         requestId: bidRequest.bidId,
         bidderCode: spec.code,
@@ -137,11 +136,11 @@ function parseSizes(sizes) {
 }
 
 function getVideoSizes(bid) {
-  return parseSizes(deepAccess(bid, 'mediaTypes.video.playerSize') || bid.sizes);
+  return parseSizes(utils.deepAccess(bid, 'mediaTypes.video.playerSize') || bid.sizes);
 }
 
 function getBannerSizes(bid) {
-  return parseSizes(deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes);
+  return parseSizes(utils.deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes);
 }
 
 function getOsVersion() {
@@ -178,19 +177,19 @@ function getDoNotTrack() {
 }
 
 function isVideoBid(bid) {
-  return deepAccess(bid, 'mediaTypes.video');
+  return utils.deepAccess(bid, 'mediaTypes.video');
 }
 
 function isBannerBid(bid) {
-  return deepAccess(bid, 'mediaTypes.banner') || !isVideoBid(bid);
+  return utils.deepAccess(bid, 'mediaTypes.banner') || !isVideoBid(bid);
 }
 
 function getVideoBidParam(bid, key) {
-  return deepAccess(bid, 'params.video.' + key) || deepAccess(bid, 'params.' + key);
+  return utils.deepAccess(bid, 'params.video.' + key) || utils.deepAccess(bid, 'params.' + key);
 }
 
 function getBannerBidParam(bid, key) {
-  return deepAccess(bid, 'params.banner.' + key) || deepAccess(bid, 'params.' + key);
+  return utils.deepAccess(bid, 'params.banner.' + key) || utils.deepAccess(bid, 'params.' + key);
 }
 
 function isVideoBidValid(bid) {

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -52,3 +52,37 @@ Module that connects to Beachfront's demand sources
         }
     ];
 ```
+
+# Multi-Format Ad Unit Example
+```javascript
+    var adUnits = [
+        {
+            code: 'test-video-banner',
+            mediaTypes: {
+                video: {
+                    context: 'instream',
+                    playerSize: [ 640, 360 ]
+                },
+                banner: {
+                    sizes: [ 300, 250 ]
+                }
+            },
+            bids: [
+                {
+                    bidder: 'beachfront',
+                    params: {
+                        video: {
+                            bidfloor: 0.01,
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+                            mimes: [ 'video/mp4', 'application/javascript' ]
+                        },
+                        banner: {
+                            bidfloor: 0.01,
+                            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+                        }
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -385,6 +385,31 @@ describe('BeachfrontAdapter', () => {
         expect(requests[0].url).to.contain(VIDEO_ENDPOINT);
         expect(requests[1].url).to.contain(BANNER_ENDPOINT);
       });
+
+      it('must parse bid sizes for each bid format', () => {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ 640, 360 ]
+          },
+          banner: {
+            sizes: [ 300, 250 ]
+          }
+        };
+        bidRequest.params = {
+          video: {
+            bidfloor: 2.00,
+            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+          },
+          banner: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        const requests = spec.buildRequests([ bidRequest ]);
+        expect(requests[0].data.imp[0].video).to.deep.contain({ w: 640, h: 360 });
+        expect(requests[1].data.slots[0].sizes).to.deep.equal([{ w: 300, h: 250 }]);
+      });
     });
   });
 

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -63,6 +63,64 @@ describe('BeachfrontAdapter', () => {
       expect(spec.isBidRequestValid()).to.equal(false);
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
+
+    describe('for multi-format bids', () => {
+      it('should return true when the required params are passed for video', () => {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {}
+        };
+        bidRequest.params = {
+          video: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+      });
+
+      it('should return false when the required params are missing for video', () => {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {}
+        };
+        bidRequest.params = {
+          banner: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+      });
+
+      it('should return true when the required params are passed for banner', () => {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          banner: {}
+        };
+        bidRequest.params = {
+          banner: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+      });
+
+      it('should return false when the required params are missing for banner', () => {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          banner: {}
+        };
+        bidRequest.params = {
+          video: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+      });
+    });
   });
 
   describe('spec.buildRequests', () => {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -356,6 +356,36 @@ describe('BeachfrontAdapter', () => {
         expect(data.gdprConsent).to.equal(consentString);
       });
     });
+
+    describe('for multi-format bids', () => {
+      it('should create a POST request for each bid format', () => {
+        const width = 300;
+        const height = 250;
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          },
+          banner: {
+            sizes: [ width, height ]
+          }
+        };
+        bidRequest.params = {
+          video: {
+            bidfloor: 2.00,
+            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+          },
+          banner: {
+            bidfloor: 1.00,
+            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
+          }
+        };
+        const requests = spec.buildRequests([ bidRequest ]);
+        expect(requests.length).to.equal(2);
+        expect(requests[0].url).to.contain(VIDEO_ENDPOINT);
+        expect(requests[1].url).to.contain(BANNER_ENDPOINT);
+      });
+    });
   });
 
   describe('spec.interpretResponse', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds scoped bidder params for video and banner so that bid requests can be sent for both formats. Previously, only a video bid request would be sent for an ad unit that declared support for video and banner.

```javascript
    var adUnits = [
        {
            code: 'test-video-banner',
            mediaTypes: {
                video: {
                    context: 'instream',
                    playerSize: [ 640, 360 ]
                },
                banner: {
                    sizes: [ 300, 250 ]
                }
            },
            bids: [
                {
                    bidder: 'beachfront',
                    params: {
                        video: {
                            bidfloor: 0.01,
                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
                            mimes: [ 'video/mp4', 'application/javascript' ]
                        },
                        banner: {
                            bidfloor: 0.01,
                            appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
                        }
                    }
                }
            ]
        }
    ];
```

prebid/prebid.github.io#763