### PR TITLE
Audience Network: deprecate fullwidth format, prefer 300x250

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -3,7 +3,7 @@
  */
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { formatQS } from 'src/url';
-import { generateUUID, getTopWindowUrl, isSafariBrowser, convertTypes } from 'src/utils';
+import { generateUUID, getTopWindowUrl, convertTypes } from 'src/utils';
 import findIndex from 'core-js/library/fn/array/find-index';
 import includes from 'core-js/library/fn/array/includes';
 
@@ -18,7 +18,7 @@ const ttl = 600;
 const videoTtl = 3600;
 const platver = '$prebid.version$';
 const platform = '241394079772386';
-const adapterver = '1.0.1';
+const adapterver = '1.1.0';
 
 /**
  * Does this bid request contain valid parameters?
@@ -72,6 +72,22 @@ const isValidSizeAndFormat = (size, format) =>
   (isFullWidth(format) && flattenSize(size) === '300x250') ||
   isValidNonSizedFormat(format) ||
   isValidSize(flattenSize(size));
+
+/**
+ * Find a preferred entry, if any, from an array of valid sizes.
+ * @param {Array<String>} acc
+ * @param {String} cur
+ */
+const sortByPreferredSize = (acc, cur) =>
+  (cur === '300x250') ? [cur, ...acc] : [...acc, cur];
+
+/**
+ * Map any deprecated size/formats to new values.
+ * @param {String} size
+ * @param {String} format
+ */
+const mapDeprecatedSizeAndFormat = (size, format) =>
+  isFullWidth(format) ? ['300x250', null] : [size, format];
 
 /**
  * Is this a video format?
@@ -142,9 +158,9 @@ const getTopWindowUrlEncoded = () => encodeURIComponent(getTopWindowUrl());
  * @param {Object} bids[].params
  * @param {String} bids[].params.placementId - Audience Network placement identifier
  * @param {String} bids[].params.platform - Audience Network platform identifier (optional)
- * @param {String} bids[].params.format - Optional format, one of 'video', 'native' or 'fullwidth' if set
+ * @param {String} bids[].params.format - Optional format, one of 'video' or 'native' if set
  * @param {Array} bids[].sizes - list of desired advert sizes
- * @param {Array} bids[].sizes[] - Size arrays [h,w]: should include one of [300, 250], [320, 50]: first matched size is used
+ * @param {Array} bids[].sizes[] - Size arrays [h,w]: should include one of [300, 250], [320, 50]
  * @returns {Array<Object>} List of URLs to fetch, plus formats and sizes for later use with interpretResponse
  */
 const buildRequests = bids => {
@@ -159,12 +175,14 @@ const buildRequests = bids => {
   bids.forEach(bid => bid.sizes
     .map(flattenSize)
     .filter(size => isValidSizeAndFormat(size, bid.params.format))
+    .reduce(sortByPreferredSize, [])
     .slice(0, 1)
-    .forEach(size => {
+    .forEach(preferredSize => {
+      const [size, format] = mapDeprecatedSizeAndFormat(preferredSize, bid.params.format);
       placementids.push(bid.params.placementId);
-      adformats.push(bid.params.format || size);
+      adformats.push(format || size);
       sizes.push(size);
-      sdk.push(sdkVersion(bid.params.format));
+      sdk.push(sdkVersion(format));
       platforms.push(bid.params.platform);
       requestIds.push(bid.bidId);
     })
@@ -174,6 +192,7 @@ const buildRequests = bids => {
   const testmode = isTestmode();
   const pageurl = getTopWindowUrlEncoded();
   const platform = findPlatform(platforms);
+  const cb = generateUUID();
   const search = {
     placementids,
     adformats,
@@ -182,14 +201,12 @@ const buildRequests = bids => {
     sdk,
     adapterver,
     platform,
-    platver
+    platver,
+    cb
   };
   const video = findIndex(adformats, isVideo);
   if (video !== -1) {
     [search.playerwidth, search.playerheight] = expandSize(sizes[video]);
-  }
-  if (isSafariBrowser()) {
-    search.cb = generateUUID();
   }
   const data = formatQS(search);
 

--- a/modules/audienceNetworkBidAdapter.md
+++ b/modules/audienceNetworkBidAdapter.md
@@ -11,7 +11,7 @@ Maintainer: Lovell Fuller
 | Name          | Scope    | Description                                     | Example                           |
 | :------------ | :------- | :---------------------------------------------- | :--------------------------------- |
 | `placementId` | required | The Placement ID from Audience Network          | "555555555555555\_555555555555555" |
-| `format`      | optional | Format, one of "native", "fullwidth" or "video" | "native"                           |
+| `format`      | optional | Format, one of "native" or "video"              | "native"                           |
 
 # Example ad units
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR for the Audience Network adapter deprecates the "fullwidth" format, replacing it instead with the preferred "300x250" size.

It also extends the cache-busting logic that was previously Safari-only to all requests.

Unit tests are updated to cover all the code changes, plus an internal version bump of the `adapterver` to aid debugging.

This work was commissioned and paid for by Facebook.