### PR TITLE
Appnexus adaptor - Added App parameters for hybrid apps.

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -62,25 +62,19 @@ export const spec = {
 
     const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
     let appDeviceObj;
-    if (appDeviceObjBid && !!appDeviceObjBid.params) {
-      if (!!appDeviceObjBid.params.app) {
-        appDeviceObj = {};
-        Object.keys(appDeviceObjBid.params.app)
-          .filter(param => includes(APP_DEVICE_PARAMS, param))
-          .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
-      }
+    if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
+      appDeviceObj = {};
+      Object.keys(appDeviceObjBid.params.app)
+        .filter(param => includes(APP_DEVICE_PARAMS, param))
+        .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
     const appIdObjBid = find(bidRequests, hasAppId);
     let appIdObj;
-    if (appIdObjBid && !!appIdObjBid.params) {
-      if (!!appDeviceObjBid.params.app) {
-        if (!!appDeviceObjBid.params.app.id) {
-          appIdObj = {
-            appid: appIdObjBid.params.app.id
-          };
-        }
-      }
+    if (appIdObjBid && appIdObjBid.params && appDeviceObjBid.params.app && appDeviceObjBid.params.app.id) {
+      appIdObj = {
+        appid: appIdObjBid.params.app.id
+      };
     }
 
     const memberIdBid = find(bidRequests, hasMemberId);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -62,19 +62,25 @@ export const spec = {
 
     const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
     let appDeviceObj;
-    if (appDeviceObjBid) {
-      appDeviceObj = {};
-      Object.keys(appDeviceObjBid.params.app)
-        .filter(param => includes(APP_DEVICE_PARAMS, param))
-        .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
+    if (appDeviceObjBid && !!appDeviceObjBid.params) {
+      if (!!appDeviceObjBid.params.app) {
+        appDeviceObj = {};
+        Object.keys(appDeviceObjBid.params.app)
+          .filter(param => includes(APP_DEVICE_PARAMS, param))
+          .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
+      }
     }
 
     const appIdObjBid = find(bidRequests, hasAppId);
     let appIdObj;
-    if (appIdObjBid) {
-      appIdObj = {
-        appid: appIdObjBid.params.app.id
-      };
+    if (appIdObjBid && !!appIdObjBid.params) {
+      if (!!appDeviceObjBid.params.app) {
+        if (!!appDeviceObjBid.params.app.id) {
+          appIdObj = {
+            appid: appIdObjBid.params.app.id
+          };
+        }
+      }
     }
 
     const memberIdBid = find(bidRequests, hasMemberId);
@@ -407,7 +413,9 @@ function hasMemberId(bid) {
 }
 
 function hasAppDeviceInfo(bid) {
-  return !!bid.params.app
+  if (!!bid.params) {
+    return !!bid.params.app
+  }
 }
 
 function hasAppId(bid) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -11,7 +11,6 @@ const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id'];  // appid is collected separately
-const AST_DEBUG = ['ast_debug', 'ast_dongle', 'ast_debug_member', 'ast_debug_timeout']
 const NATIVE_MAPPING = {
   body: 'description',
   cta: 'ctatext',
@@ -78,26 +77,6 @@ export const spec = {
       };
     }
 
-    const debugObjParams = getURLparams();
-    let debugObj = {};
-    if (hasParams(debugObjParams)) {
-      Object.keys(debugObjParams)
-        .filter(param => includes(AST_DEBUG, param))
-        .forEach(param => {
-          debugObj['enabled'] = true;
-          if (param == 'ast_dongle'){
-            debugObj['dongle'] = debugObjParams[param];
-          }
-          if (param == 'ast_debug_member'){
-            debugObj['member_id'] = parseInt(debugObjParams[param]);
-          }
-          if (param == 'ast_debug_timeout'){
-            debugObj['debug_timeout'] = parseInt(debugObjParams[param]);
-          }
-        }
-      );
-    }
-
     const memberIdBid = find(bidRequests, hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
 
@@ -118,10 +97,6 @@ export const spec = {
     }
     if (appIdObjBid) {
       payload.app = appIdObj;
-    }
-
-    if (hasParams(debugObj)) {
-      payload.debug = debugObj
     }
 
     if (bidderRequest && bidderRequest.gdprConsent) {
@@ -440,25 +415,6 @@ function hasAppId(bid) {
     return !!bid.params.app.id
   }
   return !!bid.params.app
-}
-
-function hasParams(obj) {
-  if (Object.keys(obj).length > 0){
-    return true
-  }
-  return false
-}
-
-function getURLparams() {
-  let obj = {};
-  if (window.location.search.length > 0){
-    window.location.search.substr(1).split('&').forEach(keyvalue => {
-      let key = keyvalue.split('=')[0];
-      let val = keyvalue.split('=')[1];
-      obj[key] = val
-    });
-  }
-  return obj
 }
 
 function getRtbBid(tag) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -10,7 +10,7 @@ const URL = '//ib.adnxs.com/ut/v3/prebid';
 const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
-const APP_DEVICE_PARAMS = ['geo', 'device_id'];  // appid is collected separately
+const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
 const NATIVE_MAPPING = {
   body: 'description',
   cta: 'ctatext',
@@ -407,13 +407,13 @@ function hasMemberId(bid) {
 }
 
 function hasAppDeviceInfo(bid) {
-  if (!!bid.params) {
+  if (bid.params) {
     return !!bid.params.app
   }
 }
 
 function hasAppId(bid) {
-  if (!!bid.params.app) {
+  if (bid.params && bid.params.app) {
     return !!bid.params.app.id
   }
   return !!bid.params.app

--- a/modules/appnexusBidAdapter.md
+++ b/modules/appnexusBidAdapter.md
@@ -17,9 +17,13 @@ Appnexus bid adapter supports Banner, Video (instream and outstream) and Native.
 var adUnits = [
    // Banner adUnit
    {
-       code: 'banner-div',
-       sizes: [[300, 250], [300,600]],
-       bids: [{
+      code: 'banner-div',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300,600]]
+        }
+      }
+      bids: [{
          bidder: 'appnexus',
          params: {
            placementId: '10433394'
@@ -98,6 +102,37 @@ var adUnits = [
          }
        }
      ]
+   },
+   // Banner adUnit in a App Webview
+   // Only use this for situations where prebid.js is in a webview of an App
+   // See Prebid Mobile for displaying ads via an SDK
+   {
+     code: 'banner-div',
+     mediaTypes: {
+       banner: {
+         sizes: [[300, 250], [300,600]]
+       }
+     }
+     bids: [{
+       bidder: 'appnexus',
+       params: {
+         placementId: '10433394',
+         app: {
+           id: "B1O2W3M4AN.com.prebid.webview",
+           geo: {
+             lat: 40.0964439,
+             lng: -75.3009142
+           },
+           device_id: {
+             idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE", // Apple advertising identifier
+             aaid: "38400000-8cf0-11bd-b23e-10b96e40000d", // Android advertising identifier
+             md5udid: "5756ae9022b2ea1e47d84fead75220c8", // MD5 hash of the ANDROID_ID
+             sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF", // SHA1 hash of the ANDROID_ID
+             windowsadid: "750c6be243f1c4b5c9912b95a5742fc5" // Windows advertising identifier
+           }
+         }
+       }
+     }]
    }
 ];
 ```

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -356,16 +356,16 @@ describe('AppNexusAdapter', () => {
       expect(payload.app).to.deep.equal({
         appid: "B1O2W3M4AN.com.prebid.webview"
       });
-      expect(payload.app.device_id).to.exist;
-      expect(payload.app.device_id).to.deep.equal({
+      expect(payload.device.device_id).to.exist;
+      expect(payload.device.device_id).to.deep.equal({
         aaid: "38400000-8cf0-11bd-b23e-10b96e40000d",
         idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE",
         md5udid: "5756ae9022b2ea1e47d84fead75220c8",
         sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF",
         windowsadid: "750c6be243f1c4b5c9912b95a5742fc5"
       });
-      expect(payload.app.geo).to.exist;
-      expect(payload.app.geo).to.deep.equal({
+      expect(payload.device.geo).to.exist;
+      expect(payload.device.geo).to.deep.equal({
         lat: 40.0964439,
         lng: -75.3009142
       });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -334,17 +334,17 @@ describe('AppNexusAdapter', () => {
           params: {
             placementId: '10433394',
             app: {
-              id: "B1O2W3M4AN.com.prebid.webview",
+              id: 'B1O2W3M4AN.com.prebid.webview',
               geo: {
                 lat: 40.0964439,
                 lng: -75.3009142
               },
               device_id: {
-                idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE", // Apple advertising identifier
-                aaid: "38400000-8cf0-11bd-b23e-10b96e40000d", // Android advertising identifier
-                md5udid: "5756ae9022b2ea1e47d84fead75220c8", // MD5 hash of the ANDROID_ID
-                sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF", // SHA1 hash of the ANDROID_ID
-                windowsadid: "750c6be243f1c4b5c9912b95a5742fc5" // Windows advertising identifier
+                idfa: '4D12078D-3246-4DA4-AD5E-7610481E7AE', // Apple advertising identifier
+                aaid: '38400000-8cf0-11bd-b23e-10b96e40000d', // Android advertising identifier
+                md5udid: '5756ae9022b2ea1e47d84fead75220c8', // MD5 hash of the ANDROID_ID
+                sha1udid: '4DFAA92388699AC6539885AEF1719293879985BF', // SHA1 hash of the ANDROID_ID
+                windowsadid: '750c6be243f1c4b5c9912b95a5742fc5' // Windows advertising identifier
               }
             }
           }
@@ -354,15 +354,15 @@ describe('AppNexusAdapter', () => {
       const payload = JSON.parse(request.data);
       expect(payload.app).to.exist;
       expect(payload.app).to.deep.equal({
-        appid: "B1O2W3M4AN.com.prebid.webview"
+        appid: 'B1O2W3M4AN.com.prebid.webview'
       });
       expect(payload.device.device_id).to.exist;
       expect(payload.device.device_id).to.deep.equal({
-        aaid: "38400000-8cf0-11bd-b23e-10b96e40000d",
-        idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE",
-        md5udid: "5756ae9022b2ea1e47d84fead75220c8",
-        sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF",
-        windowsadid: "750c6be243f1c4b5c9912b95a5742fc5"
+        aaid: '38400000-8cf0-11bd-b23e-10b96e40000d',
+        idfa: '4D12078D-3246-4DA4-AD5E-7610481E7AE',
+        md5udid: '5756ae9022b2ea1e47d84fead75220c8',
+        sha1udid: '4DFAA92388699AC6539885AEF1719293879985BF',
+        windowsadid: '750c6be243f1c4b5c9912b95a5742fc5'
       });
       expect(payload.device.geo).to.exist;
       expect(payload.device.geo).to.deep.equal({

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -326,6 +326,50 @@ describe('AppNexusAdapter', () => {
       expect(payload.gdpr_consent.consent_string).to.exist.and.to.equal(consentString);
       expect(payload.gdpr_consent.consent_required).to.exist.and.to.be.true;
     });
+
+    it('supports sending hybrid mobile app parameters', () => {
+      let appRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394',
+            app: {
+              id: "B1O2W3M4AN.com.prebid.webview",
+              geo: {
+                lat: 40.0964439,
+                lng: -75.3009142
+              },
+              device_id: {
+                idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE", // Apple advertising identifier
+                aaid: "38400000-8cf0-11bd-b23e-10b96e40000d", // Android advertising identifier
+                md5udid: "5756ae9022b2ea1e47d84fead75220c8", // MD5 hash of the ANDROID_ID
+                sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF", // SHA1 hash of the ANDROID_ID
+                windowsadid: "750c6be243f1c4b5c9912b95a5742fc5" // Windows advertising identifier
+              }
+            }
+          }
+        }
+      );
+      const request = spec.buildRequests([appRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.app).to.exist;
+      expect(payload.app).to.deep.equal({
+        appid: "B1O2W3M4AN.com.prebid.webview"
+      });
+      expect(payload.app.device_id).to.exist;
+      expect(payload.app.device_id).to.deep.equal({
+        aaid: "38400000-8cf0-11bd-b23e-10b96e40000d",
+        idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE",
+        md5udid: "5756ae9022b2ea1e47d84fead75220c8",
+        sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF",
+        windowsadid: "750c6be243f1c4b5c9912b95a5742fc5"
+      });
+      expect(payload.app.geo).to.exist;
+      expect(payload.app.geo).to.deep.equal({
+        lat: 40.0964439,
+        lng: -75.3009142
+      });
+    });
   })
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added App parameters for hybrid apps. This allows developers running Prebid in a webview with prebid to pass the app related parameters. (Note that this is not the same as Prebid Mobile)

- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  placementId: '10433394',
  app: {
    id: "B1O2W3M4AN.com.prebid.webview",
    geo: {
      lat: 40.0964439,
      lng: -75.3009142
    },
    device_id: {
      idfa: "4D12078D-3246-4DA4-AD5E-7610481E7AE", // Apple advertising identifier
      aaid: "38400000-8cf0-11bd-b23e-10b96e40000d", // Android advertising identifier
      md5udid: "5756ae9022b2ea1e47d84fead75220c8", // MD5 hash of the ANDROID_ID
      sha1udid: "4DFAA92388699AC6539885AEF1719293879985BF", // SHA1 hash of the ANDROID_ID
      windowsadid: "750c6be243f1c4b5c9912b95a5742fc5" // Windows advertising identifier
    }
  }
}
```
