### PR TITLE
Fix safeFrame resize issue

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -69,10 +69,14 @@ function sendAdToCreative(adObject, remoteDomain, source) {
 }
 
 function resizeRemoteCreative({ adUnitCode, width, height }) {
-  const iframe = document.getElementById(
-    find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)
-      .getSlotElementId()).querySelector('iframe');
-
-  iframe.width = '' + width;
-  iframe.height = '' + height;
+  // resize both container div + iframe
+  ['div', 'iframe'].forEach(elmType => {
+    var element = getElementByAdUnit(elmType);
+    element.style.width = width;
+    element.style.height = height;
+  });
+  function getElementByAdUnit(elmType) {
+    return document.getElementById(find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)
+      .getSlotElementId()).querySelector(elmType);
+  }
 }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -71,9 +71,9 @@ function sendAdToCreative(adObject, remoteDomain, source) {
 function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
-    var element = getElementByAdUnit(elmType);
-    element.style.width = width;
-    element.style.height = height;
+    let elementStyle = getElementByAdUnit(elmType).style;
+    elementStyle.width = width;
+    elementStyle.height = height;
   });
   function getElementByAdUnit(elmType) {
     return document.getElementById(find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This fixes the problem where safeFrame creatives are not resized correctly when DFP size override is enabled (initial size is 1x1) 