### PR TITLE
fix and move logic that updates adUnitsS2SCopy based sizeMapping results

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -179,7 +179,6 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
         auctionId,
         bidderRequestId,
         tid,
-        adUnitsS2SCopy,
         bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': adUnitsS2SCopy, labels}),
         auctionStart: auctionStart,
         timeout: _s2sConfig.timeout,
@@ -188,6 +187,21 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
       if (bidderRequest.bids.length !== 0) {
         bidRequests.push(bidderRequest);
       }
+    });
+
+    // update the s2sAdUnits object and remove all bids that didn't pass sizeConfig/label checks from getBids()
+    // this is to keep consistency and only allow bids/adunits that passed the checks to go to pbs
+    adUnitsS2SCopy.forEach((adUnitCopy) => {
+      let validBids = adUnitCopy.bids.filter((adUnitBid) => {
+        return find(bidRequests, request => {
+          return find(request.bids, (reqBid) => reqBid.bidId === adUnitBid.bid_id);
+        });
+      });
+      adUnitCopy.bids = validBids;
+    });
+
+    bidRequests.forEach(request => {
+      request.adUnitsS2SCopy = adUnitsS2SCopy.filter(adUnitCopy => adUnitCopy.bids.length > 0);
     });
   }
 
@@ -301,17 +315,6 @@ exports.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbac
     const s2sAdapter = _bidderRegistry[_s2sConfig.adapter];
     let tid = serverBidRequests[0].tid;
     let adUnitsS2SCopy = serverBidRequests[0].adUnitsS2SCopy;
-    adUnitsS2SCopy.forEach((adUnitCopy) => {
-      let validBids = adUnitCopy.bids.filter((bid) => {
-        return find(serverBidRequests, request => {
-          return request.bidderCode === bid.bidder &&
-          find(request.bids, (reqBid) => reqBid.adUnitCode === adUnitCopy.code);
-        });
-      });
-      adUnitCopy.bids = validBids;
-    });
-
-    adUnitsS2SCopy = adUnitsS2SCopy.filter(adUnitCopy => adUnitCopy.bids.length > 0);
 
     if (s2sAdapter) {
       let s2sBidRequest = {tid, 'ad_units': adUnitsS2SCopy};


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This PR:
- adds a fix to the logic we were using to update the `bidRequests.adUnitsS2SCopy` object.  This update ensured only valid bids were being included in the s2s request.
- moved this logic so that the updated `adUnitsS2SCopy` object is properly reflected in the console log messages for easier debugging/troubleshooting.

_Additional Context_
Currently for s2s requests, we resync the `adUnitsS2SCopy` object based on the various bids that exist in the `bidRequest` objects.  This resync is to remove any `bids` that were rejected by the sizeMapping/label filtering checks.

Keeping the `adUnitsS2SCopy` in sync is important, as this object (not the `bidRequest`) is used to build the POST request meant for PBS; thus this ensures only validated bids get sent to PBS.

_Notes on Fix_
The logic used for the sync operated on a combination of the `bidder` and `adUnitCode`s to match `adUnit.bid` with `bidRequest.bids` to know if they passed the sizeMapping checks.  This logic was insufficient when the same `adUnitCode` was used across different adUnits that used different labels.  It allowed bids for the wrong label to pass the screening and get added to the PBS request.

The new logic operates on the `bid_id` values, which are generated uniquely for each `adUnit.bid` object and then stored in the corresponding `bidRequest.bid` object. 

By moving this logic to the `makeBidRequest` function, we can display the updated `adUnitsS2SCopy` object in the 'Bids Requested' log message (here https://github.com/prebid/Prebid.js/blob/master/src/auction.js#L188 ) instead of digging through debugger.