### PR TITLE
Legacy Consumable Bidder Adapter commit

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -1,0 +1,177 @@
+import * as utils from 'src/utils';
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
+import { EVENTS } from 'src/constants.json';
+
+const CONSUMABLE_BIDDER_CODE = 'consumable'
+
+const SYNC_TYPES = {
+  IFRAME: {
+    TAG: 'iframe',
+    TYPE: 'iframe'
+  },
+  IMAGE: {
+    TAG: 'img',
+    TYPE: 'image'
+  }
+};
+
+const pubapiTemplate = ({host, network, placement, alias}) => `//${host}/pubapi/3.0/${network}/${placement}/0/0/ADTECH;v=2;cmd=bid;cors=yes;alias=${alias};misc=${new Date().getTime()}`
+const CONSUMABLE_URL = 'adserver-us.adtech.advertising.com';
+const CONSUMABLE_TTL = 60;
+const CONSUMABLE_NETWORK = '10947.1';
+
+$$PREBID_GLOBAL$$.consumableGlobals = {
+  pixelsDropped: false
+};
+
+function parsePixelItems(pixels) {
+  let itemsRegExp = /<(img|iframe)[\s\S]*?src\s*=\s*("|')(.*?)\2/gi;
+  let tagNameRegExp = /\w*(?=\s)/;
+  let srcRegExp = /src=("|')(.*?)\1/;
+  let pixelsItems = [];
+
+  if (pixels) {
+    let matchedItems = pixels.match(itemsRegExp);
+    if (matchedItems) {
+      matchedItems.forEach(item => {
+        let tagName = item.match(tagNameRegExp)[0];
+        let url = item.match(srcRegExp)[2];
+
+        if (tagName && url) {
+          pixelsItems.push({
+            type: tagName === SYNC_TYPES.IMAGE.TAG ? SYNC_TYPES.IMAGE.TYPE : SYNC_TYPES.IFRAME.TYPE,
+            url: url
+          });
+        }
+      });
+    }
+  }
+
+  return pixelsItems;
+}
+
+function _buildConsumableUrl(bid) {
+  const params = bid.params;
+
+  return pubapiTemplate({
+    host: CONSUMABLE_URL,
+    network: params.network || CONSUMABLE_NETWORK,
+    placement: parseInt(params.placement, 10)
+  });
+}
+
+function formatBidRequest(bid) {
+  let bidRequest;
+
+  bidRequest = {
+    url: _buildConsumableUrl(bid),
+    method: 'GET'
+  };
+
+  bidRequest.bidderCode = bid.bidder;
+  bidRequest.bidId = bid.bidId;
+  bidRequest.userSyncOn = bid.params.userSyncOn;
+  bidRequest.unitId = bid.params.unitId;
+  bidRequest.unitName = bid.params.unitName;
+  bidRequest.zoneId = bid.params.zoneId;
+  bidRequest.network = bid.params.network || CONSUMABLE_NETWORK;
+
+  return bidRequest;
+}
+
+function _parseBidResponse (response, bidRequest) {
+  let bidData;
+  try {
+    bidData = response.seatbid[0].bid[0];
+  } catch (e) {
+    return;
+  }
+
+  let cpm;
+
+  if (bidData.ext && bidData.ext.encp) {
+    cpm = bidData.ext.encp;
+  } else {
+    cpm = bidData.price;
+
+    if (cpm === null || isNaN(cpm)) {
+      utils.logError('Invalid cpm in bid response', CONSUMABLE_BIDDER_CODE, bid);
+      return;
+    }
+  }
+  cpm = cpm * (parseFloat(bidRequest.zoneId) / parseFloat(bidRequest.network));
+
+  let oad = bidData.adm;
+  let cb = bidRequest.network === '9599.1' ? 7654321 : Math.round(new Date().getTime());
+  let ad = '<script type=\'text/javascript\'>document.write(\'<div id=\"' + bidRequest.unitName + '-' + bidRequest.unitId + '\">\');</script>' + oad;
+  ad += '<script type=\'text/javascript\'>document.write(\'</div>\');</script>';
+  ad += '<script type=\'text/javascript\'>document.write(\'<div class=\"' + bidRequest.unitName + '\"></div>\');</script>';
+  ad += '<script type=\'text/javascript\'>document.write(\'<scr\'+\'ipt type=\"text/javascript\" src=\"https://yummy.consumable.com/' + bidRequest.unitId + '/' + bidRequest.unitName + '/widget/unit.js?cb=' + cb + '\" charset=\"utf-8\" async></scr\'+\'ipt>\');</script>'
+  if (response.ext && response.ext.pixels) {
+    if (config.getConfig('consumable.userSyncOn') !== EVENTS.BID_RESPONSE) {
+      ad += _formatPixels(response.ext.pixels);
+    }
+  }
+
+  return {
+    bidderCode: bidRequest.bidderCode,
+    requestId: bidRequest.bidId,
+    ad: ad,
+    cpm: cpm,
+    width: bidData.w,
+    height: bidData.h,
+    creativeId: bidData.crid,
+    pubapiId: response.id,
+    currency: response.cur,
+    dealId: bidData.dealid,
+    netRevenue: true,
+    ttl: CONSUMABLE_TTL
+  };
+}
+
+function _formatPixels (pixels) {
+  let formattedPixels = pixels.replace(/<\/?script( type=('|")text\/javascript('|")|)?>/g, '');
+
+  return '<script>var w=window,prebid;' +
+    'for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
+    'if(prebid && prebid.consumableGlobals && !prebid.consumableGlobals.pixelsDropped){' +
+    'try{prebid.consumableGlobals.pixelsDropped=true;' + formattedPixels + 'break;}' +
+    'catch(e){continue;}' +
+    '}}</script>';
+}
+
+export const spec = {
+  code: CONSUMABLE_BIDDER_CODE,
+  isBidRequestValid: function(bid) {
+    return bid.params && bid.params.placement
+  },
+  buildRequests: function (bids) {
+    return bids.map(formatBidRequest);
+  },
+  interpretResponse: function ({body}, bidRequest) {
+    if (!body) {
+      utils.logError('Empty bid response', bidRequest.bidderCode, body);
+    } else {
+      let bid = _parseBidResponse(body, bidRequest);
+      if (bid) {
+        return bid;
+      }
+    }
+  },
+  getUserSyncs: function(options, bidResponses) {
+    let bidResponse = bidResponses[0];
+
+    if (config.getConfig('consumable.userSyncOn') === EVENTS.BID_RESPONSE) {
+      if (!$$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped && bidResponse.ext && bidResponse.ext.pixels) {
+        $$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped = true;
+
+        return parsePixelItems(bidResponse.ext.pixels);
+      }
+    }
+
+    return [];
+  }
+};
+
+registerBidder(spec);

--- a/modules/consumableBidAdapter.md
+++ b/modules/consumableBidAdapter.md
@@ -1,0 +1,32 @@
+# Overview
+
+Module Name: Consumable Bid Adapter
+
+Module Type: Consumable Adapter
+
+Maintainer: naffis@consumable.com
+
+# Description
+
+Module that connects to Consumable's demand sources
+
+# Test Parameters
+```javascript
+    var adUnits = [
+        {
+            code: 'test-ad-div',
+            sizes: [[300, 250]],
+            bids: [
+                {
+                    bidder: 'consumable',
+                    params: {
+                        placement: '1234567',
+                        unitId: '1234',
+                        unitName: 'cnsmbl-300x250',
+                        zoneId: '13136.52'
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -1,0 +1,215 @@
+import {expect} from 'chai';
+import * as utils from 'src/utils';
+import {spec} from 'modules/consumableBidAdapter';
+import {config} from 'src/config';
+
+const DEFAULT_OAD_CONTENT = '<script>logInfo(\'ad\');</script>';
+const DEFAULT_AD_CONTENT = '<script type=\'text/javascript\'>document.write(\'<div id="unitname-987654">\');</script><script>logInfo(\'ad\');</script><script type=\'text/javascript\'>document.write(\'</div>\');</script><script type=\'text/javascript\'>document.write(\'<div class="unitname"></div>\');</script><script type=\'text/javascript\'>document.write(\'<scr\'+\'ipt type="text/javascript" src="https://yummy.consumable.com/987654/unitname/widget/unit.js?cb=7654321" charset="utf-8" async></scr\'+\'ipt>\');</script>'
+
+let getDefaultBidResponse = () => {
+  return {
+    id: '245730051428950632',
+    cur: 'USD',
+    seatbid: [{
+      bid: [{
+        id: 1,
+        impid: '245730051428950632',
+        price: 0.09,
+        adm: DEFAULT_OAD_CONTENT,
+        crid: 'creative-id',
+        h: 90,
+        w: 728,
+        dealid: 'deal-id',
+        ext: {sizeid: 225}
+      }]
+    }]
+  };
+};
+
+let getBidParams = () => {
+  return {
+    placement: 1234567,
+    network: '9599.1',
+    unitId: '987654',
+    unitName: 'unitname',
+    zoneId: '9599.1'
+  };
+};
+
+let getDefaultBidRequest = () => {
+  return {
+    bidderCode: 'consumable',
+    auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+    bidderRequestId: '7101db09af0db2',
+    start: new Date().getTime(),
+    bids: [{
+      bidder: 'consumable',
+      bidId: '84ab500420319d',
+      bidderRequestId: '7101db09af0db2',
+      auctionId: 'd3e07445-ab06-44c8-a9dd-5ef9af06d2a6',
+      placementCode: 'foo',
+      params: getBidParams()
+    }]
+  };
+};
+
+let getPixels = () => {
+  return '<script>document.write(\'<img src="img.org"></iframe>' +
+    '<iframe src="pixels1.org"></iframe>\');</script>';
+};
+
+describe('ConsumableAdapter', () => {
+  const CONSUMABLE_URL = '//adserver-us.adtech.advertising.com/pubapi/3.0/';
+  const CONSUMABLE_TTL = 60;
+
+  function createCustomBidRequest({bids, params} = {}) {
+    var bidderRequest = getDefaultBidRequest();
+    if (bids && Array.isArray(bids)) {
+      bidderRequest.bids = bids;
+    }
+    if (params) {
+      bidderRequest.bids.forEach(bid => bid.params = params);
+    }
+    return bidderRequest;
+  }
+
+  describe('interpretResponse()', () => {
+    let bidderSettingsBackup;
+    let bidResponse;
+    let bidRequest;
+    let logWarnSpy;
+
+    beforeEach(() => {
+      bidderSettingsBackup = $$PREBID_GLOBAL$$.bidderSettings;
+      bidRequest = {
+        bidderCode: 'test-bidder-code',
+        bidId: 'bid-id',
+        unitName: 'unitname',
+        unitId: '987654',
+        zoneId: '9599.1',
+        network: '9599.1'
+      };
+      bidResponse = {
+        body: getDefaultBidResponse()
+      };
+      logWarnSpy = sinon.spy(utils, 'logWarn');
+    });
+
+    afterEach(() => {
+      $$PREBID_GLOBAL$$.bidderSettings = bidderSettingsBackup;
+      logWarnSpy.restore();
+    });
+
+    it('should return formatted bid response with required properties', () => {
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+      expect(formattedBidResponse).to.deep.equal({
+        bidderCode: bidRequest.bidderCode,
+        requestId: 'bid-id',
+        ad: DEFAULT_AD_CONTENT,
+        cpm: 0.09,
+        width: 728,
+        height: 90,
+        creativeId: 'creative-id',
+        pubapiId: '245730051428950632',
+        currency: 'USD',
+        dealId: 'deal-id',
+        netRevenue: true,
+        ttl: 60
+      });
+    });
+
+    it('should add formatted pixels to ad content when pixels are present in the response', () => {
+      bidResponse.body.ext = {
+        pixels: 'pixels-content'
+      };
+
+      let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
+
+      expect(formattedBidResponse.ad).to.equal(DEFAULT_AD_CONTENT + '<script>var w=window,prebid;for(var i=0;i<10;i++){w = w.parent;prebid=w.pbjs;if(prebid && prebid.consumableGlobals && !prebid.consumableGlobals.pixelsDropped){try{prebid.consumableGlobals.pixelsDropped=true;pixels-contentbreak;}catch(e){continue;}}}</script>');
+      return true;
+    });
+  });
+
+  describe('buildRequests()', () => {
+    it('method exists and is a function', () => {
+      expect(spec.buildRequests).to.exist.and.to.be.a('function');
+    });
+
+    describe('Consumable', () => {
+      it('should not return request when no bids are present', () => {
+        let [request] = spec.buildRequests([]);
+        expect(request).to.be.empty;
+      });
+
+      it('should return request for endpoint', () => {
+        let bidRequest = getDefaultBidRequest();
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url).to.contain(CONSUMABLE_URL);
+      });
+
+      it('should return url with pubapi bid option', () => {
+        let bidRequest = getDefaultBidRequest();
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url).to.contain('cmd=bid;');
+      });
+
+      it('should return url with version 2 of pubapi', () => {
+        let bidRequest = getDefaultBidRequest();
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url).to.contain('v=2;');
+      });
+
+      it('should return url with cache busting option', () => {
+        let bidRequest = getDefaultBidRequest();
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url).to.match(/misc=\d+/);
+      });
+    });
+  });
+
+  describe('getUserSyncs()', () => {
+    let bidResponse;
+    let bidRequest;
+
+    beforeEach(() => {
+      $$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped = false;
+      config.setConfig({
+        consumable: {
+          userSyncOn: 'bidResponse'
+        },
+      });
+      bidResponse = getDefaultBidResponse();
+      bidResponse.ext = {
+        pixels: getPixels()
+      };
+    });
+
+    it('should return user syncs only if userSyncOn equals to "bidResponse"', () => {
+      let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
+
+      expect($$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped).to.be.true;
+      expect(userSyncs).to.deep.equal([
+        {type: 'image', url: 'img.org'},
+        {type: 'iframe', url: 'pixels1.org'}
+      ]);
+    });
+
+    it('should not return user syncs if it has already been returned', () => {
+      $$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped = true;
+
+      let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
+
+      expect($$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped).to.be.true;
+      expect(userSyncs).to.deep.equal([]);
+    });
+
+    it('should not return user syncs if pixels are not present', () => {
+      bidResponse.ext.pixels = null;
+
+      let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
+
+      expect($$PREBID_GLOBAL$$.consumableGlobals.pixelsDropped).to.be.false;
+      expect(userSyncs).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding Consumable's bidder adapter for Prebid.js.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'consumable',
  params: {
    placement: '1234567',
    network: '9599.1',
    unitId: '987654',
    unitName: 'unitname',
    zoneId: '9599.1',
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.
- [x] done

- contact email of the adapter’s maintainer: naffis@consumable.com
- [x] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
- Link to the PR in the docs repo: https://github.com/prebid/prebid.github.io/pull/703
