### PR TITLE
fix mediaType regression in rubicon adapter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -390,7 +390,6 @@ export const spec = {
           requestId: associatedBidRequest.bidId,
           currency: 'USD',
           creativeId: ad.creative_id,
-          mediaType: ad.creative_type,
           cpm: ad.cpm || 0,
           dealId: ad.deal,
           ttl: 300, // 5 minutes


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
#2478 introduced a regression on the issue fixed in #2209.  Reapplying the fix.
