### PR TITLE
don't allow null or undefined bid properties

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -381,7 +381,7 @@ function validBidSize(adUnitCode, bid, bidRequests) {
 export function isValid(adUnitCode, bid, bidRequests) {
   function hasValidKeys() {
     let bidKeys = Object.keys(bid);
-    return COMMON_BID_RESPONSE_KEYS.every(key => includes(bidKeys, key));
+    return COMMON_BID_RESPONSE_KEYS.every(key => includes(bidKeys, key) && !includes([undefined, null], bid[key]));
   }
 
   function errorMessage(msg) {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -427,6 +427,36 @@ describe('bidders created by newBidder', () => {
 
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
+
+    it('should logError when required bid response params are undefined', () => {
+      const bidder = newBidder(spec);
+
+      const bid = {
+        'ad': 'creative',
+        'cpm': '1.99',
+        'width': 300,
+        'height': 250,
+        'requestId': '1',
+        'creativeId': 'some-id',
+        'currency': undefined,
+        'netRevenue': true,
+        'ttl': 360
+      };
+
+      spec.isBidRequestValid.returns(true);
+      spec.buildRequests.returns({
+        method: 'POST',
+        url: 'test.url.com',
+        data: {}
+      });
+      spec.getUserSyncs.returns([]);
+
+      spec.interpretResponse.returns(bid);
+
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+
+      expect(logErrorSpy.calledOnce).to.equal(true);
+    });
   });
 
   describe('when the ajax call fails', () => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently it's possible to return bid responses with `undefined` or `null` values and have them considered valid when they should be invalid.  This fixes that.

This fix should coincide with an update to the OpenX endpoint to have it always turn a valid currency property.  Currently it will sometimes set the currency to `undefined`.
