### PR TITLE
Add Gambid parameter "reqformat" to HTTP request

### DIFF
--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -53,7 +53,7 @@ export const spec = {
     return validBidRequests.map(bidRequest => {
       const { adUnitCode, auctionId, mediaTypes, params, sizes, transactionId } = bidRequest;
       const baseEndpoint = params[ 'rtbEndpoint' ] || 'https://rtb.gambid.io';
-      const rtbEndpoint = `${baseEndpoint}/r/${params.supplyPartnerId}/bidr?rformat=open_rtb&bidder=prebid` + (params.query ? '&' + params.query : '');
+      const rtbEndpoint = `${baseEndpoint}/r/${params.supplyPartnerId}/bidr?rformat=open_rtb&reqformat=rtb_json&bidder=prebid` + (params.query ? '&' + params.query : '');
       const rtbBidRequest = {
         'id': auctionId,
         'site': {

--- a/test/spec/modules/gambidBidAdapter_spec.js
+++ b/test/spec/modules/gambidBidAdapter_spec.js
@@ -72,13 +72,13 @@ describe('GambidAdapter', () => {
 
       response = spec.buildRequests([ bidRequest ])[ 0 ];
       expect(response.method).to.equal('POST');
-      expect(response.url).to.match(new RegExp(`^https://rtb\\.gambid\\.io/r/${supplyPartnerId}/bidr\\?rformat=open_rtb&bidder=prebid$`, 'g'));
+      expect(response.url).to.match(new RegExp(`^https://rtb\\.gambid\\.io/r/${supplyPartnerId}/bidr\\?rformat=open_rtb&reqformat=rtb_json&bidder=prebid$`, 'g'));
       expect(response.data.id).to.equal(bidRequest.auctionId);
 
       const bidRequestWithEndpoint = utils.deepClone(bidRequest);
       bidRequestWithEndpoint.params.rtbEndpoint = 'https://rtb2.gambid.io/a12';
       response = spec.buildRequests([ bidRequestWithEndpoint ])[ 0 ];
-      expect(response.url).to.match(new RegExp(`^https://rtb2\\.gambid\\.io/a12/r/${supplyPartnerId}/bidr\\?rformat=open_rtb&bidder=prebid$`, 'g'));
+      expect(response.url).to.match(new RegExp(`^https://rtb2\\.gambid\\.io/a12/r/${supplyPartnerId}/bidr\\?rformat=open_rtb&reqformat=rtb_json&bidder=prebid$`, 'g'));
     });
 
     it('builds request correctly', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Send an additional query parameter from the bid adapter to the Gambid servers. While the parameter is not strictly required, it is the preferred method of calling the Gambid server, and so as a best practice it should be sent from the bid adapter.