### PR TITLE
Add GDPR support for Quantcast adapter

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -41,9 +41,10 @@ export const spec = {
    * `BidRequests`.
    *
    * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be send to Quantcast server
+   * @param bidderRequest
    * @return ServerRequest information describing the request to the server.
    */
-  buildRequests(bidRequests) {
+  buildRequests(bidRequests, bidderRequest) {
     const bids = bidRequests || [];
 
     const referrer = utils.getTopWindowUrl();
@@ -75,6 +76,8 @@ export const spec = {
         });
       });
 
+      const gdprConsent = bidderRequest && bidderRequest.gdprConsent || {};
+
       // Request Data Format can be found at https://wiki.corp.qc/display/adinf/QCX
       const requestData = {
         publisherId: bid.params.publisherId,
@@ -94,7 +97,9 @@ export const spec = {
           referrer,
           domain
         },
-        bidId: bid.bidId
+        bidId: bid.bidId,
+        gdprSignal: gdprConsent.gdprApplies ? 1 : 0,
+        gdprConsent: gdprConsent.consentString
       };
 
       const data = JSON.stringify(requestData);

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -76,7 +76,7 @@ export const spec = {
         });
       });
 
-      const gdprConsent = bidderRequest && bidderRequest.gdprConsent || {};
+      const gdprConsent = bidderRequest ? bidderRequest.gdprConsent : {};
 
       // Request Data Format can be found at https://wiki.corp.qc/display/adinf/QCX
       const requestData = {

--- a/modules/quantcastBidAdapter.md
+++ b/modules/quantcastBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name: Quantcast Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: xli@quantcast.com
+Maintainer: igor.soarez@quantcast.com
 ```
 
 # Description

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -129,11 +129,20 @@ describe('Quantcast adapter', () => {
           referrer,
           domain
         },
-        bidId: '2f7b179d443f14'
+        bidId: '2f7b179d443f14',
+        gdprSignal: 0
       };
 
       expect(requests[0].data).to.equal(JSON.stringify(expectedBidRequest));
     });
+  });
+
+  it('propagates GDPR consent string and signal', () => {
+    const gdprConsent = { gdprApplies: true, consentString: 'consentString' }
+    const requests = qcSpec.buildRequests([bidRequest], { gdprConsent });
+    const parsed = JSON.parse(requests[0].data)
+    expect(parsed.gdprSignal).to.equal(1);
+    expect(parsed.gdprConsent).to.equal(gdprConsent.consentString);
   });
 
   describe('`interpretResponse`', () => {


### PR DESCRIPTION

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Following up on prebid/Prebid.js#2549 (please close), this adds GDPR support for the Quantcast adapter.

- test parameters for validating bids
```
{
    bidder: 'quantcast',
    params: {
        publisherId: 'test-publisher', // REQUIRED - Publisher ID provided by Quantcast
        battr: [1, 2] // OPTIONAL - Array of blocked creative attributes as per OpenRTB Spec List 5.3
    }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/gdpr_hello_world.html) sample page.

- contact email of the adapter’s maintainer: igor.soarez@quantcast.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo: prebid/prebid.github.io#768
