### PR TITLE
fix Travis failures coming from adkernelAdnBidAdapter.js

### DIFF
--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -81,7 +81,7 @@ function buildSite() {
     ref: utils.getTopWindowReferrer(),
     secure: ~~(loc.protocol === 'https:')
   };
-  let keywords = document.getElementsByTagName('meta').namedItem('keywords');
+  let keywords = document.getElementsByTagName('meta')['keywords'];
   if (keywords && keywords.content) {
     result.keywords = keywords.content;
   }


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)
- [x] Other

## Description of change
Since https://github.com/prebid/Prebid.js/pull/2866 was merged, Travis has been failing.  See sample job below:
https://travis-ci.org/prebid/Prebid.js/builds/407460572

This PR refactors the specific line of code slightly to stop these errors.
