### PR TITLE
YIELDONE adapter - added UserSync

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -4,6 +4,7 @@ import {registerBidder} from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'yieldone';
 const ENDPOINT_URL = '//y.one.impact-ad.jp/h_bid';
+const USER_SYNC_URL = '//y.one.impact-ad.jp/push_sync';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -66,6 +67,14 @@ export const spec = {
       bidResponses.push(bidResponse);
     }
     return bidResponses;
+  },
+  getUserSyncs: function(syncOptions) {
+    if (syncOptions.iframeEnabled) {
+      return [{
+        type: 'iframe',
+        url: USER_SYNC_URL
+      }];
+    }
   }
 }
 registerBidder(spec);

--- a/modules/yieldoneBidAdapter.md
+++ b/modules/yieldoneBidAdapter.md
@@ -25,3 +25,15 @@ THE YIELDONE adapter requires setup and approval from the YIELDONE team. Please 
     }]
   }];
 ```
+
+### Configuration
+
+YIELDONE recommends the UserSync configuration below.  Without it, the YIELDONE adapter will not able to perform user syncs, which lowers match rate and reduces monetization.
+
+```javascript
+pbjs.setConfig({
+   userSync: {
+    iframeEnabled: true,
+    enabledBidders: ['yieldone']
+ }});
+```

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -144,4 +144,20 @@ describe('yieldoneBidAdapter', function() {
       expect(result.length).to.equal(0);
     });
   });
+
+  describe('getUserSyncs', function () {
+    const userSyncUrl = '//y.one.impact-ad.jp/push_sync';
+
+    it('handles empty sync options', function () {
+      expect(spec.getUserSyncs({})).to.be.empty;
+    });
+
+    it('should return a sync url if iframe syncs are enabled', function () {
+      expect(spec.getUserSyncs({
+        'iframeEnabled': true
+      })).to.deep.equal([{
+        type: 'iframe', url: userSyncUrl
+      }]);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added functions related to UserSync

Be sure to test the integration with your adserver using the [Hello World](https://webdemo.dac.co.jp/kusapan/hb/180904.html) sample page.

- contact email of the adapter’s maintainer y1dev@platform-one.co.jp
- [x] official adapter submission