### PR TITLE
Allow user to override which gpt slots should be targeted at invocation

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -156,7 +156,7 @@ $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode = function (adUnitCode) {
 /**
  * Set query string targeting on one or more GPT ad units.
  * @param {(string|string[])} adUnit a single `adUnit.code` or multiple.
- * @param {function(object)} customSlotMatching gets a GoogleTag slot and returns a filter function.
+ * @param {function(object)} customSlotMatching gets a GoogleTag slot and returns a filter function for adUnitCode, so you can decide to match on either eg. return slot => { return adUnitCode => { return slot.getSlotElementId() === 'myFavoriteDivId'; } };
  * @alias module:pbjs.setTargetingForGPTAsync
  */
 $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit, customSlotMatching) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -156,9 +156,10 @@ $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode = function (adUnitCode) {
 /**
  * Set query string targeting on one or more GPT ad units.
  * @param {(string|string[])} adUnit a single `adUnit.code` or multiple.
+ * @param {function(object)} customSlotMatching gets a GoogleTag slot and returns a filter function.
  * @alias module:pbjs.setTargetingForGPTAsync
  */
-$$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit) {
+$$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit, customSlotMatching) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.setTargetingForGPTAsync', arguments);
   if (!isGptPubadsDefined()) {
     utils.logError('window.googletag is not defined on the page');
@@ -172,7 +173,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit) {
   targeting.resetPresetTargeting(adUnit);
 
   // now set new targeting keys
-  targeting.setTargetingForGPT(targetingSet);
+  targeting.setTargetingForGPT(targetingSet, customSlotMatching);
 
   // emit event
   events.emit(SET_TARGETING, targetingSet);

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -141,9 +141,9 @@ export function newTargeting(auctionManager) {
    * Sets targeting for DFP
    * @param {Object.<string,Object.<string,string>>} targetingConfig
    */
-  targeting.setTargetingForGPT = function(targetingConfig) {
+  targeting.setTargetingForGPT = function(targetingConfig, customSlotMatching) {
     window.googletag.pubads().getSlots().forEach(slot => {
-      Object.keys(targetingConfig).filter(isAdUnitCodeMatchingSlot(slot))
+      Object.keys(targetingConfig).filter(customSlotMatching ? customSlotMatching(slot) : isAdUnitCodeMatchingSlot(slot))
         .forEach(targetId =>
           Object.keys(targetingConfig[targetId]).forEach(key => {
             let valueArr = targetingConfig[targetId][key].split(',');


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
We use the following flow:

We start a auction as early as possible. Without knowing where in the feed we're gonna place it. So depending on the outcome of the auction and how long it took we might inject it into a placement defined further down the page in order to now burn views above the fold.

The current semantics of setTargeting requires that we shall know a head of time what gptSlot the targeting should apply for because its looking into the auction object.

But allowing us to pass in an custom slot matching filter we can allow the targeting to explicitly use this slot when setting targeting

We use this in order not to place ads above fold and insert them to a better position instead of everything just being very static.

## Other information

Ref #1876 the old attempt, this is way cleaner and just follows along the new 1.x branch

cc: @mkendall07 