### PR TITLE
Add support for the 2 gdpr related fields on bids

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -1,5 +1,5 @@
 import * as utils from 'src/utils';
-import { registerBidder } from 'src/adapters/bidderFactory';
+import {registerBidder} from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'quantcast';
 const DEFAULT_BID_FLOOR = 0.0000000001;
@@ -75,6 +75,17 @@ export const spec = {
         });
       });
 
+      let gdprSignal;
+      let gdprConsentString;
+
+      if (bid.gdprConsent !== undefined) {
+        if (bid.gdprConsent.gdprApplies !== undefined) {
+          gdprSignal = bid.gdprConsent.gdprApplies ? 1 : 0;
+        }
+
+        gdprConsentString = bid.gdprConsent.consentString;
+      }
+
       // Request Data Format can be found at https://wiki.corp.qc/display/adinf/QCX
       const requestData = {
         publisherId: bid.params.publisherId,
@@ -94,6 +105,8 @@ export const spec = {
           referrer,
           domain
         },
+        gdprSignal: gdprSignal,
+        gdprConsent: gdprConsentString,
         bidId: bid.bidId
       };
 
@@ -143,7 +156,7 @@ export const spec = {
     }
 
     const bidResponsesList = response.bids.map(bid => {
-      const { ad, cpm, width, height, creativeId, currency } = bid;
+      const {ad, cpm, width, height, creativeId, currency} = bid;
 
       return {
         requestId: response.requestId,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding gdpr support to the quantcast bidder adapter


<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'quantcast',
    params: {
        publisherId: 'test-publisher', // REQUIRED - Publisher ID provided by Quantcast
        battr: [1, 2] // OPTIONAL - Array of blocked creative attributes as per OpenRTB Spec List 5.3
    }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
dharkin@quantcast.com

- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/768

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
