### PR TITLE
Update appnexusBidAdapter.js

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -29,7 +29,7 @@ const SOURCE = 'pbjs';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['appnexusAst', 'brealtime', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm'],
+  aliases: ['appnexusAst', 'brealtime', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm', 'msqClassic', 'msqBrand', 'msqMax', 'msqView', 'altice'],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   /**


### PR DESCRIPTION
## Type of change
- [ ] Feature
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding new aliases to appnexus adapter in order to use them in prebidserver (as the aliasBidder method has no equivalent in prebidserver)
