### PR TITLE
Sharethrough adapter: Check if cookieSyncUrls are provided in response before iterating over them

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -55,7 +55,7 @@ export const sharethroughAdapterSpec = {
   },
   getUserSyncs: (syncOptions, serverResponses) => {
     const syncs = [];
-    if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body) {
+    if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body && serverResponses[0].body.cookieSyncUrls) {
       serverResponses[0].body.cookieSyncUrls.forEach(url => {
         syncs.push({ type: 'image', url: url });
       });


### PR DESCRIPTION

## Type of change
- [x] Bugfix


## Description of change
If the response of sharethrough adapter does not include field cookieSyncUrls the code will throw an error:

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
