### PR TITLE
Changes on AdSize + gdpr

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -75,8 +75,8 @@ export const spec = {
       })
 
       if (matchedBid) {
-        const primarysize = bidRequest.sizes[0]
-        const customsize = typeof bidRequest.params.adSize !== 'undefined' ? parseSize(bidRequest.params.adSize) : primarysize
+        const primarysize = bidRequest.sizes.length === 2 && !utils.isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0]
+        const customsize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : primarysize
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -13,7 +13,7 @@ export const spec = {
   supportedMediaTypes: [VIDEO, BANNER],
 
   isBidRequestValid: function (bid) {
-    if (bid && bid.params && bid.params.adslotId && bid.params.adSize) {
+    if (bid && bid.params && bid.params.adslotId && bid.params.supplyId) {
       return true
     }
     return false
@@ -40,8 +40,10 @@ export const spec = {
     })
 
     if (bidderRequest && bidderRequest.gdprConsent) {
-      query.consent = bidderRequest.gdprConsent.consentString
       query.gdpr = (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+      if (query.gdpr) {
+        query.consent = bidderRequest.gdprConsent.consentString
+      }
     }
 
     const adslots = adslotIds.join(',')
@@ -73,23 +75,24 @@ export const spec = {
       })
 
       if (matchedBid) {
-        const sizes = parseSize(bidRequest.params.adSize)
+        const primarysize = bidRequest.sizes[0]
+        const customsize = typeof bidRequest.params.adSize !== 'undefined' ? parseSize(bidRequest.params.adSize) : primarysize
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
-          width: sizes[0],
-          height: sizes[1],
+          width: primarysize[0],
+          height: primarysize[1],
           creativeId: '' + matchedBid.id,
           dealId: matchedBid.pid,
           currency: CURRENCY_CODE,
           netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
-          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}"></script>`
+          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}"></script>`
         }
         if (isVideo(bidRequest)) {
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${sizes[0]}x${sizes[1]}?ts=${timestamp}`
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}`
         }
 
         bidResponses.push(bidResponse)


### PR DESCRIPTION
- Primary adsize is now the prebid slot adsize
- On bidder.params you can now overwrite the prebid slot size (Not primary size anymore)
- gdpr string will be only attached if "gdprApplies=true"

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- change the required params to set the bid valid
- only attach the gdpr-url-parameter if the "gdprApplies"-parameter in consentModule is true
- use the prebid slot size as primary size
- via adSize in "bidder.params" you can overwrite the prebid slot size for requesting prebid. If yieldlab slot size is different to the real size which you can configure in prebid slot config.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
