### PR TITLE
moved assignment of `bid.getCpmInNewCurrency` function for currency

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -154,6 +154,14 @@ export function addBidResponseHook(adUnitCode, bid, fn) {
     bid.currency = 'USD';
   }
 
+  let fromCurrency = bid.currency;
+  let cpm = bid.cpm;
+
+  // used for analytics
+  bid.getCpmInNewCurrency = function(toCurrency) {
+    return (parseFloat(cpm) * getCurrencyConversion(fromCurrency, toCurrency)).toFixed(3);
+  };
+
   // execute immediately if the bid is already in the desired currency
   if (bid.currency === adServerCurrency) {
     return fn.apply(this, arguments);
@@ -178,16 +186,12 @@ function wrapFunction(fn, context, params) {
       let fromCurrency = bid.currency;
       try {
         let conversion = getCurrencyConversion(fromCurrency);
-        let cpm = bid.originalCpm = bid.cpm;
+        bid.originalCpm = bid.cpm;
         bid.originalCurrency = bid.currency;
         if (conversion !== 1) {
           bid.cpm = (parseFloat(bid.cpm) * conversion).toFixed(4);
           bid.currency = adServerCurrency;
         }
-        // used for analytics
-        bid.getCpmInNewCurrency = function(toCurrency) {
-          return (parseFloat(cpm) * getCurrencyConversion(fromCurrency, toCurrency)).toFixed(3);
-        };
       } catch (e) {
         utils.logWarn('Returning NO_BID, getCurrencyConversion threw error: ', e);
         params[1] = bidfactory.createBid(STATUS.NO_BID, {

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -62,7 +62,9 @@ describe('currency', function () {
       	innerBid = bid;
       });
 
-      expect(innerBid.currency).to.equal('GBP')
+      expect(innerBid.currency).to.equal('GBP');
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('GBP')).to.equal('1.000');
     });
 
     it('uses adapter currency over currency override if specified', () => {
@@ -82,7 +84,9 @@ describe('currency', function () {
       	innerBid = bid;
       });
 
-      expect(innerBid.currency).to.equal('JPY')
+      expect(innerBid.currency).to.equal('JPY');
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('1.000');
     });
 
     it('uses rates specified in json when provided', () => {
@@ -103,6 +107,8 @@ describe('currency', function () {
       });
 
       expect(innerBid.cpm).to.equal('1.0000');
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('100.000');
     });
 
     it('uses default rates when currency file fails to load', () => {
@@ -128,6 +134,8 @@ describe('currency', function () {
       });
 
       expect(innerBid.cpm).to.equal('1.0000');
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('100.000');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This makes sure that `bid.getCpmInNewCurrency` is always present if the currency module is active.  This allows analytics to get `cpm` values in any currency they require.  It was only attaching that helper function when a currency conversion was applied, now it is always present and available for use.
