### PR TITLE
Sharethrough adapter - safety check for no fill

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'sharethrough';
-const VERSION = '2.0.0';
+const VERSION = '2.0.0-legacy';
 const STR_ENDPOINT = document.location.protocol + '//btlr.sharethrough.com/header-bid/v1';
 
 export const sharethroughAdapterSpec = {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -23,7 +23,9 @@ export const sharethroughAdapterSpec = {
     })
   },
   interpretResponse: ({ body }, req) => {
-    if (!Object.keys(body).length) return [];
+    if (!body || !body.creatives || !body.creatives.length) {
+      return [];
+    }
 
     const creative = body.creatives[0];
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -103,6 +103,21 @@ describe('sharethrough adapter spec', () => {
   });
 
   describe('.interpretResponse', () => {
+    it('returns a blank array if there are no creatives', () => {
+      const bidResponse = { body: { creatives: [] } };
+      expect(spec.interpretResponse(bidResponse, prebidRequest[0])).to.be.an('array').that.is.empty;
+    });
+
+    it('returns a blank array if body object is empty', () => {
+      const bidResponse = { body: {} };
+      expect(spec.interpretResponse(bidResponse, prebidRequest[0])).to.be.an('array').that.is.empty;
+    });
+
+    it('returns a blank array if body is null', () => {
+      const bidResponse = { body: null };
+      expect(spec.interpretResponse(bidResponse, prebidRequest[0])).to.be.an('array').that.is.empty;
+    });
+
     it('returns a correctly parsed out response', () => {
       expect(spec.interpretResponse(bidderResponse, prebidRequest[0])[0]).to.include(
         {


### PR DESCRIPTION
- No fill would previously result in exception in
  interpretResponse

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Safely check for the existence of creatives in the creative array.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
jchau@sharethrough.com jchau87@gmail.com
- [] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
