### PR TITLE
Fix utils problem with convertTypes

### DIFF
--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -1,5 +1,5 @@
 /* eslint dot-notation:0, quote-props:0 */
-import {logError, getTopWindowLocation} from 'src/utils';
+import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const NATIVE_DEFAULTS = {
@@ -237,7 +237,7 @@ function site(bidderRequest) {
         id: pubId.toString(),
       },
       ref: referrer(),
-      page: getTopWindowLocation().href,
+      page: utils.getTopWindowLocation().href,
     }
   }
   return null;
@@ -293,7 +293,7 @@ function parse(rawResponse) {
       return JSON.parse(rawResponse);
     }
   } catch (ex) {
-    logError('pulsepointLite.safeParse', 'ERROR', ex);
+    utils.logError('pulsepointLite.safeParse', 'ERROR', ex);
   }
   return null;
 }


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Fix `ReferenceError: utils is not defined` when running pulsepoint adapter. Introduced with #2844 (https://github.com/prebid/Prebid.js/blob/4682ae39963d09e38179280a7edbce92bb7b4114/modules/pulsepointBidAdapter.js#L71)
