### PR TITLE
fix: retrieve unexpired bids only

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -195,7 +195,7 @@ export function newTargeting(auctionManager) {
   function getBidsReceived() {
     const bidsReceived = auctionManager.getBidsReceived()
       .filter(isUnusedBid)
-      .filter(exports.isBidExpired)
+      .filter(bid => !exports.isBidExpired(bid))
     ;
 
     return getHighestCpmBidsFromBidPool(bidsReceived, getOldestHighestCpmBid);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We're often receiving expired bids. I think there's some logic which is incorrect.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://github.com/prebid/Prebid.js/issues/2676
