### PR TITLE
move generation of transactionIds to requestBids over addAdUnits

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -386,9 +386,6 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
 $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.addAdUnits', arguments);
   if (utils.isArray(adUnitArr)) {
-    // generate transactionid for each new adUnits
-    // Append array to existing
-    adUnitArr.forEach(adUnit => adUnit.transactionId = utils.generateUUID());
     $$PREBID_GLOBAL$$.adUnits.push.apply($$PREBID_GLOBAL$$.adUnits, adUnitArr);
   } else if (typeof adUnitArr === 'object') {
     $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -339,9 +339,13 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
     const bidders = adUnit.bids.map(bid => bid.bidder);
     const bidderRegistry = adaptermanager.bidderRegistry;
 
+    if (!adUnit.transactionId) {
+      adUnit.transactionId = utils.generateUUID();
+    }
+
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
-      const spec = adapter && adapter.getSpec && adapter.getSpec()
+      const spec = adapter && adapter.getSpec && adapter.getSpec();
       // banner is default if not specified in spec
       const bidderMediaTypes = (spec && spec.supportedMediaTypes) || ['banner'];
 
@@ -387,8 +391,6 @@ $$PREBID_GLOBAL$$.addAdUnits = function (adUnitArr) {
     adUnitArr.forEach(adUnit => adUnit.transactionId = utils.generateUUID());
     $$PREBID_GLOBAL$$.adUnits.push.apply($$PREBID_GLOBAL$$.adUnits, adUnitArr);
   } else if (typeof adUnitArr === 'object') {
-    // Generate the transaction id for the adunit
-    adUnitArr.transactionId = utils.generateUUID();
     $$PREBID_GLOBAL$$.adUnits.push(adUnitArr);
   }
   // emit event

--- a/test/spec/adUnits_spec.js
+++ b/test/spec/adUnits_spec.js
@@ -82,13 +82,6 @@ describe('Publisher API _ AdUnits', function () {
       assert.strictEqual(bids2[1].params.placementId, '827326', 'adUnit2 bids2 params.placementId');
     });
 
-    it('both add unit should contains a transactionId', function() {
-      assert.isString(adUnit1.transactionId);
-      assert.isString(adUnit2.transactionId);
-
-      assert.strictEqual(false, adUnit1.transactionId === adUnit2.transactionId);
-    });
-
     it('the second adUnits value should be same with the adUnits that is added by $$PREBID_GLOBAL$$.addAdUnits();', function () {
       assert.strictEqual(adUnit2.code, '/1996833/slot-2', 'adUnit2 code');
       assert.deepEqual(adUnit2.sizes, [[468, 60]], 'adUnit2 sizes');

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1251,8 +1251,6 @@ describe('Unit: Prebid Module', function () {
           ]
         });
 
-        debugger;
-
         expect(auctionArgs.adUnits[0]).to.have.property('transactionId')
           .and.to.equal('d0676a3c-ff32-45a5-af65-8175a8e7ddca');
         expect(auctionArgs.adUnits[1]).to.have.property('transactionId')

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1209,9 +1209,12 @@ describe('Unit: Prebid Module', function () {
     registerBidder(spec);
 
     describe('part 1', () => {
+      let auctionArgs;
+
       beforeEach(() => {
         adUnitsBackup = auction.getAdUnits
         auctionManagerStub = sinon.stub(auctionManager, 'createAuction').callsFake(function() {
+          auctionArgs = arguments[0];
           return auction;
         });
         logMessageSpy = sinon.spy(utils, 'logMessage');
@@ -1232,6 +1235,28 @@ describe('Unit: Prebid Module', function () {
           console.log(e);
         }
         assert.ok(logMessageSpy.calledWith('No adUnits configured. No bids requested.'), 'expected message was logged');
+      });
+
+      it('should attach transactionIds to ads (or pass through transactionId if it already exists)', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'test1',
+              transactionId: 'd0676a3c-ff32-45a5-af65-8175a8e7ddca',
+              bids: []
+            }, {
+              code: 'test2',
+              bids: []
+            }
+          ]
+        });
+
+        debugger;
+
+        expect(auctionArgs.adUnits[0]).to.have.property('transactionId')
+          .and.to.equal('d0676a3c-ff32-45a5-af65-8175a8e7ddca');
+        expect(auctionArgs.adUnits[1]).to.have.property('transactionId')
+          .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
       it('should execute callback immediately if adUnits is empty', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently the `transactionId` is generation in `addAdUnits`.  This means adUnits created and passed to `requestBids` manually will not have a `transactionId`s (unless they add them manually).  It probably makes more sense for `requestBids` to add the `transactionId`s to the objects if they don't already exist.