### PR TITLE
feat(unrulyBidAdapter): pass bidderRequest through to exchange

### DIFF
--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -73,17 +73,20 @@ export const adapter = {
     return bid.mediaType === 'video' || context === 'outstream';
   },
 
-  buildRequests: function(validBidRequests) {
+  buildRequests: function(validBidRequests, bidderRequest) {
     const url = 'https://targeting.unrulymedia.com/prebid';
     const method = 'POST';
-    const data = { bidRequests: validBidRequests };
+    const data = {
+      bidRequests: validBidRequests,
+      bidderRequest
+    };
     const options = { contentType: 'application/json' };
 
     return {
       url,
       method,
       data,
-      options,
+      options
     };
   },
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -115,7 +115,9 @@ describe('UnrulyAdapter', () => {
     });
     it('should return a server request with valid payload', () => {
       const mockBidRequests = ['mockBid'];
-      expect(adapter.buildRequests(mockBidRequests).data).to.deep.equal({bidRequests: mockBidRequests})
+      const mockBidderRequest = {bidderCode: 'mockBidder'};
+      expect(adapter.buildRequests(mockBidRequests, mockBidderRequest).data)
+        .to.deep.equal({bidRequests: mockBidRequests, bidderRequest: mockBidderRequest})
     })
   });
 


### PR DESCRIPTION
Co-authored-by: Paul Cox <paul.cox@unrulygroup.com>
Co-authored-by: Will Porter <will.porter@unrulygroup.com>

## Type of change
- [ ] Feature

## Description of change
Added bidderRequest parameter to requestBuilder in our adapter in order to pass GDPR consent to our ad exchange.

- Link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/771
