### PR TITLE
added emxdigital alias to appnexus adapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -29,7 +29,7 @@ const SOURCE = 'pbjs';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['appnexusAst', 'brealtime', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm'],
+  aliases: ['appnexusAst', 'brealtime', 'emxdigital', 'pagescience', 'defymedia', 'gourmetads', 'matomy', 'featureforward', 'oftmedia', 'districtm'],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   /**


### PR DESCRIPTION
As per [recent news](https://globenewswire.com/news-release/2018/05/09/1499361/0/en/bRealTime-and-Clearstream-Merge-to-Form-EMX-a-New-Digital-Media-Marketplace.html) bRealTime has recently formed into EMX Digital. We'd like to include the 'emxdigital' name as an alias for the APN module.

I will be submitting a PR for on the prebid website github as well. Thank you.