### PR TITLE
googleAnalyticsAdapter timeout bidder name

### DIFF
--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -235,7 +235,8 @@ function sendBidTimeouts(timedOutBidders) {
   _analyticsQueue.push(function () {
     utils._each(timedOutBidders, function (bidderCode) {
       _eventCount++;
-      window[_gaGlobal](_trackerSend, 'event', _category, 'Timeouts', bidderCode, _disableInteraction);
+      var bidderName = bidderCode.bidder;
+      window[_gaGlobal](_trackerSend, 'event', _category, 'Timeouts', bidderName, _disableInteraction);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [ x] Bugfix

## Description of change
After updating from 0.34.5 to 1.12.0 we were not getting the names of the timed out bidders into google through the googleAnalyticsAdapter, although all time outs were still present.
It seems that the argument sent from the timeout event has changed from a string to an object.
In this pull request I have changed the value sent to google from the entire recieved object to only the bidder part.