### PR TITLE
Fix #3059 by returning both hb_deal and hb_deal_${bidder_code}

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -259,9 +259,16 @@ export function newTargeting(auctionManager) {
             typeof winner.sendStandardTargeting === 'undefined' ||
             winner.sendStandardTargeting ||
             standardKeys.indexOf(key) === -1)
-          .map(key => ({
-            [(key === 'hb_deal') ? `${key}_${winner.bidderCode}`.substring(0, MAX_DFP_KEYLENGTH) : key.substring(0, MAX_DFP_KEYLENGTH)]: [winner.adserverTargeting[key]]
-          }))
+          .reduce((acc, key) => {
+            const targetingValue = [winner.adserverTargeting[key]];
+            const targeting = { [key.substring(0, MAX_DFP_KEYLENGTH)]: targetingValue };
+            if (key === 'hb_deal') {
+              const bidderCodeTargetingKey = `${key}_${winner.bidderCode}`.substring(0, MAX_DFP_KEYLENGTH);
+              const bidderCodeTargeting = { [bidderCodeTargetingKey]: targetingValue };
+              return [...acc, targeting, bidderCodeTargeting];
+            }
+            return [...acc, targeting];
+          }, [])
       };
     });
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -30,6 +30,7 @@ const bid1 = {
     'hb_bidder': 'rubicon',
     'hb_adid': '148018fe5e',
     'hb_pb': '0.53',
+    'hb_deal': '1234',
     'foobar': '300x250'
   },
   'netRevenue': true,
@@ -120,6 +121,18 @@ describe('targeting tests', function () {
       targetingModule.isBidNotExpired.restore();
     });
 
+    describe('when hb_deal is present in bid.adserverTargeting', function () {
+      it('returns targeting with both hb_deal and hb_deal_{bidder_code}', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+
+        // We should add both keys rather than one or the other
+        expect(targeting['/123456/header-bid-tag-0']).to.contain.keys('hb_deal', `hb_deal_${bid1.bidderCode}`);
+
+        // We should assign both keys the same value
+        expect(targeting['/123456/header-bid-tag-0']['hb_deal']).to.deep.equal(targeting['/123456/header-bid-tag-0'][`hb_deal_${bid1.bidderCode}`]);
+      });
+    });
+
     it('selects the top bid when _sendAllBids true', function () {
       config.setConfig({ enableSendAllBids: true });
       let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
@@ -127,7 +140,7 @@ describe('targeting tests', function () {
       // we should only get the targeting data for the one requested adunit
       expect(Object.keys(targeting).length).to.equal(1);
 
-      let sendAllBidCpm = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf('hb_pb_') != -1)
+      let sendAllBidCpm = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf('hb_pb_') != -1);
       // we shouldn't get more than 1 key for hb_pb_${bidder}
       expect(sendAllBidCpm.length).to.equal(1);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Per #3059, the targeting key `hb_deal` is being replaced by `hb_deal_${bidder_code}` rather than both being sent. This pull will change the logic of `getWinningBidTargeting` to return both `hb_deal` and `hb_deal_${bidder_code}`

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Fixes #3059 per @snapwich's report. + @mkendall07 and @jaiminpanchal27 
