### PR TITLE
Provide "mediaType" for all bids, and "vastUrl" property for video bids

### DIFF
--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -126,9 +126,9 @@ export const spec = {
         currency: bid.cur || response.cur
       };
       if (!bidRequest.bidRequest.mediaTypes || bidRequest.bidRequest.mediaTypes.banner) {
-        outBids.push(Object.assign({}, outBid, { ad: bid.adm }));
-      } else if (bidRequest.bidRequest.mediaTypes && bidRequest.bidRequest.mediaTypes.video) {
-        outBids.push(Object.assign({}, outBid, { vastXml: bid.adm }));
+        outBids.push(Object.assign({}, outBid, { mediaType: 'banner', ad: bid.adm }));
+      } else if (bidRequest.bidRequest.mediaTypes.video) {
+        outBids.push(Object.assign({}, outBid, { mediaType: 'video', vastUrl: bid.ext.vast_url, vastXml: bid.adm }));
       }
     });
     return outBids;

--- a/test/spec/modules/gambidBidAdapter_spec.js
+++ b/test/spec/modules/gambidBidAdapter_spec.js
@@ -214,6 +214,7 @@ describe('GambidAdapter', () => {
               'h': 600,
               'w': 120,
               'ext': {
+                'vast_url': 'http://my.vast.com',
                 'utrk': [
                   { 'type': 'iframe', 'url': '//p.partner1.io/user/sync/1' }
                 ]
@@ -306,6 +307,7 @@ describe('GambidAdapter', () => {
       expect(ad0.currency).to.equal(rtbResponse.seatbid[ 0 ].bid[ 0 ].cur || rtbResponse.cur || 'USD');
       expect(ad0.ad).to.be.an('undefined');
       expect(ad0.vastXml).to.equal(rtbResponse.seatbid[ 0 ].bid[ 0 ].adm);
+      expect(ad0.vastUrl).to.equal(rtbResponse.seatbid[ 0 ].bid[ 0 ].ext.vast_url);
 
       expect(ad1.requestId).to.equal(videoBidRequest.bidId);
       expect(ad1.cpm).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].price);
@@ -317,6 +319,7 @@ describe('GambidAdapter', () => {
       expect(ad1.currency).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].cur || rtbResponse.cur || 'USD');
       expect(ad1.ad).to.be.an('undefined');
       expect(ad1.vastXml).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].adm);
+      expect(ad1.vastUrl).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].ext.vast_url);
     });
     it('aggregates user-sync pixels', () => {
       const response = spec.getUserSyncs({}, [ { body: rtbResponse } ]);


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add the `mediaType` property for all returned bids, and specifically the `vastUrl` property for bideo bids, in accordance with [this example](http://prebid.org/dev-docs/bidder-adaptor.html#step-3-respond-with-a-vast-url-or-raw-vast-xml) in the Prebid.js docs.
Also added a test to ensure the `vastUrl` property is indeed populated when provided by the server.