### PR TITLE
update test command in package.json scripts area

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.25.0-pre",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
-  "scripts": {
-    "test": "gulp lint && gulp test-coverage",
-    "lint": "gulp lint"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/prebid/Prebid.js.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
-    "test": "gulp run-tests",
+    "test": "gulp lint && gulp test-coverage",
     "lint": "gulp lint"
   },
   "repository": {


### PR DESCRIPTION
## Type of change
- [x] Build related changes


## Description of change
As a follow-up from the gulp 4 upgrade (#2930), a deprecated gulp command was still present in the `package.json` scripts area.  

I replaced the old `gulp run-scripts` command with the equivalent commands it used to run (`gulp lint` & `gulp test-coverage`).