### PR TITLE
give s2s request the same amount of time from the client side

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -281,7 +281,7 @@ exports.checkBidRequestSizes = (adUnits) => {
   return adUnits;
 }
 
-exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks) => {
+exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks, requestBidsTimeout) => {
   if (!bidRequests.length) {
     utils.logWarn('callBids executed with no bidRequests.  Were they filtered by labels or sizing?');
     return;
@@ -293,7 +293,8 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbac
   }, [[], []]);
 
   if (serverBidRequests.length) {
-    const s2sAjax = ajaxBuilder(serverBidRequests[0].timeout, requestCallbacks ? {
+    // s2s should get the same client side timeout as other client side requests.
+    const s2sAjax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
       request: requestCallbacks.request.bind(null, 's2s'),
       done: requestCallbacks.done
     } : undefined);
@@ -356,7 +357,7 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbac
     events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
     bidRequest.doneCbCallCount = 0;
     let done = doneCb(bidRequest.bidderRequestId);
-    let ajax = ajaxBuilder(clientBidRequests[0].timeout, requestCallbacks ? {
+    let ajax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done
     } : undefined);

--- a/src/auction.js
+++ b/src/auction.js
@@ -229,7 +229,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
               }
             }
           }
-        });
+        }, _timeout);
       }
     };
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The s2s timeout value was not getting the full requestBids timeout value on the client side. This was causing the request to abort on the client side if you shortened the s2s timeouts.  Example, set s2s timeout to 10ms:
```
pbjs.setConfig({
      "s2sConfig": {
          defaultVendor : 'appnexus',
          accountId: '<id>',
          enabled: true,
          bidders: ['appnexus'],
          timeout: 10,
      }
  });
```
To repro. 
## Other information
May contribute to https://github.com/prebid/prebid-server/issues/592
