### PR TITLE
disable flash checks in triplelift adapter to allow travis build to complete without error

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -22,7 +22,7 @@ export const tripleliftAdapterSpec = {
 
     tlCall = utils.tryAppendQueryString(tlCall, 'lib', 'prebid');
     tlCall = utils.tryAppendQueryString(tlCall, 'v', '$prebid.version$');
-    tlCall = utils.tryAppendQueryString(tlCall, 'fe', _isFlashEnabled().toString());
+    // tlCall = utils.tryAppendQueryString(tlCall, 'fe', _isFlashEnabled().toString());
     tlCall = utils.tryAppendQueryString(tlCall, 'referrer', referrer);
 
     if (bidderRequest && bidderRequest.timeout) {
@@ -125,16 +125,16 @@ function _buildResponseObject(bidderRequest, bid) {
   return bidResponse;
 }
 
-function _isFlashEnabled() {
-  let flash;
-  try {
-    flash = Boolean(new ActiveXObject('ShockwaveFlash.ShockwaveFlash'));
-  } catch (e) {
-    flash = navigator.mimeTypes &&
-      navigator.mimeTypes['application/x-shockwave-flash'] !== undefined &&
-      navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin ? 1 : 0
-  }
-  return flash ? 1 : 0;
-}
+// function _isFlashEnabled() {
+//   let flash;
+//   try {
+//     flash = Boolean(new ActiveXObject('ShockwaveFlash.ShockwaveFlash'));
+//   } catch (e) {
+//     flash = navigator.mimeTypes &&
+//       navigator.mimeTypes['application/x-shockwave-flash'] !== undefined &&
+//       navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin ? 1 : 0
+//   }
+//   return flash ? 1 : 0;
+// }
 
 registerBidder(tripleliftAdapterSpec);

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -90,7 +90,7 @@ describe('triplelift adapter', () => {
       expect(url).to.match(/(?:tlx.3lift.com\/header\/auction)/)
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
-      expect(url).to.match(/(?:fe=)/)
+      // expect(url).to.match(/(?:fe=)/) //
       expect(url).to.match(/(?:referrer)/)
     })
   });


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
After https://github.com/prebid/Prebid.js/pull/2663 was merged into master, we began observing test failures in Travis.

Below is a copy of the error:
```
  triplelift adapter
    buildRequests
      ✗ exists and is an object
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```

When investigating, we discovered it was tied to some logic in the adapter that detected if Flash was enabled or not.

This PR temporarily disables that logic and part of the one test that used it in order to allow Travis to build successfully again.