### PR TITLE
Fix #2851 - updates in prebidServerBidAdapter to support ix bidder

### DIFF
--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -520,6 +520,7 @@ const OPEN_RTB_PROTOCOL = {
         }
 
         if (bid.bidder === 'ix') {
+          aliases.ix = 'indexExchange';
           bid.params.siteID = tryConvertType('number', bid.params.siteId);
           if (bid.params.siteId) { delete bid.params.siteId; }
         }
@@ -551,7 +552,6 @@ const OPEN_RTB_PROTOCOL = {
       request.user = { ext: { digitrust: digiTrust } };
     }
 
-    aliases.ix = 'indexExchange';
     if (!utils.isEmpty(aliases)) {
       request.ext = { prebid: { aliases } };
     }

--- a/modules/prebidServerBidAdapter.js
+++ b/modules/prebidServerBidAdapter.js
@@ -518,6 +518,12 @@ const OPEN_RTB_PROTOCOL = {
             }
           });
         }
+
+        if (bid.bidder === 'ix') {
+          bid.params.siteID = tryConvertType('number', bid.params.siteId);
+          if (bid.params.siteId) { delete bid.params.siteId; }
+        }
+
         acc[bid.bidder] = bid.params;
         return acc;
       }, {});
@@ -545,6 +551,7 @@ const OPEN_RTB_PROTOCOL = {
       request.user = { ext: { digitrust: digiTrust } };
     }
 
+    aliases.ix = 'indexExchange';
     if (!utils.isEmpty(aliases)) {
       request.ext = { prebid: { aliases } };
     }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -623,7 +623,8 @@ describe('S2S Adapter', () => {
       expect(requestBid.ext).to.deep.equal({
         prebid: {
           aliases: {
-            brealtime: 'appnexus'
+            brealtime: 'appnexus',
+            ix: 'indexExchange'
           }
         }
       });
@@ -653,7 +654,8 @@ describe('S2S Adapter', () => {
       expect(requestBid.ext).to.deep.equal({
         prebid: {
           aliases: {
-            [alias]: 'appnexus'
+            [alias]: 'appnexus',
+            ix: 'indexExchange'
           }
         }
       });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -623,8 +623,7 @@ describe('S2S Adapter', () => {
       expect(requestBid.ext).to.deep.equal({
         prebid: {
           aliases: {
-            brealtime: 'appnexus',
-            ix: 'indexExchange'
+            brealtime: 'appnexus'
           }
         }
       });
@@ -654,8 +653,7 @@ describe('S2S Adapter', () => {
       expect(requestBid.ext).to.deep.equal({
         prebid: {
           aliases: {
-            [alias]: 'appnexus',
-            ix: 'indexExchange'
+            [alias]: 'appnexus'
           }
         }
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Fixes #2851 

This PR:
* adds a dedicated alias for the ix bidder so that it's registered properly in the prebid server request (and pubs don't have to specifically register it in the setup code).
* properly converts the `ixBidAdapter` param `siteId` to the `indexExchange` variant of `siteID` while also converting the type from a `string` to an `number`

With this PR, publishers would be able to use the `ix` bidder in a s2s request in the following manner:

```

var adUnits = [{
          code: 'div-gpt-ad-1460505748561-0',
          mediaTypes: {
            banner: {
              sizes: [[300, 250], [300,600]],
            }
          },
          // Replace this object to test a new Adapter!
          bids: [{
            bidder: 'ix',
            params: {
              siteId: '12345',
              size: [300, 250]
            }
          }]
  
        }];
```

```
pbjs.setConfig({
            debug: true,
            s2sConfig: {
              accountId: 'a3de7af2-a86a-4043-a77b-c7e86744155e',
              bidders: ['ix'],
              enabled: true,
              timeout: 1000,
              adapter: 'prebidServer',
              endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
            }
          });
```