### PR TITLE
changing rubicon endpoint to openrtb2 endpoint

### DIFF
--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -12,7 +12,7 @@ export const S2S_VENDORS = {
     adapter: 'prebidServer',
     cookieSet: false,
     enabled: true,
-    endpoint: '//prebid-server.rubiconproject.com/auction',
+    endpoint: '//prebid-server.rubiconproject.com/openrtb2/auction',
     syncEndpoint: '//prebid-server.rubiconproject.com/cookie_sync',
     timeout: 500
   }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1092,7 +1092,7 @@ describe('S2S Adapter', () => {
       expect(vendorConfig.cookieSet).to.be.false;
       expect(vendorConfig.cookieSetUrl).to.be.undefined;
       expect(vendorConfig.enabled).to.be.true;
-      expect(vendorConfig).to.have.property('endpoint', '//prebid-server.rubiconproject.com/auction');
+      expect(vendorConfig).to.have.property('endpoint', '//prebid-server.rubiconproject.com/openrtb2/auction');
       expect(vendorConfig).to.have.property('syncEndpoint', '//prebid-server.rubiconproject.com/cookie_sync');
       expect(vendorConfig).to.have.property('timeout', 750);
     });


### PR DESCRIPTION
## Type of change
- [ X ] Other

## Description of change
Updating the default Prebid Server endpoint for Rubicon to openrtb2
