### PR TITLE
move logic to check if CMP is not found

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -90,6 +90,10 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
       f = f.parent;
     }
 
+    if (!cmpFrame) {
+      return cmpError('CMP not found.', hookConfig);
+    }
+
     callCmpWhileInIframe('getConsentData', cmpFrame, callbackHandler.consentDataCallback);
     callCmpWhileInIframe('getVendorConsents', cmpFrame, callbackHandler.vendorConsentsCallback);
   }
@@ -124,12 +128,6 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     /* Setup up a __cmp function to do the postMessage and stash the callback.
       This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
     window.__cmp = function(cmd, arg, callback) {
-      if (!cmpFrame) {
-        removePostMessageListener();
-
-        let errmsg = 'CMP not found';
-        return cmpError(errmsg, hookConfig);
-      }
       let callId = Math.random() + '';
       let msg = {__cmpCall: {
         command: cmd,


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
To address the issue reported in #2714 

With the old logic, the consentManagement module would go through part of the iframe workflow to detect if the CMP locator frame was not found.  While this code was part of the IAB spec for the CMP, in our case it meant that a local version of the `window.__cmp` function was still created in a page where a normal CMP doesn't exist (which was the issue that was reported).  

This fix moves the check that ultimately detects if the CMP locator frame is present so that it's outside the iframe function in order to prevent creating the `window.__cmp` function) while still throwing an error.