### PR TITLE
enhance logWarn message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,8 +14,10 @@ var t_Numb = 'Number';
 var t_Object = 'Object';
 var toString = Object.prototype.toString;
 let infoLogger = null;
+let warnLogger = null;
 try {
   infoLogger = console.info.bind(window.console);
+  warnLogger = console.warn.bind(window.console);
 } catch (e) {
 }
 
@@ -257,9 +259,15 @@ exports.getTopWindowReferrer = function() {
   }
 };
 
-exports.logWarn = function (msg) {
+exports.logWarn = function (msg, args) {
   if (debugTurnedOn() && console.warn) {
-    console.warn('WARNING: ' + msg);
+    if (warnLogger) {
+      if (!args || args.length === 0) {
+        args = '';
+      }
+
+      warnLogger('WARNING: ' + msg + ((args === '') ? '' : ' : params : '), args);
+    }
   }
 };
 


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This is to enhance the `utils.logWarn` message to act like its `logInfo` and `logError` counterparts.

If you pass in an object that's relevant to the problem (ie `utils.logWarn('this object is missing stuff: ', myVar);`, that object will be included in the browser's console allowing you to easily see it contents.  

This is the same functionality that lets you see the `bidRequests` and `bidsReceived` objects in the console in 1.x.  See https://github.com/prebid/Prebid.js/blob/master/src/auction.js#L191 for reference usage.