### PR TITLE
Display counter at Adslot level  

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -122,7 +122,8 @@ function slotParams(bidRequest) {
   let params = {
     id: bidRequest.bidId,
     ext: {
-      dfp_id: bidRequest.adUnitCode
+      dfp_id: bidRequest.adUnitCode,
+      display_count: bidRequest.displayCount
     },
     banner: transformSizes(bidRequest.sizes),
     all: bidRequest.params

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -8,11 +8,13 @@ import { ajaxBuilder } from 'src/ajax';
 import { config, RANDOM } from 'src/config';
 import includes from 'core-js/library/fn/array/includes';
 import find from 'core-js/library/fn/array/find';
+import { getGlobal } from './prebidGlobal';
 
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
 var events = require('./events');
 let s2sTestingModule; // store s2sTesting module if it's loaded
+const $$PREBID_GLOBAL$$ = getGlobal();
 
 var _bidderRegistry = {};
 exports.bidderRegistry = _bidderRegistry;
@@ -84,7 +86,8 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
               sizes: sizes,
               bidId: bid.bid_id || utils.getUniqueIdentifierStr(),
               bidderRequestId,
-              auctionId
+              auctionId,
+              displayCount: $$PREBID_GLOBAL$$.displayCount[adUnit.code]
             }));
           }
           return bids;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -47,6 +47,9 @@ utils.logInfo('Prebid.js v$prebid.version$ loaded');
 // create adUnit array
 $$PREBID_GLOBAL$$.adUnits = $$PREBID_GLOBAL$$.adUnits || [];
 
+// store the number of times requestBids has been called per ad Unit
+$$PREBID_GLOBAL$$.displayCount = $$PREBID_GLOBAL$$.displayCount || {};
+
 // Allow publishers who enable user sync override to trigger their sync
 $$PREBID_GLOBAL$$.triggerUserSyncs = triggerUserSyncs;
 
@@ -367,6 +370,8 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
         adUnit.bids = adUnit.bids.filter(bid => bid.bidder !== bidder);
       }
     });
+    // increment the number of times requestBids has been called for this adUnit
+    $$PREBID_GLOBAL$$.displayCount[adUnit.code] = ($$PREBID_GLOBAL$$.displayCount[adUnit.code] + 1) || 1;
   });
 
   if (!adUnits || adUnits.length === 0) {

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -17,7 +17,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 250]],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -33,7 +34,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 251]],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_BID_REQUEST_INVALID_BIDFLOOR = [{
     'bidder': 'medianet',
@@ -51,7 +53,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 250]],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -67,7 +70,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 251]],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_AUCTIONDATA = {
     'timeout': config.getConfig('bidderTimeout'),
@@ -103,7 +107,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -133,7 +138,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -181,7 +187,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -210,7 +217,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -372,7 +380,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [300, 250],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -388,7 +397,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [300, 251],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_BIDDER_REQUEST_WITH_GDPR = {
     'gdprConsent': {
@@ -429,7 +439,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -458,7 +469,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature


## Description of change
As discussed in  #2295  thread, some bidders will be interested  in getting the Display Counter which is added in this PR.

`buildRequests` of an adapter will be called with an key `displayCount` at adSlot level.

This PR also contains Media.net adapter integration with this feature
