### PR TITLE
fix the audienceNetwork tests comparison for pageurl

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -43,12 +43,12 @@ function newPluginsArray(browserstack) {
   ];
   if (browserstack) {
     plugins.push('karma-browserstack-launcher');
-    plugins.push('karma-firefox-launcher');
-    plugins.push('karma-opera-launcher');
-    plugins.push('karma-safari-launcher');
-    plugins.push('karma-script-launcher');
-    plugins.push('karma-ie-launcher');
   }
+  plugins.push('karma-firefox-launcher');
+  plugins.push('karma-opera-launcher');
+  plugins.push('karma-safari-launcher');
+  plugins.push('karma-script-launcher');
+  plugins.push('karma-ie-launcher');
   return plugins;
 }
 

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -20,6 +20,7 @@ const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
 const pbv = '$prebid.version$';
+const pageUrl = encodeURIComponent(utils.getTopWindowUrl());
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
@@ -139,7 +140,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&sdk[]=5.5.web&pbv=${pbv}`
+        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=${pageUrl}&sdk[]=5.5.web&pbv=${pbv}`
       }]);
     });
 
@@ -158,7 +159,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['640x480'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: `placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&sdk[]=&pbv=${pbv}&playerwidth=640&playerheight=480`
+        data: `placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=${pageUrl}&sdk[]=&pbv=${pbv}&playerwidth=640&playerheight=480`
       }]);
     });
 
@@ -177,7 +178,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['728x90'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: `placementids[]=test-placement-id&adformats[]=native&testmode=false&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&sdk[]=5.5.web&pbv=${pbv}`
+        data: `placementids[]=test-placement-id&adformats[]=native&testmode=false&pageurl=${pageUrl}&sdk[]=5.5.web&pbv=${pbv}`
       }]);
     });
 
@@ -196,7 +197,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: `placementids[]=test-placement-id&adformats[]=fullwidth&testmode=false&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&sdk[]=5.5.web&pbv=${pbv}`
+        data: `placementids[]=test-placement-id&adformats[]=fullwidth&testmode=false&pageurl=${pageUrl}&sdk[]=5.5.web&pbv=${pbv}`
       }]);
     });
 
@@ -410,7 +411,7 @@ describe('AudienceNetwork adapter', () => {
       expect(bidResponse.cpm).to.equal(1.23);
       expect(bidResponse.requestId).to.equal(requestId);
       expect(bidResponse.mediaType).to.equal('video');
-      expect(bidResponse.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${placementId}&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${bidId}`);
+      expect(bidResponse.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${placementId}&pageurl=${pageUrl}&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${bidId}`);
       expect(bidResponse.width).to.equal(playerwidth);
       expect(bidResponse.height).to.equal(playerheight);
     });
@@ -450,7 +451,7 @@ describe('AudienceNetwork adapter', () => {
       expect(bidResponseVideo.cpm).to.equal(1.23);
       expect(bidResponseVideo.requestId).to.equal(requestId);
       expect(bidResponseVideo.mediaType).to.equal('video');
-      expect(bidResponseVideo.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${videoPlacementId}&pageurl=http%3A%2F%2Flocalhost%3A9876%2F&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${videoBidId}`);
+      expect(bidResponseVideo.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${videoPlacementId}&pageurl=${pageUrl}&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${videoBidId}`);
       expect(bidResponseVideo.width).to.equal(playerwidth);
       expect(bidResponseVideo.height).to.equal(playerheight);
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fix the audienceNetwork tests that were getting different results in firefox/ie vs chrome for page_url.  Just use the same page_url result rather than hardcoding to prevent the mismatch.

Also added the loaders outside of browser stack.  No harm in adding and helps when debugging issues locally like this.

## Other information
#2673 introduced these test changes for the audienceNetwork adapter.