### PR TITLE
Pet 239 ias bid adapter bug fix for multiple slots

### DIFF
--- a/modules/iasBidAdapter.js
+++ b/modules/iasBidAdapter.js
@@ -118,9 +118,6 @@ function interpretResponse(serverResponse, request) {
     bidResponses.push(otherResponse);
   });
 
-  if (top.postIASResponse) {
-    postIASResponse(iasResponse);
-  }
   return bidResponses;
 }
 

--- a/modules/iasBidAdapter.js
+++ b/modules/iasBidAdapter.js
@@ -3,6 +3,8 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'ias';
 
+const otherBidIds = [];
+
 function isBidRequestValid(bid) {
   const { pubId, adUnitPath } = bid.params;
   return !!(pubId && adUnitPath);
@@ -37,11 +39,11 @@ function stringifySlot(bidRequest) {
 }
 
 function stringifyWindowSize() {
-  return [window.innerWidth || -1, window.innerHeight || -1].join('.');
+  return [ window.innerWidth || -1, window.innerHeight || -1 ].join('.');
 }
 
 function stringifyScreenSize() {
-  return [(window.screen && window.screen.width) || -1, (window.screen && window.screen.height) || -1].join('.');
+  return [ (window.screen && window.screen.width) || -1, (window.screen && window.screen.height) || -1 ].join('.');
 }
 
 function buildRequests(bidRequests) {
@@ -60,12 +62,18 @@ function buildRequests(bidRequests) {
 
   const queryString = encodeURI(queries.map(qs => qs.join('=')).join('&'));
 
+  bidRequests.forEach(function (request) {
+    if (bidRequests[0].bidId != request.bidId) {
+      otherBidIds.push(request.bidId);
+    }
+  });
+
   return {
     method: 'GET',
     url: IAS_HOST,
     data: queryString,
     bidRequest: bidRequests[0]
-  }
+  };
 }
 
 function getPageLevelKeywords(response) {
@@ -103,6 +111,16 @@ function interpretResponse(serverResponse, request) {
   shallowMerge(commonBidResponse, getPageLevelKeywords(iasResponse));
   commonBidResponse.slots = iasResponse.slots;
   bidResponses.push(commonBidResponse);
+
+  otherBidIds.forEach(function (bidId) {
+    var otherResponse = Object.assign({}, commonBidResponse);
+    otherResponse.requestId = bidId;
+    bidResponses.push(otherResponse);
+  });
+
+  if (top.postIASResponse) {
+    postIASResponse(iasResponse);
+  }
   return bidResponses;
 }
 

--- a/test/spec/modules/iasBidAdapter_spec.js
+++ b/test/spec/modules/iasBidAdapter_spec.js
@@ -221,7 +221,7 @@ describe('iasBidAdapter is an adapter that', () => {
       it('has property `slots`', () => {
         expect(bidResponse[0]).to.deep.include({ slots: slots });
       });
-      it('response is the same for multiple slots', ()=>{
+      it('response is the same for multiple slots', () => {
         var adapter = spec;
         var requests = adapter.buildRequests(bidRequests);
         expect(adapter.interpretResponse(serverResponse, requests)).to.length(2);

--- a/test/spec/modules/iasBidAdapter_spec.js
+++ b/test/spec/modules/iasBidAdapter_spec.js
@@ -89,6 +89,9 @@ describe('iasBidAdapter is an adapter that', () => {
           url: IAS_HOST
         });
       });
+      it('only includes the first `bidRequest` as the bidRequest variable on a multiple slot request', () => {
+        expect(spec.buildRequests(bidRequests).bidRequest.adUnitCode).to.equal(bidRequests[0].adUnitCode);
+      });
       describe('has property `data` that is an encode query string containing information such as', () => {
         let val;
         const ANID_PARAM = 'anId';
@@ -124,8 +127,41 @@ describe('iasBidAdapter is an adapter that', () => {
       expect(spec.interpretResponse).to.be.a('function');
     });
     describe('returns a list of bid response that', () => {
-      let bidResponse, slots;
+      let bidRequests, bidResponse, slots, serverResponse;
       beforeEach(() => {
+        bidRequests = [
+          {
+            adUnitCode: 'one-div-id',
+            auctionId: 'someAuctionId',
+            bidId: 'someBidId1',
+            bidder: 'ias',
+            bidderRequestId: 'someBidderRequestId',
+            params: {
+              pubId: '1234',
+              adUnitPath: '/a/b/c'
+            },
+            sizes: [
+              [10, 20],
+              [300, 400]
+            ],
+            transactionId: 'someTransactionId'
+          },
+          {
+            adUnitCode: 'two-div-id',
+            auctionId: 'someAuctionId',
+            bidId: 'someBidId2',
+            bidder: 'ias',
+            bidderRequestId: 'someBidderRequestId',
+            params: {
+              pubId: '1234',
+              adUnitPath: '/d/e/f'
+            },
+            sizes: [
+              [50, 60]
+            ],
+            transactionId: 'someTransactionId'
+          }
+        ];
         const request = {
           bidRequest: {
             bidId: '102938'
@@ -140,7 +176,7 @@ describe('iasBidAdapter is an adapter that', () => {
           id: '5678',
           vw: ['80', '90']
         };
-        const serverResponse = {
+        serverResponse = {
           body: {
             brandSafety: {
               adt: 'adtVal',
@@ -184,6 +220,11 @@ describe('iasBidAdapter is an adapter that', () => {
       });
       it('has property `slots`', () => {
         expect(bidResponse[0]).to.deep.include({ slots: slots });
+      });
+      it('response is the same for multiple slots', ()=>{
+        var adapter = spec;
+        var requests = adapter.buildRequests(bidRequests);
+        expect(adapter.interpretResponse(serverResponse, requests)).to.length(2);
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
PET-239 Fix:

* Performs the backend request for multiple slots in 1 call
* Sets all backend response data for each bid response (some is global and some is slot specific) to be parsed by the user for targeting.
* Fixed tests
* Added tests