### PR TITLE
fix failing unit test within quantcastBidAdapter

### DIFF
--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -71,8 +71,8 @@ describe('Quantcast adapter', () => {
 
     it('sends bid requests to Quantcast Canary Endpoint if `publisherId` is `test-publisher`', () => {
       const requests = qcSpec.buildRequests([bidRequest]);
-      const url = new URL(requests[0]['url']);
-      expect(url.hostname).to.equal(QUANTCAST_TEST_DOMAIN);
+      const url = requests[0]['url'].split(/[:/]/)[3];
+      expect(url).to.equal(QUANTCAST_TEST_DOMAIN);
     });
 
     it('sends bid requests to default endpoint for non standard publisher IDs', () => {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -71,8 +71,8 @@ describe('Quantcast adapter', () => {
 
     it('sends bid requests to Quantcast Canary Endpoint if `publisherId` is `test-publisher`', () => {
       const requests = qcSpec.buildRequests([bidRequest]);
-      const url = requests[0]['url'].split(/[:/]/)[3];
-      expect(url).to.equal(QUANTCAST_TEST_DOMAIN);
+      const hostname = requests[0]['url'].split(/[:/]/)[3];
+      expect(hostname).to.equal(QUANTCAST_TEST_DOMAIN);
     });
 
     it('sends bid requests to default endpoint for non standard publisher IDs', () => {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -11,6 +11,7 @@ import {
   spec as qcSpec
 } from '../../../modules/quantcastBidAdapter';
 import { newBidder } from '../../../src/adapters/bidderFactory';
+import { parse } from 'src/url';
 
 describe('Quantcast adapter', () => {
   const quantcastAdapter = newBidder(qcSpec);
@@ -71,8 +72,8 @@ describe('Quantcast adapter', () => {
 
     it('sends bid requests to Quantcast Canary Endpoint if `publisherId` is `test-publisher`', () => {
       const requests = qcSpec.buildRequests([bidRequest]);
-      const hostname = requests[0]['url'].split(/[:/]/)[3];
-      expect(hostname).to.equal(QUANTCAST_TEST_DOMAIN);
+      const url = parse(requests[0]['url']);
+      expect(url.hostname).to.equal(QUANTCAST_TEST_DOMAIN);
     });
 
     it('sends bid requests to default endpoint for non standard publisher IDs', () => {


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)
- [x] Other

## Description of change
Since the inclusion of #2828 the Travis builds for master have been failing due to a failed unit test for IE 11 within the `quantcastBIdAdapter_spec.js` file.  See job link:
https://travis-ci.org/prebid/Prebid.js/builds/406331258

This PR addresses the test failure by replacing the `new URL()` code (which isn't supported in IE) with a different set of code that performs the same action needed for the test.

CC @soarez 