### PR TITLE
ServerBid: Fixing adserver trying to get bidder name from params

### DIFF
--- a/modules/serverbidBidAdapter.js
+++ b/modules/serverbidBidAdapter.js
@@ -70,7 +70,7 @@ export const spec = {
 
     // These variables are used in creating the user sync URL.
     siteId = validBidRequests[0].params.siteId;
-    bidder = validBidRequests[0].params.bidder;
+    bidder = validBidRequests[0].bidder;
 
     const data = Object.assign({
       placements: [],


### PR DESCRIPTION
## Type of change
- [ ] Bugfix

## Description of change
When creating userSync URL, serverbid adapter is trying to set bidder name based on params object which is wrong according to documentation and general logic. This problematic especially with connectad alias, which has its own url for userSync when iframeEnabled is true.