### PR TITLE
Sharethrough - handle iframe bid param, safeframe support

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,12 +1,14 @@
 import { registerBidder } from 'src/adapters/bidderFactory';
 
+const VERSION = '3.0.0';
 const BIDDER_CODE = 'sharethrough';
-const VERSION = '2.0.0';
 const STR_ENDPOINT = document.location.protocol + '//btlr.sharethrough.com/header-bid/v1';
 
 export const sharethroughAdapterSpec = {
   code: BIDDER_CODE,
+
   isBidRequestValid: bid => !!bid.params.pkey && bid.bidder === BIDDER_CODE,
+
   buildRequests: (bidRequests, bidderRequest) => {
     return bidRequests.map(bid => {
       let query = {
@@ -26,67 +28,112 @@ export const sharethroughAdapterSpec = {
         query.consent_required = !!bidderRequest.gdprConsent.gdprApplies;
       }
 
+      // Data that does not need to go to the server,
+      // but we need as part of interpretResponse()
+      const strData = {
+        stayInIframe: bid.params.iframe,
+        sizes: bid.sizes
+      }
+
       return {
         method: 'GET',
         url: STR_ENDPOINT,
-        data: query
+        data: query,
+        strData: strData
       };
     })
   },
+
   interpretResponse: ({ body }, req) => {
-    if (!body || !Object.keys(body).length || !body.creatives.length) {
+    if (!body || !body.creatives || !body.creatives.length) {
       return [];
     }
 
     const creative = body.creatives[0];
+    let size = [0, 0];
+    if (req.strData.stayInIframe) {
+      size = getLargestSize(req.strData.sizes);
+    }
 
     return [{
       requestId: req.data.bidId,
-      width: 0,
-      height: 0,
+      width: size[0],
+      height: size[1],
       cpm: creative.cpm,
       creativeId: creative.creative.creative_key,
-      deal_id: creative.creative.deal_id,
+      dealId: creative.creative.deal_id,
       currency: 'USD',
       netRevenue: true,
       ttl: 360,
       ad: generateAd(body, req)
     }];
   },
+
   getUserSyncs: (syncOptions, serverResponses) => {
     const syncs = [];
-    if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body) {
+    const shouldCookieSync = syncOptions.pixelEnabled &&
+                             serverResponses.length > 0 &&
+                             serverResponses[0].body &&
+                             serverResponses[0].body.cookieSyncUrls;
+
+    if (shouldCookieSync) {
       serverResponses[0].body.cookieSyncUrls.forEach(url => {
         syncs.push({ type: 'image', url: url });
       });
     }
+
     return syncs;
   }
+}
+
+function getLargestSize(sizes) {
+  function area(size) {
+    return size[0] * size[1];
+  }
+
+  return sizes.reduce((prev, current) => {
+    if (area(current) > area(prev)) {
+      return current
+    } else {
+      return prev
+    }
+  }, [0, 0]);
 }
 
 function generateAd(body, req) {
   const strRespId = `str_response_${req.data.bidId}`;
 
-  return `
+  let adMarkup = `
     <div data-str-native-key="${req.data.placement_key}" data-stx-response-name="${strRespId}">
     </div>
     <script>var ${strRespId} = "${b64EncodeUnicode(JSON.stringify(body))}"</script>
-    <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>
-    <script>
-    (function() {
-      if (!(window.STR && window.STR.Tag) && !(window.top.STR && window.top.STR.Tag)) {
-        const sfp_js = document.createElement('script');
-        sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
-        sfp_js.type = 'text/javascript';
-        sfp_js.charset = 'utf-8';
-        try {
-            window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
-        } catch (e) {
-          console.log(e);
-        }
-      }
-    })()
-    </script>`;
+  `
+
+  if (req.strData.stayInIframe) {
+    // Don't break out of iframe
+    adMarkup = adMarkup + `<script src="//native.sharethrough.com/assets/sfp.js"></script>`
+  } else {
+    // Break out of iframe
+    adMarkup = adMarkup + `
+      <script src="//native.sharethrough.com/assets/sfp-set-targeting.js"></script>
+      <script>
+        (function() {
+          if (!(window.STR && window.STR.Tag) && !(window.top.STR && window.top.STR.Tag)) {
+            const sfp_js = document.createElement('script');
+            sfp_js.src = "//native.sharethrough.com/assets/sfp.js";
+            sfp_js.type = 'text/javascript';
+            sfp_js.charset = 'utf-8';
+            try {
+                window.top.document.getElementsByTagName('body')[0].appendChild(sfp_js);
+            } catch (e) {
+              console.log(e);
+            }
+          }
+        })()
+    </script>`
+  }
+
+  return adMarkup;
 }
 
 // See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem

--- a/modules/sharethroughBidAdapter.md
+++ b/modules/sharethroughBidAdapter.md
@@ -26,12 +26,13 @@ Module that connects to Sharethrough's demand sources
                ]
            },{
                code: 'test-div',
-               sizes: [[1, 1]],   // a mobile size
+               sizes: [[300,250], [1, 1]],   // a mobile size
                bids: [
                    {
                        bidder: "sharethrough",
                        params: {
-                           pkey: 'LuB3vxGGFrBZJa6tifXW4xgK'
+                           pkey: 'LuB3vxGGFrBZJa6tifXW4xgK',
+                           iframe: true
                        }
                    }
                ]


### PR DESCRIPTION
- read new bid param: `iframe`
- if true, Sharethrough ad markup will not break out of iframe
- this also makes us support safeframes

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [X] Code style update (formatting, local variables)

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds support for an `iframe` bidder param. If set to true, our ad will not break out of the iframe/safeframe to render, it will just render inside the iframe.


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
jchau@sharethrough.com, cpan@sharethrough.com, cnguyen@sharethrough.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Other contributors: @chriscpan @lestopher 
