### PR TITLE
Bugfix: Set gdpr flag to 0 for prebidServerBidAdapter

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -123,7 +123,7 @@ function queueSync(bidderCodes, gdprConsent) {
 
   if (gdprConsent) {
     // only populate gdpr field if we know CMP returned consent information (ie didn't timeout or have an error)
-    if (gdprConsent.consentString) {
+    if (typeof gdprConsent.consentString !== 'undefined') {
       payload.gdpr = (gdprConsent.gdprApplies) ? 1 : 0;
     }
     // attempt to populate gdpr_consent if we know gdprApplies or it may apply


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Prebid cookie sync did not work here because `gdpr=0` was not getting sent in request payload. When `gdprConsent.consentString` is `""` it is considered false in JavaScript so it skipped setting payload.gdpr.