### PR TITLE
Prebid server support for OpenRTB Native bids

### DIFF
--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -1,0 +1,174 @@
+<html>
+
+<head>
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+  <!-- <script async src="//acdn.adnxs.com/prebid/not-for-prod/1/prebid.js"></script> -->
+  <script type="text/javascript" src="../../build/dev/prebid.js" async></script>
+
+  <script>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+    var PREBID_TIMEOUT = 3000;
+
+    var date = new Date().getTime();
+
+    function initAdserver() {
+      if (pbjs.initAdserverSet) return;
+
+      googletag.cmd.push(function () {
+        pbjs.que.push(function () {
+          pbjs.setTargetingForGPTAsync();
+          googletag.pubads().refresh();
+        });
+      });
+
+      pbjs.initAdserverSet = true;
+    }
+
+    // Load GPT when timeout is reached.
+    // setTimeout(initAdserver, PREBID_TIMEOUT);
+
+    pbjs.que.push(function () {
+
+      pbjs.setConfig({
+        debug: true,
+        userSync: {
+          iframeEnabled: true
+        }
+      });
+
+      var adUnits = [{
+        code: '/19968336/prebid_native_example_1',
+        sizes: [[1, 1]],
+        mediaTypes: {
+          native: {
+            title: {
+              required: true,
+              len: 800
+            },
+            image: {
+              required: true,
+              sizes: [989, 742],
+            },
+            sponsoredBy: {
+              required: true
+            }
+          }
+        },
+        bids: [{
+          bidder: 'appnexus',
+          params: {
+            placementId: 13232354,
+            // placementId: 14141943,
+            allowSmallerSizes: true
+          }
+
+        }]
+      }, {
+        code: '/19968336/prebid_native_example_2',
+        sizes: [[1, 1]],
+        mediaTypes: {
+          native: {
+            title: {
+              required: true,
+              len: 800
+            },
+            body: {
+              required: true
+            },
+            image: {
+              required: true,
+              sizes: [3000, 2250]
+            },
+            sponsoredBy: {
+              required: true
+            },
+            icon: {
+              required: false,
+              sizes: [127, 83]
+            },
+          }
+        },
+        bids: [{
+          bidder: 'appnexus',
+          params: {
+            placementId: 13232354,
+            allowSmallerSizes: true
+          }
+        }]
+      }];
+
+      pbjs.addAdUnits(adUnits);
+      // pbjs.bidderSettings = {
+      //   appnexus: {
+      //     bidCpmAdjustment: function () {
+      //       return 10.00
+      //     }
+      //   }
+      // };
+      pbjs.setConfig({
+        s2sConfig: {
+          accountId: '1',
+          enabled: true, //default value set to false
+          bidders: ['appnexus'],
+          timeout: 1000, //default value is 1000
+          adapter: 'prebidServer', //if we have any other s2s adapter, default value is s2s
+          endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+        }
+      });
+      pbjs.requestBids({
+        bidsBackHandler: function (bidResponses) {
+          initAdserver();
+        }
+      });
+    });
+
+  </script>
+
+
+  <script>
+    // GPT setup
+    googletag.cmd.push(function () {
+      var slot1 = googletag.defineSlot('/19968336/prebid_native_example_1', [[360, 360]], 'div-1').addService(googletag.pubads());
+      var slot2 = googletag.defineSlot('/19968336/prebid_native_example_2', 'fluid', 'div-2').addService(googletag.pubads());
+      googletag.pubads().disableInitialLoad();
+      googletag.pubads().enableSingleRequest();
+      googletag.enableServices();
+    });
+
+  </script>
+</head>
+
+<body>
+
+  <h2>Prebid Native</h2>
+  <div id='div-1'>
+    <p>No response</p>
+    <script type='text/javascript'>
+      googletag.cmd.push(function () {
+        googletag.display('div-1');
+      });
+
+    </script>
+  </div>
+
+  <br>
+  <br>
+
+  <div id='div-2'>
+    <p>No response</p>
+    <script type='text/javascript'>
+      googletag.cmd.push(function () {
+        googletag.display('div-2');
+      });
+
+    </script>
+  </div>
+
+</body>
+
+</html>

--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -133,8 +133,8 @@
   <script>
     // GPT setup
     googletag.cmd.push(function () {
-      var slot1 = googletag.defineSlot('/19968336/prebid_native_example_1', [[360, 360]], 'div-1').addService(googletag.pubads());
-      var slot2 = googletag.defineSlot('/19968336/prebid_native_example_2', 'fluid', 'div-2').addService(googletag.pubads());
+      // var slot1 = googletag.defineSlot('/19968336/prebid_native_example_1', [[360, 360]], 'div-1').addService(googletag.pubads());
+      // var slot2 = googletag.defineSlot('/19968336/prebid_native_example_2', 'fluid', 'div-2').addService(googletag.pubads());
       googletag.pubads().disableInitialLoad();
       googletag.pubads().enableSingleRequest();
       googletag.enableServices();

--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -43,7 +43,7 @@
 
       var adUnits = [{
         code: '/19968336/prebid_native_example_1',
-        sizes: [[1, 1]],
+        // sizes: [[1, 1]],
         mediaTypes: {
           native: {
             title: {
@@ -70,7 +70,7 @@
         }]
       }, {
         code: '/19968336/prebid_native_example_2',
-        sizes: [[1, 1]],
+        // sizes: [[1, 1]],
         mediaTypes: {
           native: {
             title: {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -907,10 +907,13 @@ export function PrebidServer() {
     const adUnits = utils.deepClone(s2sBidRequest.ad_units);
 
     // at this point ad units should have a size array either directly or mapped so filter for that
-    const adUnitsWithSizes = adUnits.filter(unit => unit.sizes && unit.sizes.length);
+    const validAdUnits = adUnits.filter(unit =>
+      (unit.sizes && unit.sizes.length) ||
+      (unit.mediaTypes && unit.mediaTypes.native)
+    );
 
     // in case config.bidders contains invalid bidders, we only process those we sent requests for
-    const requestedBidders = adUnitsWithSizes
+    const requestedBidders = validAdUnits
       .map(adUnit => adUnit.bids.map(bid => bid.bidder).filter(utils.uniques))
       .reduce(utils.flatten)
       .filter(utils.uniques);
@@ -920,7 +923,7 @@ export function PrebidServer() {
       queueSync(_s2sConfig.bidders, consent);
     }
 
-    const request = protocolAdapter().buildRequest(s2sBidRequest, bidRequests, adUnitsWithSizes);
+    const request = protocolAdapter().buildRequest(s2sBidRequest, bidRequests, validAdUnits);
     const requestJson = request && JSON.stringify(request);
     if (request && requestJson) {
       ajax(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -799,16 +799,18 @@ const OPEN_RTB_PROTOCOL = {
               [nativeEventTrackerMethodMap.img]: adm.imptrackers || [],
               [nativeEventTrackerMethodMap.js]: adm.jstracker ? [adm.jstracker] : []
             };
-            adm.eventtrackers.forEach(tracker => {
-              switch (tracker.method) {
-                case nativeEventTrackerMethodMap.img:
-                  trackers[nativeEventTrackerMethodMap.img].push(tracker.url);
-                  break;
-                case nativeEventTrackerMethodMap.js:
-                  trackers[nativeEventTrackerMethodMap.js].push(tracker.url);
-                  break;
-              }
-            });
+            if (adm.eventtrackers) {
+              adm.eventtrackers.forEach(tracker => {
+                switch (tracker.method) {
+                  case nativeEventTrackerMethodMap.img:
+                    trackers[nativeEventTrackerMethodMap.img].push(tracker.url);
+                    break;
+                  case nativeEventTrackerMethodMap.js:
+                    trackers[nativeEventTrackerMethodMap.js].push(tracker.url);
+                    break;
+                }
+              });
+            }
 
             if (utils.isPlainObject(adm) && Array.isArray(adm.assets)) {
               let origAssets = nativeAssetCache[bidRequest.adUnitCode];

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -749,38 +749,39 @@ const OPEN_RTB_PROTOCOL = {
             if (!bidObject.vastUrl && bid.nurl) { bidObject.vastUrl = bid.nurl; }
           } else if (utils.deepAccess(bid, 'ext.prebid.type') === NATIVE) {
             bidObject.mediaType = NATIVE;
+            let adm;
             if (typeof bid.adm === 'string') {
-              bidObject.adm = JSON.parse(bid.adm);
+              adm = bidObject.adm = JSON.parse(bid.adm);
             } else {
-              bidObject.adm = bid.adm;
+              adm = bidObject.adm = bid.adm;
             }
 
-            if (utils.isPlainObject(bid.adm) && Array.isArray(bid.adm.assets)) {
+            if (utils.isPlainObject(adm) && Array.isArray(adm.assets)) {
               bidObject.native = utils.cleanObj({
                 image: utils.pick(
-                  utils.deepAccess(find(bid.adm.assets, asset => asset.img && asset.img.type === getNativeImgId('image')), 'img'),
+                  utils.deepAccess(find(adm.assets, asset => asset.img && asset.img.type === getNativeImgId('image')), 'img'),
                   ['url', 'w as width', 'h as height']
                 ),
                 icon: utils.pick(
-                  utils.deepAccess(find(bid.adm.assets, asset => asset.img && asset.img.type === getNativeImgId('icon')), 'img'),
+                  utils.deepAccess(find(adm.assets, asset => asset.img && asset.img.type === getNativeImgId('icon')), 'img'),
                   ['url', 'w as width', 'h as height']
                 ),
                 title: utils.deepAccess(
-                  find(bid.adm.assets, asset => asset.title),
+                  find(adm.assets, asset => asset.title),
                   'title.text'
                 ),
                 body: utils.deepAccess(
-                  find(bid.adm.assets, asset => asset.data && asset.data.type === getNativeDataId('body')),
+                  find(adm.assets, asset => asset.data && asset.data.type === getNativeDataId('body')),
                   'data.value'
                 ),
                 sponsoredBy: utils.deepAccess(
-                  find(bid.adm.assets, asset => asset.data && asset.data.type === getNativeDataId('sponsoredBy')),
+                  find(adm.assets, asset => asset.data && asset.data.type === getNativeDataId('sponsoredBy')),
                   'data.value'
                 ),
-                clickUrl: bid.adm.link,
-                clickTrackers: bid.adm.clickTrackers,
-                impressionTrackers: bid.adm.impressionTrackers,
-                javascriptTrackers: bid.adm.javascriptTrackers
+                clickUrl: adm.link,
+                clickTrackers: adm.clickTrackers,
+                impressionTrackers: adm.impressionTrackers,
+                javascriptTrackers: adm.javascriptTrackers
               });
             } else {
               utils.logError('prebid server native response contained no assets');

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -160,7 +160,7 @@ function sendMessage(auctionId, bidWonId) {
     // This allows the bidWon events to have these params even in the case of a delayed render
     Object.keys(auctionCache.bids).forEach(function (bidId) {
       let adCode = auctionCache.bids[bidId].adUnit.adUnitCode;
-      Object.assign(auctionCache.bids[bidId], _pick(adUnitMap[adCode], ['accountId', 'siteId', 'zoneId']));
+      Object.assign(auctionCache.bids[bidId], utils.pick(adUnitMap[adCode], ['accountId', 'siteId', 'zoneId']));
     });
 
     let auction = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1168,6 +1168,19 @@ export function convertCamelToUnderscore(value) {
 }
 
 /**
+ * Returns a new object with undefined properties removed from given object
+ * @param obj the object to clean
+ */
+export function cleanObj(obj) {
+  return Object.keys(obj).reduce((newObj, key) => {
+    if (typeof obj[key] !== 'undefined') {
+      newObj[key] = obj[key];
+    }
+    return newObj;
+  }, {})
+}
+
+/**
  * Converts an object of arrays (either strings or numbers) into an array of objects containing key and value properties
  * normally read from bidder params
  * eg { foo: ['bar', 'baz'], fizz: ['buzz'] }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1181,6 +1181,40 @@ export function cleanObj(obj) {
 }
 
 /**
+ * Create a new object with selected properties.  Also allows property renaming and transform functions.
+ * @param obj the original object
+ * @param properties An array of desired properties
+ */
+export function pick(obj, properties) {
+  if (!exports.isPlainObject(obj)) {
+    return undefined;
+  }
+  return properties.reduce((newObj, prop, i) => {
+    if (typeof prop === 'function') {
+      return newObj;
+    }
+
+    let newProp = prop;
+    let match = prop.match(/^(.+?)\sas\s(.+?)$/i);
+
+    if (match) {
+      prop = match[1];
+      newProp = match[2];
+    }
+
+    let value = obj[prop];
+    if (typeof properties[i + 1] === 'function') {
+      value = properties[i + 1](value, newObj);
+    }
+    if (typeof value !== 'undefined') {
+      newObj[newProp] = value;
+    }
+
+    return newObj;
+  }, {});
+}
+
+/**
  * Converts an object of arrays (either strings or numbers) into an array of objects containing key and value properties
  * normally read from bidder params
  * eg { foo: ['bar', 'baz'], fizz: ['buzz'] }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1186,8 +1186,8 @@ export function cleanObj(obj) {
  * @param properties An array of desired properties
  */
 export function pick(obj, properties) {
-  if (!exports.isPlainObject(obj)) {
-    return undefined;
+  if (typeof obj !== 'object') {
+    return {};
   }
   return properties.reduce((newObj, prop, i) => {
     if (typeof prop === 'function') {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -394,7 +394,38 @@ const RESPONSE_OPENRTB_NATIVE = {
           'id': '123',
           'impid': 'div-gpt-ad-1460505748561-0',
           'price': 0.13,
-          'adm': '{\"assets\":[{\"title\":{\"text\":\"Prebid.js\"}},{\"img\":{\"url\":\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSIzMCI+PHRleHQgeD0iMTAiIHk9IjIwIj5QcmViaWQuanM8L3RleHQ+PC9zdmc+\",\"w\":80,\"h\":30}},{\"data\":{\"type\":6,\"value\":\"free\"}}],\"link\":{\"url\":\"https://github.com/prebid/Prebid.js\"}}',
+          'adm': {
+            'assets': [
+              {
+                'title': {
+                  'text': 'Prebid.js'
+                }
+              },
+              {
+                'img': {
+                  'type': 3,
+                  'url': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSIzMCI+PHRleHQgeD0iMTAiIHk9IjIwIj5QcmViaWQuanM8L3RleHQ+PC9zdmc+',
+                  'w': 80,
+                  'h': 30
+                }
+              },
+              {
+                'data': {
+                  'type': 1,
+                  'value': 'Prebid.org'
+                }
+              },
+              {
+                'data': {
+                  'type': 6,
+                  'value': 'free'
+                }
+              }
+            ],
+            'link': {
+              'url': 'https://github.com/prebid/Prebid.js'
+            }
+          },
           'crid': '123',
           'ext': {
             'prebid': {
@@ -1442,25 +1473,25 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=a5ad3993');
     });
 
-    // it('handles OpenRTB native responses', function () {
-    //   const s2sConfig = Object.assign({}, CONFIG, {
-    //     endpoint: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-    //   });
-    //   config.setConfig({s2sConfig});
-    //
-    //   server.respondWith(JSON.stringify(RESPONSE_OPENRTB_NATIVE));
-    //   adapter.callBids(VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
-    //   server.respond();
-    //
-    //   sinon.assert.calledOnce(addBidResponse);
-    //   const response = addBidResponse.firstCall.args[1];
-    //   expect(response).to.have.property('statusMessage', 'Bid available');
-    //   expect(response).to.have.property('vastXml', RESPONSE_OPENRTB_VIDEO.seatbid[0].bid[0].adm);
-    //   expect(response).to.have.property('mediaType', 'native');
-    //   expect(response).to.have.property('bidderCode', 'appnexus');
-    //   expect(response).to.have.property('adId', '123');
-    //   expect(response).to.have.property('cpm', 10);
-    // });
+    it('handles OpenRTB native responses', function () {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+      });
+      config.setConfig({s2sConfig});
+
+      server.respondWith(JSON.stringify(RESPONSE_OPENRTB_NATIVE));
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      server.respond();
+
+      sinon.assert.calledOnce(addBidResponse);
+      const response = addBidResponse.firstCall.args[1];
+      expect(response).to.have.property('statusMessage', 'Bid available');
+      expect(response).to.have.property('adm').deep.equal(RESPONSE_OPENRTB_NATIVE.seatbid[0].bid[0].adm);
+      expect(response).to.have.property('mediaType', 'native');
+      expect(response).to.have.property('bidderCode', 'appnexus');
+      expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('cpm', 0.13);
+    });
 
     it('should log warning for unsupported bidder', function () {
       server.respondWith(JSON.stringify(RESPONSE_UNSUPPORTED_BIDDER));

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -35,7 +35,27 @@ const REQUEST = {
           'sizes': [[ 300, 250 ], [ 300, 300 ]]
         },
         'native': {
-          'type': 'image'
+          'image': {
+            'required': true,
+            'sizes': [1, 1]
+          },
+          'title': {
+            'required': true,
+            'len': 80
+          },
+          'sponsoredBy': {
+            'required': true
+          },
+          'clickUrl': {
+            'required': true
+          },
+          'body': {
+            'required': false
+          },
+          'icon': {
+            'required': false,
+            'sizes': [1, 1]
+          },
         }
       },
       'transactionId': '4ef956ad-fd83-406d-bd35-e4bb786ab86c',
@@ -758,40 +778,44 @@ describe('S2S Adapter', function () {
       config.setConfig(_config);
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       const requestBid = JSON.parse(requests[0].requestBody);
+
       expect(requestBid.imp[0].native).to.deep.equal({
         request: JSON.stringify({
+          'context': 1,
+          'plcmttype': 1,
           'assets': [
             {
-              'id': 200,
               'required': 1,
               'img': {
-                'type': 3
+                'type': 3,
+                'w': 1,
+                'h': 1
               }
             },
             {
-              'id': 201,
               'required': 1,
-              'title': {}
+              'title': {
+                'len': 80
+              }
             },
             {
-              'id': 202,
               'required': 1,
               'data': {
                 'type': 1
               }
             },
             {
-              'id': 203,
               'required': 0,
               'data': {
                 'type': 2
               }
             },
             {
-              'id': 204,
               'required': 0,
               'img': {
-                'type': 1
+                'type': 1,
+                'w': 1,
+                'h': 1
               }
             }
           ]
@@ -1489,7 +1513,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('adm').deep.equal(RESPONSE_OPENRTB_NATIVE.seatbid[0].bid[0].adm);
       expect(response).to.have.property('mediaType', 'native');
       expect(response).to.have.property('bidderCode', 'appnexus');
-      expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('requestId', '123');
       expect(response).to.have.property('cpm', 0.13);
     });
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -35,27 +35,17 @@ const REQUEST = {
           'sizes': [[ 300, 250 ], [ 300, 300 ]]
         },
         'native': {
-          'image': {
-            'required': true,
-            'sizes': [1, 1]
-          },
           'title': {
             'required': true,
-            'len': 80
+            'len': 800
+          },
+          'image': {
+            'required': true,
+            'sizes': [989, 742],
           },
           'sponsoredBy': {
             'required': true
-          },
-          'clickUrl': {
-            'required': true
-          },
-          'body': {
-            'required': false
-          },
-          'icon': {
-            'required': false,
-            'sizes': [1, 1]
-          },
+          }
         }
       },
       'transactionId': '4ef956ad-fd83-406d-bd35-e4bb786ab86c',
@@ -411,45 +401,78 @@ const RESPONSE_OPENRTB_NATIVE = {
     {
       'bid': [
         {
-          'id': '123',
+          'id': '6451317310275562039',
           'impid': 'div-gpt-ad-1460505748561-0',
-          'price': 0.13,
+          'price': 10,
           'adm': {
+            'ver': '1.2',
             'assets': [
               {
-                'title': {
-                  'text': 'Prebid.js'
-                }
-              },
-              {
+                'id': 1,
                 'img': {
-                  'type': 3,
-                  'url': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSIzMCI+PHRleHQgeD0iMTAiIHk9IjIwIj5QcmViaWQuanM8L3RleHQ+PC9zdmc+',
-                  'w': 80,
-                  'h': 30
+                  'url': 'https://vcdn.adnxs.com/p/creative-image/f8/7f/0f/13/f87f0f13-230c-4f05-8087-db9216e393de.jpg',
+                  'w': 989,
+                  'h': 742,
+                  'ext': {
+                    'appnexus': {
+                      'prevent_crop': 0
+                    }
+                  }
                 }
               },
               {
+                'id': 0,
+                'title': {
+                  'text': 'This is a Prebid Native Creative'
+                }
+              },
+              {
+                'id': 2,
                 'data': {
-                  'type': 1,
                   'value': 'Prebid.org'
-                }
-              },
-              {
-                'data': {
-                  'type': 6,
-                  'value': 'free'
                 }
               }
             ],
             'link': {
-              'url': 'https://github.com/prebid/Prebid.js'
-            }
+              'url': 'https://lax1-ib.adnxs.com/click?AAAAAAAAJEAAAAAAAAAkQAAAAAAAACRAAAAAAAAAJEAAAAAAAAAkQGdce2vBWudAJZpFu1er1zA7ZzddAAAAAOLoyQBtJAAAbSQAAAIAAAC8pM8FnPgWAAAAAABVU0QAVVNEAAEAAQBNXQAAAAABAgMCAAAAALsAuhVqdgAAAAA./cpcpm=AAAAAAAAAAA=/bcr=AAAAAAAA8D8=/pp=${AUCTION_PRICE}/cnd=%213Q5HCQj8-LwKELzJvi4YnPFbIAQoADEAAAAAAAAkQDoJTEFYMTo0MDc3QKcPSQAAAAAAAPA_UQAAAAAAAAAAWQAAAAAAAAAAYQAAAAAAAAAAaQAAAAAAAAAAcQAAAAAAAAAA/cca=OTMyNSNMQVgxOjQwNzc=/bn=84305/test=1/clickenc=http%3A%2F%2Fprebid.org%2Fdev-docs%2Fshow-native-ads.html'
+            },
+            'eventtrackers': [
+              {
+                'event': 1,
+                'method': 1,
+                'url': 'https://lax1-ib.adnxs.com/it?an_audit=0&test=1&referrer=http%3A%2F%2Flocalhost%3A9999%2FintegrationExamples%2Fgpt%2Fdemo_native.html&e=wqT_3QKCCKACBAAAAwDWAAUBCLvO3ekFEOe47duW2NbzQBiltJba--rq6zAqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlC8yb4uWJzxW2AAaM26dXjRkgWAAQGKAQNVU0SSAQEG8FKYAQGgAQGoAQGwAQC4AQLAAQPIAQLQAQnYAQDgAQHwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NjM5MTE5OTUpO3VmKCdyJywgOTc0OTQyMDQsIC4eAPQ0AZICnQIhb2pkaWlnajgtTHdLRUx6SnZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWVAwQmFBQndBSGdBZ0FFQWlBRUFrQUVCbUFFQm9BRUJxQUVEc0FFQXVRSHpyV3FrQUFBa1FNRUI4NjFxcEFBQUpFREpBVVZpYmxDaFpRQkEyUUVBQUFBQUFBRHdQLUFCQVBVQkFBQUFBUGdCQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBT0FDQU9nQ0FQZ0NBSUFEQVpBREFKZ0RBYWdEX1BpOENyb0RDVXhCV0RFNk5EQTNOLUFEcHctUUJBQ1lCQUhCQkFBQUFBQUFBQUFBeVFRQUFBQUFBQUFBQU5nRUFBLi6aAoUBITNRNUhDUWo4LUx3S0VMeiUhJG5QRmJJQVFvQUQRvVhBa1FEb0pURUZZTVRvME1EYzNRS2NQUxFUDFBBX1URDAxBQUFXHQwAWR0MAGEdDABjHQz0FwHYAgDgAq2YSOoCPmh0dHA6Ly9sb2NhbGhvc3Q6OTk5OS9pbnRlZ3JhdGlvbkV4YW1wbGVzL2dwdC9kZW1vX25hdGl2ZS5odG1sgAMAiAMBkAMAmAMUoAMBqgMAwAPgqAHIAwDYAwDgAwDoAwD4AwOABACSBAkvb3BlbnJ0YjKYBACiBA0xNzMuMjQ0LjM2LjQwqATtoySyBAwIABAAGAAgADAAOAC4BADABADIBADSBA45MzI1I0xBWDE6NDA3N9oEAggB4AQA8AS8yb4uiAUBmAUAoAX___________8BqgUkZTU5YzNlYjYtNmRkNi00MmQ5LWExMWEtM2FhMTFjOTc5MGUwwAUAyQUAAAAAAADwP9IFCQkAaVh0ANgFAeAFAfAFmfQh-gUECAAQAJAGAZgGALgGAMEGCSQk8D_IBgDaBhYKEAkQGQEBwTTgBgzyBgIIAIAHAYgHAA..&s=11ababa390e9f7983de260493fc5b91ec5b1b3d4&pp=${AUCTION_PRICE}'
+              }
+            ]
           },
-          'crid': '123',
+          'adid': '97494204',
+          'adomain': [
+            'http://prebid.org'
+          ],
+          'iurl': 'https://lax1-ib.adnxs.com/cr?id=97494204',
+          'cid': '9325',
+          'crid': '97494204',
+          'cat': [
+            'IAB3-1'
+          ],
           'ext': {
             'prebid': {
-              'type': 'native'
+              'targeting': {
+                'hb_bidder': 'appnexus',
+                'hb_pb': '10.00'
+              },
+              'type': 'native',
+              'video': {
+                'duration': 0,
+                'primary_category': ''
+              }
+            },
+            'bidder': {
+              'appnexus': {
+                'brand_id': 555545,
+                'auction_id': 4676806524825984103,
+                'bidder_id': 2,
+                'bid_ad_type': 3
+              }
             }
           }
         }
@@ -783,39 +806,29 @@ describe('S2S Adapter', function () {
         request: JSON.stringify({
           'context': 1,
           'plcmttype': 1,
+          'eventtrackers': [{
+            event: 1,
+            methods: [1]
+          }],
           'assets': [
             {
               'required': 1,
-              'img': {
-                'type': 3,
-                'w': 1,
-                'h': 1
+              'title': {
+                'len': 800
               }
             },
             {
               'required': 1,
-              'title': {
-                'len': 80
+              'img': {
+                'type': 3,
+                'w': 989,
+                'h': 742
               }
             },
             {
               'required': 1,
               'data': {
                 'type': 1
-              }
-            },
-            {
-              'required': 0,
-              'data': {
-                'type': 2
-              }
-            },
-            {
-              'required': 0,
-              'img': {
-                'type': 1,
-                'w': 1,
-                'h': 1
               }
             }
           ]
@@ -1498,6 +1511,11 @@ describe('S2S Adapter', function () {
     });
 
     it('handles OpenRTB native responses', function () {
+      sinon.stub(utils, 'getBidRequest').returns({
+        adUnitCode: 'div-gpt-ad-1460505748561-0',
+        bidder: 'appnexus',
+        bidId: '123'
+      });
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebidserverurl/openrtb2/auction?querystring=param'
       });
@@ -1514,7 +1532,9 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('mediaType', 'native');
       expect(response).to.have.property('bidderCode', 'appnexus');
       expect(response).to.have.property('requestId', '123');
-      expect(response).to.have.property('cpm', 0.13);
+      expect(response).to.have.property('cpm', 10);
+
+      utils.getBidRequest.restore();
     });
 
     it('should log warning for unsupported bidder', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This is a pull-request for following the development of native support for the prebid server adapter's OpenRTB endpoint and getting feedback on how to integrate properly with Prebid.js adUnits.

## Other information
OpenRTB Spec v2.4: https://www.iab.com/wp-content/uploads/2016/01/OpenRTB-API-Specification-Version-2-4-DRAFT.pdf

OpenRTB Native Spec 1.2: https://www.iab.com/wp-content/uploads/2017/04/OpenRTB-Native-Ads-Specification-Draft_1.2_2017-04.pdf