### PR TITLE
ADSS-358 returning size 1x1 when product is 2 or 5 and 1x1 is availab…

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -169,8 +169,17 @@ function interpretResponse (serverResponse, bidRequest) {
       pvid
     }
   } = Object.assign(defaultResponse, serverResponseBody)
-  let isTestUnit = (bidRequest.data && bidRequest.data.pi === 3 && bidRequest.data.si === 9)
-  let [width, height] = utils.parseSizesInput(bidRequest.sizes)[0].split('x')
+  let data = bidRequest.data || {}
+  let product = data.pi
+  let isTestUnit = (product === 3 && data.si === 9)
+  let sizes = utils.parseSizesInput(bidRequest.sizes)
+  let [width, height] = sizes[0].split('x')
+
+  // return 1x1 when breakout expected
+  if ((product === 2 || product === 5) && sizes.includes('1x1')) {
+    width = '1'
+    height = '1'
+  }
 
   // update Page View ID from server response
   pageViewId = pvid

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -20,7 +20,7 @@ describe('gumgumAdapter', () => {
         'inScreen': '10433394'
       },
       'adUnitCode': 'adunit-code',
-      'sizes': [[300, 250], [300, 600]],
+      'sizes': [[300, 250], [300, 600], [1, 1]],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',
@@ -97,7 +97,7 @@ describe('gumgumAdapter', () => {
     }
     let bidRequest = {
       id: 12345,
-      sizes: [[300, 250]],
+      sizes: [[300, 250], [1, 1]],
       url: ENDPOINT,
       method: 'GET',
       pi: 3
@@ -134,6 +134,43 @@ describe('gumgumAdapter', () => {
       let result = spec.interpretResponse({ body: response }, bidRequest);
       expect(result.length).to.equal(0);
     });
+
+    it('returns 1x1 when eligible product and size available', () => {
+      let inscreenBidRequest = {
+        id: 12346,
+        sizes: [[300, 250], [1, 1]],
+        url: ENDPOINT,
+        method: 'GET',
+        data: {
+          pi: 2,
+          t: 'ggumtest'
+        }
+      }
+      let inscreenServerResponse = {
+        'ad': {
+          'id': 2065333,
+          'height': 90,
+          'ipd': 2000,
+          'markup': '<html><h3>I am an inscreen ad</h3></html>',
+          'ii': true,
+          'du': null,
+          'price': 1,
+          'zi': 0,
+          'impurl': 'http://g2.gumgum.com/ad/view',
+          'clsurl': 'http://g2.gumgum.com/ad/close'
+        },
+        'pag': {
+          't': 'ggumtest',
+          'pvid': 'aa8bbb65-427f-4689-8cee-e3eed0b89eec',
+          'css': 'html { overflow-y: auto }',
+          'js': 'console.log("environment", env);'
+        },
+        'thms': 10000
+      }
+      let result = spec.interpretResponse({ body: inscreenServerResponse }, inscreenBidRequest);
+      expect(result[0].width).to.equal('1');
+      expect(result[0].height).to.equal('1');
+    })
   })
   describe('getUserSyncs', () => {
     const syncOptions = {


### PR DESCRIPTION
…le in bidrequest sizes array

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
When 1x1 is available in bidRequest sizes, the adapter will return those dimensions for eligible products.

- anthony@gumgum.com
- ricardo@gumgum.com
- [ ] official adapter submission
