### PR TITLE
Rubicon adapter: DecodeUrl if url is encoded

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -111,7 +111,7 @@ export const spec = {
       let size = parseSizes(bidRequest);
 
       let data = {
-        page_url: _getPageUrl(bidRequest),
+        page_url: _getPageUrl(bidRequest, bidderRequest),
         resolution: _getScreenResolution(),
         account_id: params.accountId,
         integration: INTEGRATION,
@@ -323,9 +323,13 @@ export const spec = {
       'tk_user_key': params.userId,
       'p_geo.latitude': isNaN(parseFloat(latitude)) ? undefined : parseFloat(latitude).toFixed(4),
       'p_geo.longitude': isNaN(parseFloat(longitude)) ? undefined : parseFloat(longitude).toFixed(4),
-      'tg_fl.eid': bidRequest.code,
-      'rf': _getPageUrl(bidRequest)
+      'tg_fl.eid': bidRequest.code
     };
+
+    if (bidderRequest || bidRequest) {
+      // add 'gdpr' only if 'gdprApplies' is defined
+      data['rf'] = _getPageUrl(bidRequest, bidderRequest);
+    }
 
     if (bidderRequest.gdprConsent) {
       // add 'gdpr' only if 'gdprApplies' is defined

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -323,13 +323,9 @@ export const spec = {
       'tk_user_key': params.userId,
       'p_geo.latitude': isNaN(parseFloat(latitude)) ? undefined : parseFloat(latitude).toFixed(4),
       'p_geo.longitude': isNaN(parseFloat(longitude)) ? undefined : parseFloat(longitude).toFixed(4),
-      'tg_fl.eid': bidRequest.code
+      'tg_fl.eid': bidRequest.code,
+      'rf': _getPageUrl(bidRequest, bidderRequest)
     };
-
-    if (bidderRequest || bidRequest) {
-      // add 'gdpr' only if 'gdprApplies' is defined
-      data['rf'] = _getPageUrl(bidRequest, bidderRequest);
-    }
 
     if (bidderRequest.gdprConsent) {
       // add 'gdpr' only if 'gdprApplies' is defined

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -500,12 +500,12 @@ function _getDigiTrustQueryParams() {
  * @param {BidRequest} bidRequest
  * @returns {string}
  */
-function _getPageUrl(bidRequest) {
+function _getPageUrl(bidRequest, bidderRequest) {
   let pageUrl = config.getConfig('pageUrl');
   if (bidRequest.params.referrer) {
     pageUrl = bidRequest.params.referrer;
   } else if (!pageUrl) {
-    pageUrl = utils.getTopWindowUrl();
+    pageUrl = bidderRequest.refererInfo.referer;
   }
   let _pageUrl = bidRequest.params.secure ? pageUrl.replace(/^http:/i, 'https:') : pageUrl;
   return decodeURIComponent(_pageUrl.replace(/\+/g, ' '))

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -507,7 +507,8 @@ function _getPageUrl(bidRequest) {
   } else if (!pageUrl) {
     pageUrl = utils.getTopWindowUrl();
   }
-  return bidRequest.params.secure ? pageUrl.replace(/^http:/i, 'https:') : pageUrl;
+  let _pageUrl = bidRequest.params.secure ? pageUrl.replace(/^http:/i, 'https:') : pageUrl;
+  return decodeURIComponent(_pageUrl.replace(/\+/g, ' '))
 }
 
 function _renderCreative(script, impId) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -467,20 +467,19 @@ describe('the rubicon adapter', function () {
         });
 
         it('should add referer info to request data', function () {
-          var refererBidderRequest = clone(bidderRequest);
-
-          delete refererBidderRequest.bids[0].params.referrer;
-          refererBidderRequest.refererInfo = {
+          let refererInfo = {
             referer: 'http%3A%2F%2Fwww.prebid.org',
             reachedTop: true,
             numIframes: 1,
             stack: [
-              'http%3A%2F%2Fwww.prebid.org',
+              'http%3A%2F%2Fwww.prebid.org%2Fpage.html',
               'http%3A%2F%2Fwww.prebid.org%2Fiframe1.html',
             ]
           };
 
-          let [request] = spec.buildRequests(refererBidderRequest.bids, refererBidderRequest);
+          bidderRequest = Object.assign({refererInfo}, bidderRequest);
+          delete bidderRequest.bids[0].params.referrer;
+          let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let data = parseQuery(request.data);
 
           expect(parseQuery(request.data).rf).to.exist;
@@ -492,7 +491,8 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('localhost');
 
           delete bidderRequest.bids[0].params.referrer;
-          bidderRequest.refererInfo = { referer: 'http%3A%2F%2Fwww.prebid.org' };
+          let refererInfo = { referer: 'http%3A%2F%2Fwww.prebid.org' };
+          bidderRequest = Object.assign({refererInfo}, bidderRequest);
           [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -468,10 +468,10 @@ describe('the rubicon adapter', function () {
 
         it('should add referer info to request data', function () {
           let refererInfo = {
-            referer: 'http%3A%2F%2Fwww.prebid.org',
-            reachedTop: true,
-            numIframes: 1,
-            stack: [
+            'referer': 'http%3A%2F%2Fwww.prebid.org',
+            'reachedTop': true,
+            'numIframes': 1,
+            'stack': [
               'http%3A%2F%2Fwww.prebid.org%2Fpage.html',
               'http%3A%2F%2Fwww.prebid.org%2Fiframe1.html',
             ]
@@ -491,8 +491,7 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('localhost');
 
           delete bidderRequest.bids[0].params.referrer;
-          let refererInfo = { referer: 'http%3A%2F%2Fwww.prebid.org' };
-          bidderRequest = Object.assign({refererInfo}, bidderRequest);
+          bidderRequest.refererInfo = { 'referer': 'http%3A%2F%2Fwww.prebid.org' };
           [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -487,7 +487,7 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
         });
 
-        it('page_url should use params.referrer, config.getConfig("pageUrl"), refererInfo.referer in that order', function () {
+        it('page_url should use params.referrer, config.getConfig("pageUrl"), bidderRequest.refererInfo in that order', function () {
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('localhost');
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -466,7 +466,7 @@ describe('the rubicon adapter', function () {
           });
         });
 
-        it('should add referer info to payload', function () {
+        it('should add referer info to request data', function () {
           var refererBidderRequest = clone(bidderRequest);
 
           delete refererBidderRequest.bids[0].params.referrer;
@@ -487,7 +487,7 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
         });
 
-        it('page_url should use params.referrer, config.getConfig("pageUrl"), utils.getTopWindowUrl() in that order', function () {
+        it('page_url should use params.referrer, config.getConfig("pageUrl"), refererInfo.referer in that order', function () {
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('localhost');
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -467,21 +467,19 @@ describe('the rubicon adapter', function () {
         });
 
         it('should add referer info to request data', function () {
-          const _bidderRequest = {
-            refererInfo: {
-              referer: 'http%3A%2F%2Fexample.com%2Fpage.html',
-              reachedTop: true,
-              numIframes: 2,
-              stack: [
-                'http%3A%2F%2Fexample.com%2Fpage.html',
-                'http%3A%2F%2Fexample.com%2Fiframe1.html',
-                'http%3A%2F%2Fexample.com%2Fiframe2.html'
-              ]
-            }
-          }
+          let refererInfo = {
+            referer: 'http%3A%2F%2Fwww.prebid.org',
+            reachedTop: true,
+            numIframes: 1,
+            stack: [
+              'http%3A%2F%2Fwww.prebid.org%2Fpage.html',
+              'http%3A%2F%2Fwww.prebid.org%2Fiframe1.html',
+            ]
+          };
 
+          bidderRequest = Object.assign({refererInfo}, bidderRequest);
           delete bidderRequest.bids[0].params.referrer;
-          let [request] = spec.buildRequests(bidderRequest.bids, _bidderRequest);
+          let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           let data = parseQuery(request.data);
 
           expect(parseQuery(request.data).rf).to.exist;
@@ -493,9 +491,8 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('localhost');
 
           delete bidderRequest.bids[0].params.referrer;
-          bidderRequest.refererInfo = {
-            'referer': 'http%3A%2F%2Fwww.prebid.org'
-          };
+          let refererInfo = { referer: 'http%3A%2F%2Fwww.prebid.org' };
+          bidderRequest = Object.assign({refererInfo}, bidderRequest);
           [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -467,19 +467,21 @@ describe('the rubicon adapter', function () {
         });
 
         it('should add referer info to request data', function () {
-          let refererInfo = {
-            'referer': 'http%3A%2F%2Fwww.prebid.org',
-            'reachedTop': true,
-            'numIframes': 1,
-            'stack': [
-              'http%3A%2F%2Fwww.prebid.org%2Fpage.html',
-              'http%3A%2F%2Fwww.prebid.org%2Fiframe1.html',
-            ]
-          };
+          const _bidderRequest = {
+            refererInfo: {
+              referer: 'http%3A%2F%2Fexample.com%2Fpage.html',
+              reachedTop: true,
+              numIframes: 2,
+              stack: [
+                'http%3A%2F%2Fexample.com%2Fpage.html',
+                'http%3A%2F%2Fexample.com%2Fiframe1.html',
+                'http%3A%2F%2Fexample.com%2Fiframe2.html'
+              ]
+            }
+          }
 
-          bidderRequest = Object.assign({refererInfo}, bidderRequest);
           delete bidderRequest.bids[0].params.referrer;
-          let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+          let [request] = spec.buildRequests(bidderRequest.bids, _bidderRequest);
           let data = parseQuery(request.data);
 
           expect(parseQuery(request.data).rf).to.exist;
@@ -491,7 +493,9 @@ describe('the rubicon adapter', function () {
           expect(parseQuery(request.data).rf).to.equal('localhost');
 
           delete bidderRequest.bids[0].params.referrer;
-          bidderRequest.refererInfo = { 'referer': 'http%3A%2F%2Fwww.prebid.org' };
+          bidderRequest.refererInfo = {
+            'referer': 'http%3A%2F%2Fwww.prebid.org'
+          };
           [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
           expect(parseQuery(request.data).rf).to.equal('http://www.prebid.org');
 


### PR DESCRIPTION
Appnexus new module is passing the encoded url and sometimes Publisher are passing encoded url in the referrer parameter. 
This fix is a protection in case a module is update and start passing encode url. Our AE is not decoding and from some test I did, monetisation could be highly impacted.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
