### PR TITLE
Bugfix: Issue 3111

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -332,7 +332,7 @@ export const spec = {
       try{
         bid = JSON.parse(JSON.stringify(original_bid));  
       }catch(e){
-        utils.logWarn(BIDDER_CODE + ': Fix for issue 3111 failed here.');
+        utils.logWarn(BIDDER_CODE + ': Creating local copy of common object failed');
         bid = {params:{}};
       }
       

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -319,7 +319,16 @@ export const spec = {
     var dctr = '';
     var dctrLen;
     var dctrArr = [];
-    validBidRequests.forEach(bid => {
+    validBidRequests.forEach(original_bid => {
+      /*
+        Making changes to fix https://github.com/prebid/Prebid.js/issues/3111
+        Fix: 
+        - Not using original_bid for further processing as it is a common object shared across adapters and we are deleting size property of the object
+        - This is a simplest and samallest change that resolves the issue
+        - Can't use Object.assign as this API copies member objects with reference thus not solving problem
+        - Can't use Object.create as this API cretaes a new object with a provided object as a prototype, this creates issue when we use hasOwnProperty check.
+      */
+      var bid = JSON.parse(JSON.stringify(original_bid));
       _parseAdSlot(bid);
       if (bid.params.hasOwnProperty('video')) {
         if (!(bid.params.adSlot && bid.params.adUnit && bid.params.adUnitIndex)) {

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -319,16 +319,22 @@ export const spec = {
     var dctr = '';
     var dctrLen;
     var dctrArr = [];
+    var bid;
     validBidRequests.forEach(original_bid => {
       /*
         Making changes to fix https://github.com/prebid/Prebid.js/issues/3111
         Fix: 
         - Not using original_bid for further processing as it is a common object shared across adapters and we are deleting size property of the object
-        - This is a simplest and samallest change that resolves the issue
-        - Can't use Object.assign as this API copies member objects with reference thus not solving problem
-        - Can't use Object.create as this API cretaes a new object with a provided object as a prototype, this creates issue when we use hasOwnProperty check.
-      */
-      var bid = JSON.parse(JSON.stringify(original_bid));
+        - This is a simplest and smallest change that resolves the issue
+        - Can't use Object.assign as this API copies member objects with reference thus not solving the problem
+        - Can't use Object.create as this API creates a new object with a provided object as a prototype, this creates an issue when we use hasOwnProperty check.
+      */      
+      try{
+        bid = JSON.parse(JSON.stringify(original_bid));  
+      }catch(e){
+        bid = {params:{}};
+      }
+      
       _parseAdSlot(bid);
       if (bid.params.hasOwnProperty('video')) {
         if (!(bid.params.adSlot && bid.params.adUnit && bid.params.adUnitIndex)) {

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -332,6 +332,7 @@ export const spec = {
       try{
         bid = JSON.parse(JSON.stringify(original_bid));  
       }catch(e){
+        utils.logWarn(BIDDER_CODE + ': Fix for issue 3111 failed here.');
         bid = {params:{}};
       }
       

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -320,8 +320,8 @@ export const spec = {
     var dctrLen;
     var dctrArr = [];
     var bid;
-    validBidRequests.forEach(original_bid => {
-      bid = utils.deepClone(original_bid);      
+    validBidRequests.forEach(originalBid => {
+      bid = utils.deepClone(originalBid);
       _parseAdSlot(bid);
       if (bid.params.hasOwnProperty('video')) {
         if (!(bid.params.adSlot && bid.params.adUnit && bid.params.adUnitIndex)) {

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -321,21 +321,7 @@ export const spec = {
     var dctrArr = [];
     var bid;
     validBidRequests.forEach(original_bid => {
-      /*
-        Making changes to fix https://github.com/prebid/Prebid.js/issues/3111
-        Fix: 
-        - Not using original_bid for further processing as it is a common object shared across adapters and we are deleting size property of the object
-        - This is a simplest and smallest change that resolves the issue
-        - Can't use Object.assign as this API copies member objects with reference thus not solving the problem
-        - Can't use Object.create as this API creates a new object with a provided object as a prototype, this creates an issue when we use hasOwnProperty check.
-      */      
-      try{
-        bid = JSON.parse(JSON.stringify(original_bid));  
-      }catch(e){
-        utils.logWarn(BIDDER_CODE + ': Creating local copy of common object failed');
-        bid = {params:{}};
-      }
-      
+      bid = utils.deepClone(original_bid);      
       _parseAdSlot(bid);
       if (bid.params.hasOwnProperty('video')) {
         if (!(bid.params.adSlot && bid.params.adUnit && bid.params.adUnitIndex)) {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -217,7 +217,13 @@ describe('PubMatic adapter', function () {
     });
 
   	describe('Request formation', function () {
-  		it('Endpoint checking', function () {
+  		it('buildRequests function should not modify original bidRequests object', function () {
+        let originalBidRequests = utils.deepClone(bidRequests);
+        let request = spec.buildRequests(bidRequests);
+        expect(bidRequests).to.deep.equal(originalBidRequests);
+      });
+
+      it('Endpoint checking', function () {
   		  let request = spec.buildRequests(bidRequests);
         expect(request.url).to.equal('//hbopenbid.pubmatic.com/translator?source=prebid-client');
         expect(request.method).to.equal('POST');


### PR DESCRIPTION
- [x] Bugfix

## Description of change
PubMatic was making changes to AdUnit object due to which IX adapter code was getting a malformed AdUnit object. Fixed this bug by creating a deepClone of AdUnit object in PubMatic adapter before using.

Issue link: https://github.com/prebid/Prebid.js/issues/3111

