### PR TITLE
AppNexus AST Debug Auction

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -173,17 +173,17 @@ export const spec = {
     }
 
     if (serverResponse.debug && serverResponse.debug.debug_info) {
-      let title = 'AppNexus Debug Auction for Prebid'
-      let debugHTML = '<html><head><title>' +title+ '</title></head><body><h2>' + title + '</h2>' + serverResponse.debug.debug_info + '<style>body {margin:40px;}</style></body></html>';
-      debugHTML = debugHTML.replace(/(.*)([^>])$/gm,"$1$2<br>").replace(/(\t)/gm, '<span style="margin-left:20px"></span>'); // Format newlines and tabs
-      let debugStream = debugHTML.split('\n');
-
-      utils.logMessage('AppNexus debug auction for prebid was opened in new tab');
-      let debugWindow = window.open();
-      for (var ln in debugStream){
-        debugWindow.document.write(debugStream[ln]);
-      }
-      setTimeout(function() { debugWindow.document.close() }, 1000); // Close the debugStream
+      let debugHeader = 'AppNexus Debug Auction for Prebid\n\n'
+      let debugText = debugHeader + serverResponse.debug.debug_info
+      debugText = debugText
+        .replace(/(?:<td>|<th>)*(<br>)(\n)/gm,'\n\t\t') // Table <br>
+        .replace(/(<td>|<th>)/gm,'\t') // Tables
+        .replace(/^<br>/gm,'') // Remove leading <br>
+        .replace(/(<br>\n|<br>)/gm,'\n') // <br>
+        .replace(/<h1>(.*)<\/h1>/gm,'\n\n===== $1 =====\n\n') // Header H1
+        .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm,'\n\n*** $1 ***\n\n') // Headers
+        .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
+      utils.logMessage(debugText);
     }
 
     return bids;

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -11,7 +11,8 @@ const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
-const AST_DEBUG = ['ast_debug', 'ast_dongle', 'ast_debug_member', 'ast_debug_timeout']
+const AST_DEBUG_URL = ['ast_debug', 'ast_dongle', 'ast_debug_member', 'ast_debug_timeout']
+const AST_DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout']
 const NATIVE_MAPPING = {
   body: 'description',
   cta: 'ctatext',
@@ -78,26 +79,36 @@ export const spec = {
       };
     }
 
-    const debugObjParams = getURLparams();
     let debugObj = {};
-    if (debugObjParams && debugObjParams.params) {
-      Object.keys(debugObjParams.params)
-        .filter(param => includes(AST_DEBUG, param))
+    const debugObjParams = find(bidRequests, hasDebug);
+    if (debugObjParams && debugObjParams.debug) {
+      Object.keys(debugObjParams.debug)
+        .filter(param => includes(AST_DEBUG_PARAMS, param))
         .forEach(param => {
-          debugObj['debug'] = debugObj['debug'] || {
-            'enabled': true
+          debugObj['debug'] = debugObj['debug'] || {};
+          debugObj.debug[param] = debugObjParams.debug[param]
+        });
+    }
+
+    const debugUrlParams = getURLparams();
+    if (debugUrlParams && debugUrlParams.params) {
+      Object.keys(debugUrlParams.params)
+        .filter(param => includes(AST_DEBUG_URL, param))
+        .forEach(param => {
+          debugObj['debug'] = debugObj['debug'] || {};
+          if (param == 'ast_debug') {
+            debugObj['debug']['enabled'] = (debugUrlParams.params[param] === 'true');
           }
-          if (param == 'ast_dongle'){
-            debugObj['debug']['dongle'] = debugObjParams.params[param];
+          if (param == 'ast_dongle') {
+            debugObj['debug']['dongle'] = debugUrlParams.params[param];
           }
-          if (param == 'ast_debug_member'){
-            debugObj['debug']['member_id'] = 958 ? parseInt(debugObjParams.params[param], 10) : 0;
+          if (param == 'ast_debug_member') {
+            debugObj['debug']['member_id'] = parseInt(debugUrlParams.params[param], 10);
           }
-          if (param == 'ast_debug_timeout'){
-            debugObj['debug']['debug_timeout'] = 3000 ? parseInt(debugObjParams.params[param], 10) : 0;
+          if (param == 'ast_debug_timeout') {
+            debugObj['debug']['debug_timeout'] = parseInt(debugUrlParams.params[param], 10);
           }
-        }
-      );
+        });
     }
 
     const memberIdBid = find(bidRequests, hasMemberId);
@@ -176,12 +187,12 @@ export const spec = {
       let debugHeader = 'AppNexus Debug Auction for Prebid\n\n'
       let debugText = debugHeader + serverResponse.debug.debug_info
       debugText = debugText
-        .replace(/(?:<td>|<th>)*(<br>)(\n)/gm,'\n\t\t') // Table <br>
-        .replace(/(<td>|<th>)/gm,'\t') // Tables
-        .replace(/^<br>/gm,'') // Remove leading <br>
-        .replace(/(<br>\n|<br>)/gm,'\n') // <br>
-        .replace(/<h1>(.*)<\/h1>/gm,'\n\n===== $1 =====\n\n') // Header H1
-        .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm,'\n\n*** $1 ***\n\n') // Headers
+        .replace(/(<td>|<th>)/gm, '\t') // Tables
+        .replace(/(<\/td>|<\/th>)/gm, '\n') // Tables
+        .replace(/^<br>/gm, '') // Remove leading <br>
+        .replace(/(<br>\n|<br>)/gm, '\n') // <br>
+        .replace(/<h1>(.*)<\/h1>/gm, '\n\n===== $1 =====\n\n') // Header H1
+        .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm, '\n\n*** $1 ***\n\n') // Headers
         .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
       utils.logMessage(debugText);
     }
@@ -461,9 +472,13 @@ function hasAppId(bid) {
   return !!bid.params.app
 }
 
+function hasDebug(bid) {
+  return !!bid.debug
+}
+
 function getURLparams() {
   let obj = {};
-  if (utils.getTopWindowLocation() && utils.getTopWindowLocation().search){
+  if (utils.getTopWindowLocation() && utils.getTopWindowLocation().search) {
     obj['params'] = {};
     utils.getTopWindowLocation().search.substr(1).split('&').forEach(keyvalue => {
       let key = keyvalue.split('=')[0];

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -372,13 +372,21 @@ describe('AppNexusAdapter', () => {
     });
 
     it('sends a debug auction', () => {
-      sandbox = sinon.sandbox.create();
-      sandbox.stub(utils, 'getTopWindowLocation').callsFake(() => {
-        return {
-          'search': '?pbjs_debug=true&ast_debug=true&ast_dongle=QWERTY&ast_debug_member=958&ast_debug_timeout=1000'
-        };
-      });
-      const request = spec.buildRequests([bidRequests[0]]);
+      let debugRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394'
+          },
+          debug: {
+            enabled: true,
+            dongle: 'QWERTY',
+            member_id: 958,
+            debug_timeout: 1000
+          }
+        }
+      );
+      const request = spec.buildRequests([debugRequest]);
       const payload = JSON.parse(request.data);
       expect(payload.debug).to.exist;
       expect(payload.debug).to.deep.equal({
@@ -552,31 +560,6 @@ describe('AppNexusAdapter', () => {
       expect(result[0].renderer.config).to.deep.equal(
         bidderRequest.bids[0].renderer.options
       );
-    });
-
-    it('returns a debug auction', () => {
-      describe('interpretResponse', () => {
-        let response = {
-          'version': '0.0.1',
-          'tags': [{
-            'uuid': '84ab500420319d',
-            'tag_id': 5976557,
-            'auction_id': '297492697822162468',
-            'nobid': true
-          }],
-          'debug': {
-            'debug_info': '<html><body>Debug Auction HTML</body></html>',
-            'request_time' : 32786.428
-          }
-        };
-      let bidderRequest;
-
-      let result = spec.interpretResponse({ body: response }, {bidderRequest});
-
-      expect(result[0].debug).to.exist;
-      /*expect(payload.app).to.deep.equal({
-        appid: 'B1O2W3M4AN.com.prebid.webview'
-      });*/
     });
   });
 });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -370,6 +370,24 @@ describe('AppNexusAdapter', () => {
         lng: -75.3009142
       });
     });
+
+    it('sends a debug auction', () => {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(utils, 'getTopWindowLocation').callsFake(() => {
+        return {
+          'search': '?pbjs_debug=true&ast_debug=true&ast_dongle=QWERTY&ast_debug_member=958&ast_debug_timeout=1000'
+        };
+      });
+      const request = spec.buildRequests([bidRequests[0]]);
+      const payload = JSON.parse(request.data);
+      expect(payload.debug).to.exist;
+      expect(payload.debug).to.deep.equal({
+        enabled: true,
+        dongle: 'QWERTY',
+        member_id: 958,
+        debug_timeout: 1000
+      });
+    });
   })
 
   describe('interpretResponse', () => {
@@ -534,6 +552,31 @@ describe('AppNexusAdapter', () => {
       expect(result[0].renderer.config).to.deep.equal(
         bidderRequest.bids[0].renderer.options
       );
+    });
+
+    it('returns a debug auction', () => {
+      describe('interpretResponse', () => {
+        let response = {
+          'version': '0.0.1',
+          'tags': [{
+            'uuid': '84ab500420319d',
+            'tag_id': 5976557,
+            'auction_id': '297492697822162468',
+            'nobid': true
+          }],
+          'debug': {
+            'debug_info': '<html><body>Debug Auction HTML</body></html>',
+            'request_time' : 32786.428
+          }
+        };
+      let bidderRequest;
+
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
+
+      expect(result[0].debug).to.exist;
+      /*expect(payload.app).to.deep.equal({
+        appid: 'B1O2W3M4AN.com.prebid.webview'
+      });*/
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
The following feature enhancement adds in the ability for a publisher or developer to request an AppNexus AST debug auction in the response back from AppNexus alongside any bids.

This feature is disabled by default and can be enabled by adding a `debug` object in parallel to the bids requested (which is the preferred way of running a debug auction):

```
{
  bidder: 'appnexus',
  params: {
    placementId: 123456789
  },
  debug: {
    enabled: true,
    dongle: 'QWERTY',
    member_id: 958,
    debug_timeout: 3000
  }
}
```

The following also may be set with a combination of the following URL parameters (and sample values) that must be used in conjunction with `pbjs_debug=true` as a URL parameter:

- `ast_debug=true`
- `ast_dongle=QWERTY`
- `ast_debug_member=958`
- `ast_debug_timeout=1200`

(e.g http://example.com/?pbjs_debug=true&ast_debug=true&ast_dongle=QWERTY&ast_debug_member=882&ast_debug_timeout=1200)

When either of the above is enabled, a debug auction will be shown in the Prebid console log statements along with relevant details about the auction that took place. e.g:

```
Running member 958 debug using no permissions
Impbus 4280.bm-impbus.prod.nym2:8001
	Header Referer: http://example.com?pbjs_debug=true&ast_debug=true&ast_dongle=sss
	Site Domain: example.com
1772142023491463321 - Predicted engagement_rate_id: 2 (view) imps 54.87%
1772142023491463321 - Predicted engagement_rate_id: 3 (view_over_total) imps 51.57%
1772142023491463321 - Predicted engagement_rate_id: 8 (predicted_100pv1s_display_view_rate) imps 47.06%
```