### PR TITLE
add bid ttl to cache call

### DIFF
--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -62,7 +62,8 @@ function toStorageRequest(bid) {
   const vastValue = bid.vastXml ? bid.vastXml : wrapURI(bid.vastUrl, bid.vastImpUrl);
   return {
     type: 'xml',
-    value: vastValue
+    value: vastValue,
+    ttlseconds: Number(bid.ttl)
   };
 }
 

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -100,7 +100,7 @@ describe('The video cache', function () {
       </Wrapper>
     </Ad>
   </VAST>`;
-      assertRequestMade({ vastUrl: 'my-mock-url.com' }, expectedValue)
+      assertRequestMade({ vastUrl: 'my-mock-url.com', ttl: 25 }, expectedValue)
     });
 
     it('should make the expected request when store() is called on an ad with a vastUrl and a vastImpUrl', function () {
@@ -114,12 +114,12 @@ describe('The video cache', function () {
       </Wrapper>
     </Ad>
   </VAST>`;
-      assertRequestMade({ vastUrl: 'my-mock-url.com', vastImpUrl: 'imptracker.com' }, expectedValue)
+      assertRequestMade({ vastUrl: 'my-mock-url.com', vastImpUrl: 'imptracker.com', ttl: 25 }, expectedValue)
     });
 
     it('should make the expected request when store() is called on an ad with vastXml', function () {
       const vastXml = '<VAST version="3.0"></VAST>';
-      assertRequestMade({ vastXml: vastXml }, vastXml);
+      assertRequestMade({ vastXml: vastXml, ttl: 25 }, vastXml);
     });
 
     function assertRequestMade(bid, expectedValue) {
@@ -134,6 +134,7 @@ describe('The video cache', function () {
         puts: [{
           type: 'xml',
           value: expectedValue,
+          ttlseconds: 25
         }],
       });
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adds support for #3120