### PR TITLE
Updated GDPR feature for Onetag bidder adapter

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -38,12 +38,20 @@ function isBidRequestValid(bid) {
  * @return ServerRequest Info describing the request to the server.
  */
 
-function buildRequests(validBidRequests) {
+function buildRequests(validBidRequests, bidderRequest) {
   const bids = validBidRequests.map(requestsToBids);
   const bidObject = {'bids': bids};
   const pageInfo = getPageInfo();
 
   const payload = Object.assign(bidObject, pageInfo);
+
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    payload.gdprConsent = {
+      consentString: bidderRequest.gdprConsent.consentString,
+      consentRequired: bidderRequest.gdprConsent.gdprApplies
+    };
+  }
+
   const payloadString = JSON.stringify(payload);
 
   return {
@@ -154,7 +162,6 @@ function requestsToBids(bid) {
   return toRet;
 }
 
-// Va bene così, questo file va aggiunto a prebidmaster
 export const spec = {
 
   code: BIDDER_CODE,

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -86,6 +86,26 @@ describe('onetag', () => {
         console.log('Error while parsing');
       }
     });
+    it('should send GDPR consent data', () => {
+      let consentString = 'consentString';
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        'gdprConsent': {
+          consentString: consentString,
+          gdprApplies: true
+        }
+      };
+      let serverRequest = spec.buildRequests([bid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+
+      expect(payload).to.exist;
+      expect(payload.gdprConsent).to.exist;
+      expect(payload.gdprConsent.consentString).to.exist.and.to.equal(consentString);
+      expect(payload.gdprConsent.consentRequired).to.exist.and.to.be.true;
+    });
   });
   describe('interpretResponse', () => {
     const resObject = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding gdpr support to the onetag bidder adapter

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer: devops@onetag.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
