### PR TITLE
Add a Prebid label to console logs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,13 +14,11 @@ var tNumb = 'Number';
 var tObject = 'Object';
 var tBoolean = 'Boolean';
 var toString = Object.prototype.toString;
-let infoLogger = null;
-let warnLogger = null;
-try {
-  infoLogger = console.info.bind(window.console);
-  warnLogger = console.warn.bind(window.console);
-} catch (e) {
-}
+let consoleExists = Boolean(window.console);
+let consoleLogExists = Boolean(consoleExists && window.console.log);
+let consoleInfoExists = Boolean(consoleExists && window.console.info);
+let consoleWarnExists = Boolean(consoleExists && window.console.warn);
+let consoleErrorExists = Boolean(consoleExists && window.console.error);
 
 /*
  *   Substitutes into a string from a given map using the token
@@ -260,42 +258,43 @@ exports.getTopWindowReferrer = function() {
   }
 };
 
-exports.logWarn = function (msg, args) {
-  if (debugTurnedOn() && console.warn) {
-    if (warnLogger) {
-      if (!args || args.length === 0) {
-        args = '';
-      }
-
-      warnLogger('WARNING: ' + msg + ((args === '') ? '' : ' : params : '), args);
-    }
+/**
+ * Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
+ */
+exports.logMessage = function () {
+  if (debugTurnedOn() && consoleLogExists) {
+    console.log.apply(console, decorateLog(arguments, 'MESSAGE:'));
   }
 };
 
-exports.logInfo = function (msg, args) {
-  if (debugTurnedOn() && hasConsoleLogger()) {
-    if (infoLogger) {
-      if (!args || args.length === 0) {
-        args = '';
-      }
-
-      infoLogger('INFO: ' + msg + ((args === '') ? '' : ' : params : '), args);
-    }
+exports.logInfo = function () {
+  if (debugTurnedOn() && consoleInfoExists) {
+    console.info.apply(console, decorateLog(arguments, 'INFO:'));
   }
 };
 
-exports.logMessage = function (msg) {
-  if (debugTurnedOn() && hasConsoleLogger()) {
-    console.log('MESSAGE: ' + msg);
+exports.logWarn = function () {
+  if (debugTurnedOn() && consoleWarnExists) {
+    console.warn.apply(console, decorateLog(arguments, 'WARNING:'));
   }
 };
 
-function hasConsoleLogger() {
-  return (window.console && window.console.log);
+exports.logError = function () {
+  if (debugTurnedOn() && consoleErrorExists) {
+    console.error.apply(console, decorateLog(arguments, 'ERROR:'));
+  }
+};
+
+function decorateLog(args, prefix) {
+  args = [].slice.call(args);
+  prefix && args.unshift(prefix);
+  args.unshift('display: inline-block; color: #fff; background: #3b88c3; padding: 1px 4px; border-radius: 3px;');
+  args.unshift('%cPrebid');
+  return args;
 }
 
-function hasConsoleError() {
-  return (window.console && window.console.error);
+function hasConsoleLogger() {
+  return consoleLogExists;
 }
 
 exports.hasConsoleLogger = hasConsoleLogger;
@@ -311,15 +310,6 @@ var debugTurnedOn = function () {
 };
 
 exports.debugTurnedOn = debugTurnedOn;
-
-/**
- * Wrapper to console.error. Takes N arguments to log the same as console.error.
- */
-exports.logError = function () {
-  if (debugTurnedOn() && hasConsoleError()) {
-    console.error.apply(console, arguments);
-  }
-};
 
 exports.createInvisibleIframe = function _createInvisibleIframe() {
   var f = document.createElement('iframe');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Prefix prebid console logs with a label. Easier to single out prebid logs at a glance, and makes it simple to filter down to just prebid logs.
**notes**:
\- I removed the current param count limitations for a few of the methods (logMessage, logInfo, logWarn), so they can behave like the native methods
\- because of this, I removed current formatting that injects the text ` : params : ` between the current params 1(`msg`) and 2(`args `) output
\- label color is Prebid blue `#3b88c3`, taken from prebid.org

## Other information
![prebid_console_log_label](https://user-images.githubusercontent.com/372590/44000332-6c68d63e-9de3-11e8-9c3e-7c1d5ee15402.gif)
