### PR TITLE
Sharethrough: Handle iframeSize parameter to allow Pub to explicitly call out the size

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from 'src/adapters/bidderFactory';
 
-const VERSION = '3.0.0';
+const VERSION = '3.0.1';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = document.location.protocol + '//btlr.sharethrough.com/header-bid/v1';
 
@@ -32,6 +32,7 @@ export const sharethroughAdapterSpec = {
       // but we need as part of interpretResponse()
       const strData = {
         stayInIframe: bid.params.iframe,
+        iframeSize: bid.params.iframeSize,
         sizes: bid.sizes
       }
 
@@ -52,7 +53,9 @@ export const sharethroughAdapterSpec = {
     const creative = body.creatives[0];
     let size = [0, 0];
     if (req.strData.stayInIframe) {
-      size = getLargestSize(req.strData.sizes);
+      size = req.strData.iframeSize != undefined
+        ? req.strData.iframeSize
+        : getLargestSize(req.strData.sizes);
     }
 
     return [{

--- a/modules/sharethroughBidAdapter.md
+++ b/modules/sharethroughBidAdapter.md
@@ -12,30 +12,27 @@ Module that connects to Sharethrough's demand sources
 
 # Test Parameters
 ```
-    var adUnits = [
-           {
-               code: 'test-div',
-               sizes: [[1, 1]],  // a display size
-               bids: [
-                   {
-                       bidder: "sharethrough",
-                       params: {
-                           pkey: 'LuB3vxGGFrBZJa6tifXW4xgK'
-                       }
-                   }
-               ]
-           },{
-               code: 'test-div',
-               sizes: [[300,250], [1, 1]],   // a mobile size
-               bids: [
-                   {
-                       bidder: "sharethrough",
-                       params: {
-                           pkey: 'LuB3vxGGFrBZJa6tifXW4xgK',
-                           iframe: true
-                       }
-                   }
-               ]
-           }
-       ];
+  var adUnits = [
+    {
+      code: 'test-div',
+      sizes: [[300,250], [1, 1]],
+      bids: [
+        {
+          bidder: "sharethrough",
+          params: {
+            // REQUIRED - The placement key
+            pkey: 'LuB3vxGGFrBZJa6tifXW4xgK',
+
+            // OPTIONAL - Render Sharethrough creative in an iframe, defaults to false
+            iframe: true,
+
+            // OPTIONAL - If iframeSize is provided, we'll use this size for the iframe
+            // otherwise we'll grab the largest size from the sizes array
+            // This is ignored if iframe: false
+            iframeSize: [250, 250]
+          }
+        }
+      ]
+    }
+  ];
 ```

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -22,7 +22,19 @@ const bidderRequest = [
       pkey: 'bbbb2222',
       iframe: true
     }
-  }];
+  },
+  {
+    bidder: 'sharethrough',
+    bidId: 'bidId3',
+    sizes: [[700, 400]],
+    placementCode: 'coconut',
+    params: {
+      pkey: 'cccc3333',
+      iframe: true,
+      iframeSize: [500, 500]
+    },
+  },
+];
 
 const prebidRequests = [
   {
@@ -46,6 +58,19 @@ const prebidRequests = [
     },
     strData: {
       stayInIframe: true,
+      sizes: [[300, 250], [300, 300], [250, 250], [600, 50]]
+    }
+  },
+  {
+    method: 'GET',
+    url: document.location.protocol + '//btlr.sharethrough.com' + '/header-bid/v1',
+    data: {
+      bidId: 'bidId',
+      placement_key: 'pKey'
+    },
+    strData: {
+      stayInIframe: true,
+      iframeSize: [500, 500],
       sizes: [[300, 250], [300, 300], [250, 250], [600, 50]]
     }
   },
@@ -160,6 +185,20 @@ describe('sharethrough adapter spec', () => {
         {
           width: 300,
           height: 300,
+          cpm: 12.34,
+          creativeId: 'aCreativeId',
+          dealId: 'aDealId',
+          currency: 'USD',
+          netRevenue: true,
+          ttl: 360,
+        });
+    });
+
+    it('returns a correctly parsed out response with explicitly defined size when strData.stayInIframe is true and strData.iframeSize is provided', () => {
+      expect(spec.interpretResponse(bidderResponse, prebidRequests[2])[0]).to.include(
+        {
+          width: 500,
+          height: 500,
           cpm: 12.34,
           creativeId: 'aCreativeId',
           dealId: 'aDealId',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Allow the Publisher to explicitly call out which size we should render in with the `iframeSize` parameter, if omitted we'll fall back to the largest size (by area). This parameter is ignored if the `iframe` parameter is omitted or false.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
jchau@sharethrough.com cpan@sharethrough.com cnguyen@sharethrough.com

- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/863

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@chriscpan @lestopher 
