### PR TITLE
Replacing all arrow functions in Mocha function calls

### DIFF
--- a/test/mocks/videoCacheStub.js
+++ b/test/mocks/videoCacheStub.js
@@ -12,7 +12,7 @@ import * as videoCache from 'src/videoCache';
 export default function useVideoCacheStub(responses) {
   let storeStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     storeStub = sinon.stub(videoCache, 'store');
 
     if (responses.store instanceof Error) {
@@ -22,7 +22,7 @@ export default function useVideoCacheStub(responses) {
     }
   });
 
-  afterEach(() => {
+  afterEach(function () {
     videoCache.store.restore();
   });
 

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -22,14 +22,14 @@ FEATURE: Analytics Adapters API
   let requests;
   let adapter;
 
-  beforeEach(() => {
+  beforeEach(function () {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
     xhr.onCreate = (request) => requests.push(request);
     adapter = new AnalyticsAdapter(config);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     xhr.restore();
     adapter.disableAnalytics();
   });
@@ -56,11 +56,11 @@ FEATURE: Analytics Adapters API
   });
 
   describe(`WHEN an event occurs after enable analytics\n`, function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.stub(events, 'getEvents').returns([]); // these tests shouldn't be affected by previous tests
     });
 
-    afterEach(() => {
+    afterEach(function () {
       events.getEvents.restore();
     });
 
@@ -134,11 +134,11 @@ FEATURE: Analytics Adapters API
       const eventType = BID_WON;
       const args = { more: 'info' };
 
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(Math, 'random').returns(0.5);
       });
 
-      afterEach(() => {
+      afterEach(function () {
         Math.random.restore();
       });
 

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -34,7 +34,7 @@ FEATURE: Analytics Adapters API
     adapter.disableAnalytics();
   });
 
-  it(`SHOULD call the endpoint WHEN an event occurs that is to be tracked`, () => {
+  it(`SHOULD call the endpoint WHEN an event occurs that is to be tracked`, function () {
     const eventType = BID_REQUESTED;
     const args = { some: 'data' };
 
@@ -44,7 +44,7 @@ FEATURE: Analytics Adapters API
     expect(result).to.deep.equal({args: {some: 'data'}, eventType: 'bidRequested'});
   });
 
-  it(`SHOULD queue the event first and then track it WHEN an event occurs before tracking library is available`, () => {
+  it(`SHOULD queue the event first and then track it WHEN an event occurs before tracking library is available`, function () {
     const eventType = BID_RESPONSE;
     const args = { wat: 'wot' };
 
@@ -64,7 +64,7 @@ FEATURE: Analytics Adapters API
       events.getEvents.restore();
     });
 
-    it('SHOULD call global when a bidWon event occurs', () => {
+    it('SHOULD call global when a bidWon event occurs', function () {
       const eventType = BID_WON;
       const args = { more: 'info' };
 
@@ -75,7 +75,7 @@ FEATURE: Analytics Adapters API
       expect(result).to.deep.equal({args: {more: 'info'}, eventType: 'bidWon'});
     });
 
-    it('SHOULD call global when a adRenderFailed event occurs', () => {
+    it('SHOULD call global when a adRenderFailed event occurs', function () {
       const eventType = AD_RENDER_FAILED;
       const args = { call: 'adRenderFailed' };
 
@@ -86,7 +86,7 @@ FEATURE: Analytics Adapters API
       expect(result).to.deep.equal({args: {call: 'adRenderFailed'}, eventType: 'adRenderFailed'});
     });
 
-    it('SHOULD call global when a bidRequest event occurs', () => {
+    it('SHOULD call global when a bidRequest event occurs', function () {
       const eventType = BID_REQUESTED;
       const args = { call: 'request' };
 
@@ -97,7 +97,7 @@ FEATURE: Analytics Adapters API
       expect(result).to.deep.equal({args: {call: 'request'}, eventType: 'bidRequested'});
     });
 
-    it('SHOULD call global when a bidResponse event occurs', () => {
+    it('SHOULD call global when a bidResponse event occurs', function () {
       const eventType = BID_RESPONSE;
       const args = { call: 'response' };
 
@@ -108,7 +108,7 @@ FEATURE: Analytics Adapters API
       expect(result).to.deep.equal({args: {call: 'response'}, eventType: 'bidResponse'});
     });
 
-    it('SHOULD call global when a bidTimeout event occurs', () => {
+    it('SHOULD call global when a bidTimeout event occurs', function () {
       const eventType = BID_TIMEOUT;
       const args = { call: 'timeout' };
 
@@ -119,7 +119,7 @@ FEATURE: Analytics Adapters API
       expect(result).to.deep.equal({args: {call: 'timeout'}, eventType: 'bidTimeout'});
     });
 
-    it('SHOULD NOT call global again when adapter.enableAnalytics is called with previous timeout', () => {
+    it('SHOULD NOT call global again when adapter.enableAnalytics is called with previous timeout', function () {
       const eventType = BID_TIMEOUT;
       const args = { call: 'timeout' };
 
@@ -142,7 +142,7 @@ FEATURE: Analytics Adapters API
         Math.random.restore();
       });
 
-      it(`THEN should enable analytics when random number is in sample range`, () => {
+      it(`THEN should enable analytics when random number is in sample range`, function () {
         adapter.enableAnalytics({
           options: {
             sampling: 0.75
@@ -155,7 +155,7 @@ FEATURE: Analytics Adapters API
         expect(result).to.deep.equal({args: {more: 'info'}, eventType: 'bidWon'});
       });
 
-      it(`THEN should disable analytics when random number is outside sample range`, () => {
+      it(`THEN should disable analytics when random number is outside sample range`, function () {
         adapter.enableAnalytics({
           options: {
             sampling: 0.25

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -55,7 +55,7 @@ FEATURE: Analytics Adapters API
     expect(result).to.deep.equal({args: {wat: 'wot'}, eventType: 'bidResponse'});
   });
 
-  describe(`WHEN an event occurs after enable analytics\n`, () => {
+  describe(`WHEN an event occurs after enable analytics\n`, function () {
     beforeEach(() => {
       sinon.stub(events, 'getEvents').returns([]); // these tests shouldn't be affected by previous tests
     });
@@ -130,7 +130,7 @@ FEATURE: Analytics Adapters API
       expect(requests.length).to.equal(1);
     });
 
-    describe(`AND sampling is enabled\n`, () => {
+    describe(`AND sampling is enabled\n`, function () {
       const eventType = BID_WON;
       const args = { more: 'info' };
 

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -15,7 +15,7 @@ describe('adLoader', function () {
     utilsLogErrorStub.restore();
   });
 
-  describe('loadExternalScript', () => {
+  describe('loadExternalScript', function () {
     it('requires moduleCode to be included on the request', () => {
       adLoader.loadExternalScript('someURL');
       expect(utilsLogErrorStub.called).to.be.true;

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -16,13 +16,13 @@ describe('adLoader', function () {
   });
 
   describe('loadExternalScript', function () {
-    it('requires moduleCode to be included on the request', () => {
+    it('requires moduleCode to be included on the request', function () {
       adLoader.loadExternalScript('someURL');
       expect(utilsLogErrorStub.called).to.be.true;
       expect(utilsinsertElementStub.called).to.be.false;
     });
 
-    it('only allows whitelisted vendors to load scripts', () => {
+    it('only allows whitelisted vendors to load scripts', function () {
       adLoader.loadExternalScript('someURL', 'criteo');
       expect(utilsLogErrorStub.called).to.be.false;
       expect(utilsinsertElementStub.called).to.be.true;

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -5,12 +5,12 @@ describe('adLoader', function () {
   let utilsinsertElementStub;
   let utilsLogErrorStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     utilsinsertElementStub = sinon.stub(utils, 'insertElement');
     utilsLogErrorStub = sinon.stub(utils, 'logError');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     utilsinsertElementStub.restore();
     utilsLogErrorStub.restore();
   });

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -484,7 +484,7 @@ describe('auctionmanager.js', function () {
   });
 
   describe('adjustBids', function () {
-    it('should adjust bids if greater than zero and pass copy of bid object', () => {
+    it('should adjust bids if greater than zero and pass copy of bid object', function () {
       const bid = Object.assign({},
         bidfactory.createBid(2),
         fixtures.getBidResponses()[5]
@@ -605,7 +605,7 @@ describe('auctionmanager.js', function () {
       it('should return proper price bucket increments for dense mode when cpm is 20+',
         checkPbDg('73.07', '20.00', '20+ caps at 20.00'));
 
-      it('should place dealIds in adserver targeting', () => {
+      it('should place dealIds in adserver targeting', function () {
         bids[0].dealId = 'test deal';
         auction.callBids();
 
@@ -613,7 +613,7 @@ describe('auctionmanager.js', function () {
         assert.equal(registeredBid.adserverTargeting[`hb_deal`], 'test deal', 'dealId placed in adserverTargeting');
       });
 
-      it('should pass through default adserverTargeting sent from adapter', () => {
+      it('should pass through default adserverTargeting sent from adapter', function () {
         bids[0].adserverTargeting = {};
         bids[0].adserverTargeting.extra = 'stuff';
         auction.callBids();
@@ -623,7 +623,7 @@ describe('auctionmanager.js', function () {
         assert.equal(registeredBid.adserverTargeting.extra, 'stuff');
       });
 
-      it('installs publisher-defined renderers on bids', () => {
+      it('installs publisher-defined renderers on bids', function () {
         let renderer = {
           url: 'renderer.js',
           render: (bid) => bid
@@ -729,7 +729,7 @@ describe('auctionmanager.js', function () {
         events.emit.restore();
         getBidderRequestStub.restore();
       });
-      it('should emit BID_TIMEOUT for timed out bids', () => {
+      it('should emit BID_TIMEOUT for timed out bids', function () {
         auction.callBids();
         assert.ok(eventsEmitSpy.calledWith(CONSTANTS.EVENTS.BID_TIMEOUT), 'emitted events BID_TIMEOUT');
       });
@@ -792,7 +792,7 @@ describe('auctionmanager.js', function () {
       auctionModule.newAuction.restore();
     });
 
-    it('should not alter bid adID', () => {
+    it('should not alter bid adID', function () {
       auction.callBids();
 
       const addedBid2 = auction.getBidsReceived().pop();
@@ -801,7 +801,7 @@ describe('auctionmanager.js', function () {
       assert.equal(addedBid1.adId, bids[0].requestId);
     });
 
-    it('should not add banner bids that have no width or height', () => {
+    it('should not add banner bids that have no width or height', function () {
       bids1[0].width = undefined;
       bids1[0].height = undefined;
 
@@ -813,7 +813,7 @@ describe('auctionmanager.js', function () {
       assert.equal(length, 1);
     });
 
-    it('should run auction after video bids have been cached', () => {
+    it('should run auction after video bids have been cached', function () {
       sinon.stub(store, 'store').callsArgWith(1, null, [{ uuid: 123 }]);
       sinon.stub(config, 'getConfig').withArgs('cache.url').returns('cache-url');
 
@@ -832,7 +832,7 @@ describe('auctionmanager.js', function () {
       store.store.restore();
     });
 
-    it('runs auction after video responses with multiple bid objects have been cached', () => {
+    it('runs auction after video responses with multiple bid objects have been cached', function () {
       sinon.stub(store, 'store').callsArgWith(1, null, [{ uuid: 123 }]);
       sinon.stub(config, 'getConfig').withArgs('cache.url').returns('cache-url');
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -109,11 +109,11 @@ function mockAjaxBuilder() {
 describe('auctionmanager.js', function () {
   let xhr;
 
-  before(() => {
+  before(function () {
     xhr = sinon.useFakeXMLHttpRequest();
   });
 
-  after(() => {
+  after(function () {
     xhr.restore();
   });
 
@@ -542,23 +542,23 @@ describe('auctionmanager.js', function () {
     let bids = TEST_BIDS;
     let makeRequestsStub;
 
-    before(() => {
+    before(function () {
       makeRequestsStub = sinon.stub(adaptermanager, 'makeBidRequests');
 
       ajaxStub = sinon.stub(ajaxLib, 'ajaxBuilder').callsFake(mockAjaxBuilder);
     });
 
-    after(() => {
+    after(function () {
       ajaxStub.restore();
       adaptermanager.makeBidRequests.restore();
     });
 
     describe('when auction timeout is 3000', function () {
       let loadScriptStub;
-      before(() => {
+      before(function () {
         makeRequestsStub.returns(TEST_BID_REQS);
       });
-      beforeEach(() => {
+      beforeEach(function () {
         adUnits = [{
           code: ADUNIT_CODE,
           bids: [
@@ -578,7 +578,7 @@ describe('auctionmanager.js', function () {
         registerBidder(spec);
       });
 
-      afterEach(() => {
+      afterEach(function () {
         auctionModule.newAuction.restore();
         loadScriptStub.restore();
       });
@@ -680,14 +680,14 @@ describe('auctionmanager.js', function () {
       let eventsEmitSpy;
       let getBidderRequestStub;
 
-      before(() => {
+      before(function () {
         bids = [mockBid(), mockBid({ bidderCode: BIDDER_CODE1 })];
         let bidRequests = bids.map(bid => mockBidRequest(bid));
 
         makeRequestsStub.returns(bidRequests);
       });
 
-      beforeEach(() => {
+      beforeEach(function () {
         adUnits = [{
           code: ADUNIT_CODE,
           bids: [
@@ -723,7 +723,7 @@ describe('auctionmanager.js', function () {
           return req;
         });
       });
-      afterEach(() => {
+      afterEach(function () {
         auctionModule.newAuction.restore();
         loadScriptStub.restore();
         events.emit.restore();
@@ -748,7 +748,7 @@ describe('auctionmanager.js', function () {
     let bids = TEST_BIDS;
     let bids1 = [mockBid({ bidderCode: BIDDER_CODE1 })];
 
-    before(() => {
+    before(function () {
       let bidRequests = [
         mockBidRequest(bids[0]),
         mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 })
@@ -759,12 +759,12 @@ describe('auctionmanager.js', function () {
       ajaxStub = sinon.stub(ajaxLib, 'ajaxBuilder').callsFake(mockAjaxBuilder);
     });
 
-    after(() => {
+    after(function () {
       ajaxStub.restore();
       adaptermanager.makeBidRequests.restore();
     });
 
-    beforeEach(() => {
+    beforeEach(function () {
       adUnits = [{
         code: ADUNIT_CODE,
         bids: [
@@ -788,7 +788,7 @@ describe('auctionmanager.js', function () {
       registerBidder(spec1);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionModule.newAuction.restore();
     });
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -483,7 +483,7 @@ describe('auctionmanager.js', function () {
     });
   });
 
-  describe('adjustBids', () => {
+  describe('adjustBids', function () {
     it('should adjust bids if greater than zero and pass copy of bid object', () => {
       const bid = Object.assign({},
         bidfactory.createBid(2),
@@ -532,7 +532,7 @@ describe('auctionmanager.js', function () {
     });
   });
 
-  describe('addBidResponse', () => {
+  describe('addBidResponse', function () {
     let createAuctionStub;
     let adUnits;
     let adUnitCodes;
@@ -553,7 +553,7 @@ describe('auctionmanager.js', function () {
       adaptermanager.makeBidRequests.restore();
     });
 
-    describe('when auction timeout is 3000', () => {
+    describe('when auction timeout is 3000', function () {
       let loadScriptStub;
       before(() => {
         makeRequestsStub.returns(TEST_BID_REQS);
@@ -675,7 +675,7 @@ describe('auctionmanager.js', function () {
       });
     });
 
-    describe('when auction timeout is 20', () => {
+    describe('when auction timeout is 20', function () {
       let loadScriptStub;
       let eventsEmitSpy;
       let getBidderRequestStub;
@@ -736,7 +736,7 @@ describe('auctionmanager.js', function () {
     });
   });
 
-  describe('addBidResponse', () => {
+  describe('addBidResponse', function () {
     let createAuctionStub;
     let adUnits;
     let adUnitCodes;

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -11,7 +11,7 @@ let setDefaults;
 describe('config API', function () {
   let logErrorSpy;
   let logWarnSpy;
-  beforeEach(() => {
+  beforeEach(function () {
     const config = newConfig();
     getConfig = config.getConfig;
     setConfig = config.setConfig;
@@ -20,7 +20,7 @@ describe('config API', function () {
     logWarnSpy = sinon.spy(utils, 'logWarn');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     utils.logError.restore();
     utils.logWarn.restore();
   });

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -8,7 +8,7 @@ let getConfig;
 let setConfig;
 let setDefaults;
 
-describe('config API', () => {
+describe('config API', function () {
   let logErrorSpy;
   let logWarnSpy;
   beforeEach(() => {

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -25,25 +25,25 @@ describe('config API', function () {
     utils.logWarn.restore();
   });
 
-  it('setConfig is a function', () => {
+  it('setConfig is a function', function () {
     expect(setConfig).to.be.a('function');
   });
 
-  it('getConfig returns an object', () => {
+  it('getConfig returns an object', function () {
     expect(getConfig()).to.be.a('object');
   });
 
-  it('sets and gets arbitrary configuarion properties', () => {
+  it('sets and gets arbitrary configuarion properties', function () {
     setConfig({ baz: 'qux' });
     expect(getConfig('baz')).to.equal('qux');
   });
 
-  it('only accepts objects', () => {
+  it('only accepts objects', function () {
     setConfig('invalid');
     expect(getConfig('0')).to.not.equal('i');
   });
 
-  it('sets multiple config properties', () => {
+  it('sets multiple config properties', function () {
     setConfig({ foo: 'bar' });
     setConfig({ biz: 'buz' });
     var config = getConfig();
@@ -51,28 +51,28 @@ describe('config API', function () {
     expect(config.biz).to.equal('buz');
   });
 
-  it('overwrites existing config properties', () => {
+  it('overwrites existing config properties', function () {
     setConfig({ foo: {biz: 'buz'} });
     setConfig({ foo: {baz: 'qux'} });
     expect(getConfig('foo')).to.eql({baz: 'qux'});
   });
 
-  it('sets debugging', () => {
+  it('sets debugging', function () {
     setConfig({ debug: true });
     expect(getConfig('debug')).to.be.true;
   });
 
-  it('sets bidderTimeout', () => {
+  it('sets bidderTimeout', function () {
     setConfig({ bidderTimeout: 1000 });
     expect(getConfig('bidderTimeout')).to.be.equal(1000);
   });
 
-  it('gets user-defined publisherDomain', () => {
+  it('gets user-defined publisherDomain', function () {
     setConfig({ publisherDomain: 'fc.kahuna' });
     expect(getConfig('publisherDomain')).to.equal('fc.kahuna');
   });
 
-  it('gets default userSync config', () => {
+  it('gets default userSync config', function () {
     const DEFAULT_USERSYNC = {
       syncEnabled: true,
       pixelEnabled: true,
@@ -83,7 +83,7 @@ describe('config API', function () {
     expect(getConfig('userSync')).to.eql(DEFAULT_USERSYNC);
   });
 
-  it('has subscribe functionality for adding listeners to config updates', () => {
+  it('has subscribe functionality for adding listeners to config updates', function () {
     const listener = sinon.spy();
 
     getConfig(listener);
@@ -94,7 +94,7 @@ describe('config API', function () {
     sinon.assert.calledWith(listener, { foo: 'bar' });
   });
 
-  it('subscribers can unsubscribe', () => {
+  it('subscribers can unsubscribe', function () {
     const listener = sinon.spy();
 
     const unsubscribe = getConfig(listener);
@@ -106,7 +106,7 @@ describe('config API', function () {
     sinon.assert.notCalled(listener);
   });
 
-  it('subscribers can subscribe to topics', () => {
+  it('subscribers can subscribe to topics', function () {
     const listener = sinon.spy();
 
     getConfig('logging', listener);
@@ -117,7 +117,7 @@ describe('config API', function () {
     sinon.assert.calledWithExactly(listener, { logging: true });
   });
 
-  it('topic subscribers are only called when that topic is changed', () => {
+  it('topic subscribers are only called when that topic is changed', function () {
     const listener = sinon.spy();
     const wildcard = sinon.spy();
 
@@ -130,12 +130,12 @@ describe('config API', function () {
     sinon.assert.calledOnce(wildcard);
   });
 
-  it('sets priceGranularity', () => {
+  it('sets priceGranularity', function () {
     setConfig({ priceGranularity: 'low' });
     expect(getConfig('priceGranularity')).to.be.equal('low');
   });
 
-  it('set mediaTypePriceGranularity', () => {
+  it('set mediaTypePriceGranularity', function () {
     const customPriceGranularity = {
       'buckets': [{
         'min': 0,
@@ -158,7 +158,7 @@ describe('config API', function () {
     expect(configResult.native).to.be.equal('medium');
   });
 
-  it('sets priceGranularity and customPriceBucket', () => {
+  it('sets priceGranularity and customPriceBucket', function () {
     const goodConfig = {
       'buckets': [{
         'min': 0,
@@ -172,18 +172,18 @@ describe('config API', function () {
     expect(getConfig('customPriceBucket')).to.equal(goodConfig);
   });
 
-  it('should log error for invalid priceGranularity', () => {
+  it('should log error for invalid priceGranularity', function () {
     setConfig({ priceGranularity: '' });
     const error = 'Prebid Error: no value passed to `setPriceGranularity()`';
     assert.ok(logErrorSpy.calledWith(error), 'expected error was logged');
   });
 
-  it('should log a warning on invalid values', () => {
+  it('should log a warning on invalid values', function () {
     setConfig({ bidderSequence: 'unrecognized sequence' });
     expect(logWarnSpy.calledOnce).to.equal(true);
   });
 
-  it('should not log warnings when given recognized values', () => {
+  it('should not log warnings when given recognized values', function () {
     setConfig({ bidderSequence: 'fixed' });
     setConfig({ bidderSequence: 'random' });
     expect(logWarnSpy.called).to.equal(false);

--- a/test/spec/cpmBucketManager_spec.js
+++ b/test/spec/cpmBucketManager_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import {getPriceBucketString, isValidPriceConfig} from 'src/cpmBucketManager';
 let cpmFixtures = require('test/fixtures/cpmInputsOutputs.json');
 
-describe('cpmBucketManager', () => {
+describe('cpmBucketManager', function () {
   it('getPriceBucketString function generates the correct price strings', () => {
     let input = cpmFixtures.cpmInputs;
     for (let i = 0; i < input.length; i++) {

--- a/test/spec/cpmBucketManager_spec.js
+++ b/test/spec/cpmBucketManager_spec.js
@@ -3,7 +3,7 @@ import {getPriceBucketString, isValidPriceConfig} from 'src/cpmBucketManager';
 let cpmFixtures = require('test/fixtures/cpmInputsOutputs.json');
 
 describe('cpmBucketManager', function () {
-  it('getPriceBucketString function generates the correct price strings', () => {
+  it('getPriceBucketString function generates the correct price strings', function () {
     let input = cpmFixtures.cpmInputs;
     for (let i = 0; i < input.length; i++) {
       let output = getPriceBucketString(input[i]);
@@ -12,7 +12,7 @@ describe('cpmBucketManager', function () {
     }
   });
 
-  it('gets the correct custom bucket strings', () => {
+  it('gets the correct custom bucket strings', function () {
     let cpm = 16.50908;
     let customConfig = {
       'buckets': [{
@@ -35,7 +35,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('gets the correct custom bucket strings with irregular increment', () => {
+  it('gets the correct custom bucket strings with irregular increment', function () {
     let cpm = 14.50908;
     let customConfig = {
       'buckets': [{
@@ -58,7 +58,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('gets the correct custom bucket strings in non-USD currency', () => {
+  it('gets the correct custom bucket strings in non-USD currency', function () {
     let cpm = 16.50908 * 110.49;
     let customConfig = {
       'buckets': [{
@@ -81,7 +81,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('gets the correct custom bucket strings with specific cpms that round oddly with certain increments', () => {
+  it('gets the correct custom bucket strings with specific cpms that round oddly with certain increments', function () {
     let customConfig = {
       'buckets': [{
         'precision': 4,
@@ -155,7 +155,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('gets custom bucket strings and it should honor 0', () => {
+  it('gets custom bucket strings and it should honor 0', function () {
     let cpm = 16.50908;
     let customConfig = {
       'buckets': [
@@ -172,7 +172,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('gets the custom bucket strings without passing precision and it should honor the default precision', () => {
+  it('gets the custom bucket strings without passing precision and it should honor the default precision', function () {
     let cpm = 16.50908;
     let customConfig = {
       'buckets': [
@@ -188,7 +188,7 @@ describe('cpmBucketManager', function () {
     expect(JSON.stringify(output)).to.deep.equal(expected);
   });
 
-  it('checks whether custom config is valid', () => {
+  it('checks whether custom config is valid', function () {
     let badConfig = {
       'buckets': [{
         'min': 0,

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -7,21 +7,21 @@ import { config } from 'src/config';
 describe('bid overrides', function () {
   let sandbox;
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     window.sessionStorage.clear();
     sandbox.restore();
   });
 
   describe('initialization', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sandbox.stub(config, 'setConfig');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       disableOverrides();
     });
 
@@ -55,7 +55,7 @@ describe('bid overrides', function () {
     let mockBids;
     let bids;
 
-    beforeEach(() => {
+    beforeEach(function () {
       let baseBid = {
         'bidderCode': 'rubicon',
         'width': 970,

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -25,7 +25,7 @@ describe('bid overrides', function () {
       disableOverrides();
     });
 
-    it('should happen when enabled with setConfig', () => {
+    it('should happen when enabled with setConfig', function () {
       getConfig({
         enabled: true
       });
@@ -33,14 +33,14 @@ describe('bid overrides', function () {
       expect(addBidResponse.hasHook(boundHook)).to.equal(true);
     });
 
-    it('should happen when configuration found in sessionStorage', () => {
+    it('should happen when configuration found in sessionStorage', function () {
       sessionLoader({
         getItem: () => ('{"enabled": true}')
       });
       expect(addBidResponse.hasHook(boundHook)).to.equal(true);
     });
 
-    it('should not throw if sessionStorage is inaccessible', () => {
+    it('should not throw if sessionStorage is inaccessible', function () {
       expect(() => {
         sessionLoader({
           getItem() {
@@ -86,7 +86,7 @@ describe('bid overrides', function () {
       });
     }
 
-    it('should allow us to exclude bidders', () => {
+    it('should allow us to exclude bidders', function () {
       run({
         enabled: true,
         bidders: ['appnexus']
@@ -96,7 +96,7 @@ describe('bid overrides', function () {
       expect(bids[0].bidderCode).to.equal('appnexus');
     });
 
-    it('should allow us to override all bids', () => {
+    it('should allow us to override all bids', function () {
       run({
         enabled: true,
         bids: [{
@@ -109,7 +109,7 @@ describe('bid overrides', function () {
       expect(bids[1].cpm).to.equal(2);
     });
 
-    it('should allow us to override bids by bidder', () => {
+    it('should allow us to override bids by bidder', function () {
       run({
         enabled: true,
         bids: [{
@@ -123,7 +123,7 @@ describe('bid overrides', function () {
       expect(bids[1].cpm).to.equal(0.5);
     });
 
-    it('should allow us to override bids by adUnitCode', () => {
+    it('should allow us to override bids by adUnitCode', function () {
       mockBids[1].adUnitCode = 'test';
 
       run({

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -4,7 +4,7 @@ import { sessionLoader, addBidResponseHook, getConfig, disableOverrides, boundHo
 import { addBidResponse } from 'src/auction';
 import { config } from 'src/config';
 
-describe('bid overrides', () => {
+describe('bid overrides', function () {
   let sandbox;
 
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('bid overrides', () => {
     sandbox.restore();
   });
 
-  describe('initialization', () => {
+  describe('initialization', function () {
     beforeEach(() => {
       sandbox.stub(config, 'setConfig');
     });
@@ -51,7 +51,7 @@ describe('bid overrides', () => {
     });
   });
 
-  describe('hook', () => {
+  describe('hook', function () {
     let mockBids;
     let bids;
 

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { createHook, hooks } from 'src/hook';
 
-describe('the hook module', () => {
+describe('the hook module', function () {
   let sandbox;
 
   beforeEach(() => {
@@ -85,7 +85,7 @@ describe('the hook module', () => {
     expect(calledBoundContext).to.equal(boundContext);
   });
 
-  describe('asyncSeries', () => {
+  describe('asyncSeries', function () {
     it('should call function as normal if no hooks attached', () => {
       let fn = sandbox.spy();
       let hookFn = createHook('asyncSeries', fn);

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -5,11 +5,11 @@ import { createHook, hooks } from 'src/hook';
 describe('the hook module', function () {
   let sandbox;
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
   });
 

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -13,7 +13,7 @@ describe('the hook module', function () {
     sandbox.restore();
   });
 
-  it('should call all sync hooks attached to a function', () => {
+  it('should call all sync hooks attached to a function', function () {
     let called = [];
     let calledWith;
 
@@ -63,7 +63,7 @@ describe('the hook module', function () {
     ]);
   });
 
-  it('should allow context to be passed to hooks, but keep bound contexts', () => {
+  it('should allow context to be passed to hooks, but keep bound contexts', function () {
     let context;
     let fn = function() {
       context = this;
@@ -86,7 +86,7 @@ describe('the hook module', function () {
   });
 
   describe('asyncSeries', function () {
-    it('should call function as normal if no hooks attached', () => {
+    it('should call function as normal if no hooks attached', function () {
       let fn = sandbox.spy();
       let hookFn = createHook('asyncSeries', fn);
 
@@ -96,7 +96,7 @@ describe('the hook module', function () {
       expect(fn.firstCall.args[0]).to.equal(1);
     });
 
-    it('should call hooks correctly applied in asyncSeries', () => {
+    it('should call hooks correctly applied in asyncSeries', function () {
       let called = [];
 
       let testFn = (called) => {
@@ -124,7 +124,7 @@ describe('the hook module', function () {
       ]);
     });
 
-    it('should allow context to be passed to hooks, but keep bound contexts', () => {
+    it('should allow context to be passed to hooks, but keep bound contexts', function () {
       let context;
       let fn = function() {
         context = this;

--- a/test/spec/modules/a4gBidAdapter_spec.js
+++ b/test/spec/modules/a4gBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/a4gBidAdapter';
 
-describe('a4gAdapterTests', () => {
-  describe('bidRequestValidity', () => {
+describe('a4gAdapterTests', function () {
+  describe('bidRequestValidity', function () {
     it('bidRequest with zoneId and deliveryUrl params', () => {
       expect(spec.isBidRequestValid({
         bidder: 'a4g',
@@ -32,7 +32,7 @@ describe('a4gAdapterTests', () => {
     });
   });
 
-  describe('bidRequest', () => {
+  describe('bidRequest', function () {
     const bidRequests = [{
       'bidder': 'a4g',
       'bidId': '51ef8751f9aead',
@@ -99,7 +99,7 @@ describe('a4gAdapterTests', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequest = [{
       'bidder': 'a4g',
       'bidId': '51ef8751f9aead',

--- a/test/spec/modules/a4gBidAdapter_spec.js
+++ b/test/spec/modules/a4gBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/a4gBidAdapter';
 
 describe('a4gAdapterTests', function () {
   describe('bidRequestValidity', function () {
-    it('bidRequest with zoneId and deliveryUrl params', () => {
+    it('bidRequest with zoneId and deliveryUrl params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'a4g',
         params: {
@@ -13,7 +13,7 @@ describe('a4gAdapterTests', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with only zoneId', () => {
+    it('bidRequest with only zoneId', function () {
       expect(spec.isBidRequestValid({
         bidder: 'a4g',
         params: {
@@ -22,7 +22,7 @@ describe('a4gAdapterTests', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with only deliveryUrl', () => {
+    it('bidRequest with only deliveryUrl', function () {
       expect(spec.isBidRequestValid({
         bidder: 'a4g',
         params: {
@@ -58,27 +58,27 @@ describe('a4gAdapterTests', function () {
       'auctionId': '18fd8b8b0bd757'
     }];
 
-    it('bidRequest method', () => {
+    it('bidRequest method', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.method).to.equal('GET');
     });
 
-    it('bidRequest url', () => {
+    it('bidRequest url', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.match(new RegExp(`${bidRequests[1].params.deliveryUrl}`));
     });
 
-    it('bidRequest data', () => {
+    it('bidRequest data', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.exists;
     });
 
-    it('bidRequest zoneIds', () => {
+    it('bidRequest zoneIds', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data.zoneId).to.equal('59304;59354');
     });
 
-    it('bidRequest gdpr consent', () => {
+    it('bidRequest gdpr consent', function () {
       const consentString = 'consentString';
       const bidderRequest = {
         bidderCode: 'a4g',
@@ -124,7 +124,7 @@ describe('a4gAdapterTests', function () {
       headers: {}
     };
 
-    it('required keys', () => {
+    it('required keys', function () {
       const result = spec.interpretResponse(bidResponse, bidRequest);
 
       let requiredKeys = [

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/aardvarkBidAdapter';
 
-describe('aardvarkAdapterTest', () => {
-  describe('forming valid bidRequests', () => {
+describe('aardvarkAdapterTest', function () {
+  describe('forming valid bidRequests', function () {
     it('should accept valid bidRequests', () => {
       expect(spec.isBidRequestValid({
         bidder: 'aardvark',
@@ -25,7 +25,7 @@ describe('aardvarkAdapterTest', () => {
     });
   });
 
-  describe('executing network requests', () => {
+  describe('executing network requests', function () {
     const bidRequests = [{
       bidder: 'aardvark',
       params: {
@@ -78,7 +78,7 @@ describe('aardvarkAdapterTest', () => {
     });
   });
 
-  describe('splitting multi-auction ad units into own requests', () => {
+  describe('splitting multi-auction ad units into own requests', function () {
     const bidRequests = [{
       bidder: 'aardvark',
       params: {
@@ -138,7 +138,7 @@ describe('aardvarkAdapterTest', () => {
     });
   });
 
-  describe('GDPR conformity', () => {
+  describe('GDPR conformity', function () {
     const bidRequests = [{
       bidder: 'aardvark',
       params: {
@@ -168,7 +168,7 @@ describe('aardvarkAdapterTest', () => {
     });
   });
 
-  describe('GDPR absence conformity', () => {
+  describe('GDPR absence conformity', function () {
     const bidRequests = [{
       bidder: 'aardvark',
       params: {
@@ -195,7 +195,7 @@ describe('aardvarkAdapterTest', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should handle bid responses', () => {
       const serverResponse = {
         body: [

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/aardvarkBidAdapter';
 
 describe('aardvarkAdapterTest', function () {
   describe('forming valid bidRequests', function () {
-    it('should accept valid bidRequests', () => {
+    it('should accept valid bidRequests', function () {
       expect(spec.isBidRequestValid({
         bidder: 'aardvark',
         params: {
@@ -14,7 +14,7 @@ describe('aardvarkAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('should reject invalid bidRequests', () => {
+    it('should reject invalid bidRequests', function () {
       expect(spec.isBidRequestValid({
         bidder: 'aardvark',
         params: {
@@ -54,20 +54,20 @@ describe('aardvarkAdapterTest', function () {
       auctionId: 'e97cafd0-ebfc-4f5c-b7c9-baa0fd335a4a'
     }];
 
-    it('should use HTTP GET method', () => {
+    it('should use HTTP GET method', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
-    it('should call the correct bidRequest url', () => {
+    it('should call the correct bidRequest url', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(1);
       expect(requests[0].url).to.match(new RegExp('^\/\/adzone.pub.com/xiby/TdAx_RAZd/aardvark\?'));
     });
 
-    it('should have correct data', () => {
+    it('should have correct data', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.version).to.equal(1);
@@ -108,21 +108,21 @@ describe('aardvarkAdapterTest', function () {
       auctionId: 'e97cafd0-ebfc-4f5c-b7c9-baa0fd335a4a'
     }];
 
-    it('should use HTTP GET method', () => {
+    it('should use HTTP GET method', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
-    it('should call the correct bidRequest urls for each auction', () => {
+    it('should call the correct bidRequest urls for each auction', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].url).to.match(new RegExp('^\/\/bidder.rtk.io/Toby/TdAx/aardvark\?'));
       expect(requests[0].data.categories.length).to.equal(2);
       expect(requests[1].url).to.match(new RegExp('^\/\/adzone.pub.com/xiby/RAZd/aardvark\?'));
     });
 
-    it('should have correct data', () => {
+    it('should have correct data', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(2);
       expect(requests[0].data.version).to.equal(1);
@@ -160,7 +160,7 @@ describe('aardvarkAdapterTest', function () {
       }
     };
 
-    it('should transmit correct data', () => {
+    it('should transmit correct data', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.gdpr).to.equal(true);
@@ -187,7 +187,7 @@ describe('aardvarkAdapterTest', function () {
       gdprConsent: undefined
     };
 
-    it('should transmit correct data', () => {
+    it('should transmit correct data', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.gdpr).to.be.undefined;
@@ -196,7 +196,7 @@ describe('aardvarkAdapterTest', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should handle bid responses', () => {
+    it('should handle bid responses', function () {
       const serverResponse = {
         body: [
           {
@@ -245,7 +245,7 @@ describe('aardvarkAdapterTest', function () {
       expect(result[1].ad).to.not.be.undefined;
     });
 
-    it('should handle nobid responses', () => {
+    it('should handle nobid responses', function () {
       var emptyResponse = [{
         nurl: '',
         cid: '9e5a09319e18f1',

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -27,7 +27,7 @@ describe('AdButler adapter', function () {
 
   describe('implementation', function () {
     describe('for requests', function () {
-      it('should accept valid bid', () => {
+      it('should accept valid bid', function () {
         let validBid = {
             bidder: 'adbutler',
             params: {
@@ -40,7 +40,7 @@ describe('AdButler adapter', function () {
         expect(isValid).to.equal(true);
       });
 
-      it('should reject invalid bid', () => {
+      it('should reject invalid bid', function () {
         let invalidBid = {
             bidder: 'adbutler',
             params: {
@@ -52,7 +52,7 @@ describe('AdButler adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-      it('should use custom domain string', () => {
+      it('should use custom domain string', function () {
         let bidRequests = [
             {
               bidId: '3c9408cdbf2f68',
@@ -73,7 +73,7 @@ describe('AdButler adapter', function () {
         expect(requestURL).to.have.string('.dan.test');
       });
 
-      it('should set default domain', () => {
+      it('should set default domain', function () {
         let requests = spec.buildRequests(bidRequests),
           request = requests[0];
 
@@ -82,14 +82,14 @@ describe('AdButler adapter', function () {
         expect(domain).to.equal('http://servedbyadbutler.com');
       });
 
-      it('should set the keyword parameter', () => {
+      it('should set the keyword parameter', function () {
         let requests = spec.buildRequests(bidRequests),
           requestURL = requests[0].url;
 
         expect(requestURL).to.have.string(';kw=red;');
       });
 
-      it('should increment the count for the same zone', () => {
+      it('should increment the count for the same zone', function () {
         let bidRequests = [
             {
               sizes: [[300, 250]],
@@ -119,7 +119,7 @@ describe('AdButler adapter', function () {
     });
 
     describe('bid responses', function () {
-      it('should return complete bid response', () => {
+      it('should return complete bid response', function () {
         let serverResponse = {
             body: {
               status: 'SUCCESS',
@@ -149,7 +149,7 @@ describe('AdButler adapter', function () {
         expect(bids[0].ad).to.have.string('http://tracking.pixel.com/params=info');
       });
 
-      it('should return empty bid response', () => {
+      it('should return empty bid response', function () {
         let serverResponse = {
             status: 'NO_ELIGIBLE_ADS',
             zone_id: 210083,
@@ -162,7 +162,7 @@ describe('AdButler adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on incorrect size', () => {
+      it('should return empty bid response on incorrect size', function () {
         let serverResponse = {
             status: 'SUCCESS',
             account_id: 167283,
@@ -177,7 +177,7 @@ describe('AdButler adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with CPM too low', () => {
+      it('should return empty bid response with CPM too low', function () {
         let serverResponse = {
             status: 'SUCCESS',
             account_id: 167283,
@@ -192,7 +192,7 @@ describe('AdButler adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with CPM too high', () => {
+      it('should return empty bid response with CPM too high', function () {
         let serverResponse = {
             status: 'SUCCESS',
             account_id: 167283,

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {spec} from 'modules/adbutlerBidAdapter';
 describe('AdButler adapter', function () {
   let bidRequests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'adbutler',

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from 'modules/adbutlerBidAdapter';
 
-describe('AdButler adapter', () => {
+describe('AdButler adapter', function () {
   let bidRequests;
 
   beforeEach(() => {
@@ -25,8 +25,8 @@ describe('AdButler adapter', () => {
     ];
   });
 
-  describe('implementation', () => {
-    describe('for requests', () => {
+  describe('implementation', function () {
+    describe('for requests', function () {
       it('should accept valid bid', () => {
         let validBid = {
             bidder: 'adbutler',
@@ -118,7 +118,7 @@ describe('AdButler adapter', () => {
       });
     });
 
-    describe('bid responses', () => {
+    describe('bid responses', function () {
       it('should return complete bid response', () => {
         let serverResponse = {
             body: {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -14,11 +14,11 @@ describe('Adform adapter', function () {
       }
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       assert(spec.isBidRequestValid(bid));
     });
 
-    it('should return false when required params are missing', () => {
+    it('should return false when required params are missing', function () {
       bid.params = {
         adxDomain: 'adx.adform.net'
       };
@@ -27,13 +27,13 @@ describe('Adform adapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should pass multiple bids via single request', () => {
+    it('should pass multiple bids via single request', function () {
       let request = spec.buildRequests(bids);
       let parsedUrl = parseUrl(request.url);
       assert.lengthOf(parsedUrl.items, 7);
     });
 
-    it('should handle global request parameters', () => {
+    it('should handle global request parameters', function () {
       let parsedUrl = parseUrl(spec.buildRequests([bids[0]]).url);
       let query = parsedUrl.query;
 
@@ -45,12 +45,12 @@ describe('Adform adapter', function () {
       assert.equal(query.url, encodeURIComponent('some// there'));
     });
 
-    it('should set correct request method', () => {
+    it('should set correct request method', function () {
       let request = spec.buildRequests([bids[0]]);
       assert.equal(request.method, 'GET');
     });
 
-    it('should correctly form bid items', () => {
+    it('should correctly form bid items', function () {
       let bidList = bids;
       let request = spec.buildRequests(bidList);
       let parsedUrl = parseUrl(request.url);
@@ -93,13 +93,13 @@ describe('Adform adapter', function () {
       ]);
     });
 
-    it('should not change original validBidRequests object', () => {
+    it('should not change original validBidRequests object', function () {
       var resultBids = JSON.parse(JSON.stringify(bids[0]));
       let request = spec.buildRequests([bids[0]]);
       assert.deepEqual(resultBids, bids[0]);
     });
 
-    it('should set gross to the request, if there is any gross priceType', () => {
+    it('should set gross to the request, if there is any gross priceType', function () {
       let request = spec.buildRequests([bids[5], bids[5]]);
       let parsedUrl = parseUrl(request.url);
 
@@ -112,7 +112,7 @@ describe('Adform adapter', function () {
     });
 
     describe('gdpr', function () {
-      it('should send GDPR Consent data to adform if gdprApplies', () => {
+      it('should send GDPR Consent data to adform if gdprApplies', function () {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
@@ -121,7 +121,7 @@ describe('Adform adapter', function () {
         assert.equal(parsedUrl.gdpr_consent, 'concentDataString');
       });
 
-      it('should not send GDPR Consent data to adform if gdprApplies is false or undefined', () => {
+      it('should not send GDPR Consent data to adform if gdprApplies is false or undefined', function () {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: false, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
@@ -134,7 +134,7 @@ describe('Adform adapter', function () {
         assert.ok(!parsedUrl.gdpr_consent);
       });
 
-      it('should return GDPR Consent data with request data', () => {
+      it('should return GDPR Consent data with request data', function () {
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
 
         assert.deepEqual(request.gdpr, {
@@ -149,11 +149,11 @@ describe('Adform adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should respond with empty response when there is empty serverResponse', () => {
+    it('should respond with empty response when there is empty serverResponse', function () {
       let result = spec.interpretResponse({ body: {} }, {});
       assert.deepEqual(result, []);
     });
-    it('should respond with empty response when response from server is not banner', () => {
+    it('should respond with empty response when response from server is not banner', function () {
       serverResponse.body[0].response = 'not banner';
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[0]];
@@ -161,7 +161,7 @@ describe('Adform adapter', function () {
 
       assert.deepEqual(result, []);
     });
-    it('should interpret server response correctly with one bid', () => {
+    it('should interpret server response correctly with one bid', function () {
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[0]];
       let result = spec.interpretResponse(serverResponse, bidRequest)[0];
@@ -180,7 +180,7 @@ describe('Adform adapter', function () {
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');
     });
 
-    it('should set correct netRevenue', () => {
+    it('should set correct netRevenue', function () {
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[1]];
       bidRequest.netRevenue = 'gross';
@@ -189,22 +189,22 @@ describe('Adform adapter', function () {
       assert.equal(result.netRevenue, false);
     });
 
-    it('should create bid response item for every requested item', () => {
+    it('should create bid response item for every requested item', function () {
       let result = spec.interpretResponse(serverResponse, bidRequest);
       assert.lengthOf(result, 5);
     });
 
-    it('should create bid response with vast xml', () => {
+    it('should create bid response with vast xml', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest)[3];
       assert.equal(result.vastXml, '<vast_xml>');
     });
 
-    it('should create bid response with vast url', () => {
+    it('should create bid response with vast url', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest)[4];
       assert.equal(result.vastUrl, 'vast://url');
     });
 
-    it('should set mediaType on bid response', () => {
+    it('should set mediaType on bid response', function () {
       const expected = [ BANNER, BANNER, BANNER, VIDEO, VIDEO ];
       const result = spec.interpretResponse(serverResponse, bidRequest);
       for (let i = 0; i < result.length; i++) {
@@ -212,7 +212,7 @@ describe('Adform adapter', function () {
       }
     });
 
-    it('should set default netRevenue as gross', () => {
+    it('should set default netRevenue as gross', function () {
       bidRequest.netRevenue = 'gross';
       const result = spec.interpretResponse(serverResponse, bidRequest);
       for (let i = 0; i < result.length; i++) {
@@ -220,7 +220,7 @@ describe('Adform adapter', function () {
       }
     });
 
-    it('should set gdpr if it exist in bidRequest', () => {
+    it('should set gdpr if it exist in bidRequest', function () {
       bidRequest.gdpr = {
         gdpr: true,
         gdpr_consent: 'ERW342EIOWT34234KMGds'
@@ -240,7 +240,7 @@ describe('Adform adapter', function () {
     });
 
     describe('verifySizes', function () {
-      it('should respond with empty response when sizes doesn\'t match', () => {
+      it('should respond with empty response when sizes doesn\'t match', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;
         serverResponse.body[0].height = 150;
@@ -253,7 +253,7 @@ describe('Adform adapter', function () {
         assert.equal(serverResponse.body[0].response, 'banner');
         assert.deepEqual(result, []);
       });
-      it('should respond with empty response when sizes as a strings doesn\'t match', () => {
+      it('should respond with empty response when sizes as a strings doesn\'t match', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;
         serverResponse.body[0].height = 150;
@@ -268,7 +268,7 @@ describe('Adform adapter', function () {
         assert.equal(serverResponse.body[0].response, 'banner');
         assert.deepEqual(result, []);
       });
-      it('should support size dimensions as a strings', () => {
+      it('should support size dimensions as a strings', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 300;
         serverResponse.body[0].height = 600;

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -3,10 +3,10 @@ import * as url from 'src/url';
 import {spec} from 'modules/adformBidAdapter';
 import { BANNER, VIDEO } from 'src/mediaTypes';
 
-describe('Adform adapter', () => {
+describe('Adform adapter', function () {
   let serverResponse, bidRequest, bidResponses;
   let bids = [];
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'adform',
       'params': {
@@ -26,7 +26,7 @@ describe('Adform adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should pass multiple bids via single request', () => {
       let request = spec.buildRequests(bids);
       let parsedUrl = parseUrl(request.url);
@@ -111,7 +111,7 @@ describe('Adform adapter', () => {
       assert.equal(parsedUrl.query.pt, 'gross');
     });
 
-    describe('gdpr', () => {
+    describe('gdpr', function () {
       it('should send GDPR Consent data to adform if gdprApplies', () => {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
@@ -148,7 +148,7 @@ describe('Adform adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should respond with empty response when there is empty serverResponse', () => {
       let result = spec.interpretResponse({ body: {} }, {});
       assert.deepEqual(result, []);
@@ -239,7 +239,7 @@ describe('Adform adapter', () => {
       };
     });
 
-    describe('verifySizes', () => {
+    describe('verifySizes', function () {
       it('should respond with empty response when sizes doesn\'t match', () => {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -285,7 +285,7 @@ describe('Adform adapter', function () {
     })
   });
 
-  beforeEach(() => {
+  beforeEach(function () {
     let sizes = [[250, 300], [300, 250], [300, 600]];
     let placementCode = ['div-01', 'div-02', 'div-03', 'div-04', 'div-05'];
     let params = [{ mid: 1, url: 'some// there' }, {adxDomain: null, mid: 2, someVar: 'someValue', pt: 'gross'}, { adxDomain: null, mid: 3, pdom: 'home' }, {mid: 5, pt: 'net'}, {mid: 6, pt: 'gross'}];

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('AdgenerationAdapter', function () {
   const ENDPOINT = ['http://api-test.scaleout.jp/adsv/v1', 'https://d.socdm.com/adsv/v1'];
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -21,11 +21,11 @@ describe('AdgenerationAdapter', function () {
         id: '58278', // banner
       }
     };
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {};
@@ -91,25 +91,25 @@ describe('AdgenerationAdapter', function () {
       banner: 'posall=SSPLOC&id=58278&sdktype=0&hb=true&t=json3&imark=1',
       native: 'posall=SSPLOC&id=58278&sdktype=0&hb=true&t=json3'
     };
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(ENDPOINT[1]);
       expect(request.method).to.equal('GET');
     });
 
-    it('sends bid request to debug ENDPOINT via GET', () => {
+    it('sends bid request to debug ENDPOINT via GET', function () {
       bidRequests[0].params.debug = true;
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(ENDPOINT[0]);
       expect(request.method).to.equal('GET');
     });
 
-    it('should attache params to the banner request', () => {
+    it('should attache params to the banner request', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.data).to.equal(data.banner);
     });
 
-    it('should attache params to the native request', () => {
+    it('should attache params to the native request', function () {
       const request = spec.buildRequests(bidRequests)[1];
       expect(request.data).to.equal(data.native);
     });
@@ -336,12 +336,12 @@ describe('AdgenerationAdapter', function () {
       }
     };
 
-    it('no bid responses', () => {
+    it('no bid responses', function () {
       const result = spec.interpretResponse({body: serverResponse.noAd}, bidRequests.banner);
       expect(result.length).to.equal(0);
     });
 
-    it('handles banner responses', () => {
+    it('handles banner responses', function () {
       const result = spec.interpretResponse({body: serverResponse.banner}, bidRequests.banner)[0];
       expect(result.requestId).to.equal(bidResponses.banner.requestId);
       expect(result.width).to.equal(bidResponses.banner.width);
@@ -355,7 +355,7 @@ describe('AdgenerationAdapter', function () {
       expect(result.ad).to.equal(bidResponses.banner.ad);
     });
 
-    it('handles native responses', () => {
+    it('handles native responses', function () {
       const result = spec.interpretResponse({body: serverResponse.native}, bidRequests.native)[0];
       expect(result.requestId).to.equal(bidResponses.native.requestId);
       expect(result.width).to.equal(bidResponses.native.width);

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -4,17 +4,17 @@ import {spec} from 'modules/adgenerationBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 import {NATIVE} from 'src/mediaTypes';
 
-describe('AdgenerationAdapter', () => {
+describe('AdgenerationAdapter', function () {
   const adapter = newBidder(spec);
   const ENDPOINT = ['http://api-test.scaleout.jp/adsv/v1', 'https://d.socdm.com/adsv/v1'];
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'adg',
       'params': {
@@ -33,7 +33,7 @@ describe('AdgenerationAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [
       { // banner
         bidder: 'adg',
@@ -115,7 +115,7 @@ describe('AdgenerationAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequests = {
       banner: {
         bidRequest: {

--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -58,56 +58,56 @@ describe('', function () {
       sandbox.reset();
     });
 
-    it('should parse first direct visit as (direct)', () => {
+    it('should parse first direct visit as (direct)', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(undefined);
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com');
       expect(source).to.be.eql(DIRECT);
     });
 
-    it('should respect past campaign visits before direct', () => {
+    it('should respect past campaign visits before direct', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(JSON.stringify(CAMPAIGN));
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com');
       expect(source).to.be.eql(CAMPAIGN);
     });
 
-    it('should parse visit from google as organic', () => {
+    it('should parse visit from google as organic', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(undefined);
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com', 'https://www.google.com/search?q=pikachu');
       expect(source).to.be.eql(GOOGLE_ORGANIC);
     });
 
-    it('should respect previous campaign visit before organic', () => {
+    it('should respect previous campaign visit before organic', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(JSON.stringify(CAMPAIGN));
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com', 'https://www.google.com/search?q=pikachu');
       expect(source).to.be.eql(CAMPAIGN);
     });
 
-    it('should parse referral visit', () => {
+    it('should parse referral visit', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(undefined);
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com', 'http://lander.com/lander.html');
       expect(source).to.be.eql(REFERRER);
     });
 
-    it('should respect previous campaign visit before referral', () => {
+    it('should respect previous campaign visit before referral', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(JSON.stringify(CAMPAIGN));
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://example.com', 'https://www.google.com/search?q=pikachu');
       expect(source).to.be.eql(CAMPAIGN);
     });
 
-    it('should parse referral visit from same domain as direct', () => {
+    it('should parse referral visit from same domain as direct', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(undefined);
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://lander.com/news.html', 'http://lander.com/lander.html');
       expect(source).to.be.eql(DIRECT);
     });
 
-    it('should parse campaign visit', () => {
+    it('should parse campaign visit', function () {
       stubGetItem.withArgs('adk_dpt_analytics').returns(undefined);
       stubSetItem.returns(undefined);
       let source = getUmtSource('http://lander.com/index.html?utm_campaign=new_campaign&utm_source=adkernel&utm_medium=email&utm_c1=1&utm_c2=2&utm_c3=3&utm_c4=4&utm_c5=5');
@@ -203,7 +203,7 @@ describe('', function () {
       events.getEvents.restore();
     });
 
-    it('should be configurable', () => {
+    it('should be configurable', function () {
       adaptermanager.registerAnalyticsAdapter({
         code: 'adkernelAdn',
         adapter: analyticsAdapter
@@ -221,21 +221,21 @@ describe('', function () {
       expect(analyticsAdapter.context).to.have.property('pubId', 777);
     });
 
-    it('should handle auction init event', () => {
+    it('should handle auction init event', function () {
       events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {config: {}, timeout: 3000});
       const ev = analyticsAdapter.context.queue.peekAll();
       expect(ev).to.have.length(1);
       expect(ev[0]).to.be.eql({event: 'auctionInit'});
     });
 
-    it('should handle bid request event', () => {
+    it('should handle bid request event', function () {
       events.emit(CONSTANTS.EVENTS.BID_REQUESTED, REQUEST);
       const ev = analyticsAdapter.context.queue.peekAll();
       expect(ev).to.have.length(2);
       expect(ev[1]).to.be.eql({event: 'bidRequested', adapter: 'adapter', tagid: 'container-1'});
     });
 
-    it('should handle bid response event', () => {
+    it('should handle bid response event', function () {
       events.emit(CONSTANTS.EVENTS.BID_RESPONSE, RESPONSE);
       const ev = analyticsAdapter.context.queue.peekAll();
       expect(ev).to.have.length(3);
@@ -248,7 +248,7 @@ describe('', function () {
       });
     });
 
-    it('should handle auction end event', () => {
+    it('should handle auction end event', function () {
       timer.tick(447);
       events.emit(CONSTANTS.EVENTS.AUCTION_END, RESPONSE);
       let ev = analyticsAdapter.context.queue.peekAll();
@@ -258,7 +258,7 @@ describe('', function () {
       expect(ev[3]).to.be.eql({event: 'auctionEnd', time: 0.447});
     });
 
-    it('should handle winning bid', () => {
+    it('should handle winning bid', function () {
       events.emit(CONSTANTS.EVENTS.BID_WON, RESPONSE);
       timer.tick(4500);
       expect(ajaxStub.calledTwice).to.be.equal(true);

--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -36,11 +36,11 @@ const CAMPAIGN = {
 describe('', function () {
   let sandbox;
 
-  before(() => {
+  before(function () {
     sandbox = sinon.sandbox.create();
   });
 
-  after(() => {
+  after(function () {
     sandbox.restore();
     analyticsAdapter.disableAnalytics();
   });
@@ -49,12 +49,12 @@ describe('', function () {
     let stubSetItem;
     let stubGetItem;
 
-    before(() => {
+    before(function () {
       stubSetItem = sandbox.stub(storage, 'setItem');
       stubGetItem = sandbox.stub(storage, 'getItem');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       sandbox.reset();
     });
 
@@ -117,10 +117,10 @@ describe('', function () {
 
   describe('ExpiringQueue', function () {
     let timer;
-    before(() => {
+    before(function () {
       timer = sandbox.useFakeTimers(0);
     });
-    after(() => {
+    after(function () {
       timer.restore();
     });
 
@@ -188,18 +188,18 @@ describe('', function () {
     let ajaxStub;
     let timer;
 
-    before(() => {
+    before(function () {
       ajaxStub = sandbox.stub(ajax, 'ajax');
       timer = sandbox.useFakeTimers(0);
     });
 
-    beforeEach(() => {
+    beforeEach(function () {
       sandbox.stub(events, 'getEvents').callsFake(() => {
         return []
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       events.getEvents.restore();
     });
 

--- a/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnAnalyticsAdapter_spec.js
@@ -33,7 +33,7 @@ const CAMPAIGN = {
   c5: '5'
 
 };
-describe('', () => {
+describe('', function () {
   let sandbox;
 
   before(() => {
@@ -45,7 +45,7 @@ describe('', () => {
     analyticsAdapter.disableAnalytics();
   });
 
-  describe('UTM source parser', () => {
+  describe('UTM source parser', function () {
     let stubSetItem;
     let stubGetItem;
 
@@ -115,7 +115,7 @@ describe('', () => {
     });
   });
 
-  describe('ExpiringQueue', () => {
+  describe('ExpiringQueue', function () {
     let timer;
     before(() => {
       timer = sandbox.useFakeTimers(0);
@@ -184,7 +184,7 @@ describe('', () => {
     size: '300x250'
   };
 
-  describe('Analytics adapter', () => {
+  describe('Analytics adapter', function () {
     let ajaxStub;
     let timer;
 

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/adkernelAdnBidAdapter';
 import * as utils from 'src/utils';
 
-describe('AdkernelAdn adapter', () => {
+describe('AdkernelAdn adapter', function () {
   const bid1_pub1 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact0',
@@ -110,7 +110,7 @@ describe('AdkernelAdn adapter', () => {
       syncpages: ['https://dsp.adkernel.com/sync']
     };
 
-  describe('input parameters validation', () => {
+  describe('input parameters validation', function () {
     it('empty request shouldn\'t generate exception', () => {
       expect(spec.isBidRequestValid({bidderCode: 'adkernelAdn'
       })).to.be.equal(false);
@@ -157,7 +157,7 @@ describe('AdkernelAdn adapter', () => {
     return [pbRequests, tagRequests];
   }
 
-  describe('banner request building', () => {
+  describe('banner request building', function () {
     let [_, tagRequests] = buildRequest([bid1_pub1]);
     let tagRequest = tagRequests[0];
 
@@ -207,7 +207,7 @@ describe('AdkernelAdn adapter', () => {
     });
   });
 
-  describe('video request building', () => {
+  describe('video request building', function () {
     let [_, tagRequests] = buildRequest([bid_video1, bid_video2]);
     let tagRequest = tagRequests[0];
 
@@ -227,7 +227,7 @@ describe('AdkernelAdn adapter', () => {
     });
   });
 
-  describe('requests routing', () => {
+  describe('requests routing', function () {
     it('should issue a request for each publisher', () => {
       let [pbRequests, tagRequests] = buildRequest([bid1_pub1, bid_video1]);
       expect(pbRequests).to.have.length(2);
@@ -246,7 +246,7 @@ describe('AdkernelAdn adapter', () => {
     });
   });
 
-  describe('responses processing', () => {
+  describe('responses processing', function () {
     let responses;
     before(() => {
       responses = spec.interpretResponse({body: response});

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -248,7 +248,7 @@ describe('AdkernelAdn adapter', function () {
 
   describe('responses processing', function () {
     let responses;
-    before(() => {
+    before(function () {
       responses = spec.interpretResponse({body: response});
     });
     it('should parse all responses', function () {

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -111,11 +111,11 @@ describe('AdkernelAdn adapter', function () {
     };
 
   describe('input parameters validation', function () {
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid({bidderCode: 'adkernelAdn'
       })).to.be.equal(false);
     });
-    it('request without pubid should be ignored', () => {
+    it('request without pubid should be ignored', function () {
       expect(spec.isBidRequestValid({
         bidder: 'adkernelAdn',
         params: {},
@@ -123,7 +123,7 @@ describe('AdkernelAdn adapter', function () {
         sizes: [[300, 250]]
       })).to.be.equal(false);
     });
-    it('request with invalid pubid should be ignored', () => {
+    it('request with invalid pubid should be ignored', function () {
       expect(spec.isBidRequestValid({
         bidder: 'adkernelAdn',
         params: {
@@ -161,37 +161,37 @@ describe('AdkernelAdn adapter', function () {
     let [_, tagRequests] = buildRequest([bid1_pub1]);
     let tagRequest = tagRequests[0];
 
-    it('should have request id', () => {
+    it('should have request id', function () {
       expect(tagRequest).to.have.property('id');
     });
-    it('should have transaction id', () => {
+    it('should have transaction id', function () {
       expect(tagRequest).to.have.property('tid');
     });
-    it('should have sizes', () => {
+    it('should have sizes', function () {
       expect(tagRequest.imp[0].banner).to.have.property('format');
       expect(tagRequest.imp[0].banner.format).to.be.eql(['300x250', '300x200']);
     });
-    it('should have impression id', () => {
+    it('should have impression id', function () {
       expect(tagRequest.imp[0]).to.have.property('id', 'bidid_1');
     });
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(tagRequest.imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
-    it('should create proper site block', () => {
+    it('should create proper site block', function () {
       expect(tagRequest.site).to.have.property('page', 'https://example.com/index.html');
       expect(tagRequest.site).to.have.property('secure', 1);
     });
 
-    it('should not have user object', () => {
+    it('should not have user object', function () {
       expect(tagRequest).to.not.have.property('user');
     });
 
-    it('shouldn\'t contain gdpr-related information for default request', () => {
+    it('shouldn\'t contain gdpr-related information for default request', function () {
       let [_, tagRequests] = buildRequest([bid1_pub1]);
       expect(tagRequests[0]).to.not.have.property('user');
     });
 
-    it('should contain gdpr-related information if consent is configured', () => {
+    it('should contain gdpr-related information if consent is configured', function () {
       let [_, bidRequests] = buildRequest([bid1_pub1],
         {gdprConsent: {gdprApplies: true, consentString: 'test-consent-string'}});
       expect(bidRequests[0]).to.have.property('user');
@@ -199,7 +199,7 @@ describe('AdkernelAdn adapter', function () {
       expect(bidRequests[0].user).to.have.property('consent', 'test-consent-string');
     });
 
-    it('should\'t contain consent string if gdpr isn\'t applied', () => {
+    it('should\'t contain consent string if gdpr isn\'t applied', function () {
       let [_, bidRequests] = buildRequest([bid1_pub1], {gdprConsent: {gdprApplies: false}});
       expect(bidRequests[0]).to.have.property('user');
       expect(bidRequests[0].user).to.have.property('gdpr', 0);
@@ -211,15 +211,15 @@ describe('AdkernelAdn adapter', function () {
     let [_, tagRequests] = buildRequest([bid_video1, bid_video2]);
     let tagRequest = tagRequests[0];
 
-    it('should have video object', () => {
+    it('should have video object', function () {
       expect(tagRequest.imp[0]).to.have.property('video');
       expect(tagRequest.imp[1]).to.have.property('video');
     });
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(tagRequest.imp[0]).to.have.property('tagid', 'video_wrapper');
       expect(tagRequest.imp[1]).to.have.property('tagid', 'video_wrapper2');
     });
-    it('should have size', () => {
+    it('should have size', function () {
       expect(tagRequest.imp[0].video).to.have.property('w', 640);
       expect(tagRequest.imp[0].video).to.have.property('h', 300);
       expect(tagRequest.imp[1].video).to.have.property('w', 1920);
@@ -228,7 +228,7 @@ describe('AdkernelAdn adapter', function () {
   });
 
   describe('requests routing', function () {
-    it('should issue a request for each publisher', () => {
+    it('should issue a request for each publisher', function () {
       let [pbRequests, tagRequests] = buildRequest([bid1_pub1, bid_video1]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].url).to.have.string(`account=${bid1_pub1.params.pubId}`);
@@ -236,7 +236,7 @@ describe('AdkernelAdn adapter', function () {
       expect(tagRequests[0].imp).to.have.length(1);
       expect(tagRequests[1].imp).to.have.length(1);
     });
-    it('should issue a request for each host', () => {
+    it('should issue a request for each host', function () {
       let [pbRequests, tagRequests] = buildRequest([bid1_pub1, bid1_pub2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].url).to.have.string('//tag.adkernel.com/tag');
@@ -251,10 +251,10 @@ describe('AdkernelAdn adapter', function () {
     before(() => {
       responses = spec.interpretResponse({body: response});
     });
-    it('should parse all responses', () => {
+    it('should parse all responses', function () {
       expect(responses).to.have.length(3);
     });
-    it('should return fully-initialized bid-response', () => {
+    it('should return fully-initialized bid-response', function () {
       let resp = responses[0];
       expect(resp).to.have.property('bidderCode', 'adkernelAdn');
       expect(resp).to.have.property('requestId', '2c5e951baeeadd');
@@ -268,7 +268,7 @@ describe('AdkernelAdn adapter', function () {
       expect(resp).to.have.property('ad');
       expect(resp.ad).to.have.string('<!-- tag goes here -->');
     });
-    it('should return fully-initialized video bid-response', () => {
+    it('should return fully-initialized video bid-response', function () {
       let resp = responses[2];
       expect(resp).to.have.property('bidderCode', 'adkernelAdn');
       expect(resp).to.have.property('requestId', '57d602ad1c9545');
@@ -280,7 +280,7 @@ describe('AdkernelAdn adapter', function () {
       expect(resp).to.have.property('vastUrl', 'http://vast.com/vast.xml');
       expect(resp).to.not.have.property('ad');
     });
-    it('should perform usersync', () => {
+    it('should perform usersync', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: false}, [{body: response}]);
       expect(syncs).to.have.length(0);
       syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: response}]);
@@ -288,12 +288,12 @@ describe('AdkernelAdn adapter', function () {
       expect(syncs[0]).to.have.property('type', 'iframe');
       expect(syncs[0]).to.have.property('url', 'https://dsp.adkernel.com/sync');
     });
-    it('should handle user-sync only response', () => {
+    it('should handle user-sync only response', function () {
       let [pbRequests, tagRequests] = buildRequest([bid1_pub1]);
       let resp = spec.interpretResponse({body: usersyncOnlyResponse}, pbRequests[0]);
       expect(resp).to.have.length(0);
     });
-    it('shouldn\' fail on empty response', () => {
+    it('shouldn\' fail on empty response', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: ''}]);
       expect(syncs).to.have.length(0);
     });

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -128,21 +128,21 @@ describe('Adkernel adapter', function () {
   }
 
   describe('input parameters validation', function () {
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid({
         bidderCode: 'adkernel'
       })).to.be.equal(false);
     });
 
-    it('request without zone shouldn\'t issue a request', () => {
+    it('request without zone shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_zone)).to.be.equal(false);
     });
 
-    it('request without host shouldn\'t issue a request', () => {
+    it('request without host shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_host)).to.be.equal(false);
     });
 
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid(bid_with_wrong_zoneId)).to.be.equal(false);
     });
   });
@@ -154,46 +154,46 @@ describe('Adkernel adapter', function () {
       bidRequest = bidRequests[0];
     });
 
-    it('should be a first-price auction', () => {
+    it('should be a first-price auction', function () {
       expect(bidRequest).to.have.property('at', 1);
     });
 
-    it('should have banner object', () => {
+    it('should have banner object', function () {
       expect(bidRequest.imp[0]).to.have.property('banner');
     });
 
-    it('should have w/h', () => {
+    it('should have w/h', function () {
       expect(bidRequest.imp[0].banner).to.have.property('format');
       expect(bidRequest.imp[0].banner.format).to.be.eql([{w: 300, h: 250}, {w: 300, h: 200}]);
     });
 
-    it('should respect secure connection', () => {
+    it('should respect secure connection', function () {
       expect(bidRequest.imp[0]).to.have.property('secure', 1);
     });
 
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(bidRequest.imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
 
-    it('should create proper site block', () => {
+    it('should create proper site block', function () {
       expect(bidRequest.site).to.have.property('domain', 'example.com');
       expect(bidRequest.site).to.have.property('page', 'https://example.com/index.html');
     });
 
-    it('should fill device with caller macro', () => {
+    it('should fill device with caller macro', function () {
       expect(bidRequest).to.have.property('device');
       expect(bidRequest.device).to.have.property('ip', 'caller');
       expect(bidRequest.device).to.have.property('ua', 'caller');
       expect(bidRequest.device).to.have.property('dnt', 1);
     });
 
-    it('shouldn\'t contain gdpr-related information for default request', () => {
+    it('shouldn\'t contain gdpr-related information for default request', function () {
       let [_, bidRequests] = buildRequest([bid1_zone1]);
       expect(bidRequests[0]).to.not.have.property('regs');
       expect(bidRequests[0]).to.not.have.property('user');
     });
 
-    it('should contain gdpr-related information if consent is configured', () => {
+    it('should contain gdpr-related information if consent is configured', function () {
       let [_, bidRequests] = buildRequest([bid1_zone1],
         {gdprConsent: {gdprApplies: true, consentString: 'test-consent-string', vendorData: {}}});
       let bidRequest = bidRequests[0];
@@ -203,7 +203,7 @@ describe('Adkernel adapter', function () {
       expect(bidRequest.user.ext).to.be.eql({'consent': 'test-consent-string'});
     });
 
-    it('should\'t contain consent string if gdpr isn\'t applied', () => {
+    it('should\'t contain consent string if gdpr isn\'t applied', function () {
       let [_, bidRequests] = buildRequest([bid1_zone1], {gdprConsent: {gdprApplies: false}});
       let bidRequest = bidRequests[0];
       expect(bidRequest).to.have.property('regs');
@@ -211,7 +211,7 @@ describe('Adkernel adapter', function () {
       expect(bidRequest).to.not.have.property('user');
     });
 
-    it('should\'t pass dnt if state is unknown', () => {
+    it('should\'t pass dnt if state is unknown', function () {
       let [_, bidRequests] = buildRequest([bid1_zone1], {}, 'https://example.com/index.html', false);
       expect(bidRequests[0].device).to.not.have.property('dnt');
     });
@@ -223,29 +223,29 @@ describe('Adkernel adapter', function () {
       [_, bidRequests] = buildRequest([bid_video]);
     });
 
-    it('should have video object', () => {
+    it('should have video object', function () {
       expect(bidRequests[0].imp[0]).to.have.property('video');
     });
 
-    it('should have h/w', () => {
+    it('should have h/w', function () {
       expect(bidRequests[0].imp[0].video).to.have.property('w', 640);
       expect(bidRequests[0].imp[0].video).to.have.property('h', 480);
     });
 
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(bidRequests[0].imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
   });
 
   describe('requests routing', function () {
-    it('should issue a request for each host', () => {
+    it('should issue a request for each host', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].url).to.have.string(`//${bid1_zone1.params.host}/`);
       expect(pbRequests[1].url).to.have.string(`//${bid3_host2.params.host}/`);
     });
 
-    it('should issue a request for each zone', () => {
+    it('should issue a request for each zone', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1, bid2_zone2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].data.zone).to.be.equal(bid1_zone1.params.zoneId);
@@ -254,7 +254,7 @@ describe('Adkernel adapter', function () {
   });
 
   describe('responses processing', function () {
-    it('should return fully-initialized banner bid-response', () => {
+    it('should return fully-initialized banner bid-response', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1]);
       let resp = spec.interpretResponse({body: bidResponse1}, pbRequests[0])[0];
       expect(resp).to.have.property('requestId', 'Bid_01');
@@ -269,7 +269,7 @@ describe('Adkernel adapter', function () {
       expect(resp.ad).to.have.string('<!-- admarkup here -->');
     });
 
-    it('should return fully-initialized video bid-response', () => {
+    it('should return fully-initialized video bid-response', function () {
       let [pbRequests, _] = buildRequest([bid_video]);
       let resp = spec.interpretResponse({body: videoBidResponse}, pbRequests[0])[0];
       expect(resp).to.have.property('requestId', 'Bid_Video');
@@ -280,20 +280,20 @@ describe('Adkernel adapter', function () {
       expect(resp.height).to.equal(480);
     });
 
-    it('should add nurl as pixel for banner response', () => {
+    it('should add nurl as pixel for banner response', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1]);
       let resp = spec.interpretResponse({body: bidResponse1}, pbRequests[0])[0];
       let expectedNurl = bidResponse1.seatbid[0].bid[0].nurl + '&px=1';
       expect(resp.ad).to.have.string(expectedNurl);
     });
 
-    it('should handle bidresponse with user-sync only', () => {
+    it('should handle bidresponse with user-sync only', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1]);
       let resp = spec.interpretResponse({body: usersyncOnlyResponse}, pbRequests[0]);
       expect(resp).to.have.length(0);
     });
 
-    it('should perform usersync', () => {
+    it('should perform usersync', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: false}, [{body: bidResponse1}]);
       expect(syncs).to.have.length(0);
       syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: bidResponse1}]);

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -149,7 +149,7 @@ describe('Adkernel adapter', function () {
 
   describe('banner request building', function () {
     let bidRequest, bidRequests, _;
-    before(() => {
+    before(function () {
       [_, bidRequests] = buildRequest([bid1_zone1]);
       bidRequest = bidRequests[0];
     });
@@ -219,7 +219,7 @@ describe('Adkernel adapter', function () {
 
   describe('video request building', function () {
     let _, bidRequests;
-    before(() => {
+    before(function () {
       [_, bidRequests] = buildRequest([bid_video]);
     });
 

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/adkernelBidAdapter';
 import * as utils from 'src/utils';
 import {parse as parseUrl} from 'src/url';
 
-describe('Adkernel adapter', () => {
+describe('Adkernel adapter', function () {
   const bid1_zone1 = {
       bidder: 'adkernel',
       bidId: 'Bid_01',
@@ -127,7 +127,7 @@ describe('Adkernel adapter', () => {
     return [pbRequests, rtbRequests];
   }
 
-  describe('input parameters validation', () => {
+  describe('input parameters validation', function () {
     it('empty request shouldn\'t generate exception', () => {
       expect(spec.isBidRequestValid({
         bidderCode: 'adkernel'
@@ -147,7 +147,7 @@ describe('Adkernel adapter', () => {
     });
   });
 
-  describe('banner request building', () => {
+  describe('banner request building', function () {
     let bidRequest, bidRequests, _;
     before(() => {
       [_, bidRequests] = buildRequest([bid1_zone1]);
@@ -217,7 +217,7 @@ describe('Adkernel adapter', () => {
     });
   });
 
-  describe('video request building', () => {
+  describe('video request building', function () {
     let _, bidRequests;
     before(() => {
       [_, bidRequests] = buildRequest([bid_video]);
@@ -237,7 +237,7 @@ describe('Adkernel adapter', () => {
     });
   });
 
-  describe('requests routing', () => {
+  describe('requests routing', function () {
     it('should issue a request for each host', () => {
       let [pbRequests, _] = buildRequest([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
@@ -253,7 +253,7 @@ describe('Adkernel adapter', () => {
     });
   });
 
-  describe('responses processing', () => {
+  describe('responses processing', function () {
     it('should return fully-initialized banner bid-response', () => {
       let [pbRequests, _] = buildRequest([bid1_zone1]);
       let resp = spec.interpretResponse({body: bidResponse1}, pbRequests[0])[0];

--- a/test/spec/modules/admixerBidAdapter_spec.js
+++ b/test/spec/modules/admixerBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('AdmixerAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.be.exist.and.to.be.a('function');
     });
   });
@@ -28,11 +28,11 @@ describe('AdmixerAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -57,14 +57,14 @@ describe('AdmixerAdapter', function () {
       }
     ];
 
-    it('should add referrer and imp to be equal bidRequest', () => {
+    it('should add referrer and imp to be equal bidRequest', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data.substr(5));
       expect(payload.referrer).to.not.be.undefined;
       expect(payload.imps[0]).to.deep.equal(bidRequests[0]);
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT_URL);
       expect(request.method).to.equal('GET');
@@ -86,7 +86,7 @@ describe('AdmixerAdapter', function () {
       }]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const body = response.body;
       let expectedResponse = [
         {
@@ -107,7 +107,7 @@ describe('AdmixerAdapter', function () {
       expect(result[0]).to.deep.equal(expectedResponse[0]);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = [];
 
       let result = spec.interpretResponse(response);

--- a/test/spec/modules/admixerBidAdapter_spec.js
+++ b/test/spec/modules/admixerBidAdapter_spec.js
@@ -6,16 +6,16 @@ const BIDDER_CODE = 'admixer';
 const ENDPOINT_URL = '//inv-nets.admixer.net/prebid.1.0.aspx';
 const ZONE_ID = '2eb6bd58-865c-47ce-af7f-a918108c3fd2';
 
-describe('AdmixerAdapter', () => {
+describe('AdmixerAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.be.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': BIDDER_CODE,
       'params': {
@@ -42,7 +42,7 @@ describe('AdmixerAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': BIDDER_CODE,
@@ -71,7 +71,7 @@ describe('AdmixerAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       body: [{
         'currency': 'USD',

--- a/test/spec/modules/adoceanBidAdapter_spec.js
+++ b/test/spec/modules/adoceanBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { spec } from 'modules/adoceanBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('AdoceanAdapter', () => {
+describe('AdoceanAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     const bid = {
       'bidder': 'adocean',
       'params': {
@@ -40,7 +40,7 @@ describe('AdoceanAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [
       {
         'bidder': 'adocean',
@@ -89,7 +89,7 @@ describe('AdoceanAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const response = {
       'body': [
         {

--- a/test/spec/modules/adoceanBidAdapter_spec.js
+++ b/test/spec/modules/adoceanBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('AdoceanAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('AdoceanAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       const bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -64,25 +64,25 @@ describe('AdoceanAdapter', function () {
       }
     };
 
-    it('should add bidIdMap with slaveId => bidId mapping', () => {
+    it('should add bidIdMap with slaveId => bidId mapping', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.bidIdMap).to.exists;
       const bidIdMap = request.bidIdMap;
       expect(bidIdMap[bidRequests[0].params.slaveId]).to.equal(bidRequests[0].bidId);
     });
 
-    it('sends bid request to url via GET', () => {
+    it('sends bid request to url via GET', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.method).to.equal('GET');
       expect(request.url).to.match(new RegExp(`^https://${bidRequests[0].params.emiter}/ad.json`));
     });
 
-    it('should attach id to url', () => {
+    it('should attach id to url', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.url).to.include('id=' + bidRequests[0].params.masterId);
     });
 
-    it('should attach consent information to url', () => {
+    it('should attach consent information to url', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.url).to.include('gdpr=1');
       expect(request.url).to.include('gdpr_consent=' + bidderRequest.gdprConsent.consentString);
@@ -128,7 +128,7 @@ describe('AdoceanAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const expectedResponse = [
         {
           'requestId': '30b31c1838de1e',
@@ -156,7 +156,7 @@ describe('AdoceanAdapter', function () {
       });
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       response.body = [
         {
           'id': 'adoceanmyaolafpjwftbz',

--- a/test/spec/modules/adomikAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adomikAnalyticsAdapter_spec.js
@@ -9,21 +9,21 @@ describe('Adomik Prebid Analytic', function () {
   let sendWonEventStub;
 
   describe('enableAnalytics', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(adomikAnalytics, 'track');
       sendEventStub = sinon.stub(adomikAnalytics, 'sendTypedEvent');
       sendWonEventStub = sinon.stub(adomikAnalytics, 'sendWonEvent');
       sinon.stub(events, 'getEvents').returns([]);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       adomikAnalytics.track.restore();
       sendEventStub.restore();
       sendWonEventStub.restore();
       events.getEvents.restore();
     });
 
-    after(() => {
+    after(function () {
       adomikAnalytics.disableAnalytics();
     });
 

--- a/test/spec/modules/adspiritBidAdapter_spec.js
+++ b/test/spec/modules/adspiritBidAdapter_spec.js
@@ -90,35 +90,35 @@ describe('Adspirit adapter tests', function () {
   });
 
   describe('test bid request', function () {
-    it('with valid data 1', () => {
+    it('with valid data 1', function () {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
-    it('with valid data 2', () => {
+    it('with valid data 2', function () {
       expect(spec.isBidRequestValid(bidRequests[1])).to.equal(true);
     });
-    it('with valid data 3', () => {
+    it('with valid data 3', function () {
       expect(spec.isBidRequestValid(bidRequests[2])).to.equal(true);
     });
-    it('with invalid data 1 (no host)', () => {
+    it('with invalid data 1 (no host)', function () {
       expect(spec.isBidRequestValid(bidRequests[3])).to.equal(false);
     });
-    it('with invalid data 2 (no placementId)', () => {
+    it('with invalid data 2 (no placementId)', function () {
       expect(spec.isBidRequestValid(bidRequests[4])).to.equal(false);
     });
-    it('with invalid data 3 (no bidder code)', () => {
+    it('with invalid data 3 (no bidder code)', function () {
       expect(spec.isBidRequestValid(bidRequests[5])).to.equal(false);
     });
   });
 
   describe('test request build', function () {
-    it('normal', () => {
+    it('normal', function () {
       var requests = spec.buildRequests([bidRequests[0]]);
       expect(requests).to.be.lengthOf(1);
     });
   });
 
   describe('test bid responses', function () {
-    it('success 1', () => {
+    it('success 1', function () {
       var bids = spec.interpretResponse(serverResponses[0], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(1);
       expect(bids[0].cpm).to.equal(1.5);
@@ -126,15 +126,15 @@ describe('Adspirit adapter tests', function () {
       expect(bids[0].height).to.equal(250);
       expect(bids[0].ad).to.have.length.above(1);
     });
-    it('fail 1 (cpm=0)', () => {
+    it('fail 1 (cpm=0)', function () {
       var bids = spec.interpretResponse(serverResponses[1], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(0);
     });
-    it('fail 2 (no response)', () => {
+    it('fail 2 (no response)', function () {
       var bids = spec.interpretResponse([], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(0);
     });
-    it('fail 3 (status fail)', () => {
+    it('fail 3 (status fail)', function () {
       var bids = spec.interpretResponse(serverResponses[2], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(0);
     });

--- a/test/spec/modules/adspiritBidAdapter_spec.js
+++ b/test/spec/modules/adspiritBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from 'modules/adspiritBidAdapter';
 
-describe('Adspirit adapter tests', () => {
+describe('Adspirit adapter tests', function () {
   let bidRequests, serverResponses;
 
   beforeEach(() => {
@@ -89,7 +89,7 @@ describe('Adspirit adapter tests', () => {
     ]
   });
 
-  describe('test bid request', () => {
+  describe('test bid request', function () {
     it('with valid data 1', () => {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
@@ -110,14 +110,14 @@ describe('Adspirit adapter tests', () => {
     });
   });
 
-  describe('test request build', () => {
+  describe('test request build', function () {
     it('normal', () => {
       var requests = spec.buildRequests([bidRequests[0]]);
       expect(requests).to.be.lengthOf(1);
     });
   });
 
-  describe('test bid responses', () => {
+  describe('test bid responses', function () {
     it('success 1', () => {
       var bids = spec.interpretResponse(serverResponses[0], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(1);

--- a/test/spec/modules/adspiritBidAdapter_spec.js
+++ b/test/spec/modules/adspiritBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {spec} from 'modules/adspiritBidAdapter';
 describe('Adspirit adapter tests', function () {
   let bidRequests, serverResponses;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       // valid for adspirit
       {

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -100,17 +100,17 @@ describe('adtelligentBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(VIDEO_REQUEST)).to.equal(12345);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, VIDEO_REQUEST);
       delete bid.params;
       expect(spec.isBidRequestValid(bid)).to.equal(undefined);
@@ -126,19 +126,19 @@ describe('adtelligentBidAdapter', function () {
     const videoRequest = spec.buildRequests(videoBidRequests, {});
     const videoAndDisplayRequests = spec.buildRequests(videoAndDisplayBidRequests, {});
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       expect(videoRequest.method).to.equal('GET');
       expect(displayRequest.method).to.equal('GET');
       expect(videoAndDisplayRequests.method).to.equal('GET');
     });
 
-    it('sends bid request to correct ENDPOINT', () => {
+    it('sends bid request to correct ENDPOINT', function () {
       expect(videoRequest.url).to.equal(ENDPOINT);
       expect(displayRequest.url).to.equal(ENDPOINT);
       expect(videoAndDisplayRequests.url).to.equal(ENDPOINT);
     });
 
-    it('sends correct video bid parameters', () => {
+    it('sends correct video bid parameters', function () {
       const bid = Object.assign({}, videoRequest.data);
       delete bid.domain;
 
@@ -152,7 +152,7 @@ describe('adtelligentBidAdapter', function () {
       expect(bid).to.deep.equal(eq);
     });
 
-    it('sends correct display bid parameters', () => {
+    it('sends correct display bid parameters', function () {
       const bid = Object.assign({}, displayRequest.data);
       delete bid.domain;
 
@@ -166,7 +166,7 @@ describe('adtelligentBidAdapter', function () {
       expect(bid).to.deep.equal(eq);
     });
 
-    it('sends correct video and display bid parameters', () => {
+    it('sends correct video and display bid parameters', function () {
       const bid = Object.assign({}, videoAndDisplayRequests.data);
       delete bid.domain;
 
@@ -196,7 +196,7 @@ describe('adtelligentBidAdapter', function () {
       eqResponse = null;
     });
 
-    it('should get correct video bid response', () => {
+    it('should get correct video bid response', function () {
       serverResponse = SERVER_VIDEO_RESPONSE;
       bidderRequest = videoBidderRequest;
       eqResponse = videoEqResponse;
@@ -204,7 +204,7 @@ describe('adtelligentBidAdapter', function () {
       bidServerResponseCheck();
     });
 
-    it('should get correct display bid response', () => {
+    it('should get correct display bid response', function () {
       serverResponse = SERVER_DISPLAY_RESPONSE;
       bidderRequest = displayBidderRequest;
       eqResponse = displayEqResponse;
@@ -225,13 +225,13 @@ describe('adtelligentBidAdapter', function () {
       expect(noBidResult.length).to.equal(0);
     }
 
-    it('handles video nobid responses', () => {
+    it('handles video nobid responses', function () {
       bidderRequest = videoBidderRequest;
 
       nobidServerResponseCheck();
     });
 
-    it('handles display nobid responses', () => {
+    it('handles display nobid responses', function () {
       bidderRequest = displayBidderRequest;
 
       nobidServerResponseCheck();

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -190,7 +190,7 @@ describe('adtelligentBidAdapter', function () {
     let bidderRequest;
     let eqResponse;
 
-    afterEach(() => {
+    afterEach(function () {
       serverResponse = null;
       bidderRequest = null;
       eqResponse = null;

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -96,16 +96,16 @@ const displayEqResponse = [{
   cpm: 0.9
 }];
 
-describe('adtelligentBidAdapter', () => {
+describe('adtelligentBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(VIDEO_REQUEST)).to.equal(12345);
     });
@@ -117,7 +117,7 @@ describe('adtelligentBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let videoBidRequests = [VIDEO_REQUEST];
     let displayBidRequests = [DISPLAY_REQUEST];
     let videoAndDisplayBidRequests = [DISPLAY_REQUEST, VIDEO_REQUEST];
@@ -185,7 +185,7 @@ describe('adtelligentBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse;
     let bidderRequest;
     let eqResponse;

--- a/test/spec/modules/aduptechBidAdapter_spec.js
+++ b/test/spec/modules/aduptechBidAdapter_spec.js
@@ -7,13 +7,13 @@ describe('AduptechBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when necessary information is given', () => {
+    it('should return true when necessary information is given', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
         params: {
@@ -23,11 +23,11 @@ describe('AduptechBidAdapter', function () {
       })).to.be.true;
     });
 
-    it('should return false on empty bid', () => {
+    it('should return false on empty bid', function () {
       expect(spec.isBidRequestValid({})).to.be.false;
     });
 
-    it('should return false on missing sizes', () => {
+    it('should return false on missing sizes', function () {
       expect(spec.isBidRequestValid({
         params: {
           publisher: 'test',
@@ -36,7 +36,7 @@ describe('AduptechBidAdapter', function () {
       })).to.be.false;
     });
 
-    it('should return false on empty sizes', () => {
+    it('should return false on empty sizes', function () {
       expect(spec.isBidRequestValid({
         sizes: [],
         params: {
@@ -46,27 +46,27 @@ describe('AduptechBidAdapter', function () {
       })).to.be.false;
     });
 
-    it('should return false on missing params', () => {
+    it('should return false on missing params', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
       })).to.be.false;
     });
 
-    it('should return false on invalid params', () => {
+    it('should return false on invalid params', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
         params: 'bar'
       })).to.be.false;
     });
 
-    it('should return false on empty params', () => {
+    it('should return false on empty params', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
         params: {}
       })).to.be.false;
     });
 
-    it('should return false on missing publisher', () => {
+    it('should return false on missing publisher', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
         params: {
@@ -75,7 +75,7 @@ describe('AduptechBidAdapter', function () {
       })).to.be.false;
     });
 
-    it('should return false on missing placement', () => {
+    it('should return false on missing placement', function () {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
         params: {
@@ -86,7 +86,7 @@ describe('AduptechBidAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should send one bid request per ad unit to the endpoint via POST', () => {
+    it('should send one bid request per ad unit to the endpoint via POST', function () {
       const bidRequests = [
         {
           bidder: BIDDER_CODE,
@@ -146,7 +146,7 @@ describe('AduptechBidAdapter', function () {
       });
     });
 
-    it('should pass gdpr informations', () => {
+    it('should pass gdpr informations', function () {
       const bidderRequest = {
         gdprConsent: {
           consentString: 'consentString',
@@ -175,7 +175,7 @@ describe('AduptechBidAdapter', function () {
       expect(result[0].data.gdpr.consentString).to.exist.and.to.equal(bidderRequest.gdprConsent.consentString);
     });
 
-    it('should encode publisher param in endpoint url', () => {
+    it('should encode publisher param in endpoint url', function () {
       const bidRequests = [
         {
           bidder: BIDDER_CODE,
@@ -196,13 +196,13 @@ describe('AduptechBidAdapter', function () {
       expect(result[0].url).to.equal(ENDPOINT_URL.replace(PUBLISHER_PLACEHOLDER, encodeURIComponent(bidRequests[0].params.publisher)));
     });
 
-    it('should handle empty bidRequests', () => {
+    it('should handle empty bidRequests', function () {
       expect(spec.buildRequests([])).to.deep.equal([]);
     });
   });
 
   describe('interpretResponse', function () {
-    it('should correctly interpret the server response', () => {
+    it('should correctly interpret the server response', function () {
       const serverResponse = {
         body: {
           bid: {
@@ -238,11 +238,11 @@ describe('AduptechBidAdapter', function () {
       ]);
     });
 
-    it('should handle empty serverResponse', () => {
+    it('should handle empty serverResponse', function () {
       expect(spec.interpretResponse({})).to.deep.equal([]);
     });
 
-    it('should handle missing bid', () => {
+    it('should handle missing bid', function () {
       expect(spec.interpretResponse({
         body: {
           creative: {}
@@ -250,7 +250,7 @@ describe('AduptechBidAdapter', function () {
       })).to.deep.equal([]);
     });
 
-    it('should handle missing creative', () => {
+    it('should handle missing creative', function () {
       expect(spec.interpretResponse({
         body: {
           bid: {}

--- a/test/spec/modules/aduptechBidAdapter_spec.js
+++ b/test/spec/modules/aduptechBidAdapter_spec.js
@@ -3,16 +3,16 @@ import { BIDDER_CODE, PUBLISHER_PLACEHOLDER, ENDPOINT_URL, ENDPOINT_METHOD, spec
 import { newBidder } from 'src/adapters/bidderFactory';
 import * as utils from 'src/utils';
 
-describe('AduptechBidAdapter', () => {
+describe('AduptechBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when necessary information is given', () => {
       expect(spec.isBidRequestValid({
         sizes: [[100, 200]],
@@ -85,7 +85,7 @@ describe('AduptechBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should send one bid request per ad unit to the endpoint via POST', () => {
       const bidRequests = [
         {
@@ -201,7 +201,7 @@ describe('AduptechBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should correctly interpret the server response', () => {
       const serverResponse = {
         body: {

--- a/test/spec/modules/adxcgAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adxcgAnalyticsAdapter_spec.js
@@ -9,14 +9,14 @@ describe('adxcg analytics adapter', function () {
   let xhr;
   let requests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
     xhr.onCreate = request => requests.push(request);
     sinon.stub(events, 'getEvents').returns([]);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     xhr.restore();
     events.getEvents.restore();
   });
@@ -164,14 +164,14 @@ describe('adxcg analytics adapter', function () {
       adapter: adxcgAnalyticsAdapter
     });
 
-    beforeEach(() => {
+    beforeEach(function () {
       adaptermanager.enableAnalytics({
         provider: 'adxcg',
         options: initOptions
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       adxcgAnalyticsAdapter.disableAnalytics();
     });
 

--- a/test/spec/modules/adxcgAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adxcgAnalyticsAdapter_spec.js
@@ -175,7 +175,7 @@ describe('adxcg analytics adapter', function () {
       adxcgAnalyticsAdapter.disableAnalytics();
     });
 
-    it('builds and sends auction data', () => {
+    it('builds and sends auction data', function () {
       // Step 1: Send auction init event
       events.emit(constants.EVENTS.AUCTION_INIT, {
         timestamp: auctionTimestamp

--- a/test/spec/modules/adxcgAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adxcgAnalyticsAdapter_spec.js
@@ -5,7 +5,7 @@ let adaptermanager = require('src/adaptermanager');
 let events = require('src/events');
 let constants = require('src/constants.json');
 
-describe('adxcg analytics adapter', () => {
+describe('adxcg analytics adapter', function () {
   let xhr;
   let requests;
 
@@ -21,7 +21,7 @@ describe('adxcg analytics adapter', () => {
     events.getEvents.restore();
   });
 
-  describe('track', () => {
+  describe('track', function () {
     let initOptions = {
       publisherId: '42'
     };

--- a/test/spec/modules/adxcgBidAdapter_spec.js
+++ b/test/spec/modules/adxcgBidAdapter_spec.js
@@ -2,8 +2,8 @@ import { expect } from 'chai'
 import * as url from 'src/url'
 import { spec } from 'modules/adxcgBidAdapter'
 
-describe('AdxcgAdapter', () => {
-  describe('isBidRequestValid', () => {
+describe('AdxcgAdapter', function () {
+  describe('isBidRequestValid', function () {
     let bidBanner = {
       'bidder': 'adxcg',
       'params': {
@@ -63,7 +63,7 @@ describe('AdxcgAdapter', () => {
     })
   })
 
-  describe('request function http', () => {
+  describe('request function http', function () {
     let bid = {
       'bidder': 'adxcg',
       'params': {
@@ -96,7 +96,7 @@ describe('AdxcgAdapter', () => {
     })
   })
 
-  describe('gdpr compliance', () => {
+  describe('gdpr compliance', function () {
     let bid = {
       'bidder': 'adxcg',
       'params': {
@@ -133,7 +133,7 @@ describe('AdxcgAdapter', () => {
     })
   })
 
-  describe('response handler', () => {
+  describe('response handler', function () {
     let BIDDER_REQUEST = {
       'bidder': 'adxcg',
       'params': {
@@ -321,7 +321,7 @@ describe('AdxcgAdapter', () => {
     })
   })
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let syncoptionsIframe = {
       'iframeEnabled': 'true'
     }

--- a/test/spec/modules/adxcgBidAdapter_spec.js
+++ b/test/spec/modules/adxcgBidAdapter_spec.js
@@ -37,22 +37,22 @@ describe('AdxcgAdapter', function () {
       'auctionId': '1d1a030790a475',
     }
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bidBanner)).to.equal(true)
     })
 
-    it('should return true when required params not found', () => {
+    it('should return true when required params not found', function () {
       expect(spec.isBidRequestValid({})).to.be.false
     })
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bidBanner)
       delete bid.params
       bid.params = {}
       expect(spec.isBidRequestValid(bid)).to.equal(false)
     })
 
-    it('should return true when required video params not found', () => {
+    it('should return true when required video params not found', function () {
       const simpleVideo = JSON.parse(JSON.stringify(bidVideo))
       simpleVideo.params.adzoneid = 123
       expect(spec.isBidRequestValid(simpleVideo)).to.be.false
@@ -76,7 +76,7 @@ describe('AdxcgAdapter', function () {
       'auctionId': '1d1a030790a475',
     }
 
-    it('creates a valid adxcg request url', () => {
+    it('creates a valid adxcg request url', function () {
       let request = spec.buildRequests([bid])
       expect(request).to.exist
       expect(request.method).to.equal('GET')
@@ -109,7 +109,7 @@ describe('AdxcgAdapter', function () {
       'auctionId': '1d1a030790a475',
     }
 
-    it('should send GDPR Consent data if gdprApplies', () => {
+    it('should send GDPR Consent data if gdprApplies', function () {
       let request = spec.buildRequests([bid], {gdprConsent: {gdprApplies: true, consentString: 'consentDataString'}})
       let parsedRequestUrl = url.parse(request.url)
       let query = parsedRequestUrl.search
@@ -118,7 +118,7 @@ describe('AdxcgAdapter', function () {
       expect(query.gdpr_consent).to.equal('consentDataString')
     })
 
-    it('should not send GDPR Consent data if gdprApplies is false or undefined', () => {
+    it('should not send GDPR Consent data if gdprApplies is false or undefined', function () {
       let request = spec.buildRequests([bid], {
         gdprConsent: {
           gdprApplies: false,
@@ -245,7 +245,7 @@ describe('AdxcgAdapter', function () {
         header: {'someheader': 'fakedata'}
       }
 
-    it('handles regular responses', () => {
+    it('handles regular responses', function () {
       let result = spec.interpretResponse(BANNER_RESPONSE, BIDDER_REQUEST)
 
       expect(result).to.have.lengthOf(1)
@@ -262,7 +262,7 @@ describe('AdxcgAdapter', function () {
       expect(result[0].dealId).to.not.exist
     })
 
-    it('handles regular responses with dealid', () => {
+    it('handles regular responses with dealid', function () {
       let result = spec.interpretResponse(BANNER_RESPONSE_WITHDEALID, BIDDER_REQUEST)
 
       expect(result).to.have.lengthOf(1)
@@ -277,7 +277,7 @@ describe('AdxcgAdapter', function () {
       expect(result[0].ttl).to.equal(300)
     })
 
-    it('handles video responses', () => {
+    it('handles video responses', function () {
       let result = spec.interpretResponse(VIDEO_RESPONSE, BIDDER_REQUEST)
       expect(result).to.have.lengthOf(1)
 
@@ -292,7 +292,7 @@ describe('AdxcgAdapter', function () {
       expect(result[0].ttl).to.equal(300)
     })
 
-    it('handles native responses', () => {
+    it('handles native responses', function () {
       let result = spec.interpretResponse(NATIVE_RESPONSE, BIDDER_REQUEST)
 
       expect(result[0].width).to.equal(0)
@@ -312,7 +312,7 @@ describe('AdxcgAdapter', function () {
       expect(result[0].native.sponsoredBy).to.equal('sponsoredByContent')
     })
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = []
       let bidderRequest = BIDDER_REQUEST
 
@@ -326,7 +326,7 @@ describe('AdxcgAdapter', function () {
       'iframeEnabled': 'true'
     }
 
-    it('should return iframe sync option', () => {
+    it('should return iframe sync option', function () {
       expect(spec.getUserSyncs(syncoptionsIframe)[0].type).to.equal('iframe')
       expect(spec.getUserSyncs(syncoptionsIframe)[0].url).to.equal('//cdn.adxcg.net/pb-sync.html')
     })

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -137,7 +137,7 @@ describe('Adyoulike Adapter', function () {
   let getEndpoint = (dc = defaultDC) => `http://${dc}.omnitagjs.com/hb-api/prebid`;
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -154,18 +154,18 @@ describe('Adyoulike Adapter', function () {
       'transactionId': 'bid_id_1_transaction_id'
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.size;
 
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -190,7 +190,7 @@ describe('Adyoulike Adapter', function () {
       canonicalQuery.restore();
     });
 
-    it('should add gdpr consent information to the request', () => {
+    it('should add gdpr consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {
         'bidderCode': 'adyoulike',
@@ -212,7 +212,7 @@ describe('Adyoulike Adapter', function () {
       expect(payload.gdprConsent.consentRequired).to.exist.and.to.be.true;
     });
 
-    it('sends bid request to endpoint with single placement', () => {
+    it('sends bid request to endpoint with single placement', function () {
       const request = spec.buildRequests(bidRequestWithSinglePlacement);
       const payload = JSON.parse(request.data);
 
@@ -226,7 +226,7 @@ describe('Adyoulike Adapter', function () {
       expect(payload.Bids['bid_id_0'].TransactionID).to.be.equal('bid_id_0_transaction_id');
     });
 
-    it('sends bid request to endpoint with single placement without canonical', () => {
+    it('sends bid request to endpoint with single placement without canonical', function () {
       canonicalQuery.restore();
       const request = spec.buildRequests(bidRequestWithSinglePlacement);
       const payload = JSON.parse(request.data);
@@ -241,7 +241,7 @@ describe('Adyoulike Adapter', function () {
       expect(payload.Bids['bid_id_0'].TransactionID).to.be.equal('bid_id_0_transaction_id');
     });
 
-    it('sends bid request to endpoint with multiple placements', () => {
+    it('sends bid request to endpoint with multiple placements', function () {
       const request = spec.buildRequests(bidRequestMultiPlacements);
       const payload = JSON.parse(request.data);
       expect(request.url).to.contain(getEndpoint());
@@ -261,7 +261,7 @@ describe('Adyoulike Adapter', function () {
       expect(payload.PageRefreshed).to.equal(false);
     });
 
-    it('sends bid request to endpoint setted by parameters', () => {
+    it('sends bid request to endpoint setted by parameters', function () {
       const request = spec.buildRequests(bidRequestWithDCPlacement);
       const payload = JSON.parse(request.data);
 
@@ -278,7 +278,7 @@ describe('Adyoulike Adapter', function () {
       }
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = [{
         BidID: '123dfsdf',
         Attempt: '32344fdse1',
@@ -289,7 +289,7 @@ describe('Adyoulike Adapter', function () {
       expect(result).deep.equal([]);
     });
 
-    it('receive reponse with single placement', () => {
+    it('receive reponse with single placement', function () {
       serverResponse.body = responseWithSinglePlacement;
       let result = spec.interpretResponse(serverResponse, bidRequestWithSinglePlacement);
 
@@ -300,7 +300,7 @@ describe('Adyoulike Adapter', function () {
       expect(result[0].height).to.equal(300);
     });
 
-    it('receive reponse with multiple placement', () => {
+    it('receive reponse with multiple placement', function () {
       serverResponse.body = responseWithMultiplePlacements;
       let result = spec.interpretResponse(serverResponse, bidRequestMultiPlacements);
 

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { parse } from '../../../src/url';
 import { spec } from 'modules/adyoulikeBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('Adyoulike Adapter', () => {
+describe('Adyoulike Adapter', function () {
   const canonicalUrl = 'http://canonical.url/?t=%26';
   const defaultDC = 'hb-api';
   const bidderCode = 'adyoulike';
@@ -136,13 +136,13 @@ describe('Adyoulike Adapter', () => {
 
   let getEndpoint = (dc = defaultDC) => `http://${dc}.omnitagjs.com/hb-api/prebid`;
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidId': 'bid_id_1',
       'bidder': 'adyoulike',
@@ -175,7 +175,7 @@ describe('Adyoulike Adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let canonicalQuery;
 
     beforeEach(() => {
@@ -269,7 +269,7 @@ describe('Adyoulike Adapter', () => {
     });
   });
   //
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse;
 
     beforeEach(() => {

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -178,7 +178,7 @@ describe('Adyoulike Adapter', function () {
   describe('buildRequests', function () {
     let canonicalQuery;
 
-    beforeEach(() => {
+    beforeEach(function () {
       let canonical = document.createElement('link');
       canonical.rel = 'canonical';
       canonical.href = canonicalUrl;
@@ -186,7 +186,7 @@ describe('Adyoulike Adapter', function () {
       canonicalQuery.withArgs('link[rel="canonical"][href]').returns(canonical);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       canonicalQuery.restore();
     });
 
@@ -272,7 +272,7 @@ describe('Adyoulike Adapter', function () {
   describe('interpretResponse', function () {
     let serverResponse;
 
-    beforeEach(() => {
+    beforeEach(function () {
       serverResponse = {
         body: {}
       }

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -3,10 +3,10 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT = '//ad.as.amanad.adtdp.com/v2/prebid';
 
-describe('AjaAdapter', () => {
+describe('AjaAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'aja',
       'params': {
@@ -33,7 +33,7 @@ describe('AjaAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'aja',
@@ -54,7 +54,7 @@ describe('AjaAdapter', () => {
       expect(requests[0].method).to.equal('GET');
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'is_ad_return': true,
       'ad': {

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -19,11 +19,11 @@ describe('AjaAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -48,7 +48,7 @@ describe('AjaAdapter', function () {
       }
     ];
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].url).to.equal(ENDPOINT);
       expect(requests[0].method).to.equal('GET');
@@ -77,7 +77,7 @@ describe('AjaAdapter', function () {
       ]
     };
 
-    it('should get correct banner bid response', () => {
+    it('should get correct banner bid response', function () {
       let expectedResponse = [
         {
           'requestId': '51ef8751f9aead',
@@ -99,7 +99,7 @@ describe('AjaAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles video responses', () => {
+    it('handles video responses', function () {
       let response = {
         'is_ad_return': true,
         'ad': {
@@ -130,7 +130,7 @@ describe('AjaAdapter', function () {
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'is_ad_return': false,
         'ad': {}

--- a/test/spec/modules/andbeyondBidAdapter_spec.js
+++ b/test/spec/modules/andbeyondBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/andbeyondBidAdapter';
 import * as utils from 'src/utils';
 
-describe('andbeyond adapter', () => {
+describe('andbeyond adapter', function () {
   const bid1_zone1 = {
       bidder: 'andbeyond',
       bidId: 'Bid_01',
@@ -80,7 +80,7 @@ describe('andbeyond adapter', () => {
       cur: 'USD'
     };
 
-  describe('input parameters validation', () => {
+  describe('input parameters validation', function () {
     it('empty request shouldn\'t generate exception', () => {
       expect(spec.isBidRequestValid({
         bidderCode: 'andbeyond'
@@ -100,7 +100,7 @@ describe('andbeyond adapter', () => {
     });
   });
 
-  describe('banner request building', () => {
+  describe('banner request building', function () {
     let bidRequest;
     before(() => {
       let wmock = sinon.stub(utils, 'getTopWindowLocation').callsFake(() => ({
@@ -151,7 +151,7 @@ describe('andbeyond adapter', () => {
     });
   });
 
-  describe('requests routing', () => {
+  describe('requests routing', function () {
     it('should issue a request for each host', () => {
       let pbRequests = spec.buildRequests([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
@@ -167,7 +167,7 @@ describe('andbeyond adapter', () => {
     });
   });
 
-  describe('responses processing', () => {
+  describe('responses processing', function () {
     it('should return fully-initialized banner bid-response', () => {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];

--- a/test/spec/modules/andbeyondBidAdapter_spec.js
+++ b/test/spec/modules/andbeyondBidAdapter_spec.js
@@ -81,21 +81,21 @@ describe('andbeyond adapter', function () {
     };
 
   describe('input parameters validation', function () {
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid({
         bidderCode: 'andbeyond'
       })).to.be.equal(false);
     });
 
-    it('request without zone shouldn\'t issue a request', () => {
+    it('request without zone shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_zone)).to.be.equal(false);
     });
 
-    it('request without host shouldn\'t issue a request', () => {
+    it('request without host shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_host)).to.be.equal(false);
     });
 
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid(bid_with_wrong_zoneId)).to.be.equal(false);
     });
   });
@@ -117,33 +117,33 @@ describe('andbeyond adapter', function () {
       dntmock.restore();
     });
 
-    it('should be a first-price auction', () => {
+    it('should be a first-price auction', function () {
       expect(bidRequest).to.have.property('at', 1);
     });
 
-    it('should have banner object', () => {
+    it('should have banner object', function () {
       expect(bidRequest.imp[0]).to.have.property('banner');
     });
 
-    it('should have w/h', () => {
+    it('should have w/h', function () {
       expect(bidRequest.imp[0].banner).to.have.property('format');
       expect(bidRequest.imp[0].banner.format).to.be.eql([{w: 300, h: 250}, {w: 300, h: 200}]);
     });
 
-    it('should respect secure connection', () => {
+    it('should respect secure connection', function () {
       expect(bidRequest.imp[0]).to.have.property('secure', 1);
     });
 
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(bidRequest.imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
 
-    it('should create proper site block', () => {
+    it('should create proper site block', function () {
       expect(bidRequest.site).to.have.property('domain', 'example.com');
       expect(bidRequest.site).to.have.property('page', 'https://example.com/index.html');
     });
 
-    it('should fill device with caller macro', () => {
+    it('should fill device with caller macro', function () {
       expect(bidRequest).to.have.property('device');
       expect(bidRequest.device).to.have.property('ip', 'caller');
       expect(bidRequest.device).to.have.property('ua', 'caller');
@@ -152,14 +152,14 @@ describe('andbeyond adapter', function () {
   });
 
   describe('requests routing', function () {
-    it('should issue a request for each host', () => {
+    it('should issue a request for each host', function () {
       let pbRequests = spec.buildRequests([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].url).to.have.string(`//${bid1_zone1.params.host}/`);
       expect(pbRequests[1].url).to.have.string(`//${bid3_host2.params.host}/`);
     });
 
-    it('should issue a request for each zone', () => {
+    it('should issue a request for each zone', function () {
       let pbRequests = spec.buildRequests([bid1_zone1, bid2_zone2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].data.zone).to.be.equal(bid1_zone1.params.zoneId);
@@ -168,7 +168,7 @@ describe('andbeyond adapter', function () {
   });
 
   describe('responses processing', function () {
-    it('should return fully-initialized banner bid-response', () => {
+    it('should return fully-initialized banner bid-response', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];
       expect(resp).to.have.property('requestId', 'Bid_01');
@@ -183,20 +183,20 @@ describe('andbeyond adapter', function () {
       expect(resp.ad).to.have.string('<!-- admarkup here -->');
     });
 
-    it('should add nurl as pixel for banner response', () => {
+    it('should add nurl as pixel for banner response', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];
       let expectedNurl = bidResponse1.seatbid[0].bid[0].nurl + '&px=1';
       expect(resp.ad).to.have.string(expectedNurl);
     });
 
-    it('should handle bidresponse with user-sync only', () => {
+    it('should handle bidresponse with user-sync only', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: usersyncOnlyResponse}, request);
       expect(resp).to.have.length(0);
     });
 
-    it('should perform usersync', () => {
+    it('should perform usersync', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: false}, [{body: bidResponse1}]);
       expect(syncs).to.have.length(0);
       syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: bidResponse1}]);

--- a/test/spec/modules/andbeyondBidAdapter_spec.js
+++ b/test/spec/modules/andbeyondBidAdapter_spec.js
@@ -102,7 +102,7 @@ describe('andbeyond adapter', function () {
 
   describe('banner request building', function () {
     let bidRequest;
-    before(() => {
+    before(function () {
       let wmock = sinon.stub(utils, 'getTopWindowLocation').callsFake(() => ({
         protocol: 'https:',
         hostname: 'example.com',

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -122,7 +122,7 @@ describe('AolAdapter', function () {
       isOneMobileBidderStub.restore();
     });
 
-    it('should return formatted bid response with required properties', () => {
+    it('should return formatted bid response with required properties', function () {
       let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
       expect(formattedBidResponse).to.deep.equal({
         bidderCode: bidRequest.bidderCode,
@@ -140,7 +140,7 @@ describe('AolAdapter', function () {
       });
     });
 
-    it('should add pixels to ad content when pixels are present in the response', () => {
+    it('should add pixels to ad content when pixels are present in the response', function () {
       bidResponse.body.ext = {
         pixels: 'pixels-content'
       };
@@ -163,23 +163,23 @@ describe('AolAdapter', function () {
   });
 
   describe('buildRequests()', function () {
-    it('method exists and is a function', () => {
+    it('method exists and is a function', function () {
       expect(spec.buildRequests).to.exist.and.to.be.a('function');
     });
 
     describe('Marketplace', function () {
-      it('should not return request when no bids are present', () => {
+      it('should not return request when no bids are present', function () {
         let [request] = spec.buildRequests([]);
         expect(request).to.be.empty;
       });
 
-      it('should return request for Marketplace endpoint', () => {
+      it('should return request for Marketplace endpoint', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).to.contain(MARKETPLACE_URL);
       });
 
-      it('should return request for Marketplace via onedisplay bidder code', () => {
+      it('should return request for Marketplace via onedisplay bidder code', function () {
         let bidRequest = createCustomBidRequest({
           bids: [{
             bidder: 'onedisplay'
@@ -233,7 +233,7 @@ describe('AolAdapter', function () {
         expect(request).to.be.empty;
       });
 
-      it('should return Marketplace URL for eu region', () => {
+      it('should return Marketplace URL for eu region', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -245,7 +245,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('adserver-eu.adtech.advertising.com/pubapi/3.0/');
       });
 
-      it('should return Marketplace URL for eu region when server option is present', () => {
+      it('should return Marketplace URL for eu region when server option is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -257,7 +257,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('adserver-eu.adtech.advertising.com/pubapi/3.0/');
       });
 
-      it('should return default Marketplace URL in case of unknown region config option', () => {
+      it('should return default Marketplace URL in case of unknown region config option', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -269,25 +269,25 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain(MARKETPLACE_URL);
       });
 
-      it('should return url with pubapi bid option', () => {
+      it('should return url with pubapi bid option', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).to.contain('cmd=bid;');
       });
 
-      it('should return url with version 2 of pubapi', () => {
+      it('should return url with version 2 of pubapi', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).to.contain('v=2;');
       });
 
-      it('should return url with cache busting option', () => {
+      it('should return url with cache busting option', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).to.match(/misc=\d+/);
       });
 
-      it('should return url with default pageId and sizeId', () => {
+      it('should return url with default pageId and sizeId', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -298,7 +298,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('/pubapi/3.0/9599.1/1234567/0/0/ADTECH;');
       });
 
-      it('should return url with custom pageId and sizeId when options are present', () => {
+      it('should return url with custom pageId and sizeId when options are present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -311,13 +311,13 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('/pubapi/3.0/9599.1/1234567/1111/2222/ADTECH;');
       });
 
-      it('should return url with default alias if alias param is missing', () => {
+      it('should return url with default alias if alias param is missing', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).to.match(/alias=\w+?;/);
       });
 
-      it('should return url with custom alias if it is present', () => {
+      it('should return url with custom alias if it is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -329,13 +329,13 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('alias=desktop_articlepage_something_box_300_250');
       });
 
-      it('should return url without bidfloor option if is is missing', () => {
+      it('should return url without bidfloor option if is is missing', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.url).not.to.contain('bidfloor=');
       });
 
-      it('should return url with bidFloor option if it is present', () => {
+      it('should return url with bidFloor option if it is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -347,7 +347,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('bidfloor=0.8');
       });
 
-      it('should return url with key values if keyValues param is present', () => {
+      it('should return url with key values if keyValues param is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -363,7 +363,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('kvage=25;kvheight=3.42;kvtest=key');
       });
 
-      it('should return request object for One Display when configuration is present', () => {
+      it('should return request object for One Display when configuration is present', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
         expect(request.method).to.equal('GET');
@@ -372,7 +372,7 @@ describe('AolAdapter', function () {
     });
 
     describe('One Mobile', function () {
-      it('should return One Mobile url when One Mobile get params are present', () => {
+      it('should return One Mobile url when One Mobile get params are present', function () {
         let bidRequest = createCustomBidRequest({
           params: getNexageGetBidParams()
         });
@@ -380,7 +380,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain(NEXAGE_URL);
       });
 
-      it('should return One Mobile url with different host when host option is present', () => {
+      it('should return One Mobile url with different host when host option is present', function () {
         let bidParams = Object.assign({
           host: 'qa-hb.nexage.com'
         }, getNexageGetBidParams());
@@ -391,7 +391,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('qa-hb.nexage.com/bidRequest?');
       });
 
-      it('should return One Mobile url when One Mobile and Marketplace params are present', () => {
+      it('should return One Mobile url when One Mobile and Marketplace params are present', function () {
         let bidParams = Object.assign(getNexageGetBidParams(), getMarketplaceBidParams());
         let bidRequest = createCustomBidRequest({
           params: bidParams
@@ -425,7 +425,7 @@ describe('AolAdapter', function () {
         expect(request).to.be.empty;
       });
 
-      it('should return One Mobile url with required params - dcn & pos', () => {
+      it('should return One Mobile url with required params - dcn & pos', function () {
         let bidRequest = createCustomBidRequest({
           params: getNexageGetBidParams()
         });
@@ -433,7 +433,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain(NEXAGE_URL + 'dcn=2c9d2b50015c5ce9db6aeeed8b9500d6&pos=header');
       });
 
-      it('should return One Mobile url with cmd=bid option', () => {
+      it('should return One Mobile url with cmd=bid option', function () {
         let bidRequest = createCustomBidRequest({
           params: getNexageGetBidParams()
         });
@@ -441,7 +441,7 @@ describe('AolAdapter', function () {
         expect(request.url).to.contain('cmd=bid');
       });
 
-      it('should return One Mobile url with generic params if ext option is present', () => {
+      it('should return One Mobile url with generic params if ext option is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             dcn: '54321123',
@@ -459,7 +459,7 @@ describe('AolAdapter', function () {
           '&param1=val1&param2=val2&param3=val3&param4=val4');
       });
 
-      it('should return request object for One Mobile POST endpoint when POST configuration is present', () => {
+      it('should return request object for One Mobile POST endpoint when POST configuration is present', function () {
         let bidConfig = getNexagePostBidParams();
         let bidRequest = createCustomBidRequest({
           params: bidConfig
@@ -508,7 +508,7 @@ describe('AolAdapter', function () {
       };
     });
 
-    it('should return user syncs only if userSyncOn equals to "bidResponse"', () => {
+    it('should return user syncs only if userSyncOn equals to "bidResponse"', function () {
       let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
 
       expect($$PREBID_GLOBAL$$.aolGlobals.pixelsDropped).to.be.true;
@@ -518,7 +518,7 @@ describe('AolAdapter', function () {
       ]);
     });
 
-    it('should not return user syncs if it has already been returned', () => {
+    it('should not return user syncs if it has already been returned', function () {
       $$PREBID_GLOBAL$$.aolGlobals.pixelsDropped = true;
 
       let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
@@ -527,7 +527,7 @@ describe('AolAdapter', function () {
       expect(userSyncs).to.deep.equal([]);
     });
 
-    it('should not return user syncs if pixels are not present', () => {
+    it('should not return user syncs if pixels are not present', function () {
       bidResponse.ext.pixels = null;
 
       let userSyncs = spec.getUserSyncs({}, [bidResponse], bidRequest);
@@ -538,7 +538,7 @@ describe('AolAdapter', function () {
   });
 
   describe('formatPixels()', function () {
-    it('should return pixels wrapped for dropping them once and within nested frames ', () => {
+    it('should return pixels wrapped for dropping them once and within nested frames ', function () {
       let pixels = '<script>document.write(\'<pixels-dom-elements/>\');</script>';
       let formattedPixels = spec.formatPixels(pixels);
 
@@ -554,29 +554,29 @@ describe('AolAdapter', function () {
   });
 
   describe('isOneMobileBidder()', function () {
-    it('should return false when when bidderCode is not present', () => {
+    it('should return false when when bidderCode is not present', function () {
       expect(spec.isOneMobileBidder(null)).to.be.false;
     });
 
-    it('should return false for unknown bidder code', () => {
+    it('should return false for unknown bidder code', function () {
       expect(spec.isOneMobileBidder('unknownBidder')).to.be.false;
     });
 
-    it('should return true for aol bidder code', () => {
+    it('should return true for aol bidder code', function () {
       expect(spec.isOneMobileBidder('aol')).to.be.true;
     });
 
-    it('should return true for one mobile bidder code', () => {
+    it('should return true for one mobile bidder code', function () {
       expect(spec.isOneMobileBidder('onemobile')).to.be.true;
     });
   });
 
   describe('isConsentRequired()', function () {
-    it('should return false when consentData object is not present', () => {
+    it('should return false when consentData object is not present', function () {
       expect(spec.isConsentRequired(null)).to.be.false;
     });
 
-    it('should return true when gdprApplies equals true and consentString is not present', () => {
+    it('should return true when gdprApplies equals true and consentString is not present', function () {
       let consentData = {
         consentString: null,
         gdprApplies: true
@@ -585,7 +585,7 @@ describe('AolAdapter', function () {
       expect(spec.isConsentRequired(consentData)).to.be.true;
     });
 
-    it('should return false when consentString is present and gdprApplies equals false', () => {
+    it('should return false when consentString is present and gdprApplies equals false', function () {
       let consentData = {
         consentString: 'consent-string',
         gdprApplies: false
@@ -594,7 +594,7 @@ describe('AolAdapter', function () {
       expect(spec.isConsentRequired(consentData)).to.be.false;
     });
 
-    it('should return true when consentString is present and gdprApplies equals true', () => {
+    it('should return true when consentString is present and gdprApplies equals true', function () {
       let consentData = {
         consentString: 'consent-string',
         gdprApplies: true
@@ -618,11 +618,11 @@ describe('AolAdapter', function () {
       formatKeyValuesStub.restore();
     });
 
-    it('should return empty string when params are not present', () => {
+    it('should return empty string when params are not present', function () {
       expect(spec.formatMarketplaceDynamicParams()).to.be.equal('');
     });
 
-    it('should return formatted params when formatConsentData returns data', () => {
+    it('should return formatted params when formatConsentData returns data', function () {
       formatConsentDataStub.returns({
         euconsent: 'test-consent',
         gdpr: 1
@@ -630,7 +630,7 @@ describe('AolAdapter', function () {
       expect(spec.formatMarketplaceDynamicParams()).to.be.equal('euconsent=test-consent;gdpr=1;');
     });
 
-    it('should return formatted params when formatKeyValues returns data', () => {
+    it('should return formatted params when formatKeyValues returns data', function () {
       formatKeyValuesStub.returns({
         param1: 'val1',
         param2: 'val2',
@@ -639,7 +639,7 @@ describe('AolAdapter', function () {
       expect(spec.formatMarketplaceDynamicParams()).to.be.equal('param1=val1;param2=val2;param3=val3;');
     });
 
-    it('should return formatted bid floor param when it is present', () => {
+    it('should return formatted bid floor param when it is present', function () {
       let params = {
         bidFloor: 0.45
       };
@@ -661,11 +661,11 @@ describe('AolAdapter', function () {
       secureProtocolStub.restore();
     });
 
-    it('should return empty string when params are not present', () => {
+    it('should return empty string when params are not present', function () {
       expect(spec.formatOneMobileDynamicParams()).to.be.equal('');
     });
 
-    it('should return formatted params when params are present', () => {
+    it('should return formatted params when params are present', function () {
       let params = {
         param1: 'val1',
         param2: 'val2',
@@ -674,7 +674,7 @@ describe('AolAdapter', function () {
       expect(spec.formatOneMobileDynamicParams(params)).to.contain('&param1=val1&param2=val2&param3=val3');
     });
 
-    it('should return formatted gdpr params when isConsentRequired returns true', () => {
+    it('should return formatted gdpr params when isConsentRequired returns true', function () {
       let consentData = {
         consentString: 'test-consent'
       };
@@ -682,7 +682,7 @@ describe('AolAdapter', function () {
       expect(spec.formatOneMobileDynamicParams({}, consentData)).to.be.equal('&gdpr=1&euconsent=test-consent');
     });
 
-    it('should return formatted secure param when isSecureProtocol returns true', () => {
+    it('should return formatted secure param when isSecureProtocol returns true', function () {
       secureProtocolStub.returns(true);
       expect(spec.formatOneMobileDynamicParams()).to.be.equal('&secure=1');
     });

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -100,7 +100,7 @@ describe('AolAdapter', function () {
     let formatPixelsStub;
     let isOneMobileBidderStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       bidderSettingsBackup = $$PREBID_GLOBAL$$.bidderSettings;
       bidRequest = {
         bidderCode: 'test-bidder-code',
@@ -115,7 +115,7 @@ describe('AolAdapter', function () {
       isOneMobileBidderStub = sinon.stub(spec, 'isOneMobileBidder');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       $$PREBID_GLOBAL$$.bidderSettings = bidderSettingsBackup;
       logWarnSpy.restore();
       formatPixelsStub.restore();
@@ -495,7 +495,7 @@ describe('AolAdapter', function () {
     let bidResponse;
     let bidRequest;
 
-    beforeEach(() => {
+    beforeEach(function () {
       $$PREBID_GLOBAL$$.aolGlobals.pixelsDropped = false;
       config.setConfig({
         aol: {
@@ -608,12 +608,12 @@ describe('AolAdapter', function () {
     let formatConsentDataStub;
     let formatKeyValuesStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       formatConsentDataStub = sinon.stub(spec, 'formatConsentData');
       formatKeyValuesStub = sinon.stub(spec, 'formatKeyValues');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       formatConsentDataStub.restore();
       formatKeyValuesStub.restore();
     });
@@ -651,12 +651,12 @@ describe('AolAdapter', function () {
     let consentRequiredStub;
     let secureProtocolStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       consentRequiredStub = sinon.stub(spec, 'isConsentRequired');
       secureProtocolStub = sinon.stub(spec, 'isSecureProtocol');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       consentRequiredStub.restore();
       secureProtocolStub.restore();
     });

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -75,7 +75,7 @@ let getPixels = () => {
     '<iframe src="pixels1.org"></iframe>\');</script>';
 };
 
-describe('AolAdapter', () => {
+describe('AolAdapter', function () {
   const MARKETPLACE_URL = '//adserver-us.adtech.advertising.com/pubapi/3.0/';
   const NEXAGE_URL = '//hb.nexage.com/bidRequest?';
   const ONE_DISPLAY_TTL = 60;
@@ -92,7 +92,7 @@ describe('AolAdapter', () => {
     return bidderRequest;
   }
 
-  describe('interpretResponse()', () => {
+  describe('interpretResponse()', function () {
     let bidderSettingsBackup;
     let bidResponse;
     let bidRequest;
@@ -162,12 +162,12 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('buildRequests()', () => {
+  describe('buildRequests()', function () {
     it('method exists and is a function', () => {
       expect(spec.buildRequests).to.exist.and.to.be.a('function');
     });
 
-    describe('Marketplace', () => {
+    describe('Marketplace', function () {
       it('should not return request when no bids are present', () => {
         let [request] = spec.buildRequests([]);
         expect(request).to.be.empty;
@@ -371,7 +371,7 @@ describe('AolAdapter', () => {
       });
     });
 
-    describe('One Mobile', () => {
+    describe('One Mobile', function () {
       it('should return One Mobile url when One Mobile get params are present', () => {
         let bidRequest = createCustomBidRequest({
           params: getNexageGetBidParams()
@@ -491,7 +491,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('getUserSyncs()', () => {
+  describe('getUserSyncs()', function () {
     let bidResponse;
     let bidRequest;
 
@@ -537,7 +537,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('formatPixels()', () => {
+  describe('formatPixels()', function () {
     it('should return pixels wrapped for dropping them once and within nested frames ', () => {
       let pixels = '<script>document.write(\'<pixels-dom-elements/>\');</script>';
       let formattedPixels = spec.formatPixels(pixels);
@@ -553,7 +553,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('isOneMobileBidder()', () => {
+  describe('isOneMobileBidder()', function () {
     it('should return false when when bidderCode is not present', () => {
       expect(spec.isOneMobileBidder(null)).to.be.false;
     });
@@ -571,7 +571,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('isConsentRequired()', () => {
+  describe('isConsentRequired()', function () {
     it('should return false when consentData object is not present', () => {
       expect(spec.isConsentRequired(null)).to.be.false;
     });
@@ -604,7 +604,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('formatMarketplaceDynamicParams()', () => {
+  describe('formatMarketplaceDynamicParams()', function () {
     let formatConsentDataStub;
     let formatKeyValuesStub;
 
@@ -647,7 +647,7 @@ describe('AolAdapter', () => {
     });
   });
 
-  describe('formatOneMobileDynamicParams()', () => {
+  describe('formatOneMobileDynamicParams()', function () {
     let consentRequiredStub;
     let secureProtocolStub;
 

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -5,16 +5,16 @@ import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
 
-describe('AppNexusAdapter', () => {
+describe('AppNexusAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'appnexus',
       'params': {
@@ -52,7 +52,7 @@ describe('AppNexusAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'appnexus',
@@ -372,7 +372,7 @@ describe('AppNexusAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'version': '3.0.0',
       'tags': [

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('AppNexusAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -27,11 +27,11 @@ describe('AppNexusAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -42,7 +42,7 @@ describe('AppNexusAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -67,7 +67,7 @@ describe('AppNexusAdapter', function () {
       }
     ];
 
-    it('should parse out private sizes', () => {
+    it('should parse out private sizes', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -85,7 +85,7 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].private_sizes).to.deep.equal([{width: 300, height: 250}]);
     });
 
-    it('should add source and verison to the tag', () => {
+    it('should add source and verison to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data);
       expect(payload.sdk).to.exist;
@@ -95,7 +95,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on all requests', () => {
+    it('should populate the ad_types array on all requests', function () {
       ['banner', 'video', 'native'].forEach(type => {
         const bidRequest = Object.assign({}, bidRequests[0]);
         bidRequest.mediaTypes = {};
@@ -108,7 +108,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on outstream requests', () => {
+    it('should populate the ad_types array on outstream requests', function () {
       const bidRequest = Object.assign({}, bidRequests[0]);
       bidRequest.mediaTypes = {};
       bidRequest.mediaTypes.video = {context: 'outstream'};
@@ -119,13 +119,13 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('POST');
     });
 
-    it('should attach valid video params to the tag', () => {
+    it('should attach valid video params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -148,7 +148,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('should attach valid user params to the tag', () => {
+    it('should attach valid user params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -171,7 +171,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('should attach native params to the request', () => {
+    it('should attach native params to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -198,7 +198,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('sets minimum native asset params when not provided on adunit', () => {
+    it('sets minimum native asset params when not provided on adunit', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -217,7 +217,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('does not overwrite native ad unit params with mimimum params', () => {
+    it('does not overwrite native ad unit params with mimimum params', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -249,7 +249,7 @@ describe('AppNexusAdapter', function () {
       });
     });
 
-    it('should convert keyword params to proper form and attaches to request', () => {
+    it('should convert keyword params to proper form and attaches to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -288,7 +288,7 @@ describe('AppNexusAdapter', function () {
       }]);
     });
 
-    it('should add payment rules to the request', () => {
+    it('should add payment rules to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -305,7 +305,7 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].use_pmt_rule).to.equal(true);
     });
 
-    it('should add gdpr consent information to the request', () => {
+    it('should add gdpr consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {
         'bidderCode': 'appnexus',
@@ -327,7 +327,7 @@ describe('AppNexusAdapter', function () {
       expect(payload.gdpr_consent.consent_required).to.exist.and.to.be.true;
     });
 
-    it('supports sending hybrid mobile app parameters', () => {
+    it('supports sending hybrid mobile app parameters', function () {
       let appRequest = Object.assign({},
         bidRequests[0],
         {
@@ -417,7 +417,7 @@ describe('AppNexusAdapter', function () {
       ]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '3db3773286ee59',
@@ -441,7 +441,7 @@ describe('AppNexusAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'version': '0.0.1',
         'tags': [{
@@ -457,7 +457,7 @@ describe('AppNexusAdapter', function () {
       expect(result.length).to.equal(0);
     });
 
-    it('handles non-banner media responses', () => {
+    it('handles non-banner media responses', function () {
       let response = {
         'tags': [{
           'uuid': '84ab500420319d',
@@ -481,7 +481,7 @@ describe('AppNexusAdapter', function () {
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 
-    it('handles native responses', () => {
+    it('handles native responses', function () {
       let response1 = deepClone(response);
       response1.tags[0].ads[0].ad_type = 'native';
       response1.tags[0].ads[0].rtb.native = {
@@ -515,7 +515,7 @@ describe('AppNexusAdapter', function () {
       expect(result[0].native.image.url).to.equal('http://cdn.adnxs.com/img.png');
     });
 
-    it('supports configuring outstream renderers', () => {
+    it('supports configuring outstream renderers', function () {
       const outstreamResponse = deepClone(response);
       outstreamResponse.tags[0].ads[0].rtb.video = {};
       outstreamResponse.tags[0].ads[0].renderer_url = 'renderer.js';

--- a/test/spec/modules/arteebeeBidAdapter_spec.js
+++ b/test/spec/modules/arteebeeBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import {expect} from 'chai';
 import {spec} from 'modules/arteebeeBidAdapter';
 
-describe('Arteebee adapater', () => {
-  describe('Test validate req', () => {
+describe('Arteebee adapater', function () {
+  describe('Test validate req', function () {
     it('should accept minimum valid bid', () => {
       let bid = {
         bidder: 'arteebee',
@@ -41,7 +41,7 @@ describe('Arteebee adapater', () => {
     });
   });
 
-  describe('Test build request', () => {
+  describe('Test build request', function () {
     it('minimum request', () => {
       let bid = {
         bidder: 'arteebee',
@@ -124,7 +124,7 @@ describe('Arteebee adapater', () => {
     });
   });
 
-  describe('Test interpret response', () => {
+  describe('Test interpret response', function () {
     it('General banner response', () => {
       let resp = spec.interpretResponse({
         body: {

--- a/test/spec/modules/arteebeeBidAdapter_spec.js
+++ b/test/spec/modules/arteebeeBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/arteebeeBidAdapter';
 
 describe('Arteebee adapater', function () {
   describe('Test validate req', function () {
-    it('should accept minimum valid bid', () => {
+    it('should accept minimum valid bid', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -16,7 +16,7 @@ describe('Arteebee adapater', function () {
       expect(isValid).to.equal(true);
     });
 
-    it('should reject missing pub', () => {
+    it('should reject missing pub', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -28,7 +28,7 @@ describe('Arteebee adapater', function () {
       expect(isValid).to.equal(false);
     });
 
-    it('should reject missing source', () => {
+    it('should reject missing source', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -42,7 +42,7 @@ describe('Arteebee adapater', function () {
   });
 
   describe('Test build request', function () {
-    it('minimum request', () => {
+    it('minimum request', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -59,7 +59,7 @@ describe('Arteebee adapater', function () {
       expect(req.imp[0]).to.not.have.property('secure');
     });
 
-    it('make test request', () => {
+    it('make test request', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -77,7 +77,7 @@ describe('Arteebee adapater', function () {
       expect(req.imp[0]).to.not.have.property('secure');
     });
 
-    it('test coppa', () => {
+    it('test coppa', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -95,7 +95,7 @@ describe('Arteebee adapater', function () {
       expect(req.imp[0]).to.not.have.property('secure');
     });
 
-    it('test gdpr', () => {
+    it('test gdpr', function () {
       let bid = {
         bidder: 'arteebee',
         params: {
@@ -125,7 +125,7 @@ describe('Arteebee adapater', function () {
   });
 
   describe('Test interpret response', function () {
-    it('General banner response', () => {
+    it('General banner response', function () {
       let resp = spec.interpretResponse({
         body: {
           id: 'abcd',

--- a/test/spec/modules/atomxBidAdapter_spec.js
+++ b/test/spec/modules/atomxBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/atomxBidAdapter';
 
 describe('atomxAdapterTest', function () {
   describe('bidRequestValidity', function () {
-    it('bidRequest with id param', () => {
+    it('bidRequest with id param', function () {
       expect(spec.isBidRequestValid({
         bidder: 'atomx',
         params: {
@@ -12,7 +12,7 @@ describe('atomxAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with no id param', () => {
+    it('bidRequest with no id param', function () {
       expect(spec.isBidRequestValid({
         bidder: 'atomx',
         params: {
@@ -47,21 +47,21 @@ describe('atomxAdapterTest', function () {
       'auctionId': 'e97cafd0-ebfc-4f5c-b7c9-baa0fd335a4a'
     }];
 
-    it('bidRequest HTTP method', () => {
+    it('bidRequest HTTP method', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
-    it('bidRequest url', () => {
+    it('bidRequest url', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.url).to.match(new RegExp('p\\.ato\\.mx/placement'));
       });
     });
 
-    it('bidRequest data', () => {
+    it('bidRequest data', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].data.id).to.equal('123');
       expect(requests[0].data.size).to.equal('300x250');
@@ -103,7 +103,7 @@ describe('atomxAdapterTest', function () {
       headers: {}
     };
 
-    it('result is correct', () => {
+    it('result is correct', function () {
       const result = spec.interpretResponse(bidResponse, bidRequest);
 
       expect(result[0].requestId).to.equal('22aidtbx5eabd9');

--- a/test/spec/modules/atomxBidAdapter_spec.js
+++ b/test/spec/modules/atomxBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/atomxBidAdapter';
 
-describe('atomxAdapterTest', () => {
-  describe('bidRequestValidity', () => {
+describe('atomxAdapterTest', function () {
+  describe('bidRequestValidity', function () {
     it('bidRequest with id param', () => {
       expect(spec.isBidRequestValid({
         bidder: 'atomx',
@@ -21,7 +21,7 @@ describe('atomxAdapterTest', () => {
     });
   });
 
-  describe('bidRequest', () => {
+  describe('bidRequest', function () {
     const bidRequests = [{
       'bidder': 'atomx',
       'params': {
@@ -72,7 +72,7 @@ describe('atomxAdapterTest', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequest = {
       'method': 'GET',
       'url': 'https://p.ato.mx/placement',

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -120,11 +120,11 @@ describe('AudienceNetwork adapter', function () {
 
   describe('buildRequests', function () {
     let isSafariBrowserStub;
-    before(() => {
+    before(function () {
       isSafariBrowserStub = sinon.stub(utils, 'isSafariBrowser');
     });
 
-    after(() => {
+    after(function () {
       isSafariBrowserStub.restore();
     });
 

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -22,8 +22,8 @@ const requestId = 'test-request-id';
 const debug = 'adapterver=1.0.1&platform=241394079772386&platver=$prebid.version$';
 const pageUrl = encodeURIComponent(utils.getTopWindowUrl());
 
-describe('AudienceNetwork adapter', () => {
-  describe('Public API', () => {
+describe('AudienceNetwork adapter', function () {
+  describe('Public API', function () {
     it('code', () => {
       expect(code).to.equal(bidder);
     });
@@ -41,7 +41,7 @@ describe('AudienceNetwork adapter', () => {
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('missing placementId parameter', () => {
       expect(isBidRequestValid({
         bidder,
@@ -118,7 +118,7 @@ describe('AudienceNetwork adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let isSafariBrowserStub;
     before(() => {
       isSafariBrowserStub = sinon.stub(utils, 'isSafariBrowser');
@@ -216,7 +216,7 @@ describe('AudienceNetwork adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('error in response', () => {
       expect(interpretResponse({
         body: {

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -24,32 +24,32 @@ const pageUrl = encodeURIComponent(utils.getTopWindowUrl());
 
 describe('AudienceNetwork adapter', function () {
   describe('Public API', function () {
-    it('code', () => {
+    it('code', function () {
       expect(code).to.equal(bidder);
     });
-    it('supportedMediaTypes', () => {
+    it('supportedMediaTypes', function () {
       expect(supportedMediaTypes).to.deep.equal(['banner', 'video']);
     });
-    it('isBidRequestValid', () => {
+    it('isBidRequestValid', function () {
       expect(isBidRequestValid).to.be.a('function');
     });
-    it('buildRequests', () => {
+    it('buildRequests', function () {
       expect(buildRequests).to.be.a('function');
     });
-    it('interpretResponse', () => {
+    it('interpretResponse', function () {
       expect(interpretResponse).to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('missing placementId parameter', () => {
+    it('missing placementId parameter', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250]]
       })).to.equal(false);
     });
 
-    it('invalid sizes parameter', () => {
+    it('invalid sizes parameter', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: ['', undefined, null, '300x100', [300, 100], [300], {}],
@@ -57,7 +57,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(false);
     });
 
-    it('valid when at least one valid size', () => {
+    it('valid when at least one valid size', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[1, 1], [300, 250]],
@@ -65,7 +65,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(true);
     });
 
-    it('valid parameters', () => {
+    it('valid parameters', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250], [320, 50]],
@@ -73,7 +73,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(true);
     });
 
-    it('fullwidth', () => {
+    it('fullwidth', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250], [336, 280]],
@@ -84,7 +84,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(true);
     });
 
-    it('native', () => {
+    it('native', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250]],
@@ -95,7 +95,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(true);
     });
 
-    it('native with non-IAB size', () => {
+    it('native with non-IAB size', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[728, 90]],
@@ -106,7 +106,7 @@ describe('AudienceNetwork adapter', function () {
       })).to.equal(true);
     });
 
-    it('video', () => {
+    it('video', function () {
       expect(isBidRequestValid({
         bidder,
         sizes: [[playerwidth, playerheight]],
@@ -128,7 +128,7 @@ describe('AudienceNetwork adapter', function () {
       isSafariBrowserStub.restore();
     });
 
-    it('can build URL for IAB unit', () => {
+    it('can build URL for IAB unit', function () {
       expect(buildRequests([{
         bidder,
         bidId: requestId,
@@ -144,7 +144,7 @@ describe('AudienceNetwork adapter', function () {
       }]);
     });
 
-    it('can build URL for video unit', () => {
+    it('can build URL for video unit', function () {
       expect(buildRequests([{
         bidder,
         bidId: requestId,
@@ -163,7 +163,7 @@ describe('AudienceNetwork adapter', function () {
       }]);
     });
 
-    it('can build URL for native unit in non-IAB size', () => {
+    it('can build URL for native unit in non-IAB size', function () {
       expect(buildRequests([{
         bidder,
         bidId: requestId,
@@ -182,7 +182,7 @@ describe('AudienceNetwork adapter', function () {
       }]);
     });
 
-    it('can build URL for fullwidth 300x250 unit, overriding platform', () => {
+    it('can build URL for fullwidth 300x250 unit, overriding platform', function () {
       const platform = 'test-platform';
       const debugPlatform = debug.replace('241394079772386', platform);
 
@@ -205,7 +205,7 @@ describe('AudienceNetwork adapter', function () {
       }]);
     });
 
-    it('can build URL on Safari that includes a cachebuster param', () => {
+    it('can build URL on Safari that includes a cachebuster param', function () {
       isSafariBrowserStub.returns(true);
       expect(buildRequests([{
         bidder,
@@ -217,7 +217,7 @@ describe('AudienceNetwork adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('error in response', () => {
+    it('error in response', function () {
       expect(interpretResponse({
         body: {
           errors: ['test-error-message']
@@ -225,7 +225,7 @@ describe('AudienceNetwork adapter', function () {
       }, {})).to.deep.equal([]);
     });
 
-    it('valid native bid in response', () => {
+    it('valid native bid in response', function () {
       const [bidResponse] = interpretResponse({
         body: {
           errors: [],
@@ -264,7 +264,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.fb_placementid).to.equal(placementId);
     });
 
-    it('valid IAB bid in response', () => {
+    it('valid IAB bid in response', function () {
       const [bidResponse] = interpretResponse({
         body: {
           errors: [],
@@ -302,7 +302,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.fb_placementid).to.equal(placementId);
     });
 
-    it('filters invalid slot sizes', () => {
+    it('filters invalid slot sizes', function () {
       const [bidResponse] = interpretResponse({
         body: {
           errors: [],
@@ -336,7 +336,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.fb_placementid).to.equal(placementId);
     });
 
-    it('valid multiple bids in response', () => {
+    it('valid multiple bids in response', function () {
       const placementIdNative = 'test-placement-id-native';
       const placementIdIab = 'test-placement-id-iab';
 
@@ -395,7 +395,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponseIab.fb_placementid).to.equal(placementIdIab);
     });
 
-    it('valid video bid in response', () => {
+    it('valid video bid in response', function () {
       const bidId = 'test-bid-id-video';
 
       const [bidResponse] = interpretResponse({
@@ -426,7 +426,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.height).to.equal(playerheight);
     });
 
-    it('mixed video and native bids', () => {
+    it('mixed video and native bids', function () {
       const videoPlacementId = 'test-video-placement-id';
       const videoBidId = 'test-video-bid-id';
       const nativePlacementId = 'test-native-placement-id';
@@ -474,7 +474,7 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponseNative.ad).to.contain(`placementid:'${nativePlacementId}',format:'native',bidid:'${nativeBidId}'`);
     });
 
-    it('mixture of valid native bid and error in response', () => {
+    it('mixture of valid native bid and error in response', function () {
       const [bidResponse] = interpretResponse({
         body: {
           errors: ['test-error-message'],

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec, VIDEO_ENDPOINT, BANNER_ENDPOINT, OUTSTREAM_SRC, DEFAULT_MIMES } from 'modules/beachfrontBidAdapter';
 import * as utils from 'src/utils';
 
-describe('BeachfrontAdapter', () => {
+describe('BeachfrontAdapter', function () {
   let bidRequests;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('BeachfrontAdapter', () => {
     ];
   });
 
-  describe('spec.isBidRequestValid', () => {
+  describe('spec.isBidRequestValid', function () {
     it('should return true when the required params are passed', () => {
       const bidRequest = bidRequests[0];
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
@@ -64,7 +64,7 @@ describe('BeachfrontAdapter', () => {
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
 
-    describe('for multi-format bids', () => {
+    describe('for multi-format bids', function () {
       it('should return true when the required params are passed for video', () => {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
@@ -123,8 +123,8 @@ describe('BeachfrontAdapter', () => {
     });
   });
 
-  describe('spec.buildRequests', () => {
-    describe('for video bids', () => {
+  describe('spec.buildRequests', function () {
+    describe('for video bids', function () {
       it('should attach the bid request object', () => {
         bidRequests[0].mediaTypes = { video: {} };
         bidRequests[1].mediaTypes = { video: {} };
@@ -242,7 +242,7 @@ describe('BeachfrontAdapter', () => {
       });
     });
 
-    describe('for banner bids', () => {
+    describe('for banner bids', function () {
       it('should attach the bid requests array', () => {
         bidRequests[0].mediaTypes = { banner: {} };
         bidRequests[1].mediaTypes = { banner: {} };
@@ -357,7 +357,7 @@ describe('BeachfrontAdapter', () => {
       });
     });
 
-    describe('for multi-format bids', () => {
+    describe('for multi-format bids', function () {
       it('should create a POST request for each bid format', () => {
         const width = 300;
         const height = 250;
@@ -413,8 +413,8 @@ describe('BeachfrontAdapter', () => {
     });
   });
 
-  describe('spec.interpretResponse', () => {
-    describe('for video bids', () => {
+  describe('spec.interpretResponse', function () {
+    describe('for video bids', function () {
       it('should return no bids if the response is not valid', () => {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
@@ -493,7 +493,7 @@ describe('BeachfrontAdapter', () => {
       });
     });
 
-    describe('for banner bids', () => {
+    describe('for banner bids', function () {
       it('should return no bids if the response is not valid', () => {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
@@ -555,8 +555,8 @@ describe('BeachfrontAdapter', () => {
     });
   });
 
-  describe('spec.getUserSyncs', () => {
-    describe('for video bids', () => {
+  describe('spec.getUserSyncs', function () {
+    describe('for video bids', function () {
       let bidResponse;
 
       beforeEach(() => {
@@ -606,7 +606,7 @@ describe('BeachfrontAdapter', () => {
       });
     });
 
-    describe('for banner bids', () => {
+    describe('for banner bids', function () {
       let bidResponse;
 
       beforeEach(() => {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -32,12 +32,12 @@ describe('BeachfrontAdapter', function () {
   });
 
   describe('spec.isBidRequestValid', function () {
-    it('should return true when the required params are passed', () => {
+    it('should return true when the required params are passed', function () {
       const bidRequest = bidRequests[0];
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return false when the "bidfloor" param is missing', () => {
+    it('should return false when the "bidfloor" param is missing', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {
         appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
@@ -45,7 +45,7 @@ describe('BeachfrontAdapter', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when the "appId" param is missing', () => {
+    it('should return false when the "appId" param is missing', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {
         bidfloor: 5.00
@@ -53,19 +53,19 @@ describe('BeachfrontAdapter', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when no bid params are passed', () => {
+    it('should return false when no bid params are passed', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when a bid request is not passed', () => {
+    it('should return false when a bid request is not passed', function () {
       expect(spec.isBidRequestValid()).to.equal(false);
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
 
     describe('for multi-format bids', function () {
-      it('should return true when the required params are passed for video', () => {
+      it('should return true when the required params are passed for video', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           video: {}
@@ -79,7 +79,7 @@ describe('BeachfrontAdapter', function () {
         expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
       });
 
-      it('should return false when the required params are missing for video', () => {
+      it('should return false when the required params are missing for video', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           video: {}
@@ -93,7 +93,7 @@ describe('BeachfrontAdapter', function () {
         expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
       });
 
-      it('should return true when the required params are passed for banner', () => {
+      it('should return true when the required params are passed for banner', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           banner: {}
@@ -107,7 +107,7 @@ describe('BeachfrontAdapter', function () {
         expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
       });
 
-      it('should return false when the required params are missing for banner', () => {
+      it('should return false when the required params are missing for banner', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           banner: {}
@@ -125,7 +125,7 @@ describe('BeachfrontAdapter', function () {
 
   describe('spec.buildRequests', function () {
     describe('for video bids', function () {
-      it('should attach the bid request object', () => {
+      it('should attach the bid request object', function () {
         bidRequests[0].mediaTypes = { video: {} };
         bidRequests[1].mediaTypes = { video: {} };
         const requests = spec.buildRequests(bidRequests);
@@ -133,7 +133,7 @@ describe('BeachfrontAdapter', function () {
         expect(requests[1].bidRequest).to.equal(bidRequests[1]);
       });
 
-      it('should create a POST request for each bid', () => {
+      it('should create a POST request for each bid', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const requests = spec.buildRequests([ bidRequest ]);
@@ -141,7 +141,7 @@ describe('BeachfrontAdapter', function () {
         expect(requests[0].url).to.equal(VIDEO_ENDPOINT + bidRequest.params.appId);
       });
 
-      it('should attach request data', () => {
+      it('should attach request data', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -164,7 +164,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.cur).to.deep.equal(['USD']);
       });
 
-      it('must parse bid size from a nested array', () => {
+      it('must parse bid size from a nested array', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -178,7 +178,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
       });
 
-      it('must parse bid size from a string', () => {
+      it('must parse bid size from a string', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -192,7 +192,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
       });
 
-      it('must handle an empty bid size', () => {
+      it('must handle an empty bid size', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           video: {
@@ -204,7 +204,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ w: undefined, h: undefined });
       });
 
-      it('must fall back to the size on the bid object', () => {
+      it('must fall back to the size on the bid object', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -215,7 +215,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
       });
 
-      it('must override video targeting params', () => {
+      it('must override video targeting params', function () {
         const bidRequest = bidRequests[0];
         const mimes = ['video/webm'];
         bidRequest.mediaTypes = { video: {} };
@@ -225,7 +225,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ mimes });
       });
 
-      it('must add GDPR consent data to the request', () => {
+      it('must add GDPR consent data to the request', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
@@ -243,14 +243,14 @@ describe('BeachfrontAdapter', function () {
     });
 
     describe('for banner bids', function () {
-      it('should attach the bid requests array', () => {
+      it('should attach the bid requests array', function () {
         bidRequests[0].mediaTypes = { banner: {} };
         bidRequests[1].mediaTypes = { banner: {} };
         const requests = spec.buildRequests(bidRequests);
         expect(requests[0].bidRequest).to.deep.equal(bidRequests);
       });
 
-      it('should create a single POST request for all bids', () => {
+      it('should create a single POST request for all bids', function () {
         bidRequests[0].mediaTypes = { banner: {} };
         bidRequests[1].mediaTypes = { banner: {} };
         const requests = spec.buildRequests(bidRequests);
@@ -259,7 +259,7 @@ describe('BeachfrontAdapter', function () {
         expect(requests[0].url).to.equal(BANNER_ENDPOINT);
       });
 
-      it('should attach request data', () => {
+      it('should attach request data', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
@@ -285,7 +285,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.ua).to.equal(navigator.userAgent);
       });
 
-      it('must parse bid size from a nested array', () => {
+      it('must parse bid size from a nested array', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
@@ -301,7 +301,7 @@ describe('BeachfrontAdapter', function () {
         ]);
       });
 
-      it('must parse bid size from a string', () => {
+      it('must parse bid size from a string', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
@@ -317,7 +317,7 @@ describe('BeachfrontAdapter', function () {
         ]);
       });
 
-      it('must handle an empty bid size', () => {
+      it('must handle an empty bid size', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           banner: {
@@ -329,7 +329,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.slots[0].sizes).to.deep.equal([]);
       });
 
-      it('must fall back to the size on the bid object', () => {
+      it('must fall back to the size on the bid object', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
@@ -340,7 +340,7 @@ describe('BeachfrontAdapter', function () {
         expect(data.slots[0].sizes).to.deep.contain({ w: width, h: height });
       });
 
-      it('must add GDPR consent data to the request', () => {
+      it('must add GDPR consent data to the request', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
         const consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
@@ -358,7 +358,7 @@ describe('BeachfrontAdapter', function () {
     });
 
     describe('for multi-format bids', function () {
-      it('should create a POST request for each bid format', () => {
+      it('should create a POST request for each bid format', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
@@ -386,7 +386,7 @@ describe('BeachfrontAdapter', function () {
         expect(requests[1].url).to.contain(BANNER_ENDPOINT);
       });
 
-      it('must parse bid sizes for each bid format', () => {
+      it('must parse bid sizes for each bid format', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           video: {
@@ -415,14 +415,14 @@ describe('BeachfrontAdapter', function () {
 
   describe('spec.interpretResponse', function () {
     describe('for video bids', function () {
-      it('should return no bids if the response is not valid', () => {
+      it('should return no bids if the response is not valid', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return no bids if the response "url" is missing', () => {
+      it('should return no bids if the response "url" is missing', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const serverResponse = {
@@ -432,7 +432,7 @@ describe('BeachfrontAdapter', function () {
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return no bids if the response "bidPrice" is missing', () => {
+      it('should return no bids if the response "bidPrice" is missing', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const serverResponse = {
@@ -442,7 +442,7 @@ describe('BeachfrontAdapter', function () {
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return a valid video bid response', () => {
+      it('should return a valid video bid response', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -473,7 +473,7 @@ describe('BeachfrontAdapter', function () {
         });
       });
 
-      it('should return a renderer for outstream video bids', () => {
+      it('should return a renderer for outstream video bids', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = {
           video: {
@@ -494,21 +494,21 @@ describe('BeachfrontAdapter', function () {
     });
 
     describe('for banner bids', function () {
-      it('should return no bids if the response is not valid', () => {
+      it('should return no bids if the response is not valid', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
         const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return no bids if the response is empty', () => {
+      it('should return no bids if the response is empty', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
         const bidResponse = spec.interpretResponse({ body: [] }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return valid banner bid responses', () => {
+      it('should return valid banner bid responses', function () {
         bidRequests[0].mediaTypes = {
           banner: {
             sizes: [[ 300, 250 ], [ 728, 90 ]]
@@ -567,7 +567,7 @@ describe('BeachfrontAdapter', function () {
         };
       });
 
-      it('should return an iframe user sync if iframes are enabled', () => {
+      it('should return an iframe user sync if iframes are enabled', function () {
         const syncOptions = {
           iframeEnabled: true,
           pixelEnabled: true
@@ -580,7 +580,7 @@ describe('BeachfrontAdapter', function () {
         expect(userSyncs[0].type).to.equal('iframe');
       });
 
-      it('should return an image user sync if iframes are disabled', () => {
+      it('should return an image user sync if iframes are disabled', function () {
         const syncOptions = {
           iframeEnabled: false,
           pixelEnabled: true
@@ -593,7 +593,7 @@ describe('BeachfrontAdapter', function () {
         expect(userSyncs[0].type).to.equal('image');
       });
 
-      it('should not return user syncs if none are enabled', () => {
+      it('should not return user syncs if none are enabled', function () {
         const syncOptions = {
           iframeEnabled: false,
           pixelEnabled: false
@@ -620,7 +620,7 @@ describe('BeachfrontAdapter', function () {
         };
       });
 
-      it('should return user syncs defined the bid response', () => {
+      it('should return user syncs defined the bid response', function () {
         const syncUrl = 'http://sync.bfmio.com/sync_iframe?ifpl=5&ifg=1&id=test&gdpr=0&gc=&gce=0';
         const syncOptions = {
           iframeEnabled: true,
@@ -638,7 +638,7 @@ describe('BeachfrontAdapter', function () {
         ]);
       });
 
-      it('should not return user syncs if iframes are disabled', () => {
+      it('should not return user syncs if iframes are disabled', function () {
         const syncUrl = 'http://sync.bfmio.com/sync_iframe?ifpl=5&ifg=1&id=test&gdpr=0&gc=&gce=0';
         const syncOptions = {
           iframeEnabled: false,
@@ -654,7 +654,7 @@ describe('BeachfrontAdapter', function () {
         expect(userSyncs).to.deep.equal([]);
       });
 
-      it('should not return user syncs if there are none in the bid response', () => {
+      it('should not return user syncs if there are none in the bid response', function () {
         const syncOptions = {
           iframeEnabled: true,
           pixelEnabled: true

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -5,7 +5,7 @@ import * as utils from 'src/utils';
 describe('BeachfrontAdapter', function () {
   let bidRequests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'beachfront',
@@ -559,7 +559,7 @@ describe('BeachfrontAdapter', function () {
     describe('for video bids', function () {
       let bidResponse;
 
-      beforeEach(() => {
+      beforeEach(function () {
         bidResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
@@ -609,7 +609,7 @@ describe('BeachfrontAdapter', function () {
     describe('for banner bids', function () {
       let bidResponse;
 
-      beforeEach(() => {
+      beforeEach(function () {
         bidResponse = {
           slot: bidRequests[0].adUnitCode,
           adm: '<div id="44851937"></div>',

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/betweenBidAdapter';
 
 describe('betweenBidAdapterTests', function () {
-  it('validate_pub_params', () => {
+  it('validate_pub_params', function () {
     expect(spec.isBidRequestValid({
       bidder: 'between',
       params: {
@@ -13,7 +13,7 @@ describe('betweenBidAdapterTests', function () {
       }
     })).to.equal(true);
   });
-  it('validate_generated_params', () => {
+  it('validate_generated_params', function () {
     let bidRequestData = [{
       bidId: 'bid1234',
       bidder: 'between',
@@ -24,7 +24,7 @@ describe('betweenBidAdapterTests', function () {
     let req_data = request[0].data;
     expect(req_data.bidid).to.equal('bid1234');
   });
-  it('validate_response_params', () => {
+  it('validate_response_params', function () {
     let serverResponse = {
       body: [{
         bidid: 'bid1234',

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/betweenBidAdapter';
 
-describe('betweenBidAdapterTests', () => {
+describe('betweenBidAdapterTests', function () {
   it('validate_pub_params', () => {
     expect(spec.isBidRequestValid({
       bidder: 'between',

--- a/test/spec/modules/bizzclickBidAdapter_spec.js
+++ b/test/spec/modules/bizzclickBidAdapter_spec.js
@@ -17,10 +17,10 @@ describe('BizzclickBidAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true when placement_id can be cast to a number', () => {
+    it('Should return true when placement_id can be cast to a number', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false when placement_id is not a number', () => {
+    it('Should return false when placement_id is not a number', function () {
       bid.params.placementId = 'aaa';
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -28,19 +28,19 @@ describe('BizzclickBidAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//supply.bizzclick.com/?c=o&m=multi');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'secure', 'host', 'page', 'placements');
@@ -59,7 +59,7 @@ describe('BizzclickBidAdapter', function () {
         expect(placement.sizes).to.be.an('array');
       }
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.placements).to.be.an('array').that.is.empty;
@@ -81,7 +81,7 @@ describe('BizzclickBidAdapter', function () {
       }]
     };
     let serverResponses = spec.interpretResponse(resObject);
-    it('Returns an array of valid server responses if response object is valid', () => {
+    it('Returns an array of valid server responses if response object is valid', function () {
       expect(serverResponses).to.be.an('array').that.is.not.empty;
       for (let i = 0; i < serverResponses.length; i++) {
         let dataItem = serverResponses[i];
@@ -97,7 +97,7 @@ describe('BizzclickBidAdapter', function () {
         expect(dataItem.currency).to.be.a('string');
         expect(dataItem.mediaType).to.be.a('string');
       }
-      it('Returns an empty array if invalid response is passed', () => {
+      it('Returns an empty array if invalid response is passed', function () {
         serverResponses = spec.interpretResponse('invalid_response');
         expect(serverResponses).to.be.an('array').that.is.empty;
       });
@@ -106,7 +106,7 @@ describe('BizzclickBidAdapter', function () {
 
   describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
-    it('Returns valid URL and type', () => {
+    it('Returns valid URL and type', function () {
       expect(userSync).to.be.an('array').with.lengthOf(1);
       expect(userSync[0].type).to.exist;
       expect(userSync[0].url).to.exist;

--- a/test/spec/modules/bizzclickBidAdapter_spec.js
+++ b/test/spec/modules/bizzclickBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/bizzclickBidAdapter';
 
-describe('BizzclickBidAdapter', () => {
+describe('BizzclickBidAdapter', function () {
   let bid = {
     bidId: '67d581a232281d',
     bidder: 'bizzclickBidAdapter',
@@ -16,7 +16,7 @@ describe('BizzclickBidAdapter', () => {
     transactionId: '3bb2f6da-87a6-4029-aeb0-1b244bbfb5'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true when placement_id can be cast to a number', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -26,7 +26,7 @@ describe('BizzclickBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -65,7 +65,7 @@ describe('BizzclickBidAdapter', () => {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let resObject = {
       body: [ {
         requestId: '123',
@@ -104,7 +104,7 @@ describe('BizzclickBidAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
     it('Returns valid URL and type', () => {
       expect(userSync).to.be.an('array').with.lengthOf(1);

--- a/test/spec/modules/brainyBidAdapter_spec.js
+++ b/test/spec/modules/brainyBidAdapter_spec.js
@@ -64,8 +64,8 @@ const invalidSyncBidResponse = [{
   }
 }];
 
-describe('brainy Adapter', () => {
-  describe('request', () => {
+describe('brainy Adapter', function () {
+  describe('request', function () {
     it('should validate bid request', () => {
       expect(spec.isBidRequestValid(validBidReq)).to.equal(true);
     });
@@ -73,7 +73,7 @@ describe('brainy Adapter', () => {
       expect(spec.isBidRequestValid(invalidBidReq)).to.equal(false);
     });
   });
-  describe('build request', () => {
+  describe('build request', function () {
     it('Verify bid request', () => {
       const request = spec.buildRequests(bidReq);
       expect(request[0].method).to.equal('GET');
@@ -83,7 +83,7 @@ describe('brainy Adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should build bid array', () => {
       const request = spec.buildRequests(bidReq);
       const result = spec.interpretResponse({body: bidResponse}, request[0]);
@@ -101,7 +101,7 @@ describe('brainy Adapter', () => {
     });
   });
 
-  describe('spec.getUserSyncs', () => {
+  describe('spec.getUserSyncs', function () {
     let syncOptions
     beforeEach(() => {
       syncOptions = {

--- a/test/spec/modules/brainyBidAdapter_spec.js
+++ b/test/spec/modules/brainyBidAdapter_spec.js
@@ -103,7 +103,7 @@ describe('brainy Adapter', function () {
 
   describe('spec.getUserSyncs', function () {
     let syncOptions
-    beforeEach(() => {
+    beforeEach(function () {
       syncOptions = {
         enabledBidders: ['brainy'],
         pixelEnabled: true

--- a/test/spec/modules/brainyBidAdapter_spec.js
+++ b/test/spec/modules/brainyBidAdapter_spec.js
@@ -66,15 +66,15 @@ const invalidSyncBidResponse = [{
 
 describe('brainy Adapter', function () {
   describe('request', function () {
-    it('should validate bid request', () => {
+    it('should validate bid request', function () {
       expect(spec.isBidRequestValid(validBidReq)).to.equal(true);
     });
-    it('should not validate incorrect bid request', () => {
+    it('should not validate incorrect bid request', function () {
       expect(spec.isBidRequestValid(invalidBidReq)).to.equal(false);
     });
   });
   describe('build request', function () {
-    it('Verify bid request', () => {
+    it('Verify bid request', function () {
       const request = spec.buildRequests(bidReq);
       expect(request[0].method).to.equal('GET');
       expect(request[0].url).to.equal(URL);
@@ -84,13 +84,13 @@ describe('brainy Adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should build bid array', () => {
+    it('should build bid array', function () {
       const request = spec.buildRequests(bidReq);
       const result = spec.interpretResponse({body: bidResponse}, request[0]);
       expect(result.length).to.equal(1);
     });
 
-    it('should have all relevant fields', () => {
+    it('should have all relevant fields', function () {
       const request = spec.buildRequests(bidReq);
       const result = spec.interpretResponse({body: bidResponse}, request[0]);
       const bid = result[0];
@@ -109,17 +109,17 @@ describe('brainy Adapter', function () {
         pixelEnabled: true
       }
     });
-    it('sucess with usersync url', () => {
+    it('sucess with usersync url', function () {
       const result = [];
       result.push({type: 'image', url: '//testparm.com/ssp-sync/p/sync?uid=2110180601155125000059&buyer=2&slot=34'});
       expect(spec.getUserSyncs(syncOptions, bidSyncResponse)).to.deep.equal(result);
     });
 
-    it('sucess without usersync url', () => {
+    it('sucess without usersync url', function () {
       const result = [];
       expect(spec.getUserSyncs(syncOptions, invalidSyncBidResponse)).to.deep.equal(result);
     });
-    it('empty response', () => {
+    it('empty response', function () {
       const serverResponse = [{body: {}}];
       const result = [];
       expect(spec.getUserSyncs(syncOptions, serverResponse)).to.deep.equal(result);

--- a/test/spec/modules/bridgewellBidAdapter_spec.js
+++ b/test/spec/modules/bridgewellBidAdapter_spec.js
@@ -170,7 +170,7 @@ describe('bridgewellBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -227,18 +227,18 @@ describe('bridgewellBidAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bidWithoutCpmWeight)).to.equal(true);
       expect(spec.isBidRequestValid(bidWithCorrectCpmWeight)).to.equal(true);
       expect(spec.isBidRequestValid(bidWithUncorrectCpmWeight)).to.equal(false);
       expect(spec.isBidRequestValid(bidWithZeroCpmWeight)).to.equal(false);
     });
 
-    it('should return false when required params not found', () => {
+    it('should return false when required params not found', function () {
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bidWithoutCpmWeight = Object.assign({}, bidWithoutCpmWeight);
       let bidWithCorrectCpmWeight = Object.assign({}, bidWithCorrectCpmWeight);
       let bidWithUncorrectCpmWeight = Object.assign({}, bidWithUncorrectCpmWeight);
@@ -273,7 +273,7 @@ describe('bridgewellBidAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       const adUnits = payload.adUnits;
@@ -286,7 +286,7 @@ describe('bridgewellBidAdapter', function () {
       }
     });
 
-    it('should attach validBidRequests to the tag', () => {
+    it('should attach validBidRequests to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const validBidRequests = request.validBidRequests;
       expect(validBidRequests).to.deep.equal(bidRequests);
@@ -440,7 +440,7 @@ describe('bridgewellBidAdapter', function () {
       }
     ];
 
-    it('should return all required parameters', () => {
+    it('should return all required parameters', function () {
       const result = spec.interpretResponse({'body': serverResponses}, request);
       result.every(res => expect(res.cpm).to.be.a('number'));
       result.every(res => expect(res.width).to.be.a('number'));
@@ -457,12 +457,12 @@ describe('bridgewellBidAdapter', function () {
       });
     });
 
-    it('should give up bid if server response is undefiend', () => {
+    it('should give up bid if server response is undefiend', function () {
       const result = spec.interpretResponse({'body': undefined}, request);
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if request sizes is missing', () => {
+    it('should give up bid if request sizes is missing', function () {
       let target = Object.assign({}, serverResponses[0]);
       target.consumed = false;
       const result = spec.interpretResponse({'body': [target]}, spec.buildRequests([{
@@ -478,7 +478,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if response sizes is invalid', () => {
+    it('should give up bid if response sizes is invalid', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -495,7 +495,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if cpm is missing', () => {
+    it('should give up bid if cpm is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -511,7 +511,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if width or height is missing', () => {
+    it('should give up bid if width or height is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -526,7 +526,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if ad is missing', () => {
+    it('should give up bid if ad is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -543,7 +543,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if revenue mode is missing', () => {
+    it('should give up bid if revenue mode is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -559,7 +559,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if currency is missing', () => {
+    it('should give up bid if currency is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -575,7 +575,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if mediaType is missing', () => {
+    it('should give up bid if mediaType is missing', function () {
       let target = {
         'id': 'e5b10774-32bf-4931-85ee-05095e8cff21',
         'bidder_code': 'bridgewell',
@@ -592,7 +592,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if property native of mediaType native is missing', () => {
+    it('should give up bid if property native of mediaType native is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -609,7 +609,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native title is missing', () => {
+    it('should give up bid if native title is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -643,7 +643,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native title is too long', () => {
+    it('should give up bid if native title is too long', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -678,7 +678,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native body is missing', () => {
+    it('should give up bid if native body is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -711,7 +711,7 @@ describe('bridgewellBidAdapter', function () {
       const result = spec.interpretResponse({'body': [target]}, request);
       expect(result).to.deep.equal([]);
 
-      it('should give up bid if native image url is missing', () => {
+      it('should give up bid if native image url is missing', function () {
         let target = {
           'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
           'bidder_code': 'bridgewell',
@@ -746,7 +746,7 @@ describe('bridgewellBidAdapter', function () {
       });
     });
 
-    it('should give up bid if native image is missing', () => {
+    it('should give up bid if native image is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -776,7 +776,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native image url is missing', () => {
+    it('should give up bid if native image url is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -808,7 +808,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native image sizes is unmatch', () => {
+    it('should give up bid if native image sizes is unmatch', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -841,7 +841,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native sponsoredBy is missing', () => {
+    it('should give up bid if native sponsoredBy is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -875,7 +875,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native icon is missing', () => {
+    it('should give up bid if native icon is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -905,7 +905,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native icon url is missing', () => {
+    it('should give up bid if native icon url is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -939,7 +939,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native icon sizes is unmatch', () => {
+    it('should give up bid if native icon sizes is unmatch', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -972,7 +972,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native clickUrl is missing', () => {
+    it('should give up bid if native clickUrl is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -1006,7 +1006,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native clickTrackers is missing', () => {
+    it('should give up bid if native clickTrackers is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -1040,7 +1040,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native clickTrackers is empty', () => {
+    it('should give up bid if native clickTrackers is empty', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -1075,7 +1075,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native impressionTrackers is missing', () => {
+    it('should give up bid if native impressionTrackers is missing', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -1109,7 +1109,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if native impressionTrackers is empty', () => {
+    it('should give up bid if native impressionTrackers is empty', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',
@@ -1144,7 +1144,7 @@ describe('bridgewellBidAdapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('should give up bid if mediaType is not support', () => {
+    it('should give up bid if mediaType is not support', function () {
       let target = {
         'id': '0e4048d3-5c74-4380-a21a-00ba35629f7d',
         'bidder_code': 'bridgewell',

--- a/test/spec/modules/bridgewellBidAdapter_spec.js
+++ b/test/spec/modules/bridgewellBidAdapter_spec.js
@@ -169,13 +169,13 @@ describe('bridgewellBidAdapter', function () {
   ];
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bidWithoutCpmWeight = {
       'bidder': 'bridgewell',
       'params': {
@@ -272,7 +272,7 @@ describe('bridgewellBidAdapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should attach valid params to the tag', () => {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -293,7 +293,7 @@ describe('bridgewellBidAdapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const request = spec.buildRequests(bidRequests);
     const serverResponses = [
       {

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('C1XAdapter', function () {
   const adapter = newBidder(c1xAdapter);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('C1XAdapter', function () {
       }
     };
 
-    it('should return true when required params are passed', () => {
+    it('should return true when required params are passed', function () {
       expect(c1xAdapter.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not found', () => {
+    it('should return false when required params are not found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -61,19 +61,19 @@ describe('C1XAdapter', function () {
       return parsedData;
     };
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = c1xAdapter.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('GET');
     });
 
-    it('should generate correct bid Id tag', () => {
+    it('should generate correct bid Id tag', function () {
       const request = c1xAdapter.buildRequests(bidRequests);
       expect(request.bids[0].adUnitCode).to.equal('adunit-code');
       expect(request.bids[0].bidId).to.equal('30b31c1838de1e');
     });
 
-    it('should convert params to proper form and attach to request', () => {
+    it('should convert params to proper form and attach to request', function () {
       const request = c1xAdapter.buildRequests(bidRequests);
       const originalPayload = parseRequest(request.data);
       const payloadObj = JSON.parse(originalPayload);
@@ -83,7 +83,7 @@ describe('C1XAdapter', function () {
       expect(payloadObj.site).to.equal('9999');
     });
 
-    it('should convert floor price to proper form and attach to request', () => {
+    it('should convert floor price to proper form and attach to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -100,7 +100,7 @@ describe('C1XAdapter', function () {
       expect(payloadObj.a1p).to.equal('4.35');
     });
 
-    it('should convert pageurl to proper form and attach to request', () => {
+    it('should convert pageurl to proper form and attach to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -115,7 +115,7 @@ describe('C1XAdapter', function () {
       expect(payloadObj.pageurl).to.equal('http://c1exchange.com/');
     });
 
-    it('should convert GDPR Consent to proper form and attach to request', () => {
+    it('should convert GDPR Consent to proper form and attach to request', function () {
       let consentString = 'BOP2gFWOQIFovABABAENBGAAAAAAMw';
       let bidderRequest = {
         'bidderCode': 'c1x',
@@ -146,7 +146,7 @@ describe('C1XAdapter', function () {
       'bidType': 'GROSS_BID'
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           width: 300,
@@ -169,7 +169,7 @@ describe('C1XAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         bid: false,
         adId: 'c1x-test'

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -5,16 +5,16 @@ import { newBidder } from 'src/adapters/bidderFactory';
 const ENDPOINT = 'https://ht.c1exchange.com/ht';
 const BIDDER_CODE = 'c1x';
 
-describe('C1XAdapter', () => {
+describe('C1XAdapter', function () {
   const adapter = newBidder(c1xAdapter);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': BIDDER_CODE,
       'adUnitCode': 'adunit-code',
@@ -38,7 +38,7 @@ describe('C1XAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': BIDDER_CODE,
@@ -134,7 +134,7 @@ describe('C1XAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'bid': true,
       'cpm': 1.5,

--- a/test/spec/modules/ccxBidAdapter_spec.js
+++ b/test/spec/modules/ccxBidAdapter_spec.js
@@ -40,16 +40,16 @@ describe('ccxAdapter', function () {
     }
   ];
   describe('isBidRequestValid', function () {
-    it('Valid bid requests', () => {
+    it('Valid bid requests', function () {
       expect(spec.isBidRequestValid(bids[0])).to.be.true;
       expect(spec.isBidRequestValid(bids[1])).to.be.true;
     });
-    it('Invalid bid reqeusts - no placementId', () => {
+    it('Invalid bid reqeusts - no placementId', function () {
       let bidsClone = utils.deepClone(bids);
       bidsClone[0].params = undefined;
       expect(spec.isBidRequestValid(bidsClone[0])).to.be.false;
     });
-    it('Invalid bid reqeusts - invalid banner sizes', () => {
+    it('Invalid bid reqeusts - invalid banner sizes', function () {
       let bidsClone = utils.deepClone(bids);
       bidsClone[0].mediaTypes.banner.sizes = [300, 250];
       expect(spec.isBidRequestValid(bidsClone[0])).to.be.false;
@@ -58,14 +58,14 @@ describe('ccxAdapter', function () {
       bidsClone[0].mediaTypes.banner.sizes = [];
       expect(spec.isBidRequestValid(bidsClone[0])).to.be.false;
     });
-    it('Invalid bid reqeusts - invalid video sizes', () => {
+    it('Invalid bid reqeusts - invalid video sizes', function () {
       let bidsClone = utils.deepClone(bids);
       bidsClone[1].mediaTypes.video.playerSize = [];
       expect(spec.isBidRequestValid(bidsClone[1])).to.be.false;
       bidsClone[1].mediaTypes.video.sizes = [640, 480];
       expect(spec.isBidRequestValid(bidsClone[1])).to.be.false;
     });
-    it('Valid bid reqeust - old style sizes', () => {
+    it('Valid bid reqeust - old style sizes', function () {
       let bidsClone = utils.deepClone(bids);
       delete (bidsClone[0].mediaTypes);
       delete (bidsClone[1].mediaTypes);

--- a/test/spec/modules/ccxBidAdapter_spec.js
+++ b/test/spec/modules/ccxBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/ccxBidAdapter';
 import * as utils from 'src/utils';
 
-describe('ccxAdapter', () => {
+describe('ccxAdapter', function () {
   let bids = [
     {
       adUnitCode: 'banner',
@@ -39,7 +39,7 @@ describe('ccxAdapter', () => {
       transactionId: 'aefddd38-cfa0-48ab-8bdd-325de4bab5f9'
     }
   ];
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Valid bid requests', () => {
       expect(spec.isBidRequestValid(bids[0])).to.be.true;
       expect(spec.isBidRequestValid(bids[1])).to.be.true;

--- a/test/spec/modules/clickforceBidAdapter_spec.js
+++ b/test/spec/modules/clickforceBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { spec } from 'modules/clickforceBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('ClickforceAdapter', () => {
+describe('ClickforceAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'clickforce',
       'params': {
@@ -40,7 +40,7 @@ describe('ClickforceAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [{
       'bidder': 'clickforce',
       'params': {
@@ -62,7 +62,7 @@ describe('ClickforceAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = [{
       'cpm': 0.5,
       'width': '300',
@@ -168,7 +168,7 @@ describe('ClickforceAdapter', () => {
     });
   });
 
-  describe('getUserSyncs function', () => {
+  describe('getUserSyncs function', function () {
     it('should register type is iframe', () => {
       const syncOptions = {
         'iframeEnabled': 'true'

--- a/test/spec/modules/clickforceBidAdapter_spec.js
+++ b/test/spec/modules/clickforceBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('ClickforceAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('ClickforceAdapter', function () {
       'auctionId': '1d1a030790a475'
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -57,7 +57,7 @@ describe('ClickforceAdapter', function () {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('sends bid request to our endpoint via POST', () => {
+    it('sends bid request to our endpoint via POST', function () {
       expect(request.method).to.equal('POST');
     });
   });
@@ -147,19 +147,19 @@ describe('ClickforceAdapter', function () {
       }
     }];
 
-    it('should get the correct bid response by display ad', () => {
+    it('should get the correct bid response by display ad', function () {
       let bidderRequest;
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('should get the correct bid response by native ad', () => {
+    it('should get the correct bid response by native ad', function () {
       let bidderRequest;
       let result = spec.interpretResponse({ body: response1 }, {bidderRequest});
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse1[0]));
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: {}
       };
@@ -169,7 +169,7 @@ describe('ClickforceAdapter', function () {
   });
 
   describe('getUserSyncs function', function () {
-    it('should register type is iframe', () => {
+    it('should register type is iframe', function () {
       const syncOptions = {
         'iframeEnabled': 'true'
       }
@@ -178,7 +178,7 @@ describe('ClickforceAdapter', function () {
       expect(userSync[0].url).to.equal('https://cdn.doublemax.net/js/capmapping.htm');
     });
 
-    it('should register type is image', () => {
+    it('should register type is image', function () {
       const syncOptions = {
         'pixelEnabled': 'true'
       }

--- a/test/spec/modules/colossussspBidAdapter_spec.js
+++ b/test/spec/modules/colossussspBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/colossussspBidAdapter';
 
-describe('ColossussspAdapter', () => {
+describe('ColossussspAdapter', function () {
   let bid = {
     bidId: '2dd581a2b6281d',
     bidder: 'colossusssp',
@@ -15,7 +15,7 @@ describe('ColossussspAdapter', () => {
     transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true when placement_id can be cast to a number', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -25,7 +25,7 @@ describe('ColossussspAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -65,7 +65,7 @@ describe('ColossussspAdapter', () => {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let resObject = {
       body: [ {
         requestId: '123',
@@ -105,7 +105,7 @@ describe('ColossussspAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
     it('Returns valid URL and type', () => {
       expect(userSync).to.be.an('array').with.lengthOf(1);

--- a/test/spec/modules/colossussspBidAdapter_spec.js
+++ b/test/spec/modules/colossussspBidAdapter_spec.js
@@ -16,10 +16,10 @@ describe('ColossussspAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true when placement_id can be cast to a number', () => {
+    it('Should return true when placement_id can be cast to a number', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false when placement_id is not a number', () => {
+    it('Should return false when placement_id is not a number', function () {
       bid.params.placement_id = 'aaa';
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -27,19 +27,19 @@ describe('ColossussspAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//colossusssp.com/?c=o&m=multi');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'language', 'secure', 'host', 'page', 'placements');
@@ -59,7 +59,7 @@ describe('ColossussspAdapter', function () {
         expect(placement.sizes).to.be.an('array');
       }
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.placements).to.be.an('array').that.is.empty;
@@ -81,7 +81,7 @@ describe('ColossussspAdapter', function () {
       } ]
     };
     let serverResponses = spec.interpretResponse(resObject);
-    it('Returns an array of valid server responses if response object is valid', () => {
+    it('Returns an array of valid server responses if response object is valid', function () {
       expect(serverResponses).to.be.an('array').that.is.not.empty;
       for (let i = 0; i < serverResponses.length; i++) {
         let dataItem = serverResponses[i];
@@ -98,7 +98,7 @@ describe('ColossussspAdapter', function () {
         expect(dataItem.currency).to.be.a('string');
         expect(dataItem.mediaType).to.be.a('string');
       }
-      it('Returns an empty array if invalid response is passed', () => {
+      it('Returns an empty array if invalid response is passed', function () {
         serverResponses = spec.interpretResponse('invalid_response');
         expect(serverResponses).to.be.an('array').that.is.empty;
       });
@@ -107,7 +107,7 @@ describe('ColossussspAdapter', function () {
 
   describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
-    it('Returns valid URL and type', () => {
+    it('Returns valid URL and type', function () {
       expect(userSync).to.be.an('array').with.lengthOf(1);
       expect(userSync[0].type).to.exist;
       expect(userSync[0].url).to.exist;

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -18,7 +18,7 @@ describe('consentManagement', function () {
         config.resetConfig();
       });
 
-      it('should use system default values', () => {
+      it('should use system default values', function () {
         setConfig({});
         expect(userCMP).to.be.equal('iab');
         expect(consentTimeout).to.be.equal(10000);
@@ -32,7 +32,7 @@ describe('consentManagement', function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
       });
-      it('results in all user settings overriding system defaults', () => {
+      it('results in all user settings overriding system defaults', function () {
         let allConfig = {
           cmpApi: 'iab',
           timeout: 7500,
@@ -82,7 +82,7 @@ describe('consentManagement', function () {
         resetConsentData();
       });
 
-      it('should throw a warning and return to hooked function when an unknown CMP framework ID is used', () => {
+      it('should throw a warning and return to hooked function when an unknown CMP framework ID is used', function () {
         let badCMPConfig = {
           cmpApi: 'bad'
         };
@@ -98,7 +98,7 @@ describe('consentManagement', function () {
         expect(consent).to.be.null;
       });
 
-      it('should throw proper errors when CMP is not found', () => {
+      it('should throw proper errors when CMP is not found', function () {
         setConfig(goodConfigWithCancelAuction);
 
         requestBidsHook({}, () => {
@@ -128,7 +128,7 @@ describe('consentManagement', function () {
         resetConsentData();
       });
 
-      it('should bypass CMP and simply use previously stored consentData', () => {
+      it('should bypass CMP and simply use previously stored consentData', function () {
         let testConsentData = {
           gdprApplies: true,
           consentData: 'xyz'
@@ -183,7 +183,7 @@ describe('consentManagement', function () {
         resetConsentData();
       });
 
-      it('should return the consent data from a safeframe callback', () => {
+      it('should return the consent data from a safeframe callback', function () {
         var testConsentData = {
           data: {
             msgName: 'cmpReturn',
@@ -308,7 +308,7 @@ describe('consentManagement', function () {
         resetConsentData();
       });
 
-      it('performs lookup check and stores consentData for a valid existing user', () => {
+      it('performs lookup check and stores consentData for a valid existing user', function () {
         let testConsentData = {
           gdprApplies: true,
           consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
@@ -331,7 +331,7 @@ describe('consentManagement', function () {
         expect(consent.gdprApplies).to.be.true;
       });
 
-      it('throws an error when processCmpData check failed while config had allowAuction set to false', () => {
+      it('throws an error when processCmpData check failed while config had allowAuction set to false', function () {
         let testConsentData = {};
         let bidsBackHandlerReturn = false;
 
@@ -352,7 +352,7 @@ describe('consentManagement', function () {
         expect(consent).to.be.null;
       });
 
-      it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', () => {
+      it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', function () {
         let testConsentData = {};
 
         cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -7,8 +7,8 @@ let assert = require('chai').assert;
 let expect = require('chai').expect;
 
 describe('consentManagement', function () {
-  describe('setConfig tests:', () => {
-    describe('empty setConfig value', () => {
+  describe('setConfig tests:', function () {
+    describe('empty setConfig value', function () {
       beforeEach(() => {
         sinon.stub(utils, 'logInfo');
       });
@@ -27,7 +27,7 @@ describe('consentManagement', function () {
       });
     });
 
-    describe('valid setConfig value', () => {
+    describe('valid setConfig value', function () {
       afterEach(() => {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
@@ -47,7 +47,7 @@ describe('consentManagement', function () {
     });
   });
 
-  describe('requestBidsHook tests:', () => {
+  describe('requestBidsHook tests:', function () {
     let goodConfigWithCancelAuction = {
       cmpApi: 'iab',
       timeout: 7500,
@@ -67,7 +67,7 @@ describe('consentManagement', function () {
       resetConsentData();
     });
 
-    describe('error checks:', () => {
+    describe('error checks:', function () {
       beforeEach(() => {
         didHookReturn = false;
         sinon.stub(utils, 'logWarn');
@@ -112,7 +112,7 @@ describe('consentManagement', function () {
       });
     });
 
-    describe('already known consentData:', () => {
+    describe('already known consentData:', function () {
       let cmpStub = sinon.stub();
 
       beforeEach(() => {
@@ -158,7 +158,7 @@ describe('consentManagement', function () {
       });
     });
 
-    describe('CMP workflow for safeframe page', () => {
+    describe('CMP workflow for safeframe page', function () {
       let registerStub = sinon.stub();
 
       beforeEach(() => {
@@ -215,7 +215,7 @@ describe('consentManagement', function () {
       });
     });
 
-    describe('CMP workflow for iframed page', () => {
+    describe('CMP workflow for iframed page', function () {
       let ifr = null;
       let stringifyResponse = false;
 
@@ -288,7 +288,7 @@ describe('consentManagement', function () {
       }
     });
 
-    describe('CMP workflow for normal pages:', () => {
+    describe('CMP workflow for normal pages:', function () {
       let cmpStub = sinon.stub();
 
       beforeEach(() => {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -9,11 +9,11 @@ let expect = require('chai').expect;
 describe('consentManagement', function () {
   describe('setConfig tests:', function () {
     describe('empty setConfig value', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(utils, 'logInfo');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         utils.logInfo.restore();
         config.resetConfig();
       });
@@ -28,7 +28,7 @@ describe('consentManagement', function () {
     });
 
     describe('valid setConfig value', function () {
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
       });
@@ -62,19 +62,19 @@ describe('consentManagement', function () {
 
     let didHookReturn;
 
-    afterEach(() => {
+    afterEach(function () {
       gdprDataHandler.consentData = null;
       resetConsentData();
     });
 
     describe('error checks:', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         didHookReturn = false;
         sinon.stub(utils, 'logWarn');
         sinon.stub(utils, 'logError');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         utils.logWarn.restore();
         utils.logError.restore();
         config.resetConfig();
@@ -115,12 +115,12 @@ describe('consentManagement', function () {
     describe('already known consentData:', function () {
       let cmpStub = sinon.stub();
 
-      beforeEach(() => {
+      beforeEach(function () {
         didHookReturn = false;
         window.__cmp = function() {};
       });
 
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
         cmpStub.restore();
@@ -161,7 +161,7 @@ describe('consentManagement', function () {
     describe('CMP workflow for safeframe page', function () {
       let registerStub = sinon.stub();
 
-      beforeEach(() => {
+      beforeEach(function () {
         didHookReturn = false;
         window.$sf = {
           ext: {
@@ -173,7 +173,7 @@ describe('consentManagement', function () {
         sinon.stub(utils, 'logWarn');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         delete window.$sf;
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
@@ -219,14 +219,14 @@ describe('consentManagement', function () {
       let ifr = null;
       let stringifyResponse = false;
 
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(utils, 'logError');
         sinon.stub(utils, 'logWarn');
         ifr = createIFrameMarker();
         window.addEventListener('message', cmpMessageHandler, false);
       });
 
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
         delete window.__cmp;
@@ -291,14 +291,14 @@ describe('consentManagement', function () {
     describe('CMP workflow for normal pages:', function () {
       let cmpStub = sinon.stub();
 
-      beforeEach(() => {
+      beforeEach(function () {
         didHookReturn = false;
         sinon.stub(utils, 'logError');
         sinon.stub(utils, 'logWarn');
         window.__cmp = function() {};
       });
 
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
         cmpStub.restore();

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -129,7 +129,7 @@ describe('Consumable BidAdapter', function () {
   });
 
   describe('bid request validation', function () {
-    it('should accept valid bid requests', () => {
+    it('should accept valid bid requests', function () {
       let bid = {
         bidder: 'consumable',
         params: {
@@ -142,7 +142,7 @@ describe('Consumable BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should accept valid bid requests with extra fields', () => {
+    it('should accept valid bid requests with extra fields', function () {
       let bid = {
         bidder: 'consumable',
         params: {
@@ -156,7 +156,7 @@ describe('Consumable BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should reject bid requests without siteId', () => {
+    it('should reject bid requests without siteId', function () {
       let bid = {
         bidder: 'consumable',
         params: {
@@ -168,7 +168,7 @@ describe('Consumable BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should reject bid requests without networkId', () => {
+    it('should reject bid requests without networkId', function () {
       let bid = {
         bidder: 'consumable',
         params: {
@@ -182,43 +182,43 @@ describe('Consumable BidAdapter', function () {
   });
 
   describe('buildRequests validation', function () {
-    it('creates request data', () => {
+    it('creates request data', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request).to.exist.and.to.be.a('object');
     });
 
-    it('request to consumable should contain a url', () => {
+    it('request to consumable should contain a url', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.url).to.have.string('serverbid.com');
     });
 
-    it('requires valid bids to make request', () => {
+    it('requires valid bids to make request', function () {
       let request = spec.buildRequests([]);
       expect(request.bidRequest).to.be.empty;
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.method).to.have.string('POST');
     });
   });
   describe('interpretResponse validation', function () {
-    it('response should have valid bidderCode', () => {
+    it('response should have valid bidderCode', function () {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
 
       expect(bid.bidderCode).to.equal('consumable');
     });
 
-    it('response should include objects for all bids', () => {
+    it('response should include objects for all bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
       expect(bids.length).to.equal(2);
     });
 
-    it('registers bids', () => {
+    it('registers bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
       bids.forEach(b => {
         expect(b).to.have.property('cpm');
@@ -238,14 +238,14 @@ describe('Consumable BidAdapter', function () {
       });
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let EMPTY_RESP = Object.assign({}, RESPONSE, {'body': {'decisions': null}})
       let bids = spec.interpretResponse(EMPTY_RESP, REQUEST);
 
       expect(bids).to.be.empty;
     });
 
-    it('handles no server response', () => {
+    it('handles no server response', function () {
       let bids = spec.interpretResponse(null, REQUEST);
 
       expect(bids).to.be.empty;
@@ -254,13 +254,13 @@ describe('Consumable BidAdapter', function () {
   describe('getUserSyncs', function () {
     let syncOptions = {'iframeEnabled': true};
 
-    it('handles empty sync options', () => {
+    it('handles empty sync options', function () {
       let opts = spec.getUserSyncs({});
 
       expect(opts).to.be.empty;
     });
 
-    it('should return a sync url if iframe syncs are enabled', () => {
+    it('should return a sync url if iframe syncs are enabled', function () {
       let opts = spec.getUserSyncs(syncOptions);
 
       expect(opts.length).to.equal(1);

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -104,7 +104,7 @@ const RESPONSE = {
   }
 };
 
-describe('Consumable BidAdapter', () => {
+describe('Consumable BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
@@ -128,7 +128,7 @@ describe('Consumable BidAdapter', () => {
     ];
   });
 
-  describe('bid request validation', () => {
+  describe('bid request validation', function () {
     it('should accept valid bid requests', () => {
       let bid = {
         bidder: 'consumable',
@@ -181,7 +181,7 @@ describe('Consumable BidAdapter', () => {
     });
   });
 
-  describe('buildRequests validation', () => {
+  describe('buildRequests validation', function () {
     it('creates request data', () => {
       let request = spec.buildRequests(bidRequests);
 
@@ -205,7 +205,7 @@ describe('Consumable BidAdapter', () => {
       expect(request.method).to.have.string('POST');
     });
   });
-  describe('interpretResponse validation', () => {
+  describe('interpretResponse validation', function () {
     it('response should have valid bidderCode', () => {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
@@ -251,7 +251,7 @@ describe('Consumable BidAdapter', () => {
       expect(bids).to.be.empty;
     });
   });
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let syncOptions = {'iframeEnabled': true};
 
     it('handles empty sync options', () => {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -108,7 +108,7 @@ describe('Consumable BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'consumable',

--- a/test/spec/modules/contentigniteBidAdapter_spec.js
+++ b/test/spec/modules/contentigniteBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spec } from '../../../modules/contentigniteBidAdapter';
 
-describe('Content Ignite adapter', () => {
+describe('Content Ignite adapter', function () {
   let bidRequests;
 
   beforeEach(() => {
@@ -25,8 +25,8 @@ describe('Content Ignite adapter', () => {
     ];
   });
 
-  describe('implementation', () => {
-    describe('for requests', () => {
+  describe('implementation', function () {
+    describe('for requests', function () {
       it('should accept valid bid', () => {
         const validBid = {
             bidder: 'contentignite',
@@ -87,7 +87,7 @@ describe('Content Ignite adapter', () => {
       });
     });
 
-    describe('bid responses', () => {
+    describe('bid responses', function () {
       it('should return complete bid response', () => {
         const serverResponse = {
             body: {

--- a/test/spec/modules/contentigniteBidAdapter_spec.js
+++ b/test/spec/modules/contentigniteBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { spec } from '../../../modules/contentigniteBidAdapter';
 describe('Content Ignite adapter', function () {
   let bidRequests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'contentignite',

--- a/test/spec/modules/contentigniteBidAdapter_spec.js
+++ b/test/spec/modules/contentigniteBidAdapter_spec.js
@@ -27,7 +27,7 @@ describe('Content Ignite adapter', function () {
 
   describe('implementation', function () {
     describe('for requests', function () {
-      it('should accept valid bid', () => {
+      it('should accept valid bid', function () {
         const validBid = {
             bidder: 'contentignite',
             params: {
@@ -40,7 +40,7 @@ describe('Content Ignite adapter', function () {
         expect(isValid).to.equal(true);
       });
 
-      it('should reject invalid bid', () => {
+      it('should reject invalid bid', function () {
         const invalidBid = {
             bidder: 'contentignite',
             params: {
@@ -52,14 +52,14 @@ describe('Content Ignite adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-      it('should set the keyword parameter', () => {
+      it('should set the keyword parameter', function () {
         const requests = spec.buildRequests(bidRequests),
           requestURL = requests[0].url;
 
         expect(requestURL).to.have.string(';kw=business;');
       });
 
-      it('should increment the count for the same zone', () => {
+      it('should increment the count for the same zone', function () {
         const bidRequests = [
             {
               sizes: [[728, 90]],
@@ -88,7 +88,7 @@ describe('Content Ignite adapter', function () {
     });
 
     describe('bid responses', function () {
-      it('should return complete bid response', () => {
+      it('should return complete bid response', function () {
         const serverResponse = {
             body: {
               status: 'SUCCESS',
@@ -116,7 +116,7 @@ describe('Content Ignite adapter', function () {
         expect(bids[0].ad).to.have.length.above(1);
       });
 
-      it('should return empty bid response', () => {
+      it('should return empty bid response', function () {
         const serverResponse = {
             status: 'NO_ELIGIBLE_ADS',
             zone_id: 299680,
@@ -131,7 +131,7 @@ describe('Content Ignite adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on incorrect size', () => {
+      it('should return empty bid response on incorrect size', function () {
         const serverResponse = {
             status: 'SUCCESS',
             account_id: 168237,
@@ -148,7 +148,7 @@ describe('Content Ignite adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with CPM too low', () => {
+      it('should return empty bid response with CPM too low', function () {
         const serverResponse = {
             status: 'SUCCESS',
             account_id: 168237,
@@ -165,7 +165,7 @@ describe('Content Ignite adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with CPM too high', () => {
+      it('should return empty bid response with CPM too high', function () {
         const serverResponse = {
             status: 'SUCCESS',
             account_id: 168237,

--- a/test/spec/modules/coxBidAdapter_spec.js
+++ b/test/spec/modules/coxBidAdapter_spec.js
@@ -3,10 +3,10 @@ import { spec } from 'modules/coxBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 
-describe('CoxBidAdapter', () => {
+describe('CoxBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     const CONFIG = {
       'bidder': 'cox',
       'params': {
@@ -35,7 +35,7 @@ describe('CoxBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const PROD_DOMAIN = 'ad.afy11.net';
     const PPE_DOMAIN = 'ppe-ad.afy11.net';
     const STG_DOMAIN = 'staging-ad.afy11.net';
@@ -91,7 +91,7 @@ describe('CoxBidAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const BID_INFO_1 = [{
       'bidder': 'cox',
       'params': {
@@ -198,7 +198,7 @@ describe('CoxBidAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const RESPONSE = [{ body: {
       'zones': {},
       'tpCookieSync': ['http://pixel.foo.com/', 'http://pixel.bar.com/']

--- a/test/spec/modules/coxBidAdapter_spec.js
+++ b/test/spec/modules/coxBidAdapter_spec.js
@@ -16,18 +16,18 @@ describe('CoxBidAdapter', function () {
       }
     };
 
-    it('should return true when required params present', () => {
+    it('should return true when required params present', function () {
       expect(spec.isBidRequestValid(CONFIG)).to.equal(true);
     });
 
-    it('should return false when id param is missing', () => {
+    it('should return false when id param is missing', function () {
       let config = deepClone(CONFIG);
       config.params.id = null;
 
       expect(spec.isBidRequestValid(config)).to.equal(false);
     });
 
-    it('should return false when size param is missing', () => {
+    it('should return false when size param is missing', function () {
       let config = deepClone(CONFIG);
       config.params.size = null;
 
@@ -52,13 +52,13 @@ describe('CoxBidAdapter', function () {
       'bidId': 'bId-bar'
     }];
 
-    it('should send bid request to PROD_DOMAIN via GET', () => {
+    it('should send bid request to PROD_DOMAIN via GET', function () {
       let request = spec.buildRequests(BID_INFO);
       expect(request.url).to.have.string(PROD_DOMAIN);
       expect(request.method).to.equal('GET');
     });
 
-    it('should send bid request to PPE_DOMAIN when configured', () => {
+    it('should send bid request to PPE_DOMAIN when configured', function () {
       let clone = deepClone(BID_INFO);
       clone[0].params.env = 'PPE';
 
@@ -66,7 +66,7 @@ describe('CoxBidAdapter', function () {
       expect(request.url).to.have.string(PPE_DOMAIN);
     });
 
-    it('should send bid request to STG_DOMAIN when configured', () => {
+    it('should send bid request to STG_DOMAIN when configured', function () {
       let clone = deepClone(BID_INFO);
       clone[0].params.env = 'STG';
 
@@ -74,7 +74,7 @@ describe('CoxBidAdapter', function () {
       expect(request.url).to.have.string(STG_DOMAIN);
     });
 
-    it('should return empty when id is invalid', () => {
+    it('should return empty when id is invalid', function () {
       let clone = deepClone(BID_INFO);
       clone[0].params.id = null;
 
@@ -82,7 +82,7 @@ describe('CoxBidAdapter', function () {
       expect(request).to.be.an('object').that.is.empty;
     });
 
-    it('should return empty when size is invalid', () => {
+    it('should return empty when size is invalid', function () {
       let clone = deepClone(BID_INFO);
       clone[0].params.size = 'FOO';
 
@@ -157,12 +157,12 @@ describe('CoxBidAdapter', function () {
       'ad': '<H1>2000005658887<br/>300x250</H1>'
     };
 
-    it('should return correct pbjs bid', () => {
+    it('should return correct pbjs bid', function () {
       let result = spec.interpretResponse(RESPONSE_2, spec.buildRequests(BID_INFO_2));
       expect(result[0]).to.eql(PBJS_BID_2);
     });
 
-    it('should handle multiple bid instances', () => {
+    it('should handle multiple bid instances', function () {
       let request1 = spec.buildRequests(BID_INFO_1);
       let request2 = spec.buildRequests(BID_INFO_2);
 
@@ -173,7 +173,7 @@ describe('CoxBidAdapter', function () {
       expect(result1[0]).to.eql(PBJS_BID_1);
     });
 
-    it('should return empty when price is zero', () => {
+    it('should return empty when price is zero', function () {
       let clone = deepClone(RESPONSE_1);
       clone.body.zones.as2000005657007.price = 0;
 
@@ -181,7 +181,7 @@ describe('CoxBidAdapter', function () {
       expect(result).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty when there is no ad', () => {
+    it('should return empty when there is no ad', function () {
       let clone = deepClone(RESPONSE_1);
       clone.body.zones.as2000005657007.ad = null;
 
@@ -189,7 +189,7 @@ describe('CoxBidAdapter', function () {
       expect(result).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty when there is no ad unit info', () => {
+    it('should return empty when there is no ad unit info', function () {
       let clone = deepClone(RESPONSE_1);
       delete (clone.body.zones.as2000005657007);
 
@@ -204,20 +204,20 @@ describe('CoxBidAdapter', function () {
       'tpCookieSync': ['http://pixel.foo.com/', 'http://pixel.bar.com/']
     }}];
 
-    it('should return correct pbjs syncs when pixels are enabled', () => {
+    it('should return correct pbjs syncs when pixels are enabled', function () {
       let syncs = spec.getUserSyncs({ pixelEnabled: true }, RESPONSE);
 
       expect(syncs.map(x => x.type)).to.eql(['image', 'image']);
       expect(syncs.map(x => x.url)).to.have.members(['http://pixel.bar.com/', 'http://pixel.foo.com/']);
     });
 
-    it('should return empty when pixels are not enabled', () => {
+    it('should return empty when pixels are not enabled', function () {
       let syncs = spec.getUserSyncs({ pixelEnabled: false }, RESPONSE);
 
       expect(syncs).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty when response has no sync data', () => {
+    it('should return empty when response has no sync data', function () {
       let clone = deepClone(RESPONSE);
       delete (clone[0].body.tpCookieSync);
 
@@ -225,7 +225,7 @@ describe('CoxBidAdapter', function () {
       expect(syncs).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty when response is empty', () => {
+    it('should return empty when response is empty', function () {
       let syncs = spec.getUserSyncs({ pixelEnabled: true }, [{}]);
       expect(syncs).to.be.an('array').that.is.empty;
     });

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from 'src/utils';
 
 describe('The Criteo bidding adapter', function () {
   describe('isBidRequestValid', function () {
-    it('should return false when given an invalid bid', () => {
+    it('should return false when given an invalid bid', function () {
       const bid = {
         bidder: 'criteo',
       };
@@ -12,7 +12,7 @@ describe('The Criteo bidding adapter', function () {
       expect(isValid).to.equal(false);
     });
 
-    it('should return true when given a zoneId bid', () => {
+    it('should return true when given a zoneId bid', function () {
       const bid = {
         bidder: 'criteo',
         params: {
@@ -23,7 +23,7 @@ describe('The Criteo bidding adapter', function () {
       expect(isValid).to.equal(true);
     });
 
-    it('should return true when given a networkId bid', () => {
+    it('should return true when given a networkId bid', function () {
       const bid = {
         bidder: 'criteo',
         params: {
@@ -34,7 +34,7 @@ describe('The Criteo bidding adapter', function () {
       expect(isValid).to.equal(true);
     });
 
-    it('should return true when given a mixed bid with both a zoneId and a networkId', () => {
+    it('should return true when given a mixed bid with both a zoneId and a networkId', function () {
       const bid = {
         bidder: 'criteo',
         params: {
@@ -60,7 +60,7 @@ describe('The Criteo bidding adapter', function () {
       },
     };
 
-    it('should properly build a zoneId request', () => {
+    it('should properly build a zoneId request', function () {
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -88,7 +88,7 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.gdprConsent.consentGiven).to.equal(true);
     });
 
-    it('should properly build a networkId request', () => {
+    it('should properly build a networkId request', function () {
       const bidderRequest = {
         timeout: 3000,
         gdprConsent: {
@@ -129,7 +129,7 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.gdprConsent.consentGiven).to.equal(undefined);
     });
 
-    it('should properly build a mixed request', () => {
+    it('should properly build a mixed request', function () {
       const bidderRequest = { timeout: 3000 };
       const bidRequests = [
         {
@@ -170,7 +170,7 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.gdprConsent).to.equal(undefined);
     });
 
-    it('should properly build request with undefined gdpr consent fields when they are not provided', () => {
+    it('should properly build request with undefined gdpr consent fields when they are not provided', function () {
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -195,14 +195,14 @@ describe('The Criteo bidding adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should return an empty array when parsing a no bid response', () => {
+    it('should return an empty array when parsing a no bid response', function () {
       const response = {};
       const request = { bidRequests: [] };
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response with a networkId', () => {
+    it('should properly parse a bid response with a networkId', function () {
       const response = {
         body: {
           slots: [{
@@ -232,7 +232,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].height).to.equal(90);
     });
 
-    it('should properly parse a bid responsewith with a zoneId', () => {
+    it('should properly parse a bid responsewith with a zoneId', function () {
       const response = {
         body: {
           slots: [{
@@ -263,7 +263,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].height).to.equal(90);
     });
 
-    it('should properly parse a bid responsewith with a zoneId passed as a string', () => {
+    it('should properly parse a bid responsewith with a zoneId passed as a string', function () {
       const response = {
         body: {
           slots: [{

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { spec } from 'modules/criteoBidAdapter';
 import * as utils from 'src/utils';
 
-describe('The Criteo bidding adapter', () => {
-  describe('isBidRequestValid', () => {
+describe('The Criteo bidding adapter', function () {
+  describe('isBidRequestValid', function () {
     it('should return false when given an invalid bid', () => {
       const bid = {
         bidder: 'criteo',
@@ -47,7 +47,7 @@ describe('The Criteo bidding adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidderRequest = { timeout: 3000,
       gdprConsent: {
         gdprApplies: 1,
@@ -194,7 +194,7 @@ describe('The Criteo bidding adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should return an empty array when parsing a no bid response', () => {
       const response = {};
       const request = { bidRequests: [] };

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -30,12 +30,12 @@ describe('currency', function () {
   });
 
   describe('setConfig', function () {
-    it('results in currencySupportEnabled = false when currency not configured', () => {
+    it('results in currencySupportEnabled = false when currency not configured', function () {
       setConfig({});
       expect(currencySupportEnabled).to.equal(false);
     });
 
-    it('results in currencySupportEnabled = true and currencyRates being loaded when configured', () => {
+    it('results in currencySupportEnabled = true and currencyRates being loaded when configured', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'JPY' });
       fakeCurrencyFileServer.respond();
@@ -45,7 +45,7 @@ describe('currency', function () {
   });
 
   describe('bidder override', function () {
-    it('allows setConfig to set bidder currency', () => {
+    it('allows setConfig to set bidder currency', function () {
       setConfig({});
 
       var bid = { cpm: 1, bidder: 'rubicon' };
@@ -67,7 +67,7 @@ describe('currency', function () {
       expect(innerBid.getCpmInNewCurrency('GBP')).to.equal('1.000');
     });
 
-    it('uses adapter currency over currency override if specified', () => {
+    it('uses adapter currency over currency override if specified', function () {
       setConfig({});
 
       var bid = { cpm: 1, currency: 'JPY', bidder: 'rubicon' };
@@ -89,7 +89,7 @@ describe('currency', function () {
       expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('1.000');
     });
 
-    it('uses rates specified in json when provided', () => {
+    it('uses rates specified in json when provided', function () {
       setConfig({
         adServerCurrency: 'USD',
         rates: {
@@ -111,7 +111,7 @@ describe('currency', function () {
       expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('100.000');
     });
 
-    it('uses default rates when currency file fails to load', () => {
+    it('uses default rates when currency file fails to load', function () {
       setConfig({});
 
       setConfig({
@@ -140,7 +140,7 @@ describe('currency', function () {
   });
 
   describe('currency.addBidResponseDecorator bidResponseQueue', function () {
-    it('not run until currency rates file is loaded', () => {
+    it('not run until currency rates file is loaded', function () {
       setConfig({});
 
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
@@ -162,7 +162,7 @@ describe('currency', function () {
   });
 
   describe('currency.addBidResponseDecorator', function () {
-    it('should leave bid at 1 when currency support is not enabled and fromCurrency is USD', () => {
+    it('should leave bid at 1 when currency support is not enabled and fromCurrency is USD', function () {
       setConfig({});
       var bid = { 'cpm': 1, 'currency': 'USD' };
       var innerBid;
@@ -172,7 +172,7 @@ describe('currency', function () {
       expect(innerBid.cpm).to.equal(1);
     });
 
-    it('should result in NO_BID when currency support is not enabled and fromCurrency is not USD', () => {
+    it('should result in NO_BID when currency support is not enabled and fromCurrency is not USD', function () {
       setConfig({});
       var bid = { 'cpm': 1, 'currency': 'GBP' };
       var innerBid;
@@ -182,7 +182,7 @@ describe('currency', function () {
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
-    it('should not buffer bid when currency is already in desired currency', () => {
+    it('should not buffer bid when currency is already in desired currency', function () {
       setConfig({
         'adServerCurrency': 'USD'
       });
@@ -194,7 +194,7 @@ describe('currency', function () {
       expect(bid).to.equal(innerBid);
     });
 
-    it('should result in NO_BID when fromCurrency is not supported in file', () => {
+    it('should result in NO_BID when fromCurrency is not supported in file', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'JPY' });
       fakeCurrencyFileServer.respond();
@@ -206,7 +206,7 @@ describe('currency', function () {
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
-    it('should result in NO_BID when adServerCurrency is not supported in file', () => {
+    it('should result in NO_BID when adServerCurrency is not supported in file', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'ABC' });
       fakeCurrencyFileServer.respond();
@@ -218,7 +218,7 @@ describe('currency', function () {
       expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
     });
 
-    it('should return 1 when currency support is enabled and same currency code is requested as is set to adServerCurrency', () => {
+    it('should return 1 when currency support is enabled and same currency code is requested as is set to adServerCurrency', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'JPY' });
       fakeCurrencyFileServer.respond();
@@ -231,7 +231,7 @@ describe('currency', function () {
       expect(innerBid.currency).to.equal('JPY');
     });
 
-    it('should return direct conversion rate when fromCurrency is one of the configured bases', () => {
+    it('should return direct conversion rate when fromCurrency is one of the configured bases', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'GBP' });
       fakeCurrencyFileServer.respond();
@@ -244,7 +244,7 @@ describe('currency', function () {
       expect(innerBid.currency).to.equal('GBP');
     });
 
-    it('should return reciprocal conversion rate when adServerCurrency is one of the configured bases, but fromCurrency is not', () => {
+    it('should return reciprocal conversion rate when adServerCurrency is one of the configured bases, but fromCurrency is not', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'GBP' });
       fakeCurrencyFileServer.respond();
@@ -257,7 +257,7 @@ describe('currency', function () {
       expect(innerBid.currency).to.equal('GBP');
     });
 
-    it('should return intermediate conversion rate when neither fromCurrency nor adServerCurrency is one of the configured bases', () => {
+    it('should return intermediate conversion rate when neither fromCurrency nor adServerCurrency is one of the configured bases', function () {
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'CNY' });
       fakeCurrencyFileServer.respond();

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -21,11 +21,11 @@ describe('currency', function () {
   let fn = sinon.spy();
   let hookFn = createHook('asyncSeries', fn, 'addBidResponse');
 
-  beforeEach(() => {
+  beforeEach(function () {
     fakeCurrencyFileServer = sinon.fakeServer.create();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     fakeCurrencyFileServer.restore();
   });
 

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -29,7 +29,7 @@ describe('currency', function () {
     fakeCurrencyFileServer.restore();
   });
 
-  describe('setConfig', () => {
+  describe('setConfig', function () {
     it('results in currencySupportEnabled = false when currency not configured', () => {
       setConfig({});
       expect(currencySupportEnabled).to.equal(false);
@@ -44,7 +44,7 @@ describe('currency', function () {
     });
   });
 
-  describe('bidder override', () => {
+  describe('bidder override', function () {
     it('allows setConfig to set bidder currency', () => {
       setConfig({});
 
@@ -139,7 +139,7 @@ describe('currency', function () {
     });
   });
 
-  describe('currency.addBidResponseDecorator bidResponseQueue', () => {
+  describe('currency.addBidResponseDecorator bidResponseQueue', function () {
     it('not run until currency rates file is loaded', () => {
       setConfig({});
 
@@ -161,7 +161,7 @@ describe('currency', function () {
     });
   });
 
-  describe('currency.addBidResponseDecorator', () => {
+  describe('currency.addBidResponseDecorator', function () {
     it('should leave bid at 1 when currency support is not enabled and fromCurrency is USD', () => {
       setConfig({});
       var bid = { 'cpm': 1, 'currency': 'USD' };

--- a/test/spec/modules/danmarketBidAdapter_spec.js
+++ b/test/spec/modules/danmarketBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('DAN_Marketplace Adapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'danmarket',
       'params': {
@@ -38,7 +38,7 @@ describe('DAN_Marketplace Adapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'danmarket',
@@ -140,7 +140,7 @@ describe('DAN_Marketplace Adapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 4, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 5, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/danmarketBidAdapter_spec.js
+++ b/test/spec/modules/danmarketBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('DAN_Marketplace Adapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('DAN_Marketplace Adapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -75,7 +75,7 @@ describe('DAN_Marketplace Adapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -84,7 +84,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(payload).to.have.property('auids', '5');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -93,7 +93,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(payload).to.have.property('auids', '5,6');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -104,7 +104,7 @@ describe('DAN_Marketplace Adapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -115,7 +115,7 @@ describe('DAN_Marketplace Adapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('if gdprConsent is present payload must have gdpr params', () => {
+    it('if gdprConsent is present payload must have gdpr params', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: true}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -123,7 +123,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(payload).to.have.property('gdpr_applies', 1);
     });
 
-    it('if gdprApplies is false gdpr_applies must be 0', () => {
+    it('if gdprApplies is false gdpr_applies must be 0', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: false}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -131,7 +131,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(payload).to.have.property('gdpr_applies', 0);
     });
 
-    it('if gdprApplies is undefined gdpr_applies must be 1', () => {
+    it('if gdprApplies is undefined gdpr_applies must be 1', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA'}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -151,7 +151,7 @@ describe('DAN_Marketplace Adapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'danmarket',
@@ -185,7 +185,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'danmarket',
@@ -265,7 +265,7 @@ describe('DAN_Marketplace Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'danmarket',

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -13,7 +13,7 @@ const bid = {
   adserverTargeting: { },
 };
 
-describe('The DFP video support module', () => {
+describe('The DFP video support module', function () {
   it('should make a legal request URL when given the required params', () => {
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
@@ -110,7 +110,7 @@ describe('The DFP video support module', () => {
     expect(customParams).to.have.property('hb_cache_id', bid.videoCacheKey);
   });
 
-  describe('special targeting unit test', () => {
+  describe('special targeting unit test', function () {
     const allTargetingData = {
       'hb_format': 'video',
       'hb_source': 'client',

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -14,7 +14,7 @@ const bid = {
 };
 
 describe('The DFP video support module', function () {
-  it('should make a legal request URL when given the required params', () => {
+  it('should make a legal request URL when given the required params', function () {
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
       bid: bid,
@@ -39,7 +39,7 @@ describe('The DFP video support module', function () {
     expect(queryParams).to.have.property('url');
   });
 
-  it('can take an adserver url as a parameter', () => {
+  it('can take an adserver url as a parameter', function () {
     const bidCopy = Object.assign({ }, bid);
     bidCopy.vastUrl = 'vastUrl.example';
 
@@ -55,7 +55,7 @@ describe('The DFP video support module', function () {
     expect(queryObject.description_url).to.equal('vastUrl.example');
   });
 
-  it('requires a params object or url', () => {
+  it('requires a params object or url', function () {
     const url = buildDfpVideoUrl({
       adUnit: adUnit,
       bid: bid,
@@ -64,7 +64,7 @@ describe('The DFP video support module', function () {
     expect(url).to.be.undefined;
   });
 
-  it('overwrites url params when both url and params object are given', () => {
+  it('overwrites url params when both url and params object are given', function () {
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
       bid: bid,
@@ -76,7 +76,7 @@ describe('The DFP video support module', function () {
     expect(queryObject.iu).to.equal('my/adUnit');
   });
 
-  it('should override param defaults with user-provided ones', () => {
+  it('should override param defaults with user-provided ones', function () {
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
       bid: bid,
@@ -89,7 +89,7 @@ describe('The DFP video support module', function () {
     expect(parseQS(url.query)).to.have.property('output', 'vast');
   });
 
-  it('should include the cache key and adserver targeting in cust_params', () => {
+  it('should include the cache key and adserver targeting in cust_params', function () {
     const bidCopy = Object.assign({ }, bid);
     bidCopy.adserverTargeting = {
       hb_adid: 'ad_id',
@@ -147,7 +147,7 @@ describe('The DFP video support module', function () {
       targetingStub.restore();
     });
 
-    it('should include all adserver targeting in cust_params if pbjs.enableSendAllBids is true', () => {
+    it('should include all adserver targeting in cust_params if pbjs.enableSendAllBids is true', function () {
       const adUnitsCopy = utils.deepClone(adUnit);
       adUnitsCopy.bids.push({
         'bidder': 'testBidder2',
@@ -183,7 +183,7 @@ describe('The DFP video support module', function () {
     });
   });
 
-  it('should merge the user-provided cust_params with the default ones', () => {
+  it('should merge the user-provided cust_params with the default ones', function () {
     const bidCopy = Object.assign({ }, bid);
     bidCopy.adserverTargeting = {
       hb_adid: 'ad_id',
@@ -206,7 +206,7 @@ describe('The DFP video support module', function () {
     expect(customParams).to.have.property('my_targeting', 'foo');
   });
 
-  it('should merge the user-provided cust-params with the default ones when using url object', () => {
+  it('should merge the user-provided cust-params with the default ones when using url object', function () {
     const bidCopy = Object.assign({ }, bid);
     bidCopy.adserverTargeting = {
       hb_adid: 'ad_id',
@@ -228,7 +228,7 @@ describe('The DFP video support module', function () {
     expect(customParams).to.have.property('hb_cache_id', 'abc');
   });
 
-  it('should not overwrite an existing description_url for object input and cache disabled', () => {
+  it('should not overwrite an existing description_url for object input and cache disabled', function () {
     const bidCopy = Object.assign({}, bid);
     bidCopy.vastUrl = 'vastUrl.example';
 
@@ -245,7 +245,7 @@ describe('The DFP video support module', function () {
     expect(queryObject.description_url).to.equal('descriptionurl.example');
   });
 
-  it('should work with nobid responses', () => {
+  it('should work with nobid responses', function () {
     const url = buildDfpVideoUrl({
       adUnit: adUnit,
       params: { 'iu': 'my/adUnit' }

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -133,7 +133,7 @@ describe('The DFP video support module', function () {
     };
     let targetingStub;
 
-    before(() => {
+    before(function () {
       targetingStub = sinon.stub(targeting, 'getAllTargeting');
       targetingStub.returns({'video1': allTargetingData});
 
@@ -142,7 +142,7 @@ describe('The DFP video support module', function () {
       });
     });
 
-    after(() => {
+    after(function () {
       config.resetConfig();
       targetingStub.restore();
     });

--- a/test/spec/modules/dgadsBidAdapter_spec.js
+++ b/test/spec/modules/dgadsBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('dgadsBidAdapter', function () {
   const VALID_ENDPOINT = 'https://ads-tr.bigmining.com/ad/p/bid';
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -22,11 +22,11 @@ describe('dgadsBidAdapter', function () {
         location_id: '1'
       }
     };
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params(location_id) are not passed', () => {
+    it('should return false when required params(location_id) are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -35,7 +35,7 @@ describe('dgadsBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when required params(site_id) are not passed', () => {
+    it('should return false when required params(site_id) are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -97,7 +97,7 @@ describe('dgadsBidAdapter', function () {
         transactionId: 'c1f1eff6-23c6-4844-a321-575212939e37'
       }
     ];
-    it('no bidRequests', () => {
+    it('no bidRequests', function () {
       const noBidRequests = [];
       expect(Object.keys(spec.buildRequests(noBidRequests)).length).to.equal(0);
     });
@@ -107,12 +107,12 @@ describe('dgadsBidAdapter', function () {
       transaction_id: 'c1f1eff6-23c6-4844-a321-575212939e37',
       bid_id: '2db3101abaec66'
     };
-    it('sends bid request to VALID_ENDPOINT via POST', () => {
+    it('sends bid request to VALID_ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(VALID_ENDPOINT);
       expect(request.method).to.equal('POST');
     });
-    it('should attache params to the request', () => {
+    it('should attache params to the request', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.data['location_id']).to.equal(data['location_id']);
       expect(request.data['site_id']).to.equal(data['site_id']);
@@ -252,11 +252,11 @@ describe('dgadsBidAdapter', function () {
       }
     };
 
-    it('no bid responses', () => {
+    it('no bid responses', function () {
       const result = spec.interpretResponse({body: serverResponse.noAd}, bidRequests.banner);
       expect(result.length).to.equal(0);
     });
-    it('handles banner responses', () => {
+    it('handles banner responses', function () {
       const result = spec.interpretResponse({body: serverResponse.banner}, bidRequests.banner)[0];
       expect(result.requestId).to.equal(bidResponses.banner.requestId);
       expect(result.width).to.equal(bidResponses.banner.width);
@@ -269,7 +269,7 @@ describe('dgadsBidAdapter', function () {
       expect(result.ad).to.equal(bidResponses.banner.ad);
     });
 
-    it('handles native responses', () => {
+    it('handles native responses', function () {
       const result = spec.interpretResponse({body: serverResponse.native}, bidRequests.native)[0];
       expect(result.requestId).to.equal(bidResponses.native.requestId);
       expect(result.creativeId).to.equal(bidResponses.native.creativeId);

--- a/test/spec/modules/dgadsBidAdapter_spec.js
+++ b/test/spec/modules/dgadsBidAdapter_spec.js
@@ -4,17 +4,17 @@ import {spec} from 'modules/dgadsBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 import { BANNER, NATIVE } from 'src/mediaTypes';
 
-describe('dgadsBidAdapter', () => {
+describe('dgadsBidAdapter', function () {
   const adapter = newBidder(spec);
   const VALID_ENDPOINT = 'https://ads-tr.bigmining.com/ad/p/bid';
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'dgads',
       params: {
@@ -45,7 +45,7 @@ describe('dgadsBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [
       { // banner
         bidder: 'dgads',
@@ -121,7 +121,7 @@ describe('dgadsBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequests = {
       banner: {
         bidRequest: {

--- a/test/spec/modules/districtmDmxBidAdapter_spec.js
+++ b/test/spec/modules/districtmDmxBidAdapter_spec.js
@@ -420,9 +420,9 @@ const responsesNegative = {
 const emptyResponse = { body: {} };
 const emptyResponseSeatBid = { body: { seatbid: [] } };
 
-describe('DistrictM Adaptor', () => {
+describe('DistrictM Adaptor', function () {
   const districtm = spec;
-  describe('All needed functions are available', () => {
+  describe('All needed functions are available', function () {
     it(`isBidRequestValid is present and type function`, () => {
       expect(districtm.isBidRequestValid).to.exist.and.to.be.a('function')
     });
@@ -440,7 +440,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`these properties are available or not`, () => {
+  describe(`these properties are available or not`, function () {
     it(`code should have a value of districtmDMX`, () => {
       expect(districtm.code).to.be.equal('districtmDMX');
     });
@@ -450,7 +450,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`isBidRequestValid test response`, () => {
+  describe(`isBidRequestValid test response`, function () {
     let params = {
       dmxid: 10001,
       memberid: 10003,
@@ -467,7 +467,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`getUserSyncs test usage`, () => {
+  describe(`getUserSyncs test usage`, function () {
     it(`return value should be an array`, () => {
       expect(districtm.getUserSyncs({ iframeEnabled: true })).to.be.an('array');
     });
@@ -479,7 +479,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`buildRequests test usage`, () => {
+  describe(`buildRequests test usage`, function () {
     const buildRequestResults = districtm.buildRequests(bidRequest, bidderRequest);
     it(`the function should return an array`, () => {
       expect(buildRequestResults).to.be.an('object');
@@ -489,7 +489,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`interpretResponse test usage`, () => {
+  describe(`interpretResponse test usage`, function () {
     const responseResults = districtm.interpretResponse(responses, {bidderRequest});
     const emptyResponseResults = districtm.interpretResponse(emptyResponse, {bidderRequest});
     const emptyResponseResultsNegation = districtm.interpretResponse(responsesNegative, {bidderRequest});
@@ -512,7 +512,7 @@ describe('DistrictM Adaptor', () => {
     });
   });
 
-  describe(`Helper function testing`, () => {
+  describe(`Helper function testing`, function () {
     const bid = matchRequest('29a28a1bbc8a8d', {bidderRequest});
     const {width, height} = defaultSize(bid);
     it(`test matchRequest`, () => {

--- a/test/spec/modules/districtmDmxBidAdapter_spec.js
+++ b/test/spec/modules/districtmDmxBidAdapter_spec.js
@@ -423,29 +423,29 @@ const emptyResponseSeatBid = { body: { seatbid: [] } };
 describe('DistrictM Adaptor', function () {
   const districtm = spec;
   describe('All needed functions are available', function () {
-    it(`isBidRequestValid is present and type function`, () => {
+    it(`isBidRequestValid is present and type function`, function () {
       expect(districtm.isBidRequestValid).to.exist.and.to.be.a('function')
     });
 
-    it(`BuildRequests is present and type function`, () => {
+    it(`BuildRequests is present and type function`, function () {
       expect(districtm.buildRequests).to.exist.and.to.be.a('function')
     });
 
-    it(`interpretResponse is present and type function`, () => {
+    it(`interpretResponse is present and type function`, function () {
       expect(districtm.interpretResponse).to.exist.and.to.be.a('function')
     });
 
-    it(`getUserSyncs is present and type function`, () => {
+    it(`getUserSyncs is present and type function`, function () {
       expect(districtm.getUserSyncs).to.exist.and.to.be.a('function')
     });
   });
 
   describe(`these properties are available or not`, function () {
-    it(`code should have a value of districtmDMX`, () => {
+    it(`code should have a value of districtmDMX`, function () {
       expect(districtm.code).to.be.equal('districtmDMX');
     });
 
-    it(`timeout should not be defined`, () => {
+    it(`timeout should not be defined`, function () {
       expect(districtm.onTimeout).to.be.an('undefined');
     });
   });
@@ -455,23 +455,23 @@ describe('DistrictM Adaptor', function () {
       dmxid: 10001,
       memberid: 10003,
     };
-    it(`function should return true`, () => {
+    it(`function should return true`, function () {
       expect(districtm.isBidRequestValid({params})).to.be.equal(true);
     });
-    it(`function should return false`, () => {
+    it(`function should return false`, function () {
       expect(districtm.isBidRequestValid({ params: { memberid: 12345 } })).to.be.equal(false);
     });
-    it(`expect to have two property available dmxid and memberid`, () => {
+    it(`expect to have two property available dmxid and memberid`, function () {
       expect(params).to.have.property('dmxid');
       expect(params).to.have.property('memberid');
     });
   });
 
   describe(`getUserSyncs test usage`, function () {
-    it(`return value should be an array`, () => {
+    it(`return value should be an array`, function () {
       expect(districtm.getUserSyncs({ iframeEnabled: true })).to.be.an('array');
     });
-    it(`array should have only one object and it should have a property type = 'iframe'`, () => {
+    it(`array should have only one object and it should have a property type = 'iframe'`, function () {
       expect(districtm.getUserSyncs({ iframeEnabled: true }).length).to.be.equal(1);
       let [userSync] = districtm.getUserSyncs({ iframeEnabled: true });
       expect(userSync).to.have.property('type');
@@ -481,10 +481,10 @@ describe('DistrictM Adaptor', function () {
 
   describe(`buildRequests test usage`, function () {
     const buildRequestResults = districtm.buildRequests(bidRequest, bidderRequest);
-    it(`the function should return an array`, () => {
+    it(`the function should return an array`, function () {
       expect(buildRequestResults).to.be.an('object');
     });
-    it(`the function should return array length of 1`, () => {
+    it(`the function should return array length of 1`, function () {
       expect(buildRequestResults.data).to.be.a('string');
     });
   });
@@ -494,20 +494,20 @@ describe('DistrictM Adaptor', function () {
     const emptyResponseResults = districtm.interpretResponse(emptyResponse, {bidderRequest});
     const emptyResponseResultsNegation = districtm.interpretResponse(responsesNegative, {bidderRequest});
     const emptyResponseResultsEmptySeat = districtm.interpretResponse(emptyResponseSeatBid, {bidderRequest});
-    it(`the function should return an array`, () => {
+    it(`the function should return an array`, function () {
       expect(responseResults).to.be.an('array');
     });
-    it(`the function should return array length of 1`, () => {
+    it(`the function should return array length of 1`, function () {
       expect(responseResults.length).to.be.equal(1);
     });
-    it(`the response return nothing`, () => {
+    it(`the response return nothing`, function () {
       expect(emptyResponseResults.length).to.be.equal(0);
     });
-    it(`the response seatbid return nothing`, () => {
+    it(`the response seatbid return nothing`, function () {
       expect(emptyResponseResultsEmptySeat.length).to.be.equal(0);
     });
 
-    it(`on invalid CPM`, () => {
+    it(`on invalid CPM`, function () {
       expect(emptyResponseResultsNegation.length).to.be.equal(0);
     });
   });
@@ -515,17 +515,17 @@ describe('DistrictM Adaptor', function () {
   describe(`Helper function testing`, function () {
     const bid = matchRequest('29a28a1bbc8a8d', {bidderRequest});
     const {width, height} = defaultSize(bid);
-    it(`test matchRequest`, () => {
+    it(`test matchRequest`, function () {
       expect(matchRequest('29a28a1bbc8a8d', {bidderRequest})).to.be.an('object');
     });
-    it(`test checkDeepArray`, () => {
+    it(`test checkDeepArray`, function () {
       expect(_.isEqual(checkDeepArray([728, 90]), [728, 90])).to.be.equal(true);
       expect(_.isEqual(checkDeepArray([[728, 90]]), [728, 90])).to.be.equal(true);
       expect(_.isEqual(checkDeepArray([[728, 90], [300, 250]]), [728, 90])).to.be.equal(true);
       expect(_.isEqual(checkDeepArray([[300, 250], [300, 250]]), [728, 90])).to.be.equal(false);
       expect(_.isEqual(checkDeepArray([300, 250]), [300, 250])).to.be.equal(true);
     });
-    it(`test defaultSize`, () => {
+    it(`test defaultSize`, function () {
       expect(width).to.be.equal(300);
       expect(height).to.be.equal(250);
     });

--- a/test/spec/modules/divreachBidAdapter_spec.js
+++ b/test/spec/modules/divreachBidAdapter_spec.js
@@ -6,16 +6,16 @@ const BIDDER_CODE = 'divreach';
 const ENDPOINT_URL = '//ads.divreach.com/prebid.1.0.aspx';
 const ZONE_ID = '2eb6bd58-865c-47ce-af7f-a918108c3fd2';
 
-describe('DivReachAdapter', () => {
+describe('DivReachAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.be.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': BIDDER_CODE,
       'params': {
@@ -42,7 +42,7 @@ describe('DivReachAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': BIDDER_CODE,
@@ -71,7 +71,7 @@ describe('DivReachAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       body: [{
         'currency': 'USD',

--- a/test/spec/modules/divreachBidAdapter_spec.js
+++ b/test/spec/modules/divreachBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('DivReachAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.be.exist.and.to.be.a('function');
     });
   });
@@ -28,11 +28,11 @@ describe('DivReachAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -57,14 +57,14 @@ describe('DivReachAdapter', function () {
       }
     ];
 
-    it('should add referrer and imp to be equal bidRequest', () => {
+    it('should add referrer and imp to be equal bidRequest', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data.substr(5));
       expect(payload.referrer).to.not.be.undefined;
       expect(payload.imps[0]).to.deep.equal(bidRequests[0]);
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT_URL);
       expect(request.method).to.equal('GET');
@@ -86,7 +86,7 @@ describe('DivReachAdapter', function () {
       }]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const body = response.body;
       let expectedResponse = [
         {
@@ -107,7 +107,7 @@ describe('DivReachAdapter', function () {
       expect(result[0]).to.deep.equal(expectedResponse[0]);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = [];
 
       let result = spec.interpretResponse(response);

--- a/test/spec/modules/ebdrBidAdapter_spec.js
+++ b/test/spec/modules/ebdrBidAdapter_spec.js
@@ -52,12 +52,12 @@ describe('ebdrBidAdapter', function () {
   });
 
   describe('spec.isBidRequestValid', function () {
-    it('should return true when the required params are passed', () => {
+    it('should return true when the required params are passed', function () {
       const bidRequest = bidRequests[0];
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return true when the only required param is missing', () => {
+    it('should return true when the only required param is missing', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {
         zoneid: '99998',
@@ -66,7 +66,7 @@ describe('ebdrBidAdapter', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return true when the "bidfloor" param is missing', () => {
+    it('should return true when the "bidfloor" param is missing', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {
         zoneid: '99998',
@@ -74,13 +74,13 @@ describe('ebdrBidAdapter', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return false when no bid params are passed', () => {
+    it('should return false when no bid params are passed', function () {
       const bidRequest = bidRequests[0];
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when a bid request is not passed', () => {
+    it('should return false when a bid request is not passed', function () {
       expect(spec.isBidRequestValid()).to.equal(false);
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
@@ -88,20 +88,20 @@ describe('ebdrBidAdapter', function () {
 
   describe('spec.buildRequests', function () {
     describe('for banner bids', function () {
-      it('must handle an empty bid size', () => {
+      it('must handle an empty bid size', function () {
         bidRequests[0].mediaTypes = { banner: {} };
         const requests = spec.buildRequests(bidRequests);
         const bidRequest = {};
         bidRequest['2c5e8a1a84522d'] = { mediaTypes: BANNER, w: null, h: null };
         expect(requests.bids['2c5e8a1a84522d']).to.deep.equals(bidRequest['2c5e8a1a84522d']);
       });
-      it('should create a single GET', () => {
+      it('should create a single GET', function () {
         bidRequests[0].mediaTypes = { banner: {} };
         bidRequests[1].mediaTypes = { banner: {} };
         const requests = spec.buildRequests(bidRequests);
         expect(requests.method).to.equal('GET');
       });
-      it('must parse bid size from a nested array', () => {
+      it('must parse bid size from a nested array', function () {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -113,7 +113,7 @@ describe('ebdrBidAdapter', function () {
       });
     });
     describe('for video bids', function () {
-      it('must handle an empty bid size', () => {
+      it('must handle an empty bid size', function () {
         bidRequests[1].mediaTypes = { video: {} };
         const requests = spec.buildRequests(bidRequests);
         const bidRequest = {};
@@ -121,7 +121,7 @@ describe('ebdrBidAdapter', function () {
         expect(requests.bids['23a01e95856577']).to.deep.equals(bidRequest['23a01e95856577']);
       });
 
-      it('should create a GET request for each bid', () => {
+      it('should create a GET request for each bid', function () {
         const bidRequest = bidRequests[1];
         const requests = spec.buildRequests([ bidRequest ]);
         expect(requests.method).to.equal('GET');
@@ -131,14 +131,14 @@ describe('ebdrBidAdapter', function () {
 
   describe('spec.interpretResponse', function () {
     describe('for video bids', function () {
-      it('should return no bids if the response is not valid', () => {
+      it('should return no bids if the response is not valid', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
         const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return a valid video bid response', () => {
+      it('should return a valid video bid response', function () {
         const ebdrReq = {bids: {}};
         bidRequests.forEach(bid => {
           let _mediaTypes = (bid.mediaTypes && bid.mediaTypes.video ? VIDEO : BANNER);
@@ -166,21 +166,21 @@ describe('ebdrBidAdapter', function () {
     });
 
     describe('for banner bids', function () {
-      it('should return no bids if the response is not valid', () => {
+      it('should return no bids if the response is not valid', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
         const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return no bids if the response is empty', () => {
+      it('should return no bids if the response is empty', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
         const bidResponse = spec.interpretResponse({ body: [] }, { bidRequest });
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return valid banner bid responses', () => {
+      it('should return valid banner bid responses', function () {
         const ebdrReq = {bids: {}};
         bidRequests.forEach(bid => {
           let _mediaTypes = (bid.mediaTypes && bid.mediaTypes.video ? VIDEO : BANNER);
@@ -214,19 +214,19 @@ describe('ebdrBidAdapter', function () {
         pixelEnabled: true
       }
     });
-    it('sucess with usersync url', () => {
+    it('sucess with usersync url', function () {
       const serverResponse = {id: '1d0c4017f02458', seatbid: [{bid: [{id: '2c5e8a1a84522d', impid: '2c5e8a1a84522d', price: 0.81, adid: 'abcde-12345', nurl: '', adm: '<div><img src="http://cdnin.bnmla.com/0b1c6e85e9376e3092df8c9fc8ab9095.gif" width=350 height=250 /></div>', adomain: ['advertiserdomain.com'], iurl: '//match.bnmla.com/usersync?sspid=59&redir=', cid: 'campaign1', crid: 'abcde-12345', w: 300, h: 250}], seat: '19513bcfca8006'}], bidid: '19513bcfca8006', cur: 'USD', w: 300, h: 250};
       const result = [];
       result.push({type: 'image', url: '//match.bnmla.com/usersync?sspid=59&redir='});
       expect(spec.getUserSyncs(syncOptions, { body: serverResponse })).to.deep.equal(result);
     });
 
-    it('sucess without usersync url', () => {
+    it('sucess without usersync url', function () {
       const serverResponse = {id: '1d0c4017f02458', seatbid: [{bid: [{id: '2c5e8a1a84522d', impid: '2c5e8a1a84522d', price: 0.81, adid: 'abcde-12345', nurl: '', adm: '<div><img src="http://cdnin.bnmla.com/0b1c6e85e9376e3092df8c9fc8ab9095.gif" width=350 height=250 /></div>', adomain: ['advertiserdomain.com'], iurl: '', cid: 'campaign1', crid: 'abcde-12345', w: 300, h: 250}], seat: '19513bcfca8006'}], bidid: '19513bcfca8006', cur: 'USD', w: 300, h: 250};
       const result = [];
       expect(spec.getUserSyncs(syncOptions, { body: serverResponse })).to.deep.equal(result);
     });
-    it('empty response', () => {
+    it('empty response', function () {
       const serverResponse = {};
       const result = [];
       expect(spec.getUserSyncs(syncOptions, { body: serverResponse })).to.deep.equal(result);

--- a/test/spec/modules/ebdrBidAdapter_spec.js
+++ b/test/spec/modules/ebdrBidAdapter_spec.js
@@ -6,7 +6,7 @@ import * as utils from 'src/utils';
 describe('ebdrBidAdapter', function () {
   let bidRequests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         code: 'div-gpt-ad-1460505748561-0',
@@ -208,7 +208,7 @@ describe('ebdrBidAdapter', function () {
   });
   describe('spec.getUserSyncs', function () {
     let syncOptions
-    beforeEach(() => {
+    beforeEach(function () {
       syncOptions = {
         enabledBidders: ['ebdr'], // only these bidders are allowed to sync
         pixelEnabled: true

--- a/test/spec/modules/ebdrBidAdapter_spec.js
+++ b/test/spec/modules/ebdrBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/ebdrBidAdapter';
 import { VIDEO, BANNER } from 'src/mediaTypes';
 import * as utils from 'src/utils';
 
-describe('ebdrBidAdapter', () => {
+describe('ebdrBidAdapter', function () {
   let bidRequests;
 
   beforeEach(() => {
@@ -51,7 +51,7 @@ describe('ebdrBidAdapter', () => {
     ];
   });
 
-  describe('spec.isBidRequestValid', () => {
+  describe('spec.isBidRequestValid', function () {
     it('should return true when the required params are passed', () => {
       const bidRequest = bidRequests[0];
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
@@ -86,8 +86,8 @@ describe('ebdrBidAdapter', () => {
     });
   });
 
-  describe('spec.buildRequests', () => {
-    describe('for banner bids', () => {
+  describe('spec.buildRequests', function () {
+    describe('for banner bids', function () {
       it('must handle an empty bid size', () => {
         bidRequests[0].mediaTypes = { banner: {} };
         const requests = spec.buildRequests(bidRequests);
@@ -112,7 +112,7 @@ describe('ebdrBidAdapter', () => {
         expect(requests.bids['2c5e8a1a84522d']).to.deep.equal(data['2c5e8a1a84522d']);
       });
     });
-    describe('for video bids', () => {
+    describe('for video bids', function () {
       it('must handle an empty bid size', () => {
         bidRequests[1].mediaTypes = { video: {} };
         const requests = spec.buildRequests(bidRequests);
@@ -129,8 +129,8 @@ describe('ebdrBidAdapter', () => {
     });
   });
 
-  describe('spec.interpretResponse', () => {
-    describe('for video bids', () => {
+  describe('spec.interpretResponse', function () {
+    describe('for video bids', function () {
       it('should return no bids if the response is not valid', () => {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
@@ -165,7 +165,7 @@ describe('ebdrBidAdapter', () => {
       });
     });
 
-    describe('for banner bids', () => {
+    describe('for banner bids', function () {
       it('should return no bids if the response is not valid', () => {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { banner: {} };
@@ -206,7 +206,7 @@ describe('ebdrBidAdapter', () => {
       });
     });
   });
-  describe('spec.getUserSyncs', () => {
+  describe('spec.getUserSyncs', function () {
     let syncOptions
     beforeEach(() => {
       syncOptions = {

--- a/test/spec/modules/eplanningAnalyticsAdapter_spec.js
+++ b/test/spec/modules/eplanningAnalyticsAdapter_spec.js
@@ -10,14 +10,14 @@ describe('eplanning analytics adapter', function () {
   let xhr;
   let requests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
     xhr.onCreate = request => { requests.push(request) };
     sinon.stub(events, 'getEvents').returns([]);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     xhr.restore();
     events.getEvents.restore();
     eplAnalyticsAdapter.disableAnalytics();

--- a/test/spec/modules/eplanningAnalyticsAdapter_spec.js
+++ b/test/spec/modules/eplanningAnalyticsAdapter_spec.js
@@ -24,7 +24,7 @@ describe('eplanning analytics adapter', function () {
   });
 
   describe('track', function () {
-    it('builds and sends auction data', () => {
+    it('builds and sends auction data', function () {
       sinon.spy(eplAnalyticsAdapter, 'track');
 
       let auctionTimestamp = 1496510254313;

--- a/test/spec/modules/eplanningAnalyticsAdapter_spec.js
+++ b/test/spec/modules/eplanningAnalyticsAdapter_spec.js
@@ -6,7 +6,7 @@ let adaptermanager = require('src/adaptermanager');
 let events = require('src/events');
 let constants = require('src/constants.json');
 
-describe('eplanning analytics adapter', () => {
+describe('eplanning analytics adapter', function () {
   let xhr;
   let requests;
 
@@ -23,7 +23,7 @@ describe('eplanning analytics adapter', () => {
     eplAnalyticsAdapter.disableAnalytics();
   });
 
-  describe('track', () => {
+  describe('track', function () {
     it('builds and sends auction data', () => {
       sinon.spy(eplAnalyticsAdapter, 'track');
 

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -168,21 +168,21 @@ describe('E-Planning Adapter', function () {
   };
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when bid has ci parameter', () => {
+    it('should return true when bid has ci parameter', function () {
       expect(spec.isBidRequestValid(validBid)).to.equal(true);
     });
 
-    it('should return false when bid does not have ci parameter and is not a test bid', () => {
+    it('should return false when bid does not have ci parameter and is not a test bid', function () {
       expect(spec.isBidRequestValid(invalidBid)).to.equal(false);
     });
 
-    it('should return true when bid does not have ci parameter but is a test bid', () => {
+    it('should return true when bid does not have ci parameter but is a test bid', function () {
       expect(spec.isBidRequestValid(testBid)).to.equal(true);
     });
   });
@@ -190,32 +190,32 @@ describe('E-Planning Adapter', function () {
   describe('buildRequests', function () {
     let bidRequests = [validBid];
 
-    it('should create the url correctly', () => {
+    it('should create the url correctly', function () {
       const url = spec.buildRequests(bidRequests).url;
       expect(url).to.equal('//ads.us.e-planning.net/hb/1/' + CI + '/1/localhost/ROS');
     });
 
-    it('should return GET method', () => {
+    it('should return GET method', function () {
       const method = spec.buildRequests(bidRequests).method;
       expect(method).to.equal('GET');
     });
 
-    it('should return r parameter with value pbjs', () => {
+    it('should return r parameter with value pbjs', function () {
       const r = spec.buildRequests(bidRequests).data.r;
       expect(r).to.equal('pbjs');
     });
 
-    it('should return pbv parameter with value prebid version', () => {
+    it('should return pbv parameter with value prebid version', function () {
       const pbv = spec.buildRequests(bidRequests).data.pbv;
       expect(pbv).to.equal('$prebid.version$');
     });
 
-    it('should return e parameter with value according to the adunit sizes', () => {
+    it('should return e parameter with value according to the adunit sizes', function () {
       const e = spec.buildRequests(bidRequests).data.e;
       expect(e).to.equal(CLEAN_ADUNIT_CODE + ':300x250,300x600');
     });
 
-    it('should return correct e parameter with more than one adunit', () => {
+    it('should return correct e parameter with more than one adunit', function () {
       const NEW_CODE = ADUNIT_CODE + '2';
       const CLEAN_NEW_CODE = CLEAN_ADUNIT_CODE + '2';
       const anotherBid = {
@@ -232,7 +232,7 @@ describe('E-Planning Adapter', function () {
       expect(e).to.equal(CLEAN_ADUNIT_CODE + ':300x250,300x600+' + CLEAN_NEW_CODE + ':100x100');
     });
 
-    it('should return correct e parameter when the adunit has no size', () => {
+    it('should return correct e parameter when the adunit has no size', function () {
       const noSizeBid = {
         'bidder': 'eplanning',
         'params': {
@@ -245,12 +245,12 @@ describe('E-Planning Adapter', function () {
       expect(e).to.equal(CLEAN_ADUNIT_CODE + ':1x1');
     });
 
-    it('should return ur parameter with current window url', () => {
+    it('should return ur parameter with current window url', function () {
       const ur = spec.buildRequests(bidRequests).data.ur;
       expect(ur).to.equal(utils.getTopWindowUrl());
     });
 
-    it('should return fr parameter when there is a referrer', () => {
+    it('should return fr parameter when there is a referrer', function () {
       const referrer = 'thisisafakereferrer';
       const stubGetReferrer = sinon.stub(utils, 'getTopWindowReferrer');
       stubGetReferrer.returns(referrer);
@@ -259,7 +259,7 @@ describe('E-Planning Adapter', function () {
       stubGetReferrer.restore()
     });
 
-    it('should return crs parameter with document charset', () => {
+    it('should return crs parameter with document charset', function () {
       let expected;
       try {
         expected = window.top.document.characterSet;
@@ -272,30 +272,30 @@ describe('E-Planning Adapter', function () {
       expect(chset).to.equal(expected);
     });
 
-    it('should return the testing url when the request has the t parameter', () => {
+    it('should return the testing url when the request has the t parameter', function () {
       const url = spec.buildRequests([testBid]).url;
       const expectedUrl = '//' + TEST_ISV + '/layers/t_pbjs_2.json';
       expect(url).to.equal(expectedUrl);
     });
 
-    it('should return the parameter ncb with value 1', () => {
+    it('should return the parameter ncb with value 1', function () {
       const ncb = spec.buildRequests(bidRequests).data.ncb;
       expect(ncb).to.equal('1');
     });
   });
 
   describe('interpretResponse', function () {
-    it('should return an empty array when there is no ads in the response', () => {
+    it('should return an empty array when there is no ads in the response', function () {
       const bidResponses = spec.interpretResponse(responseWithNoAd);
       expect(bidResponses).to.be.empty;
     });
 
-    it('should return an empty array when there is no spaces in the response', () => {
+    it('should return an empty array when there is no spaces in the response', function () {
       const bidResponses = spec.interpretResponse(responseWithNoSpace);
       expect(bidResponses).to.be.empty;
     });
 
-    it('should correctly map the parameters in the response', () => {
+    it('should correctly map the parameters in the response', function () {
       const bidResponse = spec.interpretResponse(response, { adUnitToBidId: { [CLEAN_ADUNIT_CODE]: BID_ID } })[0];
       const expectedResponse = {
         requestId: BID_ID,
@@ -330,30 +330,30 @@ describe('E-Planning Adapter', function () {
       iframeEnabled: true
     };
 
-    it('should return an empty array if the response has no syncs', () => {
+    it('should return an empty array if the response has no syncs', function () {
       const noSyncsResponse = { cs: [] };
       const syncs = spec.getUserSyncs(sOptionsAllEnabled, [noSyncsResponse]);
       expect(syncs).to.be.empty;
     });
 
-    it('should return an empty array if there is no sync options enabled', () => {
+    it('should return an empty array if there is no sync options enabled', function () {
       const syncs = spec.getUserSyncs(sOptionsAllDisabled, [response]);
       expect(syncs).to.be.empty;
     });
 
-    it('should only return pixels if iframe is not enabled', () => {
+    it('should only return pixels if iframe is not enabled', function () {
       const syncs = spec.getUserSyncs(sOptionsOnlyPixel, [response]);
       syncs.forEach(sync => expect(sync.type).to.equal('image'));
     });
 
-    it('should only return iframes if pixel is not enabled', () => {
+    it('should only return iframes if pixel is not enabled', function () {
       const syncs = spec.getUserSyncs(sOptionsOnlyIframe, [response]);
       syncs.forEach(sync => expect(sync.type).to.equal('iframe'));
     });
   });
 
   describe('adUnits mapping to bidId', function () {
-    it('should correctly map the bidId to the adunit', () => {
+    it('should correctly map the bidId to the adunit', function () {
       const requests = spec.buildRequests([validBid, validBid2]);
       const responses = spec.interpretResponse(responseWithTwoAdunits, requests);
       expect(responses[0].requestId).to.equal(BID_ID);

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/eplanningBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 import * as utils from 'src/utils';
 
-describe('E-Planning Adapter', () => {
+describe('E-Planning Adapter', function () {
   const adapter = newBidder('spec');
   const CI = '12345';
   const ADUNIT_CODE = 'adunit-code';
@@ -167,13 +167,13 @@ describe('E-Planning Adapter', () => {
     }
   };
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when bid has ci parameter', () => {
       expect(spec.isBidRequestValid(validBid)).to.equal(true);
     });
@@ -187,7 +187,7 @@ describe('E-Planning Adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [validBid];
 
     it('should create the url correctly', () => {
@@ -284,7 +284,7 @@ describe('E-Planning Adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should return an empty array when there is no ads in the response', () => {
       const bidResponses = spec.interpretResponse(responseWithNoAd);
       expect(bidResponses).to.be.empty;
@@ -312,7 +312,7 @@ describe('E-Planning Adapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const sOptionsAllEnabled = {
       pixelEnabled: true,
       iframeEnabled: true
@@ -352,7 +352,7 @@ describe('E-Planning Adapter', () => {
     });
   });
 
-  describe('adUnits mapping to bidId', () => {
+  describe('adUnits mapping to bidId', function () {
     it('should correctly map the bidId to the adunit', () => {
       const requests = spec.buildRequests([validBid, validBid2]);
       const responses = spec.interpretResponse(responseWithTwoAdunits, requests);

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -15,29 +15,29 @@ describe('etarget adapter', function () {
       }
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       assert(spec.isBidRequestValid(bid));
     });
   });
 
   describe('buildRequests', function () {
-    it('should pass multiple bids via single request', () => {
+    it('should pass multiple bids via single request', function () {
       let request = spec.buildRequests(bids);
       let parsedUrl = parseUrl(request.url);
       assert.lengthOf(parsedUrl.items, 7);
     });
 
-    it('should handle global request parameters', () => {
+    it('should handle global request parameters', function () {
       let parsedUrl = parseUrl(spec.buildRequests([bids[0]]).url);
       assert.equal(parsedUrl.path, '//sk.search.etargetnet.com/hb');
     });
 
-    it('should set correct request method', () => {
+    it('should set correct request method', function () {
       let request = spec.buildRequests([bids[0]]);
       assert.equal(request.method, 'POST');
     });
 
-    it('should correctly form bid items', () => {
+    it('should correctly form bid items', function () {
       let bidList = bids;
       let request = spec.buildRequests(bidList);
       let parsedUrl = parseUrl(request.url);
@@ -88,14 +88,14 @@ describe('etarget adapter', function () {
       ]);
     });
 
-    it('should not change original validBidRequests object', () => {
+    it('should not change original validBidRequests object', function () {
       var resultBids = JSON.parse(JSON.stringify(bids[0]));
       let request = spec.buildRequests([bids[0]]);
       assert.deepEqual(resultBids, bids[0]);
     });
 
     describe('gdpr', function () {
-      it('should send GDPR Consent data to etarget if gdprApplies', () => {
+      it('should send GDPR Consent data to etarget if gdprApplies', function () {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
@@ -104,7 +104,7 @@ describe('etarget adapter', function () {
         assert.equal(parsedUrl.gdpr_consent, 'concentDataString');
       });
 
-      it('should not send GDPR Consent data to etarget if gdprApplies is false or undefined', () => {
+      it('should not send GDPR Consent data to etarget if gdprApplies is false or undefined', function () {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: false, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
@@ -117,7 +117,7 @@ describe('etarget adapter', function () {
         assert.ok(!parsedUrl.gdpr_consent);
       });
 
-      it('should return GDPR Consent data with request data', () => {
+      it('should return GDPR Consent data with request data', function () {
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
 
         assert.deepEqual(request.gdpr, {
@@ -132,11 +132,11 @@ describe('etarget adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should respond with empty response when there is empty serverResponse', () => {
+    it('should respond with empty response when there is empty serverResponse', function () {
       let result = spec.interpretResponse({ body: {} }, {});
       assert.deepEqual(result, []);
     });
-    it('should respond with empty response when response from server is not banner', () => {
+    it('should respond with empty response when response from server is not banner', function () {
       serverResponse.body[0].response = 'not banner';
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[0]];
@@ -144,7 +144,7 @@ describe('etarget adapter', function () {
 
       assert.deepEqual(result, []);
     });
-    it('should interpret server response correctly with one bid', () => {
+    it('should interpret server response correctly with one bid', function () {
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[0]];
       let result = spec.interpretResponse(serverResponse, bidRequest)[0];
@@ -160,7 +160,7 @@ describe('etarget adapter', function () {
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');
     });
 
-    it('should set correct netRevenue', () => {
+    it('should set correct netRevenue', function () {
       serverResponse.body = [serverResponse.body[0]];
       bidRequest.bids = [bidRequest.bids[1]];
       bidRequest.netRevenue = 'net';
@@ -169,22 +169,22 @@ describe('etarget adapter', function () {
       assert.equal(result.netRevenue, true);
     });
 
-    it('should create bid response item for every requested item', () => {
+    it('should create bid response item for every requested item', function () {
       let result = spec.interpretResponse(serverResponse, bidRequest);
       assert.lengthOf(result, 5);
     });
 
-    it('should create bid response with vast xml', () => {
+    it('should create bid response with vast xml', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest)[3];
       assert.equal(result.vastXml, '<vast_xml>');
     });
 
-    it('should create bid response with vast url', () => {
+    it('should create bid response with vast url', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest)[4];
       assert.equal(result.vastUrl, 'vast://url');
     });
 
-    it('should set mediaType on bid response', () => {
+    it('should set mediaType on bid response', function () {
       const expected = [ BANNER, BANNER, BANNER, VIDEO, VIDEO ];
       const result = spec.interpretResponse(serverResponse, bidRequest);
       for (let i = 0; i < result.length; i++) {
@@ -192,7 +192,7 @@ describe('etarget adapter', function () {
       }
     });
 
-    it('should set default netRevenue as gross', () => {
+    it('should set default netRevenue as gross', function () {
       bidRequest.netRevenue = 'gross';
       const result = spec.interpretResponse(serverResponse, bidRequest);
       for (let i = 0; i < result.length; i++) {
@@ -200,7 +200,7 @@ describe('etarget adapter', function () {
       }
     });
 
-    it('should set gdpr if it exist in bidRequest', () => {
+    it('should set gdpr if it exist in bidRequest', function () {
       bidRequest.gdpr = {
         gdpr: true,
         gdpr_consent: 'ERW342EIOWT34234KMGds'
@@ -220,7 +220,7 @@ describe('etarget adapter', function () {
     });
 
     describe('verifySizes', function () {
-      it('should respond with empty response when sizes doesn\'t match', () => {
+      it('should respond with empty response when sizes doesn\'t match', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;
         serverResponse.body[0].height = 150;
@@ -233,7 +233,7 @@ describe('etarget adapter', function () {
         assert.equal(serverResponse.body[0].response, 'banner');
         assert.deepEqual(result, []);
       });
-      it('should respond with empty response when sizes as a strings doesn\'t match', () => {
+      it('should respond with empty response when sizes as a strings doesn\'t match', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;
         serverResponse.body[0].height = 150;
@@ -248,7 +248,7 @@ describe('etarget adapter', function () {
         assert.equal(serverResponse.body[0].response, 'banner');
         assert.deepEqual(result, []);
       });
-      it('should support size dimensions as a strings', () => {
+      it('should support size dimensions as a strings', function () {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 300;
         serverResponse.body[0].height = 600;

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -3,10 +3,10 @@ import * as url from 'src/url';
 import {spec} from 'modules/etargetBidAdapter';
 import { BANNER, VIDEO } from 'src/mediaTypes';
 
-describe('etarget adapter', () => {
+describe('etarget adapter', function () {
   let serverResponse, bidRequest, bidResponses;
   let bids = [];
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'etarget',
       'params': {
@@ -20,7 +20,7 @@ describe('etarget adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should pass multiple bids via single request', () => {
       let request = spec.buildRequests(bids);
       let parsedUrl = parseUrl(request.url);
@@ -94,7 +94,7 @@ describe('etarget adapter', () => {
       assert.deepEqual(resultBids, bids[0]);
     });
 
-    describe('gdpr', () => {
+    describe('gdpr', function () {
       it('should send GDPR Consent data to etarget if gdprApplies', () => {
         let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
@@ -131,7 +131,7 @@ describe('etarget adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should respond with empty response when there is empty serverResponse', () => {
       let result = spec.interpretResponse({ body: {} }, {});
       assert.deepEqual(result, []);
@@ -219,7 +219,7 @@ describe('etarget adapter', () => {
       };
     });
 
-    describe('verifySizes', () => {
+    describe('verifySizes', function () {
       it('should respond with empty response when sizes doesn\'t match', () => {
         serverResponse.body[0].response = 'banner';
         serverResponse.body[0].width = 100;

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -265,7 +265,7 @@ describe('etarget adapter', function () {
     })
   });
 
-  beforeEach(() => {
+  beforeEach(function () {
     let sizes = [[250, 300], [300, 250], [300, 600]];
     let placementCode = ['div-01', 'div-02', 'div-03', 'div-04', 'div-05'];
     let params = [{refid: 1, country: 1, url: 'some// there'}, {refid: 2, country: 1, someVar: 'someValue', pt: 'gross'}, {refid: 3, country: 1, pdom: 'home'}, {refid: 5, country: 1, pt: 'net'}, {refid: 6, country: 1, pt: 'gross'}];

--- a/test/spec/modules/fairtradeBidAdapter_spec.js
+++ b/test/spec/modules/fairtradeBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('FairTradeAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'fairtrade',
       'params': {
@@ -38,7 +38,7 @@ describe('FairTradeAdapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'fairtrade',
@@ -120,7 +120,7 @@ describe('FairTradeAdapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 165, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 166, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/fairtradeBidAdapter_spec.js
+++ b/test/spec/modules/fairtradeBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('FairTradeAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('FairTradeAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -75,7 +75,7 @@ describe('FairTradeAdapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -85,7 +85,7 @@ describe('FairTradeAdapter', function () {
       expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -95,7 +95,7 @@ describe('FairTradeAdapter', function () {
       expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -107,7 +107,7 @@ describe('FairTradeAdapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -131,7 +131,7 @@ describe('FairTradeAdapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'fairtrade',
@@ -165,7 +165,7 @@ describe('FairTradeAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'fairtrade',
@@ -245,7 +245,7 @@ describe('FairTradeAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'fairtrade',

--- a/test/spec/modules/fidelityBidAdapter_spec.js
+++ b/test/spec/modules/fidelityBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { spec } from 'modules/fidelityBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('FidelityAdapter', () => {
+describe('FidelityAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'fidelity',
       'params': {
@@ -49,7 +49,7 @@ describe('FidelityAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidderRequest = {
       bidderCode: 'fidelity',
       requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
@@ -119,7 +119,7 @@ describe('FidelityAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'id': '543210',
       'seatbid': [ {
@@ -164,7 +164,7 @@ describe('FidelityAdapter', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     const syncUrl = '//x.fidelity-media.com/delivery/matches.php?type=iframe';
 
     it('should register the sync iframe', () => {

--- a/test/spec/modules/fidelityBidAdapter_spec.js
+++ b/test/spec/modules/fidelityBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('FidelityAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('FidelityAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -39,7 +39,7 @@ describe('FidelityAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -75,7 +75,7 @@ describe('FidelityAdapter', function () {
       timeout: 5000
     };
 
-    it('should add source and verison to the tag', () => {
+    it('should add source and verison to the tag', function () {
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const payload = request.data;
       expect(payload.from).to.exist;
@@ -91,7 +91,7 @@ describe('FidelityAdapter', function () {
       expect(payload.defloc).to.exist;
     });
 
-    it('should add gdpr consent information to the request', () => {
+    it('should add gdpr consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       bidderRequest.gdprConsent = {
         gdprApplies: true,
@@ -112,7 +112,7 @@ describe('FidelityAdapter', function () {
       expect(payload.consent_given).to.equal(1);
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
       expect(request.url).to.equal('//t.fidelity-media.com/delivery/hb.php');
       expect(request.method).to.equal('GET');
@@ -134,7 +134,7 @@ describe('FidelityAdapter', function () {
       } ]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           requestId: 'bidId-123456-1',
@@ -153,7 +153,7 @@ describe('FidelityAdapter', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'id': '543210',
         'seatbid': [ ]
@@ -167,7 +167,7 @@ describe('FidelityAdapter', function () {
   describe('user sync', function () {
     const syncUrl = '//x.fidelity-media.com/delivery/matches.php?type=iframe';
 
-    it('should register the sync iframe', () => {
+    it('should register the sync iframe', function () {
       expect(spec.getUserSyncs({})).to.be.undefined;
       expect(spec.getUserSyncs({iframeEnabled: false})).to.be.undefined;
       const options = spec.getUserSyncs({iframeEnabled: true});

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -4,16 +4,16 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT = '//ads.stickyadstv.com/www/delivery/swfIndex.php';
 
-describe('freewheel-ssp BidAdapter Test', () => {
+describe('freewheel-ssp BidAdapter Test', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'freewheel-ssp',
       'params': {
@@ -40,7 +40,7 @@ describe('freewheel-ssp BidAdapter Test', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'freewheel-ssp',
@@ -78,7 +78,7 @@ describe('freewheel-ssp BidAdapter Test', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let bidRequests = [
       {
         'bidder': 'freewheel-ssp',

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('freewheel-ssp BidAdapter Test', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -59,7 +59,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
       }
     ];
 
-    it('should add parameters to the tag', () => {
+    it('should add parameters to the tag', function () {
       const request = spec.buildRequests(bidRequests, bidRequests[0]);
       const payload = request.data;
       expect(payload.reqType).to.equal('AdsSetup');
@@ -71,7 +71,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
       expect(payload._fw_gdpr_consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests, bidRequests[0]);
       expect(request.url).to.contain(ENDPOINT);
       expect(request.method).to.equal('GET');
@@ -144,7 +144,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
     let ad = '<div id="freewheelssp_prebid_target"></div><script type=\'text/javascript\'>(function() {  var st = document.createElement(\'script\'); st.type = \'text/javascript\'; st.async = true;  st.src = \'http://cdn.stickyadstv.com/mustang/mustang.min.js\';  st.onload = function(){    var vastLoader = new window.com.stickyadstv.vast.VastLoader();    var vast = vastLoader.getVast();    var topWindow = (function(){var res=window; try{while(top != res){if(res.parent.location.href.length)res=res.parent;}}catch(e){}return res;})();    vast.setXmlString(topWindow.freeheelssp_cache["adunit-code"]);    vastLoader.parseAds(vast, {      onSuccess: function() {var config = {      preloadedVast:vast,      autoPlay:true    };    var ad = new window.com.stickyadstv.vpaid.Ad(document.getElementById("freewheelssp_prebid_target"),config);    (new window.com.stickyadstv.tools.ASLoader(277225, \'mustang\')).registerEvents(ad);    ad.initAd(300,600,"",0,"",""); }    });  };  document.head.appendChild(st);})();</script>';
     let formattedAd = '<div id="freewheelssp_prebid_target"></div><script type=\'text/javascript\'>(function() {  var st = document.createElement(\'script\'); st.type = \'text/javascript\'; st.async = true;  st.src = \'http://cdn.stickyadstv.com/prime-time/floorad.min.js\';  st.onload = function(){    var vastLoader = new window.com.stickyadstv.vast.VastLoader();    var vast = vastLoader.getVast();    var topWindow = (function(){var res=window; try{while(top != res){if(res.parent.location.href.length)res=res.parent;}}catch(e){}return res;})();    vast.setXmlString(topWindow.freeheelssp_cache["adunit-code"]);    vastLoader.parseAds(vast, {      onSuccess: function() {var config = {  preloadedVast:vast,  ASLoader:new window.com.stickyadstv.tools.ASLoader(277225, \'floorad\'),domId:"adunit-code"};window.com.stickyadstv.floorad.start(config); }    });  };  document.head.appendChild(st);})();</script>';
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       var request = spec.buildRequests(formattedBidRequests, formattedBidRequests[0]);
 
       let expectedResponse = [
@@ -165,7 +165,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('should get correct bid response with formated ad', () => {
+    it('should get correct bid response with formated ad', function () {
       var request = spec.buildRequests(formattedBidRequests, formattedBidRequests[0]);
 
       let expectedResponse = [
@@ -186,7 +186,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       var reqest = spec.buildRequests(formattedBidRequests, formattedBidRequests[0]);
       let response = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><VAST version=\'2.0\'></VAST>';
 

--- a/test/spec/modules/fyberBidAdapter_spec.js
+++ b/test/spec/modules/fyberBidAdapter_spec.js
@@ -76,30 +76,30 @@ describe('FyberAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('callBids exists and is a function', () => {
+    it('callBids exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('Verifies bidder code', function () {
-    it('Verifies bidder code', () => {
+    it('Verifies bidder code', function () {
       expect(spec.code).to.equal('fyber');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       const bid = Object.assign({}, mock.bid);
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params{spotType} not found', () => {
+    it('should return false when required params{spotType} not found', function () {
       const bid = Object.assign({}, mock.bid);
       delete bid.params.spotType;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when required{appId} params not found', () => {
+    it('should return false when required{appId} params not found', function () {
       const bid = Object.assign({}, mock.bid);
       delete bid.params.appId;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
@@ -110,17 +110,17 @@ describe('FyberAdapter', function () {
     const bidsRequest = Object.assign([], mock.bidsRequest);
     const requests = spec.buildRequests(bidsRequest);
 
-    it('Verify only one build request', () => {
+    it('Verify only one build request', function () {
       expect(requests.length).to.equal(1);
     });
 
     const request = requests[0];
 
-    it('Verify build request http method', () => {
+    it('Verify build request http method', function () {
       expect(request.method).to.equal('GET');
     });
 
-    it('Verify build request bidId', () => {
+    it('Verify build request bidId', function () {
       expect(request.bidId).to.equal(bidId);
     });
   });
@@ -130,24 +130,24 @@ describe('FyberAdapter', function () {
     const validResponse = Object.assign({}, mock.validResponse);
     const validResult = spec.interpretResponse(validResponse, request);
 
-    it('Verify only one bid response', () => {
+    it('Verify only one bid response', function () {
       expect(validResult.length).to.equal(1);
     });
 
     const bidResponse = validResult[0];
 
-    it('Verify CPM', () => {
+    it('Verify CPM', function () {
       expect(bidResponse.cpm).to.equal(10000);
     });
 
-    it('Verify requestId', () => {
+    it('Verify requestId', function () {
       expect(bidResponse.requestId).to.equal(bidId);
     });
 
     const invalidResponse = Object.assign({}, mock.invalidResponse);
     const invalidResult = spec.interpretResponse(invalidResponse, request);
 
-    it('Verify empty bid response', () => {
+    it('Verify empty bid response', function () {
       expect(invalidResult.length).to.equal(0);
     });
   });

--- a/test/spec/modules/fyberBidAdapter_spec.js
+++ b/test/spec/modules/fyberBidAdapter_spec.js
@@ -72,22 +72,22 @@ const mock = {
   }
 };
 
-describe('FyberAdapter', () => {
+describe('FyberAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('callBids exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('Verifies bidder code', () => {
+  describe('Verifies bidder code', function () {
     it('Verifies bidder code', () => {
       expect(spec.code).to.equal('fyber');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       const bid = Object.assign({}, mock.bid);
       expect(spec.isBidRequestValid(bid)).to.equal(true);
@@ -106,7 +106,7 @@ describe('FyberAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidsRequest = Object.assign([], mock.bidsRequest);
     const requests = spec.buildRequests(bidsRequest);
 
@@ -125,7 +125,7 @@ describe('FyberAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const request = Object.assign([], mock.bidsRequest)[0];
     const validResponse = Object.assign({}, mock.validResponse);
     const validResult = spec.interpretResponse(validResponse, request);

--- a/test/spec/modules/gambidBidAdapter_spec.js
+++ b/test/spec/modules/gambidBidAdapter_spec.js
@@ -6,27 +6,27 @@ const supplyPartnerId = '123';
 
 describe('GambidAdapter', function () {
   describe('isBidRequestValid', function () {
-    it('should validate supply-partner ID', () => {
+    it('should validate supply-partner ID', function () {
       expect(spec.isBidRequestValid({ params: {} })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: 123 } })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123' } })).to.equal(true);
     });
-    it('should validate RTB endpoint', () => {
+    it('should validate RTB endpoint', function () {
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123' } })).to.equal(true); // RTB endpoint has a default
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', rtbEndpoint: 123 } })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', rtbEndpoint: 'https://some.url.com' } })).to.equal(true);
     });
-    it('should validate bid floor', () => {
+    it('should validate bid floor', function () {
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123' } })).to.equal(true); // bidfloor has a default
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', bidfloor: '123' } })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', bidfloor: 0.1 } })).to.equal(true);
     });
-    it('should validate adpos', () => {
+    it('should validate adpos', function () {
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123' } })).to.equal(true); // adpos has a default
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', adpos: '123' } })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', adpos: 0.1 } })).to.equal(true);
     });
-    it('should validate instl', () => {
+    it('should validate instl', function () {
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123' } })).to.equal(true); // adpos has a default
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', instl: '123' } })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', instl: -1 } })).to.equal(false);
@@ -49,7 +49,7 @@ describe('GambidAdapter', function () {
       'transactionId': 'a123456789'
     };
 
-    it('returns an array', () => {
+    it('returns an array', function () {
       let response;
 
       response = spec.buildRequests([]);
@@ -67,7 +67,7 @@ describe('GambidAdapter', function () {
       expect(response.length).to.equal(2);
     });
 
-    it('targets correct endpoint', () => {
+    it('targets correct endpoint', function () {
       let response;
 
       response = spec.buildRequests([ bidRequest ])[ 0 ];
@@ -81,7 +81,7 @@ describe('GambidAdapter', function () {
       expect(response.url).to.match(new RegExp(`^https://rtb2\\.gambid\\.io/a12/r/${supplyPartnerId}/bidr\\?rformat=open_rtb&reqformat=rtb_json&bidder=prebid$`, 'g'));
     });
 
-    it('builds request correctly', () => {
+    it('builds request correctly', function () {
       let stub = sinon.stub(utils, 'getTopWindowUrl').returns('http://www.test.com/page.html');
 
       let response;
@@ -114,7 +114,7 @@ describe('GambidAdapter', function () {
       stub.restore();
     });
 
-    it('builds request banner object correctly', () => {
+    it('builds request banner object correctly', function () {
       let response;
 
       const bidRequestWithBanner = utils.deepClone(bidRequest);
@@ -136,7 +136,7 @@ describe('GambidAdapter', function () {
       expect(response.data.imp[ 0 ].banner.pos).to.equal(bidRequestWithPosEquals1.params.pos);
     });
 
-    it('builds request video object correctly', () => {
+    it('builds request video object correctly', function () {
       let response;
 
       const bidRequestWithVideo = utils.deepClone(bidRequest);
@@ -249,7 +249,7 @@ describe('GambidAdapter', function () {
         }
       ]
     };
-    it('returns an empty array on missing response', () => {
+    it('returns an empty array on missing response', function () {
       let response;
 
       response = spec.interpretResponse(undefined, { bidRequest: bannerBidRequest });
@@ -260,7 +260,7 @@ describe('GambidAdapter', function () {
       expect(Array.isArray(response)).to.equal(true);
       expect(response.length).to.equal(0);
     });
-    it('aggregates banner bids from all seat bids', () => {
+    it('aggregates banner bids from all seat bids', function () {
       const response = spec.interpretResponse({ body: rtbResponse }, { bidRequest: bannerBidRequest });
       expect(Array.isArray(response)).to.equal(true);
       expect(response.length).to.equal(2);
@@ -291,7 +291,7 @@ describe('GambidAdapter', function () {
       // expect(ad1.ad).to.be.an('undefined');
       // expect(ad1.vastXml).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].adm);
     });
-    it('aggregates video bids from all seat bids', () => {
+    it('aggregates video bids from all seat bids', function () {
       const response = spec.interpretResponse({ body: rtbResponse }, { bidRequest: videoBidRequest });
       expect(Array.isArray(response)).to.equal(true);
       expect(response.length).to.equal(2);
@@ -321,7 +321,7 @@ describe('GambidAdapter', function () {
       expect(ad1.vastXml).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].adm);
       expect(ad1.vastUrl).to.equal(rtbResponse.seatbid[ 1 ].bid[ 0 ].ext.vast_url);
     });
-    it('aggregates user-sync pixels', () => {
+    it('aggregates user-sync pixels', function () {
       const response = spec.getUserSyncs({}, [ { body: rtbResponse } ]);
       expect(Array.isArray(response)).to.equal(true);
       expect(response.length).to.equal(4);

--- a/test/spec/modules/gambidBidAdapter_spec.js
+++ b/test/spec/modules/gambidBidAdapter_spec.js
@@ -4,8 +4,8 @@ import * as utils from 'src/utils';
 
 const supplyPartnerId = '123';
 
-describe('GambidAdapter', () => {
-  describe('isBidRequestValid', () => {
+describe('GambidAdapter', function () {
+  describe('isBidRequestValid', function () {
     it('should validate supply-partner ID', () => {
       expect(spec.isBidRequestValid({ params: {} })).to.equal(false);
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: 123 } })).to.equal(false);
@@ -35,7 +35,7 @@ describe('GambidAdapter', () => {
       expect(spec.isBidRequestValid({ params: { supplyPartnerId: '123', instl: 2 } })).to.equal(false);
     });
   });
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequest = {
       'adUnitCode': 'adunit-code',
       'auctionId': '1d1a030790a475',
@@ -158,7 +158,7 @@ describe('GambidAdapter', () => {
       expect(response.data.imp[ 0 ].video.pos).to.equal(bidRequestWithPosEquals1.params.pos);
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bannerBidRequest = {
       'adUnitCode': 'adunit-code',
       'auctionId': '1d1a030790a475',

--- a/test/spec/modules/gammaBidAdapter_spec.js
+++ b/test/spec/modules/gammaBidAdapter_spec.js
@@ -23,17 +23,17 @@ describe('gammaBidAdapter', function() {
   let bidArray = [bid];
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when require params are not passed', () => {
+    it('should return false when require params are not passed', function () {
       let bid = Object.assign({}, bid);
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when params not passed correctly', () => {
+    it('should return false when params not passed correctly', function () {
       bid.params.siteId = '';
       bid.params.zoneId = '';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
@@ -41,7 +41,7 @@ describe('gammaBidAdapter', function() {
   });
 
   describe('buildRequests', function () {
-    it('should attempt to send bid requests to the endpoint via GET', () => {
+    it('should attempt to send bid requests to the endpoint via GET', function () {
       const requests = spec.buildRequests(bidArray);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
@@ -77,7 +77,7 @@ describe('gammaBidAdapter', function() {
       };
     })
 
-    it('should get the correct bid response', () => {
+    it('should get the correct bid response', function () {
       let expectedResponse = [{
         'requestId': '23beaa6af6cdde',
         'cpm': 0.45,
@@ -94,7 +94,7 @@ describe('gammaBidAdapter', function() {
       expect(Object.keys(result)).to.deep.equal(Object.keys(expectedResponse));
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: {}
       };

--- a/test/spec/modules/gammaBidAdapter_spec.js
+++ b/test/spec/modules/gammaBidAdapter_spec.js
@@ -22,7 +22,7 @@ describe('gammaBidAdapter', function() {
   };
   let bidArray = [bid];
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
@@ -40,7 +40,7 @@ describe('gammaBidAdapter', function() {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should attempt to send bid requests to the endpoint via GET', () => {
       const requests = spec.buildRequests(bidArray);
       requests.forEach(function(requestItem) {
@@ -50,7 +50,7 @@ describe('gammaBidAdapter', function() {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse;
 
     beforeEach(() => {

--- a/test/spec/modules/gammaBidAdapter_spec.js
+++ b/test/spec/modules/gammaBidAdapter_spec.js
@@ -53,7 +53,7 @@ describe('gammaBidAdapter', function() {
   describe('interpretResponse', function () {
     let serverResponse;
 
-    beforeEach(() => {
+    beforeEach(function () {
       serverResponse = {
         body: {
           'id': '23beaa6af6cdde',

--- a/test/spec/modules/getintentBidAdapter_spec.js
+++ b/test/spec/modules/getintentBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { spec } from 'modules/getintentBidAdapter'
 
-describe('GetIntent Adapter Tests:', () => {
+describe('GetIntent Adapter Tests:', function () {
   const bidRequests = [{
     bidId: 'bid12345',
     params: {

--- a/test/spec/modules/getintentBidAdapter_spec.js
+++ b/test/spec/modules/getintentBidAdapter_spec.js
@@ -34,7 +34,7 @@ describe('GetIntent Adapter Tests:', function () {
     mediaType: 'video'
   };
 
-  it('Verify build request', () => {
+  it('Verify build request', function () {
     const serverRequests = spec.buildRequests(bidRequests);
     let serverRequest = serverRequests[0];
     expect(serverRequest.url).to.equal('//px.adhigh.net/rtb/direct_banner');
@@ -48,7 +48,7 @@ describe('GetIntent Adapter Tests:', function () {
     expect(serverRequest.data.size).to.equal('50x50,100x100');
   });
 
-  it('Verify build video request', () => {
+  it('Verify build video request', function () {
     const serverRequests = spec.buildRequests([videoBidRequest]);
     let serverRequest = serverRequests[0];
     expect(serverRequest.url).to.equal('//px.adhigh.net/rtb/direct_vast');
@@ -64,7 +64,7 @@ describe('GetIntent Adapter Tests:', function () {
     expect(serverRequest.data.skippable).to.equal(true);
   });
 
-  it('Verify parse response', () => {
+  it('Verify parse response', function () {
     const serverResponse = {
       body: {
         bid_id: 'bid12345',
@@ -90,7 +90,7 @@ describe('GetIntent Adapter Tests:', function () {
     expect(bid.ad).to.equal('Ad markup');
   });
 
-  it('Verify parse video response', () => {
+  it('Verify parse video response', function () {
     const serverResponse = {
       body: {
         bid_id: 'bid789',
@@ -116,22 +116,22 @@ describe('GetIntent Adapter Tests:', function () {
     expect(bid.vastUrl).to.equal('//vast.xml/url');
   });
 
-  it('Verify bidder code', () => {
+  it('Verify bidder code', function () {
     expect(spec.code).to.equal('getintent');
   });
 
-  it('Verify bidder aliases', () => {
+  it('Verify bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
     expect(spec.aliases[0]).to.equal('getintentAdapter');
   });
 
-  it('Verify supported media types', () => {
+  it('Verify supported media types', function () {
     expect(spec.supportedMediaTypes).to.have.lengthOf(2);
     expect(spec.supportedMediaTypes[0]).to.equal('video');
     expect(spec.supportedMediaTypes[1]).to.equal('banner');
   });
 
-  it('Verify if bid request valid', () => {
+  it('Verify if bid request valid', function () {
     expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     expect(spec.isBidRequestValid(bidRequests[1])).to.equal(true);
     expect(spec.isBidRequestValid({})).to.equal(false);

--- a/test/spec/modules/giantsBidAdapter_spec.js
+++ b/test/spec/modules/giantsBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('GiantsAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -28,11 +28,11 @@ describe('GiantsAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -57,7 +57,7 @@ describe('GiantsAdapter', function () {
       }
     ];
 
-    it('should parse out private sizes', () => {
+    it('should parse out private sizes', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -75,7 +75,7 @@ describe('GiantsAdapter', function () {
       expect(payload.tags[0].private_sizes).to.deep.equal([{width: 300, height: 250}]);
     });
 
-    it('should add source and verison to the tag', () => {
+    it('should add source and verison to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data);
       expect(payload.sdk).to.exist;
@@ -85,7 +85,7 @@ describe('GiantsAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on all requests', () => {
+    it('should populate the ad_types array on all requests', function () {
       ['banner', 'video', 'native'].forEach(type => {
         const bidRequest = Object.assign({}, bidRequests[0]);
         bidRequest.mediaTypes = {};
@@ -98,7 +98,7 @@ describe('GiantsAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on outstream requests', () => {
+    it('should populate the ad_types array on outstream requests', function () {
       const bidRequest = Object.assign({}, bidRequests[0]);
       bidRequest.mediaTypes = {};
       bidRequest.mediaTypes.video = {context: 'outstream'};
@@ -109,13 +109,13 @@ describe('GiantsAdapter', function () {
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT + utils.getTopWindowUrl());
       expect(request.method).to.equal('POST');
     });
 
-    it('should attach valid video params to the tag', () => {
+    it('should attach valid video params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -138,7 +138,7 @@ describe('GiantsAdapter', function () {
       });
     });
 
-    it('sets minimum native asset params when not provided on adunit', () => {
+    it('sets minimum native asset params when not provided on adunit', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -157,7 +157,7 @@ describe('GiantsAdapter', function () {
       });
     });
 
-    it('does not overwrite native ad unit params with mimimum params', () => {
+    it('does not overwrite native ad unit params with mimimum params', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -189,7 +189,7 @@ describe('GiantsAdapter', function () {
       });
     });
 
-    it('should convert keyword params to proper form and attaches to request', () => {
+    it('should convert keyword params to proper form and attaches to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -228,7 +228,7 @@ describe('GiantsAdapter', function () {
       }]);
     });
 
-    it('should add payment rules to the request', () => {
+    it('should add payment rules to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -262,7 +262,7 @@ describe('GiantsAdapter', function () {
       ]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '3db3773286ee59',
@@ -282,7 +282,7 @@ describe('GiantsAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'version': '0.0.1',
         'tags': [{

--- a/test/spec/modules/giantsBidAdapter_spec.js
+++ b/test/spec/modules/giantsBidAdapter_spec.js
@@ -6,16 +6,16 @@ import * as utils from 'src/utils';
 
 const ENDPOINT = '//d.admp.io/hb/multi?url=';
 
-describe('GiantsAdapter', () => {
+describe('GiantsAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'giants',
       'params': {
@@ -42,7 +42,7 @@ describe('GiantsAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'giants',
@@ -246,7 +246,7 @@ describe('GiantsAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'version': '3.0.0',
       'tags': [

--- a/test/spec/modules/gjirafaBidAdapter_spec.js
+++ b/test/spec/modules/gjirafaBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/gjirafaBidAdapter';
 
 describe('gjirafaAdapterTest', function () {
   describe('bidRequestValidity', function () {
-    it('bidRequest with placementId, minCPM and minCPC params', () => {
+    it('bidRequest with placementId, minCPM and minCPC params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'gjirafa',
         params: {
@@ -14,7 +14,7 @@ describe('gjirafaAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with only placementId param', () => {
+    it('bidRequest with only placementId param', function () {
       expect(spec.isBidRequestValid({
         bidder: 'gjirafa',
         params: {
@@ -23,7 +23,7 @@ describe('gjirafaAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with minCPM and minCPC params', () => {
+    it('bidRequest with minCPM and minCPC params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'gjirafa',
         params: {
@@ -33,7 +33,7 @@ describe('gjirafaAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with no placementId, minCPM or minCPC params', () => {
+    it('bidRequest with no placementId, minCPM or minCPC params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'gjirafa',
         params: {
@@ -74,14 +74,14 @@ describe('gjirafaAdapterTest', function () {
 	  'consent_required': 'true'
     }];
 
-    it('bidRequest HTTP method', () => {
+    it('bidRequest HTTP method', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
-    it('bidRequest url', () => {
+    it('bidRequest url', function () {
       const endpointUrl = 'https://gjc.gjirafa.com/Home/GetBid';
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
@@ -89,20 +89,20 @@ describe('gjirafaAdapterTest', function () {
       });
     });
 
-    it('bidRequest data', () => {
+    it('bidRequest data', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.data).to.exists;
       });
     });
 
-    it('bidRequest sizes', () => {
+    it('bidRequest sizes', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].data.sizes).to.equal('728x90;980x200;980x150;970x90;970x250');
       expect(requests[1].data.sizes).to.equal('300x250');
     });
 
-    it('should add GDPR data', () => {
+    it('should add GDPR data', function () {
       const requests = spec.buildRequests(bidRequests);
 	  expect(requests[0].data.consent_string).to.exists;
 	  expect(requests[0].data.consent_required).to.exists;
@@ -143,7 +143,7 @@ describe('gjirafaAdapterTest', function () {
       headers: {}
     };
 
-    it('all keys present', () => {
+    it('all keys present', function () {
       const result = spec.interpretResponse(bidResponse, bidRequest);
 
       let keys = [

--- a/test/spec/modules/gjirafaBidAdapter_spec.js
+++ b/test/spec/modules/gjirafaBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/gjirafaBidAdapter';
 
-describe('gjirafaAdapterTest', () => {
-  describe('bidRequestValidity', () => {
+describe('gjirafaAdapterTest', function () {
+  describe('bidRequestValidity', function () {
     it('bidRequest with placementId, minCPM and minCPC params', () => {
       expect(spec.isBidRequestValid({
         bidder: 'gjirafa',
@@ -42,7 +42,7 @@ describe('gjirafaAdapterTest', () => {
     });
   });
 
-  describe('bidRequest', () => {
+  describe('bidRequest', function () {
     const bidRequests = [{
       'bidder': 'gjirafa',
       'params': {
@@ -111,7 +111,7 @@ describe('gjirafaAdapterTest', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequest = {
       'method': 'GET',
       'url': 'https://gjc.gjirafa.com/Home/GetBid',

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('gumgumAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('gumgumAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -40,7 +40,7 @@ describe('gumgumAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -63,20 +63,20 @@ describe('gumgumAdapter', function () {
       }
     ];
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('GET');
       expect(request.id).to.equal('30b31c1838de1e');
     });
-    it('should add consent parameters if gdprConsent is present', () => {
+    it('should add consent parameters if gdprConsent is present', function () {
       const gdprConsent = { consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==', gdprApplies: true };
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
       expect(bidRequest.data.gdprApplies).to.eq(true);
       expect(bidRequest.data.gdprConsent).to.eq('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
     });
-    it('should handle gdprConsent is present but values are undefined case', () => {
+    it('should handle gdprConsent is present but values are undefined case', function () {
       const gdprConsent = { consent_string: undefined, gdprApplies: undefined };
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
@@ -115,7 +115,7 @@ describe('gumgumAdapter', function () {
       pi: 3
     }
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = {
         'ad': '<html><h3>I am an ad</h3></html>',
         'cpm': 0,
@@ -132,7 +132,7 @@ describe('gumgumAdapter', function () {
       expect(spec.interpretResponse({ body: serverResponse }, bidRequest)).to.deep.equal([expectedResponse]);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'ad': {},
         'pag': {
@@ -147,7 +147,7 @@ describe('gumgumAdapter', function () {
       expect(result.length).to.equal(0);
     });
 
-    it('returns 1x1 when eligible product and size available', () => {
+    it('returns 1x1 when eligible product and size available', function () {
       let inscreenBidRequest = {
         id: 12346,
         sizes: [[300, 250], [1, 1]],

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -4,16 +4,16 @@ import { spec } from 'modules/gumgumBidAdapter';
 
 const ENDPOINT = 'https://g2.gumgum.com/hbid/imp';
 
-describe('gumgumAdapter', () => {
+describe('gumgumAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'gumgum',
       'params': {
@@ -50,7 +50,7 @@ describe('gumgumAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'gumgum',
@@ -84,7 +84,7 @@ describe('gumgumAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse = {
       'ad': {
         'id': 29593,
@@ -184,7 +184,7 @@ describe('gumgumAdapter', () => {
       expect(result[0].height).to.equal('1');
     })
   })
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const syncOptions = {
       'iframeEnabled': 'true'
     }

--- a/test/spec/modules/gxoneBidAdapter_spec.js
+++ b/test/spec/modules/gxoneBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('GXOne Adapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('GXOne Adapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -83,7 +83,7 @@ describe('GXOne Adapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -92,7 +92,7 @@ describe('GXOne Adapter', function () {
       expect(payload).to.have.property('auids', '5');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -101,7 +101,7 @@ describe('GXOne Adapter', function () {
       expect(payload).to.have.property('auids', '5,6');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -112,7 +112,7 @@ describe('GXOne Adapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -135,7 +135,7 @@ describe('GXOne Adapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'gxone',
@@ -169,7 +169,7 @@ describe('GXOne Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'gxone',
@@ -249,7 +249,7 @@ describe('GXOne Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'gxone',

--- a/test/spec/modules/gxoneBidAdapter_spec.js
+++ b/test/spec/modules/gxoneBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('GXOne Adapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'gxone',
       'params': {
@@ -38,7 +38,7 @@ describe('GXOne Adapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     function parseRequest(url) {
       const res = {};
       url.split('&').forEach((it) => {
@@ -124,7 +124,7 @@ describe('GXOne Adapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 4, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 5, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/huddledmassesBidAdapter_spec.js
+++ b/test/spec/modules/huddledmassesBidAdapter_spec.js
@@ -16,14 +16,14 @@ describe('HuddledmassesAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true when placement_id can be cast to a number, and when at least one of the sizes passed is allowed', () => {
+    it('Should return true when placement_id can be cast to a number, and when at least one of the sizes passed is allowed', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false when placement_id is not a number', () => {
+    it('Should return false when placement_id is not a number', function () {
       bid.params.placement_id = 'aaa';
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
-    it('Should return false when the sizes are not allowed', () => {
+    it('Should return false when the sizes are not allowed', function () {
       bid.sizes = [[1, 1]];
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -31,19 +31,19 @@ describe('HuddledmassesAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//huddledmassessupply.com/?c=o&m=multi');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'language', 'secure', 'host', 'page', 'placements');
@@ -62,7 +62,7 @@ describe('HuddledmassesAdapter', function () {
         expect(placement.sizes).to.be.an('array');
       }
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.placements).to.be.an('array').that.is.empty;
@@ -83,7 +83,7 @@ describe('HuddledmassesAdapter', function () {
       } ]
     };
     let serverResponses = spec.interpretResponse(resObject);
-    it('Returns an array of valid server responses if response object is valid', () => {
+    it('Returns an array of valid server responses if response object is valid', function () {
       expect(serverResponses).to.be.an('array').that.is.not.empty;
       for (let i = 0; i < serverResponses.length; i++) {
         let dataItem = serverResponses[i];
@@ -99,7 +99,7 @@ describe('HuddledmassesAdapter', function () {
         expect(dataItem.netRevenue).to.be.a('boolean');
         expect(dataItem.currency).to.be.a('string');
       }
-      it('Returns an empty array if invalid response is passed', () => {
+      it('Returns an empty array if invalid response is passed', function () {
         serverResponses = spec.interpretResponse('invalid_response');
         expect(serverResponses).to.be.an('array').that.is.empty;
       });
@@ -108,7 +108,7 @@ describe('HuddledmassesAdapter', function () {
 
   describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
-    it('Returns valid URL and type', () => {
+    it('Returns valid URL and type', function () {
       expect(userSync).to.be.an('array').with.lengthOf(1);
       expect(userSync[0].type).to.exist;
       expect(userSync[0].url).to.exist;

--- a/test/spec/modules/huddledmassesBidAdapter_spec.js
+++ b/test/spec/modules/huddledmassesBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/huddledmassesBidAdapter';
 
-describe('HuddledmassesAdapter', () => {
+describe('HuddledmassesAdapter', function () {
   let bid = {
     bidId: '2dd581a2b6281d',
     bidder: 'huddledmasses',
@@ -15,7 +15,7 @@ describe('HuddledmassesAdapter', () => {
     transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true when placement_id can be cast to a number, and when at least one of the sizes passed is allowed', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -29,7 +29,7 @@ describe('HuddledmassesAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -68,7 +68,7 @@ describe('HuddledmassesAdapter', () => {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let resObject = {
       body: [ {
         requestId: '123',
@@ -106,7 +106,7 @@ describe('HuddledmassesAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
     it('Returns valid URL and type', () => {
       expect(userSync).to.be.an('array').with.lengthOf(1);

--- a/test/spec/modules/iasBidAdapter_spec.js
+++ b/test/spec/modules/iasBidAdapter_spec.js
@@ -43,7 +43,7 @@ describe('iasBidAdapter is an adapter that', function () {
     });
     describe('given bid requests, returns a `ServerRequest` instance that', function () {
       let bidRequests, IAS_HOST;
-      beforeEach(() => {
+      beforeEach(function () {
         IAS_HOST = '//pixel.adsafeprotected.com/services/pub';
         bidRequests = [
           {
@@ -100,7 +100,9 @@ describe('iasBidAdapter is an adapter that', function () {
         const SLOT_SIZE_PARAM = 'ss';
         const SLOT_AD_UNIT_PATH_PARAM = 'p';
 
-        beforeEach(() => val = decodeURI(spec.buildRequests(bidRequests).data));
+        beforeEach(function () {
+          val = decodeURI(spec.buildRequests(bidRequests).data);
+        });
         it('publisher id', function () {
           expect(val).to.have.string(`${ANID_PARAM}=1234`);
         });
@@ -128,7 +130,7 @@ describe('iasBidAdapter is an adapter that', function () {
     });
     describe('returns a list of bid response that', function () {
       let bidRequests, bidResponse, slots, serverResponse;
-      beforeEach(() => {
+      beforeEach(function () {
         bidRequests = [
           {
             adUnitCode: 'one-div-id',

--- a/test/spec/modules/iasBidAdapter_spec.js
+++ b/test/spec/modules/iasBidAdapter_spec.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { spec } from 'modules/iasBidAdapter';
 
 describe('iasBidAdapter is an adapter that', function () {
-  it('has the correct bidder code', () => {
+  it('has the correct bidder code', function () {
     expect(spec.code).to.equal('ias');
   });
   describe('has a method `isBidRequestValid` that', function () {
-    it('exists', () => {
+    it('exists', function () {
       expect(spec.isBidRequestValid).to.be.a('function');
     });
-    it('returns false if bid params misses `pubId`', () => {
+    it('returns false if bid params misses `pubId`', function () {
       expect(spec.isBidRequestValid(
         {
           params: {
@@ -17,7 +17,7 @@ describe('iasBidAdapter is an adapter that', function () {
           }
         })).to.equal(false);
     });
-    it('returns false if bid params misses `adUnitPath`', () => {
+    it('returns false if bid params misses `adUnitPath`', function () {
       expect(spec.isBidRequestValid(
         {
           params: {
@@ -25,7 +25,7 @@ describe('iasBidAdapter is an adapter that', function () {
           }
         })).to.equal(false);
     });
-    it('returns true otherwise', () => {
+    it('returns true otherwise', function () {
       expect(spec.isBidRequestValid(
         {
           params: {
@@ -38,7 +38,7 @@ describe('iasBidAdapter is an adapter that', function () {
   });
 
   describe('has a method `buildRequests` that', function () {
-    it('exists', () => {
+    it('exists', function () {
       expect(spec.buildRequests).to.be.a('function');
     });
     describe('given bid requests, returns a `ServerRequest` instance that', function () {
@@ -79,17 +79,17 @@ describe('iasBidAdapter is an adapter that', function () {
           }
         ];
       });
-      it('has property `method` of `GET`', () => {
+      it('has property `method` of `GET`', function () {
         expect(spec.buildRequests(bidRequests)).to.deep.include({
           method: 'GET'
         });
       });
-      it('has property `url` to be the correct IAS endpoint', () => {
+      it('has property `url` to be the correct IAS endpoint', function () {
         expect(spec.buildRequests(bidRequests)).to.deep.include({
           url: IAS_HOST
         });
       });
-      it('only includes the first `bidRequest` as the bidRequest variable on a multiple slot request', () => {
+      it('only includes the first `bidRequest` as the bidRequest variable on a multiple slot request', function () {
         expect(spec.buildRequests(bidRequests).bidRequest.adUnitCode).to.equal(bidRequests[0].adUnitCode);
       });
       describe('has property `data` that is an encode query string containing information such as', function () {
@@ -101,21 +101,21 @@ describe('iasBidAdapter is an adapter that', function () {
         const SLOT_AD_UNIT_PATH_PARAM = 'p';
 
         beforeEach(() => val = decodeURI(spec.buildRequests(bidRequests).data));
-        it('publisher id', () => {
+        it('publisher id', function () {
           expect(val).to.have.string(`${ANID_PARAM}=1234`);
         });
-        it('ad slot`s id, size and ad unit path', () => {
+        it('ad slot`s id, size and ad unit path', function () {
           expect(val).to.have.string(`${SLOT_PARAM}={${SLOT_ID_PARAM}:one-div-id,${SLOT_SIZE_PARAM}:[10.20,300.400],${SLOT_AD_UNIT_PATH_PARAM}:/a/b/c}`);
           expect(val).to.have.string(`${SLOT_PARAM}={${SLOT_ID_PARAM}:two-div-id,${SLOT_SIZE_PARAM}:[50.60],${SLOT_AD_UNIT_PATH_PARAM}:/d/e/f}`);
         });
-        it('window size', () => {
+        it('window size', function () {
           expect(val).to.match(/.*wr=[0-9]*\.[0-9]*/);
         });
-        it('screen size', () => {
+        it('screen size', function () {
           expect(val).to.match(/.*sr=[0-9]*\.[0-9]*/);
         });
       });
-      it('has property `bidRequest` that is the first passed in bid request', () => {
+      it('has property `bidRequest` that is the first passed in bid request', function () {
         expect(spec.buildRequests(bidRequests)).to.deep.include({
           bidRequest: bidRequests[0]
         });
@@ -123,7 +123,7 @@ describe('iasBidAdapter is an adapter that', function () {
     });
   });
   describe('has a method `interpretResponse` that', function () {
-    it('exists', () => {
+    it('exists', function () {
       expect(spec.interpretResponse).to.be.a('function');
     });
     describe('returns a list of bid response that', function () {
@@ -194,34 +194,34 @@ describe('iasBidAdapter is an adapter that', function () {
         };
         bidResponse = spec.interpretResponse(serverResponse, request);
       });
-      it('has IAS keyword `adt` as property', () => {
+      it('has IAS keyword `adt` as property', function () {
         expect(bidResponse[0]).to.deep.include({ adt: 'adtVal' });
       });
-      it('has IAS keyword `alc` as property', () => {
+      it('has IAS keyword `alc` as property', function () {
         expect(bidResponse[0]).to.deep.include({ alc: 'alcVal' });
       });
-      it('has IAS keyword `dlm` as property', () => {
+      it('has IAS keyword `dlm` as property', function () {
         expect(bidResponse[0]).to.deep.include({ dlm: 'dlmVal' });
       });
-      it('has IAS keyword `drg` as property', () => {
+      it('has IAS keyword `drg` as property', function () {
         expect(bidResponse[0]).to.deep.include({ drg: 'drgVal' });
       });
-      it('has IAS keyword `hat` as property', () => {
+      it('has IAS keyword `hat` as property', function () {
         expect(bidResponse[0]).to.deep.include({ hat: 'hatVal' });
       });
-      it('has IAS keyword `off` as property', () => {
+      it('has IAS keyword `off` as property', function () {
         expect(bidResponse[0]).to.deep.include({ off: 'offVal' });
       });
-      it('has IAS keyword `vio` as property', () => {
+      it('has IAS keyword `vio` as property', function () {
         expect(bidResponse[0]).to.deep.include({ vio: 'vioVal' });
       });
-      it('has IAS keyword `fr` as property', () => {
+      it('has IAS keyword `fr` as property', function () {
         expect(bidResponse[0]).to.deep.include({ fr: 'false' });
       });
-      it('has property `slots`', () => {
+      it('has property `slots`', function () {
         expect(bidResponse[0]).to.deep.include({ slots: slots });
       });
-      it('response is the same for multiple slots', () => {
+      it('response is the same for multiple slots', function () {
         var adapter = spec;
         var requests = adapter.buildRequests(bidRequests);
         expect(adapter.interpretResponse(serverResponse, requests)).to.length(2);

--- a/test/spec/modules/iasBidAdapter_spec.js
+++ b/test/spec/modules/iasBidAdapter_spec.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { spec } from 'modules/iasBidAdapter';
 
-describe('iasBidAdapter is an adapter that', () => {
+describe('iasBidAdapter is an adapter that', function () {
   it('has the correct bidder code', () => {
     expect(spec.code).to.equal('ias');
   });
-  describe('has a method `isBidRequestValid` that', () => {
+  describe('has a method `isBidRequestValid` that', function () {
     it('exists', () => {
       expect(spec.isBidRequestValid).to.be.a('function');
     });
@@ -37,11 +37,11 @@ describe('iasBidAdapter is an adapter that', () => {
     });
   });
 
-  describe('has a method `buildRequests` that', () => {
+  describe('has a method `buildRequests` that', function () {
     it('exists', () => {
       expect(spec.buildRequests).to.be.a('function');
     });
-    describe('given bid requests, returns a `ServerRequest` instance that', () => {
+    describe('given bid requests, returns a `ServerRequest` instance that', function () {
       let bidRequests, IAS_HOST;
       beforeEach(() => {
         IAS_HOST = '//pixel.adsafeprotected.com/services/pub';
@@ -92,7 +92,7 @@ describe('iasBidAdapter is an adapter that', () => {
       it('only includes the first `bidRequest` as the bidRequest variable on a multiple slot request', () => {
         expect(spec.buildRequests(bidRequests).bidRequest.adUnitCode).to.equal(bidRequests[0].adUnitCode);
       });
-      describe('has property `data` that is an encode query string containing information such as', () => {
+      describe('has property `data` that is an encode query string containing information such as', function () {
         let val;
         const ANID_PARAM = 'anId';
         const SLOT_PARAM = 'slot';
@@ -122,11 +122,11 @@ describe('iasBidAdapter is an adapter that', () => {
       });
     });
   });
-  describe('has a method `interpretResponse` that', () => {
+  describe('has a method `interpretResponse` that', function () {
     it('exists', () => {
       expect(spec.interpretResponse).to.be.a('function');
     });
-    describe('returns a list of bid response that', () => {
+    describe('returns a list of bid response that', function () {
       let bidRequests, bidResponse, slots, serverResponse;
       beforeEach(() => {
         bidRequests = [

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -41,21 +41,21 @@ describe('Improve Digital Adapter Tests', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('should return false when no bid', () => {
+    it('should return false when no bid', function () {
       expect(spec.isBidRequestValid()).to.equal(false);
     });
 
-    it('should return false when no bid.params', () => {
+    it('should return false when no bid.params', function () {
       let bid = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when both placementId and placementKey + publisherId are missing', () => {
+    it('should return false when both placementId and placementKey + publisherId are missing', function () {
       let bid = { 'params': {} };
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when only one of placementKey and publisherId is present', () => {
+    it('should return false when only one of placementKey and publisherId is present', function () {
       let bid = {
         params: {
           publisherId: 1234
@@ -70,19 +70,19 @@ describe('Improve Digital Adapter Tests', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return true when placementId is passed', () => {
+    it('should return true when placementId is passed', function () {
       let bid = { 'params': {} };
       expect(spec.isBidRequestValid(simpleBidRequest)).to.equal(true);
     });
 
-    it('should return true when both placementKey and publisherId are passed', () => {
+    it('should return true when both placementKey and publisherId are passed', function () {
       let bid = { 'params': {} };
       expect(spec.isBidRequestValid(simpleSmartTagBidRequest)).to.equal(true);
     });
   });
 
   describe('buildRequests', function () {
-    it('should make a well-formed request objects', () => {
+    it('should make a well-formed request objects', function () {
       const requests = spec.buildRequests([simpleBidRequest]);
       expect(requests).to.be.an('array');
       expect(requests.length).to.equal(1);
@@ -106,14 +106,14 @@ describe('Improve Digital Adapter Tests', function () {
       ]);
     });
 
-    it('should set placementKey and publisherId for smart tags', () => {
+    it('should set placementKey and publisherId for smart tags', function () {
       const requests = spec.buildRequests([simpleSmartTagBidRequest]);
       const params = JSON.parse(requests[0].data.substring(PARAM_PREFIX.length));
       expect(params.bid_request.imp[0].pubid).to.equal(1032);
       expect(params.bid_request.imp[0].pkey).to.equal('data_team_test_hb_smoke_test');
     });
 
-    it('should add keyValues', () => {
+    it('should add keyValues', function () {
       let bidRequest = Object.assign({}, simpleBidRequest);
       const keyValues = {
         testKey: [
@@ -126,7 +126,7 @@ describe('Improve Digital Adapter Tests', function () {
       expect(params.bid_request.imp[0].kvw).to.deep.equal(keyValues);
     });
 
-    it('should add size', () => {
+    it('should add size', function () {
       let bidRequest = Object.assign({}, simpleBidRequest);
       const size = {
         w: 800,
@@ -138,7 +138,7 @@ describe('Improve Digital Adapter Tests', function () {
       expect(params.bid_request.imp[0].banner).to.deep.equal(size);
     });
 
-    it('should add currency', () => {
+    it('should add currency', function () {
       const bidRequest = Object.assign({}, simpleBidRequest);
       const getConfigStub = sinon.stub(config, 'getConfig').returns('JPY');
       const request = spec.buildRequests([bidRequest])[0];
@@ -147,14 +147,14 @@ describe('Improve Digital Adapter Tests', function () {
       getConfigStub.restore();
     });
 
-    it('should add GDPR consent string', () => {
+    it('should add GDPR consent string', function () {
       const bidRequest = Object.assign({}, simpleBidRequest);
       const request = spec.buildRequests([bidRequest], bidderRequest)[0];
       const params = JSON.parse(request.data.substring(PARAM_PREFIX.length));
       expect(params.bid_request.gdpr).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
     });
 
-    it('should return 2 requests', () => {
+    it('should return 2 requests', function () {
       const requests = spec.buildRequests([
         simpleBidRequest,
         simpleSmartTagBidRequest
@@ -250,17 +250,17 @@ describe('Improve Digital Adapter Tests', function () {
       }
     ];
 
-    it('should return a well-formed bid', () => {
+    it('should return a well-formed bid', function () {
       const bids = spec.interpretResponse(serverResponse);
       expect(bids).to.deep.equal(expectedBid);
     });
 
-    it('should return two bids', () => {
+    it('should return two bids', function () {
       const bids = spec.interpretResponse(serverResponseTwoBids);
       expect(bids).to.deep.equal(expectedTwoBids);
     });
 
-    it('should register user syncs', () => {
+    it('should register user syncs', function () {
       const registerSyncSpy = sinon.spy(userSync, 'registerSync');
       const bids = spec.interpretResponse(serverResponse);
       expect(registerSyncSpy.withArgs('image', 'improvedigital', 'http://link1').calledOnce).to.equal(true);
@@ -268,7 +268,7 @@ describe('Improve Digital Adapter Tests', function () {
       registerSyncSpy.restore();
     });
 
-    it('should set dealId correctly', () => {
+    it('should set dealId correctly', function () {
       let response = JSON.parse(JSON.stringify(serverResponse));
       let bids;
 
@@ -287,14 +287,14 @@ describe('Improve Digital Adapter Tests', function () {
       expect(bids[0].dealId).to.equal(268515);
     });
 
-    it('should set currency', () => {
+    it('should set currency', function () {
       let response = JSON.parse(JSON.stringify(serverResponse));
       response.body.bid[0].currency = 'eur';
       const bids = spec.interpretResponse(response);
       expect(bids[0].currency).to.equal('EUR');
     });
 
-    it('should return empty array for bad response or no price', () => {
+    it('should return empty array for bad response or no price', function () {
       let response = JSON.parse(JSON.stringify(serverResponse));
       let bids;
 
@@ -331,7 +331,7 @@ describe('Improve Digital Adapter Tests', function () {
       expect(bids).to.deep.equal([]);
     });
 
-    it('should set netRevenue', () => {
+    it('should set netRevenue', function () {
       let response = JSON.parse(JSON.stringify(serverResponse));
       response.body.bid[0].isNet = true;
       const bids = spec.interpretResponse(response);

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -164,33 +164,6 @@ describe('Improve Digital Adapter Tests', function () {
     });
   });
 
-  describe('interpretResponse', function () {
-    const serverResponse = {
-      'body': {
-        'id': '687a06c541d8d1',
-        'site_id': 191642,
-        'bid': [
-          {
-            'isNet': false,
-            'id': '33e9500b21129f',
-            'advid': '5279',
-            'price': 1.45888594164456,
-            'nurl': 'http://ad.360yield.com/imp_pixel?ic=wVmhKI07hCVyGC1sNdFp.6buOSiGYOw8jPyZLlcMY2RCwD4ek3Fy6.xUI7U002skGBs3objMBoNU-Frpvmb9js3NKIG0YZJgWaNdcpXY9gOXE9hY4-wxybCjVSNzhOQB-zic73hzcnJnKeoGgcfvt8fMy18-yD0aVdYWt4zbqdoITOkKNCPBEgbPFu1rcje-o7a64yZ7H3dKvtnIixXQYc1Ep86xGSBGXY6xW2KfUOMT6vnkemxO72divMkMdhR8cAuqIubbx-ZID8-xf5c9k7p6DseeBW0I8ionrlTHx.rGosgxhiFaMqtr7HiA7PBzKvPdeEYN0hQ8RYo8JzYL82hA91A3V2m9Ij6y0DfIJnnrKN8YORffhxmJ6DzwEl1zjrVFbD01bqB3Vdww8w8PQJSkKQkd313tr-atU8LS26fnBmOngEkVHwAr2WCKxuUvxHmuVBTA-Lgz7wKwMoOJCA3hFxMavVb0ZFB7CK0BUTVU6z0De92Q.FJKNCHLMbjX3vcAQ90=',
-            'h': 290,
-            'pid': 1053688,
-            'sync': [
-              'http://link1',
-              'http://link2'
-            ],
-            'crid': '422031',
-            'w': 600,
-            'cid': '99006',
-            'adm': 'document.writeln(\"<a href=\\\"http:\\/\\/ad.360yield.com\\/click\\/wVmhKEKFeJufyP3hFfp7fv95ynoKe7vnG9V-j8EyAzklSoKRkownAclw4Zzcw-OcbJMg2KfjNiO8GoO9WP1jbNM8Q5GtmClbG9hZPBS4v6oBBiDi50AjRqHQsDAoBOJrIJtVyCfrnAIxvbysozCpLt20ov6jz2JPi6fe.D55HNeDLDyiLNgxVPa3y9jJZf65JBirCjOoZ-1Mj1BLB.57VdMaEhpGjjl5HnPgw0Pv7Hm1BO7PB9nCXJ9IwOH3IrKo.Wyy1iKDk6zeGwGOkQHSOMuQnCHyD35x6bhDQrpl5H6fTRTR8D2m5.-Zjh3fs8SKlo0i25EjKPw65iF.tvgcnq01U08OIh86EeSciamJgV0hNsk20TcTubfsoPN4are4nQ0y2gB-lz9tf3AjqHpSz5NoJWrpWtnrBHbjm.dS1XUQB1tzcLpIkA34nDe2eNxRZbZkZNSSs.Y8jQemfbjuLpttcemHqidFZo3xp37eSfUImw.HbyFdnK-wxFDYudgsIDxGJWI=\\/\\/http%3A%2F%2Fwww.improvedigital.com\\\" target=\\\"_blank\\\"><img style=\\\"border: 0;\\\" border=\\\"0\\\" width=\\\"600\\\" height=\\\"290\\\" src=\\\"http:\\/\\/creative.360yield.com\\/file\\/221728\\/ImproveDigital600x290.jpg\\\" alt=\\\"\\\"\\/><\\/a>\");document.writeln(\"<improvedigital_ad_output_information tp_id=\\\"\\\" buyer_id=\\\"0\\\" rtb_advertiser=\\\"\\\" campaign_id=\\\"99006\\\" line_item_id=\\\"268515\\\" creative_id=\\\"422031\\\" crid=\\\"0\\\" placement_id=\\\"1053688\\\"><\\/improvedigital_ad_output_information>\");'
-          }
-        ],
-        'debug': ''
-      }
-    };
   const serverResponse = {
     'body': {
       'id': '687a06c541d8d1',
@@ -245,7 +218,7 @@ describe('Improve Digital Adapter Tests', function () {
     }
   };
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let expectedBid = [
       {
         'ad': '<img src=\"http://ad.360yield.com/imp_pixel?ic=wVmhKI07hCVyGC1sNdFp.6buOSiGYOw8jPyZLlcMY2RCwD4ek3Fy6.xUI7U002skGBs3objMBoNU-Frpvmb9js3NKIG0YZJgWaNdcpXY9gOXE9hY4-wxybCjVSNzhOQB-zic73hzcnJnKeoGgcfvt8fMy18-yD0aVdYWt4zbqdoITOkKNCPBEgbPFu1rcje-o7a64yZ7H3dKvtnIixXQYc1Ep86xGSBGXY6xW2KfUOMT6vnkemxO72divMkMdhR8cAuqIubbx-ZID8-xf5c9k7p6DseeBW0I8ionrlTHx.rGosgxhiFaMqtr7HiA7PBzKvPdeEYN0hQ8RYo8JzYL82hA91A3V2m9Ij6y0DfIJnnrKN8YORffhxmJ6DzwEl1zjrVFbD01bqB3Vdww8w8PQJSkKQkd313tr-atU8LS26fnBmOngEkVHwAr2WCKxuUvxHmuVBTA-Lgz7wKwMoOJCA3hFxMavVb0ZFB7CK0BUTVU6z0De92Q.FJKNCHLMbjX3vcAQ90=\" width=\"0\" height=\"0\" style=\"display:none\"><script>document.writeln(\"<a href=\\\"http:\\/\\/ad.360yield.com\\/click\\/wVmhKEKFeJufyP3hFfp7fv95ynoKe7vnG9V-j8EyAzklSoKRkownAclw4Zzcw-OcbJMg2KfjNiO8GoO9WP1jbNM8Q5GtmClbG9hZPBS4v6oBBiDi50AjRqHQsDAoBOJrIJtVyCfrnAIxvbysozCpLt20ov6jz2JPi6fe.D55HNeDLDyiLNgxVPa3y9jJZf65JBirCjOoZ-1Mj1BLB.57VdMaEhpGjjl5HnPgw0Pv7Hm1BO7PB9nCXJ9IwOH3IrKo.Wyy1iKDk6zeGwGOkQHSOMuQnCHyD35x6bhDQrpl5H6fTRTR8D2m5.-Zjh3fs8SKlo0i25EjKPw65iF.tvgcnq01U08OIh86EeSciamJgV0hNsk20TcTubfsoPN4are4nQ0y2gB-lz9tf3AjqHpSz5NoJWrpWtnrBHbjm.dS1XUQB1tzcLpIkA34nDe2eNxRZbZkZNSSs.Y8jQemfbjuLpttcemHqidFZo3xp37eSfUImw.HbyFdnK-wxFDYudgsIDxGJWI=\\/\\/http%3A%2F%2Fwww.improvedigital.com\\\" target=\\\"_blank\\\"><img style=\\\"border: 0;\\\" border=\\\"0\\\" width=\\\"600\\\" height=\\\"290\\\" src=\\\"http:\\/\\/creative.360yield.com\\/file\\/221728\\/ImproveDigital600x290.jpg\\\" alt=\\\"\\\"\\/><\\/a>\");document.writeln(\"<improvedigital_ad_output_information tp_id=\\\"\\\" buyer_id=\\\"0\\\" rtb_advertiser=\\\"\\\" campaign_id=\\\"99006\\\" line_item_id=\\\"268515\\\" creative_id=\\\"422031\\\" crid=\\\"0\\\" placement_id=\\\"1053688\\\"><\\/improvedigital_ad_output_information>\");</script>',
@@ -287,16 +260,7 @@ describe('Improve Digital Adapter Tests', function () {
       expect(bids).to.deep.equal(expectedTwoBids);
     });
 
-    it('should register user syncs', function () {
-      const registerSyncSpy = sinon.spy(userSync, 'registerSync');
-      const bids = spec.interpretResponse(serverResponse);
-      expect(registerSyncSpy.withArgs('image', 'improvedigital', 'http://link1').calledOnce).to.equal(true);
-      expect(registerSyncSpy.withArgs('image', 'improvedigital', 'http://link2').calledOnce).to.equal(true);
-      registerSyncSpy.restore();
-    });
-
     it('should set dealId correctly', function () {
-    it('should set dealId correctly', () => {
       let response = JSON.parse(JSON.stringify(serverResponse));
       let bids;
 
@@ -367,15 +331,15 @@ describe('Improve Digital Adapter Tests', function () {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const serverResponses = [ serverResponseTwoBids ];
 
-    it('should return no syncs when pixel syncing is disabled', () => {
+    it('should return no syncs when pixel syncing is disabled', function () {
       const syncs = spec.getUserSyncs({ pixelEnabled: false }, serverResponses);
       expect(syncs).to.deep.equal([]);
     });
 
-    it('should return user syncs', () => {
+    it('should return user syncs', function () {
       const syncs = spec.getUserSyncs({ pixelEnabled: true }, serverResponses);
       const expected = [
         { type: 'image', url: 'http://link1' },

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -40,7 +40,7 @@ describe('Improve Digital Adapter Tests', function () {
     },
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return false when no bid', () => {
       expect(spec.isBidRequestValid()).to.equal(false);
     });
@@ -81,7 +81,7 @@ describe('Improve Digital Adapter Tests', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should make a well-formed request objects', () => {
       const requests = spec.buildRequests([simpleBidRequest]);
       expect(requests).to.be.an('array');
@@ -164,7 +164,7 @@ describe('Improve Digital Adapter Tests', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const serverResponse = {
       'body': {
         'id': '687a06c541d8d1',

--- a/test/spec/modules/innityBidAdapter_spec.js
+++ b/test/spec/modules/innityBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/innityBidAdapter';
 
 describe('innityAdapterTest', function () {
   describe('bidRequestValidity', function () {
-    it('bidRequest with pub ID and zone ID param', () => {
+    it('bidRequest with pub ID and zone ID param', function () {
       expect(spec.isBidRequestValid({
         bidder: 'innity',
         params: {
@@ -13,7 +13,7 @@ describe('innityAdapterTest', function () {
       })).to.equal(true);
     });
 
-    it('bidRequest with no required params', () => {
+    it('bidRequest with no required params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'innity',
         params: {
@@ -37,14 +37,14 @@ describe('innityAdapterTest', function () {
       'auctionId': '18fd8b8b0bd757'
     }];
 
-    it('bidRequest HTTP method', () => {
+    it('bidRequest HTTP method', function () {
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
-    it('bidRequest data', () => {
+    it('bidRequest data', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].data.pub).to.equal(267);
       expect(requests[0].data.zone).to.equal(62546);
@@ -85,7 +85,7 @@ describe('innityAdapterTest', function () {
       headers: {}
     };
 
-    it('result is correct', () => {
+    it('result is correct', function () {
       const result = spec.interpretResponse(bidResponse, bidRequest);
       expect(result[0].requestId).to.equal('51ef8751f9aead');
       expect(result[0].cpm).to.equal(1);

--- a/test/spec/modules/innityBidAdapter_spec.js
+++ b/test/spec/modules/innityBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/innityBidAdapter';
 
-describe('innityAdapterTest', () => {
-  describe('bidRequestValidity', () => {
+describe('innityAdapterTest', function () {
+  describe('bidRequestValidity', function () {
     it('bidRequest with pub ID and zone ID param', () => {
       expect(spec.isBidRequestValid({
         bidder: 'innity',
@@ -22,7 +22,7 @@ describe('innityAdapterTest', () => {
     });
   });
 
-  describe('bidRequest', () => {
+  describe('bidRequest', function () {
     const bidRequests = [{
       'bidder': 'innity',
       'params': {
@@ -54,7 +54,7 @@ describe('innityAdapterTest', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const bidRequest = {
       'method': 'GET',
       'url': 'https://as.innity.com/synd/?',

--- a/test/spec/modules/inskinBidAdapter_spec.js
+++ b/test/spec/modules/inskinBidAdapter_spec.js
@@ -99,7 +99,7 @@ const RESPONSE = {
   }
 };
 
-describe('InSkin BidAdapter', () => {
+describe('InSkin BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
@@ -121,7 +121,7 @@ describe('InSkin BidAdapter', () => {
     ];
   });
 
-  describe('bid request validation', () => {
+  describe('bid request validation', function () {
     it('should accept valid bid requests', () => {
       let bid = {
         bidder: 'inskin',
@@ -166,7 +166,7 @@ describe('InSkin BidAdapter', () => {
     });
   });
 
-  describe('buildRequests validation', () => {
+  describe('buildRequests validation', function () {
     it('creates request data', () => {
       let request = spec.buildRequests(bidRequests);
 
@@ -210,7 +210,7 @@ describe('InSkin BidAdapter', () => {
       expect(payload.consent.gdprConsentRequired).to.exist.and.to.be.true;
     });
   });
-  describe('interpretResponse validation', () => {
+  describe('interpretResponse validation', function () {
     it('response should have valid bidderCode', () => {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
@@ -255,7 +255,7 @@ describe('InSkin BidAdapter', () => {
       expect(bids).to.be.empty;
     });
   });
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     it('handles empty sync options', () => {
       let opts = spec.getUserSyncs({});
 

--- a/test/spec/modules/inskinBidAdapter_spec.js
+++ b/test/spec/modules/inskinBidAdapter_spec.js
@@ -103,7 +103,7 @@ describe('InSkin BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'inskin',

--- a/test/spec/modules/inskinBidAdapter_spec.js
+++ b/test/spec/modules/inskinBidAdapter_spec.js
@@ -122,7 +122,7 @@ describe('InSkin BidAdapter', function () {
   });
 
   describe('bid request validation', function () {
-    it('should accept valid bid requests', () => {
+    it('should accept valid bid requests', function () {
       let bid = {
         bidder: 'inskin',
         params: {
@@ -133,7 +133,7 @@ describe('InSkin BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should accept valid bid requests with extra fields', () => {
+    it('should accept valid bid requests with extra fields', function () {
       let bid = {
         bidder: 'inskin',
         params: {
@@ -145,7 +145,7 @@ describe('InSkin BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should reject bid requests without siteId', () => {
+    it('should reject bid requests without siteId', function () {
       let bid = {
         bidder: 'inskin',
         params: {
@@ -155,7 +155,7 @@ describe('InSkin BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should reject bid requests without networkId', () => {
+    it('should reject bid requests without networkId', function () {
       let bid = {
         bidder: 'inskin',
         params: {
@@ -167,30 +167,30 @@ describe('InSkin BidAdapter', function () {
   });
 
   describe('buildRequests validation', function () {
-    it('creates request data', () => {
+    it('creates request data', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request).to.exist.and.to.be.a('object');
     });
 
-    it('request to inskin should contain a url', () => {
+    it('request to inskin should contain a url', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.url).to.have.string('inskinad.com');
     });
 
-    it('requires valid bids to make request', () => {
+    it('requires valid bids to make request', function () {
       let request = spec.buildRequests([]);
       expect(request.bidRequest).to.be.empty;
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.method).to.have.string('POST');
     });
 
-    it('should add gdpr consent information to the request', () => {
+    it('should add gdpr consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {
         'bidderCode': 'inskin',
@@ -211,20 +211,20 @@ describe('InSkin BidAdapter', function () {
     });
   });
   describe('interpretResponse validation', function () {
-    it('response should have valid bidderCode', () => {
+    it('response should have valid bidderCode', function () {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
 
       expect(bid.bidderCode).to.equal('inskin');
     });
 
-    it('response should include objects for all bids', () => {
+    it('response should include objects for all bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
 
       expect(bids.length).to.equal(2);
     });
 
-    it('registers bids', () => {
+    it('registers bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
       bids.forEach(b => {
         expect(b).to.have.property('cpm');
@@ -242,34 +242,34 @@ describe('InSkin BidAdapter', function () {
       });
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let EMPTY_RESP = Object.assign({}, RESPONSE, {'body': {'decisions': null}})
       let bids = spec.interpretResponse(EMPTY_RESP, REQUEST);
 
       expect(bids).to.be.empty;
     });
 
-    it('handles no server response', () => {
+    it('handles no server response', function () {
       let bids = spec.interpretResponse(null, REQUEST);
 
       expect(bids).to.be.empty;
     });
   });
   describe('getUserSyncs', function () {
-    it('handles empty sync options', () => {
+    it('handles empty sync options', function () {
       let opts = spec.getUserSyncs({});
 
       expect(opts).to.be.empty;
     });
 
-    it('should return two sync urls if pixel syncs are enabled', () => {
+    it('should return two sync urls if pixel syncs are enabled', function () {
       let syncOptions = {'pixelEnabled': true};
       let opts = spec.getUserSyncs(syncOptions);
 
       expect(opts.length).to.equal(2);
     });
 
-    it('should return three sync urls if pixel and iframe syncs are enabled', () => {
+    it('should return three sync urls if pixel and iframe syncs are enabled', function () {
       let syncOptions = {'iframeEnabled': true, 'pixelEnabled': true};
       let opts = spec.getUserSyncs(syncOptions);
 

--- a/test/spec/modules/interactiveOffersBidAdapter_spec.js
+++ b/test/spec/modules/interactiveOffersBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {spec} from 'modules/interactiveOffersBidAdapter';
 describe('interactiveOffers adapter', function () {
   describe('implementation', function () {
     describe('for requests', function () {
-      it('should accept valid bid', () => {
+      it('should accept valid bid', function () {
         let validBid = {
             bidder: 'interactiveOffers',
             params: {
@@ -16,7 +16,7 @@ describe('interactiveOffers adapter', function () {
         expect(isValid).to.equal(true);
       });
 
-      it('should reject invalid bid', () => {
+      it('should reject invalid bid', function () {
         let invalidBid = {
             bidder: 'interactiveOffers'
           },
@@ -26,7 +26,7 @@ describe('interactiveOffers adapter', function () {
       });
     });
     describe('for requests', function () {
-      it('should accept valid bid with optional params', () => {
+      it('should accept valid bid with optional params', function () {
         let validBid = {
             bidder: 'interactiveOffers',
             params: {
@@ -44,7 +44,7 @@ describe('interactiveOffers adapter', function () {
         expect(requestUrlCustomParams).have.property('tmax', 1500);
       });
 
-      it('should accept valid bid without optional params', () => {
+      it('should accept valid bid without optional params', function () {
         let validBid = {
             bidder: 'interactiveOffers',
             params: {
@@ -60,7 +60,7 @@ describe('interactiveOffers adapter', function () {
         expect(requestUrlCustomParams).have.property('tmax');
       });
 
-      it('should reject invalid bid without pubId', () => {
+      it('should reject invalid bid without pubId', function () {
         let invalidBid = {
             bidder: 'interactiveOffers',
             params: {}
@@ -71,7 +71,7 @@ describe('interactiveOffers adapter', function () {
       });
     });
     describe('bid responses', function () {
-      it('should return complete bid response', () => {
+      it('should return complete bid response', function () {
         let serverResponse = {
           body: {
             'success': 'true',
@@ -104,7 +104,7 @@ describe('interactiveOffers adapter', function () {
         expect(bids[0].ad).to.have.length.above(1);
       });
 
-      it('should return empty bid response', () => {
+      it('should return empty bid response', function () {
         let bidRequests = [
           {
             bidder: 'interactiveOffers',
@@ -128,7 +128,7 @@ describe('interactiveOffers adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with error', () => {
+      it('should return empty bid response with error', function () {
         let bidRequests = [
           {
             bidder: 'interactiveOffers',
@@ -143,7 +143,7 @@ describe('interactiveOffers adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response without payload', () => {
+      it('should return empty bid response without payload', function () {
         let bidRequests = [
           {
             bidder: 'interactiveOffers',
@@ -158,7 +158,7 @@ describe('interactiveOffers adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on empty body', () => {
+      it('should return empty bid response on empty body', function () {
         let bidRequests = [
           {
             bidder: 'interactiveOffers',

--- a/test/spec/modules/interactiveOffersBidAdapter_spec.js
+++ b/test/spec/modules/interactiveOffersBidAdapter_spec.js
@@ -1,9 +1,9 @@
 import {expect} from 'chai';
 import {spec} from 'modules/interactiveOffersBidAdapter';
 
-describe('interactiveOffers adapter', () => {
-  describe('implementation', () => {
-    describe('for requests', () => {
+describe('interactiveOffers adapter', function () {
+  describe('implementation', function () {
+    describe('for requests', function () {
       it('should accept valid bid', () => {
         let validBid = {
             bidder: 'interactiveOffers',
@@ -25,7 +25,7 @@ describe('interactiveOffers adapter', () => {
         expect(isValid).to.equal(false);
       });
     });
-    describe('for requests', () => {
+    describe('for requests', function () {
       it('should accept valid bid with optional params', () => {
         let validBid = {
             bidder: 'interactiveOffers',
@@ -70,7 +70,7 @@ describe('interactiveOffers adapter', () => {
         expect(isValid).to.equal(false);
       });
     });
-    describe('bid responses', () => {
+    describe('bid responses', function () {
       it('should return complete bid response', () => {
         let serverResponse = {
           body: {

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -87,18 +87,18 @@ describe('invibesBidAdapter:', function () {
   });
 
   describe('buildRequests', function () {
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('GET');
     });
 
-    it('sends cookies with the bid request', () => {
+    it('sends cookies with the bid request', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.options.withCredentials).to.equal(true);
     });
 
-    it('has location, html id, placement and width/height', () => {
+    it('has location, html id, placement and width/height', function () {
       const request = spec.buildRequests(bidRequests, { auctionStart: Date.now() });
       const parsedData = request.data;
       expect(parsedData.location).to.exist;
@@ -108,53 +108,53 @@ describe('invibesBidAdapter:', function () {
       expect(parsedData.height).to.exist;
     });
 
-    it('sends all Placement Ids', () => {
+    it('sends all Placement Ids', function () {
       const request = spec.buildRequests(bidRequests);
       expect(JSON.parse(request.data.bidParamsJson).placementIds).to.contain(bidRequests[0].params.placementId);
       expect(JSON.parse(request.data.bidParamsJson).placementIds).to.contain(bidRequests[1].params.placementId);
     });
 
-    it('uses cookies', () => {
+    it('uses cookies', function () {
       global.document.cookie = 'ivNoCookie=1';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.be.undefined;
     });
 
-    it('doesnt send the domain id if not graduated', () => {
+    it('doesnt send the domain id if not graduated', function () {
       global.document.cookie = 'ivbsdid={"id":"dvdjkams6nkq","cr":1522929537626,"hc":1}';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.not.exist;
     });
 
-    it('graduate and send the domain id', () => {
+    it('graduate and send the domain id', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivbsdid={"id":"dvdjkams6nkq","cr":1521818537626,"hc":7}';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.exist;
     });
 
-    it('send the domain id if already graduated', () => {
+    it('send the domain id if already graduated', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivbsdid={"id":"f8zoh044p9oi"}';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.exist;
     });
 
-    it('send the domain id after replacing it with new format', () => {
+    it('send the domain id after replacing it with new format', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivbsdid={"id":"f8zoh044p9oi.8537626"}';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.exist;
     });
 
-    it('try to graduate but not enough count - doesnt send the domain id', () => {
+    it('try to graduate but not enough count - doesnt send the domain id', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivbsdid={"id":"dvdjkams6nkq","cr":1521818537626,"hc":5}';
       let request = spec.buildRequests(bidRequests);
       expect(request.data.lId).to.not.exist;
     });
 
-    it('try to graduate but not old enough - doesnt send the domain id', () => {
+    it('try to graduate but not old enough - doesnt send the domain id', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivbsdid={"id":"dvdjkams6nkq","cr":' + Date.now() + ',"hc":5}';
       let request = spec.buildRequests(bidRequests);
@@ -194,55 +194,55 @@ describe('invibesBidAdapter:', function () {
     }];
 
     context('when the response is not valid', function () {
-      it('handles response with no bids requested', () => {
+      it('handles response with no bids requested', function () {
         let emptyResult = spec.interpretResponse({ body: response });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles empty response', () => {
+      it('handles empty response', function () {
         let emptyResult = spec.interpretResponse(null, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles response with bidding is not configured', () => {
+      it('handles response with bidding is not configured', function () {
         let emptyResult = spec.interpretResponse({ body: { Ads: [{ BidPrice: 1 }] } }, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles response with no ads are received', () => {
+      it('handles response with no ads are received', function () {
         let emptyResult = spec.interpretResponse({ body: { BidModel: { PlacementId: '12345' }, AdReason: 'No ads' } }, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles response with no ads are received - no ad reason', () => {
+      it('handles response with no ads are received - no ad reason', function () {
         let emptyResult = spec.interpretResponse({ body: { BidModel: { PlacementId: '12345' } } }, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles response when no placement Id matches', () => {
+      it('handles response when no placement Id matches', function () {
         let emptyResult = spec.interpretResponse({ body: { BidModel: { PlacementId: '123456' }, Ads: [{ BidPrice: 1 }] } }, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
 
-      it('handles response when placement Id is not present', () => {
+      it('handles response when placement Id is not present', function () {
         let emptyResult = spec.interpretResponse({ BidModel: { }, Ads: [{ BidPrice: 1 }] }, { bidRequests });
         expect(emptyResult).to.be.empty;
       });
     });
 
     context('when the response is valid', function () {
-      it('responds with a valid bid', () => {
+      it('responds with a valid bid', function () {
         let result = spec.interpretResponse({ body: response }, { bidRequests });
         expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
       });
 
-      it('responds with a valid bid and uses logger', () => {
+      it('responds with a valid bid and uses logger', function () {
         localStorage.InvibesDEBUG = true;
         let result = spec.interpretResponse({ body: response }, { bidRequests });
         expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
       });
 
-      it('does not make multiple bids', () => {
+      it('does not make multiple bids', function () {
         localStorage.InvibesDEBUG = false;
         let result = spec.interpretResponse({ body: response }, { bidRequests });
         let secondResult = spec.interpretResponse({ body: response }, { bidRequests });
@@ -252,13 +252,13 @@ describe('invibesBidAdapter:', function () {
   });
 
   describe('getUserSyncs', function () {
-    it('returns an iframe if enabled', () => {
+    it('returns an iframe if enabled', function () {
       let response = spec.getUserSyncs({iframeEnabled: true});
       expect(response.type).to.equal('iframe');
       expect(response.url).to.include(SYNC_ENDPOINT);
     });
 
-    it('returns an iframe with params if enabled', () => {
+    it('returns an iframe with params if enabled', function () {
       top.window.invibes.optIn = 1;
       global.document.cookie = 'ivvbks=17639.0,1,2';
       let response = spec.getUserSyncs({ iframeEnabled: true });
@@ -269,7 +269,7 @@ describe('invibesBidAdapter:', function () {
       expect(response.url).to.include('ivbsdid');
     });
 
-    it('returns undefined if iframe not enabled ', () => {
+    it('returns undefined if iframe not enabled ', function () {
       let response = spec.getUserSyncs({ iframeEnabled: false });
       expect(response).to.equal(undefined);
     });

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -86,7 +86,7 @@ describe('invibesBidAdapter:', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('sends bid request to ENDPOINT via GET', () => {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);

--- a/test/spec/modules/iqmBidAdapter_spec.js
+++ b/test/spec/modules/iqmBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/iqmBidAdapter'
 import * as utils from 'src/utils';
 
-describe('iqmBidAdapter', () => {
+describe('iqmBidAdapter', function () {
   const ENDPOINT_URL = 'https://pbd.bids.iqm.com';
   const bidRequests = [{
     bidder: 'iqm',
@@ -80,7 +80,7 @@ describe('iqmBidAdapter', () => {
     headers: {}
   };
 
-  describe('Request verification', () => {
+  describe('Request verification', function () {
     it('basic property verification', () => {
       expect(spec.code).to.equal('iqm');
       expect(spec.aliases).to.be.an('array');
@@ -88,7 +88,7 @@ describe('iqmBidAdapter', () => {
       expect(spec.aliases).to.have.lengthOf(1);
     });
 
-    describe('isBidRequestValid', () => {
+    describe('isBidRequestValid', function () {
       let bid = {
         'bidder': 'iqm',
         'params': {
@@ -127,7 +127,7 @@ describe('iqmBidAdapter', () => {
       });
     });
 
-    describe('buildRequests', () => {
+    describe('buildRequests', function () {
       it('sends every bid request to ENDPOINT_URL via POST method', () => {
         const requests = spec.buildRequests(bidRequests);
         expect(requests[0].method).to.equal('POST');
@@ -175,7 +175,7 @@ describe('iqmBidAdapter', () => {
       });
     });
 
-    describe('interpretResponse', () => {
+    describe('interpretResponse', function () {
       it('should handle no bid response', () => {
         const response = spec.interpretResponse({ body: null }, { bidRequests });
         expect(response.length).to.equal(0);

--- a/test/spec/modules/iqmBidAdapter_spec.js
+++ b/test/spec/modules/iqmBidAdapter_spec.js
@@ -81,7 +81,7 @@ describe('iqmBidAdapter', function () {
   };
 
   describe('Request verification', function () {
-    it('basic property verification', () => {
+    it('basic property verification', function () {
       expect(spec.code).to.equal('iqm');
       expect(spec.aliases).to.be.an('array');
       // expect(spec.aliases).to.be.ofSize(1);
@@ -103,17 +103,17 @@ describe('iqmBidAdapter', function () {
         'auctionId': '1d1a030790a475'
       };
 
-      it('should return false for empty object', () => {
+      it('should return false for empty object', function () {
         expect(spec.isBidRequestValid({})).to.equal(false);
       });
 
-      it('should return false for request without param', () => {
+      it('should return false for request without param', function () {
         let bid = Object.assign({}, bid);
         delete bid.params;
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       });
 
-      it('should return false for invalid params', () => {
+      it('should return false for invalid params', function () {
         let bid = Object.assign({}, bid);
         delete bid.params;
         bid.params = {
@@ -122,13 +122,13 @@ describe('iqmBidAdapter', function () {
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       });
 
-      it('should return true for proper request', () => {
+      it('should return true for proper request', function () {
         expect(spec.isBidRequestValid(bid)).to.equal(true);
       });
     });
 
     describe('buildRequests', function () {
-      it('sends every bid request to ENDPOINT_URL via POST method', () => {
+      it('sends every bid request to ENDPOINT_URL via POST method', function () {
         const requests = spec.buildRequests(bidRequests);
         expect(requests[0].method).to.equal('POST');
         expect(requests[0].url).to.equal(ENDPOINT_URL);
@@ -136,7 +136,7 @@ describe('iqmBidAdapter', function () {
         // expect(requests[1].url).to.equal(ENDPOINT_URL);
       });
 
-      it('should send request data with every request', () => {
+      it('should send request data with every request', function () {
         const requests = spec.buildRequests(bidRequests);
         const data = requests[0].data;
         expect(data.id).to.equal(bidRequests[0].requestId);
@@ -176,30 +176,30 @@ describe('iqmBidAdapter', function () {
     });
 
     describe('interpretResponse', function () {
-      it('should handle no bid response', () => {
+      it('should handle no bid response', function () {
         const response = spec.interpretResponse({ body: null }, { bidRequests });
         expect(response.length).to.equal(0);
       });
 
-      it('should have at least one Seat Object', () => {
+      it('should have at least one Seat Object', function () {
         const request = spec.buildRequests(bidRequests);
         const response = spec.interpretResponse(bidResponseEmptySeat, request);
         expect(response.length).to.equal(0);
       });
 
-      it('should have at least one Bid Object', () => {
+      it('should have at least one Bid Object', function () {
         const request = spec.buildRequests(bidRequests);
         const response = spec.interpretResponse(bidResponseEmptyBid, request);
         expect(response.length).to.equal(0);
       });
 
-      it('should have impId in Bid Object', () => {
+      it('should have impId in Bid Object', function () {
         const request = spec.buildRequests(bidRequests);
         const response = spec.interpretResponse(bidResponseNoImpId, request);
         expect(response.length).to.equal(0);
       });
 
-      it('should handle valid response', () => {
+      it('should handle valid response', function () {
         const request = spec.buildRequests(bidRequests);
         const response = spec.interpretResponse(bidResponses, request);
         expect(response).to.be.an('array').to.have.lengthOf(1);

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -59,43 +59,43 @@ describe('IndexexchangeAdapter', function () {
   };
 
   describe('inherited functions', function () {
-    it('should exists and is a function', () => {
+    it('should exists and is a function', function () {
       const adapter = newBidder(spec);
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found for a banner ad', () => {
+    it('should return true when required params found for a banner ad', function () {
       expect(spec.isBidRequestValid(DEFAULT_BANNER_VALID_BID[0])).to.equal(true);
     });
 
-    it('should return true when optional params found for a banner ad', () => {
+    it('should return true when optional params found for a banner ad', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloor = 50;
       bid.params.bidFloorCur = 'USD';
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when siteID is number', () => {
+    it('should return true when siteID is number', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.siteId = 123;
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when siteID is missing', () => {
+    it('should return false when siteID is missing', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.params.siteId;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when size is missing', () => {
+    it('should return false when size is missing', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.params.size;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when size array is wrong length', () => {
+    it('should return false when size array is wrong length', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.size = [
         300,
@@ -105,13 +105,13 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when size array is array of strings', () => {
+    it('should return false when size array is array of strings', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.size = ['300', '250'];
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when mediaTypes is not banner', () => {
+    it('should return false when mediaTypes is not banner', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.mediaTypes = {
         video: {
@@ -121,7 +121,7 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when mediaTypes.banner does not have sizes', () => {
+    it('should return false when mediaTypes.banner does not have sizes', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.mediaTypes = {
         banner: {
@@ -131,7 +131,7 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when mediaType is not banner', () => {
+    it('should return false when mediaType is not banner', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.params.mediaTypes;
       bid.mediaType = 'banne';
@@ -139,7 +139,7 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when mediaType is video', () => {
+    it('should return false when mediaType is video', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.params.mediaTypes;
       bid.mediaType = 'video';
@@ -147,7 +147,7 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when mediaType is native', () => {
+    it('should return false when mediaType is native', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.params.mediaTypes;
       bid.mediaType = 'native';
@@ -155,14 +155,14 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return true when mediaType is missing and has sizes', () => {
+    it('should return true when mediaType is missing and has sizes', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.mediaTypes;
       bid.sizes = [[300, 250]];
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when mediaType is banner', () => {
+    it('should return true when mediaType is banner', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       delete bid.mediaTypes;
       bid.mediaType = 'banner';
@@ -170,26 +170,26 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when there is only bidFloor', () => {
+    it('should return false when there is only bidFloor', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloor = 50;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when there is only bidFloorCur', () => {
+    it('should return false when there is only bidFloorCur', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloorCur = 'USD';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when bidFloor is string', () => {
+    it('should return false when bidFloor is string', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloor = '50';
       bid.params.bidFloorCur = 'USD';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when bidFloorCur is number', () => {
+    it('should return false when bidFloorCur is number', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloor = 50;
       bid.params.bidFloorCur = 70;
@@ -209,12 +209,12 @@ describe('IndexexchangeAdapter', function () {
     const requestWithoutMediaType = spec.buildRequests(bidWithoutMediaType);
     const queryWithoutMediaType = requestWithoutMediaType.data;
 
-    it('request should be made to IX endpoint with GET method', () => {
+    it('request should be made to IX endpoint with GET method', function () {
       expect(requestMethod).to.equal('GET');
       expect(requestUrl).to.equal(IX_ENDPOINT);
     });
 
-    it('query object (version, siteID and request) should be correct', () => {
+    it('query object (version, siteID and request) should be correct', function () {
       expect(query.v).to.equal(BIDDER_VERSION);
       expect(query.s).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
       expect(query.r).to.exist;
@@ -222,7 +222,7 @@ describe('IndexexchangeAdapter', function () {
       expect(query.sd).to.equal(1);
     });
 
-    it('payload should have correct format and value', () => {
+    it('payload should have correct format and value', function () {
       const payload = JSON.parse(query.r);
 
       expect(payload.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidderRequestId);
@@ -238,7 +238,7 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.imp).to.have.lengthOf(1);
     });
 
-    it('impression should have correct format and value', () => {
+    it('impression should have correct format and value', function () {
       const impression = JSON.parse(query.r).imp[0];
       const sidValue = `${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`;
 
@@ -253,7 +253,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal(sidValue);
     });
 
-    it('impression should have bidFloor and bidFloorCur if configured', () => {
+    it('impression should have bidFloor and bidFloorCur if configured', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.bidFloor = 50;
       bid.params.bidFloorCur = 'USD';
@@ -264,7 +264,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
     });
 
-    it('payload without mediaType should have correct format and value', () => {
+    it('payload without mediaType should have correct format and value', function () {
       const payload = JSON.parse(queryWithoutMediaType.r);
 
       expect(payload.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidderRequestId);
@@ -280,7 +280,7 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.imp).to.have.lengthOf(1);
     });
 
-    it('impression without mediaType should have correct format and value', () => {
+    it('impression without mediaType should have correct format and value', function () {
       const impression = JSON.parse(queryWithoutMediaType.r).imp[0];
       const sidValue = `${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`;
 
@@ -295,7 +295,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal(sidValue);
     });
 
-    it('impression should have sid if id is configured as number', () => {
+    it('impression should have sid if id is configured as number', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.id = 50;
       const requestBidFloor = spec.buildRequests([bid]);
@@ -312,7 +312,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal('50');
     });
 
-    it('impression should have sid if id is configured as string', () => {
+    it('impression should have sid if id is configured as string', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.id = 'abc';
       const requestBidFloor = spec.buildRequests([bid]);
@@ -328,7 +328,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal('abc');
     });
 
-    it('should add first party data to page url in bid request if it exists in config', () => {
+    it('should add first party data to page url in bid request if it exists in config', function () {
       config.setConfig({
         ix: {
           firstPartyData: {
@@ -347,7 +347,7 @@ describe('IndexexchangeAdapter', function () {
       expect(pageUrl).to.equal(expectedPageUrl);
     });
 
-    it('should not set first party data if it is not an object', () => {
+    it('should not set first party data if it is not an object', function () {
       config.setConfig({
         ix: {
           firstPartyData: 500
@@ -360,7 +360,7 @@ describe('IndexexchangeAdapter', function () {
       expect(pageUrl).to.equal(utils.getTopWindowUrl());
     });
 
-    it('should not set first party or timeout if it is not present', () => {
+    it('should not set first party or timeout if it is not present', function () {
       config.setConfig({
         ix: {}
       });
@@ -372,7 +372,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithoutConfig.data.t).to.be.undefined;
     });
 
-    it('should not set first party or timeout if it is setConfig is not called', () => {
+    it('should not set first party or timeout if it is setConfig is not called', function () {
       const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID);
       const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
 
@@ -380,7 +380,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithoutConfig.data.t).to.be.undefined;
     });
 
-    it('should set timeout if publisher set it through setConfig', () => {
+    it('should set timeout if publisher set it through setConfig', function () {
       config.setConfig({
         ix: {
           timeout: 500
@@ -391,7 +391,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithTimeout.data.t).to.equal(500);
     });
 
-    it('should set timeout if timeout is a string', () => {
+    it('should set timeout if timeout is a string', function () {
       config.setConfig({
         ix: {
           timeout: '500'
@@ -404,7 +404,7 @@ describe('IndexexchangeAdapter', function () {
   });
 
   describe('interpretResponseBanner', function () {
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const expectedParse = [
         {
           requestId: '1a2b3c4d',
@@ -423,7 +423,7 @@ describe('IndexexchangeAdapter', function () {
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
-    it('should set creativeId to default value if not provided', () => {
+    it('should set creativeId to default value if not provided', function () {
       const bidResponse = utils.deepClone(DEFAULT_BANNER_BID_RESPONSE);
       delete bidResponse.seatbid[0].bid[0].crid;
       const expectedParse = [
@@ -444,7 +444,7 @@ describe('IndexexchangeAdapter', function () {
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
-    it('should set Japanese price correctly', () => {
+    it('should set Japanese price correctly', function () {
       const bidResponse = utils.deepClone(DEFAULT_BANNER_BID_RESPONSE);
       bidResponse.cur = 'JPY';
       const expectedParse = [
@@ -465,7 +465,7 @@ describe('IndexexchangeAdapter', function () {
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
-    it('should set dealId correctly', () => {
+    it('should set dealId correctly', function () {
       const bidResponse = utils.deepClone(DEFAULT_BANNER_BID_RESPONSE);
       bidResponse.seatbid[0].bid[0].ext.dealid = 'deal';
       const expectedParse = [
@@ -486,7 +486,7 @@ describe('IndexexchangeAdapter', function () {
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
-    it('bidrequest should have consent info if gdprApplies and consentString exist', () => {
+    it('bidrequest should have consent info if gdprApplies and consentString exist', function () {
       const options = {
         gdprConsent: {
           gdprApplies: true,
@@ -501,7 +501,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithConsent.user.ext.consent).to.equal('3huaa11=qu3198ae');
     });
 
-    it('bidrequest should not have consent field if consentString is undefined', () => {
+    it('bidrequest should not have consent field if consentString is undefined', function () {
       const options = {
         gdprConsent: {
           gdprApplies: true,
@@ -515,7 +515,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithConsent.user).to.be.undefined;
     });
 
-    it('bidrequest should not have gdpr field if gdprApplies is undefined', () => {
+    it('bidrequest should not have gdpr field if gdprApplies is undefined', function () {
       const options = {
         gdprConsent: {
           consentString: '3huaa11=qu3198ae',
@@ -529,7 +529,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requestWithConsent.user.ext.consent).to.equal('3huaa11=qu3198ae');
     });
 
-    it('bidrequest should not have consent info if options.gdprConsent is undefined', () => {
+    it('bidrequest should not have consent info if options.gdprConsent is undefined', function () {
       const options = {};
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
       const requestWithConsent = JSON.parse(validBidWithConsent.data.r);

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { spec } from 'modules/ixBidAdapter';
 
-describe('IndexexchangeAdapter', () => {
+describe('IndexexchangeAdapter', function () {
   const IX_ENDPOINT = 'http://as.casalemedia.com/cygnus';
   const BIDDER_VERSION = 7.2;
 
@@ -58,14 +58,14 @@ describe('IndexexchangeAdapter', () => {
     ]
   };
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('should exists and is a function', () => {
       const adapter = newBidder(spec);
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found for a banner ad', () => {
       expect(spec.isBidRequestValid(DEFAULT_BANNER_VALID_BID[0])).to.equal(true);
     });
@@ -197,7 +197,7 @@ describe('IndexexchangeAdapter', () => {
     });
   });
 
-  describe('buildRequestsBanner', () => {
+  describe('buildRequestsBanner', function () {
     const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID);
     const requestUrl = request.url;
     const requestMethod = request.method;
@@ -403,7 +403,7 @@ describe('IndexexchangeAdapter', () => {
     });
   });
 
-  describe('interpretResponseBanner', () => {
+  describe('interpretResponseBanner', function () {
     it('should get correct bid response', () => {
       const expectedParse = [
         {

--- a/test/spec/modules/jcmBidAdapter_spec.js
+++ b/test/spec/modules/jcmBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('jcmAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('jcmAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
@@ -55,11 +55,11 @@ describe('jcmAdapter', function () {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       expect(request.method).to.equal('GET');
     });
 
-    it('sends correct bid parameters', () => {
+    it('sends correct bid parameters', function () {
       const payloadArr = request.data.split('&');
       expect(request.method).to.equal('GET');
       expect(payloadArr.length).to.equal(4);
@@ -76,7 +76,7 @@ describe('jcmAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let serverResponse = {'bids': [{'width': 300, 'height': 250, 'creativeId': '29681110', 'ad': '<!-- Creative -->', 'cpm': 0.5, 'callbackId': '30b31c1838de1e'}]};
 
       let expectedResponse = [
@@ -109,7 +109,7 @@ describe('jcmAdapter', function () {
       expect(Object.keys(result[0]).ad).to.equal(Object.keys(expectedResponse[0]).ad);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let serverResponse = {'bids': []};
 
       let result = spec.interpretResponse({ body: serverResponse });
@@ -117,7 +117,7 @@ describe('jcmAdapter', function () {
     });
   });
   describe('getUserSyncs', function () {
-    it('Verifies sync iframe option', () => {
+    it('Verifies sync iframe option', function () {
       expect(spec.getUserSyncs({})).to.be.undefined;
       expect(spec.getUserSyncs({ iframeEnabled: false })).to.be.undefined;
       const options = spec.getUserSyncs({ iframeEnabled: true });
@@ -127,7 +127,7 @@ describe('jcmAdapter', function () {
       expect(options[0].url).to.equal('//media.adfrontiers.com/hb/jcm_usersync.html');
     });
 
-    it('Verifies sync image option', () => {
+    it('Verifies sync image option', function () {
       expect(spec.getUserSyncs({ image: false })).to.be.undefined;
       const options = spec.getUserSyncs({ image: true });
       expect(options).to.not.be.undefined;

--- a/test/spec/modules/jcmBidAdapter_spec.js
+++ b/test/spec/modules/jcmBidAdapter_spec.js
@@ -4,16 +4,16 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT = '//media.adfrontiers.com/';
 
-describe('jcmAdapter', () => {
+describe('jcmAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'jcm',
       'params': {
@@ -37,7 +37,7 @@ describe('jcmAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'jcm',
@@ -75,7 +75,7 @@ describe('jcmAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should get correct bid response', () => {
       let serverResponse = {'bids': [{'width': 300, 'height': 250, 'creativeId': '29681110', 'ad': '<!-- Creative -->', 'cpm': 0.5, 'callbackId': '30b31c1838de1e'}]};
 
@@ -116,7 +116,7 @@ describe('jcmAdapter', () => {
       expect(result.length).to.equal(0);
     });
   });
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     it('Verifies sync iframe option', () => {
       expect(spec.getUserSyncs({})).to.be.undefined;
       expect(spec.getUserSyncs({ iframeEnabled: false })).to.be.undefined;

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -22,11 +22,11 @@ describe('justpremium adapter', function () {
   ]
 
   describe('isBidRequestValid', function () {
-    it('Verifies bidder code', () => {
+    it('Verifies bidder code', function () {
       expect(spec.code).to.equal('justpremium')
     })
 
-    it('Verify build request', () => {
+    it('Verify build request', function () {
       expect(spec.isBidRequestValid({bidder: 'justpremium', params: {}})).to.equal(false)
       expect(spec.isBidRequestValid({})).to.equal(false)
       expect(spec.isBidRequestValid(adUnits[0])).to.equal(true)
@@ -35,7 +35,7 @@ describe('justpremium adapter', function () {
   })
 
   describe('buildRequests', function () {
-    it('Verify build request and parameters', () => {
+    it('Verify build request and parameters', function () {
       const request = spec.buildRequests(adUnits)
       expect(request.method).to.equal('POST')
       expect(request.url).to.match(/pre.ads.justpremium.com\/v\/2.0\/t\/xhr/)
@@ -59,7 +59,7 @@ describe('justpremium adapter', function () {
 
   describe('interpretResponse', function () {
     const request = spec.buildRequests(adUnits)
-    it('Verify server response', () => {
+    it('Verify server response', function () {
       let response = {
         'bid': {
           '28313': [{
@@ -107,7 +107,7 @@ describe('justpremium adapter', function () {
       expect(result[0].format).to.equal('lb')
     })
 
-    it('Verify wrong server response', () => {
+    it('Verify wrong server response', function () {
       let response = {
         'bid': {
           '28313': []
@@ -123,7 +123,7 @@ describe('justpremium adapter', function () {
   })
 
   describe('getUserSyncs', function () {
-    it('Verifies sync options', () => {
+    it('Verifies sync options', function () {
       const options = spec.getUserSyncs({iframeEnabled: true})
       expect(options).to.not.be.undefined
       expect(options[0].type).to.equal('iframe')

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { spec } from 'modules/justpremiumBidAdapter'
 
-describe('justpremium adapter', () => {
+describe('justpremium adapter', function () {
   let adUnits = [
     {
       adUnitCode: 'div-gpt-ad-1471513102552-1',
@@ -21,7 +21,7 @@ describe('justpremium adapter', () => {
     },
   ]
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Verifies bidder code', () => {
       expect(spec.code).to.equal('justpremium')
     })
@@ -34,7 +34,7 @@ describe('justpremium adapter', () => {
     })
   })
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('Verify build request and parameters', () => {
       const request = spec.buildRequests(adUnits)
       expect(request.method).to.equal('POST')
@@ -57,7 +57,7 @@ describe('justpremium adapter', () => {
     })
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const request = spec.buildRequests(adUnits)
     it('Verify server response', () => {
       let response = {
@@ -122,7 +122,7 @@ describe('justpremium adapter', () => {
     })
   })
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     it('Verifies sync options', () => {
       const options = spec.getUserSyncs({iframeEnabled: true})
       expect(options).to.not.be.undefined
@@ -131,7 +131,7 @@ describe('justpremium adapter', () => {
     })
   })
 
-  describe('onTimeout', () => {
+  describe('onTimeout', function () {
     it('onTimeout', (done) => {
       spec.onTimeout([{
         'bidId': '25cd3ec3fd6ed7',

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -6,12 +6,12 @@ import {config} from 'src/config';
 describe('kargo adapter tests', function () {
   var sandbox, clock, frozenNow = new Date();
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     clock = sinon.useFakeTimers(frozenNow.getTime());
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
     clock.restore();
   });
@@ -37,7 +37,7 @@ describe('kargo adapter tests', function () {
   describe('build request', function() {
     var bids, cookies = [], localStorageItems = [];
 
-    beforeEach(() => {
+    beforeEach(function () {
       sandbox.stub(config, 'getConfig').callsFake(function(key) {
         if (key === 'currency') {
           return 'USD';
@@ -67,7 +67,7 @@ describe('kargo adapter tests', function () {
       ];
     });
 
-    afterEach(() => {
+    afterEach(function () {
       for (let key in cookies) {
         let cookie = cookies[key];
         removeCookie(cookie);

--- a/test/spec/modules/komoonaBidAdapter_spec.js
+++ b/test/spec/modules/komoonaBidAdapter_spec.js
@@ -54,11 +54,11 @@ describe('Komoona.com Adapter Tests', function () {
     }
   };
 
-  it('Verifies komoonaAdapter bidder code', () => {
+  it('Verifies komoonaAdapter bidder code', function () {
     expect(spec.code).to.equal('komoona');
   });
 
-  it('Verifies komoonaAdapter bid request validation', () => {
+  it('Verifies komoonaAdapter bid request validation', function () {
     expect(spec.isBidRequestValid(bidsRequest[0])).to.equal(true);
     expect(spec.isBidRequestValid(bidsRequest[1])).to.equal(true);
     expect(spec.isBidRequestValid({})).to.equal(false);
@@ -69,7 +69,7 @@ describe('Komoona.com Adapter Tests', function () {
     expect(spec.isBidRequestValid({ params: { hbid: 12345, placementId: 67890, floorPrice: 0.8 } })).to.equal(true);
   });
 
-  it('Verify komoonaAdapter build request', () => {
+  it('Verify komoonaAdapter build request', function () {
     var startTime = new Date().getTime();
 
     const request = spec.buildRequests(bidsRequest);
@@ -127,7 +127,7 @@ describe('Komoona.com Adapter Tests', function () {
     expect(kbConf.hb_placements[1]).to.equal(bids[1].placementid);
   });
 
-  it('Verify komoonaAdapter build response', () => {
+  it('Verify komoonaAdapter build response', function () {
     const request = spec.buildRequests(bidsRequest);
     const bids = spec.interpretResponse(bidsResponse, request);
 
@@ -150,7 +150,7 @@ describe('Komoona.com Adapter Tests', function () {
     expect(bid.creativeId).to.equal(responseBids[0].creativeId);
   });
 
-  it('Verifies komoonaAdapter sync options', () => {
+  it('Verifies komoonaAdapter sync options', function () {
     // user sync disabled
     expect(spec.getUserSyncs({})).to.be.undefined;
     expect(spec.getUserSyncs({ iframeEnabled: false })).to.be.undefined;

--- a/test/spec/modules/komoonaBidAdapter_spec.js
+++ b/test/spec/modules/komoonaBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/komoonaBidAdapter';
 
-describe('Komoona.com Adapter Tests', () => {
+describe('Komoona.com Adapter Tests', function () {
   const bidsRequest = [
     {
       bidder: 'komoona',

--- a/test/spec/modules/kummaBidAdapter_spec.js
+++ b/test/spec/modules/kummaBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/kummaBidAdapter';
 import {getTopWindowLocation} from 'src/utils';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-describe('Kumma Adapter Tests', () => {
+describe('Kumma Adapter Tests', function () {
   const slotConfigs = [{
     placementCode: '/DfpAccount1/slot1',
     sizes: [[300, 250]],

--- a/test/spec/modules/kummaBidAdapter_spec.js
+++ b/test/spec/modules/kummaBidAdapter_spec.js
@@ -77,7 +77,7 @@ describe('Kumma Adapter Tests', function () {
     }
   }];
 
-  it('Verify build request', () => {
+  it('Verify build request', function () {
     const request = spec.buildRequests(slotConfigs);
     expect(request.url).to.equal('//hb.kumma.com/');
     expect(request.method).to.equal('POST');
@@ -109,7 +109,7 @@ describe('Kumma Adapter Tests', function () {
     expect(ortbRequest.imp[1].bidfloor).to.equal('0.000001');
   });
 
-  it('Verify parse response', () => {
+  it('Verify parse response', function () {
     const request = spec.buildRequests(slotConfigs);
     const ortbRequest = JSON.parse(request.data);
     const ortbResponse = {
@@ -137,13 +137,13 @@ describe('Kumma Adapter Tests', function () {
     expect(bid.ttl).to.equal(360);
   });
 
-  it('Verify full passback', () => {
+  it('Verify full passback', function () {
     const request = spec.buildRequests(slotConfigs);
     const bids = spec.interpretResponse({ body: null }, request)
     expect(bids).to.have.lengthOf(0);
   });
 
-  it('Verify Native request', () => {
+  it('Verify Native request', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//hb.kumma.com/');
     expect(request.method).to.equal('POST');
@@ -181,7 +181,7 @@ describe('Kumma Adapter Tests', function () {
     expect(nativeRequest.assets[4].img.type).to.equal(3);
   });
 
-  it('Verify Native response', () => {
+  it('Verify Native response', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//hb.kumma.com/');
     expect(request.method).to.equal('POST');
@@ -231,7 +231,7 @@ describe('Kumma Adapter Tests', function () {
     expect(nativeBid.impressionTrackers[0]).to.equal('http://rtb.adx1.com/log');
   });
 
-  it('Verify Video request', () => {
+  it('Verify Video request', function () {
     const request = spec.buildRequests(videoSlotConfig);
     expect(request.url).to.equal('//hb.kumma.com/');
     expect(request.method).to.equal('POST');
@@ -253,7 +253,7 @@ describe('Kumma Adapter Tests', function () {
     expect(videoRequest.imp[0].native).to.equal(null);
   });
 
-  it('Verify parse video response', () => {
+  it('Verify parse video response', function () {
     const request = spec.buildRequests(videoSlotConfig);
     const videoRequest = JSON.parse(request.data);
     const videoResponse = {
@@ -282,25 +282,25 @@ describe('Kumma Adapter Tests', function () {
     expect(bid.ttl).to.equal(360);
   });
 
-  it('Verifies bidder code', () => {
+  it('Verifies bidder code', function () {
     expect(spec.code).to.equal('kumma');
   });
 
-  it('Verifies supported media types', () => {
+  it('Verifies supported media types', function () {
     expect(spec.supportedMediaTypes).to.have.lengthOf(3);
     expect(spec.supportedMediaTypes[0]).to.equal('banner');
     expect(spec.supportedMediaTypes[1]).to.equal('native');
     expect(spec.supportedMediaTypes[2]).to.equal('video');
   });
 
-  it('Verifies if bid request valid', () => {
+  it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(slotConfigs[0])).to.equal(true);
     expect(spec.isBidRequestValid(slotConfigs[1])).to.equal(true);
     expect(spec.isBidRequestValid(nativeSlotConfig[0])).to.equal(true);
     expect(spec.isBidRequestValid(videoSlotConfig[0])).to.equal(true);
   });
 
-  it('Verify app requests', () => {
+  it('Verify app requests', function () {
     const request = spec.buildRequests(appSlotConfig);
     const ortbRequest = JSON.parse(request.data);
     expect(ortbRequest.site).to.equal(null);
@@ -314,7 +314,7 @@ describe('Kumma Adapter Tests', function () {
     expect(ortbRequest.app.domain).to.equal('kumma.com');
   });
 
-  it('Verify GDPR', () => {
+  it('Verify GDPR', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,

--- a/test/spec/modules/lifestreetBidAdapter_spec.js
+++ b/test/spec/modules/lifestreetBidAdapter_spec.js
@@ -61,40 +61,40 @@ describe('LifestreetAdapter', function () {
   const ADAPTER_VERSION = 'prebidJS-2.0';
 
   describe('buildRequests()', function () {
-    it('method exists and is a function', () => {
+    it('method exists and is a function', function () {
       expect(spec.buildRequests).to.exist.and.to.be.a('function');
     });
 
-    it('should not return request when no bids are present', () => {
+    it('should not return request when no bids are present', function () {
       let [request] = spec.buildRequests([]);
       expect(request).to.be.empty;
     });
 
     let bidRequest = getDefaultBidRequest();
     let [request] = spec.buildRequests(bidRequest.bids);
-    it('should return request for Lifestreet endpoint', () => {
+    it('should return request for Lifestreet endpoint', function () {
       expect(request.url).to.contain(LIFESTREET_URL);
     });
 
-    it('should use json adapter', () => {
+    it('should use json adapter', function () {
       expect(request.url).to.contain('/prebid/');
     });
 
-    it('should contain slot', () => {
+    it('should contain slot', function () {
       expect(request.url).to.contain('slot166704');
     });
-    it('should contain adkey', () => {
+    it('should contain adkey', function () {
       expect(request.url).to.contain('adkey=78c');
     });
-    it('should contain ad_size', () => {
+    it('should contain ad_size', function () {
       expect(request.url).to.contain('ad_size=160x600');
     });
 
-    it('should contain location and rferrer paramters', () => {
+    it('should contain location and rferrer paramters', function () {
       expect(request.url).to.contain('__location=');
       expect(request.url).to.contain('__referrer=');
     });
-    it('should contain info parameters', () => {
+    it('should contain info parameters', function () {
       expect(request.url).to.contain('__wn=');
       expect(request.url).to.contain('__sf=');
       expect(request.url).to.contain('__fif=');
@@ -103,24 +103,24 @@ describe('LifestreetAdapter', function () {
       expect(request.url).to.contain('__pp=');
     });
 
-    it('should contain HB enabled', () => {
+    it('should contain HB enabled', function () {
       expect(request.url).to.contain('__hb=1');
     });
-    it('should include gzip', () => {
+    it('should include gzip', function () {
       expect(request.url).to.contain('__gz=1');
     });
-    it('should not contain __gdpr parameter', () => {
+    it('should not contain __gdpr parameter', function () {
       expect(request.url).to.not.contain('__gdpr');
     });
-    it('should not contain __concent parameter', () => {
+    it('should not contain __concent parameter', function () {
       expect(request.url).to.not.contain('__consent');
     });
 
-    it('should contain the right version of adapter', () => {
+    it('should contain the right version of adapter', function () {
       expect(request.url).to.contain('__hbver=' + ADAPTER_VERSION);
     });
 
-    it('should contain __gdpr and __consent parameters', () => {
+    it('should contain __gdpr and __consent parameters', function () {
       const options = {
         gdprConsent: {
           gdprApplies: true,
@@ -132,7 +132,7 @@ describe('LifestreetAdapter', function () {
       expect(request.url).to.contain('__gdpr=1');
       expect(request.url).to.contain('__consent=test');
     });
-    it('should contain __gdpr parameters', () => {
+    it('should contain __gdpr parameters', function () {
       const options = {
         gdprConsent: {
           gdprApplies: true,
@@ -143,7 +143,7 @@ describe('LifestreetAdapter', function () {
       expect(request.url).to.contain('__gdpr=1');
       expect(request.url).to.not.contain('__consent');
     });
-    it('should contain __consent parameters', () => {
+    it('should contain __consent parameters', function () {
       const options = {
         gdprConsent: {
           consentString: 'test',
@@ -156,7 +156,7 @@ describe('LifestreetAdapter', function () {
     });
   });
   describe('interpretResponse()', function () {
-    it('should return formatted bid response with required properties', () => {
+    it('should return formatted bid response with required properties', function () {
       let bidRequest = getDefaultBidRequest().bids[0];
       let bidResponse = { body: getDefaultBidResponse(true) };
       let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
@@ -174,7 +174,7 @@ describe('LifestreetAdapter', function () {
         mediaType: 'banner'
       }]);
     });
-    it('should return formatted VAST bid response with required properties', () => {
+    it('should return formatted VAST bid response with required properties', function () {
       let bidRequest = getDefaultBidRequest().bids[0];
       let bidResponse = { body: getDefaultBidResponse(false) };
       let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);
@@ -192,7 +192,7 @@ describe('LifestreetAdapter', function () {
         mediaType: 'video'
       }]);
     });
-    it('should return formatted VAST bid response with vastUrl', () => {
+    it('should return formatted VAST bid response with vastUrl', function () {
       let bidRequest = getDefaultBidRequest().bids[0];
       let bidResponse = { body: getDefaultBidResponse(false) };
       bidResponse.body.vastUrl = 'http://lifestreet.com'; // set vastUrl
@@ -212,7 +212,7 @@ describe('LifestreetAdapter', function () {
       }]);
     });
 
-    it('should return no-bid', () => {
+    it('should return no-bid', function () {
       let bidRequest = getDefaultBidRequest().bids[0];
       let bidResponse = { body: getDefaultBidResponse(true, true) };
       let formattedBidResponse = spec.interpretResponse(bidResponse, bidRequest);

--- a/test/spec/modules/lifestreetBidAdapter_spec.js
+++ b/test/spec/modules/lifestreetBidAdapter_spec.js
@@ -56,11 +56,11 @@ let getDefaultBidResponse = (isBanner, noBid = 0) => {
   };
 };
 
-describe('LifestreetAdapter', () => {
+describe('LifestreetAdapter', function () {
   const LIFESTREET_URL = '//ads.lfstmedia.com/gate/';
   const ADAPTER_VERSION = 'prebidJS-2.0';
 
-  describe('buildRequests()', () => {
+  describe('buildRequests()', function () {
     it('method exists and is a function', () => {
       expect(spec.buildRequests).to.exist.and.to.be.a('function');
     });
@@ -155,7 +155,7 @@ describe('LifestreetAdapter', () => {
       expect(request.url).to.contain('__consent=test');
     });
   });
-  describe('interpretResponse()', () => {
+  describe('interpretResponse()', function () {
     it('should return formatted bid response with required properties', () => {
       let bidRequest = getDefaultBidRequest().bids[0];
       let bidResponse = { body: getDefaultBidResponse(true) };

--- a/test/spec/modules/lkqdBidAdapter_spec.js
+++ b/test/spec/modules/lkqdBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('LKQD Bid Adapter Test', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('LKQD Bid Adapter Test', function () {
       'transactionId': 'd6f6b392-54a9-454c-85fb-a2fd882c4a2d',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -73,7 +73,7 @@ describe('LKQD Bid Adapter Test', function () {
       }
     ];
 
-    it('should populate available parameters', () => {
+    it('should populate available parameters', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(2);
       const r1 = requests[0].data;
@@ -96,7 +96,7 @@ describe('LKQD Bid Adapter Test', function () {
       expect(r2.height).to.equal(480);
     });
 
-    it('should not populate unspecified parameters', () => {
+    it('should not populate unspecified parameters', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(2);
       const r1 = requests[0].data;
@@ -115,7 +115,7 @@ describe('LKQD Bid Adapter Test', function () {
       expect(r2).to.not.have.property('contenturl');
     });
 
-    it('should handle single size request', () => {
+    it('should handle single size request', function () {
       const requests = spec.buildRequests(bidRequest);
       expect(requests.length).to.equal(1);
       const r1 = requests[0].data;
@@ -129,7 +129,7 @@ describe('LKQD Bid Adapter Test', function () {
       expect(r1.height).to.equal(480);
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests.length).to.equal(2);
       const r1 = requests[0];
@@ -322,7 +322,7 @@ https://creative.lkqd.net/internal/lkqd_300x250.mp4
 </Ad>
 </VAST>`;
 
-    it('should correctly parse valid bid response', () => {
+    it('should correctly parse valid bid response', function () {
       const BIDDER_CODE = 'lkqd';
       let bidResponses = spec.interpretResponse(serverResponse, bidRequest);
       expect(bidResponses.length).to.equal(1);
@@ -340,7 +340,7 @@ https://creative.lkqd.net/internal/lkqd_300x250.mp4
       expect(bidResponse.mediaType).to.equal('video');
     });
 
-    it('safely handles XML parsing failure from invalid bid response', () => {
+    it('safely handles XML parsing failure from invalid bid response', function () {
       let invalidServerResponse = {};
       invalidServerResponse.body = '<Ad id="677477"><InLine></AdSystem></InLine></Ad>';
 
@@ -348,7 +348,7 @@ https://creative.lkqd.net/internal/lkqd_300x250.mp4
       expect(result.length).to.equal(0);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let nobidResponse = {};
       nobidResponse.body = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><VAST version=\'2.0\'></VAST>';
 

--- a/test/spec/modules/lkqdBidAdapter_spec.js
+++ b/test/spec/modules/lkqdBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { spec } from 'modules/lkqdBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 const { expect } = require('chai');
 
-describe('LKQD Bid Adapter Test', () => {
+describe('LKQD Bid Adapter Test', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'lkqd',
       'params': {
@@ -40,7 +40,7 @@ describe('LKQD Bid Adapter Test', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const ENDPOINT = 'https://v.lkqd.net/ad';
     let bidRequests = [
       {
@@ -141,7 +141,7 @@ describe('LKQD Bid Adapter Test', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let bidRequest = {
       'url': 'https://ssp.lkqd.net/ad?pid=263&sid=662921&output=vast&execution=any&placement=&playinit=auto&volume=100&timeout=&width=300%E2%80%8C&height=250&pbt=[PREBID_TOKEN]%E2%80%8C&dnt=[DO_NOT_TRACK]%E2%80%8C&pageurl=[PAGEURL]%E2%80%8C&contentid=[CONTENT_ID]%E2%80%8C&contenttitle=[CONTENT_TITLE]%E2%80%8C&contentlength=[CONTENT_LENGTH]%E2%80%8C&contenturl=[CONTENT_URL]&prebid=true%E2%80%8C&rnd=874313435?bidId=253dcb69fb2577&bidWidth=300&bidHeight=250&',
       'data': {

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from '../../../modules/lockerdomeBidAdapter';
 import * as utils from 'src/utils';
 
-describe('LockerDomeAdapter', () => {
+describe('LockerDomeAdapter', function () {
   const bidRequests = [{
     bidder: 'lockerdome',
     params: {
@@ -37,7 +37,7 @@ describe('LockerDomeAdapter', () => {
     auctionId: 'd4c83108-615d-4c2c-9384-dac9ffd4fd72'
   }];
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true if the adUnitId parameter is present', () => {
       expect(spec.isBidRequestValid(bidRequests[0])).to.be.true;
       expect(spec.isBidRequestValid(bidRequests[1])).to.be.true;
@@ -49,7 +49,7 @@ describe('LockerDomeAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should generate a valid single POST request for multiple bid requests', () => {
       const request = spec.buildRequests(bidRequests);
       expect(request.method).to.equal('POST');
@@ -95,7 +95,7 @@ describe('LockerDomeAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should return an empty array if an invalid response is passed', () => {
       const interpretedResponse = spec.interpretResponse({ body: {} });
       expect(interpretedResponse).to.be.an('array').that.is.empty;

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -38,11 +38,11 @@ describe('LockerDomeAdapter', function () {
   }];
 
   describe('isBidRequestValid', function () {
-    it('should return true if the adUnitId parameter is present', () => {
+    it('should return true if the adUnitId parameter is present', function () {
       expect(spec.isBidRequestValid(bidRequests[0])).to.be.true;
       expect(spec.isBidRequestValid(bidRequests[1])).to.be.true;
     });
-    it('should return false if the adUnitId parameter is not present', () => {
+    it('should return false if the adUnitId parameter is not present', function () {
       let bidRequest = utils.deepClone(bidRequests[0]);
       delete bidRequest.params.adUnitId;
       expect(spec.isBidRequestValid(bidRequest)).to.be.false;
@@ -50,7 +50,7 @@ describe('LockerDomeAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should generate a valid single POST request for multiple bid requests', () => {
+    it('should generate a valid single POST request for multiple bid requests', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.method).to.equal('POST');
       expect(request.url).to.equal('https://lockerdome.com/ladbid/prebid');
@@ -79,7 +79,7 @@ describe('LockerDomeAdapter', function () {
       expect(bids[1].sizes[0][1]).to.equal(600);
     });
 
-    it('should add GDPR data to request if available', () => {
+    it('should add GDPR data to request if available', function () {
       const bidderRequest = {
         gdprConsent: {
           consentString: 'AAABBB',
@@ -96,12 +96,12 @@ describe('LockerDomeAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should return an empty array if an invalid response is passed', () => {
+    it('should return an empty array if an invalid response is passed', function () {
       const interpretedResponse = spec.interpretResponse({ body: {} });
       expect(interpretedResponse).to.be.an('array').that.is.empty;
     });
 
-    it('should return valid response when passed valid server response', () => {
+    it('should return valid response when passed valid server response', function () {
       const serverResponse = {
         body: {
           bids: [{

--- a/test/spec/modules/madvertiseBidAdapter_spec.js
+++ b/test/spec/modules/madvertiseBidAdapter_spec.js
@@ -5,7 +5,7 @@ import {spec} from 'modules/madvertiseBidAdapter';
 
 describe('madvertise adapater', function () {
   describe('Test validate req', function () {
-    it('should accept minimum valid bid', () => {
+    it('should accept minimum valid bid', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [[728, 90]],
@@ -17,7 +17,7 @@ describe('madvertise adapater', function () {
 
       expect(isValid).to.equal(true);
     });
-    it('should reject no sizes', () => {
+    it('should reject no sizes', function () {
       let bid = {
         bidder: 'madvertise',
         params: {
@@ -28,7 +28,7 @@ describe('madvertise adapater', function () {
 
       expect(isValid).to.equal(false);
     });
-    it('should reject empty sizes', () => {
+    it('should reject empty sizes', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [],
@@ -40,7 +40,7 @@ describe('madvertise adapater', function () {
 
       expect(isValid).to.equal(false);
     });
-    it('should reject wrong format sizes', () => {
+    it('should reject wrong format sizes', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [['728x90']],
@@ -51,7 +51,7 @@ describe('madvertise adapater', function () {
       const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equal(false);
     });
-    it('should reject no params', () => {
+    it('should reject no params', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [[728, 90]]
@@ -60,7 +60,7 @@ describe('madvertise adapater', function () {
 
       expect(isValid).to.equal(false);
     });
-    it('should reject missing s', () => {
+    it('should reject missing s', function () {
       let bid = {
         bidder: 'madvertise',
         params: {}
@@ -100,7 +100,7 @@ describe('madvertise adapater', function () {
         s: 'test',
       }
     }];
-    it('minimum request with gdpr consent', () => {
+    it('minimum request with gdpr consent', function () {
       let bidderRequest = {
         gdprConsent: {
           consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
@@ -122,7 +122,7 @@ describe('madvertise adapater', function () {
       expect(req[0].url).to.contain(`&consent[0][value]=BOJ/P2HOJ/P2HABABMAAAAAZ+A==`)
     });
 
-    it('minimum request without gdpr consent', () => {
+    it('minimum request without gdpr consent', function () {
       let bidderRequest = {};
       const req = spec.buildRequests(bid, bidderRequest);
 
@@ -140,7 +140,7 @@ describe('madvertise adapater', function () {
   });
 
   describe('Test interpret response', function () {
-    it('General banner response', () => {
+    it('General banner response', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [[728, 90]],
@@ -180,7 +180,7 @@ describe('madvertise adapater', function () {
       expect(resp[0]).to.have.property('currency', 'EUR');
       expect(resp[0]).to.have.property('dealId', 'DEAL_ID');
     });
-    it('No response', () => {
+    it('No response', function () {
       let bid = {
         bidder: 'madvertise',
         sizes: [[728, 90]],

--- a/test/spec/modules/madvertiseBidAdapter_spec.js
+++ b/test/spec/modules/madvertiseBidAdapter_spec.js
@@ -3,8 +3,8 @@ import {config} from 'src/config';
 import * as utils from 'src/utils';
 import {spec} from 'modules/madvertiseBidAdapter';
 
-describe('madvertise adapater', () => {
-  describe('Test validate req', () => {
+describe('madvertise adapater', function () {
+  describe('Test validate req', function () {
     it('should accept minimum valid bid', () => {
       let bid = {
         bidder: 'madvertise',
@@ -71,7 +71,7 @@ describe('madvertise adapater', () => {
     });
   });
 
-  describe('Test build request', () => {
+  describe('Test build request', function () {
     beforeEach(function () {
       let mockConfig = {
         consentManagement: {
@@ -139,7 +139,7 @@ describe('madvertise adapater', () => {
     });
   });
 
-  describe('Test interpret response', () => {
+  describe('Test interpret response', function () {
     it('General banner response', () => {
       let bid = {
         bidder: 'madvertise',

--- a/test/spec/modules/mantisBidAdapter_spec.js
+++ b/test/spec/modules/mantisBidAdapter_spec.js
@@ -2,10 +2,10 @@ import {expect} from 'chai';
 import {spec} from 'modules/mantisBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-describe('MantisAdapter', () => {
+describe('MantisAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'mantis',
       'params': {
@@ -31,7 +31,7 @@ describe('MantisAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'mantis',
@@ -107,7 +107,7 @@ describe('MantisAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     it('iframe', () => {
       let result = spec.getUserSyncs({
         iframeEnabled: true
@@ -127,7 +127,7 @@ describe('MantisAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('display ads returned', () => {
       let response = {
         body: {

--- a/test/spec/modules/mantisBidAdapter_spec.js
+++ b/test/spec/modules/mantisBidAdapter_spec.js
@@ -19,11 +19,11 @@ describe('MantisAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {};
@@ -47,7 +47,7 @@ describe('MantisAdapter', function () {
       }
     ];
 
-    it('domain override', () => {
+    it('domain override', function () {
       window.mantis_domain = 'http://foo';
       const request = spec.buildRequests(bidRequests);
 
@@ -56,7 +56,7 @@ describe('MantisAdapter', function () {
       delete window.mantis_domain;
     });
 
-    it('standard request', () => {
+    it('standard request', function () {
       const request = spec.buildRequests(bidRequests);
 
       expect(request.url).to.include('property=10433394');
@@ -68,7 +68,7 @@ describe('MantisAdapter', function () {
       expect(request.url).to.include('bids[0][sizes][1][height]=600');
     });
 
-    it('use window uuid', () => {
+    it('use window uuid', function () {
       window.mantis_uuid = 'foo';
 
       const request = spec.buildRequests(bidRequests);
@@ -78,7 +78,7 @@ describe('MantisAdapter', function () {
       delete window.mantis_uuid;
     });
 
-    it('use storage uuid', () => {
+    it('use storage uuid', function () {
       window.localStorage.setItem('mantis:uuid', 'bar');
 
       const request = spec.buildRequests(bidRequests);
@@ -88,7 +88,7 @@ describe('MantisAdapter', function () {
       window.localStorage.removeItem('mantis:uuid');
     });
 
-    it('detect amp', () => {
+    it('detect amp', function () {
       var oldContext = window.context;
 
       window.context = {};
@@ -108,7 +108,7 @@ describe('MantisAdapter', function () {
   });
 
   describe('getUserSyncs', function () {
-    it('iframe', () => {
+    it('iframe', function () {
       let result = spec.getUserSyncs({
         iframeEnabled: true
       });
@@ -117,7 +117,7 @@ describe('MantisAdapter', function () {
       expect(result[0].url).to.include('https://mantodea.mantisadnetwork.com/prebid/iframe');
     });
 
-    it('pixel', () => {
+    it('pixel', function () {
       let result = spec.getUserSyncs({
         pixelEnabled: true
       });
@@ -128,7 +128,7 @@ describe('MantisAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('display ads returned', () => {
+    it('display ads returned', function () {
       let response = {
         body: {
           uuid: 'uuid',
@@ -166,7 +166,7 @@ describe('MantisAdapter', function () {
       expect(window.localStorage.getItem('mantis:uuid')).to.equal(response.body.uuid);
     });
 
-    it('no ads returned', () => {
+    it('no ads returned', function () {
       let response = {
         body: {
           ads: []

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -490,11 +490,11 @@ let VALID_BID_REQUEST = [{
 
 describe('Media.net bid adapter', function () {
   let sandbox;
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
   });
 
@@ -521,7 +521,7 @@ describe('Media.net bid adapter', function () {
   });
 
   describe('buildRequests', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       let documentStub = sandbox.stub(document, 'getElementById');
       let boundingRect = {
         top: 50,
@@ -582,7 +582,7 @@ describe('Media.net bid adapter', function () {
 
   describe('slot visibility', function () {
     let documentStub;
-    beforeEach(() => {
+    beforeEach(function () {
       let windowSizeStub = sandbox.stub(spec, 'getWindowSize');
       windowSizeStub.returns({
         w: 1000,

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -488,7 +488,7 @@ let VALID_BID_REQUEST = [{
     'tmax': 3000,
   };
 
-describe('Media.net bid adapter', () => {
+describe('Media.net bid adapter', function () {
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -498,7 +498,7 @@ describe('Media.net bid adapter', () => {
     sandbox.restore();
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should accept valid bid params', () => {
       let isValid = spec.isBidRequestValid(VALID_PARAMS);
       expect(isValid).to.equal(true);
@@ -520,7 +520,7 @@ describe('Media.net bid adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     beforeEach(() => {
       let documentStub = sandbox.stub(document, 'getElementById');
       let boundingRect = {
@@ -562,7 +562,7 @@ describe('Media.net bid adapter', () => {
       expect(JSON.parse(bidReq.data)).to.deep.equal(VALID_PAYLOAD_FOR_GDPR);
     });
 
-    describe('build requests: when page meta-data is available', () => {
+    describe('build requests: when page meta-data is available', function () {
       it('should pass canonical, twitter and fb paramters if available', () => {
         let documentStub = sandbox.stub(window.top.document, 'querySelector');
         documentStub.withArgs('link[rel="canonical"]').returns({
@@ -580,7 +580,7 @@ describe('Media.net bid adapter', () => {
     });
   });
 
-  describe('slot visibility', () => {
+  describe('slot visibility', function () {
     let documentStub;
     beforeEach(() => {
       let windowSizeStub = sandbox.stub(spec, 'getWindowSize');
@@ -653,7 +653,7 @@ describe('Media.net bid adapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     it('should exclude iframe syncs if iframe is disabled', () => {
       let userSyncs = spec.getUserSyncs(SYNC_OPTIONS_PIXEL_ENABLED, SERVER_CSYNC_RESPONSE);
       expect(userSyncs).to.deep.equal(ENABLED_SYNC_PIXEL);
@@ -670,7 +670,7 @@ describe('Media.net bid adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should not push bid response if cpm missing', () => {
       let validBids = [];
       let bids = spec.interpretResponse(SERVER_RESPONSE_CPM_MISSING, []);

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -499,22 +499,22 @@ describe('Media.net bid adapter', function () {
   });
 
   describe('isBidRequestValid', function () {
-    it('should accept valid bid params', () => {
+    it('should accept valid bid params', function () {
       let isValid = spec.isBidRequestValid(VALID_PARAMS);
       expect(isValid).to.equal(true);
     });
 
-    it('should reject bid if cid is not present', () => {
+    it('should reject bid if cid is not present', function () {
       let isValid = spec.isBidRequestValid(PARAMS_WITHOUT_CID);
       expect(isValid).to.equal(false);
     });
 
-    it('should reject bid if cid is not a string', () => {
+    it('should reject bid if cid is not a string', function () {
       let isValid = spec.isBidRequestValid(PARAMS_WITH_INTEGER_CID);
       expect(isValid).to.equal(false);
     });
 
-    it('should reject bid if cid is a empty string', () => {
+    it('should reject bid if cid is a empty string', function () {
       let isValid = spec.isBidRequestValid(PARAMS_WITH_EMPTY_CID);
       expect(isValid).to.equal(false);
     });
@@ -542,28 +542,28 @@ describe('Media.net bid adapter', function () {
       });
     });
 
-    it('should build valid payload on bid', () => {
+    it('should build valid payload on bid', function () {
       let requestObj = spec.buildRequests(VALID_BID_REQUEST, VALID_AUCTIONDATA);
       expect(JSON.parse(requestObj.data)).to.deep.equal(VALID_PAYLOAD);
     });
 
-    it('should accept size as a one dimensional array', () => {
+    it('should accept size as a one dimensional array', function () {
       let bidReq = spec.buildRequests(BID_REQUEST_SIZE_AS_1DARRAY, VALID_AUCTIONDATA);
       expect(JSON.parse(bidReq.data)).to.deep.equal(VALID_PAYLOAD);
     });
 
-    it('should ignore bidfloor if not a valid number', () => {
+    it('should ignore bidfloor if not a valid number', function () {
       let bidReq = spec.buildRequests(VALID_BID_REQUEST_INVALID_BIDFLOOR, VALID_AUCTIONDATA);
       expect(JSON.parse(bidReq.data)).to.deep.equal(VALID_PAYLOAD_INVALID_BIDFLOOR);
     });
 
-    it('should add gdpr to response ext', () => {
+    it('should add gdpr to response ext', function () {
       let bidReq = spec.buildRequests(VALID_BID_REQUEST, VALID_BIDDER_REQUEST_WITH_GDPR);
       expect(JSON.parse(bidReq.data)).to.deep.equal(VALID_PAYLOAD_FOR_GDPR);
     });
 
     describe('build requests: when page meta-data is available', function () {
-      it('should pass canonical, twitter and fb paramters if available', () => {
+      it('should pass canonical, twitter and fb paramters if available', function () {
         let documentStub = sandbox.stub(window.top.document, 'querySelector');
         documentStub.withArgs('link[rel="canonical"]').returns({
           href: 'http://localhost:9999/canonical-test'
@@ -590,7 +590,7 @@ describe('Media.net bid adapter', function () {
       });
       documentStub = sandbox.stub(document, 'getElementById');
     });
-    it('slot visibility should be 2 and ratio 0 when ad unit is BTF', () => {
+    it('slot visibility should be 2 and ratio 0 when ad unit is BTF', function () {
       let boundingRect = {
         top: 1010,
         left: 1010,
@@ -609,7 +609,7 @@ describe('Media.net bid adapter', function () {
       expect(data.imp[0].ext.visibility).to.equal(2);
       expect(data.imp[0].ext.viewability).to.equal(0);
     });
-    it('slot visibility should be 2 and ratio < 0.5 when ad unit is partially inside viewport', () => {
+    it('slot visibility should be 2 and ratio < 0.5 when ad unit is partially inside viewport', function () {
       let boundingRect = {
         top: 990,
         left: 990,
@@ -627,7 +627,7 @@ describe('Media.net bid adapter', function () {
       expect(data.imp[0].ext.visibility).to.equal(2);
       expect(data.imp[0].ext.viewability).to.equal(100 / 75000);
     });
-    it('slot visibility should be 1 and ratio > 0.5 when ad unit mostly in viewport', () => {
+    it('slot visibility should be 1 and ratio > 0.5 when ad unit mostly in viewport', function () {
       let boundingRect = {
         top: 800,
         left: 800,
@@ -645,7 +645,7 @@ describe('Media.net bid adapter', function () {
       expect(data.imp[0].ext.visibility).to.equal(1);
       expect(data.imp[0].ext.viewability).to.equal(40000 / 75000);
     });
-    it('co-ordinates should not be sent and slot visibility should be 0 when ad unit is not present', () => {
+    it('co-ordinates should not be sent and slot visibility should be 0 when ad unit is not present', function () {
       let bidReq = spec.buildRequests(VALID_BID_REQUEST, VALID_AUCTIONDATA);
       let data = JSON.parse(bidReq.data);
       expect(data.imp[1].ext).to.not.have.ownPropertyDescriptor('viewability');
@@ -654,36 +654,36 @@ describe('Media.net bid adapter', function () {
   });
 
   describe('getUserSyncs', function () {
-    it('should exclude iframe syncs if iframe is disabled', () => {
+    it('should exclude iframe syncs if iframe is disabled', function () {
       let userSyncs = spec.getUserSyncs(SYNC_OPTIONS_PIXEL_ENABLED, SERVER_CSYNC_RESPONSE);
       expect(userSyncs).to.deep.equal(ENABLED_SYNC_PIXEL);
     });
 
-    it('should exclude pixel syncs if pixel is disabled', () => {
+    it('should exclude pixel syncs if pixel is disabled', function () {
       let userSyncs = spec.getUserSyncs(SYNC_OPTIONS_IFRAME_ENABLED, SERVER_CSYNC_RESPONSE);
       expect(userSyncs).to.deep.equal(ENABLED_SYNC_IFRAME);
     });
 
-    it('should choose iframe sync urls if both sync options are enabled', () => {
+    it('should choose iframe sync urls if both sync options are enabled', function () {
       let userSyncs = spec.getUserSyncs(SYNC_OPTIONS_BOTH_ENABLED, SERVER_CSYNC_RESPONSE);
       expect(userSyncs).to.deep.equal(ENABLED_SYNC_IFRAME);
     });
   });
 
   describe('interpretResponse', function () {
-    it('should not push bid response if cpm missing', () => {
+    it('should not push bid response if cpm missing', function () {
       let validBids = [];
       let bids = spec.interpretResponse(SERVER_RESPONSE_CPM_MISSING, []);
       expect(bids).to.deep.equal(validBids);
     });
 
-    it('should not push bid response if cpm 0', () => {
+    it('should not push bid response if cpm 0', function () {
       let validBids = [];
       let bids = spec.interpretResponse(SERVER_RESPONSE_CPM_ZERO, []);
       expect(bids).to.deep.equal(validBids);
     });
 
-    it('should not push response if no-bid', () => {
+    it('should not push response if no-bid', function () {
       let validBids = [];
       let bids = spec.interpretResponse(SERVER_RESPONSE_NOBID, []);
       expect(bids).to.deep.equal(validBids);

--- a/test/spec/modules/mobfoxBidAdapter_spec.js
+++ b/test/spec/modules/mobfoxBidAdapter_spec.js
@@ -33,19 +33,19 @@ describe('mobfox adapter tests', function () {
       transactionId: '31f42cba-5920-4e47-adad-69c79d0d4fb4'
     }];
 
-    it('test valid MF request success', () => {
+    it('test valid MF request success', function () {
       let isValid = adapter.spec.isBidRequestValid(bidRequest[0]);
       expect(isValid).to.equal(true);
     });
 
-    it('test valid MF request failed1', () => {
+    it('test valid MF request failed1', function () {
       let isValid = adapter.spec.isBidRequestValid(bidRequestInvalid1[0]);
       expect(isValid).to.equal(false);
     });
   })
 
   describe('buildRequests', function () {
-    it('test build MF request', () => {
+    it('test build MF request', function () {
       let request = adapter.spec.buildRequests(bidRequest);
       let payload = request.data.split('&');
       expect(payload[0]).to.equal('rt=api-fetchip');
@@ -57,7 +57,7 @@ describe('mobfox adapter tests', function () {
       expect(payload[7]).to.equal('imp_instl=1');
     });
 
-    it('test build MF request', () => {
+    it('test build MF request', function () {
       let request = adapter.spec.buildRequests(bidRequest);
       let payload = request.data.split('&');
       expect(payload[0]).to.equal('rt=api-fetchip');
@@ -93,7 +93,7 @@ describe('mobfox adapter tests', function () {
         }
       }
     };
-    it('test intercept response', () => {
+    it('test intercept response', function () {
       let request = adapter.spec.buildRequests(bidRequest);
       let bidResponses = adapter.spec.interpretResponse(mockServerResponse, request);
       expect(bidResponses.length).to.equal(1);
@@ -109,7 +109,7 @@ describe('mobfox adapter tests', function () {
       expect(bidResponses[0].width).to.equal('320');
     });
 
-    it('test intercept response with empty server response', () => {
+    it('test intercept response with empty server response', function () {
       let request = adapter.spec.buildRequests(bidRequest);
       let serverResponse = {
         request: {

--- a/test/spec/modules/mobfoxBidAdapter_spec.js
+++ b/test/spec/modules/mobfoxBidAdapter_spec.js
@@ -1,4 +1,4 @@
-describe('mobfox adapter tests', () => {
+describe('mobfox adapter tests', function () {
   const expect = require('chai').expect;
   const utils = require('src/utils');
   const adapter = require('modules/mobfoxBidAdapter');
@@ -18,7 +18,7 @@ describe('mobfox adapter tests', () => {
     transactionId: '31f42cba-5920-4e47-adad-69c79d0d4fb4'
   }];
 
-  describe('validRequests', () => {
+  describe('validRequests', function () {
     let bidRequestInvalid1 = [{
       code: 'div-gpt-ad-1460505748561-0',
       sizes: [[320, 480], [300, 250], [300, 600]],
@@ -44,7 +44,7 @@ describe('mobfox adapter tests', () => {
     });
   })
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('test build MF request', () => {
       let request = adapter.spec.buildRequests(bidRequest);
       let payload = request.data.split('&');
@@ -70,7 +70,7 @@ describe('mobfox adapter tests', () => {
     });
   })
 
-  describe('interceptResponse', () => {
+  describe('interceptResponse', function () {
     let mockServerResponse = {
       body: {
         request: {

--- a/test/spec/modules/my6senseBidAdapter_spec.js
+++ b/test/spec/modules/my6senseBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import spec from 'modules/my6senseBidAdapter';
 
-describe('My6sense Bid adapter test', () => {
+describe('My6sense Bid adapter test', function () {
   let bidRequests, serverResponses;
   beforeEach(() => {
     bidRequests = [
@@ -99,7 +99,7 @@ describe('My6sense Bid adapter test', () => {
     ]
   });
 
-  describe('test if requestIsValid function', () => {
+  describe('test if requestIsValid function', function () {
     it('with valid data 1', () => {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
@@ -114,13 +114,13 @@ describe('My6sense Bid adapter test', () => {
     });
   });
 
-  describe('test if buildRequests function', () => {
+  describe('test if buildRequests function', function () {
     it('normal', () => {
       var requests = spec.buildRequests([bidRequests[0]]);
       expect(requests).to.be.lengthOf(1);
     });
   });
-  describe('test bid responses', () => {
+  describe('test bid responses', function () {
     it('success 1', () => {
       var bids = spec.interpretResponse(serverResponses[0], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(1);

--- a/test/spec/modules/my6senseBidAdapter_spec.js
+++ b/test/spec/modules/my6senseBidAdapter_spec.js
@@ -3,7 +3,7 @@ import spec from 'modules/my6senseBidAdapter';
 
 describe('My6sense Bid adapter test', function () {
   let bidRequests, serverResponses;
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         // valid 1

--- a/test/spec/modules/my6senseBidAdapter_spec.js
+++ b/test/spec/modules/my6senseBidAdapter_spec.js
@@ -100,28 +100,28 @@ describe('My6sense Bid adapter test', function () {
   });
 
   describe('test if requestIsValid function', function () {
-    it('with valid data 1', () => {
+    it('with valid data 1', function () {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
-    it('with invalid data 2', () => {
+    it('with invalid data 2', function () {
       expect(spec.isBidRequestValid(bidRequests[1])).to.equal(false);
     });
-    it('with invalid data 3', () => {
+    it('with invalid data 3', function () {
       expect(spec.isBidRequestValid(bidRequests[2])).to.equal(false);
     });
-    it('with invalid data 3', () => {
+    it('with invalid data 3', function () {
       expect(spec.isBidRequestValid(bidRequests[3])).to.equal(false);
     });
   });
 
   describe('test if buildRequests function', function () {
-    it('normal', () => {
+    it('normal', function () {
       var requests = spec.buildRequests([bidRequests[0]]);
       expect(requests).to.be.lengthOf(1);
     });
   });
   describe('test bid responses', function () {
-    it('success 1', () => {
+    it('success 1', function () {
       var bids = spec.interpretResponse(serverResponses[0], {'bidRequest': bidRequests[0]});
       expect(bids).to.be.lengthOf(1);
       expect(bids[0].cpm).to.equal(1.5);
@@ -129,7 +129,7 @@ describe('My6sense Bid adapter test', function () {
       expect(bids[0].height).to.equal(250);
       expect(bids[0].adm).to.have.length.above(1);
     });
-    it('success 2', () => {
+    it('success 2', function () {
       var bids = spec.interpretResponse(serverResponses[3]);
       expect(bids).to.be.lengthOf(1);
       expect(bids[0].cpm).to.equal(5);
@@ -139,11 +139,11 @@ describe('My6sense Bid adapter test', function () {
       expect(bids[0].ttl).to.equal(360);
       expect(bids[0].currency).to.equal('USD');
     });
-    it('fail 1 (cpm=0)', () => {
+    it('fail 1 (cpm=0)', function () {
       var bids = spec.interpretResponse(serverResponses[1]);
       expect(bids).to.be.lengthOf(1);
     });
-    it('fail 2 (no response)', () => {
+    it('fail 2 (no response)', function () {
       var bids = spec.interpretResponse([]);
       expect(bids).to.be.lengthOf(0);
     });

--- a/test/spec/modules/nanointeractiveBidAdapter_spec.js
+++ b/test/spec/modules/nanointeractiveBidAdapter_spec.js
@@ -64,10 +64,10 @@ describe('nanointeractive adapter tests', function () {
     };
   }
 
-  describe('NanoAdapter', () => {
+  describe('NanoAdapter', function () {
     let nanoBidAdapter = spec;
 
-    describe('Methods', () => {
+    describe('Methods', function () {
       it('Test isBidRequestValid() with valid param(s): pid', function () {
         expect(nanoBidAdapter.isBidRequestValid(getBidRequest({
           [DATA_PARTNER_PIXEL_ID]: DATA_PARTNER_PIXEL_ID_VALUE,

--- a/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
+++ b/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
@@ -2,16 +2,16 @@ import {expect} from 'chai';
 import {spec} from 'modules/nasmediaAdmixerBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-describe('nasmediaAdmixerBidAdapter', () => {
+describe('nasmediaAdmixerBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     const bid = {
       'bidder': 'nasmediaAdmixer',
       'params': {
@@ -38,7 +38,7 @@ describe('nasmediaAdmixerBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [
       {
         'bidder': 'nasmediaAdmixer',
@@ -60,7 +60,7 @@ describe('nasmediaAdmixerBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const response = {
       'body': {
         'bidder': 'nasmedia_admixer',

--- a/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
+++ b/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('nasmediaAdmixerBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('nasmediaAdmixerBidAdapter', function () {
       'auctionId': '124cb070528662',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       const bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -53,7 +53,7 @@ describe('nasmediaAdmixerBidAdapter', function () {
       }
     ];
 
-    it('sends bid request to url via GET', () => {
+    it('sends bid request to url via GET', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.method).to.equal('GET');
       expect(request.url).to.match(new RegExp(`https://adn.admixer.co.kr`));
@@ -94,7 +94,7 @@ describe('nasmediaAdmixerBidAdapter', function () {
       'auctionId': '169827a33f03cc',
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const expectedResponse = [
         {
           'requestId': '861a8e7952c82c',
@@ -122,7 +122,7 @@ describe('nasmediaAdmixerBidAdapter', function () {
       });
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       response.body = {
         'bidder': 'nasmedia_admixer',
         'req_id': '861a8e7952c82c',

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('OneVideoBidAdapter', function () {
   let bidderRequest;
   let mockConfig;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequest = {
       bidder: 'oneVideo',
       sizes: [640, 480],

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -34,18 +34,18 @@ describe('OneVideoBidAdapter', function () {
   });
 
   describe('spec.isBidRequestValid', function () {
-    it('should return true when the required params are passed', () => {
+    it('should return true when the required params are passed', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return false when the "video" param is missing', () => {
+    it('should return false when the "video" param is missing', function () {
       bidRequest.params = {
         pubId: 'brxd'
       };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when the "pubId" param is missing', () => {
+    it('should return false when the "pubId" param is missing', function () {
       bidRequest.params = {
         video: {
           playerWidth: 480,
@@ -60,25 +60,25 @@ describe('OneVideoBidAdapter', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when no bid params are passed', () => {
+    it('should return false when no bid params are passed', function () {
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
   });
 
   describe('spec.buildRequests', function () {
-    it('should create a POST request for every bid', () => {
+    it('should create a POST request for every bid', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].method).to.equal('POST');
       expect(requests[0].url).to.equal(location.protocol + spec.ENDPOINT + bidRequest.params.pubId);
     });
 
-    it('should attach the bid request object', () => {
+    it('should attach the bid request object', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].bidRequest).to.equal(bidRequest);
     });
 
-    it('should attach request data', () => {
+    it('should attach request data', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
       const [ width, height ] = bidRequest.sizes;
@@ -87,7 +87,7 @@ describe('OneVideoBidAdapter', function () {
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
     });
 
-    it('must parse bid size from a nested array', () => {
+    it('must parse bid size from a nested array', function () {
       const width = 640;
       const height = 480;
       bidRequest.sizes = [[ width, height ]];
@@ -99,24 +99,24 @@ describe('OneVideoBidAdapter', function () {
   });
 
   describe('spec.interpretResponse', function () {
-    it('should return no bids if the response is not valid', () => {
+    it('should return no bids if the response is not valid', function () {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return no bids if the response "nurl" and "adm" are missing', () => {
+    it('should return no bids if the response "nurl" and "adm" are missing', function () {
       const serverResponse = {seatbid: [{bid: [{price: 6.01}]}]};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return no bids if the response "price" is missing', () => {
+    it('should return no bids if the response "price" is missing', function () {
       const serverResponse = {seatbid: [{bid: [{adm: '<VAST></VAST>'}]}]};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return a valid bid response with just "adm"', () => {
+    it('should return a valid bid response with just "adm"', function () {
       const serverResponse = {seatbid: [{bid: [{id: 1, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       let o = {

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/oneVideoBidAdapter';
 import * as utils from 'src/utils';
 import {config} from 'src/config';
 
-describe('OneVideoBidAdapter', () => {
+describe('OneVideoBidAdapter', function () {
   let bidRequest;
   let bidderRequest;
   let mockConfig;
@@ -33,7 +33,7 @@ describe('OneVideoBidAdapter', () => {
     };
   });
 
-  describe('spec.isBidRequestValid', () => {
+  describe('spec.isBidRequestValid', function () {
     it('should return true when the required params are passed', () => {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
@@ -66,7 +66,7 @@ describe('OneVideoBidAdapter', () => {
     });
   });
 
-  describe('spec.buildRequests', () => {
+  describe('spec.buildRequests', function () {
     it('should create a POST request for every bid', () => {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].method).to.equal('POST');
@@ -98,7 +98,7 @@ describe('OneVideoBidAdapter', () => {
     });
   });
 
-  describe('spec.interpretResponse', () => {
+  describe('spec.interpretResponse', function () {
     it('should return no bids if the response is not valid', () => {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);

--- a/test/spec/modules/oneplanetonlyBidAdapter_spec.js
+++ b/test/spec/modules/oneplanetonlyBidAdapter_spec.js
@@ -17,10 +17,10 @@ describe('OnePlanetOnlyAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true if there are params.siteId and params.adUnitId parameters present', () => {
+    it('Should return true if there are params.siteId and params.adUnitId parameters present', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false if at least one of parameters is not present', () => {
+    it('Should return false if at least one of parameters is not present', function () {
       delete bid.params.adUnitId;
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -28,19 +28,19 @@ describe('OnePlanetOnlyAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//show.oneplanetonly.com/prebid?siteId=5');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('id', 'ver', 'prebidVer', 'transactionId', 'currency', 'timeout', 'siteId',
@@ -52,14 +52,14 @@ describe('OnePlanetOnlyAdapter', function () {
       expect(adUnit.bidId).to.equal('51ef8751f9aead');
       expect(adUnit.sizes).to.have.members(['300x250', '300x600']);
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.adUnits).to.be.an('array').that.is.empty;
     });
   });
   describe('interpretResponse', function () {
-    it('Should interpret banner response', () => {
+    it('Should interpret banner response', function () {
       const serverResponse = {
         body: {
           bids: [{
@@ -89,7 +89,7 @@ describe('OnePlanetOnlyAdapter', function () {
       expect(bidObject.netRevenue).to.be.true;
       expect(bidObject.currency).to.equal('USD');
     });
-    it('Should return an empty array if invalid response is passed', () => {
+    it('Should return an empty array if invalid response is passed', function () {
       const invalid = {
         body: {}
       };

--- a/test/spec/modules/oneplanetonlyBidAdapter_spec.js
+++ b/test/spec/modules/oneplanetonlyBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/oneplanetonlyBidAdapter';
 
-describe('OnePlanetOnlyAdapter', () => {
+describe('OnePlanetOnlyAdapter', function () {
   let bid = {
     bidId: '51ef8751f9aead',
     bidder: 'oneplanetonly',
@@ -16,7 +16,7 @@ describe('OnePlanetOnlyAdapter', () => {
     auctionId: '18fd8b8b0bd757'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true if there are params.siteId and params.adUnitId parameters present', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -26,7 +26,7 @@ describe('OnePlanetOnlyAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -58,7 +58,7 @@ describe('OnePlanetOnlyAdapter', () => {
       expect(data.adUnits).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('Should interpret banner response', () => {
       const serverResponse = {
         body: {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { spec } from 'modules/onetagBidAdapter';
 import { expect } from 'chai';
 
-describe('onetag', () => {
+describe('onetag', function () {
   let bid = {
     'bidder': 'onetag',
     'params': {
@@ -15,7 +15,7 @@ describe('onetag', () => {
     'transactionId': 'qwerty123'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true when required params are found', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -33,7 +33,7 @@ describe('onetag', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -107,7 +107,7 @@ describe('onetag', () => {
       expect(payload.gdprConsent.consentRequired).to.exist.and.to.be.true;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const resObject = {
       body: {
         nobid: false,

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -16,18 +16,18 @@ describe('onetag', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true when required params are found', () => {
+    it('Should return true when required params are found', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false when pubId is not a string', () => {
+    it('Should return false when pubId is not a string', function () {
       bid.params.pubId = 30;
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
-    it('Should return false when pubId is undefined', () => {
+    it('Should return false when pubId is undefined', function () {
       bid.params.pubId = undefined;
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
-    it('Should return false when the sizes array is empty', () => {
+    it('Should return false when the sizes array is empty', function () {
       bid.sizes = [];
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -35,23 +35,23 @@ describe('onetag', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('https://onetag-sys.com/prebid-request');
     });
 
     const d = serverRequest.data;
     try {
       const data = JSON.parse(d);
-      it('Should contains all keys', () => {
+      it('Should contains all keys', function () {
         expect(data).to.be.an('object');
         expect(data).to.have.all.keys('location', 'masked', 'referrer', 'sHeight', 'sWidth', 'timeOffset', 'date', 'wHeight', 'wWidth', 'bids');
         expect(data.location).to.be.a('string');
@@ -76,7 +76,7 @@ describe('onetag', function () {
     } catch (e) {
       console.log('Error while parsing');
     }
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let dataString = serverRequest.data;
       try {
@@ -86,7 +86,7 @@ describe('onetag', function () {
         console.log('Error while parsing');
       }
     });
-    it('should send GDPR consent data', () => {
+    it('should send GDPR consent data', function () {
       let consentString = 'consentString';
       let bidderRequest = {
         'bidderCode': 'onetag',
@@ -123,7 +123,7 @@ describe('onetag', function () {
         }]
       }
     };
-    it('Returns an array of valid server responses if response object is valid', () => {
+    it('Returns an array of valid server responses if response object is valid', function () {
       const serverResponses = spec.interpretResponse(resObject);
 
       expect(serverResponses).to.be.an('array').that.is.not.empty;
@@ -140,7 +140,7 @@ describe('onetag', function () {
         expect(dataItem.netRevenue).to.be.a('boolean');
         expect(dataItem.currency).to.be.a('string');
       }
-      it('Returns an empty array if invalid response is passed', () => {
+      it('Returns an empty array if invalid response is passed', function () {
         const serverResponses = spec.interpretResponse('invalid_response');
         expect(serverResponses).to.be.an('array').that.is.empty;
       });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -122,7 +122,7 @@ describe('OpenxAdapter', function () {
   };
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -143,7 +143,7 @@ describe('OpenxAdapter', function () {
         };
       });
 
-      it('should return false when there is no delivery domain', () => {
+      it('should return false when there is no delivery domain', function () {
         bannerBid.params = {'unit': '12345678'};
         expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
       });
@@ -153,25 +153,25 @@ describe('OpenxAdapter', function () {
           bannerBid.params = {delDomain: 'test-delivery-domain'}
         });
 
-        it('should return false when there is no ad unit id and size', () => {
+        it('should return false when there is no ad unit id and size', function () {
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
         });
 
-        it('should return true if there is an adunit id ', () => {
+        it('should return true if there is an adunit id ', function () {
           bannerBid.params.unit = '12345678';
           expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
         });
 
-        it('should return true if there is no adunit id and sizes are defined', () => {
+        it('should return true if there is no adunit id and sizes are defined', function () {
           bannerBid.mediaTypes.banner.sizes = [720, 90];
           expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
         });
 
-        it('should return false if no sizes are defined ', () => {
+        it('should return false if no sizes are defined ', function () {
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
         });
 
-        it('should return false if sizes empty ', () => {
+        it('should return false if sizes empty ', function () {
           bannerBid.mediaTypes.banner.sizes = [];
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
         });
@@ -211,21 +211,21 @@ describe('OpenxAdapter', function () {
         'auctionId': '1d1a030790a475',
         'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
       };
-      it('should return true when required params found', () => {
+      it('should return true when required params found', function () {
         expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(true);
       });
 
-      it('should return false when required params are not passed', () => {
+      it('should return false when required params are not passed', function () {
         let videoBidWithMediaTypes = Object.assign({}, videoBidWithMediaTypes);
         videoBidWithMediaTypes.params = {};
         expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(false);
       });
 
-      it('should return true when required params found', () => {
+      it('should return true when required params found', function () {
         expect(spec.isBidRequestValid(videoBidWithMediaType)).to.equal(true);
       });
 
-      it('should return false when required params are not passed', () => {
+      it('should return false when required params are not passed', function () {
         let videoBidWithMediaType = Object.assign({}, videoBidWithMediaType);
         delete videoBidWithMediaType.params;
         videoBidWithMediaType.params = {};
@@ -280,24 +280,24 @@ describe('OpenxAdapter', function () {
       'auctionId': 'test-auction-2'
     }];
 
-    it('should send bid request to openx url via GET, with mediaType specified as banner', () => {
+    it('should send bid request to openx url via GET, with mediaType specified as banner', function () {
       const request = spec.buildRequests(bidRequestsWithMediaType);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaType[0].params.delDomain + URLBASE);
       expect(request[0].method).to.equal('GET');
     });
 
-    it('should send bid request to openx url via GET, with mediaTypes specified with banner type', () => {
+    it('should send bid request to openx url via GET, with mediaTypes specified with banner type', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaTypes[0].params.delDomain + URLBASE);
       expect(request[0].method).to.equal('GET');
     });
 
-    it('should send the adunit codes', () => {
+    it('should send the adunit codes', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       expect(request[0].data.divIds).to.equal(`${encodeURIComponent(bidRequestsWithMediaTypes[0].adUnitCode)},${encodeURIComponent(bidRequestsWithMediaTypes[1].adUnitCode)}`);
     });
 
-    it('should send ad unit ids when any are defined', () => {
+    it('should send ad unit ids when any are defined', function () {
       const bidRequestsWithUnitIds = [{
         'bidder': 'openx',
         'params': {
@@ -332,7 +332,7 @@ describe('OpenxAdapter', function () {
       expect(request[0].data.auid).to.equal(`,${bidRequestsWithUnitIds[1].params.unit}`);
     });
 
-    it('should not send any ad unit ids when none are defined', () => {
+    it('should not send any ad unit ids when none are defined', function () {
       const bidRequestsWithoutUnitIds = [{
         'bidder': 'openx',
         'params': {
@@ -386,7 +386,7 @@ describe('OpenxAdapter', function () {
         requestData = spec.buildRequests(deprecatedBidRequestsFormatWithNoMediaType)[0].data;
       });
 
-      it('should have an ad unit id', () => {
+      it('should have an ad unit id', function () {
         expect(requestData.auid).to.equal('12345678');
       });
 
@@ -395,7 +395,7 @@ describe('OpenxAdapter', function () {
       });
     });
 
-    it('should send out custom params on bids that have customParams specified', () => {
+    it('should send out custom params on bids that have customParams specified', function () {
       const bidRequest = Object.assign({},
         bidRequestsWithMediaTypes[0],
         {
@@ -414,7 +414,7 @@ describe('OpenxAdapter', function () {
       expect(dataParams.tps).to.equal(btoa('test1=testval1.&test2=testval2_,testval3'));
     });
 
-    it('should send out custom floors on bids that have customFloors specified', () => {
+    it('should send out custom floors on bids that have customFloors specified', function () {
       const bidRequest = Object.assign({},
         bidRequestsWithMediaTypes[0],
         {
@@ -433,7 +433,7 @@ describe('OpenxAdapter', function () {
       expect(dataParams.aumfs).to.equal('1500');
     });
 
-    it('should send out custom bc parameter, if override is present', () => {
+    it('should send out custom bc parameter, if override is present', function () {
       const bidRequest = Object.assign({},
         bidRequestsWithMediaTypes[0],
         {
@@ -632,7 +632,7 @@ describe('OpenxAdapter', function () {
       });
     });
 
-    it('should not send a coppa query param when there are no coppa param settings in the bid requests', () => {
+    it('should not send a coppa query param when there are no coppa param settings in the bid requests', function () {
       const bidRequestsWithoutCoppa = [{
         bidder: 'openx',
         params: {
@@ -669,7 +669,7 @@ describe('OpenxAdapter', function () {
       expect(request[0].data).to.not.have.any.keys('tfcd');
     });
 
-    it('should send a coppa flag there is when there is coppa param settings in the bid requests', () => {
+    it('should send a coppa flag there is when there is coppa param settings in the bid requests', function () {
       const bidRequestsWithCoppa = [{
         bidder: 'openx',
         params: {
@@ -707,7 +707,7 @@ describe('OpenxAdapter', function () {
       expect(request[0].data.tfcd).to.equal(1);
     });
 
-    it('should not send a "no segmentation" flag there no DoNotTrack setting that is set to true', () => {
+    it('should not send a "no segmentation" flag there no DoNotTrack setting that is set to true', function () {
       const bidRequestsWithoutDnt = [{
         bidder: 'openx',
         params: {
@@ -744,7 +744,7 @@ describe('OpenxAdapter', function () {
       expect(request[0].data).to.not.have.any.keys('ns');
     });
 
-    it('should send a "no segmentation" flag there is any DoNotTrack setting that is set to true', () => {
+    it('should send a "no segmentation" flag there is any DoNotTrack setting that is set to true', function () {
       const bidRequestsWithDnt = [{
         bidder: 'openx',
         params: {
@@ -818,19 +818,19 @@ describe('OpenxAdapter', function () {
       'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
     }];
 
-    it('should send bid request to openx url via GET, with mediaType as video', () => {
+    it('should send bid request to openx url via GET, with mediaType as video', function () {
       const request = spec.buildRequests(bidRequestsWithMediaType);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaType[0].params.delDomain + URLBASEVIDEO);
       expect(request[0].method).to.equal('GET');
     });
 
-    it('should send bid request to openx url via GET, with mediaTypes having video parameter', () => {
+    it('should send bid request to openx url via GET, with mediaTypes having video parameter', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaTypes[0].params.delDomain + URLBASEVIDEO);
       expect(request[0].method).to.equal('GET');
     });
 
-    it('should have the correct parameters', () => {
+    it('should have the correct parameters', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       const dataParams = request[0].data;
 
@@ -839,7 +839,7 @@ describe('OpenxAdapter', function () {
       expect(dataParams.vwd).to.equal(640);
     });
 
-    it('should send a bc parameter', () => {
+    it('should send a bc parameter', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       const dataParams = request[0].data;
 
@@ -1030,7 +1030,7 @@ describe('OpenxAdapter', function () {
         expect(bid.ts).to.equal(adUnitOverride.ts);
       });
 
-      it('should register a beacon', () => {
+      it('should register a beacon', function () {
         resetBoPixel();
         spec.interpretResponse({body: bidResponse}, bidRequest);
         sinon.assert.calledWith(userSync.registerSync, 'image', 'openx', sinon.match(new RegExp(`\/\/openx-d\.openx\.net.*\/bo\?.*ts=${adUnitOverride.ts}`)));
@@ -1107,7 +1107,7 @@ describe('OpenxAdapter', function () {
         };
       });
 
-      it('handles nobid responses', () => {
+      it('handles nobid responses', function () {
         const bidResponse = {
           'ads':
             {
@@ -1273,7 +1273,7 @@ describe('OpenxAdapter', function () {
       'pixels': 'http://testpixels.net'
     };
 
-    it('should return correct bid response with MediaTypes', () => {
+    it('should return correct bid response with MediaTypes', function () {
       const expectedResponse = [
         {
           'requestId': '30b31c1838de1e',
@@ -1294,7 +1294,7 @@ describe('OpenxAdapter', function () {
       expect(JSON.stringify(Object.keys(result[0]).sort())).to.eql(JSON.stringify(Object.keys(expectedResponse[0]).sort()));
     });
 
-    it('should return correct bid response with MediaType', () => {
+    it('should return correct bid response with MediaType', function () {
       const expectedResponse = [
         {
           'requestId': '30b31c1838de1e',
@@ -1315,19 +1315,19 @@ describe('OpenxAdapter', function () {
       expect(JSON.stringify(Object.keys(result[0]).sort())).to.eql(JSON.stringify(Object.keys(expectedResponse[0]).sort()));
     });
 
-    it('should handle nobid responses for bidRequests with MediaTypes', () => {
+    it('should handle nobid responses for bidRequests with MediaTypes', function () {
       const bidResponse = {'vastUrl': '', 'pub_rev': '', 'width': '', 'height': '', 'adid': '', 'pixels': ''};
       const result = spec.interpretResponse({body: bidResponse}, bidRequestsWithMediaTypes);
       expect(result.length).to.equal(0);
     });
 
-    it('should handle nobid responses for bidRequests with MediaType', () => {
+    it('should handle nobid responses for bidRequests with MediaType', function () {
       const bidResponse = {'vastUrl': '', 'pub_rev': '', 'width': '', 'height': '', 'adid': '', 'pixels': ''};
       const result = spec.interpretResponse({body: bidResponse}, bidRequestsWithMediaType);
       expect(result.length).to.equal(0);
     });
 
-    it('should register a beacon', () => {
+    it('should register a beacon', function () {
       resetBoPixel();
       spec.interpretResponse({body: bidResponse}, bidRequestsWithMediaTypes);
       sinon.assert.calledWith(userSync.registerSync, 'image', 'openx', sinon.match(/^\/\/test-colo\.com/))
@@ -1339,7 +1339,7 @@ describe('OpenxAdapter', function () {
   describe('user sync', function () {
     const syncUrl = 'http://testpixels.net';
 
-    it('should register the pixel iframe from banner ad response', () => {
+    it('should register the pixel iframe from banner ad response', function () {
       let syncs = spec.getUserSyncs(
         {iframeEnabled: true},
         [{body: {ads: {pixels: syncUrl}}}]
@@ -1347,7 +1347,7 @@ describe('OpenxAdapter', function () {
       expect(syncs).to.deep.equal([{type: 'iframe', url: syncUrl}]);
     });
 
-    it('should register the pixel iframe from video ad response', () => {
+    it('should register the pixel iframe from video ad response', function () {
       let syncs = spec.getUserSyncs(
         {iframeEnabled: true},
         [{body: {pixels: syncUrl}}]
@@ -1355,7 +1355,7 @@ describe('OpenxAdapter', function () {
       expect(syncs).to.deep.equal([{type: 'iframe', url: syncUrl}]);
     });
 
-    it('should register the default iframe if no pixels available', () => {
+    it('should register the default iframe if no pixels available', function () {
       let syncs = spec.getUserSyncs(
         {iframeEnabled: true},
         []

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -8,7 +8,7 @@ import * as utils from 'src/utils';
 const URLBASE = '/w/1.0/arj';
 const URLBASEVIDEO = '/v/1.0/avjp';
 
-describe('OpenxAdapter', () => {
+describe('OpenxAdapter', function () {
   const adapter = newBidder(spec);
 
   /**
@@ -121,14 +121,14 @@ describe('OpenxAdapter', () => {
     }
   };
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
-    describe('when request is for a banner ad', () => {
+  describe('isBidRequestValid', function () {
+    describe('when request is for a banner ad', function () {
       let bannerBid;
       beforeEach(() => {
         bannerBid = {
@@ -148,7 +148,7 @@ describe('OpenxAdapter', () => {
         expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
       });
 
-      describe('when there is a delivery domain', () => {
+      describe('when there is a delivery domain', function () {
         beforeEach(function () {
           bannerBid.params = {delDomain: 'test-delivery-domain'}
         });
@@ -234,7 +234,7 @@ describe('OpenxAdapter', () => {
     });
   });
 
-  describe('buildRequests for banner ads', () => {
+  describe('buildRequests for banner ads', function () {
     const bidRequestsWithMediaType = [{
       'bidder': 'openx',
       'params': {
@@ -459,7 +459,7 @@ describe('OpenxAdapter', () => {
       expect(request[0].data.x_gdpr_f).to.equal(undefined);
     });
 
-    describe('when there is a consent management framework', () => {
+    describe('when there is a consent management framework', function () {
       let bidRequests;
       let mockConfig;
       let bidderRequest;
@@ -783,7 +783,7 @@ describe('OpenxAdapter', () => {
     });
   });
 
-  describe('buildRequests for video', () => {
+  describe('buildRequests for video', function () {
     const bidRequestsWithMediaTypes = [{
       'bidder': 'openx',
       'mediaTypes': {
@@ -933,7 +933,7 @@ describe('OpenxAdapter', () => {
     });
   });
 
-  describe('interpretResponse for banner ads', () => {
+  describe('interpretResponse for banner ads', function () {
     beforeEach(() => {
       sinon.spy(userSync, 'registerSync');
     });
@@ -1215,7 +1215,7 @@ describe('OpenxAdapter', () => {
     });
   });
 
-  describe('interpretResponse for video ads', () => {
+  describe('interpretResponse for video ads', function () {
     beforeEach(() => {
       sinon.spy(userSync, 'registerSync');
     });
@@ -1336,7 +1336,7 @@ describe('OpenxAdapter', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     const syncUrl = 'http://testpixels.net';
 
     it('should register the pixel iframe from banner ad response', () => {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -130,7 +130,7 @@ describe('OpenxAdapter', function () {
   describe('isBidRequestValid', function () {
     describe('when request is for a banner ad', function () {
       let bannerBid;
-      beforeEach(() => {
+      beforeEach(function () {
         bannerBid = {
           bidder: 'openx',
           params: {},
@@ -465,7 +465,7 @@ describe('OpenxAdapter', function () {
       let bidderRequest;
       const IAB_CONSENT_FRAMEWORK_CODE = 1;
 
-      beforeEach(() => {
+      beforeEach(function () {
         bidRequests = [{
           bidder: 'openx',
           params: {
@@ -934,7 +934,7 @@ describe('OpenxAdapter', function () {
   });
 
   describe('interpretResponse for banner ads', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(userSync, 'registerSync');
     });
 
@@ -1216,7 +1216,7 @@ describe('OpenxAdapter', function () {
   });
 
   describe('interpretResponse for video ads', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(userSync, 'registerSync');
     });
 

--- a/test/spec/modules/optimaticBidAdapter_spec.js
+++ b/test/spec/modules/optimaticBidAdapter_spec.js
@@ -5,7 +5,7 @@ import * as utils from 'src/utils';
 describe('OptimaticBidAdapter', function () {
   let bidRequest;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequest = {
       bidder: 'optimatic',
       params: {

--- a/test/spec/modules/optimaticBidAdapter_spec.js
+++ b/test/spec/modules/optimaticBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec, ENDPOINT } from 'modules/optimaticBidAdapter';
 import * as utils from 'src/utils';
 
-describe('OptimaticBidAdapter', () => {
+describe('OptimaticBidAdapter', function () {
   let bidRequest;
 
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('OptimaticBidAdapter', () => {
     };
   });
 
-  describe('spec.isBidRequestValid', () => {
+  describe('spec.isBidRequestValid', function () {
     it('should return true when the required params are passed', () => {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
@@ -50,7 +50,7 @@ describe('OptimaticBidAdapter', () => {
     });
   });
 
-  describe('spec.buildRequests', () => {
+  describe('spec.buildRequests', function () {
     it('should create a POST request for every bid', () => {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].method).to.equal('POST');
@@ -100,7 +100,7 @@ describe('OptimaticBidAdapter', () => {
     });
   });
 
-  describe('spec.interpretResponse', () => {
+  describe('spec.interpretResponse', function () {
     it('should return no bids if the response is not valid', () => {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);

--- a/test/spec/modules/optimaticBidAdapter_spec.js
+++ b/test/spec/modules/optimaticBidAdapter_spec.js
@@ -21,48 +21,48 @@ describe('OptimaticBidAdapter', function () {
   });
 
   describe('spec.isBidRequestValid', function () {
-    it('should return true when the required params are passed', () => {
+    it('should return true when the required params are passed', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return false when the "bidfloor" param is missing', () => {
+    it('should return false when the "bidfloor" param is missing', function () {
       bidRequest.params = {
         placement: '2chy7Gc2eSQL'
       };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when the "placement" param is missing', () => {
+    it('should return false when the "placement" param is missing', function () {
       bidRequest.params = {
         bidfloor: 5.00
       };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when no bid params are passed', () => {
+    it('should return false when no bid params are passed', function () {
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when a bid request is not passed', () => {
+    it('should return false when a bid request is not passed', function () {
       expect(spec.isBidRequestValid()).to.equal(false);
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
   });
 
   describe('spec.buildRequests', function () {
-    it('should create a POST request for every bid', () => {
+    it('should create a POST request for every bid', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].method).to.equal('POST');
       expect(requests[0].url).to.equal(ENDPOINT + bidRequest.params.placement);
     });
 
-    it('should attach the bid request object', () => {
+    it('should attach the bid request object', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       expect(requests[0].bidRequest).to.equal(bidRequest);
     });
 
-    it('should attach request data', () => {
+    it('should attach request data', function () {
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
       const [ width, height ] = bidRequest.sizes;
@@ -71,7 +71,7 @@ describe('OptimaticBidAdapter', function () {
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
     });
 
-    it('must parse bid size from a nested array', () => {
+    it('must parse bid size from a nested array', function () {
       const width = 640;
       const height = 480;
       bidRequest.sizes = [[ width, height ]];
@@ -81,7 +81,7 @@ describe('OptimaticBidAdapter', function () {
       expect(data.imp[0].video.h).to.equal(height);
     });
 
-    it('must parse bid size from a string', () => {
+    it('must parse bid size from a string', function () {
       const width = 640;
       const height = 480;
       bidRequest.sizes = `${width}x${height}`;
@@ -91,7 +91,7 @@ describe('OptimaticBidAdapter', function () {
       expect(data.imp[0].video.h).to.equal(height);
     });
 
-    it('must handle an empty bid size', () => {
+    it('must handle an empty bid size', function () {
       bidRequest.sizes = [];
       const requests = spec.buildRequests([ bidRequest ]);
       const data = requests[0].data;
@@ -101,24 +101,24 @@ describe('OptimaticBidAdapter', function () {
   });
 
   describe('spec.interpretResponse', function () {
-    it('should return no bids if the response is not valid', () => {
+    it('should return no bids if the response is not valid', function () {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return no bids if the response "nurl" and "adm" are missing', () => {
+    it('should return no bids if the response "nurl" and "adm" are missing', function () {
       const serverResponse = {seatbid: [{bid: [{price: 5.01}]}]};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return no bids if the response "price" is missing', () => {
+    it('should return no bids if the response "price" is missing', function () {
       const serverResponse = {seatbid: [{bid: [{adm: '<VAST></VAST>'}]}]};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return a valid bid response with just "adm"', () => {
+    it('should return a valid bid response with just "adm"', function () {
       const serverResponse = {seatbid: [{bid: [{id: 1, price: 5.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       let o = {
@@ -137,7 +137,7 @@ describe('OptimaticBidAdapter', function () {
       expect(bidResponse).to.deep.equal(o);
     });
 
-    it('should return a valid bid response with just "nurl"', () => {
+    it('should return a valid bid response with just "nurl"', function () {
       const serverResponse = {seatbid: [{bid: [{id: 1, price: 5.01, nurl: 'https://mg-bid-win.optimatic.com/win/134eb262-948a-463e-ad93-bc8b622d399c?wp=${AUCTION_PRICE}'}]}], cur: 'USD'};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       let o = {
@@ -156,7 +156,7 @@ describe('OptimaticBidAdapter', function () {
       expect(bidResponse).to.deep.equal(o);
     });
 
-    it('should return a valid bid response with "nurl" when both nurl and adm exist', () => {
+    it('should return a valid bid response with "nurl" when both nurl and adm exist', function () {
       const serverResponse = {seatbid: [{bid: [{id: 1, price: 5.01, adm: '<VAST></VAST>', nurl: 'https://mg-bid-win.optimatic.com/win/134eb262-948a-463e-ad93-bc8b622d399c?wp=${AUCTION_PRICE}'}]}], cur: 'USD'};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       let o = {

--- a/test/spec/modules/optimeraBidAdapter_spec.js
+++ b/test/spec/modules/optimeraBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('OptimeraAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   })
@@ -24,7 +24,7 @@ describe('OptimeraAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
   })
@@ -42,7 +42,7 @@ describe('OptimeraAdapter', function () {
         }
       }
     ];
-    it('buildRequests fires', () => {
+    it('buildRequests fires', function () {
       let request = spec.buildRequests(bid);
       expect(request).to.exist;
       expect(request.method).to.equal('GET');
@@ -67,7 +67,7 @@ describe('OptimeraAdapter', function () {
         }
       ]
     }
-    it('interpresResponse fires', () => {
+    it('interpresResponse fires', function () {
       let bidResponses = spec.interpretResponse(serverResponse, bidRequest);
       expect(bidResponses[0].dealId[0]).to.equal('RB_K');
       expect(bidResponses[0].dealId[1]).to.equal('728x90K');

--- a/test/spec/modules/optimeraBidAdapter_spec.js
+++ b/test/spec/modules/optimeraBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { spec } from 'modules/optimeraBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('OptimeraAdapter', () => {
+describe('OptimeraAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   })
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'optimera',
       'params': {
@@ -29,7 +29,7 @@ describe('OptimeraAdapter', () => {
     });
   })
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bid = [
       {
         'adUnitCode': 'div-0',
@@ -51,7 +51,7 @@ describe('OptimeraAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse = {};
     serverResponse.body = JSON.parse('{"div-0":["RB_K","728x90K"], "timestamp":["RB_K","1507565666"]}');
     var bidRequest = {

--- a/test/spec/modules/orbitsoftBidAdapter_spec.js
+++ b/test/spec/modules/orbitsoftBidAdapter_spec.js
@@ -5,7 +5,7 @@ const ENDPOINT_URL = 'https://orbitsoft.com/php/ads/hb.phps';
 describe('Orbitsoft adapter', function () {
   describe('implementation', function () {
     describe('for requests', function () {
-      it('should accept valid bid', () => {
+      it('should accept valid bid', function () {
         let validBid = {
             bidder: 'orbitsoft',
             params: {
@@ -18,7 +18,7 @@ describe('Orbitsoft adapter', function () {
         expect(isValid).to.equal(true);
       });
 
-      it('should reject invalid bid', () => {
+      it('should reject invalid bid', function () {
         let invalidBid = {
             bidder: 'orbitsoft'
           },
@@ -28,7 +28,7 @@ describe('Orbitsoft adapter', function () {
       });
     });
     describe('for requests', function () {
-      it('should accept valid bid with styles', () => {
+      it('should accept valid bid with styles', function () {
         let validBid = {
             bidder: 'orbitsoft',
             params: {
@@ -91,7 +91,7 @@ describe('Orbitsoft adapter', function () {
         expect(requestUrlParams).have.property('c6', '5B99FE');
       });
 
-      it('should accept valid bid with custom params', () => {
+      it('should accept valid bid with custom params', function () {
         let validBid = {
             bidder: 'orbitsoft',
             params: {
@@ -112,7 +112,7 @@ describe('Orbitsoft adapter', function () {
         expect(requestUrlCustomParams).have.property('c.clickUrl', 'http://testclickurl.com');
       });
 
-      it('should reject invalid bid without requestUrl', () => {
+      it('should reject invalid bid without requestUrl', function () {
         let invalidBid = {
             bidder: 'orbitsoft',
             params: {
@@ -124,7 +124,7 @@ describe('Orbitsoft adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-      it('should reject invalid bid without placementId', () => {
+      it('should reject invalid bid without placementId', function () {
         let invalidBid = {
             bidder: 'orbitsoft',
             params: {
@@ -137,7 +137,7 @@ describe('Orbitsoft adapter', function () {
       });
     });
     describe('bid responses', function () {
-      it('should return complete bid response', () => {
+      it('should return complete bid response', function () {
         let serverResponse = {
           body: {
             callback_uid: '265b29b70cc106',
@@ -168,7 +168,7 @@ describe('Orbitsoft adapter', function () {
         expect(bids[0].adUrl).to.have.string('https://orbitsoft.com/php/ads/hb.html');
       });
 
-      it('should return empty bid response', () => {
+      it('should return empty bid response', function () {
         let bidRequests = [
           {
             bidder: 'orbitsoft',
@@ -189,7 +189,7 @@ describe('Orbitsoft adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on incorrect size', () => {
+      it('should return empty bid response on incorrect size', function () {
         let bidRequests = [
           {
             bidder: 'orbitsoft',
@@ -212,7 +212,7 @@ describe('Orbitsoft adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response with error', () => {
+      it('should return empty bid response with error', function () {
         let bidRequests = [
           {
             bidder: 'orbitsoft',
@@ -228,7 +228,7 @@ describe('Orbitsoft adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on empty body', () => {
+      it('should return empty bid response on empty body', function () {
         let bidRequests = [
           {
             bidder: 'orbitsoft',

--- a/test/spec/modules/orbitsoftBidAdapter_spec.js
+++ b/test/spec/modules/orbitsoftBidAdapter_spec.js
@@ -2,9 +2,9 @@ import {expect} from 'chai';
 import {spec} from 'modules/orbitsoftBidAdapter';
 
 const ENDPOINT_URL = 'https://orbitsoft.com/php/ads/hb.phps';
-describe('Orbitsoft adapter', () => {
-  describe('implementation', () => {
-    describe('for requests', () => {
+describe('Orbitsoft adapter', function () {
+  describe('implementation', function () {
+    describe('for requests', function () {
       it('should accept valid bid', () => {
         let validBid = {
             bidder: 'orbitsoft',
@@ -27,7 +27,7 @@ describe('Orbitsoft adapter', () => {
         expect(isValid).to.equal(false);
       });
     });
-    describe('for requests', () => {
+    describe('for requests', function () {
       it('should accept valid bid with styles', () => {
         let validBid = {
             bidder: 'orbitsoft',
@@ -136,7 +136,7 @@ describe('Orbitsoft adapter', () => {
         expect(isValid).to.equal(false);
       });
     });
-    describe('bid responses', () => {
+    describe('bid responses', function () {
       it('should return complete bid response', () => {
         let serverResponse = {
           body: {

--- a/test/spec/modules/papyrusBidAdapter_spec.js
+++ b/test/spec/modules/papyrusBidAdapter_spec.js
@@ -4,8 +4,8 @@ import { spec } from 'modules/papyrusBidAdapter';
 const ENDPOINT = '//prebid.papyrus.global';
 const BIDDER_CODE = 'papyrus';
 
-describe('papyrus Adapter', () => {
-  describe('isBidRequestValid', () => {
+describe('papyrus Adapter', function () {
+  describe('isBidRequestValid', function () {
     let validBidReq = {
       bidder: BIDDER_CODE,
       params: {
@@ -30,7 +30,7 @@ describe('papyrus Adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         bidder: BIDDER_CODE,
@@ -68,7 +68,7 @@ describe('papyrus Adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let bidRequests = [
       {
         bidder: BIDDER_CODE,

--- a/test/spec/modules/papyrusBidAdapter_spec.js
+++ b/test/spec/modules/papyrusBidAdapter_spec.js
@@ -14,7 +14,7 @@ describe('papyrus Adapter', function () {
       }
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(validBidReq)).to.equal(true);
     });
 
@@ -25,7 +25,7 @@ describe('papyrus Adapter', function () {
       }
     };
 
-    it('should not validate incorrect bid request', () => {
+    it('should not validate incorrect bid request', function () {
       expect(spec.isBidRequestValid(invalidBidReq)).to.equal(false);
     });
   });
@@ -46,23 +46,23 @@ describe('papyrus Adapter', function () {
       }
     ];
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('POST');
     });
 
-    it('sends valid bids count', () => {
+    it('sends valid bids count', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data.length).to.equal(1);
     });
 
-    it('sends all bid parameters', () => {
+    it('sends all bid parameters', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data[0]).to.have.all.keys(['address', 'placementId', 'sizes', 'bidId', 'transactionId']);
     });
 
-    it('sedns valid sizes parameter', () => {
+    it('sedns valid sizes parameter', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data[0].sizes[0]).to.equal('300x250');
     });
@@ -96,13 +96,13 @@ describe('papyrus Adapter', function () {
       ]
     };
 
-    it('should build bid array', () => {
+    it('should build bid array', function () {
       const request = spec.buildRequests(bidRequests);
       const result = spec.interpretResponse({body: bidResponse}, request[0]);
       expect(result.length).to.equal(1);
     });
 
-    it('should have all relevant fields', () => {
+    it('should have all relevant fields', function () {
       const request = spec.buildRequests(bidRequests);
       const result = spec.interpretResponse({body: bidResponse}, request[0]);
       const bid = result[0];

--- a/test/spec/modules/peak226BidAdapter_spec.js
+++ b/test/spec/modules/peak226BidAdapter_spec.js
@@ -4,10 +4,10 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const URL = 'a.ad216.com/header_bid';
 
-describe('PeakAdapter', () => {
+describe('PeakAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       const bid = {
         params: {
@@ -27,7 +27,7 @@ describe('PeakAdapter', () => {
     });
   });
 
-  // xdescribe('buildRequests', () => {
+  // xdescribe('buildRequests', function () {
   //   const bidRequests = [
   //     {
   //       params: {
@@ -44,7 +44,7 @@ describe('PeakAdapter', () => {
   //   });
   // });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should handle empty response', () => {
       let bids = spec.interpretResponse(
         {},

--- a/test/spec/modules/peak226BidAdapter_spec.js
+++ b/test/spec/modules/peak226BidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('PeakAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       const bid = {
         params: {
           uid: 123
@@ -18,7 +18,7 @@ describe('PeakAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       const bid = {
         params: {}
       };
@@ -36,7 +36,7 @@ describe('PeakAdapter', function () {
   //     }
   //   ];
 
-  //   it('sends bid request to URL via GET', () => {
+  //   it('sends bid request to URL via GET', function () {
   //     const request = spec.buildRequests(bidRequests);
 
   //     expect(request.url).to.equal(`${URL}?uids=1234`);
@@ -45,7 +45,7 @@ describe('PeakAdapter', function () {
   // });
 
   describe('interpretResponse', function () {
-    it('should handle empty response', () => {
+    it('should handle empty response', function () {
       let bids = spec.interpretResponse(
         {},
         {
@@ -56,7 +56,7 @@ describe('PeakAdapter', function () {
       expect(bids).to.be.lengthOf(0);
     });
 
-    it('should handle no seatbid returned', () => {
+    it('should handle no seatbid returned', function () {
       let response = {};
 
       let bids = spec.interpretResponse(
@@ -69,7 +69,7 @@ describe('PeakAdapter', function () {
       expect(bids).to.be.lengthOf(0);
     });
 
-    it('should handle empty seatbid returned', () => {
+    it('should handle empty seatbid returned', function () {
       let response = { seatbid: [] };
 
       let bids = spec.interpretResponse(
@@ -82,7 +82,7 @@ describe('PeakAdapter', function () {
       expect(bids).to.be.lengthOf(0);
     });
 
-    it('should handle seatbid returned bids', () => {
+    it('should handle seatbid returned bids', function () {
       const bidsMap = { 1: [{ bidId: 11 }] };
       const bid = {
         price: 0.2,

--- a/test/spec/modules/platformioBidAdapter_spec.js
+++ b/test/spec/modules/platformioBidAdapter_spec.js
@@ -77,7 +77,7 @@ describe('Platform.io Adapter Tests', function () {
     }
   }];
 
-  it('Verify build request', () => {
+  it('Verify build request', function () {
     const request = spec.buildRequests(slotConfigs);
     expect(request.url).to.equal('//piohbdisp.hb.adx1.com/');
     expect(request.method).to.equal('POST');
@@ -109,7 +109,7 @@ describe('Platform.io Adapter Tests', function () {
     expect(ortbRequest.imp[1].bidfloor).to.equal('0.000001');
   });
 
-  it('Verify parse response', () => {
+  it('Verify parse response', function () {
     const request = spec.buildRequests(slotConfigs);
     const ortbRequest = JSON.parse(request.data);
     const ortbResponse = {
@@ -137,13 +137,13 @@ describe('Platform.io Adapter Tests', function () {
     expect(bid.ttl).to.equal(360);
   });
 
-  it('Verify full passback', () => {
+  it('Verify full passback', function () {
     const request = spec.buildRequests(slotConfigs);
     const bids = spec.interpretResponse({ body: null }, request)
     expect(bids).to.have.lengthOf(0);
   });
 
-  it('Verify Native request', () => {
+  it('Verify Native request', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//piohbdisp.hb.adx1.com/');
     expect(request.method).to.equal('POST');
@@ -181,7 +181,7 @@ describe('Platform.io Adapter Tests', function () {
     expect(nativeRequest.assets[4].img.type).to.equal(3);
   });
 
-  it('Verify Native response', () => {
+  it('Verify Native response', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//piohbdisp.hb.adx1.com/');
     expect(request.method).to.equal('POST');
@@ -231,7 +231,7 @@ describe('Platform.io Adapter Tests', function () {
     expect(nativeBid.impressionTrackers[0]).to.equal('http://rtb.adx1.com/log');
   });
 
-  it('Verify Video request', () => {
+  it('Verify Video request', function () {
     const request = spec.buildRequests(videoSlotConfig);
     expect(request.url).to.equal('//piohbdisp.hb.adx1.com/');
     expect(request.method).to.equal('POST');
@@ -253,7 +253,7 @@ describe('Platform.io Adapter Tests', function () {
     expect(videoRequest.imp[0].native).to.equal(null);
   });
 
-  it('Verify parse video response', () => {
+  it('Verify parse video response', function () {
     const request = spec.buildRequests(videoSlotConfig);
     const videoRequest = JSON.parse(request.data);
     const videoResponse = {
@@ -282,25 +282,25 @@ describe('Platform.io Adapter Tests', function () {
     expect(bid.ttl).to.equal(360);
   });
 
-  it('Verifies bidder code', () => {
+  it('Verifies bidder code', function () {
     expect(spec.code).to.equal('platformio');
   });
 
-  it('Verifies supported media types', () => {
+  it('Verifies supported media types', function () {
     expect(spec.supportedMediaTypes).to.have.lengthOf(3);
     expect(spec.supportedMediaTypes[0]).to.equal('banner');
     expect(spec.supportedMediaTypes[1]).to.equal('native');
     expect(spec.supportedMediaTypes[2]).to.equal('video');
   });
 
-  it('Verifies if bid request valid', () => {
+  it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(slotConfigs[0])).to.equal(true);
     expect(spec.isBidRequestValid(slotConfigs[1])).to.equal(true);
     expect(spec.isBidRequestValid(nativeSlotConfig[0])).to.equal(true);
     expect(spec.isBidRequestValid(videoSlotConfig[0])).to.equal(true);
   });
 
-  it('Verify app requests', () => {
+  it('Verify app requests', function () {
     const request = spec.buildRequests(appSlotConfig);
     const ortbRequest = JSON.parse(request.data);
     expect(ortbRequest.site).to.equal(null);
@@ -314,7 +314,7 @@ describe('Platform.io Adapter Tests', function () {
     expect(ortbRequest.app.domain).to.equal('platform.io');
   });
 
-  it('Verify GDPR', () => {
+  it('Verify GDPR', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,

--- a/test/spec/modules/platformioBidAdapter_spec.js
+++ b/test/spec/modules/platformioBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/platformioBidAdapter';
 import {getTopWindowLocation} from 'src/utils';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-describe('Platform.io Adapter Tests', () => {
+describe('Platform.io Adapter Tests', function () {
   const slotConfigs = [{
     placementCode: '/DfpAccount1/slot1',
     bidId: 'bid12345',

--- a/test/spec/modules/playgroundxyzBidAdapter_spec.js
+++ b/test/spec/modules/playgroundxyzBidAdapter_spec.js
@@ -6,16 +6,16 @@ import { deepClone } from 'src/utils';
 const URL = 'https://ads.playground.xyz/host-config/prebid';
 const GDPR_CONSENT = 'XYZ-CONSENT';
 
-describe('playgroundxyzBidAdapter', () => {
+describe('playgroundxyzBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'playgroundxyz',
       'params': {
@@ -42,7 +42,7 @@ describe('playgroundxyzBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'playgroundxyz',
@@ -72,7 +72,7 @@ describe('playgroundxyzBidAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'id': 'bidd_id',
       'seatbid': [ {
@@ -135,7 +135,7 @@ describe('playgroundxyzBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'playgroundxyz',

--- a/test/spec/modules/playgroundxyzBidAdapter_spec.js
+++ b/test/spec/modules/playgroundxyzBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('playgroundxyzBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -28,11 +28,11 @@ describe('playgroundxyzBidAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -57,7 +57,7 @@ describe('playgroundxyzBidAdapter', function () {
       }
     ];
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       let bidRequest = Object.assign([], bidRequests);
 
       const request = spec.buildRequests(bidRequest);
@@ -109,7 +109,7 @@ describe('playgroundxyzBidAdapter', function () {
       'bidderCode': 'playgroundxyz'
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '221f2bdc1fbc31',
@@ -128,7 +128,7 @@ describe('playgroundxyzBidAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = '';
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result.length).to.equal(0);
@@ -150,7 +150,7 @@ describe('playgroundxyzBidAdapter', function () {
       }
     ];
 
-    it('should not populate GDPR', () => {
+    it('should not populate GDPR', function () {
       let bidRequest = Object.assign([], bidRequests);
       const request = spec.buildRequests(bidRequest);
       let data = JSON.parse(request.data);
@@ -158,7 +158,7 @@ describe('playgroundxyzBidAdapter', function () {
       expect(data).to.not.have.property('regs');
     });
 
-    it('should populate GDPR and consent string when consetString is presented but not gdpApplies', () => {
+    it('should populate GDPR and consent string when consetString is presented but not gdpApplies', function () {
       let bidRequest = Object.assign([], bidRequests);
       const request = spec.buildRequests(bidRequest, {gdprConsent: {consentString: GDPR_CONSENT}});
       let data = JSON.parse(request.data);
@@ -166,7 +166,7 @@ describe('playgroundxyzBidAdapter', function () {
       expect(data.user.ext.consent).to.equal('XYZ-CONSENT');
     });
 
-    it('should populate GDPR and consent string when gdpr is set to true', () => {
+    it('should populate GDPR and consent string when gdpr is set to true', function () {
       let bidRequest = Object.assign([], bidRequests);
       const request = spec.buildRequests(bidRequest, {gdprConsent: {gdprApplies: true, consentString: GDPR_CONSENT}});
       let data = JSON.parse(request.data);
@@ -174,7 +174,7 @@ describe('playgroundxyzBidAdapter', function () {
       expect(data.user.ext.consent).to.equal('XYZ-CONSENT');
     });
 
-    it('should populate GDPR and consent string when gdpr is set to false', () => {
+    it('should populate GDPR and consent string when gdpr is set to false', function () {
       let bidRequest = Object.assign([], bidRequests);
       const request = spec.buildRequests(bidRequest, {gdprConsent: {gdprApplies: false, consentString: GDPR_CONSENT}});
       let data = JSON.parse(request.data);

--- a/test/spec/modules/polluxBidAdapter_spec.js
+++ b/test/spec/modules/polluxBidAdapter_spec.js
@@ -24,7 +24,7 @@ describe('POLLUX Bid Adapter tests', function () {
     params: {zone: '276'}
   }];
 
-  it('TEST: verify buildRequests no valid bid requests', () => {
+  it('TEST: verify buildRequests no valid bid requests', function () {
     let request = spec.buildRequests(false);
     expect(request).to.not.equal(null);
     expect(request).to.not.have.property('method');
@@ -47,7 +47,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(request).to.not.have.property('data');
   });
 
-  it('TEST: verify buildRequests single bid', () => {
+  it('TEST: verify buildRequests single bid', function () {
     const request = spec.buildRequests(setup_single_bid);
     expect(request.method).to.equal('POST');
     const requested_bids = JSON.parse(request.data);
@@ -70,7 +70,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(requested_bids[0].zones).to.equal('1806,276');
   });
 
-  it('TEST: verify buildRequests multi bid', () => {
+  it('TEST: verify buildRequests multi bid', function () {
     const request = spec.buildRequests(setup_multi_bid);
     expect(request.method).to.equal('POST');
     const requested_bids = JSON.parse(request.data);
@@ -102,7 +102,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(requested_bids[1].zones).to.equal('276');
   });
 
-  it('TEST: verify interpretResponse empty', () => {
+  it('TEST: verify interpretResponse empty', function () {
     let bids = spec.interpretResponse(false, {});
     expect(bids).to.not.equal(null);
     expect(bids).to.have.lengthOf(0);
@@ -117,7 +117,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(bids).to.have.lengthOf(0);
   });
 
-  it('TEST: verify interpretResponse ad_type url', () => {
+  it('TEST: verify interpretResponse ad_type url', function () {
     const serverResponse = {
       body: [
         {
@@ -147,7 +147,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(bids[0]).to.not.have.property('ad');
   });
 
-  it('TEST: verify interpretResponse ad_type html', () => {
+  it('TEST: verify interpretResponse ad_type html', function () {
     const serverResponse = {
       body: [
         {
@@ -176,7 +176,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(bids[0].ad).to.equal('<html><h3>I am an ad</h3></html>');
   });
 
-  it('TEST: verify url and query params', () => {
+  it('TEST: verify url and query params', function () {
     const URL = require('url-parse');
     const querystringify = require('querystringify');
     const request = spec.buildRequests(setup_single_bid);
@@ -188,7 +188,7 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(parsedQuery).to.have.property('domain').and.to.have.length.above(1);
   });
 
-  it('TEST: verify isBidRequestValid', () => {
+  it('TEST: verify isBidRequestValid', function () {
     expect(spec.isBidRequestValid({})).to.equal(false);
     expect(spec.isBidRequestValid({params: {}})).to.equal(false);
     expect(spec.isBidRequestValid(setup_single_bid[0])).to.equal(true);
@@ -196,11 +196,11 @@ describe('POLLUX Bid Adapter tests', function () {
     expect(spec.isBidRequestValid(setup_multi_bid[1])).to.equal(true);
   });
 
-  it('TEST: verify bidder code', () => {
+  it('TEST: verify bidder code', function () {
     expect(spec.code).to.equal('pollux');
   });
 
-  it('TEST: verify bidder aliases', () => {
+  it('TEST: verify bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
     expect(spec.aliases[0]).to.equal('plx');
   });

--- a/test/spec/modules/polymorphBidAdapter_spec.js
+++ b/test/spec/modules/polymorphBidAdapter_spec.js
@@ -35,17 +35,17 @@ const bidRequests = [{
 
 describe('Polymorph adapter test', function () {
   describe('.code', function () {
-    it('should return a bidder code of polymorph', () => {
+    it('should return a bidder code of polymorph', function () {
       expect(spec.code).to.eql(BIDDER_CODE);
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
 
-    it('should return false if req has no placementId', () => {
+    it('should return false if req has no placementId', function () {
       const invalidBidRequest = {
         bidder: BIDDER_CODE,
         params: {
@@ -55,7 +55,7 @@ describe('Polymorph adapter test', function () {
       expect(spec.isBidRequestValid(invalidBidRequest)).to.eql(false);
     });
 
-    it('should return false if req has wrong bidder code', () => {
+    it('should return false if req has wrong bidder code', function () {
       const invalidBidRequest = {
         bidder: 'something',
         params: {
@@ -67,7 +67,7 @@ describe('Polymorph adapter test', function () {
   });
 
   describe('buildRequests', function () {
-    it('payload test', () => {
+    it('payload test', function () {
       const requests = spec.buildRequests(bidRequests);
       var payload1 = {};
       requests[0].data.replace(/([^=&]+)=([^&]*)/g, function(m, key, value) {
@@ -92,7 +92,7 @@ describe('Polymorph adapter test', function () {
       expect(payload2.sizes).to.equal('700,250,300,600');
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const requests = spec.buildRequests(bidRequests);
       expect(requests[0].url).to.equal(ENDPOINT_URL);
       expect(requests[0].method).to.equal('GET');
@@ -133,7 +133,7 @@ describe('Polymorph adapter test', function () {
       }
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const body = response.body;
       const expectedResponse = [{
         requestId: bidRequests[0].bidId,
@@ -152,7 +152,7 @@ describe('Polymorph adapter test', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('widget use case', () => {
+    it('widget use case', function () {
       const body = response2.body;
       const expectedResponse = [
         {
@@ -173,7 +173,7 @@ describe('Polymorph adapter test', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = [];
 
       let result = spec.interpretResponse(response, { 'bidderRequest': bidRequests[0] });

--- a/test/spec/modules/polymorphBidAdapter_spec.js
+++ b/test/spec/modules/polymorphBidAdapter_spec.js
@@ -33,14 +33,14 @@ const bidRequests = [{
   'auctionId': '1d1a030790a476',
 }];
 
-describe('Polymorph adapter test', () => {
-  describe('.code', () => {
+describe('Polymorph adapter test', function () {
+  describe('.code', function () {
     it('should return a bidder code of polymorph', () => {
       expect(spec.code).to.eql(BIDDER_CODE);
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
     });
@@ -66,7 +66,7 @@ describe('Polymorph adapter test', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('payload test', () => {
       const requests = spec.buildRequests(bidRequests);
       var payload1 = {};
@@ -99,7 +99,7 @@ describe('Polymorph adapter test', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const response = {
       body: {
         'status': 'OK',

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -389,11 +389,11 @@ describe('S2S Adapter', function () {
 
     afterEach(() => xhr.restore());
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
 
-    it('exists converts types', () => {
+    it('exists converts types', function () {
       config.setConfig({s2sConfig: CONFIG});
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       const requestBid = JSON.parse(requests[0].requestBody);
@@ -408,7 +408,7 @@ describe('S2S Adapter', function () {
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
       });
 
-      it('adds gdpr consent information to ortb2 request depending on presence of module', () => {
+      it('adds gdpr consent information to ortb2 request depending on presence of module', function () {
         let ortb2Config = utils.deepClone(CONFIG);
         ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
 
@@ -437,7 +437,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user).to.not.exist;
       });
 
-      it('check gdpr info gets added into cookie_sync request: have consent data', () => {
+      it('check gdpr info gets added into cookie_sync request: have consent data', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
         cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
@@ -458,7 +458,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.gdpr_consent).is.equal('abc123def');
       });
 
-      it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', () => {
+      it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
         cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
@@ -478,7 +478,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.gdpr_consent).is.undefined;
       });
 
-      it('checks gdpr info gets added to cookie_sync request: consent data unknown', () => {
+      it('checks gdpr info gets added to cookie_sync request: consent data unknown', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
         cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
 
@@ -499,7 +499,7 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('sets invalid cacheMarkup value to 0', () => {
+    it('sets invalid cacheMarkup value to 0', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         cacheMarkup: 999
       });
@@ -509,7 +509,7 @@ describe('S2S Adapter', function () {
       expect(requestBid).to.have.property('cache_markup', 0);
     });
 
-    it('adds digitrust id is present and user is not optout', () => {
+    it('adds digitrust id is present and user is not optout', function () {
       let digiTrustObj = {
         success: true,
         identity: {
@@ -544,7 +544,7 @@ describe('S2S Adapter', function () {
       delete window.DigiTrust;
     });
 
-    it('adds device and app objects to request', () => {
+    it('adds device and app objects to request', function () {
       const _config = { s2sConfig: CONFIG,
         device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
         app: { bundle: 'com.test.app' },
@@ -562,7 +562,7 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('adds device and app objects to request for ORTB', () => {
+    it('adds device and app objects to request for ORTB', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -585,7 +585,7 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('adds site if app is not present', () => {
+    it('adds site if app is not present', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -602,7 +602,7 @@ describe('S2S Adapter', function () {
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
     });
 
-    it('adds appnexus aliases to request', () => {
+    it('adds appnexus aliases to request', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -629,7 +629,7 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('adds dynamic aliases to request', () => {
+    it('adds dynamic aliases to request', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -659,7 +659,7 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('converts appnexus params to expected format for PBS', () => {
+    it('converts appnexus params to expected format for PBS', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -735,7 +735,7 @@ describe('S2S Adapter', function () {
     });
 
     // TODO: test dependent on pbjs_api_spec.  Needs to be isolated
-    it('registers bids and calls BIDDER_DONE', () => {
+    it('registers bids and calls BIDDER_DONE', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -758,7 +758,7 @@ describe('S2S Adapter', function () {
       expect(response).to.not.have.property('vastUrl');
     });
 
-    it('registers video bids', () => {
+    it('registers video bids', function () {
       server.respondWith(JSON.stringify(VIDEO_RESPONSE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -776,7 +776,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('vastUrl', 'video_cache_url');
     });
 
-    it('does not call addBidResponse and calls done when ad unit not set', () => {
+    it('does not call addBidResponse and calls done when ad unit not set', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_BID_NO_UNIT));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -787,7 +787,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(done);
     });
 
-    it('does not call addBidResponse and calls done when server requests cookie sync', () => {
+    it('does not call addBidResponse and calls done when server requests cookie sync', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_COOKIE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -798,7 +798,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(done);
     });
 
-    it('does not call addBidResponse and calls done  when ad unit is set', () => {
+    it('does not call addBidResponse and calls done  when ad unit is set', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_BID_UNIT_SET));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -809,7 +809,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(done);
     });
 
-    it('registers successful bids and calls done when there are less bids than requests', () => {
+    it('registers successful bids and calls done when there are less bids than requests', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -827,7 +827,7 @@ describe('S2S Adapter', function () {
         .to.have.property('statusMessage', 'Bid available');
     });
 
-    it('should have dealId in bidObject', () => {
+    it('should have dealId in bidObject', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -837,7 +837,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('dealId', 'test-dealid');
     });
 
-    it('should pass through default adserverTargeting if present in bidObject', () => {
+    it('should pass through default adserverTargeting if present in bidObject', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -847,7 +847,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('adserverTargeting').that.deep.equals({'foo': 'bar'});
     });
 
-    it('registers client user syncs when client bid adapter is present', () => {
+    it('registers client user syncs when client bid adapter is present', function () {
       let rubiconAdapter = {
         registerSyncs: sinon.spy()
       };
@@ -864,7 +864,7 @@ describe('S2S Adapter', function () {
       adapterManager.getBidAdapter.restore();
     });
 
-    it('registers client user syncs when using OpenRTB endpoint', () => {
+    it('registers client user syncs when using OpenRTB endpoint', function () {
       let rubiconAdapter = {
         registerSyncs: sinon.spy()
       };
@@ -884,7 +884,7 @@ describe('S2S Adapter', function () {
       adapterManager.getBidAdapter.restore();
     });
 
-    it('registers bid responses when server requests cookie sync', () => {
+    it('registers bid responses when server requests cookie sync', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
 
       config.setConfig({s2sConfig: CONFIG});
@@ -903,7 +903,7 @@ describe('S2S Adapter', function () {
       expect(bid_request_passed).to.have.property('adId', '123');
     });
 
-    it('does not call cookieSet cookie sync when no_cookie response && not opted in', () => {
+    it('does not call cookieSet cookie sync when no_cookie response && not opted in', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
 
       let myConfig = Object.assign({}, CONFIG);
@@ -914,7 +914,7 @@ describe('S2S Adapter', function () {
       sinon.assert.notCalled(cookie.cookieSet);
     });
 
-    it('calls cookieSet cookie sync when no_cookie response && opted in', () => {
+    it('calls cookieSet cookie sync when no_cookie response && opted in', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_PBS_COOKIE));
       let myConfig = Object.assign({
         cookieSet: true,
@@ -927,7 +927,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(cookie.cookieSet);
     });
 
-    it('handles OpenRTB responses and call BIDDER_DONE', () => {
+    it('handles OpenRTB responses and call BIDDER_DONE', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
       });
@@ -950,7 +950,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('cpm', 0.5);
     });
 
-    it('handles OpenRTB video responses', () => {
+    it('handles OpenRTB video responses', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebidserverurl/openrtb2/auction?querystring=param'
       });
@@ -970,7 +970,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('cpm', 10);
     });
 
-    it('should log warning for unsupported bidder', () => {
+    it('should log warning for unsupported bidder', function () {
       server.respondWith(JSON.stringify(RESPONSE_UNSUPPORTED_BIDDER));
 
       const s2sConfig = Object.assign({}, CONFIG, {
@@ -1001,7 +1001,7 @@ describe('S2S Adapter', function () {
       utils.logError.restore();
     });
 
-    it('should log an error when accountId is missing', () => {
+    it('should log an error when accountId is missing', function () {
       const options = {
         enabled: true,
         bidders: ['appnexus'],
@@ -1014,7 +1014,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log an error when bidders is missing', () => {
+    it('should log an error when bidders is missing', function () {
       const options = {
         accountId: '1',
         enabled: true,
@@ -1027,7 +1027,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log an error when endpoint is missing', () => {
+    it('should log an error when endpoint is missing', function () {
       const options = {
         accountId: '1',
         bidders: ['appnexus'],
@@ -1040,7 +1040,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log an error when using an unknown vendor', () => {
+    it('should log an error when using an unknown vendor', function () {
       const options = {
         accountId: '1',
         bidders: ['appnexus'],
@@ -1051,7 +1051,7 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should configure the s2sConfig object with appnexus vendor defaults unless specified by user', () => {
+    it('should configure the s2sConfig object with appnexus vendor defaults unless specified by user', function () {
       const options = {
         accountId: '123',
         bidders: ['appnexus'],
@@ -1074,7 +1074,7 @@ describe('S2S Adapter', function () {
       expect(vendorConfig).to.have.property('timeout', 750);
     });
 
-    it('should configure the s2sConfig object with rubicon vendor defaults unless specified by user', () => {
+    it('should configure the s2sConfig object with rubicon vendor defaults unless specified by user', function () {
       const options = {
         accountId: 'abc',
         bidders: ['rubicon'],

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -329,7 +329,7 @@ const RESPONSE_UNSUPPORTED_BIDDER = {
   }]
 };
 
-describe('S2S Adapter', () => {
+describe('S2S Adapter', function () {
   let adapter,
     addBidResponse = sinon.spy(),
     done = sinon.spy();
@@ -375,7 +375,7 @@ describe('S2S Adapter', () => {
     done.resetHistory();
   });
 
-  describe('request function', () => {
+  describe('request function', function () {
     let xhr;
     let requests;
 
@@ -402,7 +402,7 @@ describe('S2S Adapter', () => {
       expect(requestBid.ad_units[0].bids[0].params.member).to.exist.and.to.be.a('string');
     });
 
-    describe('gdpr tests', () => {
+    describe('gdpr tests', function () {
       afterEach(() => {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
@@ -710,7 +710,7 @@ describe('S2S Adapter', () => {
     });
   });
 
-  describe('response handler', () => {
+  describe('response handler', function () {
     let server;
     let logWarnSpy;
 
@@ -990,7 +990,7 @@ describe('S2S Adapter', () => {
     });
   });
 
-  describe('s2sConfig', () => {
+  describe('s2sConfig', function () {
     let logErrorSpy;
 
     beforeEach(() => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -334,7 +334,7 @@ describe('S2S Adapter', function () {
     addBidResponse = sinon.spy(),
     done = sinon.spy();
 
-  beforeEach(() => {
+  beforeEach(function () {
     adapter = new Adapter();
     BID_REQUESTS = [
       {
@@ -370,7 +370,7 @@ describe('S2S Adapter', function () {
     ];
   });
 
-  afterEach(() => {
+  afterEach(function () {
     addBidResponse.resetHistory();
     done.resetHistory();
   });
@@ -379,7 +379,7 @@ describe('S2S Adapter', function () {
     let xhr;
     let requests;
 
-    beforeEach(() => {
+    beforeEach(function () {
       xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = request => requests.push(request);
@@ -387,7 +387,9 @@ describe('S2S Adapter', function () {
       resetSyncedStatus();
     });
 
-    afterEach(() => xhr.restore());
+    afterEach(function () {
+      xhr.restore();
+    });
 
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
@@ -403,7 +405,7 @@ describe('S2S Adapter', function () {
     });
 
     describe('gdpr tests', function () {
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
       });
@@ -714,7 +716,7 @@ describe('S2S Adapter', function () {
     let server;
     let logWarnSpy;
 
-    beforeEach(() => {
+    beforeEach(function () {
       server = sinon.fakeServer.create();
       sinon.stub(utils, 'triggerPixel');
       sinon.stub(utils, 'insertUserSyncIframe');
@@ -724,7 +726,7 @@ describe('S2S Adapter', function () {
       logWarnSpy = sinon.spy(utils, 'logWarn');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       server.restore();
       utils.triggerPixel.restore();
       utils.insertUserSyncIframe.restore();
@@ -993,11 +995,11 @@ describe('S2S Adapter', function () {
   describe('s2sConfig', function () {
     let logErrorSpy;
 
-    beforeEach(() => {
+    beforeEach(function () {
       logErrorSpy = sinon.spy(utils, 'logError');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       utils.logError.restore();
     });
 

--- a/test/spec/modules/pubCommonId_spec.js
+++ b/test/spec/modules/pubCommonId_spec.js
@@ -18,7 +18,7 @@ const COOKIE_NAME = '_pubcid';
 const TIMEOUT = 2000;
 
 describe('Publisher Common ID', function () {
-  afterEach(() => {
+  afterEach(function () {
     $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidHook);
   });
   describe('Decorate adUnits', function () {
@@ -159,7 +159,7 @@ describe('Publisher Common ID', function () {
       getUserSyncs: () => {}
     };
 
-    beforeEach(() => {
+    beforeEach(function () {
       adUnits = [{
         code: 'adUnit-code',
         mediaTypes: {
@@ -179,7 +179,7 @@ describe('Publisher Common ID', function () {
       registerBidder(sampleSpec);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionModule.newAuction.restore();
     });
 

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -157,7 +157,7 @@ describe('PubMatic adapter', function () {
 
   describe('implementation', function () {
   	describe('Bid validations', function () {
-  		it('valid bid case', () => {
+  		it('valid bid case', function () {
 		  let validBid = {
 	        bidder: 'pubmatic',
 	        params: {
@@ -169,7 +169,7 @@ describe('PubMatic adapter', function () {
 	      expect(isValid).to.equal(true);
   		});
 
-      it('invalid bid case: publisherId not passed', () => {
+      it('invalid bid case: publisherId not passed', function () {
 		    let validBid = {
 	        bidder: 'pubmatic',
 	        params: {
@@ -180,7 +180,7 @@ describe('PubMatic adapter', function () {
 	      expect(isValid).to.equal(false);
   		});
 
-      it('invalid bid case: publisherId is not string', () => {
+      it('invalid bid case: publisherId is not string', function () {
         let validBid = {
             bidder: 'pubmatic',
             params: {
@@ -192,7 +192,7 @@ describe('PubMatic adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-  		it('invalid bid case: adSlot not passed', () => {
+  		it('invalid bid case: adSlot not passed', function () {
   		  let validBid = {
 	        bidder: 'pubmatic',
 	        params: {
@@ -203,7 +203,7 @@ describe('PubMatic adapter', function () {
 	      expect(isValid).to.equal(false);
     	});
 
-      it('invalid bid case: adSlot is not string', () => {
+      it('invalid bid case: adSlot is not string', function () {
         let validBid = {
             bidder: 'pubmatic',
             params: {
@@ -217,13 +217,13 @@ describe('PubMatic adapter', function () {
     });
 
   	describe('Request formation', function () {
-  		it('Endpoint checking', () => {
+  		it('Endpoint checking', function () {
   		  let request = spec.buildRequests(bidRequests);
         expect(request.url).to.equal('//hbopenbid.pubmatic.com/translator?source=prebid-client');
         expect(request.method).to.equal('POST');
   		});
 
-  		it('Request params check', () => {
+  		it('Request params check', function () {
   		  let request = spec.buildRequests(bidRequests);
   		  let data = JSON.parse(request.data);
   		  expect(data.at).to.equal(1); // auction type
@@ -254,7 +254,7 @@ describe('PubMatic adapter', function () {
         expect(data.imp[0].bidfloorcur).to.equal(bidRequests[0].params.currency);
   		});
 
-      it('Request params multi size format object check', () => {
+      it('Request params multi size format object check', function () {
         let bidRequests = [
           {
             bidder: 'pubmatic',
@@ -309,7 +309,7 @@ describe('PubMatic adapter', function () {
         expect(data.imp[0].banner.format[0].h).to.equal(600); // height
       });
 
-      it('Request params currency check', () => {
+      it('Request params currency check', function () {
         let multipleBidRequests = [
           {
             bidder: 'pubmatic',
@@ -406,7 +406,7 @@ describe('PubMatic adapter', function () {
         expect(data.imp[1].bidfloorcur).to.equal('USD');
       });
 
-      it('Request params check with GDPR Consent', () => {
+      it('Request params check with GDPR Consent', function () {
         let bidRequest = {
           gdprConsent: {
             consentString: 'kjfdniwjnifwenrif3',
@@ -442,7 +442,7 @@ describe('PubMatic adapter', function () {
   		  expect(data.imp[0].ext.pmZoneId).to.equal(bidRequests[0].params.pmzoneid.split(',').slice(0, 50).map(id => id.trim()).join()); // pmzoneid
   		});
 
-      it('Request params check for video ad', () => {
+      it('Request params check for video ad', function () {
         let request = spec.buildRequests(videoBidRequests);
         let data = JSON.parse(request.data);
         expect(data.imp[0].video).to.exist;
@@ -480,7 +480,7 @@ describe('PubMatic adapter', function () {
         expect(data.imp[0]['video']['h']).to.equal(videoBidRequests[0].mediaTypes.video.playerSize[1]);
       });
 
-      it('Request params check for 1 banner and 1 video ad', () => {
+      it('Request params check for 1 banner and 1 video ad', function () {
         let request = spec.buildRequests(multipleMediaRequests);
         let data = JSON.parse(request.data);
 
@@ -549,7 +549,7 @@ describe('PubMatic adapter', function () {
       });
   	});
 
-    it('Request params dctr check', () => {
+    it('Request params dctr check', function () {
       let multipleBidRequests = [
         {
           bidder: 'pubmatic',
@@ -633,7 +633,7 @@ describe('PubMatic adapter', function () {
     });
 
     describe('Response checking', function () {
-      it('should check for valid response values', () => {
+      it('should check for valid response values', function () {
         let request = spec.buildRequests(bidRequests);
         let response = spec.interpretResponse(bidResponses, request);
         expect(response).to.be.an('array').with.length.above(0);
@@ -670,7 +670,7 @@ describe('PubMatic adapter', function () {
         expect(response[1].ad).to.equal(bidResponses.body.seatbid[1].bid[0].adm);
       });
 
-      it('should check for dealChannel value selection', () => {
+      it('should check for dealChannel value selection', function () {
         let request = spec.buildRequests(bidRequests);
         let response = spec.interpretResponse(bidResponses, request);
         expect(response).to.be.an('array').with.length.above(0);
@@ -678,7 +678,7 @@ describe('PubMatic adapter', function () {
         expect(response[1].dealChannel).to.equal('PREF');
       });
 
-      it('should check for unexpected dealChannel value selection', () => {
+      it('should check for unexpected dealChannel value selection', function () {
         let request = spec.buildRequests(bidRequests);
         let updateBiResponse = bidResponses;
         updateBiResponse.body.seatbid[0].bid[0].ext.deal_channel = 11;

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/pubmaticBidAdapter';
 import * as utils from 'src/utils';
 const constants = require('src/constants.json');
 
-describe('PubMatic adapter', () => {
+describe('PubMatic adapter', function () {
   let bidRequests;
   let videoBidRequests;
   let multipleMediaRequests;
@@ -155,8 +155,8 @@ describe('PubMatic adapter', () => {
     };
   });
 
-  describe('implementation', () => {
-  	describe('Bid validations', () => {
+  describe('implementation', function () {
+  	describe('Bid validations', function () {
   		it('valid bid case', () => {
 		  let validBid = {
 	        bidder: 'pubmatic',
@@ -216,7 +216,7 @@ describe('PubMatic adapter', () => {
       });
     });
 
-  	describe('Request formation', () => {
+  	describe('Request formation', function () {
   		it('Endpoint checking', () => {
   		  let request = spec.buildRequests(bidRequests);
         expect(request.url).to.equal('//hbopenbid.pubmatic.com/translator?source=prebid-client');
@@ -632,7 +632,7 @@ describe('PubMatic adapter', () => {
       expect(data.site.ext).to.not.exist;
     });
 
-    describe('Response checking', () => {
+    describe('Response checking', function () {
       it('should check for valid response values', () => {
         let request = spec.buildRequests(bidRequests);
         let response = spec.interpretResponse(bidResponses, request);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('PubMatic adapter', function () {
   let multipleMediaRequests;
   let bidResponses;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'pubmatic',

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -6,21 +6,21 @@ let constants = require('src/constants.json');
 describe('PubWise Prebid Analytics', function () {
   let xhr;
 
-  before(() => {
+  before(function () {
     xhr = sinon.useFakeXMLHttpRequest();
   });
 
-  after(() => {
+  after(function () {
     xhr.restore();
     pubwiseAnalytics.disableAnalytics();
   });
 
   describe('enableAnalytics', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.stub(events, 'getEvents').returns([]);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       events.getEvents.restore();
     });
 

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -49,7 +49,7 @@ describe('PulsePoint Adapter Tests', function () {
     }
   }];
 
-  it('Verify build request', () => {
+  it('Verify build request', function () {
     const request = spec.buildRequests(slotConfigs);
     expect(request.url).to.equal('//bid.contextweb.com/header/ortb');
     expect(request.method).to.equal('POST');
@@ -76,7 +76,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(ortbRequest.imp[1].banner.h).to.equal(90);
   });
 
-  it('Verify parse response', () => {
+  it('Verify parse response', function () {
     const request = spec.buildRequests(slotConfigs);
     const ortbRequest = JSON.parse(request.data);
     const ortbResponse = {
@@ -104,7 +104,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(bid.ttl).to.equal(20);
   });
 
-  it('Verify use ttl in ext', () => {
+  it('Verify use ttl in ext', function () {
     const request = spec.buildRequests(slotConfigs);
     const ortbRequest = JSON.parse(request.data);
     const ortbResponse = {
@@ -130,13 +130,13 @@ describe('PulsePoint Adapter Tests', function () {
     expect(bid.currency).to.equal('INR');
   });
 
-  it('Verify full passback', () => {
+  it('Verify full passback', function () {
     const request = spec.buildRequests(slotConfigs);
     const bids = spec.interpretResponse({ body: null }, request)
     expect(bids).to.have.lengthOf(0);
   });
 
-  it('Verify Native request', () => {
+  it('Verify Native request', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//bid.contextweb.com/header/ortb');
     expect(request.method).to.equal('POST');
@@ -174,7 +174,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(nativeRequest.assets[2].img.type).to.equal(3);
   });
 
-  it('Verify Native response', () => {
+  it('Verify Native response', function () {
     const request = spec.buildRequests(nativeSlotConfig);
     expect(request.url).to.equal('//bid.contextweb.com/header/ortb');
     expect(request.method).to.equal('POST');
@@ -217,22 +217,22 @@ describe('PulsePoint Adapter Tests', function () {
     expect(nativeBid.impressionTrackers[1]).to.equal('http://imp1.contextweb.com/');
   });
 
-  it('Verifies bidder code', () => {
+  it('Verifies bidder code', function () {
     expect(spec.code).to.equal('pulsepoint');
   });
 
-  it('Verifies bidder aliases', () => {
+  it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(2);
     expect(spec.aliases[0]).to.equal('pulseLite');
     expect(spec.aliases[1]).to.equal('pulsepointLite');
   });
 
-  it('Verifies supported media types', () => {
+  it('Verifies supported media types', function () {
     expect(spec.supportedMediaTypes).to.have.lengthOf(2);
     expect(spec.supportedMediaTypes[1]).to.equal('native');
   });
 
-  it('Verifies if bid request valid', () => {
+  it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(slotConfigs[0])).to.equal(true);
     expect(spec.isBidRequestValid(slotConfigs[1])).to.equal(true);
     expect(spec.isBidRequestValid(nativeSlotConfig[0])).to.equal(true);
@@ -243,7 +243,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(spec.isBidRequestValid({ params: { ct: 123, cp: 234 } })).to.equal(true);
   });
 
-  it('Verifies sync options', () => {
+  it('Verifies sync options', function () {
     expect(spec.getUserSyncs({})).to.be.undefined;
     expect(spec.getUserSyncs({ iframeEnabled: false })).to.be.undefined;
     const options = spec.getUserSyncs({ iframeEnabled: true });
@@ -253,7 +253,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(options[0].url).to.equal('//bh.contextweb.com/visitormatch');
   });
 
-  it('Verifies image pixel sync', () => {
+  it('Verifies image pixel sync', function () {
     const options = spec.getUserSyncs({ pixelEnabled: true });
     expect(options).to.not.be.undefined;
     expect(options).to.have.lengthOf(1);
@@ -261,7 +261,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(options[0].url).to.equal('//bh.contextweb.com/visitormatch/prebid');
   });
 
-  it('Verify app requests', () => {
+  it('Verify app requests', function () {
     const request = spec.buildRequests(appSlotConfig);
     const ortbRequest = JSON.parse(request.data);
     // site object
@@ -274,7 +274,7 @@ describe('PulsePoint Adapter Tests', function () {
     expect(ortbRequest.app.domain).to.equal('pulsepoint.com');
   });
 
-  it('Verify GDPR', () => {
+  it('Verify GDPR', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {spec} from 'modules/pulsepointBidAdapter';
 import {getTopWindowLocation} from 'src/utils';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-describe('PulsePoint Adapter Tests', () => {
+describe('PulsePoint Adapter Tests', function () {
   const slotConfigs = [{
     placementCode: '/DfpAccount1/slot1',
     bidId: 'bid12345',

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -17,7 +17,7 @@ describe('Quantcast adapter', function () {
   const quantcastAdapter = newBidder(qcSpec);
   let bidRequest;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequest = {
       bidder: 'quantcast',
       bidId: '2f7b179d443f14',

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -33,23 +33,23 @@ describe('Quantcast adapter', function () {
   });
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(quantcastAdapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('`isBidRequestValid`', function () {
-    it('should return `false` when bid is not passed', () => {
+    it('should return `false` when bid is not passed', function () {
       expect(qcSpec.isBidRequestValid()).to.equal(false);
     });
 
-    it('should return `false` when bid `mediaType` is `video`', () => {
+    it('should return `false` when bid `mediaType` is `video`', function () {
       const bidRequest = { mediaType: 'video' };
 
       expect(qcSpec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return `true` when bid contains required params', () => {
+    it('should return `true` when bid contains required params', function () {
       const bidRequest = { mediaType: 'banner' };
 
       expect(qcSpec.isBidRequestValid(bidRequest)).to.equal(true);
@@ -57,7 +57,7 @@ describe('Quantcast adapter', function () {
   });
 
   describe('`buildRequests`', function () {
-    it('selects protocol and port', () => {
+    it('selects protocol and port', function () {
       switch (window.location.protocol) {
         case 'https:':
           expect(QUANTCAST_PROTOCOL).to.equal('https');
@@ -70,13 +70,13 @@ describe('Quantcast adapter', function () {
       }
     });
 
-    it('sends bid requests to Quantcast Canary Endpoint if `publisherId` is `test-publisher`', () => {
+    it('sends bid requests to Quantcast Canary Endpoint if `publisherId` is `test-publisher`', function () {
       const requests = qcSpec.buildRequests([bidRequest]);
       const url = parse(requests[0]['url']);
       expect(url.hostname).to.equal(QUANTCAST_TEST_DOMAIN);
     });
 
-    it('sends bid requests to default endpoint for non standard publisher IDs', () => {
+    it('sends bid requests to default endpoint for non standard publisher IDs', function () {
       const modifiedBidRequest = Object.assign({}, bidRequest, {
         params: Object.assign({}, bidRequest.params, {
           publisherId: 'foo-bar',
@@ -88,13 +88,13 @@ describe('Quantcast adapter', function () {
       );
     });
 
-    it('sends bid requests to Quantcast Header Bidding Endpoints via POST', () => {
+    it('sends bid requests to Quantcast Header Bidding Endpoints via POST', function () {
       const requests = qcSpec.buildRequests([bidRequest]);
 
       expect(requests[0].method).to.equal('POST');
     });
 
-    it('sends bid requests contains all the required parameters', () => {
+    it('sends bid requests contains all the required parameters', function () {
       const referrer = utils.getTopWindowUrl();
       const loc = utils.getTopWindowLocation();
       const domain = loc.hostname;
@@ -126,7 +126,7 @@ describe('Quantcast adapter', function () {
     });
   });
 
-  it('propagates GDPR consent string and signal', () => {
+  it('propagates GDPR consent string and signal', function () {
     const gdprConsent = { gdprApplies: true, consentString: 'consentString' }
     const requests = qcSpec.buildRequests([bidRequest], { gdprConsent });
     const parsed = JSON.parse(requests[0].data)
@@ -159,25 +159,25 @@ describe('Quantcast adapter', function () {
       headers: {}
     };
 
-    it('should return an empty array if `serverResponse` is `undefined`', () => {
+    it('should return an empty array if `serverResponse` is `undefined`', function () {
       const interpretedResponse = qcSpec.interpretResponse();
 
       expect(interpretedResponse.length).to.equal(0);
     });
 
-    it('should return an empty array if the parsed response does NOT include `bids`', () => {
+    it('should return an empty array if the parsed response does NOT include `bids`', function () {
       const interpretedResponse = qcSpec.interpretResponse({});
 
       expect(interpretedResponse.length).to.equal(0);
     });
 
-    it('should return an empty array if the parsed response has an empty `bids`', () => {
+    it('should return an empty array if the parsed response has an empty `bids`', function () {
       const interpretedResponse = qcSpec.interpretResponse({ bids: [] });
 
       expect(interpretedResponse.length).to.equal(0);
     });
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const expectedResponse = {
         requestId: 'erlangcluster@qa-rtb002.us-ec.adtech.com-11417780270886458',
         cpm: 4.5,
@@ -195,7 +195,7 @@ describe('Quantcast adapter', function () {
       expect(interpretedResponse[0]).to.deep.equal(expectedResponse);
     });
 
-    it('handles no bid response', () => {
+    it('handles no bid response', function () {
       const body = {
         bidderCode: 'qcx', // Renaming it to use CamelCase since that is what is used in the Prebid.js variable name
         requestId: 'erlangcluster@qa-rtb002.us-ec.adtech.com-11417780270886458', // Added this field. This is not used now but could be useful in troubleshooting later on. Specially for sites using iFrames

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -13,7 +13,7 @@ import {
 import { newBidder } from '../../../src/adapters/bidderFactory';
 import { parse } from 'src/url';
 
-describe('Quantcast adapter', () => {
+describe('Quantcast adapter', function () {
   const quantcastAdapter = newBidder(qcSpec);
   let bidRequest;
 
@@ -32,13 +32,13 @@ describe('Quantcast adapter', () => {
     };
   });
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(quantcastAdapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('`isBidRequestValid`', () => {
+  describe('`isBidRequestValid`', function () {
     it('should return `false` when bid is not passed', () => {
       expect(qcSpec.isBidRequestValid()).to.equal(false);
     });
@@ -56,7 +56,7 @@ describe('Quantcast adapter', () => {
     });
   });
 
-  describe('`buildRequests`', () => {
+  describe('`buildRequests`', function () {
     it('selects protocol and port', () => {
       switch (window.location.protocol) {
         case 'https:':
@@ -134,7 +134,7 @@ describe('Quantcast adapter', () => {
     expect(parsed.gdprConsent).to.equal(gdprConsent.consentString);
   });
 
-  describe('`interpretResponse`', () => {
+  describe('`interpretResponse`', function () {
     // The sample response is from https://wiki.corp.qc/display/adinf/QCX
     const body = {
       bidderCode: 'qcx', // Renaming it to use CamelCase since that is what is used in the Prebid.js variable name

--- a/test/spec/modules/quantumBidAdapter_spec.js
+++ b/test/spec/modules/quantumBidAdapter_spec.js
@@ -207,17 +207,17 @@ describe('quantumBidAdapter', function () {
   const adapter = newBidder(spec)
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(REQUEST)).to.equal(true)
     })
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, REQUEST)
       delete bid.params
       expect(spec.isBidRequestValid(bid)).to.equal(false)
@@ -229,7 +229,7 @@ describe('quantumBidAdapter', function () {
 
     const request = spec.buildRequests(bidRequests, {})
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       expect(request[0].method).to.equal('GET')
     })
   })
@@ -256,7 +256,7 @@ describe('quantumBidAdapter', function () {
       }
     };
 
-    it('should transmit correct data', () => {
+    it('should transmit correct data', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.quantx_gdpr).to.equal(1);
@@ -283,7 +283,7 @@ describe('quantumBidAdapter', function () {
       gdprConsent: undefined
     };
 
-    it('should transmit correct data', () => {
+    it('should transmit correct data', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.quantx_gdpr).to.be.undefined;
@@ -297,7 +297,7 @@ describe('quantumBidAdapter', function () {
       bids: []
     }
 
-    it('handles native request : should get correct bid response', () => {
+    it('handles native request : should get correct bid response', function () {
       const result = spec.interpretResponse({body: nativeServerResponse}, NATIVE_REQUEST)
       expect(result[0]).to.have.property('cpm').equal(0.3)
       expect(result[0]).to.have.property('width').to.be.below(2)
@@ -306,7 +306,7 @@ describe('quantumBidAdapter', function () {
       expect(result[0]).to.have.property('native')
     })
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const result = spec.interpretResponse({body: serverResponse}, REQUEST)
       expect(result[0]).to.have.property('cpm').equal(0.3)
       expect(result[0]).to.have.property('width').equal(300)
@@ -315,7 +315,7 @@ describe('quantumBidAdapter', function () {
       expect(result[0]).to.have.property('ad')
     })
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       const nobidServerResponse = {bids: []}
       const nobidResult = spec.interpretResponse({body: nobidServerResponse}, bidderRequest)
       // console.log(nobidResult)

--- a/test/spec/modules/quantumBidAdapter_spec.js
+++ b/test/spec/modules/quantumBidAdapter_spec.js
@@ -203,16 +203,16 @@ const nativeServerResponse = {
   ]
 }
 
-describe('quantumBidAdapter', () => {
+describe('quantumBidAdapter', function () {
   const adapter = newBidder(spec)
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(REQUEST)).to.equal(true)
     })
@@ -224,7 +224,7 @@ describe('quantumBidAdapter', () => {
     })
   })
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [REQUEST]
 
     const request = spec.buildRequests(bidRequests, {})
@@ -234,7 +234,7 @@ describe('quantumBidAdapter', () => {
     })
   })
 
-  describe('GDPR conformity', () => {
+  describe('GDPR conformity', function () {
     const bidRequests = [{
       'bidder': 'quantum',
       'mediaType': 'native',
@@ -264,7 +264,7 @@ describe('quantumBidAdapter', () => {
     });
   });
 
-  describe('GDPR absence conformity', () => {
+  describe('GDPR absence conformity', function () {
     const bidRequests = [{
       'bidder': 'quantum',
       'mediaType': 'native',
@@ -291,7 +291,7 @@ describe('quantumBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let bidderRequest = {
       bidderCode: 'bidderCode',
       bids: []

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -7,7 +7,7 @@ describe('ReadPeakAdapter', function () {
   let serverResponse
   let serverRequest
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequest = {
       bidder: 'readpeak',
       nativeParams: {

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec, ENDPOINT } from 'modules/readpeakBidAdapter';
 import * as utils from 'src/utils';
 
-describe('ReadPeakAdapter', () => {
+describe('ReadPeakAdapter', function () {
   let bidRequest
   let serverResponse
   let serverRequest
@@ -113,7 +113,7 @@ describe('ReadPeakAdapter', () => {
     }
   });
 
-  describe('spec.isBidRequestValid', () => {
+  describe('spec.isBidRequestValid', function () {
     it('should return true when the required params are passed', () => {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
@@ -141,7 +141,7 @@ describe('ReadPeakAdapter', () => {
     });
   });
 
-  describe('spec.buildRequests', () => {
+  describe('spec.buildRequests', function () {
     it('should create a POST request for every bid', () => {
       const request = spec.buildRequests([ bidRequest ]);
       expect(request.method).to.equal('POST');
@@ -171,7 +171,7 @@ describe('ReadPeakAdapter', () => {
     });
   });
 
-  describe('spec.interpretResponse', () => {
+  describe('spec.interpretResponse', function () {
     it('should return no bids if the response is not valid', () => {
       const bidResponse = spec.interpretResponse({ body: null }, serverRequest);
       expect(bidResponse.length).to.equal(0);

--- a/test/spec/modules/readpeakBidAdapter_spec.js
+++ b/test/spec/modules/readpeakBidAdapter_spec.js
@@ -114,41 +114,41 @@ describe('ReadPeakAdapter', function () {
   });
 
   describe('spec.isBidRequestValid', function () {
-    it('should return true when the required params are passed', () => {
+    it('should return true when the required params are passed', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
 
-    it('should return false when the native params are missing', () => {
+    it('should return false when the native params are missing', function () {
       bidRequest.nativeParams = undefined;
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when the "publisherId" param is missing', () => {
+    it('should return false when the "publisherId" param is missing', function () {
       bidRequest.params = {
         bidfloor: 5.00
       };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when no bid params are passed', () => {
+    it('should return false when no bid params are passed', function () {
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
 
-    it('should return false when a bid request is not passed', () => {
+    it('should return false when a bid request is not passed', function () {
       expect(spec.isBidRequestValid()).to.equal(false);
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
   });
 
   describe('spec.buildRequests', function () {
-    it('should create a POST request for every bid', () => {
+    it('should create a POST request for every bid', function () {
       const request = spec.buildRequests([ bidRequest ]);
       expect(request.method).to.equal('POST');
       expect(request.url).to.equal(ENDPOINT);
     });
 
-    it('should attach request data', () => {
+    it('should attach request data', function () {
       const request = spec.buildRequests([ bidRequest ]);
 
       const data = JSON.parse(request.data);
@@ -172,12 +172,12 @@ describe('ReadPeakAdapter', function () {
   });
 
   describe('spec.interpretResponse', function () {
-    it('should return no bids if the response is not valid', () => {
+    it('should return no bids if the response is not valid', function () {
       const bidResponse = spec.interpretResponse({ body: null }, serverRequest);
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return a valid bid response', () => {
+    it('should return a valid bid response', function () {
       const bidResponse = spec.interpretResponse({ body: serverResponse }, serverRequest)[0];
       expect(bidResponse).to.contain({
         requestId: bidRequest.bidId,

--- a/test/spec/modules/realvuAnalyticsAdapter_spec.js
+++ b/test/spec/modules/realvuAnalyticsAdapter_spec.js
@@ -22,7 +22,7 @@ function addDiv(id) {
   return dv;
 }
 
-describe('RealVu Analytics Adapter.', () => {
+describe('RealVu Analytics Adapter.', function () {
   before(() => {
     addDiv('ad1');
     addDiv('ad2');
@@ -112,7 +112,7 @@ describe('RealVu Analytics Adapter.', () => {
   });
 });
 
-describe('RealVu Boost.', () => {
+describe('RealVu Boost.', function () {
   before(() => {
     addDiv('ad1');
     addDiv('ad2');

--- a/test/spec/modules/realvuAnalyticsAdapter_spec.js
+++ b/test/spec/modules/realvuAnalyticsAdapter_spec.js
@@ -23,11 +23,11 @@ function addDiv(id) {
 }
 
 describe('RealVu Analytics Adapter.', function () {
-  before(() => {
+  before(function () {
     addDiv('ad1');
     addDiv('ad2');
   });
-  after(() => {
+  after(function () {
     let a1 = document.getElementById('ad1');
     document.body.removeChild(a1);
     let a2 = document.getElementById('ad2');
@@ -113,11 +113,11 @@ describe('RealVu Analytics Adapter.', function () {
 });
 
 describe('RealVu Boost.', function () {
-  before(() => {
+  before(function () {
     addDiv('ad1');
     addDiv('ad2');
   });
-  after(() => {
+  after(function () {
     let a1 = document.getElementById('ad1');
     document.body.removeChild(a1);
     let a2 = document.getElementById('ad2');

--- a/test/spec/modules/realvuAnalyticsAdapter_spec.js
+++ b/test/spec/modules/realvuAnalyticsAdapter_spec.js
@@ -34,7 +34,7 @@ describe('RealVu Analytics Adapter.', function () {
     document.body.removeChild(a2);
   });
 
-  it('enableAnalytics', () => {
+  it('enableAnalytics', function () {
     const config = {
       options: {
         partnerId: '1Y',
@@ -46,7 +46,7 @@ describe('RealVu Analytics Adapter.', function () {
     expect(p).to.equal('1Y');
   });
 
-  it('checkIn', () => {
+  it('checkIn', function () {
     const bid = {
       adUnitCode: 'ad1',
       sizes: [
@@ -71,13 +71,13 @@ describe('RealVu Analytics Adapter.', function () {
     expect(inview).to.equal('yes');
   });
 
-  it('isInView return "NA"', () => {
+  it('isInView return "NA"', function () {
     const adUnitCode = '1234';
     let result = realvuAnalyticsAdapter.isInView(adUnitCode);
     expect(result).to.equal('NA');
   });
 
-  it('bid response event', () => {
+  it('bid response event', function () {
     const config = {
       options: {
         partnerId: '1Y',
@@ -126,25 +126,25 @@ describe('RealVu Boost.', function () {
 
   const boost = window.top1.realvu_aa;
 
-  it('brd', () => {
+  it('brd', function () {
     let a1 = document.getElementById('ad1');
     let p = boost.brd(a1, 'Left');
     expect(typeof p).to.not.equal('undefined');
   });
 
-  it('addUnitById', () => {
+  it('addUnitById', function () {
     let a1 = document.getElementById('ad1');
     let p = boost.addUnitById('1Y', 'ad1');
     expect(typeof p).to.not.equal('undefined');
   });
 
-  it('questA', () => {
+  it('questA', function () {
     const dv = document.getElementById('ad1');
     let q = boost.questA(dv);
     expect(q).to.not.equal(null);
   });
 
-  it('render', () => {
+  it('render', function () {
     let dv = document.getElementById('ad1');
     // dv.style.width = '728px';
     // dv.style.height = '90px';
@@ -155,7 +155,7 @@ describe('RealVu Boost.', function () {
     expect(q).to.not.equal(null);
   });
 
-  it('readPos', () => {
+  it('readPos', function () {
     const a = boost.ads[boost.len - 1];
     let r = boost.readPos(a);
     expect(r).to.equal(true);

--- a/test/spec/modules/rhythmoneBidAdapter_spec.js
+++ b/test/spec/modules/rhythmoneBidAdapter_spec.js
@@ -61,7 +61,7 @@ describe('rhythmone adapter tests', function () {
       assert.equal(mangoRequest.length, 1);
     });
 
-    it('should send GDPR Consent data to RhythmOne tag', () => {
+    it('should send GDPR Consent data to RhythmOne tag', function () {
 	  let _consentString = 'testConsentString';
 	  var request = z.buildRequests(
         [

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { spec, internals } from 'modules/rockyouBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('RockYouAdapter', () => {
+describe('RockYouAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('bid validator', () => {
+  describe('bid validator', function () {
     it('rejects a bid that is missing the placementId', () => {
       let testBid = {};
       expect(spec.isBidRequestValid(testBid)).to.be.false;
@@ -22,7 +22,7 @@ describe('RockYouAdapter', () => {
     });
   });
 
-  describe('request builder', () => {
+  describe('request builder', function () {
     // Taken from the docs, so used as much as is valid
     const sampleBidRequest = {
       'bidder': 'tests',
@@ -278,7 +278,7 @@ describe('RockYouAdapter', () => {
     });
   });
 
-  describe('response interpreter', () => {
+  describe('response interpreter', function () {
     it('returns an empty array when no bids present', () => {
       // an empty JSON body indicates no ad was found
 

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -6,12 +6,12 @@ describe('RockYouAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('bid validator', function () {
-    it('rejects a bid that is missing the placementId', () => {
+    it('rejects a bid that is missing the placementId', function () {
       let testBid = {};
       expect(spec.isBidRequestValid(testBid)).to.be.false;
     });
 
-    it('accepts a bid with all the expected parameters', () => {
+    it('accepts a bid with all the expected parameters', function () {
       let testBid = {
         params: {
           placementId: 'f39ba81609'
@@ -43,7 +43,7 @@ describe('RockYouAdapter', function () {
       }
     };
 
-    it('successfully generates a URL', () => {
+    it('successfully generates a URL', function () {
       const placementId = 'ZZZPLACEMENTZZZ';
 
       let bidRequests = [
@@ -65,7 +65,7 @@ describe('RockYouAdapter', function () {
       expect(result.url).to.include('/servlet/rotator/' + placementId + '/0/vo?z=')
     });
 
-    it('uses the bidId id as the openRtb request ID', () => {
+    it('uses the bidId id as the openRtb request ID', function () {
       const bidId = '51ef8751f9aead';
 
       let bidRequests = [
@@ -84,7 +84,7 @@ describe('RockYouAdapter', function () {
       expect(payload.id).to.equal(bidId);
     });
 
-    it('generates the device payload as expected', () => {
+    it('generates the device payload as expected', function () {
       let bidRequests = [
         sampleBidRequest
       ];
@@ -103,7 +103,7 @@ describe('RockYouAdapter', function () {
       expect(userData).to.not.be.null;
     });
 
-    it('generates multiple requests with single imp bodies', () => {
+    it('generates multiple requests with single imp bodies', function () {
       const SECOND_PLACEMENT_ID = 'YYYPLACEMENTIDYYY';
       let firstBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
       let secondBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
@@ -146,7 +146,7 @@ describe('RockYouAdapter', function () {
       expect(secondRequest.url.indexOf(SECOND_PLACEMENT_ID)).to.be.gt(0);
     });
 
-    it('generates a banner request as expected', () => {
+    it('generates a banner request as expected', function () {
       // clone the sample for stability
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
 
@@ -172,7 +172,7 @@ describe('RockYouAdapter', function () {
       expect(bannerData.h).to.equal(50);
     });
 
-    it('generates a banner request using a singular adSize instead of an array', () => {
+    it('generates a banner request using a singular adSize instead of an array', function () {
       // clone the sample for stability
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
       localBidRequest.sizes = [320, 50];
@@ -200,7 +200,7 @@ describe('RockYouAdapter', function () {
       expect(bannerData.h).to.equal(50);
     });
 
-    it('fails gracefully on an invalid size', () => {
+    it('fails gracefully on an invalid size', function () {
       // clone the sample for stability
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
       localBidRequest.sizes = ['x', 'w'];
@@ -229,7 +229,7 @@ describe('RockYouAdapter', function () {
       expect(bannerData.h).to.equal(null);
     });
 
-    it('generates a video request as expected', () => {
+    it('generates a video request as expected', function () {
       // clone the sample for stability
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
 
@@ -259,7 +259,7 @@ describe('RockYouAdapter', function () {
       expect(videoData.h).to.equal(56);
     });
 
-    it('propagates the mediaTypes object in the built request', () => {
+    it('propagates the mediaTypes object in the built request', function () {
       let localBidRequest = JSON.parse(JSON.stringify(sampleBidRequest));
 
       localBidRequest.mediaTypes = { video: {} };
@@ -279,7 +279,7 @@ describe('RockYouAdapter', function () {
   });
 
   describe('response interpreter', function () {
-    it('returns an empty array when no bids present', () => {
+    it('returns an empty array when no bids present', function () {
       // an empty JSON body indicates no ad was found
 
       let result = spec.interpretResponse({ body: '' }, {})
@@ -287,13 +287,13 @@ describe('RockYouAdapter', function () {
       expect(result).to.eql([]);
     });
 
-    it('gracefully fails when a non-JSON body is present', () => {
+    it('gracefully fails when a non-JSON body is present', function () {
       let result = spec.interpretResponse({ body: 'THIS IS NOT <JSON/>' }, {})
 
       expect(result).to.eql([]);
     });
 
-    it('returns a valid bid response on sucessful banner request', () => {
+    it('returns a valid bid response on sucessful banner request', function () {
       let incomingRequestId = 'XXtestingXX';
       let responsePrice = 3.14
 
@@ -365,7 +365,7 @@ describe('RockYouAdapter', function () {
       expect(processedBid.currency).to.equal(responseCurrency);
     });
 
-    it('returns an valid bid response on sucessful video request', () => {
+    it('returns an valid bid response on sucessful video request', function () {
       let incomingRequestId = 'XXtesting-275XX';
       let responsePrice = 6
 
@@ -438,7 +438,7 @@ describe('RockYouAdapter', function () {
       expect(processedBid.vastXml).to.equal(responseCreative);
     });
 
-    it('generates event callbacks as expected', () => {
+    it('generates event callbacks as expected', function () {
       let tally = {};
       let renderer = {
         handleVideoEvent: (eventObject) => {
@@ -466,7 +466,7 @@ describe('RockYouAdapter', function () {
       expect(tally['ended']).to.equal(2);
     });
 
-    it('generates a renderer that will hide on complete', () => {
+    it('generates a renderer that will hide on complete', function () {
       let elementName = 'test_element_id';
       let selector = `#${elementName}`;
 

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -161,20 +161,20 @@ describe('Roxot Prebid Analytic', function () {
   let bidderDone = bidRequested;
   let bidWon = bidAdjustmentWithBid;
 
-  before(() => {
+  before(function () {
     xhr = sinon.useFakeXMLHttpRequest();
     xhr.onCreate = request => requests.push(request);
   });
-  after(() => {
+  after(function () {
     xhr.restore();
   });
 
   describe('correct build and send events', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       requests = [];
       sinon.stub(events, 'getEvents').returns([]);
     });
-    afterEach(() => {
+    afterEach(function () {
       roxotAnalytic.disableAnalytics();
       events.getEvents.restore();
     });
@@ -249,11 +249,11 @@ describe('Roxot Prebid Analytic', function () {
   });
 
   describe('support ad unit filter', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       requests = [];
       sinon.stub(events, 'getEvents').returns([]);
     });
-    afterEach(() => {
+    afterEach(function () {
       roxotAnalytic.disableAnalytics();
       events.getEvents.restore();
     });
@@ -297,12 +297,12 @@ describe('Roxot Prebid Analytic', function () {
   });
 
   describe('should correct parse config', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       requests = [];
       sinon.stub(events, 'getEvents').returns([]);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       roxotAnalytic.disableAnalytics();
       events.getEvents.restore();
     });
@@ -428,7 +428,7 @@ describe('Roxot Prebid Analytic', function () {
   });
 
   describe('build utm tag data', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       localStorage.setItem('roxot_analytics_utm_source', 'utm_source');
       localStorage.setItem('roxot_analytics_utm_medium', 'utm_medium');
       localStorage.setItem('roxot_analytics_utm_campaign', '');
@@ -436,7 +436,7 @@ describe('Roxot Prebid Analytic', function () {
       localStorage.setItem('roxot_analytics_utm_content', '');
       localStorage.setItem('roxot_analytics_utm_ttl', Date.now());
     });
-    afterEach(() => {
+    afterEach(function () {
       localStorage.removeItem('roxot_analytics_utm_source');
       localStorage.removeItem('roxot_analytics_utm_medium');
       localStorage.removeItem('roxot_analytics_utm_campaign');

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -427,7 +427,7 @@ describe('Roxot Prebid Analytic', function () {
     });
   });
 
-  describe('build utm tag data', () => {
+  describe('build utm tag data', function () {
     beforeEach(() => {
       localStorage.setItem('roxot_analytics_utm_source', 'utm_source');
       localStorage.setItem('roxot_analytics_utm_medium', 'utm_medium');

--- a/test/spec/modules/roxotAnalyticsAdapter_spec.js
+++ b/test/spec/modules/roxotAnalyticsAdapter_spec.js
@@ -444,7 +444,7 @@ describe('Roxot Prebid Analytic', function () {
       localStorage.removeItem('roxot_analytics_utm_content');
       localStorage.removeItem('roxot_analytics_utm_ttl');
     });
-    it('should build utm data from local storage', () => {
+    it('should build utm data from local storage', function () {
       let utmTagData = roxotAnalytic.buildUtmTagData();
       expect(utmTagData.utm_source).to.equal('utm_source');
       expect(utmTagData.utm_medium).to.equal('utm_medium');

--- a/test/spec/modules/rtbdemandBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('rtbdemandAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('rtbdemandAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -39,7 +39,7 @@ describe('rtbdemandAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -89,7 +89,7 @@ describe('rtbdemandAdapter', function () {
       timeout: 5000
     };
 
-    it('should add source and verison to the tag', () => {
+    it('should add source and verison to the tag', function () {
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const payload = request.data;
       expect(payload.from).to.exist;
@@ -106,7 +106,7 @@ describe('rtbdemandAdapter', function () {
       expect(payload.tmax).to.exist;
     });
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
       expect(request.url).to.equal('//bidding.rtbdemand.com/hb');
       expect(request.method).to.equal('GET');
@@ -128,7 +128,7 @@ describe('rtbdemandAdapter', function () {
       } ]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           requestId: 'bidId-123456-1',
@@ -147,7 +147,7 @@ describe('rtbdemandAdapter', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'id': '543210',
         'seatbid': [ ]
@@ -161,7 +161,7 @@ describe('rtbdemandAdapter', function () {
   describe('user sync', function () {
     const syncUrl = '//bidding.rtbdemand.com/delivery/matches.php?type=iframe';
 
-    it('should register the sync iframe', () => {
+    it('should register the sync iframe', function () {
       expect(spec.getUserSyncs({})).to.be.undefined;
       expect(spec.getUserSyncs({iframeEnabled: false})).to.be.undefined;
       const options = spec.getUserSyncs({iframeEnabled: true});

--- a/test/spec/modules/rtbdemandBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandBidAdapter_spec.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { spec } from 'modules/rtbdemandBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('rtbdemandAdapter', () => {
+describe('rtbdemandAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'rtbdemand',
       'params': {
@@ -49,7 +49,7 @@ describe('rtbdemandAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidderRequest = {
       bidderCode: 'rtbdemand',
       auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
@@ -113,7 +113,7 @@ describe('rtbdemandAdapter', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'id': '543210',
       'seatbid': [ {
@@ -158,7 +158,7 @@ describe('rtbdemandAdapter', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     const syncUrl = '//bidding.rtbdemand.com/delivery/matches.php?type=iframe';
 
     it('should register the sync iframe', () => {

--- a/test/spec/modules/rtbdemandadkBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandadkBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/rtbdemandadkBidAdapter';
 import * as utils from 'src/utils';
 
-describe('rtbdemandadk adapter', () => {
+describe('rtbdemandadk adapter', function () {
   const bid1_zone1 = {
       bidder: 'rtbdemandadk',
       bidId: 'Bid_01',
@@ -107,7 +107,7 @@ describe('rtbdemandadk adapter', () => {
       }
     };
 
-  describe('input parameters validation', () => {
+  describe('input parameters validation', function () {
     it('empty request shouldn\'t generate exception', () => {
       expect(spec.isBidRequestValid({
         bidderCode: 'rtbdemandadk'
@@ -127,7 +127,7 @@ describe('rtbdemandadk adapter', () => {
     });
   });
 
-  describe('banner request building', () => {
+  describe('banner request building', function () {
     let bidRequest;
     before(() => {
       let wmock = sinon.stub(utils, 'getTopWindowLocation').callsFake(() => ({
@@ -178,7 +178,7 @@ describe('rtbdemandadk adapter', () => {
     });
   });
 
-  describe('video request building', () => {
+  describe('video request building', function () {
     let bidRequest;
 
     before(() => {
@@ -200,7 +200,7 @@ describe('rtbdemandadk adapter', () => {
     });
   });
 
-  describe('requests routing', () => {
+  describe('requests routing', function () {
     it('should issue a request for each host', () => {
       let pbRequests = spec.buildRequests([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
@@ -216,7 +216,7 @@ describe('rtbdemandadk adapter', () => {
     });
   });
 
-  describe('responses processing', () => {
+  describe('responses processing', function () {
     it('should return fully-initialized banner bid-response', () => {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];

--- a/test/spec/modules/rtbdemandadkBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandadkBidAdapter_spec.js
@@ -108,21 +108,21 @@ describe('rtbdemandadk adapter', function () {
     };
 
   describe('input parameters validation', function () {
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid({
         bidderCode: 'rtbdemandadk'
       })).to.be.equal(false);
     });
 
-    it('request without zone shouldn\'t issue a request', () => {
+    it('request without zone shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_zone)).to.be.equal(false);
     });
 
-    it('request without host shouldn\'t issue a request', () => {
+    it('request without host shouldn\'t issue a request', function () {
       expect(spec.isBidRequestValid(bid_without_host)).to.be.equal(false);
     });
 
-    it('empty request shouldn\'t generate exception', () => {
+    it('empty request shouldn\'t generate exception', function () {
       expect(spec.isBidRequestValid(bid_with_wrong_zoneId)).to.be.equal(false);
     });
   });
@@ -144,33 +144,33 @@ describe('rtbdemandadk adapter', function () {
       dntmock.restore();
     });
 
-    it('should be a first-price auction', () => {
+    it('should be a first-price auction', function () {
       expect(bidRequest).to.have.property('at', 1);
     });
 
-    it('should have banner object', () => {
+    it('should have banner object', function () {
       expect(bidRequest.imp[0]).to.have.property('banner');
     });
 
-    it('should have w/h', () => {
+    it('should have w/h', function () {
       expect(bidRequest.imp[0].banner).to.have.property('format');
       expect(bidRequest.imp[0].banner.format).to.be.eql([{w: 300, h: 250}, {w: 300, h: 200}]);
     });
 
-    it('should respect secure connection', () => {
+    it('should respect secure connection', function () {
       expect(bidRequest.imp[0]).to.have.property('secure', 1);
     });
 
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(bidRequest.imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
 
-    it('should create proper site block', () => {
+    it('should create proper site block', function () {
       expect(bidRequest.site).to.have.property('domain', 'example.com');
       expect(bidRequest.site).to.have.property('page', 'https://example.com/index.html');
     });
 
-    it('should fill device with caller macro', () => {
+    it('should fill device with caller macro', function () {
       expect(bidRequest).to.have.property('device');
       expect(bidRequest.device).to.have.property('ip', 'caller');
       expect(bidRequest.device).to.have.property('ua', 'caller');
@@ -186,29 +186,29 @@ describe('rtbdemandadk adapter', function () {
       bidRequest = JSON.parse(request.data.r);
     });
 
-    it('should have video object', () => {
+    it('should have video object', function () {
       expect(bidRequest.imp[0]).to.have.property('video');
     });
 
-    it('should have h/w', () => {
+    it('should have h/w', function () {
       expect(bidRequest.imp[0].video).to.have.property('w', 640);
       expect(bidRequest.imp[0].video).to.have.property('h', 480);
     });
 
-    it('should have tagid', () => {
+    it('should have tagid', function () {
       expect(bidRequest.imp[0]).to.have.property('tagid', 'ad-unit-1');
     });
   });
 
   describe('requests routing', function () {
-    it('should issue a request for each host', () => {
+    it('should issue a request for each host', function () {
       let pbRequests = spec.buildRequests([bid1_zone1, bid3_host2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].url).to.have.string(`//${bid1_zone1.params.host}/`);
       expect(pbRequests[1].url).to.have.string(`//${bid3_host2.params.host}/`);
     });
 
-    it('should issue a request for each zone', () => {
+    it('should issue a request for each zone', function () {
       let pbRequests = spec.buildRequests([bid1_zone1, bid2_zone2]);
       expect(pbRequests).to.have.length(2);
       expect(pbRequests[0].data.zone).to.be.equal(bid1_zone1.params.zoneId);
@@ -217,7 +217,7 @@ describe('rtbdemandadk adapter', function () {
   });
 
   describe('responses processing', function () {
-    it('should return fully-initialized banner bid-response', () => {
+    it('should return fully-initialized banner bid-response', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];
       expect(resp).to.have.property('requestId', 'Bid_01');
@@ -232,7 +232,7 @@ describe('rtbdemandadk adapter', function () {
       expect(resp.ad).to.have.string('<!-- admarkup here -->');
     });
 
-    it('should return fully-initialized video bid-response', () => {
+    it('should return fully-initialized video bid-response', function () {
       let request = spec.buildRequests([bid_video])[0];
       let resp = spec.interpretResponse({body: videoBidResponse}, request)[0];
       expect(resp).to.have.property('requestId', 'Bid_Video');
@@ -243,20 +243,20 @@ describe('rtbdemandadk adapter', function () {
       expect(resp.height).to.equal(480);
     });
 
-    it('should add nurl as pixel for banner response', () => {
+    it('should add nurl as pixel for banner response', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: bidResponse1}, request)[0];
       let expectedNurl = bidResponse1.seatbid[0].bid[0].nurl + '&px=1';
       expect(resp.ad).to.have.string(expectedNurl);
     });
 
-    it('should handle bidresponse with user-sync only', () => {
+    it('should handle bidresponse with user-sync only', function () {
       let request = spec.buildRequests([bid1_zone1])[0];
       let resp = spec.interpretResponse({body: usersyncOnlyResponse}, request);
       expect(resp).to.have.length(0);
     });
 
-    it('should perform usersync', () => {
+    it('should perform usersync', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: false}, [{body: bidResponse1}]);
       expect(syncs).to.have.length(0);
       syncs = spec.getUserSyncs({iframeEnabled: true}, [{body: bidResponse1}]);

--- a/test/spec/modules/rtbdemandadkBidAdapter_spec.js
+++ b/test/spec/modules/rtbdemandadkBidAdapter_spec.js
@@ -129,7 +129,7 @@ describe('rtbdemandadk adapter', function () {
 
   describe('banner request building', function () {
     let bidRequest;
-    before(() => {
+    before(function () {
       let wmock = sinon.stub(utils, 'getTopWindowLocation').callsFake(() => ({
         protocol: 'https:',
         hostname: 'example.com',
@@ -181,7 +181,7 @@ describe('rtbdemandadk adapter', function () {
   describe('video request building', function () {
     let bidRequest;
 
-    before(() => {
+    before(function () {
       let request = spec.buildRequests([bid_video])[0];
       bidRequest = JSON.parse(request.data.r);
     });

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -17,16 +17,16 @@ function buildEndpointUrl(region) {
 	* endof Helpers
 	*/
 
-describe('RTBHouseAdapter', () => {
+describe('RTBHouseAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'rtbhouse',
       'params': {
@@ -54,7 +54,7 @@ describe('RTBHouseAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
 	      'bidder': 'rtbhouse',
@@ -112,7 +112,7 @@ describe('RTBHouseAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = [{
   	  'id': 'bidder_imp_identifier',
 	    'impid': '552b8922e28f27',

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -21,7 +21,7 @@ describe('RTBHouseAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -40,11 +40,11 @@ describe('RTBHouseAdapter', function () {
       'auctionId': '1d1a030790a475'
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -71,12 +71,12 @@ describe('RTBHouseAdapter', function () {
       }
     ];
 
-    it('should build test param into the request', () => {
+    it('should build test param into the request', function () {
     	let builtTestRequest = spec.buildRequests(bidRequests).data;
     	expect(JSON.parse(builtTestRequest).test).to.equal(1);
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       let bidRequest = Object.assign([], bidRequests);
       delete bidRequest[0].params.test;
       const request = spec.buildRequests(bidRequest);
@@ -84,7 +84,7 @@ describe('RTBHouseAdapter', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('should not populate GDPR if for non-EEA users', () => {
+    it('should not populate GDPR if for non-EEA users', function () {
       let bidRequest = Object.assign([], bidRequests);
       delete bidRequest[0].params.test;
       const request = spec.buildRequests(bidRequest);
@@ -93,7 +93,7 @@ describe('RTBHouseAdapter', function () {
       expect(data).to.not.have.property('user');
     });
 
-    it('should populate GDPR and consent string if available for EEA users', () => {
+    it('should populate GDPR and consent string if available for EEA users', function () {
       let bidRequest = Object.assign([], bidRequests);
       delete bidRequest[0].params.test;
       const request = spec.buildRequests(bidRequest, {gdprConsent: {gdprApplies: true, consentString: consentStr}});
@@ -102,7 +102,7 @@ describe('RTBHouseAdapter', function () {
       expect(data.user.ext.consent).to.equal('BOJ8RZsOJ8RZsABAB8AAAAAZ-A');
     });
 
-    it('should populate GDPR and empty consent string if available for EEA users without consent string but with consent', () => {
+    it('should populate GDPR and empty consent string if available for EEA users without consent string but with consent', function () {
       let bidRequest = Object.assign([], bidRequests);
       delete bidRequest[0].params.test;
       const request = spec.buildRequests(bidRequest, {gdprConsent: {gdprApplies: true}});
@@ -125,7 +125,7 @@ describe('RTBHouseAdapter', function () {
 	    'h': 250
     }];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '552b8922e28f27',
@@ -145,7 +145,7 @@ describe('RTBHouseAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = '';
       let bidderRequest;
       let result = spec.interpretResponse({ body: response }, {bidderRequest});

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -409,7 +409,7 @@ function performStandardAuction() {
   events.emit(BID_WON, MOCK.BID_WON[1]);
 }
 
-describe('rubicon analytics adapter', () => {
+describe('rubicon analytics adapter', function () {
   let sandbox;
   let xhr;
   let requests;
@@ -466,7 +466,7 @@ describe('rubicon analytics adapter', () => {
     expect(utils.logError.called).to.equal(true);
   });
 
-  describe('sampling', () => {
+  describe('sampling', function () {
     beforeEach(() => {
       sandbox.stub(Math, 'random').returns(0.08);
       sandbox.stub(utils, 'logError');
@@ -476,7 +476,7 @@ describe('rubicon analytics adapter', () => {
       rubiconAnalyticsAdapter.disableAnalytics();
     });
 
-    describe('with options.samplingFactor', () => {
+    describe('with options.samplingFactor', function () {
       it('should sample', () => {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
@@ -520,7 +520,7 @@ describe('rubicon analytics adapter', () => {
         expect(utils.logError.called).to.equal(true);
       });
     });
-    describe('with options.sampling', () => {
+    describe('with options.sampling', function () {
       it('should sample', () => {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
@@ -566,7 +566,7 @@ describe('rubicon analytics adapter', () => {
     });
   });
 
-  describe('when handling events', () => {
+  describe('when handling events', function () {
     beforeEach(() => {
       rubiconAnalyticsAdapter.enableAnalytics({
         options: {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -416,7 +416,7 @@ describe('rubicon analytics adapter', function () {
   let oldScreen;
   let clock;
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
 
     xhr = sandbox.useFakeXMLHttpRequest();
@@ -437,7 +437,7 @@ describe('rubicon analytics adapter', function () {
     })
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
     config.resetConfig();
   });
@@ -467,12 +467,12 @@ describe('rubicon analytics adapter', function () {
   });
 
   describe('sampling', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sandbox.stub(Math, 'random').returns(0.08);
       sandbox.stub(utils, 'logError');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       rubiconAnalyticsAdapter.disableAnalytics();
     });
 
@@ -567,7 +567,7 @@ describe('rubicon analytics adapter', function () {
   });
 
   describe('when handling events', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       rubiconAnalyticsAdapter.enableAnalytics({
         options: {
           endpoint: '//localhost:9999/event',
@@ -576,7 +576,7 @@ describe('rubicon analytics adapter', function () {
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       rubiconAnalyticsAdapter.disableAnalytics();
     });
 

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -442,7 +442,7 @@ describe('rubicon analytics adapter', function () {
     config.resetConfig();
   });
 
-  it('should require accountId', () => {
+  it('should require accountId', function () {
     sandbox.stub(utils, 'logError');
 
     rubiconAnalyticsAdapter.enableAnalytics({
@@ -454,7 +454,7 @@ describe('rubicon analytics adapter', function () {
     expect(utils.logError.called).to.equal(true);
   });
 
-  it('should require endpoint', () => {
+  it('should require endpoint', function () {
     sandbox.stub(utils, 'logError');
 
     rubiconAnalyticsAdapter.enableAnalytics({
@@ -477,7 +477,7 @@ describe('rubicon analytics adapter', function () {
     });
 
     describe('with options.samplingFactor', function () {
-      it('should sample', () => {
+      it('should sample', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -491,7 +491,7 @@ describe('rubicon analytics adapter', function () {
         expect(requests.length).to.equal(1);
       });
 
-      it('should unsample', () => {
+      it('should unsample', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -505,7 +505,7 @@ describe('rubicon analytics adapter', function () {
         expect(requests.length).to.equal(0);
       });
 
-      it('should throw errors for invalid samplingFactor', () => {
+      it('should throw errors for invalid samplingFactor', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -521,7 +521,7 @@ describe('rubicon analytics adapter', function () {
       });
     });
     describe('with options.sampling', function () {
-      it('should sample', () => {
+      it('should sample', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -535,7 +535,7 @@ describe('rubicon analytics adapter', function () {
         expect(requests.length).to.equal(1);
       });
 
-      it('should unsample', () => {
+      it('should unsample', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -549,7 +549,7 @@ describe('rubicon analytics adapter', function () {
         expect(requests.length).to.equal(0);
       });
 
-      it('should throw errors for invalid samplingFactor', () => {
+      it('should throw errors for invalid samplingFactor', function () {
         rubiconAnalyticsAdapter.enableAnalytics({
           options: {
             endpoint: '//localhost:9999/event',
@@ -580,7 +580,7 @@ describe('rubicon analytics adapter', function () {
       rubiconAnalyticsAdapter.disableAnalytics();
     });
 
-    it('should build a batched message from prebid events', () => {
+    it('should build a batched message from prebid events', function () {
       performStandardAuction();
 
       expect(requests.length).to.equal(1);
@@ -594,7 +594,7 @@ describe('rubicon analytics adapter', function () {
       expect(message).to.deep.equal(ANALYTICS_MESSAGE);
     });
 
-    it('should send batched message without BID_WON if necessary and further BID_WON events individually', () => {
+    it('should send batched message without BID_WON if necessary and further BID_WON events individually', function () {
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
       events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
       events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
@@ -623,7 +623,7 @@ describe('rubicon analytics adapter', function () {
       expect(message.bidsWon[0]).to.deep.equal(ANALYTICS_MESSAGE.bidsWon[1]);
     });
 
-    it('should properly mark bids as timed out', () => {
+    it('should properly mark bids as timed out', function () {
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
       events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
       events.emit(BID_TIMEOUT, MOCK.BID_TIMEOUT);

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -332,12 +332,12 @@ describe('the rubicon adapter', function () {
   });
 
   describe('MAS mapping / ordering', function () {
-    it('should sort values without any MAS priority sizes in regular ascending order', () => {
+    it('should sort values without any MAS priority sizes in regular ascending order', function () {
       let ordering = masSizeOrdering([126, 43, 65, 16]);
       expect(ordering).to.deep.equal([16, 43, 65, 126]);
     });
 
-    it('should sort MAS priority sizes in the proper order w/ rest ascending', () => {
+    it('should sort MAS priority sizes in the proper order w/ rest ascending', function () {
       let ordering = masSizeOrdering([43, 9, 65, 15, 16, 126]);
       expect(ordering).to.deep.equal([15, 9, 16, 43, 65, 126]);
 
@@ -352,7 +352,7 @@ describe('the rubicon adapter', function () {
   describe('buildRequests implementation', function () {
     describe('for requests', function () {
       describe('to fastlane', function () {
-        it('should make a well-formed request objects', () => {
+        it('should make a well-formed request objects', function () {
           sandbox.stub(Math, 'random').callsFake(() => 0.1);
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let data = parseQuery(request.data);
@@ -394,7 +394,7 @@ describe('the rubicon adapter', function () {
           });
         });
 
-        it('ad engine query params should be ordered correctly', () => {
+        it('ad engine query params should be ordered correctly', function () {
           sandbox.stub(Math, 'random').callsFake(() => 0.1);
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
 
@@ -405,7 +405,7 @@ describe('the rubicon adapter', function () {
           });
         });
 
-        it('should make a well-formed request object without latLong', () => {
+        it('should make a well-formed request object without latLong', function () {
           let expectedQuery = {
             'account_id': '14062',
             'site_id': '70608',
@@ -466,7 +466,7 @@ describe('the rubicon adapter', function () {
           });
         });
 
-        it('page_url should use params.referrer, config.getConfig("pageUrl"), utils.getTopWindowUrl() in that order', () => {
+        it('page_url should use params.referrer, config.getConfig("pageUrl"), utils.getTopWindowUrl() in that order', function () {
           sandbox.stub(utils, 'getTopWindowUrl').callsFake(() => 'http://www.prebid.org');
 
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
@@ -491,7 +491,7 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('https://www.rubiconproject.com');
         });
 
-        it('should use rubicon sizes if present (including non-mappable sizes)', () => {
+        it('should use rubicon sizes if present (including non-mappable sizes)', function () {
           var sizesBidderRequest = clone(bidderRequest);
           sizesBidderRequest.bids[0].params.sizes = [55, 57, 59, 801];
 
@@ -502,7 +502,7 @@ describe('the rubicon adapter', function () {
           expect(data['alt_size_ids']).to.equal('57,59,801');
         });
 
-        it('should not validate bid request if no valid sizes', () => {
+        it('should not validate bid request if no valid sizes', function () {
           var sizesBidderRequest = clone(bidderRequest);
           sizesBidderRequest.bids[0].sizes = [[621, 250], [300, 251]];
 
@@ -511,7 +511,7 @@ describe('the rubicon adapter', function () {
           expect(result).to.equal(false);
         });
 
-        it('should not validate bid request if no account id is present', () => {
+        it('should not validate bid request if no account id is present', function () {
           var noAccountBidderRequest = clone(bidderRequest);
           delete noAccountBidderRequest.bids[0].params.accountId;
 
@@ -520,7 +520,7 @@ describe('the rubicon adapter', function () {
           expect(result).to.equal(false);
         });
 
-        it('should allow a floor override', () => {
+        it('should allow a floor override', function () {
           var floorBidderRequest = clone(bidderRequest);
           floorBidderRequest.bids[0].params.floor = 2;
 
@@ -530,7 +530,7 @@ describe('the rubicon adapter', function () {
           expect(data['rp_floor']).to.equal('2');
         });
 
-        it('should send digitrust params', () => {
+        it('should send digitrust params', function () {
           window.DigiTrust = {
             getUser: function () {
             }
@@ -564,7 +564,7 @@ describe('the rubicon adapter', function () {
           delete window.DigiTrust;
         });
 
-        it('should not send digitrust params when DigiTrust not loaded', () => {
+        it('should not send digitrust params when DigiTrust not loaded', function () {
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let data = parseQuery(request.data);
 
@@ -576,7 +576,7 @@ describe('the rubicon adapter', function () {
           });
         });
 
-        it('should not send digitrust params due to optout', () => {
+        it('should not send digitrust params due to optout', function () {
           window.DigiTrust = {
             getUser: function () {
             }
@@ -605,7 +605,7 @@ describe('the rubicon adapter', function () {
           delete window.DigiTrust;
         });
 
-        it('should not send digitrust params due to failure', () => {
+        it('should not send digitrust params due to failure', function () {
           window.DigiTrust = {
             getUser: function () {
             }
@@ -646,7 +646,7 @@ describe('the rubicon adapter', function () {
             delete window.DigiTrust;
           });
 
-          it('should send digiTrustId config params', () => {
+          it('should send digiTrustId config params', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               var config = {
                 digiTrustId: {
@@ -679,7 +679,7 @@ describe('the rubicon adapter', function () {
             expect(window.DigiTrust.getUser.notCalled).to.equal(true);
           });
 
-          it('should not send digiTrustId config params due to optout', () => {
+          it('should not send digiTrustId config params due to optout', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               var config = {
                 digiTrustId: {
@@ -708,7 +708,7 @@ describe('the rubicon adapter', function () {
             expect(window.DigiTrust.getUser.notCalled).to.equal(true);
           });
 
-          it('should not send digiTrustId config params due to failure', () => {
+          it('should not send digiTrustId config params due to failure', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               var config = {
                 digiTrustId: {
@@ -737,7 +737,7 @@ describe('the rubicon adapter', function () {
             expect(window.DigiTrust.getUser.notCalled).to.equal(true);
           });
 
-          it('should not send digiTrustId config params if they do not exist', () => {
+          it('should not send digiTrustId config params if they do not exist', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               var config = {};
               return config[key];
@@ -759,7 +759,7 @@ describe('the rubicon adapter', function () {
         });
 
         describe('GDPR consent config', function () {
-          it('should send "gdpr" and "gdpr_consent", when gdprConsent defines consentString and gdprApplies', () => {
+          it('should send "gdpr" and "gdpr_consent", when gdprConsent defines consentString and gdprApplies', function () {
             createGdprBidderRequest(true);
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
             let data = parseQuery(request.data);
@@ -768,7 +768,7 @@ describe('the rubicon adapter', function () {
             expect(data['gdpr_consent']).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
           });
 
-          it('should send only "gdpr_consent", when gdprConsent defines only consentString', () => {
+          it('should send only "gdpr_consent", when gdprConsent defines only consentString', function () {
             createGdprBidderRequest();
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
             let data = parseQuery(request.data);
@@ -777,7 +777,7 @@ describe('the rubicon adapter', function () {
             expect(data['gdpr']).to.equal(undefined);
           });
 
-          it('should not send GDPR params if gdprConsent is not defined', () => {
+          it('should not send GDPR params if gdprConsent is not defined', function () {
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
             let data = parseQuery(request.data);
 
@@ -785,7 +785,7 @@ describe('the rubicon adapter', function () {
             expect(data['gdpr_consent']).to.equal(undefined);
           });
 
-          it('should set "gdpr" value as 1 or 0, using "gdprApplies" value of either true/false', () => {
+          it('should set "gdpr" value as 1 or 0, using "gdprApplies" value of either true/false', function () {
             createGdprBidderRequest(true);
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
             let data = parseQuery(request.data);
@@ -799,7 +799,7 @@ describe('the rubicon adapter', function () {
         });
 
         describe('singleRequest config', function () {
-          it('should group all bid requests with the same site id', () => {
+          it('should group all bid requests with the same site id', function () {
             sandbox.stub(Math, 'random').callsFake(() => 0.1);
 
             sandbox.stub(config, 'getConfig').callsFake((key) => {
@@ -914,7 +914,7 @@ describe('the rubicon adapter', function () {
             });
           });
 
-          it('should not send more than 10 bids in a request', () => {
+          it('should not send more than 10 bids in a request', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               const config = {
                 'rubicon.singleRequest': true
@@ -945,7 +945,7 @@ describe('the rubicon adapter', function () {
             expect(data.zone_id.split(';')).to.have.lengthOf(10);
           });
 
-          it('should not group bid requests if singleRequest does not equal true', () => {
+          it('should not group bid requests if singleRequest does not equal true', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               const config = {
                 'rubicon.singleRequest': false
@@ -968,7 +968,7 @@ describe('the rubicon adapter', function () {
             expect(serverRequests).that.is.an('array').of.length(4);
           });
 
-          it('should not group video bid requests', () => {
+          it('should not group video bid requests', function () {
             sandbox.stub(config, 'getConfig').callsFake((key) => {
               const config = {
                 'rubicon.singleRequest': true
@@ -1010,7 +1010,7 @@ describe('the rubicon adapter', function () {
       });
 
       describe('for video requests', function () {
-        it('should make a well-formed video request with legacy mediaType config', () => {
+        it('should make a well-formed video request with legacy mediaType config', function () {
           createLegacyVideoBidderRequest();
 
           sandbox.stub(Date, 'now').callsFake(() =>
@@ -1074,7 +1074,7 @@ describe('the rubicon adapter', function () {
           expect(slot.visitor).to.have.property('likes').that.deep.equals(['sports', 'video games']);
         });
 
-        it('should make a well-formed video request', () => {
+        it('should make a well-formed video request', function () {
           createVideoBidderRequest();
 
           sandbox.stub(Date, 'now').callsFake(() =>
@@ -1138,7 +1138,7 @@ describe('the rubicon adapter', function () {
           expect(slot.visitor).to.have.property('likes').that.deep.equals(['sports', 'video games']);
         });
 
-        it('should send request with proper ad position', () => {
+        it('should send request with proper ad position', function () {
           createVideoBidderRequest();
           var positionBidderRequest = clone(bidderRequest);
           positionBidderRequest.bids[0].params.position = 'atf';
@@ -1182,7 +1182,7 @@ describe('the rubicon adapter', function () {
           expect(slot.position).to.equal('unknown');
         });
 
-        it('should allow a floor price override', () => {
+        it('should allow a floor price override', function () {
           createVideoBidderRequest();
 
           sandbox.stub(Date, 'now').callsFake(() =>
@@ -1202,7 +1202,7 @@ describe('the rubicon adapter', function () {
           expect(floor).to.equal(3.25);
         });
 
-        it('should validate bid request with invalid video if a mediaTypes banner property is defined', () => {
+        it('should validate bid request with invalid video if a mediaTypes banner property is defined', function () {
           const bidRequest = {
             mediaTypes: {
               video: {
@@ -1226,7 +1226,7 @@ describe('the rubicon adapter', function () {
           expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
         });
 
-        it('should not validate bid request when a invalid video object and no banner object is passed in', () => {
+        it('should not validate bid request when a invalid video object and no banner object is passed in', function () {
           createVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
@@ -1251,7 +1251,7 @@ describe('the rubicon adapter', function () {
           expect(spec.isBidRequestValid(bidRequestCopy)).to.equal(false);
         });
 
-        it('should not validate bid request when an invalid video object is passed in with legacy config mediaType', () => {
+        it('should not validate bid request when an invalid video object is passed in with legacy config mediaType', function () {
           createLegacyVideoBidderRequestNoVideo();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
@@ -1273,7 +1273,7 @@ describe('the rubicon adapter', function () {
           expect(spec.isBidRequestValid(bidderRequestCopy.bids[0])).to.equal(false);
         });
 
-        it('bid request is valid when video context is outstream', () => {
+        it('bid request is valid when video context is outstream', function () {
           createVideoBidderRequestOutstream();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
@@ -1286,7 +1286,7 @@ describe('the rubicon adapter', function () {
           expect(request.data.slots[0].size_id).to.equal(203);
         });
 
-        it('should get size from bid.sizes too', () => {
+        it('should get size from bid.sizes too', function () {
           createVideoBidderRequestNoPlayer();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
@@ -1300,7 +1300,7 @@ describe('the rubicon adapter', function () {
           expect(request.data.slots[0].height).to.equal(250);
         });
 
-        it('should get size from bid.sizes too with legacy config mediaType', () => {
+        it('should get size from bid.sizes too with legacy config mediaType', function () {
           createLegacyVideoBidderRequestNoPlayer();
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
@@ -1316,7 +1316,7 @@ describe('the rubicon adapter', function () {
       });
 
       describe('combineSlotUrlParams', function () {
-        it('should combine an array of slot url params', () => {
+        it('should combine an array of slot url params', function () {
           expect(spec.combineSlotUrlParams([])).to.deep.equal({});
 
           expect(spec.combineSlotUrlParams([{p1: 'foo', p2: 'test', p3: ''}])).to.deep.equal({p1: 'foo', p2: 'test', p3: ''});
@@ -1342,7 +1342,7 @@ describe('the rubicon adapter', function () {
       });
 
       describe('createSlotParams', function () {
-        it('should return a valid slot params object', () => {
+        it('should return a valid slot params object', function () {
           let expectedQuery = {
             'account_id': '14062',
             'site_id': '70608',
@@ -1381,13 +1381,13 @@ describe('the rubicon adapter', function () {
       });
 
       describe('hasVideoMediaType', function () {
-        it('should return true if mediaType is video and size_id is set', () => {
+        it('should return true if mediaType is video and size_id is set', function () {
           createVideoBidderRequest();
           const legacyVideoTypeBidRequest = hasVideoMediaType(bidderRequest.bids[0]);
           expect(legacyVideoTypeBidRequest).is.equal(true);
         });
 
-        it('should return false if mediaType is video and size_id is not defined', () => {
+        it('should return false if mediaType is video and size_id is not defined', function () {
           expect(spec.isBidRequestValid({
             bid: 99,
             mediaType: 'video',
@@ -1397,17 +1397,17 @@ describe('the rubicon adapter', function () {
           })).is.equal(false);
         });
 
-        it('should return false if bidRequest.mediaType is not equal to video', () => {
+        it('should return false if bidRequest.mediaType is not equal to video', function () {
           expect(hasVideoMediaType({
             mediaType: 'banner'
           })).is.equal(false);
         });
 
-        it('should return false if bidRequest.mediaType is not defined', () => {
+        it('should return false if bidRequest.mediaType is not defined', function () {
           expect(hasVideoMediaType({})).is.equal(false);
         });
 
-        it('should return true if bidRequest.mediaTypes.video.context is instream and size_id is defined', () => {
+        it('should return true if bidRequest.mediaTypes.video.context is instream and size_id is defined', function () {
           expect(hasVideoMediaType({
             mediaTypes: {
               video: {
@@ -1422,7 +1422,7 @@ describe('the rubicon adapter', function () {
           })).is.equal(true);
         });
 
-        it('should return false if bidRequest.mediaTypes.video.context is instream but size_id is not defined', () => {
+        it('should return false if bidRequest.mediaTypes.video.context is instream but size_id is not defined', function () {
           expect(spec.isBidRequestValid({
             mediaTypes: {
               video: {
@@ -1439,7 +1439,7 @@ describe('the rubicon adapter', function () {
 
     describe('interpretResponse', function () {
       describe('for fastlane', function () {
-        it('should handle a success response and sort by cpm', () => {
+        it('should handle a success response and sort by cpm', function () {
           let response = {
             'status': 'ok',
             'account_id': 14062,
@@ -1534,7 +1534,7 @@ describe('the rubicon adapter', function () {
           expect(bids[1].rubiconTargeting.rpfl_14062).to.equal('15_tier_all_test');
         });
 
-        it('should be fine with a CPM of 0', () => {
+        it('should be fine with a CPM of 0', function () {
           let response = {
             'status': 'ok',
             'account_id': 14062,
@@ -1561,7 +1561,7 @@ describe('the rubicon adapter', function () {
           expect(bids[0].cpm).to.be.equal(0);
         });
 
-        it('should handle an error with no ads returned', () => {
+        it('should handle an error with no ads returned', function () {
           let response = {
             'status': 'ok',
             'account_id': 14062,
@@ -1583,7 +1583,7 @@ describe('the rubicon adapter', function () {
           expect(bids).to.be.lengthOf(0);
         });
 
-        it('should handle an error', () => {
+        it('should handle an error', function () {
           let response = {
             'status': 'ok',
             'account_id': 14062,
@@ -1607,7 +1607,7 @@ describe('the rubicon adapter', function () {
           expect(bids).to.be.lengthOf(0);
         });
 
-        it('should handle an error because of malformed json response', () => {
+        it('should handle an error because of malformed json response', function () {
           let response = '{test{';
 
           let bids = spec.interpretResponse({body: response}, {
@@ -1617,7 +1617,7 @@ describe('the rubicon adapter', function () {
           expect(bids).to.be.lengthOf(0);
         });
 
-        it('should handle a bidRequest argument of type Array', () => {
+        it('should handle a bidRequest argument of type Array', function () {
           let response = {
             'status': 'ok',
             'account_id': 14062,
@@ -1645,7 +1645,7 @@ describe('the rubicon adapter', function () {
         });
 
         describe('singleRequest enabled', function () {
-          it('handles bidRequest of type Array and returns associated adUnits', () => {
+          it('handles bidRequest of type Array and returns associated adUnits', function () {
             const overrideMap = [];
             overrideMap[0] = { impression_id: '1' };
 
@@ -1700,7 +1700,7 @@ describe('the rubicon adapter', function () {
             });
           });
 
-          it('handles incorrect adUnits length by returning all bids with matching ads', () => {
+          it('handles incorrect adUnits length by returning all bids with matching ads', function () {
             const overrideMap = [];
             overrideMap[0] = { impression_id: '1' };
 
@@ -1730,7 +1730,7 @@ describe('the rubicon adapter', function () {
             expect(bids).to.be.a('array').with.lengthOf(6);
           });
 
-          it('skips adUnits with error status and returns all bids with ok status', () => {
+          it('skips adUnits with error status and returns all bids with ok status', function () {
             const stubAds = [];
             // Create overrides to break associations between bids and ads
             // Each override should cause one less bid to be returned by interpretResponse
@@ -1800,7 +1800,7 @@ describe('the rubicon adapter', function () {
           createVideoBidderRequest();
         });
 
-        it('should register a successful bid', () => {
+        it('should register a successful bid', function () {
           let response = {
             'status': 'ok',
             'ads': {
@@ -1856,7 +1856,7 @@ describe('the rubicon adapter', function () {
       resetUserSync();
     });
 
-    it('should register the Emily iframe', () => {
+    it('should register the Emily iframe', function () {
       let syncs = spec.getUserSyncs({
         iframeEnabled: true
       });
@@ -1864,7 +1864,7 @@ describe('the rubicon adapter', function () {
       expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
     });
 
-    it('should not register the Emily iframe more than once', () => {
+    it('should not register the Emily iframe more than once', function () {
       let syncs = spec.getUserSyncs({
         iframeEnabled: true
       });
@@ -1875,7 +1875,7 @@ describe('the rubicon adapter', function () {
       expect(syncs).to.equal(undefined);
     });
 
-    it('should pass gdpr params if consent is true', () => {
+    it('should pass gdpr params if consent is true', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         gdprApplies: true, consentString: 'foo'
       })).to.deep.equal({
@@ -1883,7 +1883,7 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass gdpr params if consent is false', () => {
+    it('should pass gdpr params if consent is false', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         gdprApplies: false, consentString: 'foo'
       })).to.deep.equal({
@@ -1891,7 +1891,7 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass gdpr param gdpr_consent only when gdprApplies is undefined', () => {
+    it('should pass gdpr param gdpr_consent only when gdprApplies is undefined', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         consentString: 'foo'
       })).to.deep.equal({
@@ -1899,13 +1899,13 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass no params if gdpr consentString is not defined', () => {
+    it('should pass no params if gdpr consentString is not defined', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {})).to.deep.equal({
         type: 'iframe', url: `${emilyUrl}`
       });
     });
 
-    it('should pass no params if gdpr consentString is a number', () => {
+    it('should pass no params if gdpr consentString is a number', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         consentString: 0
       })).to.deep.equal({
@@ -1913,7 +1913,7 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass no params if gdpr consentString is null', () => {
+    it('should pass no params if gdpr consentString is null', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         consentString: null
       })).to.deep.equal({
@@ -1921,7 +1921,7 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass no params if gdpr consentString is a object', () => {
+    it('should pass no params if gdpr consentString is a object', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
         consentString: {}
       })).to.deep.equal({
@@ -1929,7 +1929,7 @@ describe('the rubicon adapter', function () {
       });
     });
 
-    it('should pass no params if gdpr is not defined', () => {
+    it('should pass no params if gdpr is not defined', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, undefined)).to.deep.equal({
         type: 'iframe', url: `${emilyUrl}`
       });

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -12,7 +12,7 @@ var CONSTANTS = require('src/constants.json');
 
 const INTEGRATION = `pbjs_lite_v$prebid.version$`; // $prebid.version$ will be substituted in by gulp in built prebid
 
-describe('the rubicon adapter', () => {
+describe('the rubicon adapter', function () {
   let sandbox,
     bidderRequest,
     sizeMap;
@@ -331,7 +331,7 @@ describe('the rubicon adapter', () => {
     sandbox.restore();
   });
 
-  describe('MAS mapping / ordering', () => {
+  describe('MAS mapping / ordering', function () {
     it('should sort values without any MAS priority sizes in regular ascending order', () => {
       let ordering = masSizeOrdering([126, 43, 65, 16]);
       expect(ordering).to.deep.equal([16, 43, 65, 126]);
@@ -349,9 +349,9 @@ describe('the rubicon adapter', () => {
     });
   });
 
-  describe('buildRequests implementation', () => {
-    describe('for requests', () => {
-      describe('to fastlane', () => {
+  describe('buildRequests implementation', function () {
+    describe('for requests', function () {
+      describe('to fastlane', function () {
         it('should make a well-formed request objects', () => {
           sandbox.stub(Math, 'random').callsFake(() => 0.1);
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
@@ -634,7 +634,7 @@ describe('the rubicon adapter', () => {
           delete window.DigiTrust;
         });
 
-        describe('digiTrustId config', () => {
+        describe('digiTrustId config', function () {
           var origGetConfig;
           beforeEach(() => {
             window.DigiTrust = {
@@ -758,7 +758,7 @@ describe('the rubicon adapter', () => {
           });
         });
 
-        describe('GDPR consent config', () => {
+        describe('GDPR consent config', function () {
           it('should send "gdpr" and "gdpr_consent", when gdprConsent defines consentString and gdprApplies', () => {
             createGdprBidderRequest(true);
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
@@ -798,7 +798,7 @@ describe('the rubicon adapter', () => {
           });
         });
 
-        describe('singleRequest config', () => {
+        describe('singleRequest config', function () {
           it('should group all bid requests with the same site id', () => {
             sandbox.stub(Math, 'random').callsFake(() => 0.1);
 
@@ -1009,7 +1009,7 @@ describe('the rubicon adapter', () => {
         });
       });
 
-      describe('for video requests', () => {
+      describe('for video requests', function () {
         it('should make a well-formed video request with legacy mediaType config', () => {
           createLegacyVideoBidderRequest();
 
@@ -1315,7 +1315,7 @@ describe('the rubicon adapter', () => {
         });
       });
 
-      describe('combineSlotUrlParams', () => {
+      describe('combineSlotUrlParams', function () {
         it('should combine an array of slot url params', () => {
           expect(spec.combineSlotUrlParams([])).to.deep.equal({});
 
@@ -1341,7 +1341,7 @@ describe('the rubicon adapter', () => {
         });
       });
 
-      describe('createSlotParams', () => {
+      describe('createSlotParams', function () {
         it('should return a valid slot params object', () => {
           let expectedQuery = {
             'account_id': '14062',
@@ -1380,7 +1380,7 @@ describe('the rubicon adapter', () => {
         });
       });
 
-      describe('hasVideoMediaType', () => {
+      describe('hasVideoMediaType', function () {
         it('should return true if mediaType is video and size_id is set', () => {
           createVideoBidderRequest();
           const legacyVideoTypeBidRequest = hasVideoMediaType(bidderRequest.bids[0]);
@@ -1437,8 +1437,8 @@ describe('the rubicon adapter', () => {
       });
     });
 
-    describe('interpretResponse', () => {
-      describe('for fastlane', () => {
+    describe('interpretResponse', function () {
+      describe('for fastlane', function () {
         it('should handle a success response and sort by cpm', () => {
           let response = {
             'status': 'ok',
@@ -1644,7 +1644,7 @@ describe('the rubicon adapter', () => {
           expect(bids[0].cpm).to.be.equal(0);
         });
 
-        describe('singleRequest enabled', () => {
+        describe('singleRequest enabled', function () {
           it('handles bidRequest of type Array and returns associated adUnits', () => {
             const overrideMap = [];
             overrideMap[0] = { impression_id: '1' };
@@ -1795,7 +1795,7 @@ describe('the rubicon adapter', () => {
         });
       });
 
-      describe('for video', () => {
+      describe('for video', function () {
         beforeEach(() => {
           createVideoBidderRequest();
         });
@@ -1849,7 +1849,7 @@ describe('the rubicon adapter', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     const emilyUrl = 'https://eus.rubiconproject.com/usync.html';
 
     beforeEach(() => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -257,7 +257,7 @@ describe('the rubicon adapter', function () {
     };
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
 
     bidderRequest = {
@@ -327,7 +327,7 @@ describe('the rubicon adapter', function () {
     });
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
   });
 
@@ -636,13 +636,13 @@ describe('the rubicon adapter', function () {
 
         describe('digiTrustId config', function () {
           var origGetConfig;
-          beforeEach(() => {
+          beforeEach(function () {
             window.DigiTrust = {
               getUser: sandbox.spy()
             };
           });
 
-          afterEach(() => {
+          afterEach(function () {
             delete window.DigiTrust;
           });
 
@@ -1796,7 +1796,7 @@ describe('the rubicon adapter', function () {
       });
 
       describe('for video', function () {
-        beforeEach(() => {
+        beforeEach(function () {
           createVideoBidderRequest();
         });
 
@@ -1852,7 +1852,7 @@ describe('the rubicon adapter', function () {
   describe('user sync', function () {
     const emilyUrl = 'https://eus.rubiconproject.com/usync.html';
 
-    beforeEach(() => {
+    beforeEach(function () {
       resetUserSync();
     });
 

--- a/test/spec/modules/rxrtbBidAdapter_spec.js
+++ b/test/spec/modules/rxrtbBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import {expect} from 'chai';
 import {spec} from 'modules/rxrtbBidAdapter';
 
-describe('rxrtb adapater', () => {
-  describe('Test validate req', () => {
+describe('rxrtb adapater', function () {
+  describe('Test validate req', function () {
     it('should accept minimum valid bid', () => {
       let bid = {
         bidder: 'rxrtb',
@@ -58,7 +58,7 @@ describe('rxrtb adapater', () => {
     });
   });
 
-  describe('Test build request', () => {
+  describe('Test build request', function () {
     it('minimum request', () => {
       let bid = {
         bidder: 'rxrtb',
@@ -88,7 +88,7 @@ describe('rxrtb adapater', () => {
     });
   });
 
-  describe('Test interpret response', () => {
+  describe('Test interpret response', function () {
     it('General banner response', () => {
       let resp = spec.interpretResponse({
         body: {

--- a/test/spec/modules/rxrtbBidAdapter_spec.js
+++ b/test/spec/modules/rxrtbBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec} from 'modules/rxrtbBidAdapter';
 
 describe('rxrtb adapater', function () {
   describe('Test validate req', function () {
-    it('should accept minimum valid bid', () => {
+    it('should accept minimum valid bid', function () {
       let bid = {
         bidder: 'rxrtb',
         params: {
@@ -17,7 +17,7 @@ describe('rxrtb adapater', function () {
       expect(isValid).to.equal(true);
     });
 
-    it('should reject missing id', () => {
+    it('should reject missing id', function () {
       let bid = {
         bidder: 'rxrtb',
         params: {
@@ -30,7 +30,7 @@ describe('rxrtb adapater', function () {
       expect(isValid).to.equal(false);
     });
 
-    it('should reject id not Integer', () => {
+    it('should reject id not Integer', function () {
       let bid = {
         bidder: 'rxrtb',
         params: {
@@ -44,7 +44,7 @@ describe('rxrtb adapater', function () {
       expect(isValid).to.equal(false);
     });
 
-    it('should reject missing source', () => {
+    it('should reject missing source', function () {
       let bid = {
         bidder: 'rxrtb',
         params: {
@@ -59,7 +59,7 @@ describe('rxrtb adapater', function () {
   });
 
   describe('Test build request', function () {
-    it('minimum request', () => {
+    it('minimum request', function () {
       let bid = {
         bidder: 'rxrtb',
         sizes: [[728, 90]],
@@ -89,7 +89,7 @@ describe('rxrtb adapater', function () {
   });
 
   describe('Test interpret response', function () {
-    it('General banner response', () => {
+    it('General banner response', function () {
       let resp = spec.interpretResponse({
         body: {
           id: 'abcd',

--- a/test/spec/modules/s2sTesting_spec.js
+++ b/test/spec/modules/s2sTesting_spec.js
@@ -12,11 +12,11 @@ describe('s2sTesting', function () {
   let mathRandomStub;
   let randomNumber = 0;
 
-  beforeEach(() => {
+  beforeEach(function () {
     mathRandomStub = sinon.stub(Math, 'random').callsFake(() => { return randomNumber; });
   });
 
-  afterEach(() => {
+  afterEach(function () {
     mathRandomStub.restore();
   });
 
@@ -91,7 +91,7 @@ describe('s2sTesting', function () {
 
   describe('getSourceBidderMap', function () {
     describe('setting source through s2sConfig', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         // set random number for testing
         randomNumber = 0.7;
       });
@@ -158,7 +158,7 @@ describe('s2sTesting', function () {
     });
 
     describe('setting source through adUnits', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         // reset s2sconfig bid sources
         config.setConfig({s2sConfig: {testing: true}});
         // set random number for testing
@@ -276,7 +276,7 @@ describe('s2sTesting', function () {
     });
 
     describe('setting source through s2sconfig and adUnits', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         // reset s2sconfig bid sources
         config.setConfig({s2sConfig: {testing: true}});
         // set random number for testing

--- a/test/spec/modules/s2sTesting_spec.js
+++ b/test/spec/modules/s2sTesting_spec.js
@@ -28,18 +28,18 @@ describe('s2sTesting', function () {
       return getSource(sourceWeights, sources);
     }
 
-    it('returns undefined if no sources', () => {
+    it('returns undefined if no sources', function () {
       expect(getExpectedSource(0, {})).to.be.undefined;
       expect(getExpectedSource(0.5, {})).to.be.undefined;
       expect(getExpectedSource(0.9999, {})).to.be.undefined;
     });
 
-    it('returns undefined if no weights', () => {
+    it('returns undefined if no weights', function () {
       expect(getExpectedSource(0, {server: 0, client: 0})).to.be.undefined;
       expect(getExpectedSource(0.5, {client: 0})).to.be.undefined;
     });
 
-    it('gets the expected source from 3 sources', () => {
+    it('gets the expected source from 3 sources', function () {
       var sources = ['server', 'client', 'both'];
       expect(getExpectedSource(0, {server: 1, client: 1, both: 2}, sources)).to.equal('server');
       expect(getExpectedSource(0.2499999, {server: 1, client: 1, both: 2}, sources)).to.equal('server');
@@ -49,7 +49,7 @@ describe('s2sTesting', function () {
       expect(getExpectedSource(0.99999, {server: 1, client: 1, both: 2}, sources)).to.equal('both');
     });
 
-    it('gets the expected source from 2 sources', () => {
+    it('gets the expected source from 2 sources', function () {
       expect(getExpectedSource(0, {server: 2, client: 3})).to.equal('server');
       expect(getExpectedSource(0.39999, {server: 2, client: 3})).to.equal('server');
       expect(getExpectedSource(0.4, {server: 2, client: 3})).to.equal('client');
@@ -61,19 +61,19 @@ describe('s2sTesting', function () {
       expect(getExpectedSource(0.9, {server: 2, client: 3}, sources)).to.equal('client');
     });
 
-    it('gets the expected source from 1 source', () => {
+    it('gets the expected source from 1 source', function () {
       expect(getExpectedSource(0, {client: 2})).to.equal('client');
       expect(getExpectedSource(0.5, {client: 2})).to.equal('client');
       expect(getExpectedSource(0.99999, {client: 2})).to.equal('client');
     });
 
-    it('ignores an invalid source', () => {
+    it('ignores an invalid source', function () {
       expect(getExpectedSource(0, {client: 2, cache: 2})).to.equal('client');
       expect(getExpectedSource(0.3333, {server: 1, cache: 1, client: 2})).to.equal('server');
       expect(getExpectedSource(0.34, {server: 1, cache: 1, client: 2})).to.equal('client');
     });
 
-    it('ignores order of sources', () => {
+    it('ignores order of sources', function () {
       var sources = ['server', 'client', 'both'];
       expect(getExpectedSource(0, {client: 1, server: 1, both: 2}, sources)).to.equal('server');
       expect(getExpectedSource(0.2499999, {both: 2, client: 1, server: 1}, sources)).to.equal('server');
@@ -82,7 +82,7 @@ describe('s2sTesting', function () {
       expect(getExpectedSource(0.5, {both: 2, server: 1, client: 1}, sources)).to.equal('both');
     });
 
-    it('accepts an array of sources', () => {
+    it('accepts an array of sources', function () {
       expect(getExpectedSource(0.3333, {second: 2, first: 1}, ['first', 'second'])).to.equal('first');
       expect(getExpectedSource(0.34, {second: 2, first: 1}, ['first', 'second'])).to.equal('second');
       expect(getExpectedSource(0.9999, {second: 2, first: 1}, ['first', 'second'])).to.equal('second');
@@ -96,7 +96,7 @@ describe('s2sTesting', function () {
         randomNumber = 0.7;
       });
 
-      it('does not work if testing is "false"', () => {
+      it('does not work if testing is "false"', function () {
         config.setConfig({s2sConfig: {
           bidders: ['rubicon'],
           testing: false,
@@ -108,7 +108,7 @@ describe('s2sTesting', function () {
         });
       });
 
-      it('sets one client bidder', () => {
+      it('sets one client bidder', function () {
         config.setConfig({s2sConfig: {
           bidders: ['rubicon'],
           testing: true,
@@ -120,7 +120,7 @@ describe('s2sTesting', function () {
         });
       });
 
-      it('sets one server bidder', () => {
+      it('sets one server bidder', function () {
         config.setConfig({s2sConfig: {
           bidders: ['rubicon'],
           testing: true,
@@ -132,7 +132,7 @@ describe('s2sTesting', function () {
         });
       });
 
-      it('defaults to server', () => {
+      it('defaults to server', function () {
         config.setConfig({s2sConfig: {
           bidders: ['rubicon'],
           testing: true
@@ -143,7 +143,7 @@ describe('s2sTesting', function () {
         });
       });
 
-      it('sets two bidders', () => {
+      it('sets two bidders', function () {
         config.setConfig({s2sConfig: {
           bidders: ['rubicon', 'appnexus'],
           testing: true,
@@ -165,7 +165,7 @@ describe('s2sTesting', function () {
         randomNumber = 0.7;
       });
 
-      it('sets one bidder source from one adUnit', () => {
+      it('sets one bidder source from one adUnit', function () {
         var adUnits = [
           {bids: [
             {bidder: 'rubicon', bidSource: {server: 4, client: 1}}
@@ -193,7 +193,7 @@ describe('s2sTesting', function () {
         expect(adUnits[0].bids[0].finalSource).to.equal('client');
       });
 
-      it('defaults to client if no bidSource', () => {
+      it('defaults to client if no bidSource', function () {
         var adUnits = [
           {bids: [
             {bidder: 'rubicon', bidSource: {}}
@@ -208,7 +208,7 @@ describe('s2sTesting', function () {
         expect(adUnits[0].bids[0].finalSource).to.equal('client');
       });
 
-      it('sets multiple bidders sources from one adUnit', () => {
+      it('sets multiple bidders sources from one adUnit', function () {
         var adUnits = [
           {bids: [
             {bidder: 'rubicon', bidSource: {server: 2, client: 1}},
@@ -225,7 +225,7 @@ describe('s2sTesting', function () {
         expect(adUnits[0].bids[1].finalSource).to.equal('server');
       });
 
-      it('sets multiple bidders sources from multiple adUnits', () => {
+      it('sets multiple bidders sources from multiple adUnits', function () {
         var adUnits = [
           {bids: [
             {bidder: 'rubicon', bidSource: {server: 2, client: 1}},
@@ -251,7 +251,7 @@ describe('s2sTesting', function () {
         expect(adUnits[1].bids[1].finalSource).to.equal('client');
       });
 
-      it('should reuse calculated sources', () => {
+      it('should reuse calculated sources', function () {
         var adUnits = [
           {bids: [
             {bidder: 'rubicon', calcSource: 'client', bidSource: {server: 4, client: 1}},
@@ -283,7 +283,7 @@ describe('s2sTesting', function () {
         randomNumber = 0.7;
       });
 
-      it('should get sources from  both', () => {
+      it('should get sources from  both', function () {
         // set rubicon: server and appnexus: client
         var adUnits = [
           {bids: [

--- a/test/spec/modules/s2sTesting_spec.js
+++ b/test/spec/modules/s2sTesting_spec.js
@@ -20,7 +20,7 @@ describe('s2sTesting', function () {
     mathRandomStub.restore();
   });
 
-  describe('getSource', () => {
+  describe('getSource', function () {
     // helper function to set random number and get the source
     function getExpectedSource(randNumber, sourceWeights, sources) {
       // set random number for testing
@@ -89,8 +89,8 @@ describe('s2sTesting', function () {
     });
   });
 
-  describe('getSourceBidderMap', () => {
-    describe('setting source through s2sConfig', () => {
+  describe('getSourceBidderMap', function () {
+    describe('setting source through s2sConfig', function () {
       beforeEach(() => {
         // set random number for testing
         randomNumber = 0.7;
@@ -157,7 +157,7 @@ describe('s2sTesting', function () {
       });
     });
 
-    describe('setting source through adUnits', () => {
+    describe('setting source through adUnits', function () {
       beforeEach(() => {
         // reset s2sconfig bid sources
         config.setConfig({s2sConfig: {testing: true}});
@@ -275,7 +275,7 @@ describe('s2sTesting', function () {
       });
     });
 
-    describe('setting source through s2sconfig and adUnits', () => {
+    describe('setting source through s2sconfig and adUnits', function () {
       beforeEach(() => {
         // reset s2sconfig bid sources
         config.setConfig({s2sConfig: {testing: true}});

--- a/test/spec/modules/saraBidAdapter_spec.js
+++ b/test/spec/modules/saraBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('Sara Adapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('Sara Adapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -83,7 +83,7 @@ describe('Sara Adapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -92,7 +92,7 @@ describe('Sara Adapter', function () {
       expect(payload).to.have.property('auids', '5');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -101,7 +101,7 @@ describe('Sara Adapter', function () {
       expect(payload).to.have.property('auids', '5,6');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -112,7 +112,7 @@ describe('Sara Adapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -135,7 +135,7 @@ describe('Sara Adapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'sara',
@@ -169,7 +169,7 @@ describe('Sara Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'sara',
@@ -249,7 +249,7 @@ describe('Sara Adapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'sara',

--- a/test/spec/modules/saraBidAdapter_spec.js
+++ b/test/spec/modules/saraBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('Sara Adapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'sara',
       'params': {
@@ -38,7 +38,7 @@ describe('Sara Adapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     function parseRequest(url) {
       const res = {};
       url.split('&').forEach((it) => {
@@ -124,7 +124,7 @@ describe('Sara Adapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 4, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 5, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/sekindoUMBidAdapter_spec.js
+++ b/test/spec/modules/sekindoUMBidAdapter_spec.js
@@ -30,25 +30,25 @@ describe('sekindoUMAdapter', function () {
   };
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       bidRequests.mediaType = 'banner';
       bidRequests.params = bannerParams;
       expect(spec.isBidRequestValid(bidRequests)).to.equal(true);
     });
 
-    it('should return false when required video params are missing', () => {
+    it('should return false when required video params are missing', function () {
       bidRequests.mediaType = 'video';
       bidRequests.params = bannerParams;
       expect(spec.isBidRequestValid(bidRequests)).to.equal(false);
     });
 
-    it('should return true when required Video params found', () => {
+    it('should return true when required Video params found', function () {
       bidRequests.mediaType = 'video';
       bidRequests.params = videoParams;
       expect(spec.isBidRequestValid(bidRequests)).to.equal(true);
@@ -56,7 +56,7 @@ describe('sekindoUMAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('banner data should be a query string and method = GET', () => {
+    it('banner data should be a query string and method = GET', function () {
       bidRequests.mediaType = 'banner';
       bidRequests.params = bannerParams;
       const request = spec.buildRequests([bidRequests]);
@@ -64,7 +64,7 @@ describe('sekindoUMAdapter', function () {
       expect(request[0].method).to.equal('GET');
     });
 
-    it('with gdprConsent, banner data should be a query string and method = GET', () => {
+    it('with gdprConsent, banner data should be a query string and method = GET', function () {
       bidRequests.mediaType = 'banner';
       bidRequests.params = bannerParams;
       const request = spec.buildRequests([bidRequests], {'gdprConsent': {'consentString': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==', 'vendorData': {}, 'gdprApplies': true}});
@@ -72,7 +72,7 @@ describe('sekindoUMAdapter', function () {
       expect(request[0].method).to.equal('GET');
     });
 
-    it('video data should be a query string and method = GET', () => {
+    it('video data should be a query string and method = GET', function () {
       bidRequests.mediaType = 'video';
       bidRequests.params = videoParams;
       const request = spec.buildRequests([bidRequests]);
@@ -82,7 +82,7 @@ describe('sekindoUMAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('banner should get correct bid response', () => {
+    it('banner should get correct bid response', function () {
       let response = {
         'headers': function(header) {
           return 'dummy header';
@@ -110,7 +110,7 @@ describe('sekindoUMAdapter', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('vastXml video should get correct bid response', () => {
+    it('vastXml video should get correct bid response', function () {
       let response = {
         'headers': function(header) {
           return 'dummy header';
@@ -138,7 +138,7 @@ describe('sekindoUMAdapter', function () {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('vastUrl video should get correct bid response', () => {
+    it('vastUrl video should get correct bid response', function () {
       let response = {
         'headers': function(header) {
           return 'dummy header';

--- a/test/spec/modules/sekindoUMBidAdapter_spec.js
+++ b/test/spec/modules/sekindoUMBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/sekindoUMBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-describe('sekindoUMAdapter', () => {
+describe('sekindoUMAdapter', function () {
   const adapter = newBidder(spec);
 
   const bannerParams = {
@@ -29,13 +29,13 @@ describe('sekindoUMAdapter', () => {
     'mediaType': 'banner'
   };
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       bidRequests.mediaType = 'banner';
       bidRequests.params = bannerParams;
@@ -55,7 +55,7 @@ describe('sekindoUMAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('banner data should be a query string and method = GET', () => {
       bidRequests.mediaType = 'banner';
       bidRequests.params = bannerParams;
@@ -81,7 +81,7 @@ describe('sekindoUMAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('banner should get correct bid response', () => {
       let response = {
         'headers': function(header) {

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -100,7 +100,7 @@ const RESPONSE = {
   }
 };
 
-describe('Serverbid BidAdapter', () => {
+describe('Serverbid BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
@@ -122,7 +122,7 @@ describe('Serverbid BidAdapter', () => {
     ];
   });
 
-  describe('bid request validation', () => {
+  describe('bid request validation', function () {
     it('should accept valid bid requests', () => {
       let bid = {
         bidder: 'serverbid',
@@ -167,7 +167,7 @@ describe('Serverbid BidAdapter', () => {
     });
   });
 
-  describe('buildRequests validation', () => {
+  describe('buildRequests validation', function () {
     it('creates request data', () => {
       let request = spec.buildRequests(bidRequests);
 
@@ -191,7 +191,7 @@ describe('Serverbid BidAdapter', () => {
       expect(request.method).to.have.string('POST');
     });
   });
-  describe('interpretResponse validation', () => {
+  describe('interpretResponse validation', function () {
     it('response should have valid bidderCode', () => {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
@@ -236,7 +236,7 @@ describe('Serverbid BidAdapter', () => {
       expect(bids).to.be.empty;
     });
   });
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let syncOptions = {'iframeEnabled': true};
 
     it('handles empty sync options', () => {

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -104,7 +104,7 @@ describe('Serverbid BidAdapter', function () {
   let bidRequests;
   let adapter = spec;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'serverbid',

--- a/test/spec/modules/serverbidBidAdapter_spec.js
+++ b/test/spec/modules/serverbidBidAdapter_spec.js
@@ -123,7 +123,7 @@ describe('Serverbid BidAdapter', function () {
   });
 
   describe('bid request validation', function () {
-    it('should accept valid bid requests', () => {
+    it('should accept valid bid requests', function () {
       let bid = {
         bidder: 'serverbid',
         params: {
@@ -134,7 +134,7 @@ describe('Serverbid BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should accept valid bid requests with extra fields', () => {
+    it('should accept valid bid requests with extra fields', function () {
       let bid = {
         bidder: 'serverbid',
         params: {
@@ -146,7 +146,7 @@ describe('Serverbid BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should reject bid requests without siteId', () => {
+    it('should reject bid requests without siteId', function () {
       let bid = {
         bidder: 'serverbid',
         params: {
@@ -156,7 +156,7 @@ describe('Serverbid BidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should reject bid requests without networkId', () => {
+    it('should reject bid requests without networkId', function () {
       let bid = {
         bidder: 'serverbid',
         params: {
@@ -168,44 +168,44 @@ describe('Serverbid BidAdapter', function () {
   });
 
   describe('buildRequests validation', function () {
-    it('creates request data', () => {
+    it('creates request data', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request).to.exist.and.to.be.a('object');
     });
 
-    it('request to serverbid should contain a url', () => {
+    it('request to serverbid should contain a url', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.url).to.have.string('serverbid.com');
     });
 
-    it('requires valid bids to make request', () => {
+    it('requires valid bids to make request', function () {
       let request = spec.buildRequests([]);
       expect(request.bidRequest).to.be.empty;
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       let request = spec.buildRequests(bidRequests);
 
       expect(request.method).to.have.string('POST');
     });
   });
   describe('interpretResponse validation', function () {
-    it('response should have valid bidderCode', () => {
+    it('response should have valid bidderCode', function () {
       let bidRequest = spec.buildRequests(REQUEST.bidRequest);
       let bid = bidFactory.createBid(1, bidRequest.bidRequest[0]);
 
       expect(bid.bidderCode).to.equal('serverbid');
     });
 
-    it('response should include objects for all bids', () => {
+    it('response should include objects for all bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
 
       expect(bids.length).to.equal(2);
     });
 
-    it('registers bids', () => {
+    it('registers bids', function () {
       let bids = spec.interpretResponse(RESPONSE, REQUEST);
       bids.forEach(b => {
         expect(b).to.have.property('cpm');
@@ -223,14 +223,14 @@ describe('Serverbid BidAdapter', function () {
       });
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let EMPTY_RESP = Object.assign({}, RESPONSE, {'body': {'decisions': null}})
       let bids = spec.interpretResponse(EMPTY_RESP, REQUEST);
 
       expect(bids).to.be.empty;
     });
 
-    it('handles no server response', () => {
+    it('handles no server response', function () {
       let bids = spec.interpretResponse(null, REQUEST);
 
       expect(bids).to.be.empty;
@@ -239,13 +239,13 @@ describe('Serverbid BidAdapter', function () {
   describe('getUserSyncs', function () {
     let syncOptions = {'iframeEnabled': true};
 
-    it('handles empty sync options', () => {
+    it('handles empty sync options', function () {
       let opts = spec.getUserSyncs({});
 
       expect(opts).to.be.empty;
     });
 
-    it('should return a sync url if iframe syncs are enabled', () => {
+    it('should return a sync url if iframe syncs are enabled', function () {
       let opts = spec.getUserSyncs(syncOptions);
 
       expect(opts.length).to.equal(1);

--- a/test/spec/modules/serverbidServerBidAdapter_spec.js
+++ b/test/spec/modules/serverbidServerBidAdapter_spec.js
@@ -184,7 +184,7 @@ const REQUEST_TWO_UNITS = {
   ]
 };
 
-describe('ServerBid S2S Adapter', () => {
+describe('ServerBid S2S Adapter', function () {
   let adapter,
     addBidResponse = sinon.spy(),
     done = sinon.spy();
@@ -196,7 +196,7 @@ describe('ServerBid S2S Adapter', () => {
     done.resetHistory();
   });
 
-  describe('request function', () => {
+  describe('request function', function () {
     let xhr;
     let requests;
 
@@ -213,7 +213,7 @@ describe('ServerBid S2S Adapter', () => {
     });
   });
 
-  describe('response handler', () => {
+  describe('response handler', function () {
     let server;
 
     beforeEach(() => {

--- a/test/spec/modules/serverbidServerBidAdapter_spec.js
+++ b/test/spec/modules/serverbidServerBidAdapter_spec.js
@@ -189,9 +189,11 @@ describe('ServerBid S2S Adapter', function () {
     addBidResponse = sinon.spy(),
     done = sinon.spy();
 
-  beforeEach(() => adapter = new Adapter());
+  beforeEach(function () {
+    adapter = new Adapter()
+  });
 
-  afterEach(() => {
+  afterEach(function () {
     addBidResponse.resetHistory();
     done.resetHistory();
   });
@@ -200,13 +202,15 @@ describe('ServerBid S2S Adapter', function () {
     let xhr;
     let requests;
 
-    beforeEach(() => {
+    beforeEach(function () {
       xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = request => requests.push(request);
     });
 
-    afterEach(() => xhr.restore());
+    afterEach(function () {
+      xhr.restore();
+    });
 
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
@@ -216,14 +220,14 @@ describe('ServerBid S2S Adapter', function () {
   describe('response handler', function () {
     let server;
 
-    beforeEach(() => {
+    beforeEach(function () {
       server = sinon.fakeServer.create();
       sinon.stub(utils, 'getBidRequest').returns({
         bidId: '123'
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       server.restore();
       utils.getBidRequest.restore();
     });

--- a/test/spec/modules/serverbidServerBidAdapter_spec.js
+++ b/test/spec/modules/serverbidServerBidAdapter_spec.js
@@ -208,7 +208,7 @@ describe('ServerBid S2S Adapter', function () {
 
     afterEach(() => xhr.restore());
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -228,7 +228,7 @@ describe('ServerBid S2S Adapter', function () {
       utils.getBidRequest.restore();
     });
 
-    it('registers bids', () => {
+    it('registers bids', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig(CONFIG_ARG);
@@ -242,7 +242,7 @@ describe('ServerBid S2S Adapter', function () {
       expect(response).to.have.property('adId', '123');
     });
 
-    it('registers no-bid response when ad unit not set', () => {
+    it('registers no-bid response when ad unit not set', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_BID_NO_UNIT));
 
       config.setConfig(CONFIG_ARG);
@@ -260,7 +260,7 @@ describe('ServerBid S2S Adapter', function () {
       expect(bid_request_passed).to.have.property('adId', '123');
     });
 
-    it('registers no-bid response when ad unit is set', () => {
+    it('registers no-bid response when ad unit is set', function () {
       server.respondWith(JSON.stringify(RESPONSE_NO_BID_NO_UNIT));
 
       config.setConfig(CONFIG_ARG);
@@ -275,7 +275,7 @@ describe('ServerBid S2S Adapter', function () {
       expect(response).to.have.property('statusMessage', 'Bid returned empty or error response');
     });
 
-    it('registers no-bid response when there are less bids than requests', () => {
+    it('registers no-bid response when there are less bids than requests', function () {
       server.respondWith(JSON.stringify(RESPONSE));
 
       config.setConfig(CONFIG_ARG);

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -104,14 +104,14 @@ const b64EncodeUnicode = (str) => {
       }));
 }
 
-describe('sharethrough adapter spec', () => {
-  describe('.code', () => {
+describe('sharethrough adapter spec', function () {
+  describe('.code', function () {
     it('should return a bidder code of sharethrough', () => {
       expect(spec.code).to.eql('sharethrough');
     });
   })
 
-  describe('.isBidRequestValid', () => {
+  describe('.isBidRequestValid', function () {
     it('should return false if req has no pkey', () => {
       const invalidBidRequest = {
         bidder: 'sharethrough',
@@ -138,7 +138,7 @@ describe('sharethrough adapter spec', () => {
     })
   });
 
-  describe('.buildRequests', () => {
+  describe('.buildRequests', function () {
     it('should return an array of requests', () => {
       const bidRequests = spec.buildRequests(bidderRequest);
 
@@ -165,7 +165,7 @@ describe('sharethrough adapter spec', () => {
     });
   });
 
-  describe('.interpretResponse', () => {
+  describe('.interpretResponse', function () {
     it('returns a correctly parsed out response', () => {
       expect(spec.interpretResponse(bidderResponse, prebidRequests[0])[0]).to.include(
         {
@@ -254,7 +254,7 @@ describe('sharethrough adapter spec', () => {
     });
   });
 
-  describe('.getUserSyncs', () => {
+  describe('.getUserSyncs', function () {
     const cookieSyncs = ['cookieUrl1', 'cookieUrl2', 'cookieUrl3'];
     const serverResponses = [{ body: { cookieSyncUrls: cookieSyncs } }];
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -106,13 +106,13 @@ const b64EncodeUnicode = (str) => {
 
 describe('sharethrough adapter spec', function () {
   describe('.code', function () {
-    it('should return a bidder code of sharethrough', () => {
+    it('should return a bidder code of sharethrough', function () {
       expect(spec.code).to.eql('sharethrough');
     });
   })
 
   describe('.isBidRequestValid', function () {
-    it('should return false if req has no pkey', () => {
+    it('should return false if req has no pkey', function () {
       const invalidBidRequest = {
         bidder: 'sharethrough',
         params: {
@@ -122,7 +122,7 @@ describe('sharethrough adapter spec', function () {
       expect(spec.isBidRequestValid(invalidBidRequest)).to.eql(false);
     });
 
-    it('should return false if req has wrong bidder code', () => {
+    it('should return false if req has wrong bidder code', function () {
       const invalidBidRequest = {
         bidder: 'notSharethrough',
         params: {
@@ -132,14 +132,14 @@ describe('sharethrough adapter spec', function () {
       expect(spec.isBidRequestValid(invalidBidRequest)).to.eql(false);
     });
 
-    it('should return true if req is correct', () => {
+    it('should return true if req is correct', function () {
       expect(spec.isBidRequestValid(bidderRequest[0])).to.eq(true);
       expect(spec.isBidRequestValid(bidderRequest[1])).to.eq(true);
     })
   });
 
   describe('.buildRequests', function () {
-    it('should return an array of requests', () => {
+    it('should return an array of requests', function () {
       const bidRequests = spec.buildRequests(bidderRequest);
 
       expect(bidRequests[0].url).to.eq(
@@ -149,7 +149,7 @@ describe('sharethrough adapter spec', function () {
       expect(bidRequests[0].method).to.eq('GET');
     });
 
-    it('should add consent parameters if gdprConsent is present', () => {
+    it('should add consent parameters if gdprConsent is present', function () {
       const gdprConsent = { consentString: 'consent_string123', gdprApplies: true };
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidderRequest, fakeBidRequest)[0];
@@ -157,7 +157,7 @@ describe('sharethrough adapter spec', function () {
       expect(bidRequest.data.consent_string).to.eq('consent_string123');
     });
 
-    it('should handle gdprConsent is present but values are undefined case', () => {
+    it('should handle gdprConsent is present but values are undefined case', function () {
       const gdprConsent = { consent_string: undefined, gdprApplies: undefined };
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidderRequest, fakeBidRequest)[0];
@@ -166,7 +166,7 @@ describe('sharethrough adapter spec', function () {
   });
 
   describe('.interpretResponse', function () {
-    it('returns a correctly parsed out response', () => {
+    it('returns a correctly parsed out response', function () {
       expect(spec.interpretResponse(bidderResponse, prebidRequests[0])[0]).to.include(
         {
           width: 0,
@@ -180,7 +180,7 @@ describe('sharethrough adapter spec', function () {
         });
     });
 
-    it('returns a correctly parsed out response with largest size when strData.stayInIframe is true', () => {
+    it('returns a correctly parsed out response with largest size when strData.stayInIframe is true', function () {
       expect(spec.interpretResponse(bidderResponse, prebidRequests[1])[0]).to.include(
         {
           width: 300,
@@ -194,7 +194,7 @@ describe('sharethrough adapter spec', function () {
         });
     });
 
-    it('returns a correctly parsed out response with explicitly defined size when strData.stayInIframe is true and strData.iframeSize is provided', () => {
+    it('returns a correctly parsed out response with explicitly defined size when strData.stayInIframe is true and strData.iframeSize is provided', function () {
       expect(spec.interpretResponse(bidderResponse, prebidRequests[2])[0]).to.include(
         {
           width: 500,
@@ -208,22 +208,22 @@ describe('sharethrough adapter spec', function () {
         });
     });
 
-    it('returns a blank array if there are no creatives', () => {
+    it('returns a blank array if there are no creatives', function () {
       const bidResponse = { body: { creatives: [] } };
       expect(spec.interpretResponse(bidResponse, prebidRequests[0])).to.be.an('array').that.is.empty;
     });
 
-    it('returns a blank array if body object is empty', () => {
+    it('returns a blank array if body object is empty', function () {
       const bidResponse = { body: {} };
       expect(spec.interpretResponse(bidResponse, prebidRequests[0])).to.be.an('array').that.is.empty;
     });
 
-    it('returns a blank array if body is null', () => {
+    it('returns a blank array if body is null', function () {
       const bidResponse = { body: null };
       expect(spec.interpretResponse(bidResponse, prebidRequests[0])).to.be.an('array').that.is.empty;
     });
 
-    it('correctly generates ad markup', () => {
+    it('correctly generates ad markup', function () {
       const adMarkup = spec.interpretResponse(bidderResponse, prebidRequests[0])[0].ad;
       let resp = null;
 
@@ -240,7 +240,7 @@ describe('sharethrough adapter spec', function () {
         /window.top.document.getElementsByTagName\('body'\)\[0\].appendChild\(sfp_js\);/)
     });
 
-    it('correctly generates ad markup for staying in iframe', () => {
+    it('correctly generates ad markup for staying in iframe', function () {
       const adMarkup = spec.interpretResponse(bidderResponse, prebidRequests[1])[0].ad;
       let resp = null;
 
@@ -258,7 +258,7 @@ describe('sharethrough adapter spec', function () {
     const cookieSyncs = ['cookieUrl1', 'cookieUrl2', 'cookieUrl3'];
     const serverResponses = [{ body: { cookieSyncUrls: cookieSyncs } }];
 
-    it('returns an array of correctly formatted user syncs', () => {
+    it('returns an array of correctly formatted user syncs', function () {
       const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses);
       expect(syncArray).to.deep.equal([
         { type: 'image', url: 'cookieUrl1' },
@@ -267,17 +267,17 @@ describe('sharethrough adapter spec', function () {
       );
     });
 
-    it('returns an empty array if the body is null', () => {
+    it('returns an empty array if the body is null', function () {
       const syncArray = spec.getUserSyncs({ pixelEnabled: true }, [{ body: null }]);
       expect(syncArray).to.be.an('array').that.is.empty;
     });
 
-    it('returns an empty array if the body.cookieSyncUrls is missing', () => {
+    it('returns an empty array if the body.cookieSyncUrls is missing', function () {
       const syncArray = spec.getUserSyncs({ pixelEnabled: true }, [{ body: { creatives: ['creative'] } }]);
       expect(syncArray).to.be.an('array').that.is.empty;
     });
 
-    it('returns an empty array if pixels are not enabled', () => {
+    it('returns an empty array if pixels are not enabled', function () {
       const syncArray = spec.getUserSyncs({ pixelEnabled: false }, serverResponses);
       expect(syncArray).to.be.an('array').that.is.empty;
     });

--- a/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
@@ -46,7 +46,7 @@ describe('sigmoid Prebid Analytic', function () {
       sinon.assert.callCount(sigmoidAnalytic.track, 5);
     });
   });
-  describe('build utm tag data', () => {
+  describe('build utm tag data', function () {
     beforeEach(() => {
       localStorage.setItem('sigmoid_analytics_utm_source', 'utm_source');
       localStorage.setItem('sigmoid_analytics_utm_medium', 'utm_medium');

--- a/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
@@ -6,21 +6,21 @@ let constants = require('src/constants.json');
 
 describe('sigmoid Prebid Analytic', function () {
   let xhr;
-  before(() => {
+  before(function () {
     xhr = sinon.useFakeXMLHttpRequest();
   })
-  after(() => {
+  after(function () {
     sigmoidAnalytic.disableAnalytics();
     xhr.restore();
   });
 
   describe('enableAnalytics', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(sigmoidAnalytic, 'track');
       sinon.stub(events, 'getEvents').returns([]);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       sigmoidAnalytic.track.restore();
       events.getEvents.restore();
     });
@@ -47,7 +47,7 @@ describe('sigmoid Prebid Analytic', function () {
     });
   });
   describe('build utm tag data', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       localStorage.setItem('sigmoid_analytics_utm_source', 'utm_source');
       localStorage.setItem('sigmoid_analytics_utm_medium', 'utm_medium');
       localStorage.setItem('sigmoid_analytics_utm_campaign', '');

--- a/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
@@ -55,7 +55,7 @@ describe('sigmoid Prebid Analytic', function () {
       localStorage.setItem('sigmoid_analytics_utm_content', '');
       localStorage.setItem('sigmoid_analytics_utm_timeout', Date.now());
     });
-    it('should build utm data from local storage', () => {
+    it('should build utm data from local storage', function () {
       let utmTagData = sigmoidAnalytic.buildUtmTagData();
       expect(utmTagData.utm_source).to.equal('utm_source');
       expect(utmTagData.utm_medium).to.equal('utm_medium');

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -71,7 +71,7 @@ describe('Smart bid adapter tests', function () {
     }
   };
 
-  it('Verify build request', () => {
+  it('Verify build request', function () {
     config.setConfig({
       'currency': {
         'adServerCurrency': 'EUR'
@@ -106,7 +106,7 @@ describe('Smart bid adapter tests', function () {
       $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
     });
 
-    it('Verify build request with GDPR', () => {
+    it('Verify build request with GDPR', function () {
       config.setConfig({
         'currency': {
           'adServerCurrency': 'EUR'
@@ -129,7 +129,7 @@ describe('Smart bid adapter tests', function () {
       expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOKAVy4OKAVy4ABAB8AAAAAZ+A==');
     });
 
-    it('Verify build request with GDPR without gdprApplies', () => {
+    it('Verify build request with GDPR without gdprApplies', function () {
       config.setConfig({
         'currency': {
           'adServerCurrency': 'EUR'
@@ -152,7 +152,7 @@ describe('Smart bid adapter tests', function () {
     });
   });
 
-  it('Verify parse response', () => {
+  it('Verify parse response', function () {
     const request = spec.buildRequests(DEFAULT_PARAMS);
     const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
     expect(bids).to.have.lengthOf(1);
@@ -176,16 +176,16 @@ describe('Smart bid adapter tests', function () {
     }).to.not.throw();
   });
 
-  it('Verifies bidder code', () => {
+  it('Verifies bidder code', function () {
     expect(spec.code).to.equal('smartadserver');
   });
 
-  it('Verifies bidder aliases', () => {
+  it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
     expect(spec.aliases[0]).to.equal('smart');
   });
 
-  it('Verifies if bid request valid', () => {
+  it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
     expect(spec.isBidRequestValid(DEFAULT_PARAMS_WO_OPTIONAL[0])).to.equal(true);
     expect(spec.isBidRequestValid({})).to.equal(false);
@@ -243,7 +243,7 @@ describe('Smart bid adapter tests', function () {
     })).to.equal(false);
   });
 
-  it('Verifies user sync', () => {
+  it('Verifies user sync', function () {
     var syncs = spec.getUserSyncs({
       iframeEnabled: true
     }, [BID_RESPONSE]);

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -14,7 +14,7 @@ import * as utils from 'src/utils';
 import { requestBidsHook } from 'modules/consentManagement';
 
 // Default params with optional ones
-describe('Smart bid adapter tests', () => {
+describe('Smart bid adapter tests', function () {
   var DEFAULT_PARAMS = [{
     adUnitCode: 'sas_42',
     bidId: 'abcd1234',
@@ -100,7 +100,7 @@ describe('Smart bid adapter tests', () => {
     expect(requestContent).to.have.property('ckid').and.to.equal(42);
   });
 
-  describe('gdpr tests', () => {
+  describe('gdpr tests', function () {
     afterEach(() => {
       config.resetConfig();
       $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -101,7 +101,7 @@ describe('Smart bid adapter tests', function () {
   });
 
   describe('gdpr tests', function () {
-    afterEach(() => {
+    afterEach(function () {
       config.resetConfig();
       $$PREBID_GLOBAL$$.requestBids.removeHook(requestBidsHook);
     });

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/smartyadsBidAdapter';
 
-describe('SmartyadsAdapter', () => {
+describe('SmartyadsAdapter', function () {
   let bid = {
     bidId: '23fhj33i987f',
     bidder: 'smartyads',
@@ -11,7 +11,7 @@ describe('SmartyadsAdapter', () => {
     }
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true if there are bidId, params and placementId parameters present', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -21,7 +21,7 @@ describe('SmartyadsAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -57,7 +57,7 @@ describe('SmartyadsAdapter', () => {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('Should interpret banner response', () => {
       const banner = {
         body: [{
@@ -217,7 +217,7 @@ describe('SmartyadsAdapter', () => {
       expect(serverResponses).to.be.an('array').that.is.empty;
     });
   });
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
     it('Returns valid URL and type', () => {
       expect(userSync).to.be.an('array').with.lengthOf(1);

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -12,10 +12,10 @@ describe('SmartyadsAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true if there are bidId, params and placementId parameters present', () => {
+    it('Should return true if there are bidId, params and placementId parameters present', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false if at least one of parameters is not present', () => {
+    it('Should return false if at least one of parameters is not present', function () {
       delete bid.params.placementId;
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -23,19 +23,19 @@ describe('SmartyadsAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//ssp-nj.webtradehub.com/?c=o&m=multi');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'language', 'secure', 'host', 'page', 'placements');
@@ -51,14 +51,14 @@ describe('SmartyadsAdapter', function () {
       expect(placement.bidId).to.equal('23fhj33i987f');
       expect(placement.traffic).to.equal('banner');
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
   describe('interpretResponse', function () {
-    it('Should interpret banner response', () => {
+    it('Should interpret banner response', function () {
       const banner = {
         body: [{
           mediaType: 'banner',
@@ -89,7 +89,7 @@ describe('SmartyadsAdapter', function () {
       expect(dataItem.netRevenue).to.be.true;
       expect(dataItem.currency).to.equal('USD');
     });
-    it('Should interpret video response', () => {
+    it('Should interpret video response', function () {
       const video = {
         body: [{
           vastUrl: 'test.com',
@@ -118,7 +118,7 @@ describe('SmartyadsAdapter', function () {
       expect(dataItem.netRevenue).to.be.true;
       expect(dataItem.currency).to.equal('USD');
     });
-    it('Should interpret native response', () => {
+    it('Should interpret native response', function () {
       const native = {
         body: [{
           mediaType: 'native',
@@ -152,7 +152,7 @@ describe('SmartyadsAdapter', function () {
       expect(dataItem.netRevenue).to.be.true;
       expect(dataItem.currency).to.equal('USD');
     });
-    it('Should return an empty array if invalid banner response is passed', () => {
+    it('Should return an empty array if invalid banner response is passed', function () {
       const invBanner = {
         body: [{
           width: 300,
@@ -170,7 +170,7 @@ describe('SmartyadsAdapter', function () {
       let serverResponses = spec.interpretResponse(invBanner);
       expect(serverResponses).to.be.an('array').that.is.empty;
     });
-    it('Should return an empty array if invalid video response is passed', () => {
+    it('Should return an empty array if invalid video response is passed', function () {
       const invVideo = {
         body: [{
           mediaType: 'video',
@@ -186,7 +186,7 @@ describe('SmartyadsAdapter', function () {
       let serverResponses = spec.interpretResponse(invVideo);
       expect(serverResponses).to.be.an('array').that.is.empty;
     });
-    it('Should return an empty array if invalid native response is passed', () => {
+    it('Should return an empty array if invalid native response is passed', function () {
       const invNative = {
         body: [{
           mediaType: 'native',
@@ -203,7 +203,7 @@ describe('SmartyadsAdapter', function () {
       let serverResponses = spec.interpretResponse(invNative);
       expect(serverResponses).to.be.an('array').that.is.empty;
     });
-    it('Should return an empty array if invalid response is passed', () => {
+    it('Should return an empty array if invalid response is passed', function () {
       const invalid = {
         body: [{
           ttl: 120,
@@ -219,7 +219,7 @@ describe('SmartyadsAdapter', function () {
   });
   describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
-    it('Returns valid URL and type', () => {
+    it('Returns valid URL and type', function () {
       expect(userSync).to.be.an('array').with.lengthOf(1);
       expect(userSync[0].type).to.exist;
       expect(userSync[0].url).to.exist;

--- a/test/spec/modules/somoaudienceBidAdapter_spec.js
+++ b/test/spec/modules/somoaudienceBidAdapter_spec.js
@@ -4,14 +4,14 @@ import * as utils from 'src/utils';
 
 describe('Somo Audience Adapter Tests', function () {
   describe('isBidRequestValid', function () {
-    it('should return false when given an invalid bid', () => {
+    it('should return false when given an invalid bid', function () {
       const bid = {
         bidder: 'somoaudience',
       };
       const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equal(false);
     });
-    it('should return true when given a placementId bid', () => {
+    it('should return true when given a placementId bid', function () {
       const bid = {
         bidder: 'somoaudience',
         params: {
@@ -25,7 +25,7 @@ describe('Somo Audience Adapter Tests', function () {
 
   describe('buildRequests', function () {
     describe('buildBannerRequests', function () {
-      it('should properly build a banner request with type not defined and sizes not defined', () => {
+      it('should properly build a banner request with type not defined and sizes not defined', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           params: {
@@ -47,7 +47,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].banner).to.not.equal(null);
       });
 
-      it('should properly build a banner request with sizes defined in 2d array', () => {
+      it('should properly build a banner request with sizes defined in 2d array', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           sizes: [[300, 250]],
@@ -69,7 +69,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].banner.w).to.equal(300);
         expect(ortbRequest.imp[0].banner.h).to.equal(250);
       });
-      it('should properly build a banner request with sizes defined in 1d array', () => {
+      it('should properly build a banner request with sizes defined in 1d array', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           sizes: [300, 250],
@@ -96,7 +96,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].banner.battr).to.equal(undefined);
       });
 
-      it('should populate optional banner parameters', () => {
+      it('should populate optional banner parameters', function () {
         const bidRequests = [
           {
             bidder: 'somoaudience',
@@ -126,7 +126,7 @@ describe('Somo Audience Adapter Tests', function () {
     });
 
     describe('buildVideoRequests', function () {
-      it('should properly build a video request with sizes defined', () => {
+      it('should properly build a video request with sizes defined', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           mediaTypes: {
@@ -149,7 +149,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].video.h).to.equal(300);
       });
 
-      it('should properly build a video request with sizes defined in 2d array', () => {
+      it('should properly build a video request with sizes defined in 2d array', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           mediaTypes: {
@@ -171,7 +171,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].video.w).to.equal(200);
         expect(ortbRequest.imp[0].video.h).to.equal(300);
       });
-      it('should properly build a video request with sizes not defined', () => {
+      it('should properly build a video request with sizes not defined', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           mediaType: 'video',
@@ -196,7 +196,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.imp[0].video.battr).to.equal(undefined);
       });
 
-      it('should populate optional video parameters', () => {
+      it('should populate optional video parameters', function () {
         const bidRequests = [
           {
             bidder: 'somoaudience',
@@ -240,7 +240,7 @@ describe('Somo Audience Adapter Tests', function () {
     });
 
     describe('buildSiteRequests', function () {
-      it('should fill in basic site parameters', () => {
+      it('should fill in basic site parameters', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           params: {
@@ -256,7 +256,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.site.domain).to.not.be.undefined;
       });
 
-      it('should fill in optional site parameters', () => {
+      it('should fill in optional site parameters', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           params: {
@@ -283,7 +283,7 @@ describe('Somo Audience Adapter Tests', function () {
     });
 
     describe('buildAppRequests', function () {
-      it('should fill in app parameters', () => {
+      it('should fill in app parameters', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           params: {
@@ -323,7 +323,7 @@ describe('Somo Audience Adapter Tests', function () {
         },
       };
 
-      it('should properly build request with gdpr consent', () => {
+      it('should properly build request with gdpr consent', function () {
         const bidRequests = [{
           bidder: 'somoaudience',
           params: {
@@ -339,7 +339,7 @@ describe('Somo Audience Adapter Tests', function () {
         expect(ortbRequest.user.ext).to.not.equal(undefined);
         expect(ortbRequest.user.ext.consent).to.equal('test');
       });
-      it('should properly build request with gdpr not applies', () => {
+      it('should properly build request with gdpr not applies', function () {
         bidderRequest.gdprConsent.gdprApplies = false;
         const bidRequests = [{
           bidder: 'somoaudience',
@@ -359,7 +359,7 @@ describe('Somo Audience Adapter Tests', function () {
     });
 
     describe('buildExtraArgsRequests', function () {
-      it('should populate optional parameters', () => {
+      it('should populate optional parameters', function () {
         const bidRequests = [
           {
             bidder: 'somoaudience',
@@ -386,7 +386,7 @@ describe('Somo Audience Adapter Tests', function () {
   });
 
   describe('interpretResponse', function () {
-    it('Verify banner parse response', () => {
+    it('Verify banner parse response', function () {
       const bidRequests = [
         {
           bidder: 'somoaudience',
@@ -414,7 +414,7 @@ describe('Somo Audience Adapter Tests', function () {
       expect(bid.ad).to.equal('Somo Test Ad');
     });
 
-    it('Verify video parse response', () => {
+    it('Verify video parse response', function () {
       const bidRequests = [
         {
           bidder: 'somoaudience',
@@ -448,7 +448,7 @@ describe('Somo Audience Adapter Tests', function () {
   });
 
   describe('user sync', function () {
-    it('should register the pixel sync url', () => {
+    it('should register the pixel sync url', function () {
       let syncs = spec.getUserSyncs({
         pixelEnabled: true
       });
@@ -457,7 +457,7 @@ describe('Somo Audience Adapter Tests', function () {
       expect(syncs[0].type).to.equal('image');
     });
 
-    it('should pass gdpr params', () => {
+    it('should pass gdpr params', function () {
       let syncs = spec.getUserSyncs({ pixelEnabled: true }, {}, {
         gdprApplies: false, consentString: 'test'
       });
@@ -467,7 +467,7 @@ describe('Somo Audience Adapter Tests', function () {
       expect(syncs[0].url).to.contains('gdpr=0');
     });
 
-    it('should pass gdpr applies params', () => {
+    it('should pass gdpr applies params', function () {
       let syncs = spec.getUserSyncs({ pixelEnabled: true }, {}, {
         gdprApplies: true, consentString: 'test'
       });

--- a/test/spec/modules/somoaudienceBidAdapter_spec.js
+++ b/test/spec/modules/somoaudienceBidAdapter_spec.js
@@ -2,8 +2,8 @@ import {expect} from 'chai';
 import {spec} from 'modules/somoaudienceBidAdapter';
 import * as utils from 'src/utils';
 
-describe('Somo Audience Adapter Tests', () => {
-  describe('isBidRequestValid', () => {
+describe('Somo Audience Adapter Tests', function () {
+  describe('isBidRequestValid', function () {
     it('should return false when given an invalid bid', () => {
       const bid = {
         bidder: 'somoaudience',
@@ -23,8 +23,8 @@ describe('Somo Audience Adapter Tests', () => {
     });
   });
 
-  describe('buildRequests', () => {
-    describe('buildBannerRequests', () => {
+  describe('buildRequests', function () {
+    describe('buildBannerRequests', function () {
       it('should properly build a banner request with type not defined and sizes not defined', () => {
         const bidRequests = [{
           bidder: 'somoaudience',
@@ -125,7 +125,7 @@ describe('Somo Audience Adapter Tests', () => {
       });
     });
 
-    describe('buildVideoRequests', () => {
+    describe('buildVideoRequests', function () {
       it('should properly build a video request with sizes defined', () => {
         const bidRequests = [{
           bidder: 'somoaudience',
@@ -239,7 +239,7 @@ describe('Somo Audience Adapter Tests', () => {
       });
     });
 
-    describe('buildSiteRequests', () => {
+    describe('buildSiteRequests', function () {
       it('should fill in basic site parameters', () => {
         const bidRequests = [{
           bidder: 'somoaudience',
@@ -282,7 +282,7 @@ describe('Somo Audience Adapter Tests', () => {
       })
     });
 
-    describe('buildAppRequests', () => {
+    describe('buildAppRequests', function () {
       it('should fill in app parameters', () => {
         const bidRequests = [{
           bidder: 'somoaudience',
@@ -315,7 +315,7 @@ describe('Somo Audience Adapter Tests', () => {
       });
     });
 
-    describe('buildGDPRRequests', () => {
+    describe('buildGDPRRequests', function () {
       const bidderRequest = {
         gdprConsent: {
           gdprApplies: true,
@@ -358,7 +358,7 @@ describe('Somo Audience Adapter Tests', () => {
       });
     });
 
-    describe('buildExtraArgsRequests', () => {
+    describe('buildExtraArgsRequests', function () {
       it('should populate optional parameters', () => {
         const bidRequests = [
           {
@@ -385,7 +385,7 @@ describe('Somo Audience Adapter Tests', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('Verify banner parse response', () => {
       const bidRequests = [
         {
@@ -447,7 +447,7 @@ describe('Somo Audience Adapter Tests', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     it('should register the pixel sync url', () => {
       let syncs = spec.getUserSyncs({
         pixelEnabled: true

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -2,22 +2,22 @@ import { expect } from 'chai'
 import { spec, _getPlatform } from 'modules/sonobiBidAdapter'
 import { newBidder } from 'src/adapters/bidderFactory'
 
-describe('SonobiBidAdapter', () => {
+describe('SonobiBidAdapter', function () {
   const adapter = newBidder(spec)
 
-  describe('.code', () => {
+  describe('.code', function () {
     it('should return a bidder code of sonobi', () => {
       expect(spec.code).to.equal('sonobi')
     })
   })
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('should exist and be a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
 
-  describe('.isBidRequestValid', () => {
+  describe('.isBidRequestValid', function () {
     let bid = {
       'bidder': 'sonobi',
       'params': {
@@ -100,7 +100,7 @@ describe('SonobiBidAdapter', () => {
     })
   })
 
-  describe('.buildRequests', () => {
+  describe('.buildRequests', function () {
     let bidRequest = [{
       'bidder': 'sonobi',
       'params': {
@@ -214,7 +214,7 @@ describe('SonobiBidAdapter', () => {
     })
   })
 
-  describe('.interpretResponse', () => {
+  describe('.interpretResponse', function () {
     const bidRequests = {
       'method': 'GET',
       'url': 'https://apex.go.sonobi.com/trinity.json',
@@ -326,7 +326,7 @@ describe('SonobiBidAdapter', () => {
     })
   })
 
-  describe('.getUserSyncs', () => {
+  describe('.getUserSyncs', function () {
     let bidResponse = [{
       'body': {
         'sbi_px': [{
@@ -359,7 +359,7 @@ describe('SonobiBidAdapter', () => {
       expect(spec.getUserSyncs({ pixelEnabled: true }, [])).to.have.length(0);
     });
   })
-  describe('_getPlatform', () => {
+  describe('_getPlatform', function () {
     it('should return mobile', () => {
       expect(_getPlatform({innerWidth: 767})).to.equal('mobile')
     })

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -6,13 +6,13 @@ describe('SonobiBidAdapter', function () {
   const adapter = newBidder(spec)
 
   describe('.code', function () {
-    it('should return a bidder code of sonobi', () => {
+    it('should return a bidder code of sonobi', function () {
       expect(spec.code).to.equal('sonobi')
     })
   })
 
   describe('inherited functions', function () {
-    it('should exist and be a function', () => {
+    it('should exist and be a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
@@ -32,11 +32,11 @@ describe('SonobiBidAdapter', function () {
       'auctionId': '1d1a030790a475',
     }
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true)
     })
 
-    it('should return true when bid.params.placement_id and bid.params.sizes are found', () => {
+    it('should return true when bid.params.placement_id and bid.params.sizes are found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       delete bid.sizes
@@ -48,7 +48,7 @@ describe('SonobiBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true)
     })
 
-    it('should return true when bid.params.placement_id and bid.sizes are found', () => {
+    it('should return true when bid.params.placement_id and bid.sizes are found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       bid.sizes = [[300, 250], [300, 600]]
@@ -59,7 +59,7 @@ describe('SonobiBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true)
     })
 
-    it('should return true when bid.params.ad_unit and bid.params.sizes are found', () => {
+    it('should return true when bid.params.ad_unit and bid.params.sizes are found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       delete bid.sizes
@@ -71,7 +71,7 @@ describe('SonobiBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true)
     })
 
-    it('should return true when bid.params.ad_unit and bid.sizes are found', () => {
+    it('should return true when bid.params.ad_unit and bid.sizes are found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       bid.sizes = [[300, 250], [300, 600]]
@@ -82,13 +82,13 @@ describe('SonobiBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true)
     })
 
-    it('should return false when no params are found', () => {
+    it('should return false when no params are found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       expect(spec.isBidRequestValid(bid)).to.equal(false)
     })
 
-    it('should return false when bid.params.placement_id and bid.params.ad_unit are not found', () => {
+    it('should return false when bid.params.placement_id and bid.params.ad_unit are not found', function () {
       let bid = Object.assign({}, bid)
       delete bid.params
       bid.params = {
@@ -138,7 +138,7 @@ describe('SonobiBidAdapter', function () {
       },
     };
 
-    it('should return a properly formatted request', () => {
+    it('should return a properly formatted request', function () {
       const bidRequests = spec.buildRequests(bidRequest)
       const bidRequestsPageViewID = spec.buildRequests(bidRequest)
       expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
@@ -153,7 +153,7 @@ describe('SonobiBidAdapter', function () {
       expect(['mobile', 'tablet', 'desktop']).to.contain(bidRequests.data.vp);
     })
 
-    it('should return a properly formatted request with GDPR applies set to true', () => {
+    it('should return a properly formatted request with GDPR applies set to true', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
       expect(bidRequests.method).to.equal('GET')
@@ -161,7 +161,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.consent_string).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
     })
 
-    it('should return a properly formatted request with GDPR applies set to false', () => {
+    it('should return a properly formatted request with GDPR applies set to false', function () {
       bidderRequests.gdprConsent.gdprApplies = false;
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
@@ -169,7 +169,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.gdpr).to.equal('false')
       expect(bidRequests.data.consent_string).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
     })
-    it('should return a properly formatted request with GDPR applies set to false with no consent_string param', () => {
+    it('should return a properly formatted request with GDPR applies set to false with no consent_string param', function () {
       let bidderRequests = {
         'gdprConsent': {
           'consentString': undefined,
@@ -183,7 +183,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.gdpr).to.equal('false')
       expect(bidRequests.data).to.not.include.keys('consent_string')
     })
-    it('should return a properly formatted request with GDPR applies set to true with no consent_string param', () => {
+    it('should return a properly formatted request with GDPR applies set to true with no consent_string param', function () {
       let bidderRequests = {
         'gdprConsent': {
           'consentString': undefined,
@@ -197,7 +197,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.gdpr).to.equal('true')
       expect(bidRequests.data).to.not.include.keys('consent_string')
     })
-    it('should return a properly formatted request with hfa', () => {
+    it('should return a properly formatted request with hfa', function () {
       bidRequest[0].params.hfa = 'hfakey'
       bidRequest[1].params.hfa = 'hfakey'
       const bidRequests = spec.buildRequests(bidRequest)
@@ -208,7 +208,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.hfa).to.equal('hfakey')
     })
 
-    it('should return null if there is nothing to bid on', () => {
+    it('should return null if there is nothing to bid on', function () {
       const bidRequests = spec.buildRequests([{params: {}}])
       expect(bidRequests).to.equal(null);
     })
@@ -316,7 +316,7 @@ describe('SonobiBidAdapter', function () {
       }
     ];
 
-    it('should map bidResponse to prebidResponse', () => {
+    it('should map bidResponse to prebidResponse', function () {
       const response = spec.interpretResponse(bidResponse, bidRequests);
       response.forEach(resp => {
         let regx = /http:\/\/localhost:9876\/.*?(?="|$)/
@@ -338,35 +338,35 @@ describe('SonobiBidAdapter', function () {
       }
     }];
 
-    it('should return one sync pixel', () => {
+    it('should return one sync pixel', function () {
       expect(spec.getUserSyncs({ pixelEnabled: true }, bidResponse)).to.deep.equal([{
         type: 'image',
         url: 'https://pixel-test'
       }]);
     })
-    it('should return an empty array when sync is enabled but there are no bidResponses', () => {
+    it('should return an empty array when sync is enabled but there are no bidResponses', function () {
       expect(spec.getUserSyncs({ pixelEnabled: true }, [])).to.have.length(0);
     })
 
-    it('should return an empty array when sync is enabled but no sync pixel returned', () => {
+    it('should return an empty array when sync is enabled but no sync pixel returned', function () {
       const pixel = Object.assign({}, bidResponse);
       delete pixel[0].body.sbi_px;
       expect(spec.getUserSyncs({ pixelEnabled: true }, bidResponse)).to.have.length(0);
     })
 
-    it('should return an empty array', () => {
+    it('should return an empty array', function () {
       expect(spec.getUserSyncs({ pixelEnabled: false }, bidResponse)).to.have.length(0);
       expect(spec.getUserSyncs({ pixelEnabled: true }, [])).to.have.length(0);
     });
   })
   describe('_getPlatform', function () {
-    it('should return mobile', () => {
+    it('should return mobile', function () {
       expect(_getPlatform({innerWidth: 767})).to.equal('mobile')
     })
-    it('should return tablet', () => {
+    it('should return tablet', function () {
       expect(_getPlatform({innerWidth: 800})).to.equal('tablet')
     })
-    it('should return desktop', () => {
+    it('should return desktop', function () {
       expect(_getPlatform({innerWidth: 1000})).to.equal('desktop')
     })
   })

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -9,7 +9,7 @@ const ENDPOINT = `//c.deployads.com/openrtb2/auction?src=${REPO_AND_VERSION}&hos
 describe('sortableBidAdapter', function() {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     function makeBid() {
       return {
         'bidder': 'sortable',
@@ -103,7 +103,7 @@ describe('sortableBidAdapter', function() {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [{
       'bidder': 'sortable',
       'params': {
@@ -166,7 +166,7 @@ describe('sortableBidAdapter', function() {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     function makeResponse() {
       return {
         body: {

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -35,35 +35,35 @@ describe('sortableBidAdapter', function() {
       };
     }
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(makeBid())).to.equal(true);
     });
 
-    it('should return false when tagId not passed correctly', () => {
+    it('should return false when tagId not passed correctly', function () {
       let bid = makeBid();
       delete bid.params.tagId;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when sizes not passed correctly', () => {
+    it('should return false when sizes not passed correctly', function () {
       let bid = makeBid();
       delete bid.sizes;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when sizes are wrong length', () => {
+    it('should return false when sizes are wrong length', function () {
       let bid = makeBid();
       bid.sizes = [[300]];
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when require params are not passed', () => {
+    it('should return false when require params are not passed', function () {
       let bid = makeBid();
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when the floorSizeMap is invalid', () => {
+    it('should return false when the floorSizeMap is invalid', function () {
       let bid = makeBid();
       bid.params.floorSizeMap = {
         'sixforty by foureighty': 1234
@@ -77,14 +77,14 @@ describe('sortableBidAdapter', function() {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return true when the floorSizeMap is missing or empty', () => {
+    it('should return true when the floorSizeMap is missing or empty', function () {
       let bid = makeBid();
       bid.params.floorSizeMap = {};
       expect(spec.isBidRequestValid(bid)).to.equal(true);
       delete bid.params.floorSizeMap;
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
-    it('should return false when the keywords are invalid', () => {
+    it('should return false when the keywords are invalid', function () {
       let bid = makeBid();
       bid.params.keywords = {
         'badval': 1234
@@ -94,7 +94,7 @@ describe('sortableBidAdapter', function() {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return true when the keywords are missing or empty', () => {
+    it('should return true when the keywords are missing or empty', function () {
       let bid = makeBid();
       bid.params.keywords = {};
       expect(spec.isBidRequestValid(bid)).to.equal(true);
@@ -130,25 +130,25 @@ describe('sortableBidAdapter', function() {
     const request = spec.buildRequests(bidRequests);
     const requestBody = JSON.parse(request.data);
 
-    it('sends bid request to our endpoint via POST', () => {
+    it('sends bid request to our endpoint via POST', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('attaches source and version to endpoint URL as query params', () => {
+    it('attaches source and version to endpoint URL as query params', function () {
       expect(request.url).to.equal(ENDPOINT);
     });
 
-    it('sends screen dimensions', () => {
+    it('sends screen dimensions', function () {
       expect(requestBody.site.device.w).to.equal(screen.width);
       expect(requestBody.site.device.h).to.equal(screen.height);
     });
 
-    it('includes the ad size in the bid request', () => {
+    it('includes the ad size in the bid request', function () {
       expect(requestBody.imp[0].banner.format[0].w).to.equal(300);
       expect(requestBody.imp[0].banner.format[0].h).to.equal(250);
     });
 
-    it('includes the params in the bid request', () => {
+    it('includes the params in the bid request', function () {
       expect(requestBody.imp[0].ext.keywords).to.deep.equal(
         {'key1': 'val1',
           'key2': 'val2'}
@@ -158,7 +158,7 @@ describe('sortableBidAdapter', function() {
       expect(requestBody.imp[0].bidfloor).to.equal(0.21);
     });
 
-    it('should have the floor size map set', () => {
+    it('should have the floor size map set', function () {
       expect(requestBody.imp[0].ext.floorSizeMap).to.deep.equal({
         '728x90': 0.15,
         '300x250': 1.20
@@ -208,13 +208,13 @@ describe('sortableBidAdapter', function() {
       'ad': '<!-- creative --><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="http://nurl"></div>'
     };
 
-    it('should get the correct bid response', () => {
+    it('should get the correct bid response', function () {
       let result = spec.interpretResponse(makeResponse());
       expect(result.length).to.equal(1);
       expect(result[0]).to.deep.equal(expectedBid);
     });
 
-    it('should handle a missing crid', () => {
+    it('should handle a missing crid', function () {
       let noCridResponse = makeResponse();
       delete noCridResponse.body.seatbid[0].bid[0].crid;
       const fallbackCrid = noCridResponse.body.seatbid[0].bid[0].id;
@@ -224,7 +224,7 @@ describe('sortableBidAdapter', function() {
       expect(result[0]).to.deep.equal(noCridResult);
     });
 
-    it('should handle a missing nurl', () => {
+    it('should handle a missing nurl', function () {
       let noNurlResponse = makeResponse();
       delete noNurlResponse.body.seatbid[0].bid[0].nurl;
       let noNurlResult = Object.assign({}, expectedBid);
@@ -234,7 +234,7 @@ describe('sortableBidAdapter', function() {
       expect(result[0]).to.deep.equal(noNurlResult);
     });
 
-    it('should handle a missing adm', () => {
+    it('should handle a missing adm', function () {
       let noAdmResponse = makeResponse();
       delete noAdmResponse.body.seatbid[0].bid[0].adm;
       let noAdmResult = Object.assign({}, expectedBid);
@@ -245,7 +245,7 @@ describe('sortableBidAdapter', function() {
       expect(result[0]).to.deep.equal(noAdmResult);
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: {
           'id': '5e5c23a5ba71e78',

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -23,16 +23,16 @@ describe('sovrnBidAdapter', function() {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when tagid not passed correctly', () => {
+    it('should return false when tagid not passed correctly', function () {
       bid.params.tagid = 'ABCD';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when require params are not passed', () => {
+    it('should return false when require params are not passed', function () {
       let bid = Object.assign({}, bid);
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
@@ -56,15 +56,15 @@ describe('sovrnBidAdapter', function() {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('sends bid request to our endpoint via POST', () => {
+    it('sends bid request to our endpoint via POST', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('attaches source and version to endpoint URL as query params', () => {
+    it('attaches source and version to endpoint URL as query params', function () {
       expect(request.url).to.equal(ENDPOINT)
     });
 
-    it('sends \'iv\' as query param if present', () => {
+    it('sends \'iv\' as query param if present', function () {
       const ivBidRequests = [{
         'bidder': 'sovrn',
         'params': {
@@ -84,7 +84,7 @@ describe('sovrnBidAdapter', function() {
       expect(request.url).to.contain('iv=vet')
     });
 
-    it('sends gdpr info if exists', () => {
+    it('sends gdpr info if exists', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {
         'bidderCode': 'sovrn',
@@ -107,7 +107,7 @@ describe('sovrnBidAdapter', function() {
       expect(payload.user.ext.consent).to.equal(consentString);
     });
 
-    it('converts tagid to string', () => {
+    it('converts tagid to string', function () {
       const ivBidRequests = [{
         'bidder': 'sovrn',
         'params': {
@@ -150,7 +150,7 @@ describe('sovrnBidAdapter', function() {
       };
     });
 
-    it('should get the correct bid response', () => {
+    it('should get the correct bid response', function () {
       let expectedResponse = [{
         'requestId': '263c448586f5a1',
         'cpm': 0.45882675,
@@ -169,7 +169,7 @@ describe('sovrnBidAdapter', function() {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('crid should default to the bid id if not on the response', () => {
+    it('crid should default to the bid id if not on the response', function () {
       delete response.body.seatbid[0].bid[0].crid;
       let expectedResponse = [{
         'requestId': '263c448586f5a1',
@@ -189,7 +189,7 @@ describe('sovrnBidAdapter', function() {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('should get correct bid response when dealId is passed', () => {
+    it('should get correct bid response when dealId is passed', function () {
       response.body.dealid = 'baking';
 
       let expectedResponse = [{
@@ -210,7 +210,7 @@ describe('sovrnBidAdapter', function() {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: {
           'id': '37386aade21a71',

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -130,7 +130,7 @@ describe('sovrnBidAdapter', function() {
 
   describe('interpretResponse', function () {
     let response;
-    beforeEach(() => {
+    beforeEach(function () {
       response = {
         body: {
           'id': '37386aade21a71',

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -8,7 +8,7 @@ const ENDPOINT = `//ap.lijit.com/rtb/bid?src=${REPO_AND_VERSION}`;
 describe('sovrnBidAdapter', function() {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'sovrn',
       'params': {
@@ -39,7 +39,7 @@ describe('sovrnBidAdapter', function() {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [{
       'bidder': 'sovrn',
       'params': {
@@ -128,7 +128,7 @@ describe('sovrnBidAdapter', function() {
     })
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response;
     beforeEach(() => {
       response = {

--- a/test/spec/modules/telariaBidAdapter_spec.js
+++ b/test/spec/modules/telariaBidAdapter_spec.js
@@ -34,16 +34,16 @@ const RESPONSE = {
   }]
 };
 
-describe('TelariaAdapter', () => {
+describe('TelariaAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = REQUEST.bids[0];
 
     it('should return true when required params found', () => {
@@ -71,7 +71,7 @@ describe('TelariaAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const stub = [{
       bidder: 'tremor',
       sizes: [[300, 250], [300, 600]],
@@ -126,7 +126,7 @@ describe('TelariaAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responseStub = RESPONSE;
     const stub = [{
       bidder: 'tremor',
@@ -171,7 +171,7 @@ describe('TelariaAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const responses = [{body: RESPONSE}];
     responses[0].body.ext = {
       telaria: {

--- a/test/spec/modules/telariaBidAdapter_spec.js
+++ b/test/spec/modules/telariaBidAdapter_spec.js
@@ -38,7 +38,7 @@ describe('TelariaAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -46,14 +46,14 @@ describe('TelariaAdapter', function () {
   describe('isBidRequestValid', function () {
     let bid = REQUEST.bids[0];
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let tempBid = bid;
       tempBid.params.adCode = 'ssp-!demo!-lufip';
       tempBid.params.supplyCode = 'ssp-demo-rm6rh';
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let tempBid = bid;
       delete tempBid.params;
       tempBid.params = {
@@ -64,7 +64,7 @@ describe('TelariaAdapter', function () {
       expect(spec.isBidRequestValid(tempBid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let tempBid = bid;
       tempBid.params = {};
       expect(spec.isBidRequestValid(tempBid)).to.equal(false);
@@ -82,16 +82,16 @@ describe('TelariaAdapter', function () {
       }
     }];
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(spec.buildRequests).to.exist.and.to.be.a('function');
     });
 
-    it('requires supply code, ad code and sizes to make a request', () => {
+    it('requires supply code, ad code and sizes to make a request', function () {
       const tempRequest = spec.buildRequests(stub);
       expect(tempRequest.length).to.equal(1);
     });
 
-    it('generates an array of requests with 4 params, method, url, bidId and vastUrl', () => {
+    it('generates an array of requests with 4 params, method, url, bidId and vastUrl', function () {
       const tempRequest = spec.buildRequests(stub);
 
       expect(tempRequest.length).to.equal(1);
@@ -101,7 +101,7 @@ describe('TelariaAdapter', function () {
       expect(tempRequest[0].vastUrl).to.exist;
     });
 
-    it('requires sizes to make a request', () => {
+    it('requires sizes to make a request', function () {
       let tempBid = stub;
       tempBid[0].sizes = null;
       const tempRequest = spec.buildRequests(tempBid);
@@ -109,13 +109,13 @@ describe('TelariaAdapter', function () {
       expect(tempRequest.length).to.equal(0);
     });
 
-    it('generates a valid request with sizes as an array of two elements', () => {
+    it('generates a valid request with sizes as an array of two elements', function () {
       let tempBid = stub;
       tempBid[0].sizes = [640, 480];
       expect(spec.buildRequests(tempBid).length).to.equal(1);
     });
 
-    it('requires ad code and supply code to make a request', () => {
+    it('requires ad code and supply code to make a request', function () {
       let tempBid = stub;
       tempBid[0].params.adCode = null;
       tempBid[0].params.supplyCode = null;
@@ -138,7 +138,7 @@ describe('TelariaAdapter', function () {
       }
     }];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponseKeys = ['bidderCode', 'width', 'height', 'statusMessage', 'adId', 'mediaType', 'source',
         'getStatusCode', 'getSize', 'requestId', 'cpm', 'creativeId', 'vastXml',
         'vastUrl', 'currency', 'netRevenue', 'ttl', 'ad'];
@@ -149,7 +149,7 @@ describe('TelariaAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(expectedResponseKeys);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let tempResponse = responseStub;
       tempResponse.seatbid = [];
 
@@ -160,12 +160,12 @@ describe('TelariaAdapter', function () {
       expect(result.length).to.equal(0);
     });
 
-    it('handles invalid responses', () => {
+    it('handles invalid responses', function () {
       let result = spec.interpretResponse(null, {bbidderCode: 'telaria'});
       expect(result.length).to.equal(0);
     });
 
-    it('handles error responses', () => {
+    it('handles error responses', function () {
       let result = spec.interpretResponse({body: {error: 'Invalid request'}}, {bbidderCode: 'telaria'});
       expect(result.length).to.equal(0);
     });
@@ -182,7 +182,7 @@ describe('TelariaAdapter', function () {
       }
     };
 
-    it('should get the correct number of sync urls', () => {
+    it('should get the correct number of sync urls', function () {
       let urls = spec.getUserSyncs({pixelEnabled: true}, responses);
       expect(urls.length).to.equal(2);
     });

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -35,7 +35,7 @@ const TRION_BID_RESPONSE = {
 
 };
 
-describe('Trion adapter tests', () => {
+describe('Trion adapter tests', function () {
   let adapter;
 
   beforeEach(() => {
@@ -45,7 +45,7 @@ describe('Trion adapter tests', () => {
 
   afterEach(() => document.body.appendChild.restore());
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true with correct params', () => {
       expect(spec.isBidRequestValid(TRION_BID)).to.equal(true);
     });
@@ -85,7 +85,7 @@ describe('Trion adapter tests', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should return bids requests with empty params', () => {
       let bidRequests = spec.buildRequests([]);
       expect(bidRequests.length).to.equal(0);
@@ -119,7 +119,7 @@ describe('Trion adapter tests', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('when there is no response do not bid', () => {
       let response = spec.interpretResponse(null, {bidRequest: TRION_BID});
       expect(response).to.deep.equal([]);
@@ -169,7 +169,7 @@ describe('Trion adapter tests', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     const USER_SYNC_URL = 'https://in-appadvertising.com/api/userSync.html';
     const BASE_KEY = '_trion_';
 

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -46,11 +46,11 @@ describe('Trion adapter tests', function () {
   afterEach(() => document.body.appendChild.restore());
 
   describe('isBidRequestValid', function () {
-    it('should return true with correct params', () => {
+    it('should return true with correct params', function () {
       expect(spec.isBidRequestValid(TRION_BID)).to.equal(true);
     });
 
-    it('should return false when params are missing', () => {
+    it('should return false when params are missing', function () {
       TRION_BID.params = {};
 
       expect(spec.isBidRequestValid(TRION_BID)).to.equal(false);
@@ -60,7 +60,7 @@ describe('Trion adapter tests', function () {
       };
     });
 
-    it('should return false when pubId is missing', () => {
+    it('should return false when pubId is missing', function () {
       TRION_BID.params = {
         sectionId: '2'
       };
@@ -72,7 +72,7 @@ describe('Trion adapter tests', function () {
       };
     });
 
-    it('should return false when sectionId is missing', () => {
+    it('should return false when sectionId is missing', function () {
       TRION_BID.params = {
         pubId: '1'
       };
@@ -86,19 +86,19 @@ describe('Trion adapter tests', function () {
   });
 
   describe('buildRequests', function () {
-    it('should return bids requests with empty params', () => {
+    it('should return bids requests with empty params', function () {
       let bidRequests = spec.buildRequests([]);
       expect(bidRequests.length).to.equal(0);
     });
 
-    it('should include the base bidrequest url', () => {
+    it('should include the base bidrequest url', function () {
       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
 
       let bidUrl = bidRequests[0].url;
       expect(bidUrl).to.include(BID_REQUEST_BASE_URL);
     });
 
-    it('should call buildRequests with the correct required params', () => {
+    it('should call buildRequests with the correct required params', function () {
       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
 
       let bidUrlParams = bidRequests[0].data;
@@ -107,7 +107,7 @@ describe('Trion adapter tests', function () {
       expect(bidUrlParams).to.include('sizes=300x250,300x600');
     });
 
-    it('should call buildRequests with the correct optional params', () => {
+    it('should call buildRequests with the correct optional params', function () {
       let params = TRION_BID_REQUEST[0].params;
       params.re = 1;
       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
@@ -120,12 +120,12 @@ describe('Trion adapter tests', function () {
   });
 
   describe('interpretResponse', function () {
-    it('when there is no response do not bid', () => {
+    it('when there is no response do not bid', function () {
       let response = spec.interpretResponse(null, {bidRequest: TRION_BID});
       expect(response).to.deep.equal([]);
     });
 
-    it('when place bid is returned as false', () => {
+    it('when place bid is returned as false', function () {
       TRION_BID_RESPONSE.result.placeBid = false;
       let response = spec.interpretResponse({body: TRION_BID_RESPONSE}, {bidRequest: TRION_BID});
 
@@ -134,21 +134,21 @@ describe('Trion adapter tests', function () {
       TRION_BID_RESPONSE.result.placeBid = true;
     });
 
-    it('when no cpm is in the response', () => {
+    it('when no cpm is in the response', function () {
       TRION_BID_RESPONSE.result.cpm = 0;
       let response = spec.interpretResponse({body: TRION_BID_RESPONSE}, {bidRequest: TRION_BID});
       expect(response).to.deep.equal([]);
       TRION_BID_RESPONSE.result.cpm = 1;
     });
 
-    it('when no ad is in the response', () => {
+    it('when no ad is in the response', function () {
       TRION_BID_RESPONSE.result.ad = null;
       let response = spec.interpretResponse({body: TRION_BID_RESPONSE}, {bidRequest: TRION_BID});
       expect(response).to.deep.equal([]);
       TRION_BID_RESPONSE.result.ad = 'test';
     });
 
-    it('height and width are appropriately set', () => {
+    it('height and width are appropriately set', function () {
       let bidWidth = '1';
       let bidHeight = '2';
       TRION_BID_RESPONSE.result.width = bidWidth;
@@ -160,7 +160,7 @@ describe('Trion adapter tests', function () {
       TRION_BID_RESPONSE.result.height = '250';
     });
 
-    it('cpm is properly set and transformed to cents', () => {
+    it('cpm is properly set and transformed to cents', function () {
       let bidCpm = 2;
       TRION_BID_RESPONSE.result.cpm = bidCpm * 100;
       let response = spec.interpretResponse({body: TRION_BID_RESPONSE}, {bidRequest: TRION_BID});
@@ -177,7 +177,7 @@ describe('Trion adapter tests', function () {
       delete window.TR_INT_T;
     });
 
-    it('trion int is included in bid url', () => {
+    it('trion int is included in bid url', function () {
       window.TR_INT_T = 'test_user_sync';
       let userTag = encodeURIComponent(window.TR_INT_T);
       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
@@ -186,7 +186,7 @@ describe('Trion adapter tests', function () {
       expect(bidUrlParams).to.include(userTag);
     });
 
-    it('should register trion user script', () => {
+    it('should register trion user script', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: true});
       let url = utils.getTopWindowUrl();
       let pubId = 1;
@@ -195,7 +195,7 @@ describe('Trion adapter tests', function () {
       expect(syncs[0]).to.deep.equal({type: 'iframe', url: USER_SYNC_URL + syncString});
     });
 
-    it('should except posted messages from user sync script', () => {
+    it('should except posted messages from user sync script', function () {
       let testId = 'testId';
       let message = BASE_KEY + 'userId=' + testId;
       setStorageData(BASE_KEY + 'int_t', null);
@@ -204,7 +204,7 @@ describe('Trion adapter tests', function () {
       expect(newKey).to.equal(testId);
     });
 
-    it('should not try to post messages not from trion', () => {
+    it('should not try to post messages not from trion', function () {
       let testId = 'testId';
       let badId = 'badId';
       let message = 'Not Trion: userId=' + testId;

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -38,12 +38,14 @@ const TRION_BID_RESPONSE = {
 describe('Trion adapter tests', function () {
   let adapter;
 
-  beforeEach(() => {
+  beforeEach(function () {
     // adapter = trionAdapter.createNew();
     sinon.stub(document.body, 'appendChild');
   });
 
-  afterEach(() => document.body.appendChild.restore());
+  afterEach(function () {
+    document.body.appendChild.restore();
+  });
 
   describe('isBidRequestValid', function () {
     it('should return true with correct params', function () {
@@ -173,7 +175,7 @@ describe('Trion adapter tests', function () {
     const USER_SYNC_URL = 'https://in-appadvertising.com/api/userSync.html';
     const BASE_KEY = '_trion_';
 
-    beforeEach(() => {
+    beforeEach(function () {
       delete window.TR_INT_T;
     });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('triplelift adapter', function () {
   const adapter = newBidder(tripleliftAdapterSpec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -28,11 +28,11 @@ describe('triplelift adapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true for valid bid request', () => {
+    it('should return true for valid bid request', function () {
       expect(tripleliftAdapterSpec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -42,7 +42,7 @@ describe('triplelift adapter', function () {
       expect(tripleliftAdapterSpec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -68,18 +68,18 @@ describe('triplelift adapter', function () {
       }
     ];
 
-    it('exists and is an object', () => {
+    it('exists and is an object', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests);
       expect(request).to.exist.and.to.be.a('object');
     });
 
-    it('should only parse sizes that are of the proper length and format', () => {
+    it('should only parse sizes that are of the proper length and format', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests);
       expect(request.data.imp[0].banner.format).to.have.length(2);
       expect(request.data.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
-    it('should be a post request and populate the payload', () => {
+    it('should be a post request and populate the payload', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.exist;
@@ -88,7 +88,7 @@ describe('triplelift adapter', function () {
       expect(payload.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
-    it('should return a query string for TL call', () => {
+    it('should return a query string for TL call', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests);
       const url = request.url;
       expect(url).to.exist;
@@ -136,7 +136,7 @@ describe('triplelift adapter', function () {
       }
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           requestId: '3db3773286ee59',
@@ -156,7 +156,7 @@ describe('triplelift adapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('should return multile responses to support SRA', () => {
+    it('should return multile responses to support SRA', function () {
       let response = {
         body: {
           bids: [

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -5,16 +5,16 @@ import { deepClone } from 'src/utils';
 
 const ENDPOINT = document.location.protocol + '//tlx.3lift.com/header/auction?';
 
-describe('triplelift adapter', () => {
+describe('triplelift adapter', function () {
   const adapter = newBidder(tripleliftAdapterSpec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       bidder: 'triplelift',
       params: {
@@ -52,7 +52,7 @@ describe('triplelift adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         bidder: 'triplelift',
@@ -101,7 +101,7 @@ describe('triplelift adapter', () => {
     })
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       body: {
         bids: [

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('TrustXAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'trustx',
       'params': {
@@ -38,7 +38,7 @@ describe('TrustXAdapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     function parseRequest(url) {
       const res = {};
       url.split('&').forEach((it) => {
@@ -152,7 +152,7 @@ describe('TrustXAdapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 43, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 44, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('TrustXAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -24,11 +24,11 @@ describe('TrustXAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -83,7 +83,7 @@ describe('TrustXAdapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -93,7 +93,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -103,7 +103,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('r', '22edbae2733bf6');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -115,7 +115,7 @@ describe('TrustXAdapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       expect(request.data).to.be.an('string');
@@ -127,7 +127,7 @@ describe('TrustXAdapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('if gdprConsent is present payload must have gdpr params', () => {
+    it('if gdprConsent is present payload must have gdpr params', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: true}});
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -135,7 +135,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('gdpr_applies', '1');
     });
 
-    it('if gdprApplies is false gdpr_applies must be 0', () => {
+    it('if gdprApplies is false gdpr_applies must be 0', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: false}});
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -143,7 +143,7 @@ describe('TrustXAdapter', function () {
       expect(payload).to.have.property('gdpr_applies', '0');
     });
 
-    it('if gdprApplies is undefined gdpr_applies must be 1', () => {
+    it('if gdprApplies is undefined gdpr_applies must be 1', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA'}});
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
@@ -163,7 +163,7 @@ describe('TrustXAdapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'trustx',
@@ -198,7 +198,7 @@ describe('TrustXAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'trustx',
@@ -281,7 +281,7 @@ describe('TrustXAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'trustx',

--- a/test/spec/modules/ucfunnelBidAdapter_spec.js
+++ b/test/spec/modules/ucfunnelBidAdapter_spec.js
@@ -89,8 +89,8 @@ const validNativeBidRes = {
   width: 1
 };
 
-describe('ucfunnel Adapter', () => {
-  describe('request', () => {
+describe('ucfunnel Adapter', function () {
+  describe('request', function () {
     it('should validate bid request', () => {
       expect(spec.isBidRequestValid(validBannerBidReq)).to.equal(true);
     });
@@ -98,7 +98,7 @@ describe('ucfunnel Adapter', () => {
       expect(spec.isBidRequestValid(invalidBannerBidReq)).to.equal(false);
     });
   });
-  describe('build request', () => {
+  describe('build request', function () {
     const request = spec.buildRequests([validBannerBidReq]);
     it('should create a POST request for every bid', () => {
       expect(request[0].method).to.equal('GET');
@@ -127,8 +127,8 @@ describe('ucfunnel Adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
-    describe('should support banner', () => {
+  describe('interpretResponse', function () {
+    describe('should support banner', function () {
       const request = spec.buildRequests([ validBannerBidReq ]);
       const result = spec.interpretResponse({body: validBannerBidRes}, request[0]);
       it('should build bid array for banner', () => {
@@ -147,7 +147,7 @@ describe('ucfunnel Adapter', () => {
       });
     });
 
-    describe('should support video', () => {
+    describe('should support video', function () {
       const request = spec.buildRequests([ validVideoBidReq ]);
       const result = spec.interpretResponse({body: validVideoBidRes}, request[0]);
       it('should build bid array', () => {
@@ -167,7 +167,7 @@ describe('ucfunnel Adapter', () => {
       });
     });
 
-    describe('should support native', () => {
+    describe('should support native', function () {
       const request = spec.buildRequests([ validNativeBidReq ]);
       const result = spec.interpretResponse({body: validNativeBidRes}, request[0]);
       it('should build bid array', () => {

--- a/test/spec/modules/ucfunnelBidAdapter_spec.js
+++ b/test/spec/modules/ucfunnelBidAdapter_spec.js
@@ -91,32 +91,32 @@ const validNativeBidRes = {
 
 describe('ucfunnel Adapter', function () {
   describe('request', function () {
-    it('should validate bid request', () => {
+    it('should validate bid request', function () {
       expect(spec.isBidRequestValid(validBannerBidReq)).to.equal(true);
     });
-    it('should not validate incorrect bid request', () => {
+    it('should not validate incorrect bid request', function () {
       expect(spec.isBidRequestValid(invalidBannerBidReq)).to.equal(false);
     });
   });
   describe('build request', function () {
     const request = spec.buildRequests([validBannerBidReq]);
-    it('should create a POST request for every bid', () => {
+    it('should create a POST request for every bid', function () {
       expect(request[0].method).to.equal('GET');
       expect(request[0].url).to.equal(location.protocol + spec.ENDPOINT);
     });
 
-    it('should attach the bid request object', () => {
+    it('should attach the bid request object', function () {
       expect(request[0].bidRequest).to.equal(validBannerBidReq);
     });
 
-    it('should attach request data', () => {
+    it('should attach request data', function () {
       const data = request[0].data;
       const [ width, height ] = validBannerBidReq.sizes[0];
       expect(data.w).to.equal(width);
       expect(data.h).to.equal(height);
     });
 
-    it('must parse bid size from a nested array', () => {
+    it('must parse bid size from a nested array', function () {
       const width = 640;
       const height = 480;
       validBannerBidReq.sizes = [[ width, height ]];
@@ -131,11 +131,11 @@ describe('ucfunnel Adapter', function () {
     describe('should support banner', function () {
       const request = spec.buildRequests([ validBannerBidReq ]);
       const result = spec.interpretResponse({body: validBannerBidRes}, request[0]);
-      it('should build bid array for banner', () => {
+      it('should build bid array for banner', function () {
         expect(result.length).to.equal(1);
       });
 
-      it('should have all relevant fields', () => {
+      it('should have all relevant fields', function () {
         const bid = result[0];
 
         expect(bid.mediaType).to.equal(BANNER);
@@ -150,11 +150,11 @@ describe('ucfunnel Adapter', function () {
     describe('should support video', function () {
       const request = spec.buildRequests([ validVideoBidReq ]);
       const result = spec.interpretResponse({body: validVideoBidRes}, request[0]);
-      it('should build bid array', () => {
+      it('should build bid array', function () {
         expect(result.length).to.equal(1);
       });
 
-      it('should have all relevant fields', () => {
+      it('should have all relevant fields', function () {
         const bid = result[0];
 
         expect(bid.mediaType).to.equal(VIDEO);
@@ -170,11 +170,11 @@ describe('ucfunnel Adapter', function () {
     describe('should support native', function () {
       const request = spec.buildRequests([ validNativeBidReq ]);
       const result = spec.interpretResponse({body: validNativeBidRes}, request[0]);
-      it('should build bid array', () => {
+      it('should build bid array', function () {
         expect(result.length).to.equal(1);
       });
 
-      it('should have all relevant fields', () => {
+      it('should have all relevant fields', function () {
         const bid = result[0];
 
         expect(bid.mediaType).to.equal(NATIVE);

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -5,7 +5,7 @@ describe('UnderdogMedia adapter', function () {
   let bidRequests;
   let bidderRequest;
 
-  beforeEach(() => {
+  beforeEach(function () {
     bidRequests = [
       {
         bidder: 'underdogmedia',

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -37,7 +37,7 @@ describe('UnderdogMedia adapter', function () {
 
   describe('implementation', function () {
     describe('for requests', function () {
-      it('should accept valid bid', () => {
+      it('should accept valid bid', function () {
         let validBid = {
           bidder: 'underdogmedia',
           params: {
@@ -50,7 +50,7 @@ describe('UnderdogMedia adapter', function () {
         expect(isValid).to.equal(true);
       });
 
-      it('should reject invalid bid missing sizes', () => {
+      it('should reject invalid bid missing sizes', function () {
         let invalidBid = {
           bidder: 'underdogmedia',
           params: {
@@ -62,7 +62,7 @@ describe('UnderdogMedia adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-      it('should reject invalid bid missing siteId', () => {
+      it('should reject invalid bid missing siteId', function () {
         let invalidBid = {
           bidder: 'underdogmedia',
           params: {},
@@ -73,7 +73,7 @@ describe('UnderdogMedia adapter', function () {
         expect(isValid).to.equal(false);
       });
 
-      it('request data should contain sid', () => {
+      it('request data should contain sid', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -91,7 +91,7 @@ describe('UnderdogMedia adapter', function () {
         expect(request.data.sid).to.equal('12143');
       });
 
-      it('request data should contain sizes', () => {
+      it('request data should contain sizes', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -109,7 +109,7 @@ describe('UnderdogMedia adapter', function () {
         expect(request.data.sizes).to.equal('300x250,728x90');
       });
 
-      it('request data should contain gdpr info', () => {
+      it('request data should contain gdpr info', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -129,7 +129,7 @@ describe('UnderdogMedia adapter', function () {
         expect(request.data.consentData).to.equal('consentDataString');
       });
 
-      it('should not build a request if no vendorConsent', () => {
+      it('should not build a request if no vendorConsent', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -160,7 +160,7 @@ describe('UnderdogMedia adapter', function () {
         expect(request).to.equal(undefined);
       });
 
-      it('should properly build a request if no vendorConsent but no gdprApplies', () => {
+      it('should properly build a request if no vendorConsent but no gdprApplies', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -195,7 +195,7 @@ describe('UnderdogMedia adapter', function () {
         expect(request.data.consentData).to.equal('consentDataString');
       });
 
-      it('should properly build a request if gdprConsent empty', () => {
+      it('should properly build a request if gdprConsent empty', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
@@ -221,7 +221,7 @@ describe('UnderdogMedia adapter', function () {
     });
 
     describe('bid responses', function () {
-      it('should return complete bid response', () => {
+      it('should return complete bid response', function () {
         let serverResponse = {
           body: {
             mids: [
@@ -260,7 +260,7 @@ describe('UnderdogMedia adapter', function () {
         expect(bids[0].currency).to.equal('USD');
       });
 
-      it('should return empty bid response if mids empty', () => {
+      it('should return empty bid response if mids empty', function () {
         let serverResponse = {
           body: {
             mids: []
@@ -272,7 +272,7 @@ describe('UnderdogMedia adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on incorrect size', () => {
+      it('should return empty bid response on incorrect size', function () {
         let serverResponse = {
           body: {
             mids: [
@@ -294,7 +294,7 @@ describe('UnderdogMedia adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response on 0 cpm', () => {
+      it('should return empty bid response on 0 cpm', function () {
         let serverResponse = {
           body: {
             mids: [
@@ -316,7 +316,7 @@ describe('UnderdogMedia adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('should return empty bid response if no ad in response', () => {
+      it('should return empty bid response if no ad in response', function () {
         let serverResponse = {
           body: {
             mids: [
@@ -338,7 +338,7 @@ describe('UnderdogMedia adapter', function () {
         expect(bids).to.be.lengthOf(0);
       });
 
-      it('ad html string should contain the notification urls', () => {
+      it('ad html string should contain the notification urls', function () {
         let serverResponse = {
           body: {
             mids: [

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/underdogmediaBidAdapter';
 
-describe('UnderdogMedia adapter', () => {
+describe('UnderdogMedia adapter', function () {
   let bidRequests;
   let bidderRequest;
 
@@ -35,8 +35,8 @@ describe('UnderdogMedia adapter', () => {
     }
   });
 
-  describe('implementation', () => {
-    describe('for requests', () => {
+  describe('implementation', function () {
+    describe('for requests', function () {
       it('should accept valid bid', () => {
         let validBid = {
           bidder: 'underdogmedia',
@@ -220,7 +220,7 @@ describe('UnderdogMedia adapter', () => {
       });
     });
 
-    describe('bid responses', () => {
+    describe('bid responses', function () {
       it('should return complete bid response', () => {
         let serverResponse = {
           body: {

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -89,22 +89,22 @@ const bidResArray = [
 
 describe('Undertone Adapter', function () {
   describe('request', function () {
-    it('should validate bid request', () => {
+    it('should validate bid request', function () {
       expect(spec.isBidRequestValid(validBidReq)).to.equal(true);
     });
-    it('should not validate incorrect bid request', () => {
+    it('should not validate incorrect bid request', function () {
       expect(spec.isBidRequestValid(invalidBidReq)).to.equal(undefined);
     });
   });
   describe('build request', function () {
-    it('should send request to correct url via POST', () => {
+    it('should send request to correct url via POST', function () {
       const request = spec.buildRequests(bidReq);
       const domain = null;
       const REQ_URL = `${URL}?pid=${bidReq[0].params.publisherId}&domain=${domain}`;
       expect(request.url).to.equal(REQ_URL);
       expect(request.method).to.equal('POST');
     });
-    it('should have all relevant fields', () => {
+    it('should have all relevant fields', function () {
       const request = spec.buildRequests(bidReq);
       const bid1 = JSON.parse(request.data)['x-ut-hb-params'][0];
       expect(bid1.bidRequestId).to.equal('263be71e91dd9d');
@@ -122,12 +122,12 @@ describe('Undertone Adapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should build bid array', () => {
+    it('should build bid array', function () {
       let result = spec.interpretResponse({body: bidResponse});
       expect(result.length).to.equal(1);
     });
 
-    it('should have all relevant fields', () => {
+    it('should have all relevant fields', function () {
       const result = spec.interpretResponse({body: bidResponse});
       const bid = result[0];
 
@@ -141,12 +141,12 @@ describe('Undertone Adapter', function () {
       expect(bid.ttl).to.equal(360);
     });
 
-    it('should return empty array when response is incorrect', () => {
+    it('should return empty array when response is incorrect', function () {
       expect(spec.interpretResponse({body: {}}).length).to.equal(0);
       expect(spec.interpretResponse({body: []}).length).to.equal(0);
     });
 
-    it('should only use valid bid responses', () => {
+    it('should only use valid bid responses', function () {
       expect(spec.interpretResponse({ body: bidResArray }).length).to.equal(1);
     });
   });

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -87,8 +87,8 @@ const bidResArray = [
   }
 ];
 
-describe('Undertone Adapter', () => {
-  describe('request', () => {
+describe('Undertone Adapter', function () {
+  describe('request', function () {
     it('should validate bid request', () => {
       expect(spec.isBidRequestValid(validBidReq)).to.equal(true);
     });
@@ -96,7 +96,7 @@ describe('Undertone Adapter', () => {
       expect(spec.isBidRequestValid(invalidBidReq)).to.equal(undefined);
     });
   });
-  describe('build request', () => {
+  describe('build request', function () {
     it('should send request to correct url via POST', () => {
       const request = spec.buildRequests(bidReq);
       const domain = null;
@@ -121,7 +121,7 @@ describe('Undertone Adapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should build bid array', () => {
       let result = spec.interpretResponse({body: bidResponse});
       expect(result.length).to.equal(1);

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -55,7 +55,7 @@ describe('UnrulyAdapter', function () {
     delete parent.window.unruly
   });
 
-  it('should expose Unruly Bidder code', () => {
+  it('should expose Unruly Bidder code', function () {
     expect(adapter.code).to.equal('unruly')
   });
 
@@ -64,21 +64,21 @@ describe('UnrulyAdapter', function () {
   });
 
   describe('isBidRequestValid', function () {
-    it('should be a function', () => {
+    it('should be a function', function () {
       expect(typeof adapter.isBidRequestValid).to.equal('function')
     });
 
-    it('should return false if bid is falsey', () => {
+    it('should return false if bid is falsey', function () {
       expect(adapter.isBidRequestValid()).to.be.false;
     });
 
-    it('should return true if bid.mediaType is "video"', () => {
+    it('should return true if bid.mediaType is "video"', function () {
       const mockBid = { mediaType: 'video' };
 
       expect(adapter.isBidRequestValid(mockBid)).to.be.true;
     });
 
-    it('should return true if bid.mediaTypes.video.context is "outstream"', () => {
+    it('should return true if bid.mediaTypes.video.context is "outstream"', function () {
       const mockBid = {
         mediaTypes: {
           video: {
@@ -92,18 +92,18 @@ describe('UnrulyAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should be a function', () => {
+    it('should be a function', function () {
       expect(typeof adapter.buildRequests).to.equal('function');
     });
-    it('should return an object', () => {
+    it('should return an object', function () {
       const mockBidRequests = ['mockBid'];
       expect(typeof adapter.buildRequests(mockBidRequests)).to.equal('object')
     });
-    it('should return a server request with a valid exchange url', () => {
+    it('should return a server request with a valid exchange url', function () {
       const mockBidRequests = ['mockBid'];
       expect(adapter.buildRequests(mockBidRequests).url).to.equal('https://targeting.unrulymedia.com/prebid')
     });
-    it('should return a server request with method === POST', () => {
+    it('should return a server request with method === POST', function () {
       const mockBidRequests = ['mockBid'];
       expect(adapter.buildRequests(mockBidRequests).method).to.equal('POST');
     });
@@ -113,7 +113,7 @@ describe('UnrulyAdapter', function () {
         contentType: 'application/json'
       });
     });
-    it('should return a server request with valid payload', () => {
+    it('should return a server request with valid payload', function () {
       const mockBidRequests = ['mockBid'];
       const mockBidderRequest = {bidderCode: 'mockBidder'};
       expect(adapter.buildRequests(mockBidRequests, mockBidderRequest).data)
@@ -122,17 +122,17 @@ describe('UnrulyAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should be a function', () => {
+    it('should be a function', function () {
       expect(typeof adapter.interpretResponse).to.equal('function');
     });
-    it('should return empty array when serverResponse is undefined', () => {
+    it('should return empty array when serverResponse is undefined', function () {
       expect(adapter.interpretResponse()).to.deep.equal([]);
     });
-    it('should return empty array when  serverResponse has no bids', () => {
+    it('should return empty array when  serverResponse has no bids', function () {
       const mockServerResponse = { body: { bids: [] } };
       expect(adapter.interpretResponse(mockServerResponse)).to.deep.equal([])
     });
-    it('should return array of bids when receive a successful response from server', () => {
+    it('should return array of bids when receive a successful response from server', function () {
       const mockExchangeBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
       const mockServerResponse = createExchangeResponse(mockExchangeBid);
       expect(adapter.interpretResponse(mockServerResponse)).to.deep.equal([
@@ -151,7 +151,7 @@ describe('UnrulyAdapter', function () {
       ])
     });
 
-    it('should initialize and set the renderer', () => {
+    it('should initialize and set the renderer', function () {
       expect(Renderer.install).not.to.have.been.called;
       expect(fakeRenderer.setRender).not.to.have.been.called;
 
@@ -172,7 +172,7 @@ describe('UnrulyAdapter', function () {
       sinon.assert.calledWithExactly(fakeRenderer.setRender, sinon.match.func)
     });
 
-    it('bid is placed on the bid queue when render is called', () => {
+    it('bid is placed on the bid queue when render is called', function () {
       const exchangeBid = createOutStreamExchangeBid({ adUnitCode: 'video', vastUrl: 'value: vastUrl' });
       const exchangeResponse = createExchangeResponse(exchangeBid);
 
@@ -192,7 +192,7 @@ describe('UnrulyAdapter', function () {
       expect(sentRendererConfig.adUnitCode).to.equal('video')
     })
 
-    it('should ensure that renderer is placed in Prebid supply mode', () => {
+    it('should ensure that renderer is placed in Prebid supply mode', function () {
       const mockExchangeBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
       const mockServerResponse = createExchangeResponse(mockExchangeBid);
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -39,7 +39,7 @@ describe('UnrulyAdapter', function () {
   let sandbox;
   let fakeRenderer;
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(utils, 'logError');
     sandbox.stub(Renderer, 'install');
@@ -50,7 +50,7 @@ describe('UnrulyAdapter', function () {
     Renderer.install.returns(fakeRenderer)
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sandbox.restore();
     delete parent.window.unruly
   });

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -6,7 +6,7 @@ import { VIDEO } from 'src/mediaTypes'
 import { Renderer } from 'src/Renderer'
 import { adapter } from 'modules/unrulyBidAdapter'
 
-describe('UnrulyAdapter', () => {
+describe('UnrulyAdapter', function () {
   function createOutStreamExchangeBid({
     adUnitCode = 'placement2',
     statusCode = 1,
@@ -63,7 +63,7 @@ describe('UnrulyAdapter', () => {
     expect(adapter.supportedMediaTypes).to.deep.equal([ VIDEO ])
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should be a function', () => {
       expect(typeof adapter.isBidRequestValid).to.equal('function')
     });
@@ -91,7 +91,7 @@ describe('UnrulyAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should be a function', () => {
       expect(typeof adapter.buildRequests).to.equal('function');
     });
@@ -121,7 +121,7 @@ describe('UnrulyAdapter', () => {
     })
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should be a function', () => {
       expect(typeof adapter.interpretResponse).to.equal('function');
     });

--- a/test/spec/modules/uolBidAdapter_spec.js
+++ b/test/spec/modules/uolBidAdapter_spec.js
@@ -20,7 +20,7 @@ describe('UOL Bid Adapter', function () {
       'auctionId': 'eb511c63-df7e-4240-9b65-2f8ae50303e4',
     };
 
-    it('should return true for valid params', () => {
+    it('should return true for valid params', function () {
       let clonedBid = Object.assign({}, bid);
       expect(spec.isBidRequestValid(clonedBid)).to.equal(true);
 
@@ -40,13 +40,13 @@ describe('UOL Bid Adapter', function () {
       expect(spec.isBidRequestValid(clonedBid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let clonedBid = Object.assign({}, bid);
       delete clonedBid.params;
       expect(spec.isBidRequestValid(clonedBid)).to.equal(false);
     });
 
-    it('should return false when params are invalid', () => {
+    it('should return false when params are invalid', function () {
       let clonedBid = Object.assign({}, bid);
       delete clonedBid.params;
       clonedBid.params = {
@@ -69,7 +69,7 @@ describe('UOL Bid Adapter', function () {
       expect(spec.isBidRequestValid(clonedBid)).to.equal(false);
     });
 
-    it('should return false when cpmFactor is passed and test flag isn\'t active', () => {
+    it('should return false when cpmFactor is passed and test flag isn\'t active', function () {
       let clonedBid = Object.assign({}, bid);
       delete clonedBid.params;
       clonedBid.params = {
@@ -80,7 +80,7 @@ describe('UOL Bid Adapter', function () {
       expect(spec.isBidRequestValid(clonedBid)).to.equal(false);
     });
 
-    it('should not allow empty size', () => {
+    it('should not allow empty size', function () {
       let clonedBid = Object.assign({}, bid);
       delete clonedBid.sizes;
       expect(spec.isBidRequestValid(clonedBid)).to.equal(false);
@@ -152,19 +152,19 @@ describe('UOL Bid Adapter', function () {
       const requestObject = spec.buildRequests(bidRequests, bidderRequest);
       const payload = JSON.parse(requestObject.data);
 
-      it('should send bid requests to expected endpoint via POST method', () => {
+      it('should send bid requests to expected endpoint via POST method', function () {
         expect(requestObject.url).to.equal(ENDPOINT);
         expect(requestObject.method).to.equal('POST');
       });
 
-      it('should contain referrer URL', () => {
+      it('should contain referrer URL', function () {
         expect(payload.referrerURL).to.exist.and.to.match(/^http(s)?:\/\/.+$/)
       });
 
-      it('should contain an array of requests with length equivalent to bid count', () => {
+      it('should contain an array of requests with length equivalent to bid count', function () {
         expect(payload.requests).to.have.length(bidRequests.length);
       });
-      it('should return propper ad size if at least one entry is provided', () => {
+      it('should return propper ad size if at least one entry is provided', function () {
         expect(payload.requests[0].sizes).to.deep.equal(bidRequests[0].sizes);
       });
     });
@@ -173,7 +173,7 @@ describe('UOL Bid Adapter', function () {
       describe('buildRequest geolocation param', function () { // shall only be tested if browser engine supports geolocation and permissions API.
         let geolocation = { lat: 4, long: 3, timestamp: 123121451 };
 
-        it('should contain user coordinates if (i) DNT is off; (ii) browser supports implementation; (iii) localStorage contains geolocation history', () => {
+        it('should contain user coordinates if (i) DNT is off; (ii) browser supports implementation; (iii) localStorage contains geolocation history', function () {
           localStorage.setItem('uolLocationTracker', JSON.stringify(geolocation));
           grantTriangulation();
           const requestObject = spec.buildRequests(bidRequests, bidderRequest);
@@ -182,7 +182,7 @@ describe('UOL Bid Adapter', function () {
           cleanup();
         })
 
-        it('should not contain user coordinates if localStorage is empty', () => {
+        it('should not contain user coordinates if localStorage is empty', function () {
           localStorage.removeItem('uolLocationTracker');
           denyTriangulation();
           const requestObject = spec.buildRequests(bidRequests, bidderRequest);
@@ -191,7 +191,7 @@ describe('UOL Bid Adapter', function () {
           cleanup();
         })
 
-        it('should not contain user coordinates if browser doesnt support permission query', () => {
+        it('should not contain user coordinates if browser doesnt support permission query', function () {
           localStorage.setItem('uolLocationTracker', JSON.stringify(geolocation));
           removeQuerySupport();
           const requestObject = spec.buildRequests(bidRequests, bidderRequest);
@@ -202,7 +202,7 @@ describe('UOL Bid Adapter', function () {
       })
     }
     describe('buildRequest test params', function () {
-      it('should return test and cpmFactor params if defined', () => {
+      it('should return test and cpmFactor params if defined', function () {
         let clonedBid = JSON.parse(JSON.stringify(bidRequests));
         delete clonedBid[0].params;
         clonedBid.splice(1, 1);
@@ -261,7 +261,7 @@ describe('UOL Bid Adapter', function () {
     };
     let bidRequest = {};
 
-    it('should return the correct bid response structure', () => {
+    it('should return the correct bid response structure', function () {
       let expectedResponse = [
         {
           'requestId': '2a21a2fc993ef9',
@@ -281,7 +281,7 @@ describe('UOL Bid Adapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('should corretly return an empty array of bidResponses if no ads were received', () => {
+    it('should corretly return an empty array of bidResponses if no ads were received', function () {
       let emptyResponse = Object.assign({}, serverResponse);
       emptyResponse.body.ads = [];
       let result = spec.interpretResponse(emptyResponse, {bidRequest});
@@ -293,11 +293,11 @@ describe('UOL Bid Adapter', function () {
     let syncOptions = { iframeEnabled: true };
     let serverResponses = [{ body: { trackingPixel: 'https://www.uol.com.br' } }, { body: { trackingPixel: 'http://www.dynad.net/' } }];
 
-    it('should return the two sync params for iframeEnabled bids with a trackingPixel response', () => {
+    it('should return the two sync params for iframeEnabled bids with a trackingPixel response', function () {
       expect(spec.getUserSyncs(syncOptions, serverResponses)).to.have.length(2);
     })
 
-    it('should not return any sync params if iframe is disabled or no trackingPixel is received', () => {
+    it('should not return any sync params if iframe is disabled or no trackingPixel is received', function () {
       let cloneOptions = Object.assign({}, syncOptions);
       delete cloneOptions.iframeEnabled;
       expect(spec.getUserSyncs(cloneOptions, serverResponses)).to.have.length(0);

--- a/test/spec/modules/uolBidAdapter_spec.js
+++ b/test/spec/modules/uolBidAdapter_spec.js
@@ -4,10 +4,10 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT = 'https://prebid.adilligo.com/v1/prebid.json';
 
-describe('UOL Bid Adapter', () => {
+describe('UOL Bid Adapter', function () {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'uol',
       'params': {
@@ -87,7 +87,7 @@ describe('UOL Bid Adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let queryPermission;
     let cleanup = function() {
       navigator.permissions.query = queryPermission;
@@ -148,7 +148,7 @@ describe('UOL Bid Adapter', () => {
       'timeout': 3000
     };
 
-    describe('buildRequest basic params', () => {
+    describe('buildRequest basic params', function () {
       const requestObject = spec.buildRequests(bidRequests, bidderRequest);
       const payload = JSON.parse(requestObject.data);
 
@@ -170,7 +170,7 @@ describe('UOL Bid Adapter', () => {
     });
 
     if (navigator.permissions && navigator.permissions.query && navigator.geolocation) {
-      describe('buildRequest geolocation param', () => { // shall only be tested if browser engine supports geolocation and permissions API.
+      describe('buildRequest geolocation param', function () { // shall only be tested if browser engine supports geolocation and permissions API.
         let geolocation = { lat: 4, long: 3, timestamp: 123121451 };
 
         it('should contain user coordinates if (i) DNT is off; (ii) browser supports implementation; (iii) localStorage contains geolocation history', () => {
@@ -201,7 +201,7 @@ describe('UOL Bid Adapter', () => {
         })
       })
     }
-    describe('buildRequest test params', () => {
+    describe('buildRequest test params', function () {
       it('should return test and cpmFactor params if defined', () => {
         let clonedBid = JSON.parse(JSON.stringify(bidRequests));
         delete clonedBid[0].params;
@@ -229,7 +229,7 @@ describe('UOL Bid Adapter', () => {
     })
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse = {
       'body': {
         'bidderRequestId': '2a21a2fc993ef9',
@@ -289,7 +289,7 @@ describe('UOL Bid Adapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let syncOptions = { iframeEnabled: true };
     let serverResponses = [{ body: { trackingPixel: 'https://www.uol.com.br' } }, { body: { trackingPixel: 'http://www.dynad.net/' } }];
 

--- a/test/spec/modules/vertamediaBidAdapter_spec.js
+++ b/test/spec/modules/vertamediaBidAdapter_spec.js
@@ -168,7 +168,7 @@ describe('vertamediaBidAdapter', function () {
     let bidderRequest;
     let eqResponse;
 
-    afterEach(() => {
+    afterEach(function () {
       serverResponse = null;
       bidderRequest = null;
       eqResponse = null;

--- a/test/spec/modules/vertamediaBidAdapter_spec.js
+++ b/test/spec/modules/vertamediaBidAdapter_spec.js
@@ -100,17 +100,17 @@ describe('vertamediaBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(VIDEO_REQUEST)).to.equal(12345);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, VIDEO_REQUEST);
       delete bid.params;
       expect(spec.isBidRequestValid(bid)).to.equal(undefined);
@@ -124,17 +124,17 @@ describe('vertamediaBidAdapter', function () {
     const displayRequest = spec.buildRequests(dispalyBidRequests, {});
     const videoRequest = spec.buildRequests(videoBidRequests, {});
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       expect(videoRequest.method).to.equal('GET');
       expect(displayRequest.method).to.equal('GET');
     });
 
-    it('sends bid request to correct ENDPOINT', () => {
+    it('sends bid request to correct ENDPOINT', function () {
       expect(videoRequest.url).to.equal(ENDPOINT);
       expect(displayRequest.url).to.equal(ENDPOINT);
     });
 
-    it('sends correct video bid parameters', () => {
+    it('sends correct video bid parameters', function () {
       const bid = Object.assign({}, videoRequest.data);
       delete bid.domain;
 
@@ -148,7 +148,7 @@ describe('vertamediaBidAdapter', function () {
       expect(bid).to.deep.equal(eq);
     });
 
-    it('sends correct display bid parameters', () => {
+    it('sends correct display bid parameters', function () {
       const bid = Object.assign({}, displayRequest.data);
       delete bid.domain;
 
@@ -174,7 +174,7 @@ describe('vertamediaBidAdapter', function () {
       eqResponse = null;
     });
 
-    it('should get correct video bid response', () => {
+    it('should get correct video bid response', function () {
       serverResponse = SERVER_VIDEO_RESPONSE;
       bidderRequest = videoBidderRequest;
       eqResponse = videoEqResponse;
@@ -182,7 +182,7 @@ describe('vertamediaBidAdapter', function () {
       bidServerResponseCheck();
     });
 
-    it('should get correct display bid response', () => {
+    it('should get correct display bid response', function () {
       serverResponse = SERVER_DISPLAY_RESPONSE;
       bidderRequest = displayBidderRequest;
       eqResponse = displayEqResponse;
@@ -203,13 +203,13 @@ describe('vertamediaBidAdapter', function () {
       expect(noBidResult.length).to.equal(0);
     }
 
-    it('handles video nobid responses', () => {
+    it('handles video nobid responses', function () {
       bidderRequest = videoBidderRequest;
 
       nobidServerResponseCheck();
     });
 
-    it('handles display nobid responses', () => {
+    it('handles display nobid responses', function () {
       bidderRequest = displayBidderRequest;
 
       nobidServerResponseCheck();

--- a/test/spec/modules/vertamediaBidAdapter_spec.js
+++ b/test/spec/modules/vertamediaBidAdapter_spec.js
@@ -96,16 +96,16 @@ const displayEqResponse = [{
   cpm: 0.9
 }];
 
-describe('vertamediaBidAdapter', () => {
+describe('vertamediaBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(VIDEO_REQUEST)).to.equal(12345);
     });
@@ -117,7 +117,7 @@ describe('vertamediaBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let videoBidRequests = [VIDEO_REQUEST];
     let dispalyBidRequests = [DISPLAY_REQUEST];
 
@@ -163,7 +163,7 @@ describe('vertamediaBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse;
     let bidderRequest;
     let eqResponse;

--- a/test/spec/modules/vertozBidAdapter_spec.js
+++ b/test/spec/modules/vertozBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('VertozAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -26,11 +26,11 @@ describe('VertozAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -55,7 +55,7 @@ describe('VertozAdapter', function () {
       }
     ];
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(BASE_URI);
       expect(request.method).to.equal('POST');
@@ -75,7 +75,7 @@ describe('VertozAdapter', function () {
       'statusText': 'Vertoz:Success'
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '44b3fcfd24aa93',
@@ -97,7 +97,7 @@ describe('VertozAdapter', function () {
       expect(result[0].cpm).to.not.equal(null);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'vzhPlacementId': 'VZ-HB-I617046VBGE3EH',
         'slotBidId': 'f00412ac86b79',

--- a/test/spec/modules/vertozBidAdapter_spec.js
+++ b/test/spec/modules/vertozBidAdapter_spec.js
@@ -4,16 +4,16 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const BASE_URI = '//hb.vrtzads.com/vzhbidder/bid?';
 
-describe('VertozAdapter', () => {
+describe('VertozAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'vertoz',
       'params': {
@@ -40,7 +40,7 @@ describe('VertozAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'vertoz',
@@ -62,7 +62,7 @@ describe('VertozAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'vzhPlacementId': 'VZ-HB-B784382V6C6G3C',
       'bid': '76021e56-adaf-4114-b68d-ccacd1b3e551_1',

--- a/test/spec/modules/viBidAdapter_spec.js
+++ b/test/spec/modules/viBidAdapter_spec.js
@@ -27,11 +27,11 @@ describe('viBidAdapter', function() {
       'transactionId': '474da635-9cf0-4188-a3d9-58961be8f905'
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when pubId not passed', () => {
+    it('should return false when pubId not passed', function () {
       bid.params.pubId = undefined;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
@@ -59,11 +59,11 @@ describe('viBidAdapter', function() {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('POST bid request to vi', () => {
+    it('POST bid request to vi', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('check endpoint URL', () => {
+    it('check endpoint URL', function () {
       expect(request.url).to.equal(ENDPOINT)
     });
   });
@@ -88,11 +88,11 @@ describe('viBidAdapter', function() {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('POST bid request to vi', () => {
+    it('POST bid request to vi', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('check endpoint URL', () => {
+    it('check endpoint URL', function () {
       expect(request.url).to.equal(ENDPOINT)
     });
   });
@@ -109,7 +109,7 @@ describe('viBidAdapter', function() {
       }]
     };
 
-    it('should get the correct bid response', () => {
+    it('should get the correct bid response', function () {
       let expectedResponse = [{
         'requestId': '29b891ad542377',
         'cpm': 0.1,
@@ -128,7 +128,7 @@ describe('viBidAdapter', function() {
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: []
       };

--- a/test/spec/modules/viBidAdapter_spec.js
+++ b/test/spec/modules/viBidAdapter_spec.js
@@ -7,7 +7,7 @@ const ENDPOINT = `//pb.vi-serve.com/prebid/bid`;
 describe('viBidAdapter', function() {
   newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'vi',
       'params': {
@@ -37,7 +37,7 @@ describe('viBidAdapter', function() {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [{
       'bidder': 'vi',
       'params': {
@@ -68,7 +68,7 @@ describe('viBidAdapter', function() {
     });
   });
 
-  describe('buildRequests can handle size in 1-dim array', () => {
+  describe('buildRequests can handle size in 1-dim array', function () {
     let bidRequests = [{
       'bidder': 'vi',
       'params': {
@@ -97,7 +97,7 @@ describe('viBidAdapter', function() {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       body: [{
         'id': '29b891ad542377',

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -54,8 +54,8 @@ const SYNC_OPTIONS = {
   'pixelEnabled': true
 };
 
-describe('VidazooBidAdapter', () => {
-  describe('validtae spec', () => {
+describe('VidazooBidAdapter', function () {
+  describe('validtae spec', function () {
     it('exists and is a function', () => {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
     });
@@ -77,7 +77,7 @@ describe('VidazooBidAdapter', () => {
     });
   });
 
-  describe('validate bid requests', () => {
+  describe('validate bid requests', function () {
     it('should require cId', () => {
       const isValid = adapter.isBidRequestValid({
         params: {
@@ -107,7 +107,7 @@ describe('VidazooBidAdapter', () => {
     });
   });
 
-  describe('build requests', () => {
+  describe('build requests', function () {
     let sandbox;
     before(() => {
       sandbox = sinon.sandbox.create();
@@ -157,7 +157,7 @@ describe('VidazooBidAdapter', () => {
     });
   });
 
-  describe('interpret response', () => {
+  describe('interpret response', function () {
     it('should return empty array when there is no response', () => {
       const responses = adapter.interpretResponse(null);
       expect(responses).to.be.empty;

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -56,29 +56,29 @@ const SYNC_OPTIONS = {
 
 describe('VidazooBidAdapter', function () {
   describe('validtae spec', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
     });
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.buildRequests).to.exist.and.to.be.a('function');
     });
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.interpretResponse).to.exist.and.to.be.a('function');
     });
 
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.getUserSyncs).to.exist.and.to.be.a('function');
     });
 
-    it('exists and is a string', () => {
+    it('exists and is a string', function () {
       expect(adapter.code).to.exist.and.to.be.a('string');
     });
   });
 
   describe('validate bid requests', function () {
-    it('should require cId', () => {
+    it('should require cId', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
           pId: 'pid'
@@ -87,7 +87,7 @@ describe('VidazooBidAdapter', function () {
       expect(isValid).to.be.false;
     });
 
-    it('should require pId', () => {
+    it('should require pId', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
           cId: 'cid'
@@ -96,7 +96,7 @@ describe('VidazooBidAdapter', function () {
       expect(isValid).to.be.false;
     });
 
-    it('should validate correctly', () => {
+    it('should validate correctly', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
           cId: 'cid',
@@ -115,7 +115,7 @@ describe('VidazooBidAdapter', function () {
       sandbox.stub(Date, 'now').returns(1000);
     });
 
-    it('should build request for each size', () => {
+    it('should build request for each size', function () {
       const requests = adapter.buildRequests([BID], BIDDER_REQUEST);
       expect(requests).to.have.length(2);
       expect(requests[0]).to.deep.equal({
@@ -158,22 +158,22 @@ describe('VidazooBidAdapter', function () {
   });
 
   describe('interpret response', function () {
-    it('should return empty array when there is no response', () => {
+    it('should return empty array when there is no response', function () {
       const responses = adapter.interpretResponse(null);
       expect(responses).to.be.empty;
     });
 
-    it('should return empty array when there is no ad', () => {
+    it('should return empty array when there is no ad', function () {
       const responses = adapter.interpretResponse({price: 1, ad: ''});
       expect(responses).to.be.empty;
     });
 
-    it('should return empty array when there is no price', () => {
+    it('should return empty array when there is no price', function () {
       const responses = adapter.interpretResponse({price: null, ad: 'great ad'});
       expect(responses).to.be.empty;
     });
 
-    it('should return an array of interpreted responses', () => {
+    it('should return an array of interpreted responses', function () {
       const responses = adapter.interpretResponse(SERVER_RESPONSE, REQUEST);
       expect(responses).to.have.length(1);
       expect(responses[0]).to.deep.equal({
@@ -189,7 +189,7 @@ describe('VidazooBidAdapter', function () {
       });
     });
 
-    it('should take default TTL', () => {
+    it('should take default TTL', function () {
       const serverResponse = utils.deepClone(SERVER_RESPONSE);
       delete serverResponse.body.exp;
       const responses = adapter.interpretResponse(serverResponse, REQUEST);

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -109,7 +109,7 @@ describe('VidazooBidAdapter', function () {
 
   describe('build requests', function () {
     let sandbox;
-    before(() => {
+    before(function () {
       sandbox = sinon.sandbox.create();
       sandbox.stub(utils, 'getTopWindowUrl').returns('http://www.greatsite.com');
       sandbox.stub(Date, 'now').returns(1000);
@@ -152,7 +152,7 @@ describe('VidazooBidAdapter', function () {
       });
     });
 
-    after(() => {
+    after(function () {
       sandbox.restore();
     });
   });

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -7,7 +7,7 @@ describe('VisxAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -25,11 +25,11 @@ describe('VisxAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -76,7 +76,7 @@ describe('VisxAdapter', function () {
       }
     ];
 
-    it('should attach valid params to the tag', () => {
+    it('should attach valid params to the tag', function () {
       const request = spec.buildRequests([bidRequests[0]]);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -87,7 +87,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'EUR');
     });
 
-    it('auids must not be duplicated', () => {
+    it('auids must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -98,7 +98,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'EUR');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', () => {
+    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -111,7 +111,7 @@ describe('VisxAdapter', function () {
       delete bidRequests[1].params.priceType;
     });
 
-    it('pt parameter must be "net" or "gross"', () => {
+    it('pt parameter must be "net" or "gross"', function () {
       bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
@@ -123,7 +123,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'EUR');
       delete bidRequests[1].params.priceType;
     });
-    it('should add currency from currency.bidderCurrencyDefault', () => {
+    it('should add currency from currency.bidderCurrencyDefault', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? 'JPY' : 'USD');
       const request = spec.buildRequests(bidRequests);
@@ -136,7 +136,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'JPY');
       getConfigStub.restore();
     });
-    it('should add currency from currency.adServerCurrency', () => {
+    it('should add currency from currency.adServerCurrency', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? '' : 'USD');
       const request = spec.buildRequests(bidRequests);
@@ -149,7 +149,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'USD');
       getConfigStub.restore();
     });
-    it('if gdprConsent is present payload must have gdpr params', () => {
+    it('if gdprConsent is present payload must have gdpr params', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: true}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -157,7 +157,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('gdpr_applies', 1);
     });
 
-    it('if gdprApplies is false gdpr_applies must be 0', () => {
+    it('if gdprApplies is false gdpr_applies must be 0', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: false}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -165,7 +165,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('gdpr_applies', 0);
     });
 
-    it('if gdprApplies is undefined gdpr_applies must be 1', () => {
+    it('if gdprApplies is undefined gdpr_applies must be 1', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA'}});
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -185,7 +185,7 @@ describe('VisxAdapter', function () {
       {'seat': '1'},
     ];
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const bidRequests = [
         {
           'bidder': 'visx',
@@ -219,7 +219,7 @@ describe('VisxAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should get correct multi bid response', () => {
+    it('should get correct multi bid response', function () {
       const bidRequests = [
         {
           'bidder': 'visx',
@@ -299,7 +299,7 @@ describe('VisxAdapter', function () {
       expect(result).to.deep.equal(expectedResponse);
     });
 
-    it('should return right currency', () => {
+    it('should return right currency', function () {
       const bidRequests = [
         {
           'bidder': 'visx',
@@ -335,7 +335,7 @@ describe('VisxAdapter', function () {
       getConfigStub.restore();
     });
 
-    it('handles wrong and nobid responses', () => {
+    it('handles wrong and nobid responses', function () {
       const bidRequests = [
         {
           'bidder': 'visx',

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -6,13 +6,13 @@ import { newBidder } from 'src/adapters/bidderFactory';
 describe('VisxAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'visx',
       'params': {
@@ -39,7 +39,7 @@ describe('VisxAdapter', function () {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'visx',
@@ -174,7 +174,7 @@ describe('VisxAdapter', function () {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 90, 'w': 728}], 'seat': '1'},

--- a/test/spec/modules/vubleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/vubleAnalyticsAdapter_spec.js
@@ -6,21 +6,21 @@ let constants = require('src/constants.json');
 
 describe('Vuble Prebid Analytic', function () {
   let xhr;
-  before(() => {
+  before(function () {
     xhr = sinon.useFakeXMLHttpRequest();
   });
-  after(() => {
+  after(function () {
     vubleAnalytics.disableAnalytics();
     xhr.restore();
   });
 
   describe('enableAnalytics', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(vubleAnalytics, 'track');
       sinon.stub(events, 'getEvents').returns([]);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       vubleAnalytics.track.restore();
       events.getEvents.restore();
     });

--- a/test/spec/modules/vubleBidAdapter_spec.js
+++ b/test/spec/modules/vubleBidAdapter_spec.js
@@ -86,7 +86,7 @@ describe('VubleAdapter', function () {
 
   describe('Check buildRequests method', function () {
     let sandbox;
-    before(() => {
+    before(function () {
       sandbox = sinon.sandbox.create();
       sandbox.stub(utils, 'getTopWindowUrl').returns('http://www.vuble.tv/');
     });
@@ -166,7 +166,7 @@ describe('VubleAdapter', function () {
       expect(adapter.buildRequests([bid1, bid2])).to.deep.equal([request1, request2]);
     });
 
-    after(() => {
+    after(function () {
       sandbox.restore();
     });
   });

--- a/test/spec/modules/vubleBidAdapter_spec.js
+++ b/test/spec/modules/vubleBidAdapter_spec.js
@@ -6,16 +6,16 @@ import * as utils from 'src/utils';
 
 describe('VubleAdapter', function () {
   describe('Check methods existance', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
     });
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.buildRequests).to.exist.and.to.be.a('function');
     });
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.interpretResponse).to.exist.and.to.be.a('function');
     });
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.getUserSyncs).to.exist.and.to.be.a('function');
     });
   });
@@ -37,11 +37,11 @@ describe('VubleAdapter', function () {
       },
     };
 
-    it('should be true', () => {
+    it('should be true', function () {
       expect(adapter.isBidRequestValid(bid)).to.be.true;
     });
 
-    it('should be false because the sizes are missing or in the wrong format', () => {
+    it('should be false because the sizes are missing or in the wrong format', function () {
       let wrongBid = utils.deepClone(bid);
       wrongBid.sizes = '640360';
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
@@ -51,7 +51,7 @@ describe('VubleAdapter', function () {
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
     });
 
-    it('should be false because the mediaType is missing or wrong', () => {
+    it('should be false because the mediaType is missing or wrong', function () {
       let wrongBid = utils.deepClone(bid);
       wrongBid.mediaTypes = {};
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
@@ -61,7 +61,7 @@ describe('VubleAdapter', function () {
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
     });
 
-    it('should be false because the env is missing or wrong', () => {
+    it('should be false because the env is missing or wrong', function () {
       let wrongBid = utils.deepClone(bid);
       wrongBid.params.env = 'us';
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
@@ -71,13 +71,13 @@ describe('VubleAdapter', function () {
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
     });
 
-    it('should be false because params.pubId is missing', () => {
+    it('should be false because params.pubId is missing', function () {
       let wrongBid = utils.deepClone(bid);
       delete wrongBid.params.pubId;
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
     });
 
-    it('should be false because params.zoneId is missing', () => {
+    it('should be false because params.zoneId is missing', function () {
       let wrongBid = utils.deepClone(bid);
       delete wrongBid.params.zoneId;
       expect(adapter.isBidRequestValid(wrongBid)).to.be.false;
@@ -161,7 +161,7 @@ describe('VubleAdapter', function () {
       }
     };
 
-    it('must return the right formatted requests', () => {
+    it('must return the right formatted requests', function () {
       let rs = adapter.buildRequests([bid1, bid2]);
       expect(adapter.buildRequests([bid1, bid2])).to.deep.equal([request1, request2]);
     });
@@ -213,11 +213,11 @@ describe('VubleAdapter', function () {
       mediaType: 'video'
     };
 
-    it('should equal to the expected formatted result', () => {
+    it('should equal to the expected formatted result', function () {
       expect(adapter.interpretResponse(response, bid)).to.deep.equal([result]);
     });
 
-    it('should be empty because the status is missing or wrong', () => {
+    it('should be empty because the status is missing or wrong', function () {
       let wrongResponse = utils.deepClone(response);
       wrongResponse.body.status = 'ko';
       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
@@ -227,7 +227,7 @@ describe('VubleAdapter', function () {
       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
     });
 
-    it('should be empty because the body is missing or wrong', () => {
+    it('should be empty because the body is missing or wrong', function () {
       let wrongResponse = utils.deepClone(response);
       wrongResponse.body = [1, 2, 3];
       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
@@ -237,7 +237,7 @@ describe('VubleAdapter', function () {
       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
     });
 
-    it('should equal to the expected formatted result', () => {
+    it('should equal to the expected formatted result', function () {
       response.body.renderer_url = 'vuble_renderer.js';
       result.adUnitCode = 'code';
       let formattedResponses = adapter.interpretResponse(response, bid);
@@ -265,7 +265,7 @@ describe('VubleAdapter', function () {
       url: 'http://player.mediabong.net/csifr?1234'
     };
 
-    it('should return an empty array', () => {
+    it('should return an empty array', function () {
       expect(adapter.getUserSyncs({}, [])).to.be.empty;
       expect(adapter.getUserSyncs({}, [])).to.be.empty;
       expect(adapter.getUserSyncs(syncOptions, [response])).to.be.empty;
@@ -275,7 +275,7 @@ describe('VubleAdapter', function () {
       expect(adapter.getUserSyncs(syncOptions, [response])).to.be.empty;
     });
 
-    it('should be equal to the expected result', () => {
+    it('should be equal to the expected result', function () {
       response.body.iframeSync = 'http://player.mediabong.net/csifr?1234';
       expect(adapter.getUserSyncs(syncOptions, [response])).to.deep.equal([result]);
     })

--- a/test/spec/modules/vubleBidAdapter_spec.js
+++ b/test/spec/modules/vubleBidAdapter_spec.js
@@ -4,8 +4,8 @@ import {expect} from 'chai';
 import {spec as adapter} from 'modules/vubleBidAdapter';
 import * as utils from 'src/utils';
 
-describe('VubleAdapter', () => {
-  describe('Check methods existance', () => {
+describe('VubleAdapter', function () {
+  describe('Check methods existance', function () {
     it('exists and is a function', () => {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
     });
@@ -20,7 +20,7 @@ describe('VubleAdapter', () => {
     });
   });
 
-  describe('Check method isBidRequestValid return', () => {
+  describe('Check method isBidRequestValid return', function () {
     let bid = {
       bidder: 'vuble',
       params: {
@@ -84,7 +84,7 @@ describe('VubleAdapter', () => {
     });
   });
 
-  describe('Check buildRequests method', () => {
+  describe('Check buildRequests method', function () {
     let sandbox;
     before(() => {
       sandbox = sinon.sandbox.create();
@@ -171,7 +171,7 @@ describe('VubleAdapter', () => {
     });
   });
 
-  describe('Check interpretResponse method return', () => {
+  describe('Check interpretResponse method return', function () {
     // Server's response
     let response = {
       body: {
@@ -245,7 +245,7 @@ describe('VubleAdapter', () => {
     });
   });
 
-  describe('Check getUserSyncs method return', () => {
+  describe('Check getUserSyncs method return', function () {
     // Sync options
     let syncOptions = {
       iframeEnabled: false

--- a/test/spec/modules/weboramaBidAdapter_spec.js
+++ b/test/spec/modules/weboramaBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/weboramaBidAdapter';
 
-describe('WeboramaAdapter', () => {
+describe('WeboramaAdapter', function () {
   let bid = {
     bidId: '2dd581a2b6281d',
     bidder: 'weborama',
@@ -16,7 +16,7 @@ describe('WeboramaAdapter', () => {
     transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62'
   };
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('Should return true when placementId can be cast to a number', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -26,7 +26,7 @@ describe('WeboramaAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
     it('Creates a ServerRequest object with method, URL and data', () => {
       expect(serverRequest).to.exist;
@@ -65,7 +65,7 @@ describe('WeboramaAdapter', () => {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let resObject = {
       body: [ {
         requestId: '123',
@@ -105,7 +105,7 @@ describe('WeboramaAdapter', () => {
     });
   });
 
-  describe('getUserSyncs', () => {
+  describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
     it('Returns valid URL and `', () => {
       expect(userSync).to.be.an('array').with.lengthOf(1);

--- a/test/spec/modules/weboramaBidAdapter_spec.js
+++ b/test/spec/modules/weboramaBidAdapter_spec.js
@@ -17,10 +17,10 @@ describe('WeboramaAdapter', function () {
   };
 
   describe('isBidRequestValid', function () {
-    it('Should return true when placementId can be cast to a number', () => {
+    it('Should return true when placementId can be cast to a number', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
-    it('Should return false when placementId is not a number', () => {
+    it('Should return false when placementId is not a number', function () {
       bid.params.placementId = 'aaa';
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
@@ -28,19 +28,19 @@ describe('WeboramaAdapter', function () {
 
   describe('buildRequests', function () {
     let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', () => {
+    it('Creates a ServerRequest object with method, URL and data', function () {
       expect(serverRequest).to.exist;
       expect(serverRequest.method).to.exist;
       expect(serverRequest.url).to.exist;
       expect(serverRequest.data).to.exist;
     });
-    it('Returns POST method', () => {
+    it('Returns POST method', function () {
       expect(serverRequest.method).to.equal('POST');
     });
-    it('Returns valid URL', () => {
+    it('Returns valid URL', function () {
       expect(serverRequest.url).to.equal('//supply.nl.weborama.fr/?c=o&m=multi');
     });
-    it('Returns valid data if array of bids is valid', () => {
+    it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
       expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'secure', 'host', 'page', 'placements');
@@ -59,7 +59,7 @@ describe('WeboramaAdapter', function () {
         expect(placement.sizes).to.be.an('array');
       }
     });
-    it('Returns empty data if no valid requests are passed', () => {
+    it('Returns empty data if no valid requests are passed', function () {
       serverRequest = spec.buildRequests([]);
       let data = serverRequest.data;
       expect(data.placements).to.be.an('array').that.is.empty;
@@ -81,7 +81,7 @@ describe('WeboramaAdapter', function () {
       } ]
     };
     let serverResponses = spec.interpretResponse(resObject);
-    it('Returns an array of valid server responses if response object is valid', () => {
+    it('Returns an array of valid server responses if response object is valid', function () {
       expect(serverResponses).to.be.an('array').that.is.not.empty;
       for (let i = 0; i < serverResponses.length; i++) {
         let dataItem = serverResponses[i];
@@ -98,7 +98,7 @@ describe('WeboramaAdapter', function () {
         expect(dataItem.currency).to.be.a('string');
         expect(dataItem.mediaType).to.be.a('string');
       }
-      it('Returns an empty array if invalid response is passed', () => {
+      it('Returns an empty array if invalid response is passed', function () {
         serverResponses = spec.interpretResponse('invalid_response');
         expect(serverResponses).to.be.an('array').that.is.empty;
       });
@@ -107,7 +107,7 @@ describe('WeboramaAdapter', function () {
 
   describe('getUserSyncs', function () {
     let userSync = spec.getUserSyncs();
-    it('Returns valid URL and `', () => {
+    it('Returns valid URL and `', function () {
       expect(userSync).to.be.an('array').with.lengthOf(1);
       expect(userSync[0].type).to.exist;
       expect(userSync[0].url).to.exist;

--- a/test/spec/modules/widespaceBidAdapter_spec.js
+++ b/test/spec/modules/widespaceBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/widespaceBidAdapter';
 import includes from 'core-js/library/fn/array/includes';
 
-describe('+widespaceAdatperTest', () => {
+describe('+widespaceAdatperTest', function () {
   // Dummy bid request
   const bidRequest = [{
     'adUnitCode': 'div-gpt-ad-1460505748561-0',
@@ -110,7 +110,7 @@ describe('+widespaceAdatperTest', () => {
     navigator.connection.type = 'wifi';
   }
 
-  describe('+bidRequestValidity', () => {
+  describe('+bidRequestValidity', function () {
     it('bidRequest with sid and currency params', () => {
       expect(spec.isBidRequestValid({
         bidder: 'widespace',
@@ -140,7 +140,7 @@ describe('+widespaceAdatperTest', () => {
     });
   });
 
-  describe('+bidRequest', () => {
+  describe('+bidRequest', function () {
     const request = spec.buildRequests(bidRequest, bidderRequest);
     const UrlRegExp = /^((ftp|http|https):)?\/\/[^ "]+$/;
 
@@ -169,7 +169,7 @@ describe('+widespaceAdatperTest', () => {
     });
   });
 
-  describe('+interpretResponse', () => {
+  describe('+interpretResponse', function () {
     it('-required params available in response', () => {
       const result = spec.interpretResponse(bidResponse, bidRequest);
       let requiredKeys = [
@@ -212,7 +212,7 @@ describe('+widespaceAdatperTest', () => {
     });
   });
 
-  describe('+getUserSyncs', () => {
+  describe('+getUserSyncs', function () {
     it('-always return an array', () => {
       const userSync_test1 = spec.getUserSyncs({}, [bidResponse]);
       expect(Array.isArray(userSync_test1)).to.equal(true);

--- a/test/spec/modules/widespaceBidAdapter_spec.js
+++ b/test/spec/modules/widespaceBidAdapter_spec.js
@@ -111,7 +111,7 @@ describe('+widespaceAdatperTest', function () {
   }
 
   describe('+bidRequestValidity', function () {
-    it('bidRequest with sid and currency params', () => {
+    it('bidRequest with sid and currency params', function () {
       expect(spec.isBidRequestValid({
         bidder: 'widespace',
         params: {
@@ -121,7 +121,7 @@ describe('+widespaceAdatperTest', function () {
       })).to.equal(true);
     });
 
-    it('-bidRequest with missing sid', () => {
+    it('-bidRequest with missing sid', function () {
       expect(spec.isBidRequestValid({
         bidder: 'widespace',
         params: {
@@ -130,7 +130,7 @@ describe('+widespaceAdatperTest', function () {
       })).to.equal(false);
     });
 
-    it('-bidRequest with missing currency', () => {
+    it('-bidRequest with missing currency', function () {
       expect(spec.isBidRequestValid({
         bidder: 'widespace',
         params: {
@@ -144,33 +144,33 @@ describe('+widespaceAdatperTest', function () {
     const request = spec.buildRequests(bidRequest, bidderRequest);
     const UrlRegExp = /^((ftp|http|https):)?\/\/[^ "]+$/;
 
-    it('-bidRequest method is POST', () => {
+    it('-bidRequest method is POST', function () {
       expect(request[0].method).to.equal('POST');
     });
 
-    it('-bidRequest url is valid', () => {
+    it('-bidRequest url is valid', function () {
       expect(UrlRegExp.test(request[0].url)).to.equal(true);
     });
 
-    it('-bidRequest data exist', () => {
+    it('-bidRequest data exist', function () {
       expect(request[0].data).to.exists;
     });
 
-    it('-bidRequest data is form data', () => {
+    it('-bidRequest data is form data', function () {
       expect(typeof request[0].data).to.equal('string');
     });
 
-    it('-bidRequest options have header type', () => {
+    it('-bidRequest options have header type', function () {
       expect(request[0].options.contentType).to.exists;
     });
 
-    it('-cookie test for wsCustomData ', () => {
+    it('-cookie test for wsCustomData ', function () {
       expect(request[0].data.indexOf('hb.cd') > -1).to.equal(true);
     });
   });
 
   describe('+interpretResponse', function () {
-    it('-required params available in response', () => {
+    it('-required params available in response', function () {
       const result = spec.interpretResponse(bidResponse, bidRequest);
       let requiredKeys = [
         'requestId',
@@ -201,19 +201,19 @@ describe('+widespaceAdatperTest', function () {
       });
     });
 
-    it('-empty result if noad responded', () => {
+    it('-empty result if noad responded', function () {
       const noAdResult = spec.interpretResponse(bidResponseNoAd, bidRequest);
       expect(noAdResult.length).to.equal(0);
     });
 
-    it('-empty response should not breake anything in adapter', () => {
+    it('-empty response should not breake anything in adapter', function () {
       const noResponse = spec.interpretResponse({}, bidRequest);
       expect(noResponse.length).to.equal(0);
     });
   });
 
   describe('+getUserSyncs', function () {
-    it('-always return an array', () => {
+    it('-always return an array', function () {
       const userSync_test1 = spec.getUserSyncs({}, [bidResponse]);
       expect(Array.isArray(userSync_test1)).to.equal(true);
 

--- a/test/spec/modules/xendizBidAdapter_spec.js
+++ b/test/spec/modules/xendizBidAdapter_spec.js
@@ -34,16 +34,16 @@ const bidResponse = {
 
 const noBidResponse = { body: { id: '1d1a030790a475', bids: [] } };
 
-describe('xendizBidAdapter', () => {
+describe('xendizBidAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return false', () => {
       let bid = Object.assign({}, bidRequest);
       bid.params = {};
@@ -55,7 +55,7 @@ describe('xendizBidAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should format valid url', () => {
       const request = spec.buildRequests([bidRequest]);
       expect(request.url).to.equal(VALID_ENDPOINT);
@@ -92,7 +92,7 @@ describe('xendizBidAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should get correct bid response', () => {
       const result = spec.interpretResponse(bidResponse);
       const validResponse = [{

--- a/test/spec/modules/xendizBidAdapter_spec.js
+++ b/test/spec/modules/xendizBidAdapter_spec.js
@@ -38,35 +38,35 @@ describe('xendizBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
   describe('isBidRequestValid', function () {
-    it('should return false', () => {
+    it('should return false', function () {
       let bid = Object.assign({}, bidRequest);
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return true', () => {
+    it('should return true', function () {
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     });
   });
 
   describe('buildRequests', function () {
-    it('should format valid url', () => {
+    it('should format valid url', function () {
       const request = spec.buildRequests([bidRequest]);
       expect(request.url).to.equal(VALID_ENDPOINT);
     });
 
-    it('should format valid url', () => {
+    it('should format valid url', function () {
       const request = spec.buildRequests([bidRequest]);
       expect(request.url).to.equal(VALID_ENDPOINT);
     });
 
-    it('should format valid request body', () => {
+    it('should format valid request body', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
       expect(payload.id).to.exist;
@@ -74,7 +74,7 @@ describe('xendizBidAdapter', function () {
       expect(payload.device).to.exist;
     });
 
-    it('should attach valid device info', () => {
+    it('should attach valid device info', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
       expect(payload.device).to.deep.equal([
@@ -84,7 +84,7 @@ describe('xendizBidAdapter', function () {
       ]);
     });
 
-    it('should transform sizes', () => {
+    it('should transform sizes', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
       const item = payload.items[0];
@@ -93,7 +93,7 @@ describe('xendizBidAdapter', function () {
   });
 
   describe('interpretResponse', function () {
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const result = spec.interpretResponse(bidResponse);
       const validResponse = [{
         requestId: '30b31c1838de1e',
@@ -111,7 +111,7 @@ describe('xendizBidAdapter', function () {
       expect(result).to.deep.equal(validResponse);
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let result = spec.interpretResponse(noBidResponse);
       expect(result.length).to.equal(0);
     });

--- a/test/spec/modules/xhbBidAdapter_spec.js
+++ b/test/spec/modules/xhbBidAdapter_spec.js
@@ -5,16 +5,16 @@ import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
 
-describe('xhbAdapter', () => {
+describe('xhbAdapter', function () {
   const adapter = newBidder(spec);
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'xhb',
       'params': {
@@ -52,7 +52,7 @@ describe('xhbAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'xhb',
@@ -328,7 +328,7 @@ describe('xhbAdapter', () => {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let response = {
       'version': '3.0.0',
       'tags': [

--- a/test/spec/modules/xhbBidAdapter_spec.js
+++ b/test/spec/modules/xhbBidAdapter_spec.js
@@ -9,7 +9,7 @@ describe('xhbAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
@@ -27,11 +27,11 @@ describe('xhbAdapter', function () {
       'auctionId': '1d1a030790a475',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -42,7 +42,7 @@ describe('xhbAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
@@ -67,7 +67,7 @@ describe('xhbAdapter', function () {
       }
     ];
 
-    it('should parse out private sizes', () => {
+    it('should parse out private sizes', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -85,7 +85,7 @@ describe('xhbAdapter', function () {
       expect(payload.tags[0].private_sizes).to.deep.equal([{width: 300, height: 250}]);
     });
 
-    it('should add source and verison to the tag', () => {
+    it('should add source and verison to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data);
       expect(payload.sdk).to.exist;
@@ -95,7 +95,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on all requests', () => {
+    it('should populate the ad_types array on all requests', function () {
       ['banner', 'video', 'native'].forEach(type => {
         const bidRequest = Object.assign({}, bidRequests[0]);
         bidRequest.mediaTypes = {};
@@ -108,7 +108,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('should populate the ad_types array on outstream requests', () => {
+    it('should populate the ad_types array on outstream requests', function () {
       const bidRequest = Object.assign({}, bidRequests[0]);
       bidRequest.mediaTypes = {};
       bidRequest.mediaTypes.video = {context: 'outstream'};
@@ -119,13 +119,13 @@ describe('xhbAdapter', function () {
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
     });
 
-    it('sends bid request to ENDPOINT via POST', () => {
+    it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('POST');
     });
 
-    it('should attach valid video params to the tag', () => {
+    it('should attach valid video params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -148,7 +148,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('should attach valid user params to the tag', () => {
+    it('should attach valid user params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -171,7 +171,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('should attach native params to the request', () => {
+    it('should attach native params to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -198,7 +198,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('sets minimum native asset params when not provided on adunit', () => {
+    it('sets minimum native asset params when not provided on adunit', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -217,7 +217,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('does not overwrite native ad unit params with mimimum params', () => {
+    it('does not overwrite native ad unit params with mimimum params', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -249,7 +249,7 @@ describe('xhbAdapter', function () {
       });
     });
 
-    it('should convert keyword params to proper form and attaches to request', () => {
+    it('should convert keyword params to proper form and attaches to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -288,7 +288,7 @@ describe('xhbAdapter', function () {
       }]);
     });
 
-    it('should add payment rules to the request', () => {
+    it('should add payment rules to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
@@ -305,7 +305,7 @@ describe('xhbAdapter', function () {
       expect(payload.tags[0].use_pmt_rule).to.equal(true);
     });
 
-    it('should add gdpr consent information to the request', () => {
+    it('should add gdpr consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {
         'bidderCode': 'xhb',
@@ -373,7 +373,7 @@ describe('xhbAdapter', function () {
       ]
     };
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       let expectedResponse = [
         {
           'requestId': '3db3773286ee59',
@@ -397,7 +397,7 @@ describe('xhbAdapter', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       let response = {
         'version': '0.0.1',
         'tags': [{
@@ -413,7 +413,7 @@ describe('xhbAdapter', function () {
       expect(result.length).to.equal(0);
     });
 
-    it('handles non-banner media responses', () => {
+    it('handles non-banner media responses', function () {
       let response = {
         'tags': [{
           'uuid': '84ab500420319d',
@@ -437,7 +437,7 @@ describe('xhbAdapter', function () {
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 
-    it('handles native responses', () => {
+    it('handles native responses', function () {
       let response1 = deepClone(response);
       response1.tags[0].ads[0].ad_type = 'native';
       response1.tags[0].ads[0].rtb.native = {
@@ -471,7 +471,7 @@ describe('xhbAdapter', function () {
       expect(result[0].native.image.url).to.equal('http://cdn.adnxs.com/img.png');
     });
 
-    it('supports configuring outstream renderers', () => {
+    it('supports configuring outstream renderers', function () {
       const outstreamResponse = deepClone(response);
       outstreamResponse.tags[0].ads[0].rtb.video = {};
       outstreamResponse.tags[0].ads[0].renderer_url = 'renderer.js';

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -29,16 +29,16 @@ const RESPONSE = {
   pid: 2222
 }
 
-describe('yieldlabBidAdapter', () => {
+describe('yieldlabBidAdapter', function () {
   const adapter = newBidder(spec)
 
-  describe('inherited functions', () => {
+  describe('inherited functions', function () {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when required params found', () => {
       const request = {
         'params': {
@@ -55,7 +55,7 @@ describe('yieldlabBidAdapter', () => {
     })
   })
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidRequests = [REQUEST]
     const request = spec.buildRequests(bidRequests)
 
@@ -84,7 +84,7 @@ describe('yieldlabBidAdapter', () => {
     })
   })
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     const validRequests = {
       validBidRequests: [REQUEST]
     }

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -33,13 +33,13 @@ describe('yieldlabBidAdapter', function () {
   const adapter = newBidder(spec)
 
   describe('inherited functions', function () {
-    it('exists and is a function', () => {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function')
     })
   })
 
   describe('isBidRequestValid', function () {
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       const request = {
         'params': {
           'adslotId': '1111',
@@ -50,7 +50,7 @@ describe('yieldlabBidAdapter', function () {
       expect(spec.isBidRequestValid(request)).to.equal(true)
     })
 
-    it('should return false when required params are not passed', () => {
+    it('should return false when required params are not passed', function () {
       expect(spec.isBidRequestValid({})).to.equal(false)
     })
   })
@@ -59,15 +59,15 @@ describe('yieldlabBidAdapter', function () {
     const bidRequests = [REQUEST]
     const request = spec.buildRequests(bidRequests)
 
-    it('sends bid request to ENDPOINT via GET', () => {
+    it('sends bid request to ENDPOINT via GET', function () {
       expect(request.method).to.equal('GET')
     })
 
-    it('returns a list of valid requests', () => {
+    it('returns a list of valid requests', function () {
       expect(request.validBidRequests).to.eql([REQUEST])
     })
 
-    it('passes targeting to bid request', () => {
+    it('passes targeting to bid request', function () {
       expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2')
     })
 
@@ -78,7 +78,7 @@ describe('yieldlabBidAdapter', function () {
       }
     })
 
-    it('passes gdpr flag and consent if present', () => {
+    it('passes gdpr flag and consent if present', function () {
       expect(gdprRequest.url).to.include('consent=BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA')
       expect(gdprRequest.url).to.include('gdpr=true')
     })
@@ -89,12 +89,12 @@ describe('yieldlabBidAdapter', function () {
       validBidRequests: [REQUEST]
     }
 
-    it('handles nobid responses', () => {
+    it('handles nobid responses', function () {
       expect(spec.interpretResponse({body: {}}, {validBidRequests: []}).length).to.equal(0)
       expect(spec.interpretResponse({body: []}, {validBidRequests: []}).length).to.equal(0)
     })
 
-    it('should get correct bid response', () => {
+    it('should get correct bid response', function () {
       const result = spec.interpretResponse({body: [RESPONSE]}, validRequests)
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
@@ -110,7 +110,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
     })
 
-    it('should add vastUrl when type is video', () => {
+    it('should add vastUrl when type is video', function () {
       const VIDEO_REQUEST = Object.assign({}, REQUEST, {
         'mediaTypes': {
           'video': {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/yieldmoBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 import * as utils from 'src/utils';
 
-describe('YieldmoAdapter', () => {
+describe('YieldmoAdapter', function () {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://ads.yieldmo.com/exchange/prebid';
 
@@ -18,7 +18,7 @@ describe('YieldmoAdapter', () => {
   };
   let bidArray = [bid];
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     it('should return true when necessary information is found', () => {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
@@ -40,7 +40,7 @@ describe('YieldmoAdapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     it('should attempt to send bid requests to the endpoint via GET', () => {
       const request = spec.buildRequests(bidArray);
       expect(request.method).to.equal('GET');
@@ -93,7 +93,7 @@ describe('YieldmoAdapter', () => {
     })
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let serverResponse;
 
     beforeEach(() => {
@@ -137,7 +137,7 @@ describe('YieldmoAdapter', () => {
     });
   });
 
-  describe('getUserSync', () => {
+  describe('getUserSync', function () {
     const SYNC_ENDPOINT = 'https://static.yieldmo.com/blank.min.html?orig=';
     let options = {
       iframeEnabled: true,

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -96,7 +96,7 @@ describe('YieldmoAdapter', function () {
   describe('interpretResponse', function () {
     let serverResponse;
 
-    beforeEach(() => {
+    beforeEach(function () {
       serverResponse = {
         body: [{
           callback_id: '21989fdbef550a',

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -19,11 +19,11 @@ describe('YieldmoAdapter', function () {
   let bidArray = [bid];
 
   describe('isBidRequestValid', function () {
-    it('should return true when necessary information is found', () => {
+    it('should return true when necessary information is found', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
-    it('should return false when necessary information is not found', () => {
+    it('should return false when necessary information is not found', function () {
       // empty bid
       expect(spec.isBidRequestValid({})).to.be.false;
 
@@ -41,13 +41,13 @@ describe('YieldmoAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    it('should attempt to send bid requests to the endpoint via GET', () => {
+    it('should attempt to send bid requests to the endpoint via GET', function () {
       const request = spec.buildRequests(bidArray);
       expect(request.method).to.equal('GET');
       expect(request.url).to.be.equal(ENDPOINT);
     });
 
-    it('should place bid information into the p parameter of data', () => {
+    it('should place bid information into the p parameter of data', function () {
       let placementInfo = spec.buildRequests(bidArray).data.p;
       expect(placementInfo).to.equal('[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]]}]');
 
@@ -66,7 +66,7 @@ describe('YieldmoAdapter', function () {
       expect(placementInfo).to.equal('[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]]},{"placement_id":"adunit-code-1","callback_id":"123456789","sizes":[[300,250],[300,600]]}]');
     });
 
-    it('should add placement id if given', () => {
+    it('should add placement id if given', function () {
       bidArray[0].params.placementId = 'ym_1293871298';
       let placementInfo = spec.buildRequests(bidArray).data.p;
       expect(placementInfo).to.include('"ym_placement_id":"ym_1293871298"}');
@@ -78,7 +78,7 @@ describe('YieldmoAdapter', function () {
       expect(placementInfo).to.include('"ym_placement_id":"ym_0987654321"}');
     });
 
-    it('should add additional information to data parameter of request', () => {
+    it('should add additional information to data parameter of request', function () {
       const data = spec.buildRequests(bidArray).data;
       expect(data.hasOwnProperty('page_url')).to.be.true;
       expect(data.hasOwnProperty('bust')).to.be.true;
@@ -110,7 +110,7 @@ describe('YieldmoAdapter', function () {
       };
     })
 
-    it('should correctly reorder the server response', () => {
+    it('should correctly reorder the server response', function () {
       const newResponse = spec.interpretResponse(serverResponse);
       expect(newResponse.length).to.be.equal(1);
       expect(newResponse[0]).to.deep.equal({
@@ -126,7 +126,7 @@ describe('YieldmoAdapter', function () {
       });
     });
 
-    it('should not add responses if the cpm is 0 or null', () => {
+    it('should not add responses if the cpm is 0 or null', function () {
       serverResponse.body[0].cpm = 0;
       let response = spec.interpretResponse(serverResponse);
       expect(response).to.deep.equal([]);
@@ -144,7 +144,7 @@ describe('YieldmoAdapter', function () {
       pixelEnabled: true
     };
 
-    it('should return a tracker with type and url as parameters', () => {
+    it('should return a tracker with type and url as parameters', function () {
       if (/iPhone|iPad|iPod/i.test(window.navigator.userAgent)) {
         expect(spec.getUserSync(options)).to.deep.equal([{
           type: 'iframe',

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -7,7 +7,7 @@ const ENDPOINT = '//y.one.impact-ad.jp/h_bid';
 describe('yieldoneBidAdapter', function() {
   const adapter = newBidder(spec);
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'yieldone',
       'params': {
@@ -38,7 +38,7 @@ describe('yieldoneBidAdapter', function() {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     let bidRequests = [
       {
         'bidder': 'yieldone',
@@ -81,7 +81,7 @@ describe('yieldoneBidAdapter', function() {
     });
   });
 
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     let bidRequest = [
       {
         'method': 'GET',

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -22,16 +22,16 @@ describe('yieldoneBidAdapter', function() {
       'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
     };
 
-    it('should return true when required params found', () => {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when placementId not passed correctly', () => {
+    it('should return false when placementId not passed correctly', function () {
       bid.params.placementId = '';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should return false when require params are not passed', () => {
+    it('should return false when require params are not passed', function () {
       let bid = Object.assign({}, bid);
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
@@ -70,12 +70,12 @@ describe('yieldoneBidAdapter', function() {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('sends bid request to our endpoint via GET', () => {
+    it('sends bid request to our endpoint via GET', function () {
       expect(request[0].method).to.equal('GET');
       expect(request[1].method).to.equal('GET');
     });
 
-    it('attaches source and version to endpoint URL as query params', () => {
+    it('attaches source and version to endpoint URL as query params', function () {
       expect(request[0].url).to.equal(ENDPOINT);
       expect(request[1].url).to.equal(ENDPOINT);
     });
@@ -111,7 +111,7 @@ describe('yieldoneBidAdapter', function() {
       }
     };
 
-    it('should get the correct bid response', () => {
+    it('should get the correct bid response', function () {
       let expectedResponse = [{
         'requestId': '23beaa6af6cdde',
         'cpm': 53.6616,
@@ -129,7 +129,7 @@ describe('yieldoneBidAdapter', function() {
       expect(Object.keys(result)).to.deep.equal(Object.keys(expectedResponse));
     });
 
-    it('handles empty bid response', () => {
+    it('handles empty bid response', function () {
       let response = {
         body: {
           'uid': '2c0b634db95a01',

--- a/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
+++ b/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
@@ -4,7 +4,7 @@ let adaptermanager = require('src/adaptermanager');
 let events = require('src/events');
 let constants = require('src/constants.json');
 
-describe('YuktaMedia analytics adapter', () => {
+describe('YuktaMedia analytics adapter', function () {
   let xhr;
   let requests;
 
@@ -20,7 +20,7 @@ describe('YuktaMedia analytics adapter', () => {
     events.getEvents.restore();
   });
 
-  describe('track', () => {
+  describe('track', function () {
     let initOptions = {
       pubId: '1',
       pubKey: 'ZXlKaGJHY2lPaUpJVXpJMU5pSjkuT=='

--- a/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
+++ b/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
@@ -8,14 +8,14 @@ describe('YuktaMedia analytics adapter', function () {
   let xhr;
   let requests;
 
-  beforeEach(() => {
+  beforeEach(function () {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
     xhr.onCreate = request => requests.push(request);
     sinon.stub(events, 'getEvents').returns([]);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     xhr.restore();
     events.getEvents.restore();
   });
@@ -31,14 +31,14 @@ describe('YuktaMedia analytics adapter', function () {
       adapter: yuktamediaAnalyticsAdapter
     });
 
-    beforeEach(() => {
+    beforeEach(function () {
       adaptermanager.enableAnalytics({
         provider: 'yuktamedia',
         options: initOptions
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       yuktamediaAnalyticsAdapter.disableAnalytics();
     });
 

--- a/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
+++ b/test/spec/modules/yuktamediaAnalyticsAdaptor_spec.js
@@ -42,7 +42,7 @@ describe('YuktaMedia analytics adapter', function () {
       yuktamediaAnalyticsAdapter.disableAnalytics();
     });
 
-    it('builds and sends auction data', () => {
+    it('builds and sends auction data', function () {
       let auctionTimestamp = 1496510254313;
       let bidRequest = {
         'bidderCode': 'appnexus',

--- a/test/spec/modules/zedoBidAdapter_spec.js
+++ b/test/spec/modules/zedoBidAdapter_spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/zedoBidAdapter';
 
-describe('The ZEDO bidding adapter', () => {
-  describe('isBidRequestValid', () => {
+describe('The ZEDO bidding adapter', function () {
+  describe('isBidRequestValid', function () {
     it('should return false when given an invalid bid', () => {
       const bid = {
         bidder: 'zedo',
@@ -24,7 +24,7 @@ describe('The ZEDO bidding adapter', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('buildRequests', function () {
     const bidderRequest = {
       timeout: 3000,
     };
@@ -74,7 +74,7 @@ describe('The ZEDO bidding adapter', () => {
       expect(zedoRequest).to.equal('g={"placements":[{"network":20,"channel":0,"width":640,"height":480,"dimension":85,"version":"$prebid.version$","keyword":"","transactionId":"12345667","renderers":[{"name":"Inarticle"}]}]}');
     });
 
-    describe('buildGDPRRequests', () => {
+    describe('buildGDPRRequests', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       const bidderRequest = {
         timeout: 3000,
@@ -104,7 +104,7 @@ describe('The ZEDO bidding adapter', () => {
       });
     });
   });
-  describe('interpretResponse', () => {
+  describe('interpretResponse', function () {
     it('should return an empty array when there is bid response', () => {
       const response = {};
       const request = { bidRequests: [] };
@@ -245,7 +245,7 @@ describe('The ZEDO bidding adapter', () => {
     });
   });
 
-  describe('user sync', () => {
+  describe('user sync', function () {
     it('should register the iframe sync url', () => {
       let syncs = spec.getUserSyncs({
         iframeEnabled: true

--- a/test/spec/modules/zedoBidAdapter_spec.js
+++ b/test/spec/modules/zedoBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec } from 'modules/zedoBidAdapter';
 
 describe('The ZEDO bidding adapter', function () {
   describe('isBidRequestValid', function () {
-    it('should return false when given an invalid bid', () => {
+    it('should return false when given an invalid bid', function () {
       const bid = {
         bidder: 'zedo',
       };
@@ -11,7 +11,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(isValid).to.equal(false);
     });
 
-    it('should return true when given a channelcode bid', () => {
+    it('should return true when given a channelcode bid', function () {
       const bid = {
         bidder: 'zedo',
         params: {
@@ -29,7 +29,7 @@ describe('The ZEDO bidding adapter', function () {
       timeout: 3000,
     };
 
-    it('should properly build a channelCode request for dim Id with type not defined', () => {
+    it('should properly build a channelCode request for dim Id with type not defined', function () {
       const bidRequests = [
         {
           bidder: 'zedo',
@@ -49,7 +49,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(zedoRequest).to.equal('g={"placements":[{"network":20,"channel":0,"width":300,"height":200,"dimension":10,"version":"$prebid.version$","keyword":"","transactionId":"12345667","renderers":[{"name":"display"}]}]}');
     });
 
-    it('should properly build a channelCode request for video with type defined', () => {
+    it('should properly build a channelCode request for video with type defined', function () {
       const bidRequests = [
         {
           bidder: 'zedo',
@@ -84,7 +84,7 @@ describe('The ZEDO bidding adapter', function () {
         }
       };
 
-      it('should properly build request with gdpr consent', () => {
+      it('should properly build request with gdpr consent', function () {
         const bidRequests = [
           {
             bidder: 'zedo',
@@ -105,14 +105,14 @@ describe('The ZEDO bidding adapter', function () {
     });
   });
   describe('interpretResponse', function () {
-    it('should return an empty array when there is bid response', () => {
+    it('should return an empty array when there is bid response', function () {
       const response = {};
       const request = { bidRequests: [] };
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response with no valid creative', () => {
+    it('should properly parse a bid response with no valid creative', function () {
       const response = {
         body: {
           ad: [
@@ -156,7 +156,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response with valid display creative', () => {
+    it('should properly parse a bid response with valid display creative', function () {
       const response = {
         body: {
           ad: [
@@ -199,7 +199,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(bids[0].height).to.equal('600');
     });
 
-    it('should properly parse a bid response with valid video creative', () => {
+    it('should properly parse a bid response with valid video creative', function () {
       const response = {
         body: {
           ad: [
@@ -246,7 +246,7 @@ describe('The ZEDO bidding adapter', function () {
   });
 
   describe('user sync', function () {
-    it('should register the iframe sync url', () => {
+    it('should register the iframe sync url', function () {
       let syncs = spec.getUserSyncs({
         iframeEnabled: true
       });
@@ -255,7 +255,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(syncs[0].type).to.equal('iframe');
     });
 
-    it('should pass gdpr params', () => {
+    it('should pass gdpr params', function () {
       let syncs = spec.getUserSyncs({ iframeEnabled: true }, {}, {
         gdprApplies: false, consentString: 'test'
       });

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -15,7 +15,7 @@ const bid = {
   }
 };
 
-describe('native.js', () => {
+describe('native.js', function () {
   let triggerPixelStub;
   let insertHtmlIntoIframeStub;
 
@@ -50,7 +50,7 @@ describe('native.js', () => {
   });
 });
 
-describe('validate native', () => {
+describe('validate native', function () {
   let bidReq = [{
     bids: [{
       bidderCode: 'test_bidder',

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -19,12 +19,12 @@ describe('native.js', function () {
   let triggerPixelStub;
   let insertHtmlIntoIframeStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
     insertHtmlIntoIframeStub = sinon.stub(utils, 'insertHtmlIntoIframe');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     utils.triggerPixel.restore();
     utils.insertHtmlIntoIframe.restore();
   });
@@ -149,9 +149,9 @@ describe('validate native', function () {
     }
   };
 
-  beforeEach(() => {});
+  beforeEach(function () {});
 
-  afterEach(() => {});
+  afterEach(function () {});
 
   it('should reject bid if no image sizes are defined', function () {
     let result = nativeBidIsValid(validBid, bidReq);

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -29,21 +29,21 @@ describe('native.js', function () {
     utils.insertHtmlIntoIframe.restore();
   });
 
-  it('gets native targeting keys', () => {
+  it('gets native targeting keys', function () {
     const targeting = getNativeTargeting(bid);
     expect(targeting.hb_native_title).to.equal(bid.native.title);
     expect(targeting.hb_native_body).to.equal(bid.native.body);
     expect(targeting.hb_native_linkurl).to.equal(bid.native.clickUrl);
   });
 
-  it('fires impression trackers', () => {
+  it('fires impression trackers', function () {
     fireNativeTrackers({}, bid);
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
     sinon.assert.calledWith(insertHtmlIntoIframeStub, bid.native.javascriptTrackers);
   });
 
-  it('fires click trackers', () => {
+  it('fires click trackers', function () {
     fireNativeTrackers({ action: 'click' }, bid);
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
@@ -153,7 +153,7 @@ describe('validate native', function () {
 
   afterEach(() => {});
 
-  it('should reject bid if no image sizes are defined', () => {
+  it('should reject bid if no image sizes are defined', function () {
     let result = nativeBidIsValid(validBid, bidReq);
     expect(result).to.be.true;
     result = nativeBidIsValid(noIconDimBid, bidReq);

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -10,7 +10,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
 
   let loadScriptStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
       args[1]();
     });
@@ -30,7 +30,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
     spyEventHandler = sinon.spy();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     loadScriptStub.restore();
   });
 

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -34,29 +34,29 @@ describe('Renderer: A renderer installed on a bid response', function () {
     loadScriptStub.restore();
   });
 
-  it('is an instance of Renderer', () => {
+  it('is an instance of Renderer', function () {
     expect(testRenderer1 instanceof Renderer).to.equal(true);
   });
 
-  it('has expected properties ', () => {
+  it('has expected properties ', function () {
     expect(testRenderer1.url).to.equal('https://httpbin.org/post');
     expect(testRenderer1.config).to.deep.equal({ test: 'config1' });
     expect(testRenderer1.id).to.equal(1);
   });
 
-  it('returns config from getConfig method', () => {
+  it('returns config from getConfig method', function () {
     expect(testRenderer1.getConfig()).to.deep.equal({ test: 'config1' });
     expect(testRenderer2.getConfig()).to.deep.equal({ test: 'config2' });
   });
 
-  it('sets a render function with setRender method', () => {
+  it('sets a render function with setRender method', function () {
     testRenderer1.setRender(spyRenderFn);
     expect(typeof testRenderer1.render).to.equal('function');
     testRenderer1.render();
     expect(spyRenderFn.called).to.equal(true);
   });
 
-  it('sets event handlers with setEventHandlers method and handles events with installed handlers', () => {
+  it('sets event handlers with setEventHandlers method and handles events with installed handlers', function () {
     testRenderer1.setEventHandlers({
       testEvent: spyEventHandler
     });
@@ -69,7 +69,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
     expect(spyEventHandler.called).to.equal(true);
   });
 
-  it('pushes commands to queue if renderer is not loaded', () => {
+  it('pushes commands to queue if renderer is not loaded', function () {
     testRenderer1.loaded = false;
     testRenderer1.push(spyRenderFn);
     expect(testRenderer1.cmd.length).to.equal(1);
@@ -78,7 +78,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
     testRenderer1.cmd = [];
   });
 
-  it('fires commands immediately if the renderer is loaded', () => {
+  it('fires commands immediately if the renderer is loaded', function () {
     const func = sinon.spy();
 
     testRenderer1.loaded = true;
@@ -89,7 +89,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
     sinon.assert.calledOnce(func);
   });
 
-  it('processes queue by calling each function in queue', () => {
+  it('processes queue by calling each function in queue', function () {
     testRenderer1.loaded = false;
     const func1 = sinon.spy();
     const func2 = sinon.spy();

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Renderer } from 'src/Renderer';
 const adloader = require('../../src/adloader');
 
-describe('Renderer: A renderer installed on a bid response', () => {
+describe('Renderer: A renderer installed on a bid response', function () {
   let testRenderer1;
   let testRenderer2;
   let spyRenderFn;

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -49,7 +49,7 @@ describe('sizeMapping', function () {
   let sandbox,
     matchMediaOverride;
 
-  beforeEach(() => {
+  beforeEach(function () {
     setSizeConfig(sizeConfig);
 
     sandbox = sinon.sandbox.create();
@@ -64,7 +64,7 @@ describe('sizeMapping', function () {
     });
   });
 
-  afterEach(() => {
+  afterEach(function () {
     setSizeConfig([]);
 
     sandbox.restore();

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -5,7 +5,7 @@ import includes from 'core-js/library/fn/array/includes';
 let utils = require('src/utils');
 let deepClone = utils.deepClone;
 
-describe('sizeMapping', () => {
+describe('sizeMapping', function () {
   var testSizes = [[970, 90], [728, 90], [300, 250], [300, 100], [80, 80]];
 
   var sizeConfig = [{
@@ -70,7 +70,7 @@ describe('sizeMapping', () => {
     sandbox.restore();
   });
 
-  describe('when handling sizes', () => {
+  describe('when handling sizes', function () {
     it('should log a warning when mediaQuery property missing from sizeConfig', () => {
       let errorConfig = deepClone(sizeConfig);
 
@@ -137,7 +137,7 @@ describe('sizeMapping', () => {
     });
   });
 
-  describe('when handling labels', () => {
+  describe('when handling labels', function () {
     it('should activate/deactivate adUnits/bidders based on sizeConfig.labels', () => {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -71,7 +71,7 @@ describe('sizeMapping', function () {
   });
 
   describe('when handling sizes', function () {
-    it('should log a warning when mediaQuery property missing from sizeConfig', () => {
+    it('should log a warning when mediaQuery property missing from sizeConfig', function () {
       let errorConfig = deepClone(sizeConfig);
 
       delete errorConfig[0].mediaQuery;
@@ -82,7 +82,7 @@ describe('sizeMapping', function () {
       expect(utils.logWarn.firstCall.args[0]).to.match(/missing.+?mediaQuery/);
     });
 
-    it('when one mediaQuery block matches, it should filter the adUnit.sizes passed in', () => {
+    it('when one mediaQuery block matches, it should filter the adUnit.sizes passed in', function () {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, sizeConfig);
@@ -93,7 +93,7 @@ describe('sizeMapping', function () {
       })
     });
 
-    it('when multiple mediaQuery block matches, it should filter a union of the matched sizesSupported', () => {
+    it('when multiple mediaQuery block matches, it should filter a union of the matched sizesSupported', function () {
       matchMediaOverride = (str) => includes([
         '(min-width: 1200px)',
         '(min-width: 768px) and (max-width: 1199px)'
@@ -106,7 +106,7 @@ describe('sizeMapping', function () {
       })
     });
 
-    it('if no mediaQueries match, it should allow all sizes specified', () => {
+    it('if no mediaQueries match, it should allow all sizes specified', function () {
       matchMediaOverride = () => ({matches: false});
 
       let status = resolveStatus(undefined, testSizes, sizeConfig);
@@ -116,7 +116,7 @@ describe('sizeMapping', function () {
       })
     });
 
-    it('if a mediaQuery matches and has sizesSupported: [], it should filter all sizes', () => {
+    it('if a mediaQuery matches and has sizesSupported: [], it should filter all sizes', function () {
       matchMediaOverride = (str) => str === '(min-width: 0px) and (max-width: 767px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, sizeConfig);
@@ -126,7 +126,7 @@ describe('sizeMapping', function () {
       })
     });
 
-    it('if a mediaQuery matches and no sizesSupported specified, it should not effect adUnit.sizes', () => {
+    it('if a mediaQuery matches and no sizesSupported specified, it should not effect adUnit.sizes', function () {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, sizeConfigWithLabels);
@@ -138,7 +138,7 @@ describe('sizeMapping', function () {
   });
 
   describe('when handling labels', function () {
-    it('should activate/deactivate adUnits/bidders based on sizeConfig.labels', () => {
+    it('should activate/deactivate adUnits/bidders based on sizeConfig.labels', function () {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus({
@@ -160,7 +160,7 @@ describe('sizeMapping', function () {
       });
     });
 
-    it('should active/deactivate adUnits/bidders based on requestBids labels', () => {
+    it('should active/deactivate adUnits/bidders based on requestBids labels', function () {
       let activeLabels = ['us-visitor', 'desktop', 'smart'];
 
       let status = resolveStatus({

--- a/test/spec/unit/adServerManager_spec.js
+++ b/test/spec/unit/adServerManager_spec.js
@@ -4,7 +4,7 @@ import { registerVideoSupport } from 'src/adServerManager';
 
 const prebid = getGlobal();
 
-describe('The ad server manager', () => {
+describe('The ad server manager', function () {
   beforeEach(() => {
     delete prebid.adServers;
   });

--- a/test/spec/unit/adServerManager_spec.js
+++ b/test/spec/unit/adServerManager_spec.js
@@ -5,7 +5,7 @@ import { registerVideoSupport } from 'src/adServerManager';
 const prebid = getGlobal();
 
 describe('The ad server manager', function () {
-  beforeEach(() => {
+  beforeEach(function () {
     delete prebid.adServers;
   });
 

--- a/test/spec/unit/adServerManager_spec.js
+++ b/test/spec/unit/adServerManager_spec.js
@@ -9,7 +9,7 @@ describe('The ad server manager', function () {
     delete prebid.adServers;
   });
 
-  it('should register video support to the proper place on the API', () => {
+  it('should register video support to the proper place on the API', function () {
     function videoSupport() { }
     registerVideoSupport('dfp', { buildVideoUrl: videoSupport });
 
@@ -18,7 +18,7 @@ describe('The ad server manager', function () {
     expect(prebid.adServers.dfp).to.have.property('buildVideoUrl', videoSupport);
   });
 
-  it('should keep the first function when we try to add a second', () => {
+  it('should keep the first function when we try to add a second', function () {
     function videoSupport() { }
     registerVideoSupport('dfp', { buildVideoUrl: videoSupport });
     registerVideoSupport('dfp', { buildVideoUrl: function noop() { } });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -81,7 +81,7 @@ describe('adapterManager tests', function () {
       delete AdapterManager.bidderRegistry['appnexus'];
     });
 
-    it('should log an error if a bidder is used that does not exist', () => {
+    it('should log an error if a bidder is used that does not exist', function () {
       const adUnits = [{
         code: 'adUnit-code',
         sizes: [[728, 90]],
@@ -97,7 +97,7 @@ describe('adapterManager tests', function () {
       sinon.assert.called(utils.logError);
     });
 
-    it('should emit BID_REQUESTED event', () => {
+    it('should emit BID_REQUESTED event', function () {
       // function to count BID_REQUESTED events
       let cnt = 0;
       let count = () => cnt++;
@@ -147,7 +147,7 @@ describe('adapterManager tests', function () {
       prebidServerAdapterMock.callBids.reset();
     });
 
-    it('invokes callBids on the S2S adapter', () => {
+    it('invokes callBids on the S2S adapter', function () {
       let bidRequests = [{
         'bidderCode': 'appnexus',
         'auctionId': '1863e370099523',
@@ -295,7 +295,7 @@ describe('adapterManager tests', function () {
     });
 
     // Enable this test when prebidServer adapter is made 1.0 compliant
-    it('invokes callBids with only s2s bids', () => {
+    it('invokes callBids with only s2s bids', function () {
       const adUnits = getAdUnits();
       // adUnit without appnexus bidder
       adUnits.push({
@@ -474,7 +474,7 @@ describe('adapterManager tests', function () {
         events.off(CONSTANTS.EVENTS.BID_REQUESTED, count);
       });
 
-      it('should fire for s2s requests', () => {
+      it('should fire for s2s requests', function () {
         let adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
           adUnit.bids = adUnit.bids.filter(bid => includes(['appnexus'], bid.bidder));
           return adUnit;
@@ -485,7 +485,7 @@ describe('adapterManager tests', function () {
         sinon.assert.calledOnce(prebidServerAdapterMock.callBids);
       });
 
-      it('should fire for simultaneous s2s and client requests', () => {
+      it('should fire for simultaneous s2s and client requests', function () {
         AdapterManager.bidderRegistry['adequant'] = adequantAdapterMock;
         let adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
           adUnit.bids = adUnit.bids.filter(bid => includes(['adequant', 'appnexus'], bid.bidder));
@@ -563,7 +563,7 @@ describe('adapterManager tests', function () {
       s2sTesting.getSourceBidderMap.restore();
     });
 
-    it('calls server adapter if no sources defined', () => {
+    it('calls server adapter if no sources defined', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: [], [s2sTesting.SERVER]: []});
       callBids();
 
@@ -577,7 +577,7 @@ describe('adapterManager tests', function () {
       sinon.assert.notCalled(adequantAdapterMock.callBids);
     });
 
-    it('calls client adapter if one client source defined', () => {
+    it('calls client adapter if one client source defined', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus'], [s2sTesting.SERVER]: []});
       callBids();
 
@@ -591,7 +591,7 @@ describe('adapterManager tests', function () {
       sinon.assert.notCalled(adequantAdapterMock.callBids);
     });
 
-    it('calls client adapters if client sources defined', () => {
+    it('calls client adapters if client sources defined', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       callBids();
 
@@ -605,7 +605,7 @@ describe('adapterManager tests', function () {
       checkClientCalled(adequantAdapterMock, 2);
     });
 
-    it('calls client adapters if client sources defined', () => {
+    it('calls client adapters if client sources defined', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       callBids();
 
@@ -619,7 +619,7 @@ describe('adapterManager tests', function () {
       checkClientCalled(adequantAdapterMock, 2);
     });
 
-    it('does not call server adapter for bidders that go to client', () => {
+    it('does not call server adapter for bidders that go to client', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       var adUnits = getTestAdUnits();
       adUnits[0].bids[0].finalSource = s2sTesting.CLIENT;
@@ -638,7 +638,7 @@ describe('adapterManager tests', function () {
       checkClientCalled(adequantAdapterMock, 2);
     });
 
-    it('does not call client adapters for bidders that go to server', () => {
+    it('does not call client adapters for bidders that go to server', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       var adUnits = getTestAdUnits();
       adUnits[0].bids[0].finalSource = s2sTesting.SERVER;
@@ -657,7 +657,7 @@ describe('adapterManager tests', function () {
       sinon.assert.notCalled(adequantAdapterMock.callBids);
     });
 
-    it('calls client and server adapters for bidders that go to both', () => {
+    it('calls client and server adapters for bidders that go to both', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       var adUnits = getTestAdUnits();
       adUnits[0].bids[0].finalSource = s2sTesting.BOTH;
@@ -676,7 +676,7 @@ describe('adapterManager tests', function () {
       checkClientCalled(adequantAdapterMock, 2);
     });
 
-    it('makes mixed client/server adapter calls for mixed bidder sources', () => {
+    it('makes mixed client/server adapter calls for mixed bidder sources', function () {
       stubGetSourceBidderMap.returns({[s2sTesting.CLIENT]: ['appnexus', 'adequant'], [s2sTesting.SERVER]: []});
       var adUnits = getTestAdUnits();
       adUnits[0].bids[0].finalSource = s2sTesting.CLIENT;
@@ -732,7 +732,7 @@ describe('adapterManager tests', function () {
         utils.logError.restore();
       });
 
-      it('should allow an alias if alias is part of s2sConfig.bidders', () => {
+      it('should allow an alias if alias is part of s2sConfig.bidders', function () {
         let testS2sConfig = utils.deepClone(CONFIG);
         testS2sConfig.bidders = ['s2sAlias'];
         config.setConfig({s2sConfig: testS2sConfig});
@@ -741,7 +741,7 @@ describe('adapterManager tests', function () {
         expect(AdapterManager.aliasRegistry).to.have.property('s2sAlias');
       });
 
-      it('should throw an error if alias + bidder are unknown and not part of s2sConfig.bidders', () => {
+      it('should throw an error if alias + bidder are unknown and not part of s2sConfig.bidders', function () {
         let testS2sConfig = utils.deepClone(CONFIG);
         testS2sConfig.bidders = ['s2sAlias'];
         config.setConfig({s2sConfig: testS2sConfig});
@@ -772,7 +772,7 @@ describe('adapterManager tests', function () {
         utils.shuffle.restore();
       });
 
-      it('setting to `random` uses shuffled order of adUnits', () => {
+      it('setting to `random` uses shuffled order of adUnits', function () {
         config.setConfig({ bidderSequence: 'random' });
         let bidRequests = AdapterManager.makeBidRequests(
           adUnits,
@@ -796,7 +796,7 @@ describe('adapterManager tests', function () {
         setSizeConfig([]);
       });
 
-      it('should not filter bids w/ no labels', () => {
+      it('should not filter bids w/ no labels', function () {
         let bidRequests = AdapterManager.makeBidRequests(
           adUnits,
           Date.now(),
@@ -816,7 +816,7 @@ describe('adapterManager tests', function () {
         expect(appnexusBidRequests.bids[1].sizes).to.deep.equal(find(adUnits, adUnit => adUnit.code === appnexusBidRequests.bids[1].adUnitCode).sizes);
       });
 
-      it('should filter sizes using size config', () => {
+      it('should filter sizes using size config', function () {
         let validSizes = [
           [728, 90],
           [300, 250]
@@ -868,7 +868,7 @@ describe('adapterManager tests', function () {
         expect(bidRequests.length).to.equal(0);
       });
 
-      it('should filter adUnits/bidders based on applied labels', () => {
+      it('should filter adUnits/bidders based on applied labels', function () {
         adUnits[0].labelAll = ['visitor-uk', 'mobile'];
         adUnits[1].labelAny = ['visitor-uk', 'desktop'];
         adUnits[1].bids[0].labelAny = ['mobile'];
@@ -889,7 +889,7 @@ describe('adapterManager tests', function () {
         expect(bidRequests[0].bids[0].adUnitCode).to.equal(adUnits[1].code);
       });
 
-      it('should filter adUnits/bidders based on applid labels for s2s requests', () => {
+      it('should filter adUnits/bidders based on applid labels for s2s requests', function () {
         adUnits[0].labelAll = ['visitor-uk', 'mobile'];
         adUnits[1].labelAny = ['visitor-uk', 'desktop'];
         adUnits[1].bids[0].labelAny = ['mobile'];
@@ -918,7 +918,7 @@ describe('adapterManager tests', function () {
     });
 
     describe('gdpr consent module', function () {
-      it('inserts gdprConsent object to bidRequest only when module was enabled', () => {
+      it('inserts gdprConsent object to bidRequest only when module was enabled', function () {
         AdapterManager.gdprDataHandler.setConsentData({
           consentString: 'abc123def456',
           consentRequired: true
@@ -958,7 +958,7 @@ describe('adapterManager tests', function () {
         utils.logInfo.restore();
       });
 
-      it('should maintain adUnit structure and adUnits.sizes is replaced', () => {
+      it('should maintain adUnit structure and adUnits.sizes is replaced', function () {
         let fullAdUnit = [{
           sizes: [[300, 250], [300, 600]],
           mediaTypes: {
@@ -1043,7 +1043,7 @@ describe('adapterManager tests', function () {
         sinon.assert.calledOnce(utils.logInfo);
       });
 
-      it('should normalize adUnit.sizes and adUnit.mediaTypes.banner.sizes', () => {
+      it('should normalize adUnit.sizes and adUnit.mediaTypes.banner.sizes', function () {
         let fullAdUnit = [{
           sizes: [300, 250],
           mediaTypes: {
@@ -1067,7 +1067,7 @@ describe('adapterManager tests', function () {
         utils.logError.restore();
       });
 
-      it('should throw error message and delete an object/property', () => {
+      it('should throw error message and delete an object/property', function () {
         let badBanner = [{
           sizes: [[300, 250], [300, 600]],
           mediaTypes: {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -41,7 +41,7 @@ var rubiconAdapterMock = {
 };
 let loadScriptStub;
 
-describe('adapterManager tests', () => {
+describe('adapterManager tests', function () {
   let orgAppnexusAdapter;
   let orgAdequantAdapter;
   let orgPrebidServerAdapter;
@@ -65,7 +65,7 @@ describe('adapterManager tests', () => {
     config.setConfig({s2sConfig: { enabled: false }});
   });
 
-  describe('callBids', () => {
+  describe('callBids', function () {
     before(() => {
       config.setConfig({s2sConfig: { enabled: false }});
     });
@@ -140,7 +140,7 @@ describe('adapterManager tests', () => {
     });
   });
 
-  describe('S2S tests', () => {
+  describe('S2S tests', function () {
     beforeEach(() => {
       config.setConfig({s2sConfig: CONFIG});
       AdapterManager.bidderRegistry['prebidServer'] = prebidServerAdapterMock;
@@ -460,7 +460,7 @@ describe('adapterManager tests', () => {
       sinon.assert.calledOnce(prebidServerAdapterMock.callBids);
     });
 
-    describe('BID_REQUESTED event', () => {
+    describe('BID_REQUESTED event', function () {
       // function to count BID_REQUESTED events
       let cnt, count = () => cnt++;
 
@@ -502,7 +502,7 @@ describe('adapterManager tests', () => {
     });
   }); // end s2s tests
 
-  describe('s2sTesting', () => {
+  describe('s2sTesting', function () {
     let doneStub = sinon.stub();
     let ajaxStub = sinon.stub();
 
@@ -722,7 +722,7 @@ describe('adapterManager tests', () => {
       });
     });
 
-    describe('special case for s2s-only bidders', () => {
+    describe('special case for s2s-only bidders', function () {
       beforeEach(() => {
         sinon.stub(utils, 'logError');
       });
@@ -753,7 +753,7 @@ describe('adapterManager tests', () => {
     });
   });
 
-  describe('makeBidRequests', () => {
+  describe('makeBidRequests', function () {
     let adUnits;
     beforeEach(() => {
       adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
@@ -762,7 +762,7 @@ describe('adapterManager tests', () => {
       })
     });
 
-    describe('setBidderSequence', () => {
+    describe('setBidderSequence', function () {
       beforeEach(() => {
         sinon.spy(utils, 'shuffle');
       });
@@ -785,7 +785,7 @@ describe('adapterManager tests', () => {
       });
     });
 
-    describe('sizeMapping', () => {
+    describe('sizeMapping', function () {
       beforeEach(() => {
         sinon.stub(window, 'matchMedia').callsFake(() => ({matches: true}));
       });
@@ -917,7 +917,7 @@ describe('adapterManager tests', () => {
       });
     });
 
-    describe('gdpr consent module', () => {
+    describe('gdpr consent module', function () {
       it('inserts gdprConsent object to bidRequest only when module was enabled', () => {
         AdapterManager.gdprDataHandler.setConsentData({
           consentString: 'abc123def456',
@@ -948,8 +948,8 @@ describe('adapterManager tests', () => {
     });
   });
 
-  describe('isValidBidRequest', () => {
-    describe('positive tests for validating bid request', () => {
+  describe('isValidBidRequest', function () {
+    describe('positive tests for validating bid request', function () {
       beforeEach(() => {
         sinon.stub(utils, 'logInfo');
       });
@@ -1058,7 +1058,7 @@ describe('adapterManager tests', () => {
       });
     });
 
-    describe('negative tests for validating bid requests', () => {
+    describe('negative tests for validating bid requests', function () {
       beforeEach(() => {
         sinon.stub(utils, 'logError');
       });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -46,7 +46,7 @@ describe('adapterManager tests', function () {
   let orgAdequantAdapter;
   let orgPrebidServerAdapter;
   let orgRubiconAdapter;
-  before(() => {
+  before(function () {
     orgAppnexusAdapter = AdapterManager.bidderRegistry['appnexus'];
     orgAdequantAdapter = AdapterManager.bidderRegistry['adequant'];
     orgPrebidServerAdapter = AdapterManager.bidderRegistry['prebidServer'];
@@ -56,7 +56,7 @@ describe('adapterManager tests', function () {
     });
   });
 
-  after(() => {
+  after(function () {
     AdapterManager.bidderRegistry['appnexus'] = orgAppnexusAdapter;
     AdapterManager.bidderRegistry['adequant'] = orgAdequantAdapter;
     AdapterManager.bidderRegistry['prebidServer'] = orgPrebidServerAdapter;
@@ -66,17 +66,17 @@ describe('adapterManager tests', function () {
   });
 
   describe('callBids', function () {
-    before(() => {
+    before(function () {
       config.setConfig({s2sConfig: { enabled: false }});
     });
 
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.stub(utils, 'logError');
       appnexusAdapterMock.callBids.reset();
       AdapterManager.bidderRegistry['appnexus'] = appnexusAdapterMock;
     });
 
-    afterEach(() => {
+    afterEach(function () {
       utils.logError.restore();
       delete AdapterManager.bidderRegistry['appnexus'];
     });
@@ -141,7 +141,7 @@ describe('adapterManager tests', function () {
   });
 
   describe('S2S tests', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       config.setConfig({s2sConfig: CONFIG});
       AdapterManager.bidderRegistry['prebidServer'] = prebidServerAdapterMock;
       prebidServerAdapterMock.callBids.reset();
@@ -464,13 +464,13 @@ describe('adapterManager tests', function () {
       // function to count BID_REQUESTED events
       let cnt, count = () => cnt++;
 
-      beforeEach(() => {
+      beforeEach(function () {
         prebidServerAdapterMock.callBids.reset();
         cnt = 0;
         events.on(CONSTANTS.EVENTS.BID_REQUESTED, count);
       });
 
-      afterEach(() => {
+      afterEach(function () {
         events.off(CONSTANTS.EVENTS.BID_REQUESTED, count);
       });
 
@@ -543,7 +543,7 @@ describe('adapterManager tests', function () {
     });
     let stubGetSourceBidderMap;
 
-    beforeEach(() => {
+    beforeEach(function () {
       config.setConfig({s2sConfig: TESTING_CONFIG});
       AdapterManager.bidderRegistry['prebidServer'] = prebidServerAdapterMock;
       AdapterManager.bidderRegistry['adequant'] = adequantAdapterMock;
@@ -558,7 +558,7 @@ describe('adapterManager tests', function () {
       rubiconAdapterMock.callBids.reset();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       config.setConfig({s2sConfig: {}});
       s2sTesting.getSourceBidderMap.restore();
     });
@@ -702,7 +702,7 @@ describe('adapterManager tests', function () {
     describe('using bidderFactory', function() {
       let spec;
 
-      beforeEach(() => {
+      beforeEach(function () {
         spec = {
           code: CODE,
           isBidRequestValid: () => {},
@@ -723,11 +723,11 @@ describe('adapterManager tests', function () {
     });
 
     describe('special case for s2s-only bidders', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(utils, 'logError');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         utils.logError.restore();
       });
@@ -755,7 +755,7 @@ describe('adapterManager tests', function () {
 
   describe('makeBidRequests', function () {
     let adUnits;
-    beforeEach(() => {
+    beforeEach(function () {
       adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
         adUnit.bids = adUnit.bids.filter(bid => includes(['appnexus', 'rubicon'], bid.bidder));
         return adUnit;
@@ -763,11 +763,11 @@ describe('adapterManager tests', function () {
     });
 
     describe('setBidderSequence', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.spy(utils, 'shuffle');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         config.resetConfig();
         utils.shuffle.restore();
       });
@@ -786,11 +786,11 @@ describe('adapterManager tests', function () {
     });
 
     describe('sizeMapping', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(window, 'matchMedia').callsFake(() => ({matches: true}));
       });
 
-      afterEach(() => {
+      afterEach(function () {
         matchMedia.restore();
         config.resetConfig();
         setSizeConfig([]);
@@ -950,11 +950,11 @@ describe('adapterManager tests', function () {
 
   describe('isValidBidRequest', function () {
     describe('positive tests for validating bid request', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(utils, 'logInfo');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         utils.logInfo.restore();
       });
 
@@ -1059,11 +1059,11 @@ describe('adapterManager tests', function () {
     });
 
     describe('negative tests for validating bid requests', function () {
-      beforeEach(() => {
+      beforeEach(function () {
         sinon.stub(utils, 'logError');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         utils.logError.restore();
       });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -61,7 +61,7 @@ describe('bidders created by newBidder', function () {
       ajaxStub.restore();
     });
 
-    it('should handle bad bid requests gracefully', () => {
+    it('should handle bad bid requests gracefully', function () {
       const bidder = newBidder(spec);
 
       spec.getUserSyncs.returns([]);
@@ -75,7 +75,7 @@ describe('bidders created by newBidder', function () {
       expect(spec.interpretResponse.called).to.equal(false);
     });
 
-    it('should call buildRequests(bidRequest) the params are valid', () => {
+    it('should call buildRequests(bidRequest) the params are valid', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -89,7 +89,7 @@ describe('bidders created by newBidder', function () {
       expect(spec.buildRequests.firstCall.args[0]).to.deep.equal(MOCK_BIDS_REQUEST.bids);
     });
 
-    it('should not call buildRequests the params are invalid', () => {
+    it('should not call buildRequests the params are invalid', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(false);
@@ -102,7 +102,7 @@ describe('bidders created by newBidder', function () {
       expect(spec.buildRequests.called).to.equal(false);
     });
 
-    it('should filter out invalid bids before calling buildRequests', () => {
+    it('should filter out invalid bids before calling buildRequests', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.onFirstCall().returns(true);
@@ -117,7 +117,7 @@ describe('bidders created by newBidder', function () {
       expect(spec.buildRequests.firstCall.args[0]).to.deep.equal([MOCK_BIDS_REQUEST.bids[0]]);
     });
 
-    it('should make no server requests if the spec doesn\'t return any', () => {
+    it('should make no server requests if the spec doesn\'t return any', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -128,7 +128,7 @@ describe('bidders created by newBidder', function () {
       expect(ajaxStub.called).to.equal(false);
     });
 
-    it('should make the appropriate POST request', () => {
+    it('should make the appropriate POST request', function () {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
@@ -151,7 +151,7 @@ describe('bidders created by newBidder', function () {
       });
     });
 
-    it('should make the appropriate POST request when options are passed', () => {
+    it('should make the appropriate POST request when options are passed', function () {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
@@ -176,7 +176,7 @@ describe('bidders created by newBidder', function () {
       });
     });
 
-    it('should make the appropriate GET request', () => {
+    it('should make the appropriate GET request', function () {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
@@ -198,7 +198,7 @@ describe('bidders created by newBidder', function () {
       });
     });
 
-    it('should make the appropriate GET request when options are passed', () => {
+    it('should make the appropriate GET request when options are passed', function () {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
@@ -222,7 +222,7 @@ describe('bidders created by newBidder', function () {
       });
     });
 
-    it('should make multiple calls if the spec returns them', () => {
+    it('should make multiple calls if the spec returns them', function () {
       const bidder = newBidder(spec);
       const url = 'test.url.com';
       const data = { arg: 2 };
@@ -245,7 +245,7 @@ describe('bidders created by newBidder', function () {
       expect(ajaxStub.calledTwice).to.equal(true);
     });
 
-    it('should not add bids for each placement code if no requests are given', () => {
+    it('should not add bids for each placement code if no requests are given', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -282,7 +282,7 @@ describe('bidders created by newBidder', function () {
       utils.logError.restore();
     });
 
-    it('should call spec.interpretResponse() with the response content', () => {
+    it('should call spec.interpretResponse() with the response content', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -307,7 +307,7 @@ describe('bidders created by newBidder', function () {
       expect(doneStub.calledOnce).to.equal(true);
     });
 
-    it('should call spec.interpretResponse() once for each request made', () => {
+    it('should call spec.interpretResponse() once for each request made', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -331,7 +331,7 @@ describe('bidders created by newBidder', function () {
       expect(doneStub.calledOnce).to.equal(true);
     });
 
-    it('should only add bids for valid adUnit code into the auction, even if the bidder doesn\'t bid on all of them', () => {
+    it('should only add bids for valid adUnit code into the auction, even if the bidder doesn\'t bid on all of them', function () {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -364,7 +364,7 @@ describe('bidders created by newBidder', function () {
       expect(logErrorSpy.callCount).to.equal(0);
     });
 
-    it('should call spec.getUserSyncs() with the response', () => {
+    it('should call spec.getUserSyncs() with the response', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -384,7 +384,7 @@ describe('bidders created by newBidder', function () {
       expect(spec.getUserSyncs.firstCall.args[1][0].headers.get).to.be.a('function');
     });
 
-    it('should register usersync pixels', () => {
+    it('should register usersync pixels', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(false);
@@ -402,7 +402,7 @@ describe('bidders created by newBidder', function () {
       expect(userSyncStub.firstCall.args[2]).to.equal('usersync.com');
     });
 
-    it('should logError when required bid response params are missing', () => {
+    it('should logError when required bid response params are missing', function () {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -428,7 +428,7 @@ describe('bidders created by newBidder', function () {
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
 
-    it('should logError when required bid response params are undefined', () => {
+    it('should logError when required bid response params are undefined', function () {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -474,7 +474,7 @@ describe('bidders created by newBidder', function () {
       ajaxStub.restore();
     });
 
-    it('should not spec.interpretResponse()', () => {
+    it('should not spec.interpretResponse()', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -491,7 +491,7 @@ describe('bidders created by newBidder', function () {
       expect(doneStub.calledOnce).to.equal(true);
     });
 
-    it('should not add bids for each adunit code into the auction', () => {
+    it('should not add bids for each adunit code into the auction', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -509,7 +509,7 @@ describe('bidders created by newBidder', function () {
       expect(doneStub.calledOnce).to.equal(true);
     });
 
-    it('should call spec.getUserSyncs() with no responses', () => {
+    it('should call spec.getUserSyncs() with no responses', function () {
       const bidder = newBidder(spec);
 
       spec.isBidRequestValid.returns(true);
@@ -552,7 +552,7 @@ describe('registerBidder', function () {
     };
   }
 
-  it('should register a bidder with the adapterManager', () => {
+  it('should register a bidder with the adapterManager', function () {
     registerBidder(newEmptySpec());
     expect(registerBidAdapterStub.calledOnce).to.equal(true);
     expect(registerBidAdapterStub.firstCall.args[0]).to.have.property('callBids');
@@ -562,14 +562,14 @@ describe('registerBidder', function () {
     expect(registerBidAdapterStub.firstCall.args[2]).to.be.undefined;
   });
 
-  it('should register a bidder with the appropriate mediaTypes', () => {
+  it('should register a bidder with the appropriate mediaTypes', function () {
     const thisSpec = Object.assign(newEmptySpec(), { supportedMediaTypes: ['video'] });
     registerBidder(thisSpec);
     expect(registerBidAdapterStub.calledOnce).to.equal(true);
     expect(registerBidAdapterStub.firstCall.args[2]).to.deep.equal({supportedMediaTypes: ['video']});
   });
 
-  it('should register bidders with the appropriate aliases', () => {
+  it('should register bidders with the appropriate aliases', function () {
     const thisSpec = Object.assign(newEmptySpec(), { aliases: ['foo', 'bar'] });
     registerBidder(thisSpec);
 
@@ -636,7 +636,7 @@ describe('validate bid response: ', function () {
     logErrorSpy.restore();
   });
 
-  it('should add native bids that do have required assets', () => {
+  it('should add native bids that do have required assets', function () {
     let bidRequest = {
       bids: [{
         bidId: 1,
@@ -673,7 +673,7 @@ describe('validate bid response: ', function () {
     expect(logErrorSpy.callCount).to.equal(0);
   });
 
-  it('should not add native bids that do not have required assets', () => {
+  it('should not add native bids that do not have required assets', function () {
     let bidRequest = {
       bids: [{
         bidId: 1,
@@ -709,7 +709,7 @@ describe('validate bid response: ', function () {
     expect(logErrorSpy.callCount).to.equal(1);
   });
 
-  it('should add bid when renderer is present on outstream bids', () => {
+  it('should add bid when renderer is present on outstream bids', function () {
     let bidRequest = {
       bids: [{
         bidId: 1,
@@ -743,7 +743,7 @@ describe('validate bid response: ', function () {
     expect(logErrorSpy.callCount).to.equal(0);
   });
 
-  it('should add banner bids that have no width or height but single adunit size', () => {
+  it('should add banner bids that have no width or height but single adunit size', function () {
     let bidRequest = {
       bids: [{
         bidder: CODE,

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -35,7 +35,7 @@ describe('bidders created by newBidder', function () {
   let addBidResponseStub;
   let doneStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     spec = {
       code: CODE,
       isBidRequestValid: sinon.stub(),
@@ -51,13 +51,13 @@ describe('bidders created by newBidder', function () {
   describe('when the ajax response is irrelevant', function () {
     let ajaxStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       ajaxStub = sinon.stub(ajax, 'ajax');
       addBidResponseStub.reset();
       doneStub.reset();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       ajaxStub.restore();
     });
 
@@ -264,7 +264,7 @@ describe('bidders created by newBidder', function () {
     let userSyncStub;
     let logErrorSpy;
 
-    beforeEach(() => {
+    beforeEach(function () {
       ajaxStub = sinon.stub(ajax, 'ajax').callsFake(function(url, callbacks) {
         const fakeResponse = sinon.stub();
         fakeResponse.returns('headerContent');
@@ -276,7 +276,7 @@ describe('bidders created by newBidder', function () {
       logErrorSpy = sinon.spy(utils, 'logError');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       ajaxStub.restore();
       userSyncStub.restore();
       utils.logError.restore();
@@ -462,7 +462,7 @@ describe('bidders created by newBidder', function () {
   describe('when the ajax call fails', function () {
     let ajaxStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       ajaxStub = sinon.stub(ajax, 'ajax').callsFake(function(url, callbacks) {
         callbacks.error('ajax call failed.');
       });
@@ -470,7 +470,7 @@ describe('bidders created by newBidder', function () {
       doneStub.reset();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       ajaxStub.restore();
     });
 
@@ -533,12 +533,12 @@ describe('registerBidder', function () {
   let registerBidAdapterStub;
   let aliasBidAdapterStub;
 
-  beforeEach(() => {
+  beforeEach(function () {
     registerBidAdapterStub = sinon.stub(adaptermanager, 'registerBidAdapter');
     aliasBidAdapterStub = sinon.stub(adaptermanager, 'aliasBidAdapter');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     registerBidAdapterStub.restore();
     aliasBidAdapterStub.restore();
   });
@@ -606,7 +606,7 @@ describe('validate bid response: ', function () {
     'ttl': 360
   }];
 
-  beforeEach(() => {
+  beforeEach(function () {
     spec = {
       code: CODE,
       isBidRequestValid: sinon.stub(),
@@ -631,7 +631,7 @@ describe('validate bid response: ', function () {
     logErrorSpy = sinon.spy(utils, 'logError');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     ajaxStub.restore();
     logErrorSpy.restore();
   });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -29,7 +29,7 @@ const MOCK_BIDS_REQUEST = {
   ]
 }
 
-describe('bidders created by newBidder', () => {
+describe('bidders created by newBidder', function () {
   let spec;
   let bidder;
   let addBidResponseStub;
@@ -48,7 +48,7 @@ describe('bidders created by newBidder', () => {
     doneStub = sinon.stub();
   });
 
-  describe('when the ajax response is irrelevant', () => {
+  describe('when the ajax response is irrelevant', function () {
     let ajaxStub;
 
     beforeEach(() => {
@@ -259,7 +259,7 @@ describe('bidders created by newBidder', () => {
     });
   });
 
-  describe('when the ajax call succeeds', () => {
+  describe('when the ajax call succeeds', function () {
     let ajaxStub;
     let userSyncStub;
     let logErrorSpy;
@@ -459,7 +459,7 @@ describe('bidders created by newBidder', () => {
     });
   });
 
-  describe('when the ajax call fails', () => {
+  describe('when the ajax call fails', function () {
     let ajaxStub;
 
     beforeEach(() => {
@@ -529,7 +529,7 @@ describe('bidders created by newBidder', () => {
   });
 });
 
-describe('registerBidder', () => {
+describe('registerBidder', function () {
   let registerBidAdapterStub;
   let aliasBidAdapterStub;
 
@@ -586,7 +586,7 @@ describe('registerBidder', () => {
   });
 })
 
-describe('validate bid response: ', () => {
+describe('validate bid response: ', function () {
   let spec;
   let bidder;
   let addBidResponseStub;

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -97,8 +97,8 @@ const bid3 = {
   'ttl': 300
 };
 
-describe('targeting tests', () => {
-  describe('getAllTargeting', () => {
+describe('targeting tests', function () {
+  describe('getAllTargeting', function () {
     let amBidsReceivedStub;
     let amGetAdUnitsStub;
     let bidExpiryStub;
@@ -136,7 +136,7 @@ describe('targeting tests', () => {
     });
   }); // end getAllTargeting tests
 
-  describe('getAllTargeting without bids return empty object', () => {
+  describe('getAllTargeting without bids return empty object', function () {
     let amBidsReceivedStub;
     let amGetAdUnitsStub;
     let bidExpiryStub;
@@ -166,8 +166,8 @@ describe('targeting tests', () => {
     });
   }); // end getAllTargeting without bids return empty object
 
-  describe('Targeting in concurrent auctions', () => {
-    describe('check getOldestBid', () => {
+  describe('Targeting in concurrent auctions', function () {
+    describe('check getOldestBid', function () {
       let bidExpiryStub;
       let auctionManagerStub;
       beforeEach(() => {
@@ -231,7 +231,7 @@ describe('targeting tests', () => {
       });
     });
 
-    describe('check bidExpiry', () => {
+    describe('check bidExpiry', function () {
       let auctionManagerStub;
       let timestampStub;
       beforeEach(() => {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -103,7 +103,7 @@ describe('targeting tests', function () {
     let amGetAdUnitsStub;
     let bidExpiryStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       $$PREBID_GLOBAL$$._sendAllBids = false;
       amBidsReceivedStub = sinon.stub(auctionManager, 'getBidsReceived').callsFake(function() {
         return [bid1, bid2, bid3];
@@ -114,7 +114,7 @@ describe('targeting tests', function () {
       bidExpiryStub = sinon.stub(targetingModule, 'isBidNotExpired').returns(true);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionManager.getBidsReceived.restore();
       auctionManager.getAdUnitCodes.restore();
       targetingModule.isBidNotExpired.restore();
@@ -141,7 +141,7 @@ describe('targeting tests', function () {
     let amGetAdUnitsStub;
     let bidExpiryStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       $$PREBID_GLOBAL$$._sendAllBids = false;
       amBidsReceivedStub = sinon.stub(auctionManager, 'getBidsReceived').callsFake(function() {
         return [];
@@ -152,7 +152,7 @@ describe('targeting tests', function () {
       bidExpiryStub = sinon.stub(targetingModule, 'isBidNotExpired').returns(true);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionManager.getBidsReceived.restore();
       auctionManager.getAdUnitCodes.restore();
       targetingModule.isBidNotExpired.restore();
@@ -170,12 +170,12 @@ describe('targeting tests', function () {
     describe('check getOldestBid', function () {
       let bidExpiryStub;
       let auctionManagerStub;
-      beforeEach(() => {
+      beforeEach(function () {
         bidExpiryStub = sinon.stub(targetingModule, 'isBidNotExpired').returns(true);
         auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         bidExpiryStub.restore();
         auctionManagerStub.restore();
       });
@@ -234,12 +234,12 @@ describe('targeting tests', function () {
     describe('check bidExpiry', function () {
       let auctionManagerStub;
       let timestampStub;
-      beforeEach(() => {
+      beforeEach(function () {
         auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');
         timestampStub = sinon.stub(utils, 'timestamp');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         auctionManagerStub.restore();
         timestampStub.restore();
       });

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -120,7 +120,7 @@ describe('targeting tests', function () {
       targetingModule.isBidNotExpired.restore();
     });
 
-    it('selects the top bid when _sendAllBids true', () => {
+    it('selects the top bid when _sendAllBids true', function () {
       config.setConfig({ enableSendAllBids: true });
       let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
 
@@ -158,7 +158,7 @@ describe('targeting tests', function () {
       targetingModule.isBidNotExpired.restore();
     });
 
-    it('returns targetingSet correctly', () => {
+    it('returns targetingSet correctly', function () {
       let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
 
       // we should only get the targeting data for the one requested adunit to at least exist even though it has no keys to set
@@ -180,7 +180,7 @@ describe('targeting tests', function () {
         auctionManagerStub.restore();
       });
 
-      it('should use bids from pool to get Winning Bid', () => {
+      it('should use bids from pool to get Winning Bid', function () {
         let bidsReceived = [
           createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1'}),
           createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2'}),
@@ -196,7 +196,7 @@ describe('targeting tests', function () {
         expect(bids[1].adId).to.equal('adid-2');
       });
 
-      it('should not use rendered bid to get winning bid', () => {
+      it('should not use rendered bid to get winning bid', function () {
         let bidsReceived = [
           createBidReceived({bidder: 'appnexus', cpm: 8, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1', status: 'rendered'}),
           createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2'}),
@@ -213,7 +213,7 @@ describe('targeting tests', function () {
         expect(bids[1].adId).to.equal('adid-3');
       });
 
-      it('should use highest cpm bid from bid pool to get winning bid', () => {
+      it('should use highest cpm bid from bid pool to get winning bid', function () {
         // Pool is having 4 bids from 2 auctions. There are 2 bids from rubicon, #2 which is highest cpm bid will be selected to take part in auction.
         let bidsReceived = [
           createBidReceived({bidder: 'appnexus', cpm: 8, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1'}),
@@ -243,7 +243,7 @@ describe('targeting tests', function () {
         auctionManagerStub.restore();
         timestampStub.restore();
       });
-      it('should not include expired bids in the auction', () => {
+      it('should not include expired bids in the auction', function () {
         timestampStub.returns(200000);
         // Pool is having 4 bids from 2 auctions. All the bids are expired and only bid #3 is passing the bidExpiry check.
         let bidsReceived = [

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -149,7 +149,7 @@ window.apntag = {
 
 describe('Unit: Prebid Module', function () {
   let bidExpiryStub;
-  before(() => {
+  before(function () {
     bidExpiryStub = sinon.stub(targetingModule, 'isBidNotExpired').callsFake(() => true);
   });
 
@@ -159,7 +159,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       resetAuction();
     });
 
@@ -192,11 +192,11 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getAdServerTargeting', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       resetAuction();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       resetAuction();
     });
 
@@ -411,7 +411,7 @@ describe('Unit: Prebid Module', function () {
       }]
     };
 
-    before(() => {
+    before(function () {
       $$PREBID_GLOBAL$$.bidderSettings = {};
       currentPriceBucket = configObj.getConfig('priceGranularity');
       configObj.setConfig({ priceGranularity: customConfigObject });
@@ -447,12 +447,12 @@ describe('Unit: Prebid Module', function () {
       ));
     });
 
-    after(() => {
+    after(function () {
       configObj.setConfig({ priceGranularity: currentPriceBucket });
       adaptermanager.makeBidRequests.restore();
     })
 
-    beforeEach(() => {
+    beforeEach(function () {
       let auctionManagerInstance = newAuctionManager();
       targeting = newTargeting(auctionManagerInstance);
       let adUnits = [{
@@ -476,7 +476,7 @@ describe('Unit: Prebid Module', function () {
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       ajaxStub.restore();
     });
 
@@ -678,7 +678,7 @@ describe('Unit: Prebid Module', function () {
       });
     };
 
-    before(() => {
+    before(function () {
       currentPriceBucket = configObj.getConfig('priceGranularity');
       sinon.stub(adaptermanager, 'makeBidRequests').callsFake(() => ([{
         'bidderCode': 'appnexus',
@@ -711,12 +711,12 @@ describe('Unit: Prebid Module', function () {
       }]));
     });
 
-    after(() => {
+    after(function () {
       configObj.setConfig({ priceGranularity: currentPriceBucket });
       adaptermanager.makeBidRequests.restore();
     })
 
-    afterEach(() => {
+    afterEach(function () {
       ajaxStub.restore();
     });
 
@@ -789,12 +789,12 @@ describe('Unit: Prebid Module', function () {
   describe('setTargetingForGPTAsync', function () {
     let logErrorSpy;
 
-    beforeEach(() => {
+    beforeEach(function () {
       logErrorSpy = sinon.spy(utils, 'logError');
       resetAuction();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       utils.logError.restore();
       resetAuction();
     });
@@ -1128,7 +1128,7 @@ describe('Unit: Prebid Module', function () {
       'start': 1000
     }];
 
-    beforeEach(() => {
+    beforeEach(function () {
       logMessageSpy = sinon.spy(utils, 'logMessage');
       makeRequestsStub = sinon.stub(adaptermanager, 'makeBidRequests');
       makeRequestsStub.returns(bidRequests);
@@ -1151,7 +1151,7 @@ describe('Unit: Prebid Module', function () {
       createAuctionStub.returns(auction);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       clock.restore();
       adaptermanager.makeBidRequests.restore();
       auctionModule.newAuction.restore();
@@ -1197,13 +1197,15 @@ describe('Unit: Prebid Module', function () {
     let xhr;
     let requests;
 
-    beforeEach(() => {
+    beforeEach(function () {
       xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = request => requests.push(request);
     });
 
-    afterEach(() => xhr.restore());
+    afterEach(function () {
+      xhr.restore();
+    });
     var adUnitsBackup;
     var auctionManagerStub;
     let logMessageSpy
@@ -1220,7 +1222,7 @@ describe('Unit: Prebid Module', function () {
     describe('part 1', function () {
       let auctionArgs;
 
-      beforeEach(() => {
+      beforeEach(function () {
         adUnitsBackup = auction.getAdUnits
         auctionManagerStub = sinon.stub(auctionManager, 'createAuction').callsFake(function() {
           auctionArgs = arguments[0];
@@ -1229,7 +1231,7 @@ describe('Unit: Prebid Module', function () {
         logMessageSpy = sinon.spy(utils, 'logMessage');
       });
 
-      afterEach(() => {
+      afterEach(function () {
         auction.getAdUnits = adUnitsBackup;
         auctionManager.createAuction.restore();
         utils.logMessage.restore();
@@ -1300,7 +1302,7 @@ describe('Unit: Prebid Module', function () {
       let createAuctionStub;
       let adUnits;
 
-      beforeEach(() => {
+      beforeEach(function () {
         adUnits = [{
           code: 'adUnit-code',
           mediaTypes: {
@@ -1321,7 +1323,7 @@ describe('Unit: Prebid Module', function () {
         createAuctionStub.returns(auction);
       })
 
-      afterEach(() => {
+      afterEach(function () {
         auctionModule.newAuction.restore();
         adaptermanager.callBids.restore();
       });
@@ -1356,7 +1358,7 @@ describe('Unit: Prebid Module', function () {
       let createAuctionStub;
       let adUnits;
 
-      before(() => {
+      before(function () {
         adUnits = [{
           code: 'adUnit-code',
           sizes: [[300, 250], [300, 600]],
@@ -1387,15 +1389,15 @@ describe('Unit: Prebid Module', function () {
         createAuctionStub.returns(auction);
       });
 
-      after(() => {
+      after(function () {
         auctionModule.newAuction.restore();
       });
 
-      beforeEach(() => {
+      beforeEach(function () {
         spyCallBids = sinon.spy(adaptermanager, 'callBids');
       })
 
-      afterEach(() => {
+      afterEach(function () {
         adaptermanager.callBids.restore();
       })
 
@@ -1717,13 +1719,13 @@ describe('Unit: Prebid Module', function () {
 
   describe('emit event', function () {
     let auctionManagerStub;
-    beforeEach(() => {
+    beforeEach(function () {
       auctionManagerStub = sinon.stub(auctionManager, 'createAuction').callsFake(function() {
         return auction;
       });
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionManager.createAuction.restore();
     });
   });
@@ -1758,11 +1760,11 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getDealTargeting', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       resetAuction();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       resetAuction();
     });
 
@@ -1809,7 +1811,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getHighestCpm', function () {
-    after(() => {
+    after(function () {
       resetAuction();
     });
 
@@ -1923,7 +1925,7 @@ describe('Unit: Prebid Module', function () {
     let targeting;
     let auctionManagerInstance;
 
-    beforeEach(() => {
+    beforeEach(function () {
       resetAuction();
       auctionManagerInstance = newAuctionManager();
       sinon.stub(auctionManagerInstance, 'getBidsReceived').callsFake(function() {
@@ -1938,7 +1940,7 @@ describe('Unit: Prebid Module', function () {
       targeting = newTargeting(auctionManagerInstance);
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionManagerInstance.getBidsReceived.restore();
       auctionManagerInstance.getAdUnitCodes.restore();
       resetAuction();
@@ -2008,11 +2010,11 @@ describe('Unit: Prebid Module', function () {
 
   describe('getAllPrebidWinningBids', function () {
     let auctionManagerStub;
-    beforeEach(() => {
+    beforeEach(function () {
       auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');
     });
 
-    afterEach(() => {
+    afterEach(function () {
       auctionManagerStub.restore();
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -207,7 +207,7 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual(targeting, expected, 'targeting ok');
     });
 
-    it('should return correct targeting with default settings', () => {
+    it('should return correct targeting with default settings', function () {
       var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
       var expected = {
         '/19968336/header-bid-tag-0': {
@@ -228,14 +228,14 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual(targeting, expected);
     });
 
-    it('should return correct targeting with bid landscape targeting on', () => {
+    it('should return correct targeting with bid landscape targeting on', function () {
       $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       var targeting = $$PREBID_GLOBAL$$.getAdserverTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
       var expected = getAdServerTargeting(['/19968336/header-bid-tag-0', '/19968336/header-bid-tag1']);
       assert.deepEqual(targeting, expected);
     });
 
-    it("should include a losing bid's custom ad targeting key", () => {
+    it("should include a losing bid's custom ad targeting key", function () {
       // Let's make sure we're getting the expected losing bid.
       assert.equal(auction.getBidsReceived()[0]['bidderCode'], 'triplelift');
       assert.equal(auction.getBidsReceived()[0]['cpm'], 0.112256);
@@ -276,7 +276,7 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual(targeting, expected);
     });
 
-    it('should not overwrite winning bids custom keys targeting key', () => {
+    it('should not overwrite winning bids custom keys targeting key', function () {
       resetAuction();
       // mimic a bidderSetting.standard key here for each bid and alwaysUseBid true for every bid
       let _bidsReceived = getBidResponses();
@@ -337,7 +337,7 @@ describe('Unit: Prebid Module', function () {
       $$PREBID_GLOBAL$$.bidderSettings = {};
     });
 
-    it('should not send standard targeting keys when the bid has `sendStandardTargeting` set to `false`', () => {
+    it('should not send standard targeting keys when the bid has `sendStandardTargeting` set to `false`', function () {
       let _bidsReceived = getBidResponses();
       _bidsReceived.forEach(bid => {
         bid.adserverTargeting.custom_ad_id = bid.adId;
@@ -480,28 +480,28 @@ describe('Unit: Prebid Module', function () {
       ajaxStub.restore();
     });
 
-    it('should get correct hb_pb when using bid.cpm is between 0 to 5', () => {
+    it('should get correct hb_pb when using bid.cpm is between 0 to 5', function () {
       RESPONSE.tags[0].ads[0].cpm = 2.1234;
       auction.callBids(cbTimeout);
       let bidTargeting = targeting.getAllTargeting();
       expect(bidTargeting['div-gpt-ad-1460505748561-0']['hb_pb']).to.equal('2.12');
     });
 
-    it('should get correct hb_pb when using bid.cpm is between 5 to 8', () => {
+    it('should get correct hb_pb when using bid.cpm is between 5 to 8', function () {
       RESPONSE.tags[0].ads[0].cpm = 6.78;
       auction.callBids(cbTimeout);
       let bidTargeting = targeting.getAllTargeting();
       expect(bidTargeting['div-gpt-ad-1460505748561-0']['hb_pb']).to.equal('6.75');
     });
 
-    it('should get correct hb_pb when using bid.cpm is between 8 to 20', () => {
+    it('should get correct hb_pb when using bid.cpm is between 8 to 20', function () {
       RESPONSE.tags[0].ads[0].cpm = 19.5234;
       auction.callBids(cbTimeout);
       let bidTargeting = targeting.getAllTargeting();
       expect(bidTargeting['div-gpt-ad-1460505748561-0']['hb_pb']).to.equal('19.50');
     });
 
-    it('should get correct hb_pb when using bid.cpm is between 20 to 25', () => {
+    it('should get correct hb_pb when using bid.cpm is between 20 to 25', function () {
       RESPONSE.tags[0].ads[0].cpm = 21.5234;
       auction.callBids(cbTimeout);
       let bidTargeting = targeting.getAllTargeting();
@@ -720,7 +720,7 @@ describe('Unit: Prebid Module', function () {
       ajaxStub.restore();
     });
 
-    it('should get correct hb_pb with cpm between 0 - 5', () => {
+    it('should get correct hb_pb with cpm between 0 - 5', function () {
       initTestConfig({
         adUnits: [createAdUnit('div-gpt-ad-1460505748561-0')],
         adUnitCodes: ['div-gpt-ad-1460505748561-0']
@@ -734,7 +734,7 @@ describe('Unit: Prebid Module', function () {
       expect(bidTargeting['div-gpt-ad-1460505748561-0']['hb_pb']).to.equal('3.25');
     });
 
-    it('should get correct hb_pb with cpm between 21 - 100', () => {
+    it('should get correct hb_pb with cpm between 21 - 100', function () {
       initTestConfig({
         adUnits: [createAdUnit('div-gpt-ad-1460505748561-0')],
         adUnitCodes: ['div-gpt-ad-1460505748561-0']
@@ -748,7 +748,7 @@ describe('Unit: Prebid Module', function () {
       expect(bidTargeting['div-gpt-ad-1460505748561-0']['hb_pb']).to.equal('43.00');
     });
 
-    it('should only apply price granularity if bid media type matches', () => {
+    it('should only apply price granularity if bid media type matches', function () {
       initTestConfig({
         adUnits: [ createAdUnit('div-gpt-ad-1460505748561-0', 'video') ],
         adUnitCodes: ['div-gpt-ad-1460505748561-0']
@@ -770,7 +770,7 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual(result, compare, 'expected bid responses are returned');
     });
 
-    it('should return bid responses for most recent requestId only', () => {
+    it('should return bid responses for most recent requestId only', function () {
       const responses = $$PREBID_GLOBAL$$.getBidResponses();
       assert.equal(responses[Object.keys(responses)[0]].bids.length, 4);
     });
@@ -1024,7 +1024,7 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyLogError.calledWith(error), 'expected error was logged');
     });
 
-    it('should log an error when not in an iFrame', () => {
+    it('should log an error when not in an iFrame', function () {
       pushBidResponseToAuction({
         ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>"
       });
@@ -1034,7 +1034,7 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyLogError.calledWith(error), 'expected error was logged');
     });
 
-    it('should not render videos', () => {
+    it('should not render videos', function () {
       pushBidResponseToAuction({
         mediatype: 'video'
       });
@@ -1070,7 +1070,7 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual($$PREBID_GLOBAL$$.getAllWinningBids()[0], adResponse);
     });
 
-    it('fires billing url if present on s2s bid', () => {
+    it('fires billing url if present on s2s bid', function () {
       const burl = 'http://www.example.com/burl';
       pushBidResponseToAuction({
         ad: '<div>ad</div>',
@@ -1159,7 +1159,7 @@ describe('Unit: Prebid Module', function () {
       xhr.restore();
     });
 
-    it('should execute callback after timeout', () => {
+    it('should execute callback after timeout', function () {
       let spec = {
         code: BIDDER_CODE,
         isBidRequestValid: sinon.stub(),
@@ -1236,7 +1236,7 @@ describe('Unit: Prebid Module', function () {
         resetAuction();
       });
 
-      it('should log message when adUnits not configured', () => {
+      it('should log message when adUnits not configured', function () {
         $$PREBID_GLOBAL$$.adUnits = [];
         try {
           $$PREBID_GLOBAL$$.requestBids({});
@@ -1246,7 +1246,7 @@ describe('Unit: Prebid Module', function () {
         assert.ok(logMessageSpy.calledWith('No adUnits configured. No bids requested.'), 'expected message was logged');
       });
 
-      it('should attach transactionIds to ads (or pass through transactionId if it already exists)', () => {
+      it('should attach transactionIds to ads (or pass through transactionId if it already exists)', function () {
         $$PREBID_GLOBAL$$.requestBids({
           adUnits: [
             {
@@ -1266,7 +1266,7 @@ describe('Unit: Prebid Module', function () {
           .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
-      it('should execute callback immediately if adUnits is empty', () => {
+      it('should execute callback immediately if adUnits is empty', function () {
         var bidsBackHandler = function bidsBackHandlerCallback() {};
         var spyExecuteCallback = sinon.spy(bidsBackHandler);
 
@@ -1279,7 +1279,7 @@ describe('Unit: Prebid Module', function () {
           ' empty');
       });
 
-      it('should not propagate exceptions from bidsBackHandler', () => {
+      it('should not propagate exceptions from bidsBackHandler', function () {
         $$PREBID_GLOBAL$$.adUnits = [];
 
         var requestObj = {
@@ -1326,7 +1326,7 @@ describe('Unit: Prebid Module', function () {
         adaptermanager.callBids.restore();
       });
 
-      it('bidders that support one of the declared formats are allowed to participate', () => {
+      it('bidders that support one of the declared formats are allowed to participate', function () {
         $$PREBID_GLOBAL$$.requestBids({adUnits});
         sinon.assert.calledOnce(adaptermanager.callBids);
 
@@ -1337,7 +1337,7 @@ describe('Unit: Prebid Module', function () {
         expect(biddersCalled.length).to.equal(2);
       });
 
-      it('bidders that do not support one of the declared formats are dropped', () => {
+      it('bidders that do not support one of the declared formats are dropped', function () {
         delete adUnits[0].mediaTypes.banner;
 
         $$PREBID_GLOBAL$$.requestBids({adUnits});
@@ -1399,12 +1399,12 @@ describe('Unit: Prebid Module', function () {
         adaptermanager.callBids.restore();
       })
 
-      it('should callBids if a native adUnit has all native bidders', () => {
+      it('should callBids if a native adUnit has all native bidders', function () {
         $$PREBID_GLOBAL$$.requestBids({adUnits});
         sinon.assert.calledOnce(adaptermanager.callBids);
       });
 
-      it('should call callBids function on adaptermanager', () => {
+      it('should call callBids function on adaptermanager', function () {
         let adUnits = [{
           code: 'adUnit-code',
           sizes: [[300, 250], [300, 600]],
@@ -1416,7 +1416,7 @@ describe('Unit: Prebid Module', function () {
         assert.ok(spyCallBids.called, 'called adaptermanager.callBids');
       });
 
-      it('splits native type to individual native assets', () => {
+      it('splits native type to individual native assets', function () {
         let adUnits = [{
           code: 'adUnit-code',
           nativeParams: {type: 'image'},
@@ -1500,7 +1500,7 @@ describe('Unit: Prebid Module', function () {
         adaptermanager.callBids.restore();
       });
 
-      it('should not queue bid requests when a previous bid request is in process', () => {
+      it('should not queue bid requests when a previous bid request is in process', function () {
         var requestObj1 = {
           bidsBackHandler: function bidsBackHandlerCallback() {},
           timeout: 2000,
@@ -1544,7 +1544,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('onEvent', function () {
-    it('should log an error when handler is not a function', () => {
+    it('should log an error when handler is not a function', function () {
       var spyLogError = sinon.spy(utils, 'logError');
       var event = 'testEvent';
       $$PREBID_GLOBAL$$.onEvent(event);
@@ -1553,7 +1553,7 @@ describe('Unit: Prebid Module', function () {
       utils.logError.restore();
     });
 
-    it('should log an error when id provided is not valid for event', () => {
+    it('should log an error when id provided is not valid for event', function () {
       var spyLogError = sinon.spy(utils, 'logError');
       var event = 'bidWon';
       $$PREBID_GLOBAL$$.onEvent(event, Function, 'testId');
@@ -1562,7 +1562,7 @@ describe('Unit: Prebid Module', function () {
       utils.logError.restore();
     });
 
-    it('should call events.on with valid parameters', () => {
+    it('should call events.on with valid parameters', function () {
       var spyEventsOn = sinon.spy(events, 'on');
       $$PREBID_GLOBAL$$.onEvent('bidWon', Function);
       assert.ok(spyEventsOn.calledWith('bidWon', Function));
@@ -1571,14 +1571,14 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('offEvent', function () {
-    it('should return when id provided is not valid for event', () => {
+    it('should return when id provided is not valid for event', function () {
       var spyEventsOff = sinon.spy(events, 'off');
       $$PREBID_GLOBAL$$.offEvent('bidWon', Function, 'testId');
       assert.ok(spyEventsOff.notCalled);
       events.off.restore();
     });
 
-    it('should call events.off with valid parameters', () => {
+    it('should call events.off with valid parameters', function () {
       var spyEventsOff = sinon.spy(events, 'off');
       $$PREBID_GLOBAL$$.offEvent('bidWon', Function);
       assert.ok(spyEventsOff.calledWith('bidWon', Function));
@@ -1587,7 +1587,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('emit', function () {
-    it('should be able to emit event without arguments', () => {
+    it('should be able to emit event without arguments', function () {
       var spyEventsEmit = sinon.spy(events, 'emit');
       events.emit(CONSTANTS.EVENTS.AUCTION_END);
       assert.ok(spyEventsEmit.calledWith('auctionEnd'));
@@ -1596,14 +1596,14 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('registerBidAdapter', function () {
-    it('should register bidAdaptor with adaptermanager', () => {
+    it('should register bidAdaptor with adaptermanager', function () {
       var registerBidAdapterSpy = sinon.spy(adaptermanager, 'registerBidAdapter');
       $$PREBID_GLOBAL$$.registerBidAdapter(Function, 'biddercode');
       assert.ok(registerBidAdapterSpy.called, 'called adaptermanager.registerBidAdapter');
       adaptermanager.registerBidAdapter.restore();
     });
 
-    it('should catch thrown errors', () => {
+    it('should catch thrown errors', function () {
       var spyLogError = sinon.spy(utils, 'logError');
       var errorObject = { message: 'bidderAdaptor error' };
       var bidderAdaptor = sinon.stub().throws(errorObject);
@@ -1617,7 +1617,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('createBid', function () {
-    it('should return a bid object', () => {
+    it('should return a bid object', function () {
       const statusCode = 1;
       const bid = $$PREBID_GLOBAL$$.createBid(statusCode);
       assert.isObject(bid, 'bid is an object');
@@ -1630,7 +1630,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('loadScript', function () {
-    it('should call adloader.loadScript', () => {
+    it('should call adloader.loadScript', function () {
       const loadScriptSpy = sinon.spy(adloader, 'loadScript');
       const tagSrc = '';
       const callback = Function;
@@ -1643,7 +1643,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('aliasBidder', function () {
-    it('should call adaptermanager.aliasBidder', () => {
+    it('should call adaptermanager.aliasBidder', function () {
       const aliasBidAdapterSpy = sinon.spy(adaptermanager, 'aliasBidAdapter');
       const bidderCode = 'testcode';
       const alias = 'testalias';
@@ -1653,7 +1653,7 @@ describe('Unit: Prebid Module', function () {
       adaptermanager.aliasBidAdapter.restore();
     });
 
-    it('should log error when not passed correct arguments', () => {
+    it('should log error when not passed correct arguments', function () {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'bidderCode and alias must be passed as arguments';
 
@@ -1664,7 +1664,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('setPriceGranularity', function () {
-    it('should log error when not passed granularity', () => {
+    it('should log error when not passed granularity', function () {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'Prebid Error: no value passed to `setPriceGranularity()`';
 
@@ -1673,7 +1673,7 @@ describe('Unit: Prebid Module', function () {
       utils.logError.restore();
     });
 
-    it('should log error when not passed a valid config object', () => {
+    it('should log error when not passed a valid config object', function () {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'Invalid custom price value passed to `setPriceGranularity()`';
       const badConfig = {
@@ -1696,7 +1696,7 @@ describe('Unit: Prebid Module', function () {
       utils.logError.restore();
     });
 
-    it('should set customPriceBucket with custom config buckets', () => {
+    it('should set customPriceBucket with custom config buckets', function () {
       let customPriceBucket = configObj.getConfig('customPriceBucket');
       const goodConfig = {
         'buckets': [{
@@ -1729,7 +1729,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('removeAdUnit', function () {
-    it('should remove given adUnit in adUnits array', () => {
+    it('should remove given adUnit in adUnits array', function () {
       const adUnit1 = {
         code: 'adUnit1',
         bids: [{
@@ -1766,7 +1766,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('should truncate deal keys', () => {
+    it('should truncate deal keys', function () {
       $$PREBID_GLOBAL$$._bidsReceived = [
         {
           'bidderCode': 'appnexusDummyName',
@@ -1813,18 +1813,18 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('returns an array containing the highest bid object for the given adUnitCode', () => {
+    it('returns an array containing the highest bid object for the given adUnitCode', function () {
       const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/19968336/header-bid-tag-0');
       expect(highestCpmBids.length).to.equal(1);
       expect(highestCpmBids[0]).to.deep.equal(auctionManager.getBidsReceived()[1]);
     });
 
-    it('returns an empty array when the given adUnit is not found', () => {
+    it('returns an empty array when the given adUnit is not found', function () {
       const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/stallone');
       expect(highestCpmBids.length).to.equal(0);
     });
 
-    it('returns an empty array when the given adUnit has no bids', () => {
+    it('returns an empty array when the given adUnit has no bids', function () {
       let _bidsReceived = getBidResponses()[0];
       _bidsReceived.cpm = 0;
       auction.getBidsReceived = function() { return _bidsReceived };
@@ -1852,7 +1852,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('markWinningBidAsUsed', function () {
-    it('marks the bid object as used for the given adUnitCode/adId combination', () => {
+    it('marks the bid object as used for the given adUnitCode/adId combination', function () {
       // make sure the auction has "state" and does not reload the fixtures
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
@@ -1869,7 +1869,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('try and mark the bid object, but fail because we supplied the wrong adId', () => {
+    it('try and mark the bid object, but fail because we supplied the wrong adId', function () {
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
       auction.getBidsReceived = function() { return bidsReceived.bids };
@@ -1884,7 +1884,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('marks the winning bid object as used for the given adUnitCode', () => {
+    it('marks the winning bid object as used for the given adUnitCode', function () {
       // make sure the auction has "state" and does not reload the fixtures
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
@@ -1901,7 +1901,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('marks a bid object as used for the given adId', () => {
+    it('marks a bid object as used for the given adId', function () {
       // make sure the auction has "state" and does not reload the fixtures
       const adUnitCode = '/19968336/header-bid-tag-0';
       const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
@@ -1944,7 +1944,7 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     });
 
-    it('should set targeting for appnexus apntag object', () => {
+    it('should set targeting for appnexus apntag object', function () {
       const bids = auctionManagerInstance.getBidsReceived();
       const adUnitCode = '/19968336/header-bid-tag-0';
 
@@ -1963,7 +1963,7 @@ describe('Unit: Prebid Module', function () {
       expect(newAdserverTargeting).to.deep.equal(window.apntag.tags[adUnitCode].keywords);
     });
 
-    it('should not find hb_adid key in lowercase for all bidders', () => {
+    it('should not find hb_adid key in lowercase for all bidders', function () {
       const adUnitCode = '/19968336/header-bid-tag-0';
       $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: true });
       targeting.setTargetingForAst();
@@ -2016,7 +2016,7 @@ describe('Unit: Prebid Module', function () {
       auctionManagerStub.restore();
     });
 
-    it('should return prebid auction winning bids', () => {
+    it('should return prebid auction winning bids', function () {
       let bidsReceived = [
         createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1', status: 'targetingSet'}),
         createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2'}),

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1085,7 +1085,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('requestBids', () => {
+  describe('requestBids', function () {
     let logMessageSpy;
     let makeRequestsStub;
     let xhr;
@@ -1193,7 +1193,7 @@ describe('Unit: Prebid Module', function () {
     });
   })
 
-  describe('requestBids', () => {
+  describe('requestBids', function () {
     let xhr;
     let requests;
 
@@ -1217,7 +1217,7 @@ describe('Unit: Prebid Module', function () {
     };
     registerBidder(spec);
 
-    describe('part 1', () => {
+    describe('part 1', function () {
       let auctionArgs;
 
       beforeEach(() => {
@@ -1295,7 +1295,7 @@ describe('Unit: Prebid Module', function () {
       });
     });
 
-    describe('multiformat requests', () => {
+    describe('multiformat requests', function () {
       let spyCallBids;
       let createAuctionStub;
       let adUnits;
@@ -1351,7 +1351,7 @@ describe('Unit: Prebid Module', function () {
       });
     });
 
-    describe('part 2', () => {
+    describe('part 2', function () {
       let spyCallBids;
       let createAuctionStub;
       let adUnits;
@@ -1440,7 +1440,7 @@ describe('Unit: Prebid Module', function () {
       });
     });
 
-    describe('part-3', () => {
+    describe('part-3', function () {
       let auctionManagerInstance = newAuctionManager();
       let auctionManagerStub;
       let adUnits1 = getAdUnits().filter((adUnit) => {
@@ -1543,7 +1543,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('onEvent', () => {
+  describe('onEvent', function () {
     it('should log an error when handler is not a function', () => {
       var spyLogError = sinon.spy(utils, 'logError');
       var event = 'testEvent';
@@ -1570,7 +1570,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('offEvent', () => {
+  describe('offEvent', function () {
     it('should return when id provided is not valid for event', () => {
       var spyEventsOff = sinon.spy(events, 'off');
       $$PREBID_GLOBAL$$.offEvent('bidWon', Function, 'testId');
@@ -1586,7 +1586,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('emit', () => {
+  describe('emit', function () {
     it('should be able to emit event without arguments', () => {
       var spyEventsEmit = sinon.spy(events, 'emit');
       events.emit(CONSTANTS.EVENTS.AUCTION_END);
@@ -1595,7 +1595,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('registerBidAdapter', () => {
+  describe('registerBidAdapter', function () {
     it('should register bidAdaptor with adaptermanager', () => {
       var registerBidAdapterSpy = sinon.spy(adaptermanager, 'registerBidAdapter');
       $$PREBID_GLOBAL$$.registerBidAdapter(Function, 'biddercode');
@@ -1616,7 +1616,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('createBid', () => {
+  describe('createBid', function () {
     it('should return a bid object', () => {
       const statusCode = 1;
       const bid = $$PREBID_GLOBAL$$.createBid(statusCode);
@@ -1629,7 +1629,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('loadScript', () => {
+  describe('loadScript', function () {
     it('should call adloader.loadScript', () => {
       const loadScriptSpy = sinon.spy(adloader, 'loadScript');
       const tagSrc = '';
@@ -1642,7 +1642,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('aliasBidder', () => {
+  describe('aliasBidder', function () {
     it('should call adaptermanager.aliasBidder', () => {
       const aliasBidAdapterSpy = sinon.spy(adaptermanager, 'aliasBidAdapter');
       const bidderCode = 'testcode';
@@ -1663,7 +1663,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('setPriceGranularity', () => {
+  describe('setPriceGranularity', function () {
     it('should log error when not passed granularity', () => {
       const logErrorSpy = sinon.spy(utils, 'logError');
       const error = 'Prebid Error: no value passed to `setPriceGranularity()`';
@@ -1715,7 +1715,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('emit event', () => {
+  describe('emit event', function () {
     let auctionManagerStub;
     beforeEach(() => {
       auctionManagerStub = sinon.stub(auctionManager, 'createAuction').callsFake(function() {
@@ -1728,7 +1728,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('removeAdUnit', () => {
+  describe('removeAdUnit', function () {
     it('should remove given adUnit in adUnits array', () => {
       const adUnit1 = {
         code: 'adUnit1',
@@ -1757,7 +1757,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('getDealTargeting', () => {
+  describe('getDealTargeting', function () {
     beforeEach(() => {
       resetAuction();
     });
@@ -1808,7 +1808,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('getHighestCpm', () => {
+  describe('getHighestCpm', function () {
     after(() => {
       resetAuction();
     });
@@ -1851,7 +1851,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('markWinningBidAsUsed', () => {
+  describe('markWinningBidAsUsed', function () {
     it('marks the bid object as used for the given adUnitCode/adId combination', () => {
       // make sure the auction has "state" and does not reload the fixtures
       const adUnitCode = '/19968336/header-bid-tag-0';
@@ -1919,7 +1919,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('setTargetingForAst', () => {
+  describe('setTargetingForAst', function () {
     let targeting;
     let auctionManagerInstance;
 
@@ -2006,7 +2006,7 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('getAllPrebidWinningBids', () => {
+  describe('getAllPrebidWinningBids', function () {
     let auctionManagerStub;
     beforeEach(() => {
       auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -9,23 +9,23 @@ describe('helpers.url', function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash');
     });
 
-    it('extracts the protocol', () => {
+    it('extracts the protocol', function () {
       expect(parsed).to.have.property('protocol', 'http');
     });
 
-    it('extracts the hostname', () => {
+    it('extracts the hostname', function () {
       expect(parsed).to.have.property('hostname', 'example.com');
     });
 
-    it('extracts the port', () => {
+    it('extracts the port', function () {
       expect(parsed).to.have.property('port', 3000);
     });
 
-    it('extracts the pathname', () => {
+    it('extracts the pathname', function () {
       expect(parsed).to.have.property('pathname', '/pathname/');
     });
 
-    it('extracts the search query', () => {
+    it('extracts the search query', function () {
       expect(parsed).to.have.property('search');
       expect(parsed.search).to.eql({
         foo: 'xxx',
@@ -34,11 +34,11 @@ describe('helpers.url', function () {
       });
     });
 
-    it('extracts the hash', () => {
+    it('extracts the hash', function () {
       expect(parsed).to.have.property('hash', 'hash');
     });
 
-    it('extracts the host', () => {
+    it('extracts the host', function () {
       expect(parsed).to.have.property('host', 'example.com:3000');
     });
   });
@@ -50,7 +50,7 @@ describe('helpers.url', function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash', {noDecodeWholeURL: true});
     });
 
-    it('extracts the search query', () => {
+    it('extracts the search query', function () {
       expect(parsed).to.have.property('search');
       expect(parsed.search).to.eql({
         foo: 'bar',
@@ -61,7 +61,7 @@ describe('helpers.url', function () {
   });
 
   describe('format()', function () {
-    it('formats an object in to a URL', () => {
+    it('formats an object in to a URL', function () {
       expect(format({
         protocol: 'http',
         hostname: 'example.com',
@@ -72,7 +72,7 @@ describe('helpers.url', function () {
       })).to.equal('http://example.com:3000/pathname/?foo=bar&search=test&bar=foo%26foo%3Dxxx#hash');
     });
 
-    it('will use defaults for missing properties', () => {
+    it('will use defaults for missing properties', function () {
       expect(format({
         hostname: 'example.com'
       })).to.equal('http://example.com');
@@ -86,7 +86,7 @@ describe('helpers.url', function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash', {decodeSearchAsString: true});
     });
 
-    it('extracts the search query', () => {
+    it('extracts the search query', function () {
       expect(parsed).to.have.property('search');
       expect(parsed.search).to.equal('?search=test&foo=bar&bar=foo&foo=xxx');
     });

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -5,7 +5,7 @@ describe('helpers.url', function () {
   describe('parse()', function () {
     let parsed;
 
-    beforeEach(() => {
+    beforeEach(function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash');
     });
 
@@ -46,7 +46,7 @@ describe('helpers.url', function () {
   describe('parse(url, {noDecodeWholeURL: true})', function () {
     let parsed;
 
-    beforeEach(() => {
+    beforeEach(function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash', {noDecodeWholeURL: true});
     });
 
@@ -82,7 +82,7 @@ describe('helpers.url', function () {
   describe('parse(url, {decodeSearchAsString: true})', function () {
     let parsed;
 
-    beforeEach(() => {
+    beforeEach(function () {
       parsed = parse('http://example.com:3000/pathname/?search=test&foo=bar&bar=foo%26foo%3Dxxx#hash', {decodeSearchAsString: true});
     });
 

--- a/test/spec/url_spec.js
+++ b/test/spec/url_spec.js
@@ -1,8 +1,8 @@
 import {format, parse} from '../../src/url';
 import { expect } from 'chai';
 
-describe('helpers.url', () => {
-  describe('parse()', () => {
+describe('helpers.url', function () {
+  describe('parse()', function () {
     let parsed;
 
     beforeEach(() => {
@@ -43,7 +43,7 @@ describe('helpers.url', () => {
     });
   });
 
-  describe('parse(url, {noDecodeWholeURL: true})', () => {
+  describe('parse(url, {noDecodeWholeURL: true})', function () {
     let parsed;
 
     beforeEach(() => {
@@ -60,7 +60,7 @@ describe('helpers.url', () => {
     });
   });
 
-  describe('format()', () => {
+  describe('format()', function () {
     it('formats an object in to a URL', () => {
       expect(format({
         protocol: 'http',
@@ -79,7 +79,7 @@ describe('helpers.url', () => {
     });
   });
 
-  describe('parse(url, {decodeSearchAsString: true})', () => {
+  describe('parse(url, {decodeSearchAsString: true})', function () {
     let parsed;
 
     beforeEach(() => {

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -25,15 +25,15 @@ describe('user sync', function () {
     })
   }
   let clock;
-  before(() => {
+  before(function () {
     clock = sinon.useFakeTimers();
   });
 
-  after(() => {
+  after(function () {
     clock.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function () {
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
     logWarnStub = sinon.stub(utils, 'logWarn');
     shuffleStub = sinon.stub(utils, 'shuffle').callsFake((array) => array.reverse());
@@ -41,7 +41,7 @@ describe('user sync', function () {
     insertUserSyncIframeStub = sinon.stub(utils, 'insertUserSyncIframe');
   });
 
-  afterEach(() => {
+  afterEach(function () {
     triggerPixelStub.restore();
     logWarnStub.restore();
     shuffleStub.restore();

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -4,7 +4,7 @@ import { config } from 'src/config';
 const utils = require('../../src/utils');
 let { newUserSync } = require('../../src/userSync');
 
-describe('user sync', () => {
+describe('user sync', function () {
   let triggerPixelStub;
   let logWarnStub;
   let timeoutStub;

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -49,7 +49,7 @@ describe('user sync', function () {
     insertUserSyncIframeStub.restore();
   });
 
-  it('should register and fire a pixel URL', () => {
+  it('should register and fire a pixel URL', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('image', 'testBidder', 'http://example.com');
     userSync.syncUsers();
@@ -57,13 +57,13 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
   });
 
-  it('should clear queue after sync', () => {
+  it('should clear queue after sync', function () {
     const userSync = newTestUserSync();
     userSync.syncUsers();
     expect(triggerPixelStub.callCount).to.equal(0);
   });
 
-  it('should delay firing a pixel by the expected amount', () => {
+  it('should delay firing a pixel by the expected amount', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('image', 'testBidder', 'http://example.com');
     // This implicitly tests cookie and browser support
@@ -72,7 +72,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
   });
 
-  it('should register and fires multiple pixel URLs', () => {
+  it('should register and fires multiple pixel URLs', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
     userSync.registerSync('image', 'testBidder', 'http://example.com/2');
@@ -84,21 +84,21 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(2)).to.be.null;
   });
 
-  it('should not register pixel URL since it is not supported', () => {
+  it('should not register pixel URL since it is not supported', function () {
     const userSync = newTestUserSync({pixelEnabled: false});
     userSync.registerSync('image', 'testBidder', 'http://example.com');
     userSync.syncUsers();
     expect(triggerPixelStub.getCall(0)).to.be.null;
   });
 
-  it('should register and load an iframe', () => {
+  it('should register and load an iframe', function () {
     const userSync = newTestUserSync({iframeEnabled: true});
     userSync.registerSync('iframe', 'testBidder', 'http://example.com/iframe');
     userSync.syncUsers();
     expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
   });
 
-  it('should only trigger syncs once per page', () => {
+  it('should only trigger syncs once per page', function () {
     const userSync = newTestUserSync({pixelEnabled: true});
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
     userSync.syncUsers();
@@ -109,20 +109,20 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(1)).to.be.null;
   });
 
-  it('should not fire syncs if cookies are not supported', () => {
+  it('should not fire syncs if cookies are not supported', function () {
     const userSync = newTestUserSync({pixelEnabled: true}, true);
     userSync.registerSync('image', 'testBidder', 'http://example.com');
     userSync.syncUsers();
     expect(triggerPixelStub.getCall(0)).to.be.null;
   });
 
-  it('should prevent registering invalid type', () => {
+  it('should prevent registering invalid type', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('invalid', 'testBidder', 'http://example.com');
     expect(logWarnStub.getCall(0).args[0]).to.exist;
   });
 
-  it('should expose the syncUsers method for the publisher to manually trigger syncs', () => {
+  it('should expose the syncUsers method for the publisher to manually trigger syncs', function () {
     // triggerUserSyncs should do nothing by default
     let userSync = newTestUserSync();
     let syncUsersSpy = sinon.spy(userSync, 'syncUsers');
@@ -135,7 +135,7 @@ describe('user sync', function () {
     expect(syncUsersSpy.called).to.be.true;
   });
 
-  it('should limit the sync per bidder', () => {
+  it('should limit the sync per bidder', function () {
     const userSync = newTestUserSync({syncsPerBidder: 2});
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
     userSync.registerSync('image', 'testBidder', 'http://example.com/2');
@@ -148,7 +148,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(2)).to.be.null;
   });
 
-  it('should balance out bidder requests', () => {
+  it('should balance out bidder requests', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('image', 'atestBidder', 'http://example.com/1');
     userSync.registerSync('image', 'atestBidder', 'http://example.com/3');
@@ -164,7 +164,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(3)).to.be.null;
   });
 
-  it('should disable user sync', () => {
+  it('should disable user sync', function () {
     const userSync = newTestUserSync({syncEnabled: false});
     userSync.registerSync('pixel', 'testBidder', 'http://example.com');
     expect(logWarnStub.getCall(0).args[0]).to.exist;
@@ -172,7 +172,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0)).to.be.null;
   });
 
-  it('should only sync enabled bidders', () => {
+  it('should only sync enabled bidders', function () {
     const userSync = newTestUserSync({enabledBidders: ['testBidderA']});
     userSync.registerSync('image', 'testBidderA', 'http://example.com/1');
     userSync.registerSync('image', 'testBidderB', 'http://example.com/2');
@@ -182,7 +182,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(1)).to.be.null;
   });
 
-  it('should register config set after instantiation', () => {
+  it('should register config set after instantiation', function () {
     // start with userSync off
     const userSync = newTestUserSync({syncEnabled: false});
     // turn it on with setConfig()
@@ -193,7 +193,7 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
   });
 
-  it('should register both image and iframe pixels with filterSettings.all config', () => {
+  it('should register both image and iframe pixels with filterSettings.all config', function () {
     const userSync = newTestUserSync({
       filterSettings: {
         all: {
@@ -211,7 +211,7 @@ describe('user sync', function () {
     expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
   });
 
-  it('should register iframe and not register image pixels based on filterSettings config', () => {
+  it('should register iframe and not register image pixels based on filterSettings config', function () {
     const userSync = newTestUserSync({
       filterSettings: {
         image: {
@@ -231,7 +231,7 @@ describe('user sync', function () {
     expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
   });
 
-  it('should throw a warning and default to basic resgistration rules when filterSettings config is invalid', () => {
+  it('should throw a warning and default to basic resgistration rules when filterSettings config is invalid', function () {
     // invalid config - passed invalid filter option
     const userSync1 = newTestUserSync({
       filterSettings: {
@@ -317,7 +317,7 @@ describe('user sync', function () {
     expect(insertUserSyncIframeStub.getCall(0)).to.be.null;
   });
 
-  it('should overwrite logic of deprecated fields when filterSettings is defined', () => {
+  it('should overwrite logic of deprecated fields when filterSettings is defined', function () {
     const userSync = newTestUserSync({
       pixelsEnabled: false,
       iframeEnabled: true,

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -639,7 +639,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('getDefinedParams', () => {
+  describe('getDefinedParams', function () {
     it('builds an object consisting of defined params', () => {
       const adUnit = {
         mediaType: 'video',
@@ -658,7 +658,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('deepClone', () => {
+  describe('deepClone', function () {
     it('deep copies objects', () => {
       const adUnit = [{
         code: 'swan',
@@ -679,7 +679,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('getUserConfiguredParams', () => {
+  describe('getUserConfiguredParams', function () {
     const adUnits = [{
       code: 'adUnit1',
       bids: [{
@@ -719,7 +719,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('getTopWindowLocation', () => {
+  describe('getTopWindowLocation', function () {
     let sandbox;
 
     beforeEach(() => {
@@ -806,7 +806,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('convertCamelToUnderscore', () => {
+  describe('convertCamelToUnderscore', function () {
     it('returns converted string value using underscore syntax instead of camelCase', () => {
       let var1 = 'placementIdTest';
       let test1 = utils.convertCamelToUnderscore(var1);
@@ -818,7 +818,7 @@ describe('Utils', function () {
     });
   });
 
-  describe('getAdUnitSizes', () => {
+  describe('getAdUnitSizes', function () {
     it('returns an empty response when adUnits is undefined', () => {
       let sizes = utils.getAdUnitSizes();
       expect(sizes).to.be.undefined;

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -722,11 +722,11 @@ describe('Utils', function () {
   describe('getTopWindowLocation', function () {
     let sandbox;
 
-    beforeEach(() => {
+    beforeEach(function () {
       sandbox = sinon.sandbox.create();
     });
 
-    afterEach(() => {
+    afterEach(function () {
       sandbox.restore();
     });
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -640,7 +640,7 @@ describe('Utils', function () {
   });
 
   describe('getDefinedParams', function () {
-    it('builds an object consisting of defined params', () => {
+    it('builds an object consisting of defined params', function () {
       const adUnit = {
         mediaType: 'video',
         comeWithMe: 'ifuwant2live',
@@ -659,7 +659,7 @@ describe('Utils', function () {
   });
 
   describe('deepClone', function () {
-    it('deep copies objects', () => {
+    it('deep copies objects', function () {
       const adUnit = [{
         code: 'swan',
         mediaTypes: {video: {context: 'outstream'}},
@@ -692,7 +692,7 @@ describe('Utils', function () {
       }]
     }];
 
-    it('should return params configured', () => {
+    it('should return params configured', function () {
       const output = utils.getUserConfiguredParams(adUnits, 'adUnit1', 'bidder1');
       const expected = [{
         key1: 'value1'
@@ -700,19 +700,19 @@ describe('Utils', function () {
       assert.deepEqual(output, expected);
     });
 
-    it('should return array containting empty object, if bidder present and no params are configured', () => {
+    it('should return array containting empty object, if bidder present and no params are configured', function () {
       const output = utils.getUserConfiguredParams(adUnits, 'adUnit1', 'bidder2');
       const expected = [{}];
       assert.deepEqual(output, expected);
     });
 
-    it('should return empty array, if bidder is not present', () => {
+    it('should return empty array, if bidder is not present', function () {
       const output = utils.getUserConfiguredParams(adUnits, 'adUnit1', 'bidder3');
       const expected = [];
       assert.deepEqual(output, expected);
     });
 
-    it('should return empty array, if adUnit is not present', () => {
+    it('should return empty array, if adUnit is not present', function () {
       const output = utils.getUserConfiguredParams(adUnits, 'adUnit2', 'bidder3');
       const expected = [];
       assert.deepEqual(output, expected);
@@ -730,7 +730,7 @@ describe('Utils', function () {
       sandbox.restore();
     });
 
-    it('returns window.location if not in iFrame', () => {
+    it('returns window.location if not in iFrame', function () {
       sandbox.stub(utils, 'getWindowLocation').returns({
         href: 'https://www.google.com/',
         ancestorOrigins: {},
@@ -762,7 +762,7 @@ describe('Utils', function () {
       expect(topWindowLocation.host).to.equal('www.google.com');
     });
 
-    it('returns parsed dom string from ancestorOrigins if in iFrame & ancestorOrigins is populated', () => {
+    it('returns parsed dom string from ancestorOrigins if in iFrame & ancestorOrigins is populated', function () {
       sandbox.stub(utils, 'getWindowSelf').returns(
         { self: 'is not same as top' }
       );
@@ -783,7 +783,7 @@ describe('Utils', function () {
       expect(topWindowLocation.host).to.be.oneOf(['www.google.com', 'www.google.com:443']);
     });
 
-    it('returns parsed referrer string if in iFrame but no ancestorOrigins', () => {
+    it('returns parsed referrer string if in iFrame but no ancestorOrigins', function () {
       sandbox.stub(utils, 'getWindowSelf').returns(
         { self: 'is not same as top' }
       );
@@ -807,7 +807,7 @@ describe('Utils', function () {
   });
 
   describe('convertCamelToUnderscore', function () {
-    it('returns converted string value using underscore syntax instead of camelCase', () => {
+    it('returns converted string value using underscore syntax instead of camelCase', function () {
       let var1 = 'placementIdTest';
       let test1 = utils.convertCamelToUnderscore(var1);
       expect(test1).to.equal('placement_id_test');
@@ -819,17 +819,17 @@ describe('Utils', function () {
   });
 
   describe('getAdUnitSizes', function () {
-    it('returns an empty response when adUnits is undefined', () => {
+    it('returns an empty response when adUnits is undefined', function () {
       let sizes = utils.getAdUnitSizes();
       expect(sizes).to.be.undefined;
     });
 
-    it('returns an empty array when invalid data is present in adUnit object', () => {
+    it('returns an empty array when invalid data is present in adUnit object', function () {
       let sizes = utils.getAdUnitSizes({ sizes: 300 });
       expect(sizes).to.deep.equal([]);
     });
 
-    it('retuns an array of arrays when reading from adUnit.sizes', () => {
+    it('retuns an array of arrays when reading from adUnit.sizes', function () {
       let sizes = utils.getAdUnitSizes({ sizes: [300, 250] });
       expect(sizes).to.deep.equal([[300, 250]]);
 
@@ -837,7 +837,7 @@ describe('Utils', function () {
       expect(sizes).to.deep.equal([[300, 250], [300, 600]]);
     });
 
-    it('returns an array of arrays when reading from adUnit.mediaTypes.banner.sizes', () => {
+    it('returns an array of arrays when reading from adUnit.mediaTypes.banner.sizes', function () {
       let sizes = utils.getAdUnitSizes({ mediaTypes: { banner: { sizes: [300, 250] } } });
       expect(sizes).to.deep.equal([[300, 250]]);
 

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -5,7 +5,7 @@ import { config } from 'src/config';
 
 const should = chai.should();
 
-describe('The video cache', () => {
+describe('The video cache', function () {
   function assertError(callbackSpy) {
     callbackSpy.calledOnce.should.equal(true);
     callbackSpy.firstCall.args[0].should.be.an('error');
@@ -16,7 +16,7 @@ describe('The video cache', () => {
     should.not.exist(callbackSpy.firstCall.args[0]);
   }
 
-  describe('when the cache server is unreachable', () => {
+  describe('when the cache server is unreachable', function () {
     let xhr;
     let requests;
 
@@ -41,7 +41,7 @@ describe('The video cache', () => {
     });
   });
 
-  describe('when the cache server is available', () => {
+  describe('when the cache server is available', function () {
     let xhr;
     let requests;
 
@@ -150,7 +150,7 @@ describe('The video cache', () => {
   });
 });
 
-describe('The getCache function', () => {
+describe('The getCache function', function () {
   beforeEach(() => {
     config.setConfig({
       cache: {

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -20,13 +20,15 @@ describe('The video cache', function () {
     let xhr;
     let requests;
 
-    beforeEach(() => {
+    beforeEach(function () {
       xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = (request) => requests.push(request);
     });
 
-    afterEach(() => xhr.restore());
+    afterEach(function () {
+      xhr.restore();
+    });
 
     it('should execute the callback with an error when store() is called', function () {
       const callback = sinon.spy();
@@ -45,7 +47,7 @@ describe('The video cache', function () {
     let xhr;
     let requests;
 
-    beforeEach(() => {
+    beforeEach(function () {
       xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = (request) => requests.push(request);
@@ -56,7 +58,7 @@ describe('The video cache', function () {
       })
     });
 
-    afterEach(() => {
+    afterEach(function () {
       xhr.restore();
       config.resetConfig();
     });
@@ -151,7 +153,7 @@ describe('The video cache', function () {
 });
 
 describe('The getCache function', function () {
-  beforeEach(() => {
+  beforeEach(function () {
     config.setConfig({
       cache: {
         url: 'https://prebid.adnxs.com/pbc/v1/cache'
@@ -159,7 +161,7 @@ describe('The getCache function', function () {
     })
   });
 
-  afterEach(() => {
+  afterEach(function () {
     config.resetConfig();
   });
 

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -28,7 +28,7 @@ describe('The video cache', function () {
 
     afterEach(() => xhr.restore());
 
-    it('should execute the callback with an error when store() is called', () => {
+    it('should execute the callback with an error when store() is called', function () {
       const callback = sinon.spy();
       store([ { vastUrl: 'my-mock-url.com' } ], callback);
 
@@ -61,7 +61,7 @@ describe('The video cache', function () {
       config.resetConfig();
     });
 
-    it('should execute the callback with a successful result when store() is called', () => {
+    it('should execute the callback with a successful result when store() is called', function () {
       const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
       const callback = fakeServerCall(
         { vastUrl: 'my-mock-url.com' },
@@ -71,7 +71,7 @@ describe('The video cache', function () {
       callback.firstCall.args[1].should.deep.equal([{ uuid: uuid }]);
     });
 
-    it('should execute the callback with an error if the cache server response has no responses property', () => {
+    it('should execute the callback with an error if the cache server response has no responses property', function () {
       const callback = fakeServerCall(
         { vastUrl: 'my-mock-url.com' },
         '{"broken":[{"uuid":"c488b101-af3e-4a99-b538-00423e5a3371"}]}');
@@ -79,7 +79,7 @@ describe('The video cache', function () {
       callback.firstCall.args[1].should.deep.equal([]);
     });
 
-    it('should execute the callback with an error if the cache server responds with malformed JSON', () => {
+    it('should execute the callback with an error if the cache server responds with malformed JSON', function () {
       const callback = fakeServerCall(
         { vastUrl: 'my-mock-url.com' },
         'Not JSON here');
@@ -87,7 +87,7 @@ describe('The video cache', function () {
       callback.firstCall.args[1].should.deep.equal([]);
     });
 
-    it('should make the expected request when store() is called on an ad with a vastUrl', () => {
+    it('should make the expected request when store() is called on an ad with a vastUrl', function () {
       const expectedValue = `<VAST version="3.0">
     <Ad>
       <Wrapper>
@@ -101,7 +101,7 @@ describe('The video cache', function () {
       assertRequestMade({ vastUrl: 'my-mock-url.com' }, expectedValue)
     });
 
-    it('should make the expected request when store() is called on an ad with a vastUrl and a vastImpUrl', () => {
+    it('should make the expected request when store() is called on an ad with a vastUrl and a vastImpUrl', function () {
       const expectedValue = `<VAST version="3.0">
     <Ad>
       <Wrapper>
@@ -115,7 +115,7 @@ describe('The video cache', function () {
       assertRequestMade({ vastUrl: 'my-mock-url.com', vastImpUrl: 'imptracker.com' }, expectedValue)
     });
 
-    it('should make the expected request when store() is called on an ad with vastXml', () => {
+    it('should make the expected request when store() is called on an ad with vastXml', function () {
       const vastXml = '<VAST version="3.0"></VAST>';
       assertRequestMade({ vastXml: vastXml }, vastXml);
     });
@@ -163,7 +163,7 @@ describe('The getCache function', function () {
     config.resetConfig();
   });
 
-  it('should return the expected URL', () => {
+  it('should return the expected URL', function () {
     const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
     const url = getCacheUrl(uuid);
     url.should.equal(`https://prebid.adnxs.com/pbc/v1/cache?uuid=${uuid}`);

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,7 +1,7 @@
 import { isValidVideoBid } from 'src/video';
 
 describe('video.js', function () {
-  it('validates valid instream bids', () => {
+  it('validates valid instream bids', function () {
     const bid = {
       adId: '123abc',
       vastUrl: 'http://www.example.com/vastUrl'
@@ -19,7 +19,7 @@ describe('video.js', function () {
     expect(valid).to.equal(true);
   });
 
-  it('catches invalid instream bids', () => {
+  it('catches invalid instream bids', function () {
     const bid = {
       adId: '123abc'
     };
@@ -36,7 +36,7 @@ describe('video.js', function () {
     expect(valid).to.equal(false);
   });
 
-  it('catches invalid bids when prebid-cache is disabled', () => {
+  it('catches invalid bids when prebid-cache is disabled', function () {
     const bidRequests = [{
       bids: [{
         bidder: 'vastOnlyVideoBidder',
@@ -49,7 +49,7 @@ describe('video.js', function () {
     expect(valid).to.equal(false);
   });
 
-  it('validates valid outstream bids', () => {
+  it('validates valid outstream bids', function () {
     const bid = {
       adId: '123abc',
       renderer: {
@@ -70,7 +70,7 @@ describe('video.js', function () {
     expect(valid).to.equal(true);
   });
 
-  it('catches invalid outstream bids', () => {
+  it('catches invalid outstream bids', function () {
     const bid = {
       adId: '123abc'
     };

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,6 +1,6 @@
 import { isValidVideoBid } from 'src/video';
 
-describe('video.js', () => {
+describe('video.js', function () {
   it('validates valid instream bids', () => {
     const bid = {
       adId: '123abc',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Replacing all arrow functions in Mocha function calls (`describe`, `it`, `before`, `beforeEach`, `after`, `afterEach`) to answer #2987.
