### PR TITLE
Audience Network (legacy): deprecate fullwidth format, prefer 300x250

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -3,7 +3,7 @@
  */
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { formatQS } from 'src/url';
-import { getTopWindowUrl } from 'src/utils';
+import { generateUUID, getTopWindowUrl } from 'src/utils';
 import includes from 'core-js/library/fn/array/includes';
 
 const code = 'audienceNetwork';
@@ -17,7 +17,7 @@ const ttl = 600;
 const videoTtl = 3600;
 const platver = '$prebid.version$';
 const platform = '241394079772386';
-const adapterver = '0.1.1';
+const adapterver = '0.2.1';
 
 /**
  * Does this bid request contain valid parameters?
@@ -71,6 +71,22 @@ const isValidSizeAndFormat = (size, format) =>
   (isFullWidth(format) && flattenSize(size) === '300x250') ||
   isValidNonSizedFormat(format) ||
   isValidSize(flattenSize(size));
+
+/**
+ * Find a preferred entry, if any, from an array of valid sizes.
+ * @param {Array<String>} acc
+ * @param {String} cur
+ */
+const sortByPreferredSize = (acc, cur) =>
+  (cur === '300x250') ? [cur, ...acc] : [...acc, cur];
+
+/**
+ * Map any deprecated size/formats to new values.
+ * @param {String} size
+ * @param {String} format
+ */
+const mapDeprecatedSizeAndFormat = (size, format) =>
+  isFullWidth(format) ? ['300x250', null] : [size, format];
 
 /**
  * Is this a video format?
@@ -141,9 +157,9 @@ const getTopWindowUrlEncoded = () => encodeURIComponent(getTopWindowUrl());
  * @param {Object} bids[].params
  * @param {String} bids[].params.placementId - Audience Network placement identifier
  * @param {String} bids[].params.platform - Audience Network platform identifier (optional)
- * @param {String} bids[].params.format - Optional format, one of 'video', 'native' or 'fullwidth' if set
+ * @param {String} bids[].params.format - Optional format, one of 'video' or 'native' if set
  * @param {Array} bids[].sizes - list of desired advert sizes
- * @param {Array} bids[].sizes[] - Size arrays [h,w]: should include one of [300, 250], [320, 50]: first matched size is used
+ * @param {Array} bids[].sizes[] - Size arrays [h,w]: should include one of [300, 250], [320, 50]
  * @returns {Array<Object>} List of URLs to fetch, plus formats and sizes for later use with interpretResponse
  */
 const buildRequests = bids => {
@@ -158,12 +174,14 @@ const buildRequests = bids => {
   bids.forEach(bid => bid.sizes
     .map(flattenSize)
     .filter(size => isValidSizeAndFormat(size, bid.params.format))
+    .reduce(sortByPreferredSize, [])
     .slice(0, 1)
-    .forEach(size => {
+    .forEach(preferredSize => {
+      const [size, format] = mapDeprecatedSizeAndFormat(preferredSize, bid.params.format);
       placementids.push(bid.params.placementId);
-      adformats.push(bid.params.format || size);
+      adformats.push(format || size);
       sizes.push(size);
-      sdk.push(sdkVersion(bid.params.format));
+      sdk.push(sdkVersion(format));
       platforms.push(bid.params.platform);
       requestIds.push(bid.bidId);
     })
@@ -173,6 +191,7 @@ const buildRequests = bids => {
   const testmode = isTestmode();
   const pageurl = getTopWindowUrlEncoded();
   const platform = findPlatform(platforms);
+  const cb = generateUUID();
   const search = {
     placementids,
     adformats,
@@ -181,7 +200,8 @@ const buildRequests = bids => {
     sdk,
     adapterver,
     platform,
-    platver
+    platver,
+    cb
   };
   const video = adformats.findIndex(isVideo);
   if (video !== -1) {

--- a/modules/audienceNetworkBidAdapter.md
+++ b/modules/audienceNetworkBidAdapter.md
@@ -11,7 +11,7 @@ Maintainer: Lovell Fuller
 | Name          | Scope    | Description                                     | Example                           |
 | :------------ | :------- | :---------------------------------------------- | :--------------------------------- |
 | `placementId` | required | The Placement ID from Audience Network          | "555555555555555\_555555555555555" |
-| `format`      | optional | Format, one of "native", "fullwidth" or "video" | "native"                           |
+| `format`      | optional | Format, one of "native" or "video"              | "native"                           |
 
 # Example ad units
 

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 
 import { spec } from 'modules/audienceNetworkBidAdapter';
+import * as utils from 'src/utils';
 
 const {
   code,
@@ -18,7 +19,7 @@ const placementId = 'test-placement-id';
 const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
-const debug = 'adapterver=0.1.1&platform=241394079772386&platver=$prebid.version$';
+const debug = 'adapterver=0.2.1&platform=241394079772386&platver=$prebid.version$&cb=test-uuid';
 
 describe('AudienceNetwork adapter', () => {
   describe('Public API', () => {
@@ -71,7 +72,7 @@ describe('AudienceNetwork adapter', () => {
       })).to.equal(true);
     });
 
-    it('fullwidth', () => {
+    it('fullwidth (deprecated)', () => {
       expect(isBidRequestValid({
         bidder,
         sizes: [[300, 250], [336, 280]],
@@ -117,6 +118,16 @@ describe('AudienceNetwork adapter', () => {
   });
 
   describe('buildRequests', () => {
+    before(function () {
+      sinon
+        .stub(utils, 'generateUUID')
+        .returns('test-uuid');
+    });
+
+    after(function () {
+      utils.generateUUID.restore();
+    });
+
     it('can build URL for IAB unit, overriding platform', () => {
       const platform = 'test-platform';
       const debugPlatform = debug.replace('241394079772386', platform);
@@ -124,7 +135,7 @@ describe('AudienceNetwork adapter', () => {
       expect(buildRequests([{
         bidder,
         bidId: requestId,
-        sizes: [[300, 250], [320, 50]],
+        sizes: [[300, 50], [300, 250], [320, 50]],
         params: { placementId, platform }
       }])).to.deep.equal([{
         adformats: ['300x250'],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR for the Audience Network adapter is the legacy v0.x branch equivalent of PR #3085 to deprecate the "fullwidth" format, replacing it instead with the preferred "300x250" size.

Unit tests are updated to cover all the code changes, plus an internal version bump of the adapterver to aid debugging.

This work was commissioned and paid for by Facebook.