### PR TITLE
replace find reference with imported version

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -298,7 +298,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidRequest, auctionId}) {
   events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bidObject);
 
   // a publisher-defined renderer can be used to render bids
-  const bidReq = bidRequest.bids && bidRequest.bids.find(bid => bid.adUnitCode == adUnitCode);
+  const bidReq = bidRequest.bids && find(bidRequest.bids, bid => bid.adUnitCode == adUnitCode);
   const adUnitRenderer = bidReq && bidReq.renderer;
 
   if (adUnitRenderer && adUnitRenderer.url) {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -7,6 +7,7 @@ import { newBidder, registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import * as store from 'src/videoCache';
 import * as ajaxLib from 'src/ajax';
+import find from 'core-js/library/fn/array/find';
 
 const adloader = require('../../src/adloader');
 var assert = require('assert');
@@ -669,7 +670,7 @@ describe('auctionmanager.js', function () {
 
         auction.callBids();
 
-        const addedBid = auction.getBidsReceived().find(bid => bid.adUnitCode == ADUNIT_CODE);
+        const addedBid = find(auction.getBidsReceived(), bid => bid.adUnitCode == ADUNIT_CODE);
         assert.equal(addedBid.renderer.url, 'renderer.js');
       });
     });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)


## Description of change
This PR replaces the `find` references introduced in the recently merged PR https://github.com/prebid/Prebid.js/pull/2505 with the imported version to maintain backwards-compatibility for old browsers.