### PR TITLE
fix domain extraction in undertone adapter

### DIFF
--- a/modules/undertoneBidAdapter.js
+++ b/modules/undertoneBidAdapter.js
@@ -25,9 +25,9 @@ export const spec = {
     let domain = null;
     if (domains != null && domains.length > 0) {
       domain = domains[0];
-      for (let i=1; i<domains.length; i++) {
+      for (let i = 1; i < domains.length; i++) {
         if (domains[i].length > domain.length) {
-          domain=domains[i];
+          domain = domains[i];
         }
       }
     }

--- a/modules/undertoneBidAdapter.js
+++ b/modules/undertoneBidAdapter.js
@@ -21,11 +21,15 @@ export const spec = {
       'x-ut-hb-params': []
     };
     const location = utils.getTopWindowLocation();
-    let domain = /[-\w]+\.(?:[-\w]+\.xn--[-\w]+|[-\w]{3,}|[-\w]+\.[-\w]{2})$/i.exec(location.host);
-    if (domain == null || domain.length == 0) {
-      domain = null;
-    } else {
-      domain = domain[0];
+    let domains = /[-\w]+\.([-\w]+|[-\w]{3,}|[-\w]{1,3}\.[-\w]{2})$/i.exec(location.host);
+    let domain = null;
+    if (domains != null && domains.length > 0) {
+      domain = domains[0];
+      for (let i=1; i<domains.length; i++) {
+        if (domains[i].length > domain.length) {
+          domain=domains[i];
+        }
+      }
     }
 
     const pubid = validBidRequests[0].params.publisherId;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
There was a bug when trying to extract domain from hostnames with two letter suffixes such as .co / .io / etc
This fix solves this issue
