### PR TITLE
Update secureCreatives.js (#3010)

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -44,7 +44,7 @@ function receiveMessage(ev) {
     //   message: 'Prebid Native',
     //   adId: '%%PATTERN:hb_adid%%'
     // }), '*');
-    if (data.message === 'Prebid Native') {
+    else if (data.message === 'Prebid Native') {
       fireNativeTrackers(data, adObject);
       auctionManager.addWinningBid(adObject);
       events.emit(BID_WON, adObject);


### PR DESCRIPTION
https://github.com/prebid/Prebid.js/issues/3010

## Type of change
- [x] Bugfix

## Description of change
I think inside the `if (data.message === 'Prebid Request')`-block data is being overwritten.
Resulting in data being null here `if (data.message === 'Prebid Native')`

