### PR TITLE
Make size mapping mediaType aware

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,5 +1,5 @@
 import { config } from 'src/config';
-import { logWarn } from 'src/utils';
+import {logWarn, isPlainObject, deepAccess, deepClone} from 'src/utils';
 import includes from 'core-js/library/fn/array/includes';
 
 let sizeConfig = [];
@@ -29,35 +29,54 @@ config.getConfig('sizeConfig', config => setSizeConfig(config.sizeConfig));
  * @param {Array<string>} labels Labels specified on adUnit or bidder
  * @param {boolean} labelAll if true, all labels must match to be enabled
  * @param {Array<string>} activeLabels Labels passed in through requestBids
- * @param {Array<Array<number>>} sizes Sizes specified on adUnit
+ * @param {object} mediaTypes A mediaTypes object describing the various media types (banner, video, native)
+ * @param {Array<Array<number>>} sizes Sizes specified on adUnit (deprecated)
  * @param {Array<SizeConfig>} configs
  * @returns {{labels: Array<string>, sizes: Array<Array<number>>}}
  */
-export function resolveStatus({labels = [], labelAll = false, activeLabels = []} = {}, sizes = [], configs = sizeConfig) {
+export function resolveStatus({labels = [], labelAll = false, activeLabels = []} = {}, mediaTypes, sizes, configs = sizeConfig) {
   let maps = evaluateSizeConfig(configs);
 
-  let filteredSizes;
-  if (maps.shouldFilter) {
-    filteredSizes = sizes.filter(size => maps.sizesSupported[size]);
+  if (!isPlainObject(mediaTypes)) {
+    mediaTypes = {};
   } else {
-    filteredSizes = sizes;
+    mediaTypes = deepClone(mediaTypes);
   }
 
+  // add support for deprecated adUnit.sizes by creating correct banner mediaTypes if they don't already exist
+  if (sizes) {
+    if (!mediaTypes.banner) {
+      mediaTypes.banner = {
+        sizes
+      }
+    } else if (!mediaTypes.banner.sizes) {
+      mediaTypes.banner.sizes = sizes;
+    }
+  }
+
+  if (maps.shouldFilter && mediaTypes.banner && mediaTypes.banner.sizes) {
+    mediaTypes.banner.sizes = mediaTypes.banner.sizes.filter(size => maps.sizesSupported[size]);
+  }
+
+  let allMediaTypes = Object.keys(mediaTypes);
+
   return {
-    active: filteredSizes.length > 0 && (
-      labels.length === 0 || (
-        (!labelAll && (
-          labels.some(label => maps.labels[label]) ||
-          labels.some(label => includes(activeLabels, label))
-        )) ||
-        (labelAll && (
-          labels.reduce((result, label) => !result ? result : (
-            maps.labels[label] || includes(activeLabels, label)
-          ), true)
-        ))
+    active: allMediaTypes.length > 1 || (
+      allMediaTypes[0] === 'banner' && deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
+        labels.length === 0 || (
+          (!labelAll && (
+            labels.some(label => maps.labels[label]) ||
+            labels.some(label => includes(activeLabels, label))
+          )) ||
+          (labelAll && (
+            labels.reduce((result, label) => !result ? result : (
+              maps.labels[label] || includes(activeLabels, label)
+            ), true)
+          ))
+        )
       )
     ),
-    sizes: filteredSizes
+    mediaTypes
   };
 }
 

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -61,7 +61,9 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
   let allMediaTypes = Object.keys(mediaTypes);
 
   return {
-    active: allMediaTypes.length > 1 || (
+    active: (
+      allMediaTypes.length > 1 || (allMediaTypes.length === 1 && allMediaTypes[0] !== 'banner')
+    ) || (
       allMediaTypes[0] === 'banner' && deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
         labels.length === 0 || (
           (!labelAll && (

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -54,13 +54,14 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
     }
   }
 
-  if (maps.shouldFilter && mediaTypes.banner && mediaTypes.banner.sizes) {
-    mediaTypes.banner.sizes = mediaTypes.banner.sizes.filter(size => maps.sizesSupported[size]);
+  let oldSizes = deepAccess(mediaTypes, 'banner.sizes');
+  if (maps.shouldFilter && oldSizes) {
+    mediaTypes.banner.sizes = oldSizes.filter(size => maps.sizesSupported[size]);
   }
 
   let allMediaTypes = Object.keys(mediaTypes);
 
-  return {
+  let results = {
     active: (
       allMediaTypes.length > 1 || (allMediaTypes.length === 1 && allMediaTypes[0] !== 'banner')
     ) || (
@@ -80,6 +81,15 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
     ),
     mediaTypes
   };
+
+  if (oldSizes && oldSizes.length !== mediaTypes.banner.sizes.length) {
+    results.filterResults = {
+      before: oldSizes,
+      after: mediaTypes.banner.sizes
+    }
+  }
+
+  return results;
 }
 
 function evaluateSizeConfig(configs) {

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -91,12 +91,10 @@ describe('sizeMapping', function () {
 
       let status = resolveStatus(undefined, undefined, testSizes.banner.sizes, sizeConfig);
 
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: {
-          banner: {
-            sizes: [[970, 90], [728, 90], [300, 250]]
-          }
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: [[970, 90], [728, 90], [300, 250]]
         }
       });
     });
@@ -106,12 +104,10 @@ describe('sizeMapping', function () {
 
       let status = resolveStatus(undefined, testSizes, undefined, sizeConfig);
 
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: {
-          banner: {
-            sizes: [[970, 90], [728, 90], [300, 250]]
-          }
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: [[970, 90], [728, 90], [300, 250]]
         }
       });
     });
@@ -123,38 +119,32 @@ describe('sizeMapping', function () {
       ], str) ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, undefined, sizeConfig);
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: {
-          banner: {
-            sizes: [[970, 90], [728, 90], [300, 250], [300, 100]]
-          }
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: [[970, 90], [728, 90], [300, 250], [300, 100]]
         }
-      })
+      });
     });
 
     it('if no mediaQueries match, it should allow all sizes specified', function () {
       matchMediaOverride = () => ({matches: false});
 
       let status = resolveStatus(undefined, testSizes, undefined, sizeConfig);
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: testSizes
-      })
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
     });
 
     it('if a mediaQuery matches and has sizesSupported: [], it should filter all sizes', function () {
       matchMediaOverride = (str) => str === '(min-width: 0px) and (max-width: 767px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, undefined, sizeConfig);
-      expect(status).to.deep.equal({
-        active: false,
-        mediaTypes: {
-          banner: {
-            sizes: []
-          }
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: []
         }
-      })
+      });
     });
 
     it('should filter all banner sizes but not disable adUnit if multiple mediaTypes are present', function () {
@@ -165,27 +155,23 @@ describe('sizeMapping', function () {
           type: 'image'
         }
       }), undefined, sizeConfig);
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: {
-          banner: {
-            sizes: []
-          },
-          native: {
-            type: 'image'
-          }
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: []
+        },
+        native: {
+          type: 'image'
         }
-      })
+      });
     });
 
     it('if a mediaQuery matches and no sizesSupported specified, it should not affect adUnit.sizes', function () {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 
       let status = resolveStatus(undefined, testSizes, undefined, sizeConfigWithLabels);
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: testSizes
-      })
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
     });
   });
 
@@ -206,10 +192,8 @@ describe('sizeMapping', function () {
         labels: ['tablet']
       }, testSizes, undefined, sizeConfigWithLabels);
 
-      expect(status).to.deep.equal({
-        active: false,
-        mediaTypes: testSizes
-      });
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
     });
 
     it('should active/deactivate adUnits/bidders based on requestBids labels', function () {
@@ -220,20 +204,16 @@ describe('sizeMapping', function () {
         activeLabels
       }, testSizes, undefined, sizeConfigWithLabels);
 
-      expect(status).to.deep.equal({
-        active: false,
-        mediaTypes: testSizes
-      });
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
 
       status = resolveStatus({
         labels: ['us-visitor'],
         activeLabels
       }, testSizes, undefined, sizeConfigWithLabels);
 
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: testSizes
-      });
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
 
       status = resolveStatus({
         labels: ['us-visitor', 'tablet'],
@@ -241,10 +221,8 @@ describe('sizeMapping', function () {
         activeLabels
       }, testSizes, undefined, sizeConfigWithLabels);
 
-      expect(status).to.deep.equal({
-        active: false,
-        mediaTypes: testSizes
-      });
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
 
       status = resolveStatus({
         labels: ['us-visitor', 'desktop'],
@@ -252,10 +230,8 @@ describe('sizeMapping', function () {
         activeLabels
       }, testSizes, undefined, sizeConfigWithLabels);
 
-      expect(status).to.deep.equal({
-        active: true,
-        mediaTypes: testSizes
-      });
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal(testSizes);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This makes the Prebid size mapping feature work on mediaTypes objects rather than size arrays.  In other words, it is now mediaTypes aware and works specifically on `mediaTypes.banner.sizes` rather than `adUnit.sizes` (although the later is still supported, but deprecated).

This fixes issue #2462 since it only actively filters `mediaType.banner.sizes` while allowing non-banner (such as native and video) and even multi-mediaType bid requests to remain active without `adUnit.sizes`.  However in the future, now that size mapping is aware of media types, we can use this feature to add sizeMapping support for filtering other non-banner media types if we want (we still need to have a discussion of how that would work).
