### PR TITLE
Audience Network (legacy): backport debug params

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -14,6 +14,9 @@ const url = 'https://an.facebook.com/v2/placementbid.json';
 const supportedMediaTypes = ['video'];
 const netRevenue = true;
 const hb_bidder = 'fan';
+const platver = '$prebid.version$';
+const platform = '241394079772386';
+const adapterver = '0.1.0';
 
 /**
  * Does this bid request contain valid parameters?
@@ -163,7 +166,10 @@ const buildRequests = bids => {
     adformats,
     testmode,
     pageurl,
-    sdk
+    sdk,
+    adapterver,
+    platform,
+    platver
   };
   const video = adformats.findIndex(isVideo);
   if (video !== -1) {

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -18,6 +18,7 @@ const placementId = 'test-placement-id';
 const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
+const debug = 'adapterver=0.1.0&platform=241394079772386&platver=$prebid.version$';
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
@@ -128,7 +129,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web'
+        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web&${debug}`
       }]);
     });
 
@@ -147,7 +148,7 @@ describe('AudienceNetwork adapter', () => {
         requestIds: [requestId],
         sizes: ['640x480'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: 'placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=&sdk[]=&playerwidth=640&playerheight=480'
+        data: `placementids[]=test-placement-id&adformats[]=video&testmode=false&pageurl=&sdk[]=&${debug}&playerwidth=640&playerheight=480`
       }]);
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR is a backport to the legacy v0.x branch of the Audience Network debug params introduced in #2657

This work was commissioned and paid for by Facebook.