### PR TITLE
AOL adapter - dropping pixels when creatives in safe frames.

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -407,11 +407,10 @@ export const spec = {
     let formattedPixels = pixels.replace(/<\/?script( type=('|")text\/javascript('|")|)?>/g, '');
 
     return '<script>var w=window,prebid;' +
-      'for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
+      'try{for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
       'if(prebid && prebid.aolGlobals && !prebid.aolGlobals.pixelsDropped){' +
-      'try{prebid.aolGlobals.pixelsDropped=true;' + formattedPixels + 'break;}' +
-      'catch(e){continue;}' +
-      '}}</script>';
+      'prebid.aolGlobals.pixelsDropped=true;' + formattedPixels + 'break;}' +
+      '}}catch(e){' + formattedPixels + '}</script>';
   },
   isOneMobileBidder: _isOneMobileBidder,
   isSecureProtocol() {

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -544,12 +544,11 @@ describe('AolAdapter', () => {
 
       expect(formattedPixels).to.equal(
         '<script>var w=window,prebid;' +
-        'for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
+        'try{for(var i=0;i<10;i++){w = w.parent;prebid=w.$$PREBID_GLOBAL$$;' +
         'if(prebid && prebid.aolGlobals && !prebid.aolGlobals.pixelsDropped){' +
-        'try{prebid.aolGlobals.pixelsDropped=true;' +
+        'prebid.aolGlobals.pixelsDropped=true;' +
         'document.write(\'<pixels-dom-elements/>\');break;}' +
-        'catch(e){continue;}' +
-        '}}</script>');
+        '}}catch(e){document.write(\'<pixels-dom-elements/>\');}</script>');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixed dropping pixels when creatives are served into safe frames.
