### PR TITLE
InSkin Bid Adapter: support passing GDPR consent string on bid requests

### DIFF
--- a/modules/inskinBidAdapter.js
+++ b/modules/inskinBidAdapter.js
@@ -26,10 +26,11 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {validBidRequests[]} - an array of bids
+   * @param {bidderRequest} - the full bidder request object
    * @return ServerRequest Info describing the request to the server.
    */
 
-  buildRequests: function(validBidRequests) {
+  buildRequests: function(validBidRequests, bidderRequest) {
     // Do we need to group by bidder? i.e. to make multiple requests for
     // different endpoints.
 
@@ -55,6 +56,14 @@ export const spec = {
       includePricingData: true,
       parallel: true
     }, validBidRequests[0].params);
+
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      data.consent = {
+        gdprConsentString: bidderRequest.gdprConsent.consentString,
+        // will check if the gdprApplies field was populated with a boolean value (ie from page config).  If it's undefined, then default to true
+        gdprConsentRequired: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+      };
+    }
 
     validBidRequests.map(bid => {
       let config = CONFIG[bid.bidder];

--- a/test/spec/modules/inskinBidAdapter_spec.js
+++ b/test/spec/modules/inskinBidAdapter_spec.js
@@ -189,6 +189,26 @@ describe('InSkin BidAdapter', () => {
 
       expect(request.method).to.have.string('POST');
     });
+
+    it('should add gdpr consent information to the request', () => {
+      let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
+      let bidderRequest = {
+        'bidderCode': 'inskin',
+        'gdprConsent': {
+          consentString: consentString,
+          gdprApplies: true
+        }
+      };
+      bidderRequest.bids = bidRequests;
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.consent.gdprConsentString).to.exist;
+      expect(payload.consent.gdprConsentRequired).to.exist;
+      expect(payload.consent.gdprConsentString).to.exist.and.to.equal(consentString);
+      expect(payload.consent.gdprConsentRequired).to.exist.and.to.be.true;
+    });
   });
   describe('interpretResponse validation', () => {
     it('response should have valid bidderCode', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [X] Other

## Description of change
Add support for passing GDPR consent string and requirement data on bid requests to the InSkin Bid Adapter.
