### PR TITLE
fix sortable adapter unit test failure in travis

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -15,7 +15,7 @@ export const spec = {
     const sortableConfig = config.getConfig('sortable');
     const haveSiteId = (sortableConfig && !!sortableConfig.siteId) || bid.params.siteId;
     return !!(bid.params.tagId && haveSiteId && bid.sizes &&
-      bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(Number.isInteger)));
+      bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(num => utils.isNumber(num))));
   },
 
   buildRequests: function(validBidReqs, bidderRequest) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)


## Description of change
Since merging https://github.com/prebid/Prebid.js/pull/2824 into master, Travis reported some test failures in the sortable bid adapter for certain browsers.  See link below for errors: 
https://travis-ci.org/prebid/Prebid.js/builds/402733184

After investigating, it was determined to be caused by the usage of `Number.isInteger()` in the `sortableBidAdapter` file.  This PR swaps out the reference for the `utils.isNumber()` function which has the proper polyfills for the needed browsers.  