### PR TITLE
Fix #3055 and maintain compatibility with Node v4.0.0 by removing .includes from build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,7 +181,7 @@ function bundle(dev, moduleArr) {
   var allModules = helpers.getModuleNames(modules);
 
   if (modules.length === 0) {
-    modules = allModules.filter(module => !explicitModules.includes(module));
+    modules = allModules.filter(module => explicitModules.indexOf(module) === -1);
   } else {
     var diff = _.difference(modules, allModules);
     if (diff.length !== 0) {

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -19,7 +19,7 @@ module.exports = {
     ],
   },
   output: {
-    jsonpFunction: prebid.globalVarName+"Chunk"
+    jsonpFunction: prebid.globalVarName + "Chunk"
   },
   module: {
     rules: [
@@ -88,7 +88,7 @@ module.exports = {
       name: 'prebid',
       filename: 'prebid-core.js',
       minChunks: function(module, count) {
-        return !(count < 2 || neverBundle.includes(path.basename(module.resource)))
+        return !(count < 2 || neverBundle.indexOf(path.basename(module.resource)) !== -1)
       }
     })
   ]


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Ensure compatibility Node v4.0.0 (as advertised by `package.json` and README) by replacing `.includes` with equivalent `.indexOf` in `gulpfile.js` and `webpack.conf.js`

## Other information
Fixes #3055, though via maintaining compatibility with advertised Node version rather than upping advertised requirement to v.6.0.0.

Tested with Node v4.0.0 and lts/argon (v4.9.1)
