### PR TITLE
check for null in data

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -25,7 +25,7 @@ function receiveMessage(ev) {
     return;
   }
 
-  if (data.adId) {
+  if (data && data.adId) {
     const adObject = find(auctionManager.getBidsReceived(), function (bid) {
       return bid.adId === data.adId;
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Since null is a valid json. Directly checking data.adId was throwing js error.
