### PR TITLE
Sharethrough GDPR updates

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -14,12 +14,16 @@ export const sharethroughAdapterSpec = {
         placement_key: bid.params.pkey,
         hbVersion: '$prebid.version$',
         strVersion: VERSION,
-        hbSource: 'prebid'
+        hbSource: 'prebid',
+        consent_required: false
       };
 
-      if (bidderRequest && bidderRequest.gdprConsent) {
+      if (bidderRequest && bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString) {
         query.consent_string = bidderRequest.gdprConsent.consentString;
-        query.consent_required = bidderRequest.gdprConsent.gdprApplies;
+      }
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        query.consent_required = !!bidderRequest.gdprConsent.gdprApplies;
       }
 
       return {
@@ -51,7 +55,7 @@ export const sharethroughAdapterSpec = {
   },
   getUserSyncs: (syncOptions, serverResponses) => {
     const syncs = [];
-    if (syncOptions.pixelEnabled && serverResponses.length > 0) {
+    if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body) {
       serverResponses[0].body.cookieSyncUrls.forEach(url => {
         syncs.push({ type: 'image', url: url });
       });

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -105,8 +105,15 @@ describe('sharethrough adapter spec', () => {
       const gdprConsent = { consentString: 'consent_string123', gdprApplies: true };
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidderRequest, fakeBidRequest)[0];
-      expect(bidRequest.data.consent_string).to.eq('consent_string123');
       expect(bidRequest.data.consent_required).to.eq(true);
+      expect(bidRequest.data.consent_string).to.eq('consent_string123');
+    });
+
+    it('should handle gdprConsent is present but values are undefined case', () => {
+      const gdprConsent = { consent_string: undefined, gdprApplies: undefined };
+      const fakeBidRequest = { gdprConsent: gdprConsent };
+      const bidRequest = spec.buildRequests(bidderRequest, fakeBidRequest)[0];
+      expect(bidRequest.data).to.not.include.any.keys('consent_string')
     });
   });
 
@@ -169,6 +176,11 @@ describe('sharethrough adapter spec', () => {
         { type: 'image', url: 'cookieUrl2' },
         { type: 'image', url: 'cookieUrl3' }]
       );
+    });
+
+    it('returns an empty array if the body is null', () => {
+      const syncArray = spec.getUserSyncs({ pixelEnabled: true }, [{ body: null }]);
+      expect(syncArray).to.be.an('array').that.is.empty;
     });
 
     it('returns an empty array if pixels are not enabled', () => {


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)
## Description of change
<!-- Describe the change proposed in this pull request -->
- Updates the query passed to our ad server in `buildRequests`
- Handles case when ad server returns a `null` body in `getUserSyncs`
