### PR TITLE
In ix bid adapter, default to assuming media type is banner

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -185,7 +185,8 @@ export const spec = {
 
       // If the bid request is for banner, then transform the bid request based on banner format.
       if (utils.deepAccess(validBidRequest, 'mediaTypes.banner') ||
-        validBidRequest.mediaType === 'banner') {
+        validBidRequest.mediaType === 'banner' ||
+        (validBidRequest.mediaType === undefined && utils.deepAccess(validBidRequest, 'mediaTypes.banner') === undefined)) {
         bannerImp = bidToBannerImp(validBidRequest);
         bannerImps.push(bannerImp);
       }

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -272,6 +272,21 @@ describe('IndexexchangeAdapter', () => {
 
       expect(requestStringTimeout.data.t).to.be.undefined;
     });
+
+    it('should default to assuming media type is banner', () => {
+      const bidsWithoutMediaType = [
+        Object.assign({}, DEFAULT_BANNER_VALID_BID[0])
+      ];
+      delete bidsWithoutMediaType[0].mediaTypes;
+
+      const request = spec.buildRequests(bidsWithoutMediaType);
+      const payload = JSON.parse(request.data.r);
+
+      expect(payload.id).to.equal(bidsWithoutMediaType[0].bidderRequestId);
+      expect(payload.imp).to.exist;
+      expect(payload.imp).to.be.an('array');
+      expect(payload.imp).to.have.lengthOf(1);
+    });
   });
 
   describe('interpretResponseBanner', () => {


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

As described in #2574, this code:

    if (utils.deepAccess(validBidRequest, 'mediaTypes.banner') ||
            validBidRequest.mediaType === 'banner') {
            bannerImp = bidToBannerImp(validBidRequest);
            bannerImps.push(bannerImp);
    }

assumes that `mediaType` or `mediaTypes` is set. According to http://prebid.org/dev-docs/publisher-api-reference.html specifying the media type is optional and it should default to assuming it's a banner.

This PR makes it assume the media type is banner if it's not set.

## Other information

#2574