### PR TITLE
Add onBidWon handler to bid adapters spec

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -477,6 +477,19 @@ exports.setS2STestingModule = function (module) {
   s2sTestingModule = module;
 };
 
+function tryCallBidderMethod(bidder, method, param) {
+  try {
+    const adapter = _bidderRegistry[bidder];
+    const spec = adapter.getSpec();
+    if (spec && spec[method] && typeof spec[method] === 'function') {
+      utils.logInfo(`Invoking ${bidder}.${method}`);
+      spec[method](param);
+    }
+  } catch (e) {
+    utils.logWarn(`Error calling ${method} of ${bidder}`);
+  }
+}
+
 exports.callTimedOutBidders = function(adUnits, timedOutBidders, cbTimeout) {
   timedOutBidders = timedOutBidders.map((timedOutBidder) => {
     // Adding user configured params & timeout to timeout event data
@@ -487,15 +500,10 @@ exports.callTimedOutBidders = function(adUnits, timedOutBidders, cbTimeout) {
   timedOutBidders = utils.groupBy(timedOutBidders, 'bidder');
 
   Object.keys(timedOutBidders).forEach((bidder) => {
-    try {
-      const adapter = _bidderRegistry[bidder];
-      const spec = adapter.getSpec();
-      if (spec && spec.onTimeout && typeof spec.onTimeout === 'function') {
-        utils.logInfo(`Invoking ${bidder}.onTimeout`);
-        spec.onTimeout(timedOutBidders[bidder]);
-      }
-    } catch (e) {
-      utils.logWarn(`Error calling onTimeout of ${bidder}`);
-    }
+    tryCallBidderMethod(bidder, 'onTimeout', timedOutBidders[bidder]);
   });
 }
+
+exports.callBidWonBidder = function(bidder, bid) {
+  tryCallBidderMethod(bidder, 'onBidWon', bid);
+};

--- a/src/auction.js
+++ b/src/auction.js
@@ -279,12 +279,17 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
     }
   }
 
+  function addWinningBid(winningBid) {
+    _winningBids = _winningBids.concat(winningBid);
+    adaptermanager.callBidWonBidder(winningBid.bidder, winningBid);
+  }
+
   return {
     addBidReceived,
     executeCallback,
     callBids,
     bidsBackAll,
-    addWinningBid: (winningBid) => { _winningBids = _winningBids.concat(winningBid) },
+    addWinningBid,
     getWinningBids: () => _winningBids,
     getTimeout: () => _timeout,
     getAuctionId: () => _auctionId,


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Some bid adapters might want to know when their bid won the auction. Given listening to events is off-limits for bid adapters, they can now add a `onBidWon` handler to their spec that will be called with their winning bid.

Corresponding PR for documentation: prebid/prebid.github.io#864.