### PR TITLE
Disable ajax timeout

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,4 +1,5 @@
 import {parse as parseURL, format as formatURL} from './url';
+import { config } from 'src/config';
 
 var utils = require('./utils');
 
@@ -53,9 +54,11 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
       };
 
       // Disabled timeout temporarily to avoid xhr failed requests. https://github.com/prebid/Prebid.js/issues/2648
-      // x.ontimeout = function () {
-      //   utils.logError('  xhr timeout after ', x.timeout, 'ms');
-      // };
+      if (!config.getConfig('disableAjaxTimeout')) {
+        x.ontimeout = function () {
+          utils.logError('  xhr timeout after ', x.timeout, 'ms');
+        };
+      }
 
       if (method === 'GET' && data) {
         let urlInfo = parseURL(url, options);
@@ -66,7 +69,9 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
       x.open(method, url);
       // IE needs timoeut to be set after open - see #1410
       // Disabled timeout temporarily to avoid xhr failed requests. https://github.com/prebid/Prebid.js/issues/2648
-      // x.timeout = timeout;
+      if (!config.getConfig('disableAjaxTimeout')) {
+        x.timeout = timeout;
+      }
 
       if (options.withCredentials) {
         x.withCredentials = true;

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -51,9 +51,11 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
           }
         }
       };
-      x.ontimeout = function () {
-        utils.logError('  xhr timeout after ', x.timeout, 'ms');
-      };
+
+      // Disabled timeout temporarily to avoid xhr failed requests. https://github.com/prebid/Prebid.js/issues/2648
+      // x.ontimeout = function () {
+      //   utils.logError('  xhr timeout after ', x.timeout, 'ms');
+      // };
 
       if (method === 'GET' && data) {
         let urlInfo = parseURL(url, options);
@@ -63,7 +65,8 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
 
       x.open(method, url);
       // IE needs timoeut to be set after open - see #1410
-      x.timeout = timeout;
+      // Disabled timeout temporarily to avoid xhr failed requests. https://github.com/prebid/Prebid.js/issues/2648
+      // x.timeout = timeout;
 
       if (options.withCredentials) {
         x.withCredentials = true;

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 const DEFAULT_COOKIESYNC_DELAY = 100;
 const DEFAULT_ENABLE_SEND_ALL_BIDS = true;
+const DEFAULT_DISABLE_AJAX_TIMEOUT = false;
 
 const DEFAULT_TIMEOUTBUFFER = 200;
 
@@ -161,6 +162,14 @@ export function newConfig() {
       },
       set timeoutBuffer(val) {
         this._timoutBuffer = val;
+      },
+
+      _disableAjaxTimeout: DEFAULT_DISABLE_AJAX_TIMEOUT,
+      get disableAjaxTimeout() {
+        return this._disableAjaxTimeout;
+      },
+      set disableAjaxTimeout(val) {
+        this._disableAjaxTimeout = val;
       },
 
     };


### PR DESCRIPTION
## Type of change
- [x] Bugfix


## Description of change
Disabled timeout temporarily to avoid xhr failed requests. #2648 