### PR TITLE
update some unit tests to clean-up consentManagement hooks

### DIFF
--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -402,97 +402,101 @@ describe('S2S Adapter', () => {
       expect(requestBid.ad_units[0].bids[0].params.member).to.exist.and.to.be.a('string');
     });
 
-    it('adds gdpr consent information to ortb2 request depending on presence of module', () => {
-      let ortb2Config = utils.deepClone(CONFIG);
-      ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+    describe('gdpr tests', () => {
+      afterEach(() => {
+        config.resetConfig();
+        $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
+      });
 
-      let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: ortb2Config };
-      config.setConfig(consentConfig);
+      it('adds gdpr consent information to ortb2 request depending on presence of module', () => {
+        let ortb2Config = utils.deepClone(CONFIG);
+        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
 
-      let gdprBidRequest = utils.deepClone(BID_REQUESTS);
-      gdprBidRequest[0].gdprConsent = {
-        consentString: 'abc123',
-        gdprApplies: true
-      };
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: ortb2Config };
+        config.setConfig(consentConfig);
 
-      adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(requests[0].requestBody);
+        let gdprBidRequest = utils.deepClone(BID_REQUESTS);
+        gdprBidRequest[0].gdprConsent = {
+          consentString: 'abc123',
+          gdprApplies: true
+        };
 
-      expect(requestBid.regs.ext.gdpr).is.equal(1);
-      expect(requestBid.user.ext.consent).is.equal('abc123');
+        adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
+        let requestBid = JSON.parse(requests[0].requestBody);
 
-      config.resetConfig();
-      config.setConfig({s2sConfig: CONFIG});
+        expect(requestBid.regs.ext.gdpr).is.equal(1);
+        expect(requestBid.user.ext.consent).is.equal('abc123');
 
-      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
-      requestBid = JSON.parse(requests[1].requestBody);
+        config.resetConfig();
+        config.setConfig({s2sConfig: CONFIG});
 
-      expect(requestBid.regs).to.not.exist;
-      expect(requestBid.user).to.not.exist;
+        adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+        requestBid = JSON.parse(requests[1].requestBody);
 
-      config.resetConfig();
-      $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
-    });
+        expect(requestBid.regs).to.not.exist;
+        expect(requestBid.user).to.not.exist;
+      });
 
-    it('check gdpr info gets added into cookie_sync request: have consent data', () => {
-      let cookieSyncConfig = utils.deepClone(CONFIG);
-      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
+      it('check gdpr info gets added into cookie_sync request: have consent data', () => {
+        let cookieSyncConfig = utils.deepClone(CONFIG);
+        cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
-      let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
-      config.setConfig(consentConfig);
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        config.setConfig(consentConfig);
 
-      let gdprBidRequest = utils.deepClone(BID_REQUESTS);
+        let gdprBidRequest = utils.deepClone(BID_REQUESTS);
 
-      gdprBidRequest[0].gdprConsent = {
-        consentString: 'abc123def',
-        gdprApplies: true
-      };
+        gdprBidRequest[0].gdprConsent = {
+          consentString: 'abc123def',
+          gdprApplies: true
+        };
 
-      adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(requests[0].requestBody);
+        adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
+        let requestBid = JSON.parse(requests[0].requestBody);
 
-      expect(requestBid.gdpr).is.equal(1);
-      expect(requestBid.gdpr_consent).is.equal('abc123def');
-    });
+        expect(requestBid.gdpr).is.equal(1);
+        expect(requestBid.gdpr_consent).is.equal('abc123def');
+      });
 
-    it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', () => {
-      let cookieSyncConfig = utils.deepClone(CONFIG);
-      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
+      it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', () => {
+        let cookieSyncConfig = utils.deepClone(CONFIG);
+        cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
-      let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
-      config.setConfig(consentConfig);
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        config.setConfig(consentConfig);
 
-      let gdprBidRequest = utils.deepClone(BID_REQUESTS);
-      gdprBidRequest[0].gdprConsent = {
-        consentString: 'xyz789abcc',
-        gdprApplies: false
-      };
+        let gdprBidRequest = utils.deepClone(BID_REQUESTS);
+        gdprBidRequest[0].gdprConsent = {
+          consentString: 'xyz789abcc',
+          gdprApplies: false
+        };
 
-      adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(requests[0].requestBody);
+        adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
+        let requestBid = JSON.parse(requests[0].requestBody);
 
-      expect(requestBid.gdpr).is.equal(0);
-      expect(requestBid.gdpr_consent).is.undefined;
-    });
+        expect(requestBid.gdpr).is.equal(0);
+        expect(requestBid.gdpr_consent).is.undefined;
+      });
 
-    it('checks gdpr info gets added to cookie_sync request: consent data unknown', () => {
-      let cookieSyncConfig = utils.deepClone(CONFIG);
-      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
+      it('checks gdpr info gets added to cookie_sync request: consent data unknown', () => {
+        let cookieSyncConfig = utils.deepClone(CONFIG);
+        cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
-      let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
-      config.setConfig(consentConfig);
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        config.setConfig(consentConfig);
 
-      let gdprBidRequest = utils.deepClone(BID_REQUESTS);
-      gdprBidRequest[0].gdprConsent = {
-        consentString: undefined,
-        gdprApplies: undefined
-      };
+        let gdprBidRequest = utils.deepClone(BID_REQUESTS);
+        gdprBidRequest[0].gdprConsent = {
+          consentString: undefined,
+          gdprApplies: undefined
+        };
 
-      adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(requests[0].requestBody);
+        adapter.callBids(REQUEST, gdprBidRequest, addBidResponse, done, ajax);
+        let requestBid = JSON.parse(requests[0].requestBody);
 
-      expect(requestBid.gdpr).is.undefined;
-      expect(requestBid.gdpr_consent).is.undefined;
+        expect(requestBid.gdpr).is.undefined;
+        expect(requestBid.gdpr_consent).is.undefined;
+      });
     });
 
     it('sets invalid cacheMarkup value to 0', () => {

--- a/test/spec/modules/pubCommonId_spec.js
+++ b/test/spec/modules/pubCommonId_spec.js
@@ -18,6 +18,9 @@ const COOKIE_NAME = '_pubcid';
 const TIMEOUT = 2000;
 
 describe('Publisher Common ID', function () {
+  afterEach(() => {
+    $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidHook);
+  });
   describe('Decorate adUnits', function () {
     before(function() {
       window.document.cookie = COOKIE_NAME + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -11,6 +11,7 @@ import {
   config
 } from 'src/config';
 import * as utils from 'src/utils';
+import { requestBidsHook } from 'modules/consentManagement';
 
 // Default params with optional ones
 describe('Smart bid adapter tests', () => {
@@ -99,49 +100,56 @@ describe('Smart bid adapter tests', () => {
     expect(requestContent).to.have.property('ckid').and.to.equal(42);
   });
 
-  it('Verify build request with GDPR', () => {
-    config.setConfig({
-      'currency': {
-        'adServerCurrency': 'EUR'
-      },
-      consentManagement: {
-        cmp: 'iab',
-        consentRequired: true,
-        timeout: 1000,
-        allowAuctionWithoutConsent: true
-      }
+  describe('gdpr tests', () => {
+    afterEach(() => {
+      config.resetConfig();
+      $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
-      gdprConsent: {
-        consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A==',
-        gdprApplies: true
-      }
-    });
-    const requestContent = JSON.parse(request[0].data);
-    expect(requestContent).to.have.property('gdpr').and.to.equal(true);
-    expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
-  });
 
-  it('Verify build request with GDPR without gdprApplies', () => {
-    config.setConfig({
-      'currency': {
-        'adServerCurrency': 'EUR'
-      },
-      consentManagement: {
-        cmp: 'iab',
-        consentRequired: true,
-        timeout: 1000,
-        allowAuctionWithoutConsent: true
-      }
+    it('Verify build request with GDPR', () => {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        },
+        consentManagement: {
+          cmp: 'iab',
+          consentRequired: true,
+          timeout: 1000,
+          allowAuctionWithoutConsent: true
+        }
+      });
+      const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+        gdprConsent: {
+          consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A==',
+          gdprApplies: true
+        }
+      });
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('gdpr').and.to.equal(true);
+      expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
-      gdprConsent: {
-        consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A=='
-      }
+
+    it('Verify build request with GDPR without gdprApplies', () => {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        },
+        consentManagement: {
+          cmp: 'iab',
+          consentRequired: true,
+          timeout: 1000,
+          allowAuctionWithoutConsent: true
+        }
+      });
+      const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+        gdprConsent: {
+          consentString: 'BOKAVy4OKAVy4ABAB8AAAAAZ+A=='
+        }
+      });
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.not.have.property('gdpr');
+      expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
     });
-    const requestContent = JSON.parse(request[0].data);
-    expect(requestContent).to.not.have.property('gdpr');
-    expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
   });
 
   it('Verify parse response', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)


## Description of change
This fixes issue #2707 

Several unit tests were calling the `config.setConfig` to initialize the `consentManagement` module, but they weren't cleaning up after the test which left a lingering hook on the `pbjs.requestBids` function that was being used in latter unrelated tests (specifically in the `pbjs_api_spec.js` file).

This change adds the necessary clean-up on those tests.