### PR TITLE
Adding appnexus debug via cookie/params

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -198,7 +198,7 @@ export const spec = {
         .replace(/<h1>(.*)<\/h1>/gm, '\n\n===== $1 =====\n\n') // Header H1
         .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm, '\n\n*** $1 ***\n\n') // Headers
         .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
-      utils.logMessage("AppNexus Debug Auction Glossary: https://wiki.appnexus.com/x/qwmHAg");
+      utils.logMessage('AppNexus Debug Auction Glossary: https://wiki.appnexus.com/x/qwmHAg');
       utils.logMessage(debugText);
     }
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -91,12 +91,12 @@ export const spec = {
       }
     } else {
       const debugBidRequest = find(bidRequests, hasDebug);
-      if (debugBidRequest && debugBidRequest['debug']) {
-        debugObj = debugBidRequest['debug'];
+      if (debugBidRequest && debugBidRequest.debug) {
+        debugObj = debugBidRequest.debug;
       }
     }
 
-    if (debugObj && debugObj['enabled']) {
+    if (debugObj && debugObj.enabled) {
       Object.keys(debugObj)
         .filter(param => includes(DEBUG_PARAMS, param))
         .forEach(param => {
@@ -126,7 +126,7 @@ export const spec = {
       payload.app = appIdObj;
     }
 
-    if (debugObjParams && debugObjParams['enabled']) {
+    if (debugObjParams.enabled) {
       payload.debug = debugObjParams;
       utils.logInfo('AppNexus Debug Auction Settings:\n\n' + JSON.stringify(debugObjParams, null, 4));
     }
@@ -188,8 +188,8 @@ export const spec = {
     }
 
     if (serverResponse.debug && serverResponse.debug.debug_info) {
-      let debugHeader = 'AppNexus Debug Auction for Prebid\n\n'
-      let debugText = debugHeader + serverResponse.debug.debug_info
+      let debugHeader = 'AppNexus Debug Auction for Prebid\n\n';
+      let debugText = debugHeader + serverResponse.debug.debug_info;
       debugText = debugText
         .replace(/(<td>|<th>)/gm, '\t') // Tables
         .replace(/(<\/td>|<\/th>)/gm, '\n') // Tables
@@ -198,6 +198,7 @@ export const spec = {
         .replace(/<h1>(.*)<\/h1>/gm, '\n\n===== $1 =====\n\n') // Header H1
         .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm, '\n\n*** $1 ***\n\n') // Headers
         .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
+      utils.logMessage("AppNexus Debug Auction Glossary: https://wiki.appnexus.com/x/qwmHAg");
       utils.logMessage(debugText);
     }
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -11,6 +11,7 @@ const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
+const DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout'];
 const NATIVE_MAPPING = {
   body: 'description',
   cta: 'ctatext',
@@ -77,6 +78,30 @@ export const spec = {
       };
     }
 
+    let debugObj = {};
+    let debugObjParams = {};
+    const debugCookieName = 'apn_prebid_debug';
+    const debugCookie = getCookie(debugCookieName) || false;
+
+    if (debugCookie) {
+      try {
+        debugObjParams['debug'] = JSON.parse(debugCookie);
+      } catch (e) {
+        utils.logError('AppNexus Debug Auction Cookie Error:\n\n' + e);
+      }
+    } else {
+      debugObjParams = find(bidRequests, hasDebug);
+    }
+
+    if (debugObjParams && debugObjParams.debug) {
+      Object.keys(debugObjParams.debug)
+        .filter(param => includes(DEBUG_PARAMS, param))
+        .forEach(param => {
+          debugObj['debug'] = debugObj['debug'] || {};
+          debugObj.debug[param] = debugObjParams.debug[param]
+        });
+    }
+
     const memberIdBid = find(bidRequests, hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
 
@@ -97,6 +122,11 @@ export const spec = {
     }
     if (appIdObjBid) {
       payload.app = appIdObj;
+    }
+
+    if (debugObj && debugObj.debug) {
+      payload.debug = debugObj.debug;
+      utils.logInfo('AppNexus Debug Auction Settings:\n\n' + JSON.stringify(debugObj.debug, null, 4));
     }
 
     if (bidderRequest && bidderRequest.gdprConsent) {
@@ -154,6 +184,21 @@ export const spec = {
         }
       });
     }
+
+    if (serverResponse.debug && serverResponse.debug.debug_info) {
+      let debugHeader = 'AppNexus Debug Auction for Prebid\n\n'
+      let debugText = debugHeader + serverResponse.debug.debug_info
+      debugText = debugText
+        .replace(/(<td>|<th>)/gm, '\t') // Tables
+        .replace(/(<\/td>|<\/th>)/gm, '\n') // Tables
+        .replace(/^<br>/gm, '') // Remove leading <br>
+        .replace(/(<br>\n|<br>)/gm, '\n') // <br>
+        .replace(/<h1>(.*)<\/h1>/gm, '\n\n===== $1 =====\n\n') // Header H1
+        .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm, '\n\n*** $1 ***\n\n') // Headers
+        .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
+      utils.logMessage(debugText);
+    }
+
     return bids;
   },
 
@@ -427,6 +472,15 @@ function hasAppId(bid) {
     return !!bid.params.app.id
   }
   return !!bid.params.app
+}
+
+function hasDebug(bid) {
+  return !!bid.debug
+}
+
+function getCookie(name) {
+  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
+  return m ? decodeURIComponent(m[2]) : null;
 }
 
 function getRtbBid(tag) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -81,24 +81,26 @@ export const spec = {
     let debugObj = {};
     let debugObjParams = {};
     const debugCookieName = 'apn_prebid_debug';
-    const debugCookie = getCookie(debugCookieName) || false;
+    const debugCookie = getCookie(debugCookieName) || null;
 
     if (debugCookie) {
       try {
-        debugObjParams['debug'] = JSON.parse(debugCookie);
+        debugObj = JSON.parse(debugCookie);
       } catch (e) {
         utils.logError('AppNexus Debug Auction Cookie Error:\n\n' + e);
       }
     } else {
-      debugObjParams = find(bidRequests, hasDebug);
+      const debugBidRequest = find(bidRequests, hasDebug);
+      if (debugBidRequest && debugBidRequest['debug']) {
+        debugObj = debugBidRequest['debug'];
+      }
     }
 
-    if (debugObjParams && debugObjParams.debug) {
-      Object.keys(debugObjParams.debug)
+    if (debugObj && debugObj['enabled']) {
+      Object.keys(debugObj)
         .filter(param => includes(DEBUG_PARAMS, param))
         .forEach(param => {
-          debugObj['debug'] = debugObj['debug'] || {};
-          debugObj.debug[param] = debugObjParams.debug[param]
+          debugObjParams[param] = debugObj[param];
         });
     }
 
@@ -124,9 +126,9 @@ export const spec = {
       payload.app = appIdObj;
     }
 
-    if (debugObj && debugObj.debug) {
-      payload.debug = debugObj.debug;
-      utils.logInfo('AppNexus Debug Auction Settings:\n\n' + JSON.stringify(debugObj.debug, null, 4));
+    if (debugObjParams && debugObjParams['enabled']) {
+      payload.debug = debugObjParams;
+      utils.logInfo('AppNexus Debug Auction Settings:\n\n' + JSON.stringify(debugObjParams, null, 4));
     }
 
     if (bidderRequest && bidderRequest.gdprConsent) {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -396,7 +396,33 @@ describe('AppNexusAdapter', function () {
         rd_stk: bidderRequest.refererInfo.stack.map((url) => encodeURIComponent(url)).join(',')
       });
     });
-  })
+
+    it('adds debug auction settings to payload', () => {
+      let debugRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394'
+          },
+          debug: {
+            enabled: true,
+            dongle: 'QWERTY',
+            member_id: 958,
+            debug_timeout: 1000
+          }
+        }
+      );
+      const request = spec.buildRequests([debugRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.debug).to.exist;
+      expect(payload.debug).to.deep.equal({
+        enabled: true,
+        dongle: 'QWERTY',
+        member_id: 958,
+        debug_timeout: 1000
+      });
+    });
+  });
 
   describe('interpretResponse', function () {
     let response = {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
The following feature enhancement adds in the ability for a publisher or developer to request an AppNexus AST debug auction in the response back from AppNexus alongside any bids.

This feature can be enabled by either of the following two methods along with the `pbjs_debug=true` query string parameter.

1) By adding a `debug` object in parallel to the bids requested:

```
{
  bidder: 'appnexus',
  params: {
    placementId: 123456789
  },
  debug: {
    enabled: true,
    dongle: 'QWERTY',
    member_id: 958,
    debug_timeout: 3000
  }
}
```

2) By setting an `apn_prebid_debug` cookie with a JSON string:

```
{ "enabled": true, "dongle": "QWERTY", "debug_timeout": 1000, "member_id": 958 }
```

When both of the above are enabled, settings from the browser cookie will prevail.

There also is no guarantee that the prebid debug may not freeze the browser (e.g in the case where gigabytes of data are returned) but this should be okay since this enables further debug information for developers only.

For more information on how to read the debug auction results, please see https://wiki.appnexus.com/display/console/Debug+Auction+Glossary

*Sample Console Log:*

```
Running member 958 debug using no permissions
Impbus 4280.bm-impbus.prod.nym2:8001
	Header Referer: http://example.com?pbjs_debug=true&ast_debug=true&ast_dongle=sss
	Site Domain: example.com
1772142023491463321 - Predicted engagement_rate_id: 2 (view) imps 54.87%
1772142023491463321 - Predicted engagement_rate_id: 3 (view_over_total) imps 51.57%
1772142023491463321 - Predicted engagement_rate_id: 8 (predicted_100pv1s_display_view_rate) imps 47.06%
```