### PR TITLE
SOR-233 Sortable bid adapter handles extra information in server response

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -124,6 +124,9 @@ export const spec = {
           } else if (bid.nurl) {
             bidObj.adUrl = bid.nurl;
           }
+          if (bid.ext) {
+            bidObj[BIDDER_CODE] = bid.ext;
+          }
           sortableBids.push(bidObj);
         });
       });

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -255,5 +255,15 @@ describe('sortableBidAdapter', function() {
       let result = spec.interpretResponse(response);
       expect(result.length).to.equal(0);
     });
+
+    it('should keep custom properties', () => {
+      const customProperties = {test: 'a test message', param: {testParam: 1}};
+      const expectedResult = Object.assign({}, expectedBid, {[spec.code]: customProperties});
+      const response = makeResponse();
+      response.body.seatbid[0].bid[0].ext = customProperties;
+      const result = spec.interpretResponse(response);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(expectedResult);
+    });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Other

## Description of change
Sortable bid adapter allows users to access OpenRTB bidder-specific extension in server response.