### PR TITLE
Consistent targeting set

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -78,25 +78,6 @@ export function newTargeting(auctionManager) {
       .concat(getCustomBidTargeting(adUnitCodes, bidsReceived))
       .concat(config.getConfig('enableSendAllBids') ? getBidLandscapeTargeting(adUnitCodes, bidsReceived) : []);
 
-    // make sure at least there is a entry per adUnitCode in the targeting so receivers of SET_TARGETING call's can know what ad units are being invoked
-
-    adUnitCodes.forEach(key => {
-      if (!targeting.some(target => {
-        let hasMatchingAdUnitCode = false;
-
-        Object.getOwnPropertyNames(target).forEach(targetKey => {
-          if (targetKey === key) {
-            hasMatchingAdUnitCode = true;
-          }
-        });
-        return hasMatchingAdUnitCode;
-      })) {
-        const emptyTargeting = {};
-        emptyTargeting[key] = [];
-        targeting.push(emptyTargeting);
-      }
-    });
-
     // store a reference of the targeting keys
     targeting.map(adUnitCode => {
       Object.keys(adUnitCode).map(key => {
@@ -109,6 +90,15 @@ export function newTargeting(auctionManager) {
     });
 
     targeting = flattenTargeting(targeting);
+
+    // make sure at least there is a entry per adUnit code in the targetingSet so receivers of SET_TARGETING call's can know what ad units are being invoked
+
+    adUnitCodes.forEach(code => {
+      if (!targeting[code]) {
+        targeting[code] = {};
+      }
+    });
+
     return targeting;
   };
 

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -78,6 +78,25 @@ export function newTargeting(auctionManager) {
       .concat(getCustomBidTargeting(adUnitCodes, bidsReceived))
       .concat(config.getConfig('enableSendAllBids') ? getBidLandscapeTargeting(adUnitCodes, bidsReceived) : []);
 
+    // make sure at least there is a entry per adUnitCode in the targeting so receivers of SET_TARGETING call's can know what ad units are being invoked
+
+    adUnitCodes.forEach(key => {
+      if (!targeting.some(target => {
+        let hasMatchingAdUnitCode = false;
+
+        Object.getOwnPropertyNames(target).forEach(targetKey => {
+          if (targetKey === key) {
+            hasMatchingAdUnitCode = true;
+          }
+        });
+        return hasMatchingAdUnitCode;
+      })) {
+        const emptyTargeting = {};
+        emptyTargeting[key] = [];
+        targeting.push(emptyTargeting);
+      }
+    });
+
     // store a reference of the targeting keys
     targeting.map(adUnitCode => {
       Object.keys(adUnitCode).map(key => {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -136,6 +136,36 @@ describe('targeting tests', () => {
     });
   }); // end getAllTargeting tests
 
+  describe('getAllTargeting without bids return empty object', () => {
+    let amBidsReceivedStub;
+    let amGetAdUnitsStub;
+    let bidExpiryStub;
+
+    beforeEach(() => {
+      $$PREBID_GLOBAL$$._sendAllBids = false;
+      amBidsReceivedStub = sinon.stub(auctionManager, 'getBidsReceived').callsFake(function() {
+        return [];
+      });
+      amGetAdUnitsStub = sinon.stub(auctionManager, 'getAdUnitCodes').callsFake(function() {
+        return ['/123456/header-bid-tag-0'];
+      });
+      bidExpiryStub = sinon.stub(targetingModule, 'isBidExpired').returns(true);
+    });
+
+    afterEach(() => {
+      auctionManager.getBidsReceived.restore();
+      auctionManager.getAdUnitCodes.restore();
+      targetingModule.isBidExpired.restore();
+    });
+
+    it('returns targetingSet correctly', () => {
+      let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+
+      // we should only get the targeting data for the one requested adunit to at least exist even though it has no keys to set
+      expect(Object.keys(targeting).length).to.equal(1);
+    });
+  }); // end getAllTargeting without bids return empty object
+
   describe('Targeting in concurrent auctions', () => {
     describe('check getOldestBid', () => {
       let bidExpiryStub;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -202,13 +202,13 @@ describe('Unit: Prebid Module', function () {
 
     it('should return current targeting data for slots', function () {
       $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
-      const targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
-      const expected = getAdServerTargeting();
+      const targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
+      const expected = getAdServerTargeting(['/19968336/header-bid-tag-0, /19968336/header-bid-tag1']);
       assert.deepEqual(targeting, expected, 'targeting ok');
     });
 
     it('should return correct targeting with default settings', () => {
-      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
       var expected = {
         '/19968336/header-bid-tag-0': {
           foobar: '0x0,300x250,300x600',
@@ -230,8 +230,8 @@ describe('Unit: Prebid Module', function () {
 
     it('should return correct targeting with bid landscape targeting on', () => {
       $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
-      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
-      var expected = getAdServerTargeting();
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
+      var expected = getAdServerTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
       assert.deepEqual(targeting, expected);
     });
 
@@ -248,7 +248,7 @@ describe('Unit: Prebid Module', function () {
 
       auction.getBidsReceived = function() { return _bidsReceived };
 
-      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
 
       // Ensure targeting for both ad placements includes the custom key.
       assert.equal(
@@ -312,7 +312,7 @@ describe('Unit: Prebid Module', function () {
         }
       };
 
-      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
 
       var expected = {
         '/19968336/header-bid-tag-0': {
@@ -346,7 +346,7 @@ describe('Unit: Prebid Module', function () {
 
       auction.getBidsReceived = function() { return _bidsReceived };
 
-      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting();
+      var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
 
       var expected = {
         '/19968336/header-bid-tag-0': {
@@ -1487,7 +1487,7 @@ describe('Unit: Prebid Module', function () {
         assert.ok(spyCallBids.calledTwice, 'When two requests for bids are made both should be' +
           ' callBids immediately');
 
-        let result = targeting.getAllTargeting(); // $$PREBID_GLOBAL$$.getAdserverTargeting();
+        let result = targeting.getAllTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']); // $$PREBID_GLOBAL$$.getAdserverTargeting();
         let expected = {
           '/19968336/header-bid-tag-0': {
             'foobar': '0x0,300x250,300x600',


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
The idea is that users of SET_TARGETING who receives the argument targeting set, should be able to get the ad unit codes always involved even though a bid not might be available when rendering the ad

## Other information
Previously I tried to introduce the adUnits into the arguments https://github.com/prebid/Prebid.js/pull/1875
and since then the targetingSet has been starting to get passed. In order to make this without breaking any contracts my suggestion is that we always return a entry even though there is no bid available to the receiver of SET_TARGETING can iterate which ad unit codes are getting invoked.

