### PR TITLE
adding logInfo message to note the consentManagement module was activated

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -348,7 +348,7 @@ export function setConfig(config) {
     allowAuction = DEFAULT_ALLOW_AUCTION_WO_CONSENT;
     utils.logInfo(`consentManagement config did not specify allowAuctionWithoutConsent.  Using system default setting (${DEFAULT_ALLOW_AUCTION_WO_CONSENT}).`);
   }
-
+  utils.logInfo('consentManagement module has been activated...');
   $$PREBID_GLOBAL$$.requestBids.addHook(requestBidsHook, 50);
 }
 config.getConfig('consentManagement', config => setConfig(config.consentManagement));

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -23,7 +23,7 @@ describe('consentManagement', function () {
         expect(userCMP).to.be.equal('iab');
         expect(consentTimeout).to.be.equal(10000);
         expect(allowAuction).to.be.true;
-        sinon.assert.callCount(utils.logInfo, 3);
+        sinon.assert.callCount(utils.logInfo, 4);
       });
     });
 


### PR DESCRIPTION
## Type of change

- [x] Other

## Description of change
Adding a simple log message in the browser console to note that the consentManagement module was activated.