### PR TITLE
Sortable adapter: support different floors for each size

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -14,7 +14,19 @@ export const spec = {
   isBidRequestValid: function(bid) {
     const sortableConfig = config.getConfig('sortable');
     const haveSiteId = (sortableConfig && !!sortableConfig.siteId) || bid.params.siteId;
-    return !!(bid.params.tagId && haveSiteId && bid.sizes &&
+    const validFloor = !bid.params.floor || utils.isNumber(bid.params.floor);
+    const validSize = /\d+x\d+/;
+    const validFloorSizeMap = !bid.params.floorSizeMap ||
+      (utils.isPlainObject(bid.params.floorSizeMap) &&
+        Object.keys(bid.params.floorSizeMap).every(size =>
+          size.match(validSize) && utils.isNumber(bid.params.floorSizeMap[size])
+        ))
+    const validKeywords = !bid.params.keywords ||
+      (utils.isPlainObject(bid.params.keywords) &&
+        Object.keys(bid.params.keywords).every(key =>
+          utils.isStr(key) && utils.isStr(bid.params.keywords[key])
+        ))
+    return !!(bid.params.tagId && haveSiteId && validFloor && validFloorSizeMap && validKeywords && bid.sizes &&
       bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(num => utils.isNumber(num))));
   },
 
@@ -36,13 +48,15 @@ export const spec = {
         rv.bidfloor = bid.params.floor;
       }
       if (bid.params.keywords) {
-        let keywords = utils._map(bid.params.keywords, (foo, bar) => ({name: bar, value: foo}));
-        rv.ext.keywords = keywords;
+        rv.ext.keywords = bid.params.keywords;
       }
       if (bid.params.bidderParams) {
         utils._each(bid.params.bidderParams, (params, partner) => {
           rv.ext[partner] = params;
         });
+      }
+      if (bid.params.floorSizeMap) {
+        rv.ext.floorSizeMap = bid.params.floorSizeMap;
       }
       return rv;
     });
@@ -95,7 +109,7 @@ export const spec = {
             cpm: parseFloat(bid.price),
             width: parseInt(bid.w),
             height: parseInt(bid.h),
-            creativeId: bid.id,
+            creativeId: bid.crid || bid.id,
             dealId: bid.dealid || null,
             currency: 'USD',
             netRevenue: true,


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add a `floorSizeMap` param to allow setting different floors for each requested size.

And some other minor fixes
- Update the way keywords are sent to the server
- Use the correct creativeId
