### PR TITLE
remove library analyticsAdapter type

### DIFF
--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -1,5 +1,4 @@
 import CONSTANTS from './constants';
-import { loadScript } from './adloader';
 import { ajax } from './ajax';
 
 const events = require('./events');
@@ -20,7 +19,6 @@ const {
   }
 } = CONSTANTS;
 
-const LIBRARY = 'library';
 const ENDPOINT = 'endpoint';
 const BUNDLE = 'bundle';
 
@@ -31,10 +29,6 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
   var _eventCount = 0;
   var _enableCheck = true;
   var _handlers;
-
-  if (analyticsType === LIBRARY) {
-    loadScript(url, _emptyQueue);
-  }
 
   if (analyticsType === ENDPOINT || BUNDLE) {
     _emptyQueue();
@@ -52,7 +46,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
   };
 
   function _track({ eventType, args }) {
-    if (this.getAdapterType() === LIBRARY || BUNDLE) {
+    if (this.getAdapterType() === BUNDLE) {
       window[global](handler, eventType, args);
     }
 

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -1,7 +1,6 @@
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import events from 'src/events';
 import CONSTANTS from 'src/constants.json';
-import * as ajax from 'src/ajax';
 
 const BID_REQUESTED = CONSTANTS.EVENTS.BID_REQUESTED;
 const BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -1,6 +1,7 @@
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import events from 'src/events';
 import CONSTANTS from 'src/constants.json';
+import * as ajax from 'src/ajax';
 
 const BID_REQUESTED = CONSTANTS.EVENTS.BID_REQUESTED;
 const BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
@@ -10,74 +11,57 @@ const AD_RENDER_FAILED = CONSTANTS.EVENTS.AD_RENDER_FAILED;
 
 const AnalyticsAdapter = require('src/AnalyticsAdapter').default;
 const config = {
-  url: 'http://localhost:9999/src/adapters/analytics/libraries/example.js',
-  analyticsType: 'library',
-  global: 'ExampleAnalyticsGlobalObject',
-  handler: 'on'
+  url: 'http://localhost:9999/endpoint',
+  analyticsType: 'endpoint'
 };
-
-window[config.global] = () => {};
 
 describe(`
 FEATURE: Analytics Adapters API
   SCENARIO: A publisher enables analytics
-    GIVEN a global object \`window['testGlobal']\`
     AND an  \`example\` instance of \`AnalyticsAdapter\`\n`, () => {
-  describe(`WHEN an event occurs that is to be tracked\n`, () => {
+  let xhr;
+  let requests;
+  let adapter;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = (request) => requests.push(request);
+    adapter = new AnalyticsAdapter(config);
+  });
+
+  afterEach(() => {
+    xhr.restore();
+    adapter.disableAnalytics();
+  });
+
+  it(`SHOULD call the endpoint WHEN an event occurs that is to be tracked`, () => {
     const eventType = BID_REQUESTED;
     const args = { some: 'data' };
-    const adapter = new AnalyticsAdapter(config);
-    var spyTestGlobal = sinon.spy(window, config.global);
 
     adapter.track({ eventType, args });
 
-    it(`THEN should call \`window.${config.global}\` function\n`, () => {
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
-    });
-    window[config.global].restore();
+    let result = JSON.parse(requests[0].requestBody);
+    expect(result).to.deep.equal({args: {some: 'data'}, eventType: 'bidRequested'});
   });
 
-  describe(`WHEN an event occurs before tracking library is available\n`, () => {
+  it(`SHOULD queue the event first and then track it WHEN an event occurs before tracking library is available`, () => {
     const eventType = BID_RESPONSE;
     const args = { wat: 'wot' };
-    const adapter = new AnalyticsAdapter(config);
 
-    window[config.global] = null;
-    events.emit(BID_RESPONSE, args);
+    events.emit(eventType, args);
+    adapter.enableAnalytics();
 
-    describe(`AND the adapter is then enabled\n`, () => {
-      window[config.global] = () => {};
-
-      var spyTestGlobal = sinon.spy(window, config.global);
-
-      adapter.enableAnalytics();
-
-      it(`THEN should queue the event first and then track it\n`, () => {
-        assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-        assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
-      });
-
-      adapter.disableAnalytics();
-      window[config.global].restore();
-    });
+    let result = JSON.parse(requests[0].requestBody);
+    expect(result).to.deep.equal({args: {wat: 'wot'}, eventType: 'bidResponse'});
   });
 
   describe(`WHEN an event occurs after enable analytics\n`, () => {
-    var spyTestGlobal,
-      adapter;
-
     beforeEach(() => {
-      adapter = new AnalyticsAdapter(config);
-      spyTestGlobal = sinon.spy(window, config.global);
-
       sinon.stub(events, 'getEvents').returns([]); // these tests shouldn't be affected by previous tests
     });
 
     afterEach(() => {
-      adapter.disableAnalytics();
-      window[config.global].restore();
-
       events.getEvents.restore();
     });
 
@@ -88,8 +72,8 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+      let result = JSON.parse(requests[0].requestBody);
+      expect(result).to.deep.equal({args: {more: 'info'}, eventType: 'bidWon'});
     });
 
     it('SHOULD call global when a adRenderFailed event occurs', () => {
@@ -99,8 +83,8 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+      let result = JSON.parse(requests[0].requestBody);
+      expect(result).to.deep.equal({args: {call: 'adRenderFailed'}, eventType: 'adRenderFailed'});
     });
 
     it('SHOULD call global when a bidRequest event occurs', () => {
@@ -110,8 +94,8 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+      let result = JSON.parse(requests[0].requestBody);
+      expect(result).to.deep.equal({args: {call: 'request'}, eventType: 'bidRequested'});
     });
 
     it('SHOULD call global when a bidResponse event occurs', () => {
@@ -121,8 +105,8 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+      let result = JSON.parse(requests[0].requestBody);
+      expect(result).to.deep.equal({args: {call: 'response'}, eventType: 'bidResponse'});
     });
 
     it('SHOULD call global when a bidTimeout event occurs', () => {
@@ -132,8 +116,8 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert.ok(spyTestGlobal.args[0][1] === eventType, `with expected event type\n`);
-      assert.deepEqual(spyTestGlobal.args[0][2], args, `with expected event data\n`);
+      let result = JSON.parse(requests[0].requestBody);
+      expect(result).to.deep.equal({args: {call: 'timeout'}, eventType: 'bidTimeout'});
     });
 
     it('SHOULD NOT call global again when adapter.enableAnalytics is called with previous timeout', () => {
@@ -144,7 +128,7 @@ FEATURE: Analytics Adapters API
       adapter.enableAnalytics();
       events.emit(eventType, args);
 
-      assert(spyTestGlobal.calledOnce === true);
+      expect(requests.length).to.equal(1);
     });
 
     describe(`AND sampling is enabled\n`, () => {
@@ -167,7 +151,9 @@ FEATURE: Analytics Adapters API
         });
         events.emit(eventType, args);
 
-        assert(spyTestGlobal.called === true);
+        expect(requests.length).to.equal(1);
+        let result = JSON.parse(requests[0].requestBody);
+        expect(result).to.deep.equal({args: {more: 'info'}, eventType: 'bidWon'});
       });
 
       it(`THEN should disable analytics when random number is outside sample range`, () => {
@@ -178,7 +164,7 @@ FEATURE: Analytics Adapters API
         });
         events.emit(eventType, args);
 
-        assert(spyTestGlobal.called === false);
+        expect(requests.length).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
fixes #2423

The library AnalyticsAdapter type is not currently used, so we're removing its support to limit the use of external scripts in Prebid.js as well as to the goal of eventually deprecating the `adloader.js` file's `loadScript` function.


Docs PR for this change: https://github.com/prebid/prebid.github.io/pull/862