### PR TITLE
ixBidAdapter.js: allow siteId param to be number

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -153,7 +153,7 @@ export const spec = {
       return false;
     }
 
-    if (typeof bid.params.siteId !== 'string' || typeof bid.params.siteId !== 'number') {
+    if (typeof bid.params.siteId !== 'string' && typeof bid.params.siteId !== 'number') {
       return false;
     }
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -153,7 +153,7 @@ export const spec = {
       return false;
     }
 
-    if (typeof bid.params.siteId !== 'string') {
+    if (typeof bid.params.siteId !== 'string' || typeof bid.params.siteId !== 'number') {
       return false;
     }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -77,10 +77,10 @@ describe('IndexexchangeAdapter', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when siteID is number', () => {
+    it('should return true when siteID is number', () => {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.siteId = 123;
-      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
     it('should return false when siteID is missing', () => {


### PR DESCRIPTION
In v0.x, the siteID param would be string or number. Somehow, this was restricted to just a string in v1.x.

## Type of change
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
This is a backwards-compatibility change only for v0.x => v1.x transition.

The v0.x adapter checked existence of the "siteID" parameter, which has been renamed to "siteId".  The IndexExchange migration documentation does not include a reference to restricting the var-type of this parameter, it only mentioned a change in name.  To be consistent with the documentation, it must also allow numbers.

## Other information
* Not sure who is maintainer of IX adapter. *