### PR TITLE
Legacy Sortable bid adapter

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import { BANNER } from 'src/mediaTypes';
 import { REPO_AND_VERSION } from 'src/constants';
+import { ajax } from 'src/ajax';
 
 const BIDDER_CODE = 'sortable';
 const SERVER_URL = 'c.deployads.com';
@@ -129,13 +130,8 @@ export const spec = {
   },
 
   onTimeout(details) {
-    fetch(`//${SERVER_URL}/prebid/timeout`, {
-      method: 'POST',
-      body: JSON.stringify(details),
-      mode: 'no-cors',
-      headers: new Headers({
-        'Content-Type': 'text/plain'
-      })
+    ajax(`//${SERVER_URL}/prebid/timeout`, null, JSON.stringify(details), {
+      method: 'POST'
     });
   }
 };

--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -1,0 +1,143 @@
+import * as utils from 'src/utils';
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
+import { BANNER } from 'src/mediaTypes';
+import { REPO_AND_VERSION } from 'src/constants';
+
+const BIDDER_CODE = 'sortable';
+const SERVER_URL = 'c.deployads.com';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid: function(bid) {
+    const sortableConfig = config.getConfig('sortable');
+    const haveSiteId = (sortableConfig && !!sortableConfig.siteId) || bid.params.siteId;
+    const validFloor = !bid.params.floor || utils.isNumber(bid.params.floor);
+    const validSize = /\d+x\d+/;
+    const validFloorSizeMap = !bid.params.floorSizeMap ||
+      (utils.isA(bid.params.floorSizeMap, 'Object') &&
+        Object.keys(bid.params.floorSizeMap).every(size =>
+          size.match(validSize) && utils.isNumber(bid.params.floorSizeMap[size])
+        ));
+    const validKeywords = !bid.params.keywords ||
+      (utils.isA(bid.params.keywords, 'Object') &&
+        Object.keys(bid.params.keywords).every(key =>
+          utils.isStr(key) && utils.isStr(bid.params.keywords[key])
+        ));
+    return !!(bid.params.tagId && haveSiteId && validFloor && validFloorSizeMap && validKeywords && bid.sizes &&
+      bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(num => utils.isNumber(num))));
+  },
+
+  buildRequests: function(validBidReqs, bidderRequest) {
+    const sortableConfig = config.getConfig('sortable') || {};
+    const globalSiteId = sortableConfig.siteId;
+    let loc = utils.getTopWindowLocation();
+
+    const sortableImps = utils._map(validBidReqs, bid => {
+      let rv = {
+        id: bid.bidId,
+        tagid: bid.params.tagId,
+        banner: {
+          format: utils._map(bid.sizes, ([width, height]) => ({w: width, h: height}))
+        },
+        ext: {}
+      };
+      if (bid.params.floor) {
+        rv.bidfloor = bid.params.floor;
+      }
+      if (bid.params.keywords) {
+        rv.ext.keywords = bid.params.keywords;
+      }
+      if (bid.params.bidderParams) {
+        utils._each(bid.params.bidderParams, (params, partner) => {
+          rv.ext[partner] = params;
+        });
+      }
+      if (bid.params.floorSizeMap) {
+        rv.ext.floorSizeMap = bid.params.floorSizeMap;
+      }
+      return rv;
+    });
+    const sortableBidReq = {
+      id: utils.getUniqueIdentifierStr(),
+      imp: sortableImps,
+      site: {
+        domain: loc.hostname,
+        page: loc.href,
+        ref: utils.getTopWindowReferrer(),
+        publisher: {
+          id: globalSiteId || validBidReqs[0].params.siteId,
+        },
+        device: {
+          w: screen.width,
+          h: screen.height
+        },
+      },
+    };
+    return {
+      method: 'POST',
+      url: `//${SERVER_URL}/openrtb2/auction?src=${REPO_AND_VERSION}&host=${loc.host}`,
+      data: JSON.stringify(sortableBidReq),
+      options: {contentType: 'text/plain'}
+    };
+  },
+
+  interpretResponse: function(serverResponse) {
+    const { body: {id, seatbid} } = serverResponse;
+    const sortableBids = [];
+    if (id && seatbid) {
+      utils._each(seatbid, seatbid => {
+        utils._each(seatbid.bid, bid => {
+          const bidObj = {
+            requestId: bid.impid,
+            cpm: parseFloat(bid.price),
+            width: parseInt(bid.w),
+            height: parseInt(bid.h),
+            creativeId: bid.crid || bid.id,
+            dealId: bid.dealid || null,
+            currency: 'USD',
+            netRevenue: true,
+            mediaType: BANNER,
+            ttl: 60
+          };
+          if (bid.adm && bid.nurl) {
+            bidObj.ad = bid.adm;
+            bidObj.ad += utils.createTrackPixelHtml(decodeURIComponent(bid.nurl));
+          } else if (bid.adm) {
+            bidObj.ad = bid.adm;
+          } else if (bid.nurl) {
+            bidObj.adUrl = bid.nurl;
+          }
+          sortableBids.push(bidObj);
+        });
+      });
+    }
+    return sortableBids;
+  },
+
+  getUserSyncs: (syncOptions, responses) => {
+    const sortableConfig = config.getConfig('sortable');
+    if (syncOptions.iframeEnabled && sortableConfig && !!sortableConfig.siteId) {
+      let syncUrl = `//${SERVER_URL}/sync?f=html&s=${sortableConfig.siteId}&u=${encodeURIComponent(utils.getTopWindowLocation())}`;
+      return [{
+        type: 'iframe',
+        url: syncUrl
+      }];
+    }
+  },
+
+  onTimeout(details) {
+    fetch(`//${SERVER_URL}/prebid/timeout`, {
+      method: 'POST',
+      body: JSON.stringify(details),
+      mode: 'no-cors',
+      headers: new Headers({
+        'Content-Type': 'text/plain'
+      })
+    });
+  }
+};
+
+registerBidder(spec);

--- a/modules/sortableBidAdapter.md
+++ b/modules/sortableBidAdapter.md
@@ -1,0 +1,56 @@
+# Overview
+
+```
+Module Name: Sortable Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@sortable.com
+```
+
+# Description
+
+Sortable's adapter integration to the Prebid library. Posts plain-text JSON to the /openrtb2/auction endpoint.
+
+# Test Parameters
+
+```
+var adUnits = [
+  {
+    code: 'test-pb-leaderboard',
+    sizes: [[728, 90]],
+    bids: [{
+      bidder: 'sortable',
+      params: {
+        tagId: 'test-pb-leaderboard',
+        siteId: 'prebid.example.com',
+        'keywords': {
+          'key1': 'val1',
+          'key2': 'val2'
+        }
+      }
+    }]
+  }, {
+    code: 'test-pb-banner',
+    sizes: [[300, 250]],
+    bids: [{
+      bidder: 'sortable',
+      params: {
+        tagId: 'test-pb-banner',
+        siteId: 'prebid.example.com'
+      }
+    }]
+  }, {
+    code: 'test-pb-sidebar',
+    size: [[160, 600]],
+    bids: [{
+      bidder: 'sortable',
+      params: {
+        tagId: 'test-pb-sidebar',
+        siteId: 'prebid.example.com',
+        'keywords': {
+          'keyA': 'valA'
+        }
+      }
+    }]
+  }
+]
+```

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -1,0 +1,259 @@
+import { expect } from 'chai';
+import { spec } from 'modules/sortableBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+import { REPO_AND_VERSION } from 'src/constants';
+import * as utils from 'src/utils';
+
+const ENDPOINT = `//c.deployads.com/openrtb2/auction?src=${REPO_AND_VERSION}&host=${utils.getTopWindowLocation().host}`;
+
+describe('sortableBidAdapter', function() {
+  const adapter = newBidder(spec);
+
+  describe('isBidRequestValid', () => {
+    function makeBid() {
+      return {
+        'bidder': 'sortable',
+        'params': {
+          'tagId': '403370',
+          'siteId': 'example.com',
+          'keywords': {
+            'key1': 'val1',
+            'key2': 'val2'
+          },
+          'floorSizeMap': {
+            '728x90': 0.15,
+            '300x250': 1.20
+          }
+        },
+        'adUnitCode': 'adunit-code',
+        'sizes': [
+          [300, 250]
+        ],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475',
+      };
+    }
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(makeBid())).to.equal(true);
+    });
+
+    it('should return false when tagId not passed correctly', () => {
+      let bid = makeBid();
+      delete bid.params.tagId;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when sizes not passed correctly', () => {
+      let bid = makeBid();
+      delete bid.sizes;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when sizes are wrong length', () => {
+      let bid = makeBid();
+      bid.sizes = [[300]];
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when require params are not passed', () => {
+      let bid = makeBid();
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when the floorSizeMap is invalid', () => {
+      let bid = makeBid();
+      bid.params.floorSizeMap = {
+        'sixforty by foureighty': 1234
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params.floorSizeMap = {
+        '728x90': 'three'
+      }
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params.floorSizeMap = 'a';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return true when the floorSizeMap is missing or empty', () => {
+      let bid = makeBid();
+      bid.params.floorSizeMap = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+      delete bid.params.floorSizeMap;
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return false when the keywords are invalid', () => {
+      let bid = makeBid();
+      bid.params.keywords = {
+        'badval': 1234
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params.keywords = 'a';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return true when the keywords are missing or empty', () => {
+      let bid = makeBid();
+      bid.params.keywords = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+      delete bid.params.keywords;
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+  });
+
+  describe('buildRequests', () => {
+    const bidRequests = [{
+      'bidder': 'sortable',
+      'params': {
+        'tagId': '403370',
+        'siteId': 'example.com',
+        'floor': 0.21,
+        'keywords': {
+          'key1': 'val1',
+          'key2': 'val2'
+        },
+        'floorSizeMap': {
+          '728x90': 0.15,
+          '300x250': 1.20
+        }
+      },
+      'sizes': [
+        [300, 250]
+      ],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475'
+    }];
+
+    const request = spec.buildRequests(bidRequests);
+    const requestBody = JSON.parse(request.data);
+
+    it('sends bid request to our endpoint via POST', () => {
+      expect(request.method).to.equal('POST');
+    });
+
+    it('attaches source and version to endpoint URL as query params', () => {
+      expect(request.url).to.equal(ENDPOINT);
+    });
+
+    it('sends screen dimensions', () => {
+      expect(requestBody.site.device.w).to.equal(screen.width);
+      expect(requestBody.site.device.h).to.equal(screen.height);
+    });
+
+    it('includes the ad size in the bid request', () => {
+      expect(requestBody.imp[0].banner.format[0].w).to.equal(300);
+      expect(requestBody.imp[0].banner.format[0].h).to.equal(250);
+    });
+
+    it('includes the params in the bid request', () => {
+      expect(requestBody.imp[0].ext.keywords).to.deep.equal(
+        {'key1': 'val1',
+          'key2': 'val2'}
+      );
+      expect(requestBody.site.publisher.id).to.equal('example.com');
+      expect(requestBody.imp[0].tagid).to.equal('403370');
+      expect(requestBody.imp[0].bidfloor).to.equal(0.21);
+    });
+
+    it('should have the floor size map set', () => {
+      expect(requestBody.imp[0].ext.floorSizeMap).to.deep.equal({
+        '728x90': 0.15,
+        '300x250': 1.20
+      });
+    });
+  });
+
+  describe('interpretResponse', () => {
+    function makeResponse() {
+      return {
+        body: {
+          'id': '5e5c23a5ba71e78',
+          'seatbid': [
+            {
+              'bid': [
+                {
+                  'id': '6vmb3isptf',
+                  'crid': 'sortablescreative',
+                  'impid': '322add653672f68',
+                  'price': 1.22,
+                  'adm': '<!-- creative -->',
+                  'attr': [5],
+                  'h': 90,
+                  'nurl': 'http://nurl',
+                  'w': 728
+                }
+              ],
+              'seat': 'MOCK'
+            }
+          ],
+          'bidid': '5e5c23a5ba71e78'
+        }
+      };
+    }
+
+    const expectedBid = {
+      'requestId': '322add653672f68',
+      'cpm': 1.22,
+      'width': 728,
+      'height': 90,
+      'creativeId': 'sortablescreative',
+      'dealId': null,
+      'currency': 'USD',
+      'netRevenue': true,
+      'mediaType': 'banner',
+      'ttl': 60,
+      'ad': '<!-- creative --><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="http://nurl"></div>'
+    };
+
+    it('should get the correct bid response', () => {
+      let result = spec.interpretResponse(makeResponse());
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(expectedBid);
+    });
+
+    it('should handle a missing crid', () => {
+      let noCridResponse = makeResponse();
+      delete noCridResponse.body.seatbid[0].bid[0].crid;
+      const fallbackCrid = noCridResponse.body.seatbid[0].bid[0].id;
+      let noCridResult = Object.assign({}, expectedBid, {'creativeId': fallbackCrid});
+      let result = spec.interpretResponse(noCridResponse);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(noCridResult);
+    });
+
+    it('should handle a missing nurl', () => {
+      let noNurlResponse = makeResponse();
+      delete noNurlResponse.body.seatbid[0].bid[0].nurl;
+      let noNurlResult = Object.assign({}, expectedBid);
+      noNurlResult.ad = '<!-- creative -->';
+      let result = spec.interpretResponse(noNurlResponse);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(noNurlResult);
+    });
+
+    it('should handle a missing adm', () => {
+      let noAdmResponse = makeResponse();
+      delete noAdmResponse.body.seatbid[0].bid[0].adm;
+      let noAdmResult = Object.assign({}, expectedBid);
+      delete noAdmResult.ad;
+      noAdmResult.adUrl = 'http://nurl';
+      let result = spec.interpretResponse(noAdmResponse);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(noAdmResult);
+    });
+
+    it('handles empty bid response', () => {
+      let response = {
+        body: {
+          'id': '5e5c23a5ba71e78',
+          'seatbid': []
+        }
+      };
+      let result = spec.interpretResponse(response);
+      expect(result.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x ] New bidder adapter  

## Description of change
The PR backporst Sortable bid adapter to legacy. GDPR support is removed and `utils.isPlainObject(...)` is replaced with `utils.isA(..., 'Object')`. 

- test parameters for validating bids
```
var adUnits = [
  {
    code: 'test-pb-leaderboard',
    sizes: [[728, 90]],
    bids: [{
      bidder: 'sortable',
      params: {
        tagId: 'test-pb-leaderboard',
        siteId: 1,
        'keywords': {
          'key1': 'val1',
          'key2': 'val2'
        }
      }
    }]
  }, {
    code: 'test-pb-banner',
    sizes: [[300, 250]],
    bids: [{
      bidder: 'sortable',
      params: {
        tagId: 'test-pb-banner',
        siteId: 1
      }
    }]
  }, {
    code: 'test-pb-sidebar',
    size: [[160, 600]],
    bids: [{
      bidder: 'sortable',
      params: {
        tagId: 'test-pb-sidebar',
        siteId: 1,
        'keywords': {
          'keyA': 'valA'
        }
      }
    }]
  }
];
```
