### PR TITLE
AOL adapter - add defaults for currency and creative ID until fix issued server-side

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -389,7 +389,7 @@ export const spec = {
       height: bidData.h,
       creativeId: bidData.crid || 0,
       pubapiId: response.id,
-      currency: response.cur || "USD",
+      currency: response.cur || 'USD',
       dealId: bidData.dealid,
       netRevenue: true,
       ttl: bidRequest.ttl

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -387,9 +387,9 @@ export const spec = {
       cpm: cpm,
       width: bidData.w,
       height: bidData.h,
-      creativeId: bidData.crid,
+      creativeId: bidData.crid || 0,
       pubapiId: response.id,
-      currency: response.cur,
+      currency: response.cur || "USD",
       dealId: bidData.dealid,
       netRevenue: true,
       ttl: bidRequest.ttl


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This provides temporary defaults for currency code and creative ID for the AOL ONE bidder while these are added to server-side bid responses. This required due to PR #2923

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
cc @vzhukovsky  fyi