### PR TITLE
update aardvark to not return zero bids

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -100,9 +100,15 @@ export const spec = {
     }
 
     utils._each(serverResponse.body, function(rawBid) {
+      var cpm = +(rawBid.cpm || 0);
+
+      if (!cpm) {
+        return;
+      }
+
       var bidResponse = {
         requestId: rawBid.cid,
-        cpm: rawBid.cpm || 0,
+        cpm: cpm,
         width: rawBid.width || 0,
         height: rawBid.height || 0,
         currency: rawBid.currency ? rawBid.currency : AARDVARK_CURRENCY,

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -257,8 +257,7 @@ describe('aardvarkAdapterTest', () => {
       }];
 
       var result = spec.interpretResponse({ body: emptyResponse }, {});
-      expect(result.length).to.equal(1);
-      expect(result[0].cpm).to.equal(0.0);
+      expect(result.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Aardvark adapter was submitting also zero-cpm bids to Prebid. Changing to only cpm > 0.

- [x] official adapter submission

Adapter maintainer: chris@rtk.io