### PR TITLE
Fix rubicon video playersize issue

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -531,13 +531,13 @@ function parseSizes(bid) {
   let params = bid.params;
   if (hasVideoMediaType(bid)) {
     let size = [];
-    if (typeof utils.deepAccess(bid, 'mediaTypes.video.playerSize') !== 'undefined') {
-      size = bid.mediaTypes.video.playerSize[0];
-    } else if (params.video && params.video.playerWidth && params.video.playerHeight) {
+    if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
         params.video.playerWidth,
         params.video.playerHeight
       ];
+    } else if (Array.isArray(utils.deepAccess(bid, 'mediaTypes.video.playerSize')) && bid.mediaTypes.video.playerSize.length === 1) {
+      size = bid.mediaTypes.video.playerSize[0];
     } else if (Array.isArray(bid.sizes) && bid.sizes.length > 0 && Array.isArray(bid.sizes[0]) && bid.sizes[0].length > 1) {
       size = bid.sizes[0];
     }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -532,7 +532,7 @@ function parseSizes(bid) {
   if (hasVideoMediaType(bid)) {
     let size = [];
     if (typeof utils.deepAccess(bid, 'mediaTypes.video.playerSize') !== 'undefined') {
-      size = bid.mediaTypes.video.playerSize;
+      size = bid.mediaTypes.video.playerSize[0];
     } else if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
         params.video.playerWidth,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
video player size is always doubly wrapped, which means it's always an array of size array, need to read size from the inside array