### PR TITLE
execute bidsBackHandler when auction is canceled by consent module

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -22,6 +22,7 @@ let consentData;
 let context;
 let args;
 let nextFn;
+let bidsBackHandler;
 
 let timer;
 let haveExited;
@@ -163,6 +164,7 @@ export function requestBidsHook(config, fn) {
   nextFn = fn;
   haveExited = false;
   let adUnits = config.adUnits || $$PREBID_GLOBAL$$.adUnits;
+  bidsBackHandler = config.bidsBackHandler;
 
   // in case we already have consent (eg during bid refresh)
   if (consentData) {
@@ -262,6 +264,11 @@ function exitModule(errMsg) {
         nextFn.apply(context, args);
       } else {
         utils.logError(errMsg + ' Canceling auction as per consentManagement config.');
+        if (typeof bidsBackHandler === 'function') {
+          bidsBackHandler();
+        } else {
+          utils.logError('Error executing bidsBackHandler');
+        }
       }
     } else {
       nextFn.apply(context, args);

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -155,16 +155,16 @@ function lookupIabConsent(cmpSuccess, cmpError, adUnits) {
  * user's encoded consent string from the supported CMP.  Once obtained, the module will store this
  * data as part of a gdprConsent object which gets transferred to adaptermanager's gdprDataHandler object.
  * This information is later added into the bidRequest object for any supported adapters to read/pass along to their system.
- * @param {object} config required; This is the same param that's used in pbjs.requestBids.
+ * @param {object} reqBidsConfigObj required; This is the same param that's used in pbjs.requestBids.
  * @param {function} fn required; The next function in the chain, used by hook.js
  */
-export function requestBidsHook(config, fn) {
+export function requestBidsHook(reqBidsConfigObj, fn) {
   context = this;
   args = arguments;
   nextFn = fn;
   haveExited = false;
-  let adUnits = config.adUnits || $$PREBID_GLOBAL$$.adUnits;
-  bidsBackHandler = config.bidsBackHandler;
+  let adUnits = reqBidsConfigObj.adUnits || $$PREBID_GLOBAL$$.adUnits;
+  bidsBackHandler = reqBidsConfigObj.bidsBackHandler;
 
   // in case we already have consent (eg during bid refresh)
   if (consentData) {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -303,6 +303,7 @@ describe('consentManagement', function () {
 
       it('throws an error when processCmpData check failed while config had allowAuction set to false', () => {
         let testConsentData = null;
+        let bidsBackHandlerReturn = false;
 
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
           args[2](testConsentData);
@@ -310,13 +311,14 @@ describe('consentManagement', function () {
 
         setConfig(goodConfigWithCancelAuction);
 
-        requestBidsHook({}, () => {
+        requestBidsHook({ bidsBackHandler: () => bidsBackHandlerReturn = true }, () => {
           didHookReturn = true;
         });
         let consent = gdprDataHandler.getConsentData();
 
         sinon.assert.calledOnce(utils.logError);
         expect(didHookReturn).to.be.false;
+        expect(bidsBackHandlerReturn).to.be.true;
         expect(consent).to.be.null;
       });
 


### PR DESCRIPTION

## Type of change
- [x] Bugfix


## Description of change
Fixes issue #2551 

Currently when the prebid auction is canceled by the consentManagement module, the `bidsBackHandler` included in the `requestBids` function is not executed.

This fix will now execute the `bidsBackHandler` function when cancellation happens.

