### PR TITLE
New function markWinningBidAsUsed for marking video bids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -612,8 +612,20 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
  * @alias module:pbjs.markWinningBidAsUsed
 */
 $$PREBID_GLOBAL$$.markWinningBidAsUsed = function (markBidRequest) {
-  const bids = targeting.getWinningBids(markBidRequest.adUnitCode);
-  if (bids.length > 0 && bids[0].adId === markBidRequest.adId) {
+  let bids = [];
+
+  if (markBidRequest.adUnitCode && markBidRequest.adId) {
+    bids = auctionManager.getBidsReceived()
+      .filter(bid => bid.adId === markBidRequest.adId && bid.adUnitCode === markBidRequest.adUnitCode);
+  } else if (markBidRequest.adUnitCode) {
+    bids = targeting.getWinningBids(markBidRequest.adUnitCode);
+  } else if (markBidRequest.adId) {
+    bids = auctionManager.getBidsReceived().filter(bid => bid.adId === markBidRequest.adId);
+  } else {
+    utils.logWarn('Inproper usage of markWinningBidAsUsed. It\'ll need an adUnitCode and/or adId to function.');
+  }
+
+  if (bids.length > 0) {
     bids[0].status = RENDERED;
   }
 };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -605,12 +605,15 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
 
 /**
  * Mark the winning bid as used, should only be used in conjunction with video
- * @param {string} adUnitCode - required ad unit code
+ * @typedef {Object} MarkBidRequest
+ * @property {string} adUnitCode The ad unit code
+ * @property {string} adId The id representing the ad we want to mark
+ *
  * @alias module:pbjs.markWinningBidAsUsed
- */
-$$PREBID_GLOBAL$$.markWinningBidAsUsed = function (adUnitCode) {
-  const bids = targeting.getWinningBids(adUnitCode);
-  if (bids.length > 0) {
+*/
+$$PREBID_GLOBAL$$.markWinningBidAsUsed = function (markBidRequest) {
+  const bids = targeting.getWinningBids(markBidRequest.adUnitCode);
+  if (bids.length > 0 && bids[0].adId === markBidRequest.adId) {
     bids[0].status = RENDERED;
   }
 };

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1838,12 +1838,27 @@ describe('Unit: Prebid Module', function () {
 
       // mark the bid and verify the state has changed to RENDERED
       const winningBid = targeting.getWinningBids(adUnitCode)[0];
-      $$PREBID_GLOBAL$$.markWinningBidAsUsed(adUnitCode);
+      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: winningBid.adId });
       const markedBid = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode)
         .bids
         .find(bid => bid.adId === winningBid.adId);
 
       expect(markedBid.status).to.equal(RENDERED);
+      resetAuction();
+    });
+
+    it('try and mark the winning bid, but fail because we supplied the wrong adId', () => {
+      const adUnitCode = '/19968336/header-bid-tag-0';
+      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+      auction.getBidsReceived = function() { return bidsReceived.bids };
+
+      const winningBid = targeting.getWinningBids(adUnitCode)[0];
+      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: 'miss' });
+      const markedBid = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode)
+        .bids
+        .find(bid => bid.adId === winningBid.adId);
+
+      expect(markedBid.status).to.not.equal(RENDERED);
       resetAuction();
     });
   });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1830,7 +1830,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('markWinningBidAsUsed', () => {
-    it('marks the winning bid object as used for the given adUnitCode', () => {
+    it('marks the bid object as used for the given adUnitCode/adId combination', () => {
       // make sure the auction has "state" and does not reload the fixtures
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
@@ -1847,7 +1847,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('try and mark the winning bid, but fail because we supplied the wrong adId', () => {
+    it('try and mark the bid object, but fail because we supplied the wrong adId', () => {
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
       auction.getBidsReceived = function() { return bidsReceived.bids };
@@ -1859,6 +1859,40 @@ describe('Unit: Prebid Module', function () {
         .find(bid => bid.adId === winningBid.adId);
 
       expect(markedBid.status).to.not.equal(RENDERED);
+      resetAuction();
+    });
+
+    it('marks the winning bid object as used for the given adUnitCode', () => {
+      // make sure the auction has "state" and does not reload the fixtures
+      const adUnitCode = '/19968336/header-bid-tag-0';
+      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+      auction.getBidsReceived = function() { return bidsReceived.bids };
+
+      // mark the bid and verify the state has changed to RENDERED
+      const winningBid = targeting.getWinningBids(adUnitCode)[0];
+      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode });
+      const markedBid = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode)
+        .bids
+        .find(bid => bid.adId === winningBid.adId);
+
+      expect(markedBid.status).to.equal(RENDERED);
+      resetAuction();
+    });
+
+    it('marks a bid object as used for the given adId', () => {
+      // make sure the auction has "state" and does not reload the fixtures
+      const adUnitCode = '/19968336/header-bid-tag-0';
+      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+      auction.getBidsReceived = function() { return bidsReceived.bids };
+
+      // mark the bid and verify the state has changed to RENDERED
+      const winningBid = targeting.getWinningBids(adUnitCode)[0];
+      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adId: winningBid.adId });
+      const markedBid = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode)
+        .bids
+        .find(bid => bid.adId === winningBid.adId);
+
+      expect(markedBid.status).to.equal(RENDERED);
       resetAuction();
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
In accordance with the discussion in https://github.com/prebid/Prebid.js/issues/2282 I’ve created a new function that’s capable of marking a winning bid as used. This addresses the issue where a video-advertisement can be played multiple times on the same page. By proactively calling ```pbjs.markWinningBidAsUsed``` the winning video-bid can be marked as consumed. We currently use it in production and call it straight after the buildVideoUrl function. It resolved most of our discrepancy issues video header bidding partners.

Documentation update: https://github.com/prebid/prebid.github.io/pull/861