### PR TITLE
Do not encode url in refererDetection module

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -109,10 +109,10 @@ export const spec = {
 
     if (bidderRequest && bidderRequest.refererInfo) {
       let refererinfo = {
-        rd_ref: bidderRequest.refererInfo.referer,
+        rd_ref: encodeURIComponent(bidderRequest.refererInfo.referer),
         rd_top: bidderRequest.refererInfo.reachedTop,
         rd_ifs: bidderRequest.refererInfo.numIframes,
-        rd_stk: bidderRequest.refererInfo.stack.join(',')
+        rd_stk: bidderRequest.refererInfo.stack.map((url) => encodeURIComponent(url)).join(',')
       }
       payload.referrer_detection = refererinfo;
     }

--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -27,7 +27,6 @@ export function detectReferer(win) {
   function getPubUrlStack(levels) {
     let stack = [];
     let defUrl = null;
-    let encodedUrl = null;
     let frameLocation = null;
     let prevFrame = null;
     let prevRef = null;
@@ -43,10 +42,9 @@ export function detectReferer(win) {
       }
 
       if (frameLocation) {
-        encodedUrl = encodeURIComponent(frameLocation);
-        stack.push(encodedUrl);
+        stack.push(frameLocation);
         if (!detectedRefererUrl) {
-          detectedRefererUrl = encodedUrl;
+          detectedRefererUrl = frameLocation;
         }
       } else if (i !== 0) {
         prevFrame = levels[i - 1];
@@ -58,16 +56,14 @@ export function detectReferer(win) {
         }
 
         if (prevRef) {
-          encodedUrl = encodeURIComponent(prevRef);
-          stack.push(encodedUrl);
+          stack.push(prevRef);
           if (!detectedRefererUrl) {
-            detectedRefererUrl = encodedUrl;
+            detectedRefererUrl = prevRef;
           }
         } else if (ancestor) {
-          encodedUrl = encodeURIComponent(ancestor);
-          stack.push(encodedUrl);
+          stack.push(ancestor);
           if (!detectedRefererUrl) {
-            detectedRefererUrl = encodedUrl;
+            detectedRefererUrl = ancestor;
           }
         } else {
           stack.push(defUrl);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -375,13 +375,13 @@ describe('AppNexusAdapter', function () {
       const bidRequest = Object.assign({}, bidRequests[0])
       const bidderRequest = {
         refererInfo: {
-          referer: 'http%3A%2F%2Fexample.com%2Fpage.html',
+          referer: 'http://example.com/page.html',
           reachedTop: true,
           numIframes: 2,
           stack: [
-            'http%3A%2F%2Fexample.com%2Fpage.html',
-            'http%3A%2F%2Fexample.com%2Fiframe1.html',
-            'http%3A%2F%2Fexample.com%2Fiframe2.html'
+            'http://example.com/page.html',
+            'http://example.com/iframe1.html',
+            'http://example.com/iframe2.html'
           ]
         }
       }
@@ -393,7 +393,7 @@ describe('AppNexusAdapter', function () {
         rd_ref: 'http%3A%2F%2Fexample.com%2Fpage.html',
         rd_top: true,
         rd_ifs: 2,
-        rd_stk: bidderRequest.refererInfo.stack.join(',')
+        rd_stk: bidderRequest.refererInfo.stack.map((url) => encodeURIComponent(url)).join(',')
       });
     });
   })

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -35,13 +35,13 @@ describe('referer detection', () => {
     const getRefererInfo = detectReferer(mockIframe2WinObject);
     let result = getRefererInfo();
     let expectedResult = {
-      referer: 'http%3A%2F%2Fexample.com%2Fpage.html',
+      referer: 'http://example.com/page.html',
       reachedTop: true,
       numIframes: 2,
       stack: [
-        'http%3A%2F%2Fexample.com%2Fpage.html',
-        'http%3A%2F%2Fexample.com%2Fiframe1.html',
-        'http%3A%2F%2Fexample.com%2Fiframe2.html'
+        'http://example.com/page.html',
+        'http://example.com/iframe1.html',
+        'http://example.com/iframe2.html'
       ]
     };
     expect(result).to.deep.equal(expectedResult);
@@ -66,13 +66,13 @@ describe('referer detection', () => {
     const getRefererInfo = detectReferer(mockIframe2WinObject);
     let result = getRefererInfo();
     let expectedResult = {
-      referer: 'http%3A%2F%2Faaa.com%2Fiframe1.html',
+      referer: 'http://aaa.com/iframe1.html',
       reachedTop: false,
       numIframes: 2,
       stack: [
         null,
-        'http%3A%2F%2Faaa.com%2Fiframe1.html',
-        'http%3A%2F%2Fbbb.com%2Fiframe2.html'
+        'http://aaa.com/iframe1.html',
+        'http://bbb.com/iframe2.html'
       ]
     };
     expect(result).to.deep.equal(expectedResult);


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
refererDetection module will send url as detected. Adapter needs to decide whether they want to encode or send it raw.