### PR TITLE
Audience Network (legacy): backport native non-IAB size fix

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -5,6 +5,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import { formatQS } from 'src/url';
 import { getTopWindowUrl } from 'src/utils';
+import includes from 'core-js/library/fn/array/includes';
 
 const code = 'audienceNetwork';
 const currency = 'USD';
@@ -24,7 +25,8 @@ const isBidRequestValid = bid =>
   typeof bid.params.placementId === 'string' &&
   bid.params.placementId.length > 0 &&
   Array.isArray(bid.sizes) && bid.sizes.length > 0 &&
-  (isVideo(bid.params.format) || bid.sizes.map(flattenSize).some(isValidSize));
+  (isFullWidth(bid.params.format) ? bid.sizes.map(flattenSize).some(size => size === '300x250') : true) &&
+  (isValidNonSizedFormat(bid.params.format) || bid.sizes.map(flattenSize).some(isValidSize));
 
 /**
  * Flattens a 2-element [W, H] array as a 'WxH' string,
@@ -47,7 +49,24 @@ const expandSize = size => size.split('x').map(Number);
  * @param {String} size
  * @returns {Boolean}
  */
-const isValidSize = size => ['300x250', '320x50'].includes(size);
+const isValidSize = size => includes(['300x250', '320x50'], size);
+
+/**
+ * Is this a valid, non-sized format?
+ * @param {String} size
+ * @returns {Boolean}
+ */
+const isValidNonSizedFormat = format => includes(['video', 'native'], format);
+
+/**
+ * Is this a valid size and format?
+ * @param {String} size
+ * @returns {Boolean}
+ */
+const isValidSizeAndFormat = (size, format) =>
+  (isFullWidth(format) && flattenSize(size) === '300x250') ||
+  isValidNonSizedFormat(format) ||
+  isValidSize(flattenSize(size));
 
 /**
  * Is this a video format?
@@ -55,6 +74,13 @@ const isValidSize = size => ['300x250', '320x50'].includes(size);
  * @returns {Boolean}
  */
 const isVideo = format => format === 'video';
+
+/**
+ * Is this a fullwidth format?
+ * @param {String} format
+ * @returns {Boolean}
+ */
+const isFullWidth = format => format === 'fullwidth';
 
 /**
  * Which SDK version should be used for this format?
@@ -118,7 +144,7 @@ const buildRequests = bids => {
 
   bids.forEach(bid => bid.sizes
     .map(flattenSize)
-    .filter(size => isValidSize(size) || isVideo(bid.params.format))
+    .filter(size => isValidSizeAndFormat(size, bid.params.format))
     .slice(0, 1)
     .forEach(size => {
       placementids.push(bid.params.placementId);

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -73,7 +73,7 @@ describe('AudienceNetwork adapter', () => {
     it('fullwidth', () => {
       expect(isBidRequestValid({
         bidder,
-        sizes: [[300, 250]],
+        sizes: [[300, 250], [336, 280]],
         params: {
           placementId,
           format: 'fullwidth'
@@ -85,6 +85,17 @@ describe('AudienceNetwork adapter', () => {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250]],
+        params: {
+          placementId,
+          format: 'native'
+        }
+      })).to.equal(true);
+    });
+
+    it('native with non-IAB size', () => {
+      expect(isBidRequestValid({
+        bidder,
+        sizes: [[728, 90]],
         params: {
           placementId,
           format: 'native'


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR is to backport bug fixes #2203 and #2417 to the "legacy" 0.x release branch.

This work was commissioned and paid for by Facebook.
