### PR TITLE
alter sonobi unit test to fix Edge test failure

### DIFF
--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -318,6 +318,10 @@ describe('SonobiBidAdapter', () => {
 
     it('should map bidResponse to prebidResponse', () => {
       const response = spec.interpretResponse(bidResponse, bidRequests);
+      response.forEach(resp => {
+        let regx = /http:\/\/localhost:9876\/.*?(?="|$)/
+        resp.ad = resp.ad.replace(regx, 'http://localhost:9876/');
+      });
       expect(response).to.deep.equal(prebidResponse);
     })
   })

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -220,7 +220,7 @@ describe('SonobiBidAdapter', () => {
       'url': 'https://apex.go.sonobi.com/trinity.json',
       'withCredentials': true,
       'data': {
-        'key_maker': '{"30b31c1838de1f":"1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25","/7780971/sparks_prebid_LB|30b31c1838de1e":"300x250,300x600"}', 'ref': 'http://localhost:9876/', 's': '2474372d-c0ff-4f46-aef4-a173058403d9', 'pv': 'c9cfc207-cd83-4a01-b591-8bb29389d4b0'
+        'key_maker': '{"30b31c1838de1f":"1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25","/7780971/sparks_prebid_LB|30b31c1838de1e":"300x250,300x600"}', 'ref': 'http://localhost/', 's': '2474372d-c0ff-4f46-aef4-a173058403d9', 'pv': 'c9cfc207-cd83-4a01-b591-8bb29389d4b0'
       },
       'bidderRequests': [
         {
@@ -294,7 +294,7 @@ describe('SonobiBidAdapter', () => {
         'cpm': 1.07,
         'width': 300,
         'height': 600,
-        'ad': '<script type="text/javascript" src="https://mco-1-apex.go.sonobi.com/sbi.js?aid=30292e432662bd5f86d90774b944b039&as=null&ref=http://localhost:9876/"></script>',
+        'ad': '<script type="text/javascript" src="https://mco-1-apex.go.sonobi.com/sbi.js?aid=30292e432662bd5f86d90774b944b039&as=null&ref=http://localhost/"></script>',
         'ttl': 500,
         'creativeId': '1234abcd',
         'netRevenue': true,
@@ -306,7 +306,7 @@ describe('SonobiBidAdapter', () => {
         'cpm': 1.25,
         'width': 300,
         'height': 250,
-        'ad': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http://localhost:9876/',
+        'ad': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http://localhost/',
         'ttl': 500,
         'creativeId': '30292e432662bd5f86d90774b944b038',
         'netRevenue': true,
@@ -320,7 +320,7 @@ describe('SonobiBidAdapter', () => {
       const response = spec.interpretResponse(bidResponse, bidRequests);
       response.forEach(resp => {
         let regx = /http:\/\/localhost:9876\/.*?(?="|$)/
-        resp.ad = resp.ad.replace(regx, 'http://localhost:9876/');
+        resp.ad = resp.ad.replace(regx, 'http://localhost/');
       });
       expect(response).to.deep.equal(prebidResponse);
     })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
After https://github.com/prebid/Prebid.js/pull/2891 was merged into master, Travis began reporting test failures in the sonobiBidAdapter_spec.js file for a unit test in Edge.

See link below:
https://travis-ci.org/prebid/Prebid.js/builds/408728279?utm_source=slack&utm_medium=notification

This PR fixes the error by standardizing the `ref` href URL the unit test utilizes to just the domain (since random numbers are sometimes added in the url when running browserstack).