### PR TITLE
fix tests running in headless chrome inside a docker environment

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -99,7 +99,7 @@ function setBrowsers(karmaConf, browserstack) {
         base: 'ChromeHeadless',
         // We must disable the Chrome sandbox when running Chrome inside Docker (Chrome's sandbox needs
         // more permissions than Docker allows by default)
-        flags: isDocker ? ['--no-sandbox'] : []
+        flags: ['--no-sandbox']
       }
       karmaConf.browsers = ['ChromeCustom'];
     } else {

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -92,7 +92,19 @@ function setBrowsers(karmaConf, browserstack) {
     karmaConf.customLaunchers = require('./browsers.json')
     karmaConf.browsers = Object.keys(karmaConf.customLaunchers);
   } else {
-    karmaConf.browsers = ['ChromeHeadless'];
+    var isDocker = require('is-docker')();
+    if (isDocker) {
+      karmaConf.customLaunchers = karmaConf.customLaunchers || {};
+      karmaConf.customLaunchers.ChromeCustom = {
+        base: 'ChromeHeadless',
+        // We must disable the Chrome sandbox when running Chrome inside Docker (Chrome's sandbox needs
+        // more permissions than Docker allows by default)
+        flags: isDocker ? ['--no-sandbox'] : []
+      }
+      karmaConf.browsers = ['ChromeCustom'];
+    } else {
+      karmaConf.browsers = ['ChromeHeadless'];
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
     "gulp-sourcemaps": "^2.6.0",
+    "is-docker": "^1.1.0",
     "just-clone": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.0",
     "ignore-loader": "^0.1.2",
+    "is-docker": "^1.1.0",
     "istanbul": "^0.4.5",
     "istanbul-instrumenter-loader": "^3.0.0",
     "json-loader": "^0.5.1",
@@ -105,7 +106,6 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
     "gulp-sourcemaps": "^2.6.0",
-    "is-docker": "^1.1.0",
     "just-clone": "^1.0.2"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
#### Background
karma tests were failing when trying to run tests inside a docker container environment because headless chrome was running without the  `--no-sandbox` flag. 
#### Fix
add a custom Chrome launcher configuration in` karma.conf.maker.js` if tests run in a docker environment 
