### PR TITLE
normalize sizes if only using adUnit.sizes

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -227,22 +227,22 @@ exports.checkBidRequestSizes = (adUnits) => {
   }
 
   adUnits.forEach((adUnit) => {
-    if (adUnit.sizes) {
-      utils.logWarn('Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).');
-    }
-
     const mediaTypes = adUnit.mediaTypes;
+    const normalizedSize = utils.getAdUnitSizes(adUnit);
+
     if (mediaTypes && mediaTypes.banner) {
       const banner = mediaTypes.banner;
       if (banner.sizes) {
         // make sure we always send [[h,w]] format
-        const normalizedSize = utils.getAdUnitSizes(adUnit);
         banner.sizes = normalizedSize;
         adUnit.sizes = normalizedSize;
       } else {
         utils.logError('Detected a mediaTypes.banner object did not include sizes.  This is a required field for the mediaTypes.banner object.  Removing invalid mediaTypes.banner object from request.');
         delete adUnit.mediaTypes.banner;
       }
+    } else if (adUnit.sizes) {
+      utils.logWarn('Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).');
+      adUnit.sizes = normalizedSize;
     }
 
     if (mediaTypes && mediaTypes.video) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The change to normalize flat sizes (one-dimensional arrays) in #2738 only got applied if `mediaType.banner.sizes` was used.  This fixes it so sizes are normalized even when only using  the deprecated `adUnit.sizes`.
