### PR TITLE
Ensuring correct events order with bidsBackHandler

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -131,7 +131,11 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
         const bids = [_bidsReceived
           .filter(adUnitsFilter.bind(this, adUnitCodes))
           .reduce(groupByPlacement, {})];
-        _callback.apply($$PREBID_GLOBAL$$, bids);
+        setTimeout((function(callback, bids) {
+          return function() {
+            callback.apply($$PREBID_GLOBAL$$, bids);
+          };
+        })(_callback, bids), 0);
       } catch (e) {
         utils.logError('Error executing bidsBackHandler', null, e);
       } finally {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -360,7 +360,7 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
     if (typeof bidsBackHandler === 'function') {
       // executeCallback, this will only be called in case of first request
       try {
-        bidsBackHandler();
+        setTimeout(bidsBackHandler, 0);
       } catch (e) {
         utils.logError('Error executing bidsBackHandler', null, e);
       }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Events such as BIDDER_DONE will fire only after the bidsBackHandler has completed. This is due to inline execution of the callbacks and handlers. Instead, in this patch, using setTimeout(_cb_, 0), we will postpone execution of the callback after the current execution flow has finished. This makes events fire in the correct order.