### PR TITLE
Added render param in Sonobi adapter

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -66,6 +66,9 @@ export const spec = {
     if (validBidRequests[0].params.referrer) {
       payload.ref = validBidRequests[0].params.referrer;
     }
+    if (validBidRequests[0].params.render) {
+      payload.render = validBidRequests[0].params.render;
+    }
 
     // Apply GDPR parameters to request.
     if (bidderRequest && bidderRequest.gdprConsent) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -207,6 +207,11 @@ describe('SonobiBidAdapter', () => {
       expect(bidRequests.data.s).not.to.be.empty
       expect(bidRequests.data.hfa).to.equal('hfakey')
     })
+    it('should return a properly formatted request with render', () => {
+      bidRequest[0].params.render = 'safeframe'
+      const bidRequests = spec.buildRequests(bidRequest)
+      expect(bidRequests.data.render).to.equal('safeframe')
+    })
 
     it('should return null if there is nothing to bid on', () => {
       const bidRequests = spec.buildRequests([{params: {}}])


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Having Sonobi in a Safeframe requires sending the 'render=safeframe' parameter to Sonobi. This makes sure it can happen.

- contact email of the adapter’s maintainer: apex.prebid@sonobi.com
- [ ] official adapter submission
