### PR TITLE
Add gdpr and targeting support for Yieldlab adapter

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -27,16 +27,24 @@ export const spec = {
   buildRequests: function (validBidRequests) {
     const adslotIds = []
     const timestamp = Date.now()
+    const query = {
+      ts: timestamp,
+      json: true
+    }
 
     utils._each(validBidRequests, function (bid) {
       adslotIds.push(bid.params.adslotId)
+      if (bid.params.targeting) {
+        query.t = createQueryString(bid.params.targeting)
+      }
     })
 
     const adslots = adslotIds.join(',')
+    const queryString = createQueryString(query)
 
     return {
       method: 'GET',
-      url: `${ENDPOINT}/yp/${adslots}?ts=${timestamp}&json=true`,
+      url: `${ENDPOINT}/yp/${adslots}?${queryString}`,
       validBidRequests: validBidRequests
     }
   },
@@ -102,6 +110,21 @@ function isVideo (format) {
  */
 function parseSize (size) {
   return size.split('x').map(Number)
+}
+
+/**
+ * Creates a querystring out of an object with key-values
+ * @param {Object} obj
+ * @returns {String}
+ */
+function createQueryString (obj) {
+  let str = []
+  for (var p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]))
+    }
+  }
+  return str.join('&')
 }
 
 registerBidder(spec)

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -24,7 +24,7 @@ export const spec = {
    * @param validBidRequests
    * @returns {{method: string, url: string}}
    */
-  buildRequests: function (validBidRequests) {
+  buildRequests: function (validBidRequests, bidderRequest) {
     const adslotIds = []
     const timestamp = Date.now()
     const query = {
@@ -38,6 +38,11 @@ export const spec = {
         query.t = createQueryString(bid.params.targeting)
       }
     })
+
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      query.consent = bidderRequest.gdprConsent.consentString
+      query.gdpr = (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+    }
 
     const adslots = adslotIds.join(',')
     const queryString = createQueryString(query)

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -21,7 +21,11 @@ Module that connects to Yieldlab's demand sources
                    params: {
                        adslotId: "5220336",
                        supplyId: "1381604",
-                       adSize: "728x90"
+                       adSize: "728x90",
+                       targeting: {
+                           key1: "value1",
+                           key2: "value2"
+                       }
                    }
                }]
            }, {

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -70,6 +70,18 @@ describe('yieldlabBidAdapter', () => {
     it('passes targeting to bid request', () => {
       expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2')
     })
+
+    const gdprRequest = spec.buildRequests(bidRequests, {
+      gdprConsent: {
+        consentString: 'BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA',
+        gdprApplies: true
+      }
+    })
+
+    it('passes gdpr flag and consent if present', () => {
+      expect(gdprRequest.url).to.include('consent=BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA')
+      expect(gdprRequest.url).to.include('gdpr=true')
+    })
   })
 
   describe('interpretResponse', () => {

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -7,7 +7,11 @@ const REQUEST = {
   'params': {
     'adslotId': '1111',
     'supplyId': '2222',
-    'adSize': '728x90'
+    'adSize': '728x90',
+    'targeting': {
+      'key1': 'value1',
+      'key2': 'value2'
+    }
   },
   'bidderRequestId': '143346cf0f1731',
   'auctionId': '2e41f65424c87c',
@@ -61,6 +65,10 @@ describe('yieldlabBidAdapter', () => {
 
     it('returns a list of valid requests', () => {
       expect(request.validBidRequests).to.eql([REQUEST])
+    })
+
+    it('passes targeting to bid request', () => {
+      expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2')
     })
   })
 


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
https://github.com/prebid/prebid.github.io/pull/851

## Description of change
- added support for the gdpr consent management module 
- added support for key-value targeting 

solutions@yieldlab.de
- [x] official adapter submission