### PR TITLE
getTopWindowLocation was not returning the same value always

### DIFF
--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -784,14 +784,10 @@ describe('Utils', function () {
     });
 
     it('returns parsed referrer string if in iFrame but no ancestorOrigins', function () {
-      sandbox.stub(utils, 'getWindowSelf').returns(
-        { self: 'is not same as top' }
-      );
-      sandbox.stub(utils, 'getWindowTop').returns(
-        { top: 'is not same as self' }
+      sandbox.stub(utils, 'getTopFrame').returns(
+        { location: { origin: 'https://www.example.com/' } }
       );
       sandbox.stub(utils, 'getAncestorOrigins').returns(null);
-      sandbox.stub(utils, 'getTopFrameReferrer').returns('https://www.example.com/');
       var topWindowLocation = utils.getTopWindowLocation();
       expect(topWindowLocation).to.be.a('object');
       expect(topWindowLocation.href).to.equal('https://www.example.com/');


### PR DESCRIPTION
there is difference between firefox and chrome described in #2938.

In Chrome, the location is returned from [`getAncestorOrigins`](https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L227), but since that property is not available to Firefox, in Firefox the path leads to `getTopFrameReferrer` and in line [213](https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L213) where `currentWindow` is the top frame, `currentWindow.document.referrer` is undefined.

According to a [discussion in Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1085214#c0):
> location.ancestorOrigins should contain a read-only array of **hostnames** for all the parent frames.

And according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer), `Document.referrer` is a different thing:
> Returns the **URI** of the page that linked to this page.

So I think the problem starts with [`getTopWindowLocation`](https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L196) interchanging hostname with referrer.

The closest I could find to `ancestorOrigins` in Firefox is `location.origin`.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other