### PR TITLE
Feature : Display counter at Adslot level

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -122,7 +122,8 @@ function slotParams(bidRequest) {
   let params = {
     id: bidRequest.bidId,
     ext: {
-      dfp_id: bidRequest.adUnitCode
+      dfp_id: bidRequest.adUnitCode,
+      display_count: bidRequest.displayCount
     },
     banner: transformSizes(bidRequest.sizes),
     all: bidRequest.params

--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -123,7 +123,7 @@ function slotParams(bidRequest) {
     id: bidRequest.bidId,
     ext: {
       dfp_id: bidRequest.adUnitCode,
-      display_count: bidRequest.displayCount
+      display_count: bidRequest.bidRequestsCount
     },
     banner: transformSizes(bidRequest.sizes),
     all: bidRequest.params

--- a/src/adUnits.js
+++ b/src/adUnits.js
@@ -1,0 +1,18 @@
+import { deepAccess } from './utils';
+
+let adUnits = {};
+
+function incrementCounter(adunit) {
+  adUnits[adunit] = adUnits[adunit] || {};
+  adUnits[adunit].counter = (deepAccess(adUnits, `${adunit}.counter`) + 1) || 1;
+  return adUnits[adunit].counter;
+}
+
+function getCounter(adunit) {
+  return deepAccess(adUnits, `${adunit}.counter`) || 0;
+}
+
+exports.adunitCounter = {
+  incrementCounter,
+  getCounter
+}

--- a/src/adUnits.js
+++ b/src/adUnits.js
@@ -2,17 +2,33 @@ import { deepAccess } from './utils';
 
 let adUnits = {};
 
+/**
+ * Increments and returns current Adunit counter
+ * @param {string} adunit id
+ * @returns {number} current adunit count
+ */
 function incrementCounter(adunit) {
   adUnits[adunit] = adUnits[adunit] || {};
   adUnits[adunit].counter = (deepAccess(adUnits, `${adunit}.counter`) + 1) || 1;
   return adUnits[adunit].counter;
 }
 
+/**
+ * Returns current Adunit counter
+ * @param {string} adunit id
+ * @returns {number} current adunit count
+ */
 function getCounter(adunit) {
   return deepAccess(adUnits, `${adunit}.counter`) || 0;
 }
 
-exports.adunitCounter = {
+/**
+ * A module which counts how many times an adunit was called
+ * @module adunitCounter
+ */
+let adunitCounter = {
   incrementCounter,
   getCounter
 }
+
+export { adunitCounter };

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -97,7 +97,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
               bidId: bid.bid_id || utils.getUniqueIdentifierStr(),
               bidderRequestId,
               auctionId,
-              displayCount: adunitCounter.getCounter(adUnit.code)
+              bidRequestsCount: adunitCounter.getCounter(adUnit.code)
             }));
           }
           return bids;

--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -8,6 +8,7 @@ import { ajaxBuilder } from 'src/ajax';
 import { config, RANDOM } from 'src/config';
 import includes from 'core-js/library/fn/array/includes';
 import find from 'core-js/library/fn/array/find';
+import { adunitCounter } from './adUnits';
 
 var utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -95,7 +96,8 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
               sizes: sizes,
               bidId: bid.bid_id || utils.getUniqueIdentifierStr(),
               bidderRequestId,
-              auctionId
+              auctionId,
+              displayCount: adunitCounter.getCounter(adUnit.code)
             }));
           }
           return bids;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -11,6 +11,7 @@ import { targeting, getHighestCpmBidsFromBidPool, RENDERED, BID_TARGETING_SET } 
 import { createHook } from 'src/hook';
 import { sessionLoader } from 'src/debugging';
 import includes from 'core-js/library/fn/array/includes';
+import { adunitCounter } from './adUnits';
 
 const $$PREBID_GLOBAL$$ = getGlobal();
 const CONSTANTS = require('./constants.json');
@@ -367,6 +368,7 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
         adUnit.bids = adUnit.bids.filter(bid => bid.bidder !== bidder);
       }
     });
+    adunitCounter.incrementCounter(adUnit.code);
   });
 
   if (!adUnits || adUnits.length === 0) {

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -17,7 +17,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 250]],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -33,7 +34,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 251]],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_BID_REQUEST_INVALID_BIDFLOOR = [{
     'bidder': 'medianet',
@@ -51,7 +53,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 250]],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -67,7 +70,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [[300, 251]],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_AUCTIONDATA = {
     'timeout': config.getConfig('bidderTimeout'),
@@ -103,7 +107,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -133,7 +138,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -181,7 +187,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -210,7 +217,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -372,7 +380,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [300, 250],
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -388,7 +397,8 @@ let VALID_BID_REQUEST = [{
     'sizes': [300, 251],
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
-    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d'
+    'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
+    'displayCount': 1
   }],
   VALID_BIDDER_REQUEST_WITH_GDPR = {
     'gdprConsent': {
@@ -429,7 +439,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,
@@ -458,7 +469,8 @@ let VALID_BID_REQUEST = [{
             x: 100,
             y: 100
           }
-        }
+        },
+        'display_count': 1
       },
       'banner': [{
         'w': 300,

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -18,7 +18,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -35,7 +35,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }],
   VALID_BID_REQUEST_INVALID_BIDFLOOR = [{
     'bidder': 'medianet',
@@ -54,7 +54,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -71,7 +71,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }],
   VALID_AUCTIONDATA = {
     'timeout': config.getConfig('bidderTimeout'),
@@ -381,7 +381,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '28f8f8130a583e',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }, {
     'bidder': 'medianet',
     'params': {
@@ -398,7 +398,7 @@ let VALID_BID_REQUEST = [{
     'bidId': '3f97ca71b1e5c2',
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
-    'displayCount': 1
+    'bidRequestsCount': 1
   }],
   VALID_BIDDER_REQUEST_WITH_GDPR = {
     'gdprConsent': {

--- a/test/spec/unit/adUnits_spec.js
+++ b/test/spec/unit/adUnits_spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { adunitCounter } from 'src/adUnits';
+
+describe('Adunit Counter', function () {
+  const ADUNIT_ID_1 = 'test1';
+  const ADUNIT_ID_2 = 'test2';
+
+  it('increments and checks counter of adunit 1', function () {
+    adunitCounter.incrementCounter(ADUNIT_ID_1);
+    expect(adunitCounter.getCounter(ADUNIT_ID_1)).to.be.equal(1);
+  });
+  it('checks counter of adunit 2', function () {
+    expect(adunitCounter.getCounter(ADUNIT_ID_2)).to.be.equal(0);
+  });
+  it('increments and checks counter of adunit 1', function () {
+    adunitCounter.incrementCounter(ADUNIT_ID_1);
+    expect(adunitCounter.getCounter(ADUNIT_ID_1)).to.be.equal(2);
+  });
+  it('increments and checks counter of adunit 2', function () {
+    adunitCounter.incrementCounter(ADUNIT_ID_2);
+    expect(adunitCounter.getCounter(ADUNIT_ID_2)).to.be.equal(1);
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
As discussed in #2295 thread, some bidders will be interested in getting the Display Counter which is added in this PR.

`buildRequests` of an adapter will be called with an key `displayCount` at adSlot level.

This PR also contains Media.net adapter integration with this feature

## Other information
As discussed in #2802  with @mkendall07 , the ad unit counter variable is set private.

