### PR TITLE
adding account to s2s bidder-sync request

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -98,7 +98,8 @@ function queueSync(bidderCodes, gdprConsent) {
 
   const payload = {
     uuid: utils.generateUUID(),
-    bidders: bidderCodes
+    bidders: bidderCodes,
+    account_id: _s2sConfig.accountId
   };
 
   if (gdprConsent) {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -99,7 +99,7 @@ function queueSync(bidderCodes, gdprConsent) {
   const payload = {
     uuid: utils.generateUUID(),
     bidders: bidderCodes,
-    account_id: _s2sConfig.accountId
+    account: _s2sConfig.accountId
   };
 
   if (gdprConsent) {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -458,6 +458,8 @@ describe('S2S Adapter', function () {
 
         expect(requestBid.gdpr).is.equal(1);
         expect(requestBid.gdpr_consent).is.equal('abc123def');
+        expect(requestBid.bidders).to.contain('appnexus').and.to.have.lengthOf(1);
+        expect(requestBid.account_id).is.equal('1');
       });
 
       it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -459,7 +459,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.gdpr).is.equal(1);
         expect(requestBid.gdpr_consent).is.equal('abc123def');
         expect(requestBid.bidders).to.contain('appnexus').and.to.have.lengthOf(1);
-        expect(requestBid.account_id).is.equal('1');
+        expect(requestBid.account).is.equal('1');
       });
 
       it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

For GDPR reasons, the Rubicon version of Prebid Server needs to know the account ID provided in  `s2sConfig` on the /cookie-sync call.

e.g.

```
POST /cookie_sync
{"uuid":"ed4df869-bc53-48c4-9c61-6100be76fad6","bidders":["rubicon"],"account":12345 }
```

Specifically, Rubicon's PBS cluster has a forked difference from open source where we set an "audit" cookie for GDPR to be able to back into how the main `uids` cookie was set. This is not a general requirement, just one that Rubicon's lawyers added.

So there isn't currently a use-case for this in PBS-Go, but there could be one in the future.

We don't view this PBJS change as unreasonable even without other existing use cases -- it's a small data field that's already in `s2sConfig` and has the same attribute/value that's provided there.