### PR TITLE
Small bugfix and cleanup for Prebid Server OpenRTB code

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -47,7 +47,7 @@ function getLabels(bidOrAdUnit, activeLabels) {
   return {labelAll: false, labels: bidOrAdUnit.labelAny, activeLabels};
 }
 
-function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
+function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels, src}) {
   return adUnits.reduce((result, adUnit) => {
     let bannerSizes = utils.deepAccess(adUnit, 'mediaTypes.banner.sizes');
 
@@ -98,6 +98,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels}) {
               bidId: bid.bid_id || utils.getUniqueIdentifierStr(),
               bidderRequestId,
               auctionId,
+              src,
               bidRequestsCount: adunitCounter.getCounter(adUnit.code),
             }));
           }
@@ -194,7 +195,7 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
         auctionId,
         bidderRequestId,
         tid,
-        bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': utils.deepClone(adUnitsS2SCopy), labels}),
+        bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': utils.deepClone(adUnitsS2SCopy), labels, src: CONSTANTS.S2S.SRC}),
         auctionStart: auctionStart,
         timeout: _s2sConfig.timeout,
         src: CONSTANTS.S2S.SRC,
@@ -229,7 +230,7 @@ exports.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, 
       bidderCode,
       auctionId,
       bidderRequestId,
-      bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': utils.deepClone(adUnitsClientCopy), labels}),
+      bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': utils.deepClone(adUnitsClientCopy), labels, src: 'client'}),
       auctionStart: auctionStart,
       timeout: cbTimeout,
       refererInfo


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Cleanup

## Description of change
Fixed `bid_id` property access error in prebidServer OpenRTB when bid request cannot be found (shouldn't happen usually, but in testing it can).

Changed the bid request map to be a `bid_id` map to be clearer on its intent and made it friendlier for minifcation by removing it from object literal.

Cleaned up some code duplication.  Don't overwrite `bid.source` and `bid.bidderCode` and instead use code in bid factory by passing in bid request stub if request does not exist.