### PR TITLE
Adform adapter supports string type sizes

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -114,13 +114,12 @@ export const spec = {
         bidRespones.push(bidObject);
       }
     }
-
     return bidRespones;
 
     function verifySize(adItem, validSizes) {
       for (var j = 0, k = validSizes.length; j < k; j++) {
-        if (adItem.width === validSizes[j][0] &&
-            adItem.height === validSizes[j][1]) {
+        if (adItem.width == validSizes[j][0] &&
+            adItem.height == validSizes[j][1]) {
           return true;
         }
       }

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -153,19 +153,6 @@ describe('Adform adapter', () => {
       let result = spec.interpretResponse({ body: {} }, {});
       assert.deepEqual(result, []);
     });
-    it('should respond with empty response when sizes doesn\'t match', () => {
-      serverResponse.body[0].response = 'banner';
-      serverResponse.body[0].width = 100;
-      serverResponse.body[0].height = 150;
-
-      serverResponse.body = [serverResponse.body[0]];
-      bidRequest.bids = [bidRequest.bids[0]];
-      let result = spec.interpretResponse(serverResponse, bidRequest);
-
-      assert.equal(serverResponse.body.length, 1);
-      assert.equal(serverResponse.body[0].response, 'banner');
-      assert.deepEqual(result, []);
-    });
     it('should respond with empty response when response from server is not banner', () => {
       serverResponse.body[0].response = 'not banner';
       serverResponse.body = [serverResponse.body[0]];
@@ -250,7 +237,53 @@ describe('Adform adapter', () => {
         assert.ok(!result[i].gdpr);
         assert.ok(!result[i].gdpr_consent);
       };
+    });
+
+    describe("verifySizes", () => {
+      it('should respond with empty response when sizes doesn\'t match', () => {
+        serverResponse.body[0].response = 'banner';
+        serverResponse.body[0].width = 100;
+        serverResponse.body[0].height = 150;
+
+        serverResponse.body = [serverResponse.body[0]];
+        bidRequest.bids = [bidRequest.bids[0]];
+        let result = spec.interpretResponse(serverResponse, bidRequest);
+
+        assert.equal(serverResponse.body.length, 1);
+        assert.equal(serverResponse.body[0].response, 'banner');
+        assert.deepEqual(result, []);
+      });
+      it('should respond with empty response when sizes as a strings doesn\'t match', () => {
+        serverResponse.body[0].response = 'banner';
+        serverResponse.body[0].width = 100;
+        serverResponse.body[0].height = 150;
+
+        serverResponse.body = [serverResponse.body[0]];
+        bidRequest.bids = [bidRequest.bids[0]];
+
+        bidRequest.bids[0].sizes = [['101', '150']];
+        let result = spec.interpretResponse(serverResponse, bidRequest);
+
+        assert.equal(serverResponse.body.length, 1);
+        assert.equal(serverResponse.body[0].response, 'banner');
+        assert.deepEqual(result, []);
+      });
+      it("should support size dimensions as a strings", () => {
+        serverResponse.body[0].response = 'banner';
+        serverResponse.body[0].width = 300;
+        serverResponse.body[0].height = 600;
+
+        serverResponse.body = [serverResponse.body[0]];
+        bidRequest.bids = [bidRequest.bids[0]];
+
+        bidRequest.bids[0].sizes = [['300', '250'], ['250', '300'], ['300', '600'], ['600', '300']]
+        let result = spec.interpretResponse(serverResponse, bidRequest);
+
+        assert.equal(result[0].width, 300);
+        assert.equal(result[0].height, 600);
+      });
     })
+
   });
 
   beforeEach(() => {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -239,7 +239,7 @@ describe('Adform adapter', () => {
       };
     });
 
-    describe("verifySizes", () => {
+    describe('verifySizes', () => {
       it('should respond with empty response when sizes doesn\'t match', () => {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;
@@ -268,7 +268,7 @@ describe('Adform adapter', () => {
         assert.equal(serverResponse.body[0].response, 'banner');
         assert.deepEqual(result, []);
       });
-      it("should support size dimensions as a strings", () => {
+      it('should support size dimensions as a strings', () => {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 300;
         serverResponse.body[0].height = 600;
@@ -283,7 +283,6 @@ describe('Adform adapter', () => {
         assert.equal(result[0].height, 600);
       });
     })
-
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Google Tag Manager passes adUnit sizes in a string formats, for example `(['300', '600']) `. Our adapter used to check if bid is valid by sizes, and sizes must have been number type. This update enables to give sizes in string format.

- contact email of the adapter’s maintainer
Scope.FL.Scripts@adform.com
- [x] official adapter submission