### PR TITLE
Audience Network (legacy): correct TTL, allow platform override

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -2,7 +2,6 @@
  * @file AudienceNetwork adapter.
  */
 import { registerBidder } from 'src/adapters/bidderFactory';
-import { config } from 'src/config';
 import { formatQS } from 'src/url';
 import { getTopWindowUrl } from 'src/utils';
 import includes from 'core-js/library/fn/array/includes';
@@ -14,9 +13,11 @@ const url = 'https://an.facebook.com/v2/placementbid.json';
 const supportedMediaTypes = ['video'];
 const netRevenue = true;
 const hb_bidder = 'fan';
+const ttl = 600;
+const videoTtl = 3600;
 const platver = '$prebid.version$';
 const platform = '241394079772386';
-const adapterver = '0.1.0';
+const adapterver = '0.1.1';
 
 /**
  * Does this bid request contain valid parameters?
@@ -93,6 +94,13 @@ const isFullWidth = format => format === 'fullwidth';
 const sdkVersion = format => isVideo(format) ? '' : '5.5.web';
 
 /**
+ * Which platform identifier should be used?
+ * @param {Array<String>} platforms Possible platform identifiers
+ * @returns {String} First valid platform found, or default if none found
+ */
+const findPlatform = platforms => [...platforms.filter(Boolean), platform][0];
+
+/**
  * Does the search part of the URL contain "anhb_testmode"
  * and therefore indicate testmode should be used?
  * @returns {String} "true" or "false"
@@ -132,6 +140,7 @@ const getTopWindowUrlEncoded = () => encodeURIComponent(getTopWindowUrl());
  * @param {String} bids[].placementCode - Prebid placement identifier
  * @param {Object} bids[].params
  * @param {String} bids[].params.placementId - Audience Network placement identifier
+ * @param {String} bids[].params.platform - Audience Network platform identifier (optional)
  * @param {String} bids[].params.format - Optional format, one of 'video', 'native' or 'fullwidth' if set
  * @param {Array} bids[].sizes - list of desired advert sizes
  * @param {Array} bids[].sizes[] - Size arrays [h,w]: should include one of [300, 250], [320, 50]: first matched size is used
@@ -143,6 +152,7 @@ const buildRequests = bids => {
   const adformats = [];
   const sizes = [];
   const sdk = [];
+  const platforms = [];
   const requestIds = [];
 
   bids.forEach(bid => bid.sizes
@@ -154,6 +164,7 @@ const buildRequests = bids => {
       adformats.push(bid.params.format || size);
       sizes.push(size);
       sdk.push(sdkVersion(bid.params.format));
+      platforms.push(bid.params.platform);
       requestIds.push(bid.bidId);
     })
   );
@@ -161,6 +172,7 @@ const buildRequests = bids => {
   // Build URL
   const testmode = isTestmode();
   const pageurl = getTopWindowUrlEncoded();
+  const platform = findPlatform(platforms);
   const search = {
     placementids,
     adformats,
@@ -190,8 +202,6 @@ const buildRequests = bids => {
  * @returns {Array<Object>} A list of bid response objects
  */
 const interpretResponse = ({ body }, { adformats, requestIds, sizes }) => {
-  const ttl = Number(config.getConfig().bidderTimeout);
-
   return body.errors && body.errors.length
     ? []
     : Object.keys(body.bids)
@@ -234,6 +244,7 @@ const interpretResponse = ({ body }, { adformats, requestIds, sizes }) => {
           const pageurl = getTopWindowUrlEncoded();
           bidResponse.mediaType = 'video';
           bidResponse.vastUrl = `https://an.facebook.com/v1/instream/vast.xml?placementid=${creativeId}&pageurl=${pageurl}&playerwidth=${width}&playerheight=${height}&bidid=${fb_bidid}`;
+          bidResponse.ttl = videoTtl;
         }
         return bidResponse;
       });

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -18,7 +18,7 @@ const placementId = 'test-placement-id';
 const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
-const debug = 'adapterver=0.1.0&platform=241394079772386&platver=$prebid.version$';
+const debug = 'adapterver=0.1.1&platform=241394079772386&platver=$prebid.version$';
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
@@ -117,19 +117,22 @@ describe('AudienceNetwork adapter', () => {
   });
 
   describe('buildRequests', () => {
-    it('can build URL for IAB unit', () => {
+    it('can build URL for IAB unit, overriding platform', () => {
+      const platform = 'test-platform';
+      const debugPlatform = debug.replace('241394079772386', platform);
+
       expect(buildRequests([{
         bidder,
         bidId: requestId,
         sizes: [[300, 250], [320, 50]],
-        params: { placementId }
+        params: { placementId, platform }
       }])).to.deep.equal([{
         adformats: ['300x250'],
         method: 'GET',
         requestIds: [requestId],
         sizes: ['300x250'],
         url: 'https://an.facebook.com/v2/placementbid.json',
-        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web&${debug}`
+        data: `placementids[]=test-placement-id&adformats[]=300x250&testmode=false&pageurl=&sdk[]=5.5.web&${debugPlatform}`
       }]);
     });
 
@@ -190,6 +193,7 @@ describe('AudienceNetwork adapter', () => {
         .to.contain(`placementid:'${placementId}',format:'native',bidid:'test-bid-id'`, 'ad missing parameters')
         .and.to.contain('getElementsByTagName("style")', 'ad missing native styles')
         .and.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad missing native container');
+      expect(bidResponse.ttl).to.equal(600);
       expect(bidResponse.creativeId).to.equal(placementId);
       expect(bidResponse.netRevenue).to.equal(true);
       expect(bidResponse.currency).to.equal('USD');
@@ -228,6 +232,7 @@ describe('AudienceNetwork adapter', () => {
         .to.contain(`placementid:'${placementId}',format:'300x250',bidid:'test-bid-id'`, 'ad missing parameters')
         .and.not.to.contain('getElementsByTagName("style")', 'ad should not contain native styles')
         .and.not.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad should not contain native container');
+      expect(bidResponse.ttl).to.equal(600);
       expect(bidResponse.creativeId).to.equal(placementId);
       expect(bidResponse.netRevenue).to.equal(true);
       expect(bidResponse.currency).to.equal('USD');
@@ -262,6 +267,7 @@ describe('AudienceNetwork adapter', () => {
       expect(bidResponse.width).to.equal(300);
       expect(bidResponse.height).to.equal(250);
       expect(bidResponse.creativeId).to.equal(placementId);
+      expect(bidResponse.ttl).to.equal(600);
       expect(bidResponse.netRevenue).to.equal(true);
       expect(bidResponse.currency).to.equal('USD');
       expect(bidResponse.hb_bidder).to.equal('fan');
@@ -305,6 +311,7 @@ describe('AudienceNetwork adapter', () => {
       expect(bidResponseNative.width).to.equal(300);
       expect(bidResponseNative.height).to.equal(250);
       expect(bidResponseNative.ad).to.contain(`placementid:'${placementIdNative}',format:'native',bidid:'test-bid-id-native'`, 'ad missing parameters');
+      expect(bidResponseNative.ttl).to.equal(600);
       expect(bidResponseNative.creativeId).to.equal(placementIdNative);
       expect(bidResponseNative.netRevenue).to.equal(true);
       expect(bidResponseNative.currency).to.equal('USD');
@@ -318,6 +325,7 @@ describe('AudienceNetwork adapter', () => {
       expect(bidResponseIab.width).to.equal(300);
       expect(bidResponseIab.height).to.equal(250);
       expect(bidResponseIab.ad).to.contain(`placementid:'${placementIdIab}',format:'300x250',bidid:'test-bid-id-iab'`, 'ad missing parameters');
+      expect(bidResponseIab.ttl).to.equal(600);
       expect(bidResponseIab.creativeId).to.equal(placementIdIab);
       expect(bidResponseIab.netRevenue).to.equal(true);
       expect(bidResponseIab.currency).to.equal('USD');
@@ -351,6 +359,7 @@ describe('AudienceNetwork adapter', () => {
 
       expect(bidResponse.cpm).to.equal(1.23);
       expect(bidResponse.requestId).to.equal(requestId);
+      expect(bidResponse.ttl).to.equal(3600);
       expect(bidResponse.mediaType).to.equal('video');
       expect(bidResponse.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${placementId}&pageurl=&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${bidId}`);
       expect(bidResponse.width).to.equal(playerwidth);
@@ -391,6 +400,7 @@ describe('AudienceNetwork adapter', () => {
 
       expect(bidResponseVideo.cpm).to.equal(1.23);
       expect(bidResponseVideo.requestId).to.equal(requestId);
+      expect(bidResponseVideo.ttl).to.equal(3600);
       expect(bidResponseVideo.mediaType).to.equal('video');
       expect(bidResponseVideo.vastUrl).to.equal(`https://an.facebook.com/v1/instream/vast.xml?placementid=${videoPlacementId}&pageurl=&playerwidth=${playerwidth}&playerheight=${playerheight}&bidid=${videoBidId}`);
       expect(bidResponseVideo.width).to.equal(playerwidth);
@@ -398,6 +408,7 @@ describe('AudienceNetwork adapter', () => {
 
       expect(bidResponseNative.cpm).to.equal(4.56);
       expect(bidResponseNative.requestId).to.equal(requestId);
+      expect(bidResponseNative.ttl).to.equal(600);
       expect(bidResponseNative.width).to.equal(300);
       expect(bidResponseNative.height).to.equal(250);
       expect(bidResponseNative.ad).to.contain(`placementid:'${nativePlacementId}',format:'native',bidid:'${nativeBidId}'`);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR is the same logic change as #2974 but targeted at the legacy 0.x branch.

It fixes the TTL problem reported in #2885. Also included is a small addition to allow the Audience Network specific platform to be overridden, which was missing from #2657.

Unit tests are updated to cover all the code changes, plus an internal version bump of the adapterver to aid debugging.

This work was commissioned and paid for by Facebook.