### PR TITLE
Fix the secure creative resizing

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -72,8 +72,8 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
     let elementStyle = getElementByAdUnit(elmType).style;
-    elementStyle.width = width;
-    elementStyle.height = height;
+    elementStyle.width = `${width}px`;
+    elementStyle.height = `${height}px`;
   });
   function getElementByAdUnit(elmType) {
     return document.getElementById(find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -72,8 +72,8 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
     let elementStyle = getElementByAdUnit(elmType).style;
-    elementStyle.width = `${width}px`;
-    elementStyle.height = `${height}px`;
+    elementStyle.width = width + 'px';
+    elementStyle.height = height + 'px';
   });
   function getElementByAdUnit(elmType) {
     return document.getElementById(find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)


### PR DESCRIPTION
## Type of change
- [ x ] Bugfix

## Description of change
Explicitly setting the unit, `px`, when resizing the safeframe and its container div. 

## Other information
Issue #3065 
