### PR TITLE
Add video params to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -13,7 +13,7 @@ export const VIDEO_ENDPOINT = '//reachms.bfmio.com/bid.json?exchange_id=';
 export const BANNER_ENDPOINT = '//display.bfmio.com/prebid_display';
 export const OUTSTREAM_SRC = '//player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
 
-export const VIDEO_TARGETING = ['mimes'];
+export const VIDEO_TARGETING = ['mimes', 'playbackmethod'];
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 
 let appId = '';

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -5,7 +5,7 @@ import { VIDEO, BANNER } from 'src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
-const ADAPTER_VERSION = '1.2';
+const ADAPTER_VERSION = '1.3';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -13,7 +13,7 @@ export const VIDEO_ENDPOINT = '//reachms.bfmio.com/bid.json?exchange_id=';
 export const BANNER_ENDPOINT = '//display.bfmio.com/prebid_display';
 export const OUTSTREAM_SRC = '//player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
 
-export const VIDEO_TARGETING = ['mimes', 'playbackmethod'];
+export const VIDEO_TARGETING = ['mimes', 'playbackmethod', 'maxduration'];
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 
 let appId = '';

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -218,11 +218,12 @@ describe('BeachfrontAdapter', function () {
       it('must override video targeting params', function () {
         const bidRequest = bidRequests[0];
         const mimes = ['video/webm'];
+        const playbackmethod = 2;
         bidRequest.mediaTypes = { video: {} };
-        bidRequest.params.video = { mimes };
+        bidRequest.params.video = { mimes, playbackmethod };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
-        expect(data.imp[0].video).to.deep.contain({ mimes });
+        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod });
       });
 
       it('must add GDPR consent data to the request', function () {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -219,11 +219,12 @@ describe('BeachfrontAdapter', function () {
         const bidRequest = bidRequests[0];
         const mimes = ['video/webm'];
         const playbackmethod = 2;
+        const maxduration = 30;
         bidRequest.mediaTypes = { video: {} };
-        bidRequest.params.video = { mimes, playbackmethod };
+        bidRequest.params.video = { mimes, playbackmethod, maxduration };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
-        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod });
+        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod, maxduration });
       });
 
       it('must add GDPR consent data to the request', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds bidder params to pass video playback method and max duration.

```javascript
{
  bidder: 'beachfront',
  params: {
    bidfloor: 0.01,
    appId: '3b16770b-17af-4d22-daff-9606bdf2c9c3'
    video: {
      playbackmethod: 1,
      maxduration: 30
    }
  }
}
```

PR for docs:
prebid/prebid.github.io#974