### PR TITLE
Kargo adapter BidID support

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -12,7 +12,8 @@ export const spec = {
     return !!bid.params.placementId;
   },
   buildRequests: function(validBidRequests, bidderRequest) {
-    const currency = config.getConfig('currency');
+    const currencyObj = config.getConfig('currency');
+    const currency = (currencyObj && currencyObj.adServerCurrency) || 'USD';
     const bidIds = {};
     utils._each(validBidRequests, bid => bidIds[bid.bidId] = bid.params.placementId);
     const transformedParams = Object.assign({}, {

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -13,6 +13,8 @@ export const spec = {
   },
   buildRequests: function(validBidRequests, bidderRequest) {
     const currency = config.getConfig('currency');
+    const bidIds = {};
+    utils._each(validBidRequests, bid => bidIds[bid.bidId] = bid.params.placementId);
     const transformedParams = Object.assign({}, {
       timeout: bidderRequest.timeout,
       currency: currency,
@@ -22,31 +24,29 @@ export const spec = {
         floor: 0,
         ceil: 20
       },
-      adSlotIDs: utils._map(validBidRequests, bid => bid.params.placementId)
+      bidIDs: bidIds
     }, spec._getAllMetadata());
     const encodedParams = encodeURIComponent(JSON.stringify(transformedParams));
     return Object.assign({}, bidderRequest, {
       method: 'GET',
-      url: `${HOST}/api/v1/bid`,
+      url: `${HOST}/api/v2/bid`,
       data: `json=${encodedParams}`,
       currency: currency
     });
   },
   interpretResponse: function(response, bidRequest) {
-    let adUnits = response.body;
-    let bids = {};
-    utils._each(bidRequest.bids, bid => bids[bid.params.placementId] = bid);
+    let bids = response.body;
     const bidResponses = [];
-    for (let adUnitId in adUnits) {
-      let adUnit = adUnits[adUnitId];
+    for (let bidId in bids) {
+      let adUnit = bids[bidId];
       bidResponses.push({
-        requestId: bids[adUnitId].bidId,
+        requestId: bidId,
         cpm: Number(adUnit.cpm),
         width: adUnit.width,
         height: adUnit.height,
         ad: adUnit.adm,
         ttl: 300,
-        creativeId: adUnitId,
+        creativeId: adUnit.id,
         netRevenue: true,
         currency: bidRequest.currency
       });

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -50,13 +50,19 @@ describe('kargo adapter tests', function () {
           params: {
             placementId: 'foo'
           },
-          placementCode: 1
+          bidId: 1
         },
         {
           params: {
             placementId: 'bar'
           },
-          placementCode: 2
+          bidId: 2
+        },
+        {
+          params: {
+            placementId: 'bar'
+          },
+          bidId: 3
         }
       ];
     });
@@ -173,10 +179,11 @@ describe('kargo adapter tests', function () {
           floor: 0,
           ceil: 20
         },
-        adSlotIDs: [
-          'foo',
-          'bar'
-        ],
+        bidIDs: {
+          1: 'foo',
+          2: 'bar',
+          3: 'bar'
+        },
         userIDs: {
           kargoID: '5f108831-302d-11e7-bf6b-4595acd3bf6c',
           clientID: '2410d8f2-c111-4811-88a5-7b5e190e475f',
@@ -235,7 +242,7 @@ describe('kargo adapter tests', function () {
       var request = spec.buildRequests(bids, {timeout: 200, foo: 'bar'});
       var krakenParams = JSON.parse(decodeURIComponent(request.data.slice(5)));
       expect(request.data.slice(0, 5)).to.equal('json=');
-      expect(request.url).to.equal('https://krk.kargo.com/api/v1/bid');
+      expect(request.url).to.equal('https://krk.kargo.com/api/v2/bid');
       expect(request.method).to.equal('GET');
       expect(request.currency).to.equal('USD');
       expect(request.timeout).to.equal(200);
@@ -306,13 +313,22 @@ describe('kargo adapter tests', function () {
   describe('response handler', function() {
     it('handles bid responses', function() {
       var resp = spec.interpretResponse({body: {
-        foo: {
+        1: {
+          id: 'foo',
           cpm: 3,
           adm: '<div id="1"></div>',
           width: 320,
           height: 50
         },
-        bar: {
+        2: {
+          id: 'bar',
+          cpm: 2.5,
+          adm: '<div id="2"></div>',
+          width: 300,
+          height: 250
+        },
+        3: {
+          id: 'bar',
           cpm: 2.5,
           adm: '<div id="2"></div>',
           width: 300,
@@ -321,19 +337,24 @@ describe('kargo adapter tests', function () {
       }}, {
         currency: 'USD',
         bids: [{
-          bidId: 'fake bid id 1',
+          bidId: 1,
           params: {
             placementId: 'foo'
           }
         }, {
-          bidId: 'fake bid id 2',
+          bidId: 2,
+          params: {
+            placementId: 'bar'
+          }
+        }, {
+          bidId: 3,
           params: {
             placementId: 'bar'
           }
         }]
       });
       var expectation = [{
-        requestId: 'fake bid id 1',
+        requestId: '1',
         cpm: 3,
         width: 320,
         height: 50,
@@ -343,7 +364,17 @@ describe('kargo adapter tests', function () {
         netRevenue: true,
         currency: 'USD'
       }, {
-        requestId: 'fake bid id 2',
+        requestId: '2',
+        cpm: 2.5,
+        width: 300,
+        height: 250,
+        ad: '<div id="2"></div>',
+        ttl: 300,
+        creativeId: 'bar',
+        netRevenue: true,
+        currency: 'USD'
+      }, {
+        requestId: '3',
         cpm: 2.5,
         width: 300,
         height: 250,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This updates the adapter to point to a new bid endpoint. The endpoint is versioned so that the old endpoint and payload will still work. The new endpoint accepts placements mapped by prebid bid IDs. This allows multiples of the same placement per request/response.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
This is a fix for the adapter regarding #2873