### PR TITLE
Add Piximedia adapter

### DIFF
--- a/modules/piximediaBidAdapter.js
+++ b/modules/piximediaBidAdapter.js
@@ -1,0 +1,46 @@
+import * as utils from 'src/utils';
+import { registerBidder } from 'src/adapters/bidderFactory';
+
+const BIDDER_CODE = 'piximedia';
+const ENDPOINT = '//ad.piximedia.com/prebid';
+
+export const spec = {
+  code: BIDDER_CODE,
+  isBidRequestValid: function(bid) {
+    return !!(bid.params && bid.params.siteId && bid.params.placementId);
+  },
+  buildRequests: function(validBidRequests) {
+    return validBidRequests.map(bidRequest => {
+      let parseSized = utils.parseSizesInput(bidRequest.sizes);
+      let arrSize = parseSized[0].split('x');
+      return {
+        method: 'GET',
+        url: ENDPOINT,
+        data: {
+          timestamp: utils.timestamp(),
+          pver: '1.0',
+          pbparams: JSON.stringify(bidRequest.params),
+          pbwidth: arrSize[0],
+          pbheight: arrSize[1],
+          pbbidid: bidRequest.bidId,
+        },
+      };
+    });
+  },
+  interpretResponse: function(serverResponse, request) {
+    const res = serverResponse.body;
+    const bidResponse = {
+      requestId: res.bidId,
+      cpm: parseFloat(res.cpm),
+      width: res.width,
+      height: res.height,
+      creativeId: res.creative_id,
+      currency: res.currency,
+      netRevenue: true,
+      ttl: 300,
+      ad: res.adm
+    };
+    return [bidResponse];
+  }
+}
+registerBidder(spec);

--- a/modules/piximediaBidAdapter.md
+++ b/modules/piximediaBidAdapter.md
@@ -1,0 +1,25 @@
+# Overview
+
+**Module Name**: Piximedia Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**:  contact@piximedia.fr
+
+# Description
+
+Piximedia Bidder Adapter for Prebid.js.
+
+# Test Parameters
+```	
+    var adUnits = [{
+      code: 'mpu',
+      sizes: [[300, 250]],
+      bids: [{
+        bidder: 'piximedia',
+        params: {
+          siteId: 'PIXIMEDIA',
+          placementId: 'PREBID'
+        }
+      }]
+    }];
+	
+```

--- a/test/spec/modules/piximediaBidAdapter_spec.js
+++ b/test/spec/modules/piximediaBidAdapter_spec.js
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import { spec } from 'modules/piximediaBidAdapter';
+
+describe('piximediaAdapterTest', () => {
+  describe('bidRequestValidity', () => {
+    it('bidRequest with site ID and placement ID param', () => {
+      expect(spec.isBidRequestValid({
+        bidder: 'piximedia',
+        params: {
+          'siteId': 'PIXIMEDIA_PREBID10',
+          'placementId': 'RG'
+        },
+      })).to.equal(true);
+    });
+
+    it('bidRequest with no required params', () => {
+      expect(spec.isBidRequestValid({
+        bidder: 'piximedia',
+        params: {
+        },
+      })).to.equal(false);
+    });
+  });
+
+  describe('bidRequest', () => {
+    const bidRequests = [{
+      'bidder': 'piximedia',
+      'params': {
+        'siteId': 'PIXIMEDIA_PREBID10',
+        'placementId': 'RG'
+      },
+      'adUnitCode': 'div-gpt-ad-1460505748561-0',
+      'transactionId': 'd7b773de-ceaa-484d-89ca-d9f51b8d61ec',
+      'sizes': [300, 250],
+      'bidId': '51ef8751f9aead',
+      'bidderRequestId': '418b37f85e772c',
+      'auctionId': '18fd8b8b0bd757'
+    }];
+
+    it('bidRequest HTTP method', () => {
+      const requests = spec.buildRequests(bidRequests);
+      requests.forEach(function(requestItem) {
+        expect(requestItem.method).to.equal('GET');
+      });
+    });
+
+    it('bidRequest data', () => {
+      const requests = spec.buildRequests(bidRequests);
+      expect(typeof requests[0].data.timestamp).to.equal('number');
+      expect(requests[0].data.pver).to.equal('1.0');
+      expect(requests[0].data.pbparams).to.equal(JSON.stringify(bidRequests[0].params));
+      expect(requests[0].data.pbwidth).to.equal('300');
+      expect(requests[0].data.pbheight).to.equal('250');
+      expect(requests[0].data.pbbidid).to.equal('51ef8751f9aead');
+    });
+  });
+
+  describe('interpretResponse', () => {
+    const bidRequest = {
+      'method': 'GET',
+      'url': 'https://ad.piximedia.com/',
+      'data': {
+        'ver': 2,
+        'hb': 1,
+        'output': 'js',
+        'pub': 267,
+        'zone': 62546,
+        'width': '300',
+        'height': '250',
+        'callback': 'json',
+        'callback_uid': '51ef8751f9aead',
+        'url': 'https://example.com',
+        'cb': '',
+      }
+    };
+
+    const bidResponse = {
+      body: {
+        'bidId': '51ef8751f9aead',
+        'cpm': 4.2,
+        'width': '300',
+        'height': '250',
+        'creative_id': '1234',
+        'currency': 'EUR',
+        'adm': '<div></div>',
+      },
+      headers: {}
+    };
+
+    it('result is correct', () => {
+      const result = spec.interpretResponse(bidResponse, bidRequest);
+      expect(result[0].requestId).to.equal('51ef8751f9aead');
+      expect(result[0].cpm).to.equal(4.2);
+      expect(result[0].width).to.equal('300');
+      expect(result[0].height).to.equal('250');
+      expect(result[0].creativeId).to.equal('1234');
+      expect(result[0].currency).to.equal('EUR');
+      expect(result[0].ttl).to.equal(300);
+      expect(result[0].ad).to.equal('<div></div>');
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [X] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add Piximedia adapter for Prebid 1.0.

Some test parameters for the bidder:

```     
    var adUnits = [{
      code: 'mpu',
      sizes: [[300, 250]],
      bids: [{
        bidder: 'piximedia',
        params: {
          siteId: 'PIXIMEDIA',
          placementId: 'PREBID'
        }
      }]
    }];

```

Our general contact email address is contact@piximedia.fr, and for anything related to this bidder, feel free to reach out to me at christopher.allene@piximedia.fr.
