### PR TITLE
Kumma adapter: GDPR support

### DIFF
--- a/modules/kummaBidAdapter.js
+++ b/modules/kummaBidAdapter.js
@@ -23,7 +23,7 @@ export const spec = {
   isBidRequestValid: bid => (
     !!(bid && bid.params && bid.params.pubId && bid.params.placementId)
   ),
-  buildRequests: bidRequests => {
+  buildRequests: (bidRequests, bidderRequest) => {
     const request = {
       id: bidRequests[0].bidderRequestId,
       at: 2,
@@ -32,6 +32,7 @@ export const spec = {
       app: app(bidRequests),
       device: device(bidRequests),
     };
+    applyGdpr(bidderRequest, request);
     return {
       method: 'POST',
       url: '//hb.kumma.com/',
@@ -268,6 +269,13 @@ function parse(rawResponse) {
     logError('kumma.parse', 'ERROR', ex);
   }
   return null;
+}
+
+function applyGdpr(bidderRequest, ortbRequest) {
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    ortbRequest.regs = { ext: { gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0 } };
+    ortbRequest.user = { ext: { consent: bidderRequest.gdprConsent.consentString } };
+  }
 }
 
 function nativeResponse(imp, bid) {

--- a/test/spec/modules/kummaBidAdapter_spec.js
+++ b/test/spec/modules/kummaBidAdapter_spec.js
@@ -313,4 +313,23 @@ describe('Kumma Adapter Tests', () => {
     expect(ortbRequest.app.storeurl).to.equal('http://kumma.com/apps');
     expect(ortbRequest.app.domain).to.equal('kumma.com');
   });
+
+  it('Verify GDPR', () => {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'serialized_gpdr_data'
+      }
+    };
+    const request = spec.buildRequests(slotConfigs, bidderRequest);
+    expect(request.url).to.equal('//hb.kumma.com/');
+    expect(request.method).to.equal('POST');
+    const ortbRequest = JSON.parse(request.data);
+    expect(ortbRequest.user).to.not.equal(null);
+    expect(ortbRequest.user.ext).to.not.equal(null);
+    expect(ortbRequest.user.ext.consent).to.equal('serialized_gpdr_data');
+    expect(ortbRequest.regs).to.not.equal(null);
+    expect(ortbRequest.regs.ext).to.not.equal(null);
+    expect(ortbRequest.regs.ext.gdpr).to.equal(1);
+  });
 });


### PR DESCRIPTION


## Type of change


- [X] Feature


## Description of change
Adding GDPR support to Kumma adapter

- contact email of the adapter’s maintainer
yehonatan@kumma.com
- [ ] official adapter submission

