### PR TITLE
Pass the "vastUrl" property from the bid to the outstream renderer

### DIFF
--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -134,7 +134,7 @@ export const spec = {
           mediaType: 'video',
           vastUrl: bid.ext.vast_url,
           vastXml: bid.adm,
-          renderer: context === 'outstream' ? newRenderer( bidRequest.bidRequest, bid) : undefined
+          renderer: context === 'outstream' ? newRenderer(bidRequest.bidRequest, bid) : undefined
         }));
       }
     });
@@ -176,7 +176,7 @@ export const spec = {
 
 function newRenderer(bidRequest, bid, rendererOptions = {}) {
   const renderer = Renderer.install({
-    url: bidRequest.params && bidRequest.params.rendererUrl || bid.ext && bid.ext.renderer_url || '//s.gamoshi.io/video/latest/renderer.js',
+    url: (bidRequest.params && bidRequest.params.rendererUrl) || (bid.ext && bid.ext.renderer_url) || '//s.gamoshi.io/video/latest/renderer.js',
     config: rendererOptions,
     loaded: false,
   });

--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -134,7 +134,7 @@ export const spec = {
           mediaType: 'video',
           vastUrl: bid.ext.vast_url,
           vastXml: bid.adm,
-          renderer: context === 'outstream' ? newRenderer(bidRequest, bid) : undefined
+          renderer: context === 'outstream' ? newRenderer( bidRequest.bidRequest, bid) : undefined
         }));
       }
     });
@@ -176,7 +176,7 @@ export const spec = {
 
 function newRenderer(bidRequest, bid, rendererOptions = {}) {
   const renderer = Renderer.install({
-    url: bid.ext && bid.ext.renderer_url || '//s.gamoshi.io/video/latest/renderer.js',
+    url: bidRequest.params && bidRequest.params.rendererUrl || bid.ext && bid.ext.renderer_url || '//s.gamoshi.io/video/latest/renderer.js',
     config: rendererOptions,
     loaded: false,
   });

--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -202,6 +202,7 @@ function renderOutstream(bid) {
           window['GamoshiPlayer'].removeAd(unitId);
         }, 300)
       },
+      vastUrl: bid.vastUrl,
       vastXml: bid.vastXml
     });
   });

--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -176,7 +176,7 @@ export const spec = {
 
 function newRenderer(bidRequest, bid, rendererOptions = {}) {
   const renderer = Renderer.install({
-    url: '//s.gamoshi.io/video/latest/renderer.js',
+    url: bid.ext && bid.ext.renderer_url || '//s.gamoshi.io/video/latest/renderer.js',
     config: rendererOptions,
     loaded: false,
   });

--- a/modules/gambidBidAdapter.js
+++ b/modules/gambidBidAdapter.js
@@ -174,7 +174,7 @@ export const spec = {
   }
 };
 
-function newRenderer(adUnitCode, bid, rendererOptions = {}) {
+function newRenderer(bidRequest, bid, rendererOptions = {}) {
   const renderer = Renderer.install({
     url: '//s.gamoshi.io/video/latest/renderer.js',
     config: rendererOptions,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
While currently all bids from Gambid server provide the `vastXml` property, it is possible that in the future we will only have the `vastUrl` property; for such cases, it's best we always pass both `vastXml` *and* `vastUrl` from the bid adapter to the Gambid outstream renderer.