### PR TITLE
AdForm Adapter - setting alias code in received bids

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -15,6 +15,7 @@ export const spec = {
     var request = [];
     var globalParams = [ [ 'adxDomain', 'adx.adform.net' ], [ 'fd', 1 ], [ 'url', null ], [ 'tid', null ] ];
     var bids = JSON.parse(JSON.stringify(validBidRequests));
+    var bidder = (bids[0] && bids[0].bidder) || BIDDER_CODE
     for (i = 0, l = bids.length; i < l; i++) {
       bid = bids[i];
       if ((bid.params.priceType === 'net') || (bid.params.pt === 'net')) {
@@ -60,7 +61,7 @@ export const spec = {
       url: request.join('&'),
       bids: validBidRequests,
       netRevenue: netRevenue,
-      bidder: 'adform',
+      bidder,
       gdpr: gdprObject
     };
 


### PR DESCRIPTION
## Type of change
- [ ] Bugfix

## Description of change
When setting alias of AdForm adapter, requested bid has proper bidderCode of given alias, which is correct. However, returning bids are still named as source adapter, because of hardcoded string constant 'adform'. This change allows setting proper alias name into returning bids which is important i.e. for DFP statistics.