### PR TITLE
Added GDPR consent management to YOC VIS.X Bid Adapter

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -22,7 +22,7 @@ export const spec = {
   isBidRequestValid: function(bid) {
     return !!bid.params.uid;
   },
-  buildRequests: function(validBidRequests) {
+  buildRequests: function(validBidRequests, bidderRequest) {
     const auids = [];
     const bidsMap = {};
     const bids = validBidRequests || [];
@@ -55,6 +55,15 @@ export const spec = {
       cur: currency,
     };
 
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      if (bidderRequest.gdprConsent.consentString) {
+        payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+      }
+      payload.gdpr_applies =
+        (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean')
+          ? Number(bidderRequest.gdprConsent.gdprApplies) : 1;
+    }
+
     return {
       method: 'GET',
       url: ENDPOINT_URL,
@@ -84,11 +93,20 @@ export const spec = {
     if (errorMessage) utils.logError(errorMessage);
     return bidResponses;
   },
-  getUserSyncs: function(syncOptions) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent) {
     if (syncOptions.pixelEnabled) {
+      var query = [];
+      if (gdprConsent) {
+        if (gdprConsent.consentString) {
+          query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString));
+        }
+        query.push('gdpr_applies=' + encodeURIComponent(
+          (typeof gdprConsent.gdprApplies === 'boolean')
+            ? Number(gdprConsent.gdprApplies) : 1));
+      }
       return [{
         type: 'image',
-        url: ADAPTER_SYNC_URL
+        url: ADAPTER_SYNC_URL + (query.length ? '?' + query.join('&') : '')
       }];
     }
   }

--- a/modules/visxBidAdapter.md
+++ b/modules/visxBidAdapter.md
@@ -1,14 +1,14 @@
 # Overview
 
 ```
-Module Name:    VIS.X Bidder Adapter
+Module Name:    YOC VIS.X Bidder Adapter
 Module Type:    Bidder Adapter
 Maintainer:     service@yoc.com
 ```
 
 # Description
 
-Module that connects to VIS.X demand source to fetch bids.
+Module that connects to YOC VIS.X® demand source to fetch bids.
 
 # Test Parameters
 ```

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -149,6 +149,29 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'USD');
       getConfigStub.restore();
     });
+    it('if gdprConsent is present payload must have gdpr params', () => {
+      const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: true}});
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('gdpr_consent', 'AAA');
+      expect(payload).to.have.property('gdpr_applies', 1);
+    });
+
+    it('if gdprApplies is false gdpr_applies must be 0', () => {
+      const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: false}});
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('gdpr_consent', 'AAA');
+      expect(payload).to.have.property('gdpr_applies', 0);
+    });
+
+    it('if gdprApplies is undefined gdpr_applies must be 1', () => {
+      const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA'}});
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('gdpr_consent', 'AAA');
+      expect(payload).to.have.property('gdpr_applies', 1);
+    });
   });
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added GDPR consent management to YOC VIS.X Bid Adapter:
- Added GDPR consent management support
- Description updated


- contact email: service@yoc.com
- [x] official adapter submission