### PR TITLE
Update ixBidAdapter.md

### DIFF
--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -141,18 +141,20 @@ var adUnits = [{
     bids: [{
         bidder: 'ix',
         params: {
-            siteId: '4622',
+            siteId: '12345',
             size: [300, 250]
         }
     }, {
         bidder: 'ix',
         params: {
-            siteId: '6242',
+            siteId: '12345',
             size: [300, 600]
         }
     }]
 }];
 ```
+
+Please note that you can re-use the existing `siteId` within the same flex position.
 
 ##### 2. Include `ixBidAdapter` in your build process
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other: adapter documentation

## Description of change

Clarify use of `siteId` and fix mismatch of `siteId` for 'flex position' units based on documentation emailed out:
https://gallery.mailchimp.com/41ac5884406c48bd6f31af7a1/files/09ffb712-5455-4c0c-8453-592c5a3bcb67/Prebid_1.0_Upgrade_Doc_052118_v2.pdf

Further clarification is recommended, given the comment in the FAQ:

> An IX site ID maps to a single size, whereas an ad unit can have multiple sizes. To ensure that the right site ID is mapped to the correct size in the ad unit we require the size to be explicitly stated.

...which contradicts the statement in the upgrade documentation linked above, which states:

> Please note that you can re-use the existing `siteId` within the same flex position.

Contact email of the adapter’s maintainer: prebid.support@indexexchange.com

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/786

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

@indexexchange 

- https://github.com/prebid/Prebid.js/issues/2574#issuecomment-390773053
- https://github.com/prebid/Prebid.js/issues/2590