### PR TITLE
Fix creativeId field in Yieldmo bid response

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -111,7 +111,7 @@ function createNewBid(response) {
     cpm: response.cpm,
     width: response.width,
     height: response.height,
-    creativeId: response.creativeId,
+    creativeId: response.creative_id,
     currency: CURRENCY,
     netRevenue: NET_REVENUE,
     ttl: TIME_TO_LIVE,

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -104,7 +104,7 @@ describe('YieldmoAdapter', function () {
           width: 300,
           height: 250,
           ad: '<html><head></head><body><script>//GEX ad object</script><div id=\"ym_123\" class=\"ym\"></div><script>//js code</script></body></html>',
-          creativeId: '9874652394875'
+          creative_id: '9874652394875'
         }],
         header: 'header?'
       };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We had an issue whereby prebid wasn't passing us yieldmo bids even though we could see them in the network requests. Turned out that the `creativeId` field was being set to `undefined` because the response body from the yieldmo server uses snake case, not camel case. Tested the proposed fix and saw prebid log the bid as expected.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
