### PR TITLE
GDPR use getConsentData CMP call to get consentString

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -77,7 +77,8 @@ function lookupIabConsent(cmpSuccess, cmpError, adUnits) {
   function callCmpWhileInSafeFrame(commandName, callback) {
     function sfCallback(msgName, data) {
       if (msgName === 'cmpReturn') {
-        callback(data.vendorConsents);
+        let responseObj = (commandName === 'getConsentData') ? data.vendorConsentData : data.vendorConsents;
+        callback(responseObj);
       }
     }
 
@@ -159,7 +160,10 @@ function lookupIabConsent(cmpSuccess, cmpError, adUnits) {
     }
 
     function cmpIframeCallback(consentObject) {
+      // will delete the local version of the window.__cmp function and the eventlistener that was created from the iframe CMP code
+      delete window.__cmp;
       removePostMessageListener();
+
       moduleCallback(consentObject);
     }
   }

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -305,7 +305,7 @@ describe('consentManagement', function () {
       });
 
       it('throws an error when processCmpData check failed while config had allowAuction set to false', () => {
-        let testConsentData = null;
+        let testConsentData = {};
         let bidsBackHandlerReturn = false;
 
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
@@ -326,7 +326,7 @@ describe('consentManagement', function () {
       });
 
       it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', () => {
-        let testConsentData = null;
+        let testConsentData = {};
 
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
           args[2](testConsentData);

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -119,7 +119,7 @@ describe('consentManagement', function () {
       it('should bypass CMP and simply use previously stored consentData', () => {
         let testConsentData = {
           gdprApplies: true,
-          metadata: 'xyz'
+          consentData: 'xyz'
         };
 
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
@@ -140,7 +140,7 @@ describe('consentManagement', function () {
         let consent = gdprDataHandler.getConsentData();
 
         expect(didHookReturn).to.be.true;
-        expect(consent.consentString).to.equal(testConsentData.metadata);
+        expect(consent.consentString).to.equal(testConsentData.consentData);
         expect(consent.gdprApplies).to.be.true;
         sinon.assert.notCalled(cmpStub);
       });
@@ -176,7 +176,7 @@ describe('consentManagement', function () {
           data: {
             msgName: 'cmpReturn',
             vendorConsents: {
-              metadata: 'abc123def',
+              consentData: 'abc123def',
               gdprApplies: true
             }
           }
@@ -227,7 +227,7 @@ describe('consentManagement', function () {
             __cmpReturn: {
               returnValue: {
                 gdprApplies: true,
-                metadata: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
+                consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
               }
             }
           }
@@ -238,7 +238,7 @@ describe('consentManagement', function () {
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
           args[2]({
             gdprApplies: true,
-            metadata: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
+            consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
           });
         });
 
@@ -280,7 +280,7 @@ describe('consentManagement', function () {
       it('performs lookup check and stores consentData for a valid existing user', () => {
         let testConsentData = {
           gdprApplies: true,
-          metadata: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
+          consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
         };
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
           args[2](testConsentData);
@@ -296,7 +296,7 @@ describe('consentManagement', function () {
         sinon.assert.notCalled(utils.logWarn);
         sinon.assert.notCalled(utils.logError);
         expect(didHookReturn).to.be.true;
-        expect(consent.consentString).to.equal(testConsentData.metadata);
+        expect(consent.consentString).to.equal(testConsentData.consentData);
         expect(consent.gdprApplies).to.be.true;
       });
 

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -176,6 +176,10 @@ describe('consentManagement', function () {
           data: {
             msgName: 'cmpReturn',
             vendorConsents: {
+              metadata: 'abc123def',
+              gdprApplies: true
+            },
+            vendorConsentData: {
               consentData: 'abc123def',
               gdprApplies: true
             }


### PR DESCRIPTION
## Type of change
- [x] Bugfix


## Description of change
Previously the consentManagement module was using the CMP function `getVendorConsents` to obtain all aspects of the user's consent information.  It was pointed out in #2591 that this function is not the ideal one to use to obtain the user's consent information (specifically the encoded string).

This PR updates the logic of the module to use the `getConsentData` CMP function to grab the `consentString` and `gdprApplies` and then executes the `getVendorConsents` CMP function to grab the unparsed vendor consent information (to maintain backwards compatibility for that variable we offer to adapters).  