### PR TITLE
Temporarily remove ios browsers from browserstack testing

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -62,23 +62,5 @@
     "browser_version": "8.0",
     "device": null,
     "os": "OS X"
-  },
-  "bs_ios_9": {
-    "base": "BrowserStack",
-    "os": "ios",
-    "os_version": "11.0",
-    "browser": "iphone",
-    "device": "iPhone 8",
-    "browser_version": null,
-    "realMobile": true
-  },
-  "bs_ios_10": {
-    "base": "BrowserStack",
-    "os": "ios",
-    "os_version": "10.3",
-    "browser": "iphone",
-    "device": "iPhone 7",
-    "browser_version": null,
-    "realMobile": true
   }
 }

--- a/browsers.json
+++ b/browsers.json
@@ -66,17 +66,19 @@
   "bs_ios_9": {
     "base": "BrowserStack",
     "os": "ios",
-    "os_version": "9.1",
+    "os_version": "11.0",
     "browser": "iphone",
-    "device": "iPhone 6S",
-    "browser_version": null
+    "device": "iPhone 8",
+    "browser_version": null,
+    "realMobile": true
   },
-  "bs_ios_8": {
+  "bs_ios_10": {
     "base": "BrowserStack",
     "os": "ios",
-    "os_version": "8.3",
+    "os_version": "10.3",
     "browser": "iphone",
-    "device": "iPhone 6",
-    "browser_version": null
+    "device": "iPhone 7",
+    "browser_version": null,
+    "realMobile": true
   }
 }


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes
- [x] Other

## Description of change
Temporarily remove ios browsers from the browserstack testing to avoid the Travis build failures.

Some added context:
For the prebid browserstack account - it doesn't seem to have the permissions/access(?) to run tests on mobile emulators as of today (June 21).  We're seeing the following types of errors each time Travis runs a build with the browserstack tests:
```
21 06 2018 13:16:09.447:ERROR [launcher.browserstack]: Can not start iphone (ios 8.3)
  Error: We're sorry, but we no longer support emulators or simulators. However, you can now run your selenium tests on real iOS and Android devices. Real devices are faster and more stable. Please contact our Sales team by visiting https://www.browserstack.com/contact and creating a query related to Sales.
21 06 2018 13:16:09.462:ERROR [launcher.browserstack]: Can not start iphone (ios 9.1)
  Error: We're sorry, but we no longer support emulators or simulators. However, you can now run your selenium tests on real iOS and Android devices. Real devices are faster and more stable. Please contact our Sales team by visiting https://www.browserstack.com/contact and creating a query related to Sales.
```

While we're investigating with the browserstack support team separately, this temporary change will allow the builds to run successfully again.