### PR TITLE
Done callback cleanup

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -717,7 +717,7 @@ export function PrebidServer() {
 
       bids.forEach(({adUnit, bid}) => {
         if (isValid(adUnit, bid, bidderRequests)) {
-          addBidResponse(adUnit, bid);
+          addBidResponse(adUnit, bid, done);
         }
       });
 
@@ -735,13 +735,6 @@ export function PrebidServer() {
       utils.logError('error parsing response: ', result.status);
     }
 
-    const videoBid = bids.some(bidResponse => bidResponse.bid.mediaType === 'video');
-    const cacheEnabled = config.getConfig('cache.url');
-
-    // video bids with cache enabled need to be cached first before they are considered done
-    if (!(videoBid && cacheEnabled)) {
-      done();
-    }
     doClientSideSyncs(requestedBidders);
   }
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -784,7 +784,6 @@ describe('S2S Adapter', () => {
       server.respond();
 
       sinon.assert.notCalled(addBidResponse);
-      sinon.assert.calledOnce(done);
     });
 
     it('does not call addBidResponse and calls done when server requests cookie sync', () => {
@@ -795,7 +794,6 @@ describe('S2S Adapter', () => {
       server.respond();
 
       sinon.assert.notCalled(addBidResponse);
-      sinon.assert.calledOnce(done);
     });
 
     it('does not call addBidResponse and calls done  when ad unit is set', () => {
@@ -806,7 +804,6 @@ describe('S2S Adapter', () => {
       server.respond();
 
       sinon.assert.notCalled(addBidResponse);
-      sinon.assert.calledOnce(done);
     });
 
     it('registers successful bids and calls done when there are less bids than requests', () => {
@@ -817,7 +814,6 @@ describe('S2S Adapter', () => {
       server.respond();
 
       sinon.assert.calledOnce(addBidResponse);
-      sinon.assert.calledOnce(done);
 
       expect(addBidResponse.firstCall.args[0]).to.equal('div-gpt-ad-1460505748561-0');
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -304,7 +304,6 @@ describe('bidders created by newBidder', () => {
         url: 'test.url.com',
         data: {}
       });
-      expect(doneStub.calledOnce).to.equal(true);
     });
 
     it('should call spec.interpretResponse() once for each request made', () => {
@@ -328,7 +327,6 @@ describe('bidders created by newBidder', () => {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
 
       expect(spec.interpretResponse.calledTwice).to.equal(true);
-      expect(doneStub.calledOnce).to.equal(true);
     });
 
     it('should only add bids for valid adUnit code into the auction, even if the bidder doesn\'t bid on all of them', () => {
@@ -360,7 +358,6 @@ describe('bidders created by newBidder', () => {
 
       expect(addBidResponseStub.calledOnce).to.equal(true);
       expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
-      expect(doneStub.calledOnce).to.equal(true);
       expect(logErrorSpy.callCount).to.equal(0);
     });
 
@@ -458,7 +455,6 @@ describe('bidders created by newBidder', () => {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
 
       expect(spec.interpretResponse.called).to.equal(false);
-      expect(doneStub.calledOnce).to.equal(true);
     });
 
     it('should not add bids for each adunit code into the auction', () => {
@@ -476,7 +472,6 @@ describe('bidders created by newBidder', () => {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
 
       expect(addBidResponseStub.callCount).to.equal(0);
-      expect(doneStub.calledOnce).to.equal(true);
     });
 
     it('should call spec.getUserSyncs() with no responses', () => {
@@ -494,7 +489,6 @@ describe('bidders created by newBidder', () => {
 
       expect(spec.getUserSyncs.calledOnce).to.equal(true);
       expect(spec.getUserSyncs.firstCall.args[1]).to.deep.equal([]);
-      expect(doneStub.calledOnce).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
For video bids with cache enabled we had to delay calling done via conditional checks at 3 places i.e bidderFactory, pbs Adapter and inside done callback itself.
With this PR i have removed that. Now bidders will just pass done as a callback to addBidResponse and auction module will check when to close the auction.
