### PR TITLE
Rubicon able to read mediaTypes.size

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -523,10 +523,10 @@ function parseSizes(bid) {
   let sizes = [];
   if (Array.isArray(params.sizes)) {
     sizes = params.sizes;
-  } else if (Array.isArray(bid.sizes) && bid.sizes.length > 0) {
-    sizes = mapSizes(bid.sizes)
   } else if (typeof utils.deepAccess(bid, 'mediaTypes.banner.sizes') !== 'undefined') {
     sizes = mapSizes(bid.mediaTypes.banner.sizes);
+  } else if (Array.isArray(bid.sizes) && bid.sizes.length > 0) {
+    sizes = mapSizes(bid.sizes)
   } else {
     utils.logWarn('Warning: no sizes are setup or found');
   }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -524,7 +524,7 @@ function parseSizes(bid) {
   if (typeof utils.deepAccess(bid, 'mediaTypes.' + _mediaTypes.BANNER) !== 'undefined') {
     if (Array.isArray(bid.mediaTypes.banner.sizes) && bid.mediaTypes.banner.sizes.length > 0 && Array.isArray(bid.mediaTypes.banner.sizes[0]) && bid.mediaTypes.banner.sizes[0].length > 1) {
       sizes = mapSizes(bid.mediaTypes.banner.sizes);
-    } 
+    }
   } else {
     sizes = Array.isArray(params.sizes) ? params.sizes : mapSizes(bid.sizes)
   }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -521,10 +521,14 @@ function parseSizes(bid) {
 
   // deprecated: temp legacy support
   let sizes = [];
-  if (typeof utils.deepAccess(bid, 'mediaTypes.banner.sizes') !== 'undefined') {
+  if (Array.isArray(params.sizes)) {
+    sizes = params.sizes;
+  } else if (Array.isArray(bid.sizes) && bid.sizes.length > 0) {
+    sizes = mapSizes(bid.sizes)
+  } else if (typeof utils.deepAccess(bid, 'mediaTypes.banner.sizes') !== 'undefined') {
     sizes = mapSizes(bid.mediaTypes.banner.sizes);
   } else {
-    sizes = Array.isArray(params.sizes) ? params.sizes : mapSizes(bid.sizes)
+    utils.logWarn('Warning: no sizes are setup or found');
   }
 
   return masSizeOrdering(sizes);

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -521,7 +521,7 @@ function parseSizes(bid) {
 
   // deprecated: temp legacy support
   let sizes = [];
-  if (typeof utils.deepAccess(bid, 'mediaTypes.' + _mediaTypes.BANNER) !== 'undefined') {
+  if (typeof bid.mediaTypes.banner !== 'undefined') {
     if (Array.isArray(bid.mediaTypes.banner.sizes) && bid.mediaTypes.banner.sizes.length > 0 && Array.isArray(bid.mediaTypes.banner.sizes[0]) && bid.mediaTypes.banner.sizes[0].length > 1) {
       sizes = mapSizes(bid.mediaTypes.banner.sizes);
     }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -506,7 +506,9 @@ function parseSizes(bid) {
   let params = bid.params;
   if (spec.hasVideoMediaType(bid)) {
     let size = [];
-    if (params.video && params.video.playerWidth && params.video.playerHeight) {
+    if (Array.isArray(bid.mediaTypes.video.playerSize) && bid.mediaTypes.video.playerSize.length === 1) {
+      size = bid.mediaTypes.video.playerSize;
+    } else if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
         params.video.playerWidth,
         params.video.playerHeight
@@ -518,7 +520,14 @@ function parseSizes(bid) {
   }
 
   // deprecated: temp legacy support
-  let sizes = Array.isArray(params.sizes) ? params.sizes : mapSizes(bid.sizes)
+  let sizes = [];
+  if (typeof utils.deepAccess(bid, 'mediaTypes.' + _mediaTypes.BANNER) !== 'undefined') {
+    if (Array.isArray(bid.mediaTypes.banner.sizes) && bid.mediaTypes.banner.sizes.length > 0 && Array.isArray(bid.mediaTypes.banner.sizes[0]) && bid.mediaTypes.banner.sizes[0].length > 1) {
+      sizes = mapSizes(bid.mediaTypes.banner.sizes);
+    } 
+  } else {
+    sizes = Array.isArray(params.sizes) ? params.sizes : mapSizes(bid.sizes)
+  }
 
   return masSizeOrdering(sizes);
 }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -506,7 +506,7 @@ function parseSizes(bid) {
   let params = bid.params;
   if (spec.hasVideoMediaType(bid)) {
     let size = [];
-    if (Array.isArray(bid.mediaTypes.video.playerSize) && bid.mediaTypes.video.playerSize.length === 1) {
+    if (typeof utils.deepAccess(bid, 'mediaTypes.video.playerSize') !== 'undefined') {
       size = bid.mediaTypes.video.playerSize;
     } else if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
@@ -521,10 +521,8 @@ function parseSizes(bid) {
 
   // deprecated: temp legacy support
   let sizes = [];
-  if (typeof bid.mediaTypes.banner !== 'undefined') {
-    if (Array.isArray(bid.mediaTypes.banner.sizes) && bid.mediaTypes.banner.sizes.length > 0 && Array.isArray(bid.mediaTypes.banner.sizes[0]) && bid.mediaTypes.banner.sizes[0].length > 1) {
-      sizes = mapSizes(bid.mediaTypes.banner.sizes);
-    }
+  if (typeof utils.deepAccess(bid, 'mediaTypes.banner.sizes') !== 'undefined') {
+    sizes = mapSizes(bid.mediaTypes.banner.sizes);
   } else {
     sizes = Array.isArray(params.sizes) ? params.sizes : mapSizes(bid.sizes)
   }


### PR DESCRIPTION
<!--
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->
checkBidRequestSizes is normally present in adaptermanager.js to add the mediaTypes.banner.sizes to bid.sizes. However our adapter need to be able to read these fields in case the method is deprecated.
Same for the Video.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
