### PR TITLE
Wrap window.top reference with try/catch in aardvark adapter

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -28,9 +28,12 @@ export const spec = {
     var referer = utils.getTopWindowUrl();
     var pageCategories = [];
 
-    if (window.top.rtkcategories && Array.isArray(window.top.rtkcategories)) {
-      pageCategories = window.top.rtkcategories;
-    }
+    // This reference to window.top can cause issues when loaded in an iframe if not protected with a try/catch.
+    try {
+      if (window.top.rtkcategories && Array.isArray(window.top.rtkcategories)) {
+        pageCategories = window.top.rtkcategories;
+      }
+    } catch (e) {}
 
     utils._each(validBidRequests, function(b) {
       var rMap = requestsMap[b.params.ai];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
A reference to `window.top` in the Aardvark adapter caused issues for us when delivered in a cross-domain iframe. There was no error specifically from the Prebid.js lib but many of our separate frontend tests failed due to auction timeouts. Adding this try/catch was the simplest fix which solved the issue.

