### PR TITLE
Explicitly set ajax() XHR to asynchronous.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -66,7 +66,7 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
         url = formatURL(urlInfo);
       }
 
-      x.open(method, url);
+      x.open(method, url, true);
       // IE needs timoeut to be set after open - see #1410
       // Disabled timeout temporarily to avoid xhr failed requests. https://github.com/prebid/Prebid.js/issues/2648
       if (!config.getConfig('disableAjaxTimeout')) {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
I ran into an issue where Prebid was running on a site that also loaded some third-party JavaScript that modified the XHR.prototype.open. This overwritten version of the function did not set the request to be asynchronous by default. Setting it explicitly would resolve issues like this going forward. 
