### PR TITLE
fixes #3128 YieldlabBidAdapter is not using bidRequest.params.adSize

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -80,8 +80,8 @@ export const spec = {
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
-          width: primarysize[0],
-          height: primarysize[1],
+          width: customsize[0],
+          height: customsize[1],
           creativeId: '' + matchedBid.id,
           dealId: matchedBid.pid,
           currency: CURRENCY_CODE,

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -85,17 +85,36 @@ describe('yieldlabBidAdapter', function () {
   })
 
   describe('interpretResponse', function () {
-    const validRequests = {
-      validBidRequests: [REQUEST]
-    }
-
     it('handles nobid responses', function () {
       expect(spec.interpretResponse({body: {}}, {validBidRequests: []}).length).to.equal(0)
       expect(spec.interpretResponse({body: []}, {validBidRequests: []}).length).to.equal(0)
     })
 
     it('should get correct bid response', function () {
-      const result = spec.interpretResponse({body: [RESPONSE]}, validRequests)
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST]})
+
+      expect(result[0].requestId).to.equal('2d925f27f5079f')
+      expect(result[0].cpm).to.equal(0.01)
+      expect(result[0].width).to.equal(728)
+      expect(result[0].height).to.equal(90)
+      expect(result[0].creativeId).to.equal('1111')
+      expect(result[0].dealId).to.equal(2222)
+      expect(result[0].currency).to.equal('EUR')
+      expect(result[0].netRevenue).to.equal(false)
+      expect(result[0].ttl).to.equal(300)
+      expect(result[0].referrer).to.equal('')
+      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+    })
+
+    it('should get correct bid response when passing more than one size', function () {
+      const REQUEST2 = Object.assign({}, REQUEST, {
+        'sizes': [
+          [800, 250],
+          [728, 90],
+          [970, 90],
+        ]
+      })
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST2]})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
@@ -118,10 +137,7 @@ describe('yieldlabBidAdapter', function () {
           }
         }
       })
-      const validRequests = {
-        validBidRequests: [VIDEO_REQUEST]
-      }
-      const result = spec.interpretResponse({body: [RESPONSE]}, validRequests)
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [VIDEO_REQUEST]})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
when bidRequest.params.adSize is available, it has to be used in bidResponse or it will impact ad delivery

## Other information
- fixes issue which was introduced in PR #3035 
- affected versions prebid 1.24.0, 1.24.1, 1.25.0