### PR TITLE
Max origin concurrent auctions

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -273,7 +273,7 @@ exports.checkBidRequestSizes = (adUnits) => {
   return adUnits;
 }
 
-exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
+exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks) => {
   if (!bidRequests.length) {
     utils.logWarn('callBids executed with no bidRequests.  Were they filtered by labels or sizing?');
     return;
@@ -285,7 +285,10 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
   }, [[], []]);
 
   if (serverBidRequests.length) {
-    const s2sAjax = ajaxBuilder(serverBidRequests[0].timeout);
+    const s2sAjax = ajaxBuilder(serverBidRequests[0].timeout, requestCallbacks ? {
+      request: requestCallbacks.request.bind(null, 's2s'),
+      done: requestCallbacks.done
+    } : undefined);
     let adaptersServerSide = _s2sConfig.bidders;
     const s2sAdapter = _bidderRegistry[_s2sConfig.adapter];
     let tid = serverBidRequests[0].tid;
@@ -336,7 +339,6 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
     }
   }
 
-  const ajax = (clientBidRequests.length) ? ajaxBuilder(clientBidRequests[0].timeout) : null;
   // handle client adapter requests
   clientBidRequests.forEach(bidRequest => {
     bidRequest.start = timestamp();
@@ -347,6 +349,10 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb) => {
       events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
       bidRequest.doneCbCallCount = 0;
       let done = doneCb(bidRequest.bidderRequestId);
+      let ajax = ajaxBuilder(clientBidRequests[0].timeout, requestCallbacks ? {
+        request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
+        done: requestCallbacks.done
+      } : undefined);
       adapter.callBids(bidRequest, addBidResponse, done, ajax);
     } else {
       utils.logError(`Adapter trying to be called which does not exist: ${bidRequest.bidderCode} adaptermanager.callBids`);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -15,12 +15,13 @@ const XHR_DONE = 4;
  */
 export const ajax = ajaxBuilder();
 
-export function ajaxBuilder(timeout = 3000) {
+export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
   return function(url, callback, data, options = {}) {
     try {
       let x;
-      let useXDomainRequest = false;
       let method = options.method || (data ? 'POST' : 'GET');
+      let parser = document.createElement('a');
+      parser.href = url;
 
       let callbacks = typeof callback === 'object' && callback !== null ? callback : {
         success: function() {
@@ -35,46 +36,27 @@ export function ajaxBuilder(timeout = 3000) {
         callbacks.success = callback;
       }
 
-      if (!window.XMLHttpRequest) {
-        useXDomainRequest = true;
-      } else {
-        x = new window.XMLHttpRequest();
-        if (x.responseType === undefined) {
-          useXDomainRequest = true;
-        }
-      }
+      x = new window.XMLHttpRequest();
 
-      if (useXDomainRequest) {
-        x = new window.XDomainRequest();
-        x.onload = function () {
-          callbacks.success(x.responseText, x);
-        };
-
-        // http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
-        x.onerror = function () {
-          callbacks.error('error', x);
-        };
-        x.ontimeout = function () {
-          callbacks.error('timeout', x);
-        };
-        x.onprogress = function() {
-          utils.logMessage('xhr onprogress');
-        };
-      } else {
-        x.onreadystatechange = function () {
-          if (x.readyState === XHR_DONE) {
-            let status = x.status;
-            if ((status >= 200 && status < 300) || status === 304) {
-              callbacks.success(x.responseText, x);
-            } else {
-              callbacks.error(x.statusText, x);
-            }
+      x.onreadystatechange = function () {
+        if (x.readyState === XHR_DONE) {
+          if (typeof done === 'function') {
+            done(parser.origin);
           }
-        };
-        x.ontimeout = function () {
-          utils.logError('  xhr timeout after ', x.timeout, 'ms');
-        };
-      }
+          let status = x.status;
+          if ((status >= 200 && status < 300) || status === 304) {
+            callbacks.success(x.responseText, x);
+          } else {
+            callbacks.error(x.statusText, x);
+          }
+        }
+      };
+      x.ontimeout = function () {
+        if (typeof done === 'function') {
+          done(parser.origin);
+        }
+        utils.logError('  xhr timeout after ', x.timeout, 'ms');
+      };
 
       if (method === 'GET' && data) {
         let urlInfo = parseURL(url, options);
@@ -86,18 +68,21 @@ export function ajaxBuilder(timeout = 3000) {
       // IE needs timoeut to be set after open - see #1410
       x.timeout = timeout;
 
-      if (!useXDomainRequest) {
-        if (options.withCredentials) {
-          x.withCredentials = true;
-        }
-        utils._each(options.customHeaders, (value, header) => {
-          x.setRequestHeader(header, value);
-        });
-        if (options.preflight) {
-          x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-        }
-        x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
+      if (options.withCredentials) {
+        x.withCredentials = true;
       }
+      utils._each(options.customHeaders, (value, header) => {
+        x.setRequestHeader(header, value);
+      });
+      if (options.preflight) {
+        x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      }
+      x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
+
+      if (typeof request === 'function') {
+        request(parser.origin);
+      }
+
       if (method === 'POST' && data) {
         x.send(data);
       } else {

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -52,9 +52,6 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
         }
       };
       x.ontimeout = function () {
-        if (typeof done === 'function') {
-          done(parser.origin);
-        }
         utils.logError('  xhr timeout after ', x.timeout, 'ms');
       };
 

--- a/src/auction.js
+++ b/src/auction.js
@@ -74,7 +74,7 @@ events.on(CONSTANTS.EVENTS.BID_ADJUSTMENT, function (bid) {
   adjustBids(bid);
 });
 
-const MAX_REQUESTS_PER_ORIGIN = 6;
+const MAX_REQUESTS_PER_ORIGIN = 4;
 const outstandingRequests = {};
 const sourceInfo = {};
 const queuedCalls = [];
@@ -241,6 +241,8 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
     function runIfOriginHasCapacity(call) {
       let hasCapacity = true;
 
+      let maxRequests = config.getConfig('maxRequestsPerOrigin') || MAX_REQUESTS_PER_ORIGIN;
+
       call.bidRequests.some(bidRequest => {
         let requests = 1;
         let source = (typeof bidRequest.src !== 'undefined' && bidRequest.src === CONSTANTS.S2S.SRC) ? 's2s'
@@ -251,9 +253,9 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
             // some bidders might use more than the MAX_REQUESTS_PER_ORIGIN in a single auction.  In those cases
             // set their request count to MAX_REQUESTS_PER_ORIGIN so the auction isn't permanently queued waiting
             // for capacity for that bidder
-            requests = Math.min(bidRequest.bids.length, MAX_REQUESTS_PER_ORIGIN);
+            requests = Math.min(bidRequest.bids.length, maxRequests);
           }
-          if (outstandingRequests[sourceInfo[source].origin] + requests > MAX_REQUESTS_PER_ORIGIN) {
+          if (outstandingRequests[sourceInfo[source].origin] + requests > maxRequests) {
             hasCapacity = false;
           }
         }

--- a/src/auction.js
+++ b/src/auction.js
@@ -74,7 +74,7 @@ events.on(CONSTANTS.EVENTS.BID_ADJUSTMENT, function (bid) {
   adjustBids(bid);
 });
 
-const MAX_REQUESTS_PER_ORIGIN = 4;
+export let MAX_REQUESTS_PER_ORIGIN = 4;
 const outstandingRequests = {};
 const sourceInfo = {};
 const queuedCalls = [];
@@ -224,7 +224,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
           done(origin) {
             outstandingRequests[origin]--;
             if (queuedCalls[0]) {
-              if(runIfOriginHasCapacity(queuedCalls[0])) {
+              if (runIfOriginHasCapacity(queuedCalls[0])) {
                 queuedCalls.shift();
               }
             }

--- a/src/auction.js
+++ b/src/auction.js
@@ -74,7 +74,7 @@ events.on(CONSTANTS.EVENTS.BID_ADJUSTMENT, function (bid) {
   adjustBids(bid);
 });
 
-export let MAX_REQUESTS_PER_ORIGIN = 4;
+const MAX_REQUESTS_PER_ORIGIN = 4;
 const outstandingRequests = {};
 const sourceInfo = {};
 const queuedCalls = [];

--- a/src/auction.js
+++ b/src/auction.js
@@ -181,16 +181,8 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
   }
 
   function callBids() {
-    startAuctionTimer();
     _auctionStatus = AUCTION_STARTED;
     _auctionStart = Date.now();
-
-    const auctionInit = {
-      timestamp: _auctionStart,
-      auctionId: _auctionId,
-      timeout: _timeout
-    };
-    events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
 
     let bidRequests = adaptermanager.makeBidRequests(_adUnits, _auctionStart, _auctionId, _timeout, _labels);
     utils.logInfo(`Bids Requested for Auction with id: ${_auctionId}`, bidRequests);
@@ -200,11 +192,20 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
 
     let requests = {};
 
-    _auctionStatus = AUCTION_IN_PROGRESS;
-
     let call = {
       bidRequests,
       run: () => {
+        startAuctionTimer();
+
+        _auctionStatus = AUCTION_IN_PROGRESS;
+
+        const auctionInit = {
+          timestamp: _auctionStart,
+          auctionId: _auctionId,
+          timeout: _timeout
+        };
+        events.emit(CONSTANTS.EVENTS.AUCTION_INIT, auctionInit);
+
         adaptermanager.callBids(_adUnits, bidRequests, addBidResponse.bind(this), done.bind(this), {
           request(source, origin) {
             increment(outstandingRequests, origin);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1305,6 +1305,7 @@ describe('Unit: Prebid Module', function () {
           ]
         }];
         adUnitCodes = ['adUnit-code'];
+        configObj.setConfig({maxRequestsPerOrigin: Number.MAX_SAFE_INTEGER || 99999999});
         let auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: timeout});
         spyCallBids = sinon.spy(adaptermanager, 'callBids');
         createAuctionStub = sinon.stub(auctionModule, 'newAuction');


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
In testing I was seeing poorer performance with 1-x (compared to 0.34) when concurrent auctions (simultaneous `pbjs.requestBids()`) were running on slow connection.  1-x is concurrent by default, and 0.34 is never concurrent.

A lot of concurrency issues seemed to be related to [max requests per origin limits in browsers](https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser).  This pull-request adds a queuing feature for auctions that will queue auctions that would put the client over the limit of requests per origin (with that limit defaulting to `4` and being configurable with `config.setConfig({maxRequestsPerOrigin: 6})`).   Setting the `maxRequestsPerOrigin` to `1` will effectively emulate the behavior in 0.34 by having all concurrent auctions be queued until the previous auction has finished.

Comparison of results before and after this pull-request change on 1-x for a fast connection. (stacked requests from first example go off bottom of screen whereas second example shows all requests)
![comparison1](https://user-images.githubusercontent.com/551085/41629074-bf2909f8-73e4-11e8-8924-9fe79fb5d3b0.png)
Speeds are very similar between each other and both results are very fast compared to 0.34 (1-x total time for requests in both examples above about ~1s, but ~3.5 seconds for 0.34 below due to no concurrency)
![comparison2](https://user-images.githubusercontent.com/551085/41629136-18351c6c-73e5-11e8-8285-93dc63b24a88.png)

Comparison of results on **slow** connection in 1-x before and after max concurrency per origin implemented.
![comparison3](https://user-images.githubusercontent.com/551085/41629321-0e0a04e0-73e6-11e8-9b1d-cb57403a7562.png)
Total time of all auctions on left is 3.5s, but without max concurrency per origin timed-out bids cause further auctions to miss their boat.  Much improved on the right with limited requests per origin, total time of 7s for all auctions (as some are queued) but get back 3 times as many bids.

## Other information
Related to #2648.

Also cleaned up the ajax module to remove `XDomainRequest` support as `IE9` is no longer supported by Prebid.js.
