### PR TITLE
Yieldbot ad markup for SafeFrame rendering in pbjs legacy deployments

### DIFF
--- a/modules/yieldbotBidAdapter.js
+++ b/modules/yieldbotBidAdapter.js
@@ -31,10 +31,10 @@ function YieldbotAdapter() {
      * @param {String} size - The dimenstions of the slot
      * @private
      */
-    buildCreative: function (slot, size) {
+    buildCreative: function (slot, size, pageviewId) {
       return '<script type="text/javascript" src="//cdn.yldbt.com/js/yieldbot.intent.js"></script>' +
         '<script type="text/javascript">var ybotq = ybotq || [];' +
-        'ybotq.push(function () {yieldbot.renderAd(\'' + slot + ':' + size + '\');});</script>';
+        'ybotq.push(function () {yieldbot.renderAd(\'' + slot + ':' + size + ':' + pageviewId + '\');});</script>';
     },
     /**
      * Bid response builder.
@@ -53,11 +53,12 @@ function YieldbotAdapter() {
         var szArr = slotCriteria.ybot_size ? slotCriteria.ybot_size.split('x') : [0, 0];
         var slot = slotCriteria.ybot_slot || '';
         var sizeStr = slotCriteria.ybot_size || ''; // Creative template needs the dimensions string
+        var pageviewId = slotCriteria.ybot_pvi || '';
 
         bid.width = szArr[0] || 0;
         bid.height = szArr[1] || 0;
 
-        bid.ad = ybotlib.buildCreative(slot, sizeStr);
+        bid.ad = ybotlib.buildCreative(slot, sizeStr, pageviewId);
 
         // Add Yieldbot parameters to allow publisher bidderSettings.yieldbot specific targeting
         for (var k in slotCriteria) {

--- a/test/spec/modules/yieldbotBidAdapter_spec.js
+++ b/test/spec/modules/yieldbotBidAdapter_spec.js
@@ -44,7 +44,8 @@ const YB_BID_FIXTURE = {
     ybot_ad: 'y',
     ybot_slot: 'medrec',
     ybot_cpm: '200',
-    ybot_size: '300x250'
+    ybot_size: '300x250',
+    ybot_pvi: '0a1b2c3d4e5f-1234'
   },
   leaderboard: {
     ybot_ad: 'n'
@@ -53,7 +54,8 @@ const YB_BID_FIXTURE = {
     ybot_ad: 'y',
     ybot_slot: 'noop',
     ybot_cpm: '200',
-    ybot_size: '300x250'
+    ybot_size: '300x250',
+    ybot_pvi: '0a1b2c3d4e5f-1234'
   }
 };
 
@@ -270,11 +272,12 @@ describe('Yieldbot adapter tests', function() {
       expect(pb_bid1.ybot_slot).to.equal('medrec');
       expect(pb_bid1.ybot_cpm).to.equal('200');
       expect(pb_bid1.ybot_size).to.equal('300x250');
+      expect(pb_bid1.ybot_pvi).to.equal('0a1b2c3d4e5f-1234');
 
       expect(pb_bid1.width).to.equal('300');
       expect(pb_bid1.height).to.equal('250');
       expect(pb_bid1.ad).to.match(/src="\/\/cdn\.yldbt\.com\/js\/yieldbot\.intent\.js/);
-      expect(pb_bid1.ad).to.match(/yieldbot\.renderAd\('medrec:300x250'\)/);
+      expect(pb_bid1.ad).to.match(/yieldbot\.renderAd\('medrec:300x250:0a1b2c3d4e5f-1234'\)/);
 
       const plc2 = bidManagerStub.secondCall.args[0];
       expect(plc2).to.equal(localRequest.bids[1].placementCode);
@@ -306,7 +309,8 @@ describe('Yieldbot adapter tests', function() {
         ybot_ad: 'y',
         ybot_slot: 'medrec',
         ybot_cpm: '200',
-        ybot_size: '300x250'
+        ybot_size: '300x250',
+        ybot_pvi: '0a1b2c3d4e5f-1234'
       };
 
       localRequest.bids = [invalidSizeBid];
@@ -329,7 +333,8 @@ describe('Yieldbot adapter tests', function() {
         ybot_ad: 'y',
         ybot_slot: 'medrec',
         ybot_cpm: '200',
-        ybot_size: '300x250'
+        ybot_size: '300x250',
+        ybot_pvi: '0a1b2c3d4e5f-1234'
       };
 
       const bidResponseNone = {
@@ -450,7 +455,8 @@ describe('Yieldbot adapter tests', function() {
         ybot_ad: 'y',
         ybot_slot: 'medrec',
         ybot_cpm: '200',
-        ybot_size: '300x250'
+        ybot_size: '300x250',
+        ybot_pvi: '0a1b2c3d4e5f-1234'
       };
 
       const bidResponseNone = {


### PR DESCRIPTION
## Type of change
- [x] Feature

## This is for Prebid.js Legacy
### Context Overview
At the time of writing, it is expected that Prebid.js DFP Line Item Creatives serve into a friendly `iFrame`.
http://prebid.org/prebid-mobile/adops-line-item-setup-dfp.html#step-2-add-a-creative
> The “Serve in Safeframe” box has to be UNCHECKED (there are plans to make the below creative safeframe compatible)

For publishers who are limited to serve into DFP SafeFrame containers, the project provides this workaround example:
- [creative.html](integrationExamples/gpt/x-domain/creative.html)

***Prior to this change***, even with the Prebid.js Line Item Creative above, the Yieldbot adapter creative ad markup is dependent on being rendered into a friendly `iFrame` container.

### Description of change
This change adds Prebid.js ***legacy*** (*i.e.  v0.34.x*) support for using the [x-domain creative.html](integrationExamples/gpt/x-domain/creative.html) technique for DFP "**Render into a SafeFrame**".

## Note - Yieldbot SafeFrame Support Exists for Prebid.js v1.x
The Yieldbot adapter for `v1.x` currently supports the [x-domain creative.html](integrationExamples/gpt/x-domain/creative.html) technique suggested as a solution by the project.


