### PR TITLE
use version replace rather than package.json in widespace

### DIFF
--- a/modules/widespaceBidAdapter.js
+++ b/modules/widespaceBidAdapter.js
@@ -1,4 +1,3 @@
-import { version } from '../package.json';
 import { config } from 'src/config';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import {
@@ -66,7 +65,7 @@ export const spec = {
         'hb.floor': bid.bidfloor || '',
         'hb.spb': i === 0 ? pixelSyncPossibility() : -1,
         'hb.ver': WS_ADAPTER_VERSION,
-        'hb.name': `prebidjs-${version}`,
+        'hb.name': 'prebidjs-$prebid.version$',
         'hb.bidId': bid.bidId,
         'hb.sizes': parseSizesInput(bid.sizes).join(','),
         'hb.currency': bid.params.cur || bid.params.currency || ''


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Noticed the widespace adapter was pulling in the entire package.json file into its built files just for the version.  Replaced package.json import with string replaced constant.
