### PR TITLE
Pass Prebid version and update IDs in Criteo bidding adapter

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -51,7 +51,7 @@ export const spec = {
     }
 
     if (publisherTagAvailable()) {
-      const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest);
+      const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
     } else {
@@ -158,6 +158,7 @@ function buildCdbUrl(context) {
   let url = CDB_ENDPOINT;
   url += '?profileId=' + PROFILE_ID;
   url += '&av=' + String(ADAPTER_VERSION);
+  url += '&wv=' + encodeURIComponent('$prebid.version$');
   url += '&cb=' + String(Math.floor(Math.random() * 99999999999));
 
   if (context.integrationMode in INTEGRATION_MODES) {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -4,14 +4,15 @@ import { parse } from 'src/url';
 import * as utils from 'src/utils';
 import find from 'core-js/library/fn/array/find';
 
-const ADAPTER_VERSION = 8;
+const ADAPTER_VERSION = 11;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;
 const INTEGRATION_MODES = {
   'amp': 1,
 };
-const PROFILE_ID = 207;
+const PROFILE_ID_INLINE = 207;
+const PROFILE_ID_PUBLISHERTAG = 185;
 
 // Unminified source code can be found in: https://github.com/Prebid-org/prebid-js-external-js-criteo/blob/master/dist/prod.js
 const PUBLISHER_TAG_URL = '//static.criteo.net/js/ld/publishertag.prebid.js';
@@ -51,7 +52,7 @@ export const spec = {
     }
 
     if (publisherTagAvailable()) {
-      const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
+      const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID_PUBLISHERTAG, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
     } else {
@@ -156,7 +157,7 @@ function buildContext(bidRequests) {
  */
 function buildCdbUrl(context) {
   let url = CDB_ENDPOINT;
-  url += '?profileId=' + PROFILE_ID;
+  url += '?profileId=' + PROFILE_ID_INLINE;
   url += '&av=' + String(ADAPTER_VERSION);
   url += '&wv=' + encodeURIComponent('$prebid.version$');
   url += '&cb=' + String(Math.floor(Math.random() * 99999999999));

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -73,7 +73,7 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
@@ -113,7 +113,7 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());
@@ -152,7 +152,7 @@ describe('The Criteo bidding adapter', () => {
         },
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&cb=\d/);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.url).to.equal(utils.getTopWindowUrl());


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Passing the Prebid version and correct profile IDs to our bidding endpoint will allow us to better know our publishers' setup globally.

_PS: the "adapter version" jumped from 8 to 11 because of some internal testing versions._