### PR TITLE
rubicon adapter - make sure creativeId is not empty

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -415,7 +415,7 @@ export const spec = {
         let bid = {
           requestId: associatedBidRequest.bidId,
           currency: 'USD',
-          creativeId: ad.creative_id,
+          creativeId: ad.creative_id || `${ad.network || ''}-${ad.advertiser || ''}`,
           cpm: ad.cpm || 0,
           dealId: ad.deal,
           ttl: 300, // 5 minutes

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1534,6 +1534,129 @@ describe('the rubicon adapter', function () {
           expect(bids[1].rubiconTargeting.rpfl_14062).to.equal('15_tier_all_test');
         });
 
+        it('should use "network-advertiser" if no creative_id', function () {
+          let response = {
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
+              43, 10, 2
+            ],
+            'tracking': '',
+            'inventory': {}
+          };
+
+          response.ads = [
+            {
+              'status': 'ok',
+              'impression_id': '153dc240-8229-4604-b8f5-256933b9374c',
+              'size_id': '15',
+              'ad_id': '6',
+              'advertiser': 7,
+              'network': 8,
+              'type': 'script',
+              'script': 'alert(\'foo\')',
+              'campaign_id': 10,
+              'cpm': 0.811,
+              'targeting': [
+                {
+                  'key': 'rpfl_14062',
+                  'values': [
+                    '15_tier_all_test'
+                  ]
+                }
+              ]
+            }
+          ];
+
+          let bids = spec.interpretResponse({body: response}, {
+            bidRequest: bidderRequest.bids[0]
+          });
+          expect(bids[0].creativeId).to.equal('8-7');
+
+          response.ads = [
+            {
+              'status': 'ok',
+              'impression_id': '153dc240-8229-4604-b8f5-256933b9374d',
+              'size_id': '43',
+              'ad_id': '7',
+              'type': 'script',
+              'script': 'alert(\'foo\')',
+              'campaign_id': 10,
+              'cpm': 0.911,
+              'targeting': [
+                {
+                  'key': 'rpfl_14062',
+                  'values': [
+                    '43_tier_all_test'
+                  ]
+                }
+              ]
+            }
+          ];
+
+          bids = spec.interpretResponse({body: response}, {
+            bidRequest: bidderRequest.bids[0]
+          });
+          expect(bids[0].creativeId).to.equal('-');
+
+          response.ads = [
+            {
+              'status': 'ok',
+              'impression_id': '153dc240-8229-4604-b8f5-256933b9374d',
+              'size_id': '10',
+              'ad_id': '7',
+              'network': 8,
+              'type': 'script',
+              'script': 'alert(\'foo\')',
+              'campaign_id': 10,
+              'cpm': 0.911,
+              'targeting': [
+                {
+                  'key': 'rpfl_14062',
+                  'values': [
+                    '10_tier_all_test'
+                  ]
+                }
+              ]
+            }
+          ];
+
+          bids = spec.interpretResponse({body: response}, {
+            bidRequest: bidderRequest.bids[0]
+          });
+          expect(bids[0].creativeId).to.equal('8-');
+
+          response.ads = [
+            {
+              'status': 'ok',
+              'impression_id': '153dc240-8229-4604-b8f5-256933b9374d',
+              'size_id': '2',
+              'ad_id': '7',
+              'advertiser': 7,
+              'type': 'script',
+              'script': 'alert(\'foo\')',
+              'campaign_id': 10,
+              'cpm': 0.911,
+              'targeting': [
+                {
+                  'key': 'rpfl_14062',
+                  'values': [
+                    '2_tier_all_test'
+                  ]
+                }
+              ]
+            }
+          ];
+
+          bids = spec.interpretResponse({body: response}, {
+            bidRequest: bidderRequest.bids[0]
+          });
+          expect(bids[0].creativeId).to.equal('-7');
+        });
+
         it('should be fine with a CPM of 0', function () {
           let response = {
             'status': 'ok',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
