### PR TITLE
Fix kargo bidResponse size to size from bidRequest.

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -42,8 +42,8 @@ export const spec = {
       bidResponses.push({
         requestId: bids[adUnitId].bidId,
         cpm: Number(adUnit.cpm),
-        width: adUnit.width,
-        height: adUnit.height,
+        width: bids[adUnitId].sizes[0][0],
+        height: bids[adUnitId].sizes[0][1],
         ad: adUnit.adm,
         ttl: 300,
         creativeId: adUnitId,

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -322,11 +322,17 @@ describe('kargo adapter tests', function () {
         currency: 'USD',
         bids: [{
           bidId: 'fake bid id 1',
+          sizes: [
+            [320, 50]
+          ],
           params: {
             placementId: 'foo'
           }
         }, {
           bidId: 'fake bid id 2',
+          sizes: [
+            [300, 250]
+          ],
           params: {
             placementId: 'bar'
           }


### PR DESCRIPTION
Kargo always returns 0x0 size even though other size was requested.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Kargo returns always 0x0 size, no matter what size set is provided. This is not compliant with how other adapters work. In order to fix this, this PR overwrites the 0x0 size with size taken from bid request.

- contact to the adapter’s maintainer: @samuelhorwitz 