### PR TITLE
rubiconBidAdapter - Checking FPD values are defined before toString()

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -341,7 +341,7 @@ export const spec = {
     // visitor properties
     if (params.visitor !== null && typeof params.visitor === 'object') {
       Object.keys(params.visitor).forEach((key) => {
-        if (typeof params.visitor[key] !== 'undefined') {
+        if (params.visitor[key] != null) {
           data[`tg_v.${key}`] = params.visitor[key].toString(); // initialize array;
         }
       });
@@ -350,7 +350,7 @@ export const spec = {
     // inventory properties
     if (params.inventory !== null && typeof params.inventory === 'object') {
       Object.keys(params.inventory).forEach((key) => {
-        if (typeof params.inventory[key] !== 'undefined') {
+        if (params.inventory[key] != null) {
           data[`tg_i.${key}`] = params.inventory[key].toString();
         }
       });

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -341,14 +341,18 @@ export const spec = {
     // visitor properties
     if (params.visitor !== null && typeof params.visitor === 'object') {
       Object.keys(params.visitor).forEach((key) => {
-        data[`tg_v.${key}`] = params.visitor[key].toString();
+        if (typeof params.visitor[key] !== 'undefined') {
+          data[`tg_v.${key}`] = params.visitor[key].toString(); // initialize array;
+        }
       });
     }
 
     // inventory properties
     if (params.inventory !== null && typeof params.inventory === 'object') {
       Object.keys(params.inventory).forEach((key) => {
-        data[`tg_i.${key}`] = params.inventory[key].toString();
+        if (typeof params.inventory[key] !== 'undefined') {
+          data[`tg_i.${key}`] = params.inventory[key].toString();
+        }
       });
     }
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -822,12 +822,12 @@ describe('the rubicon adapter', function () {
           it('should not have any tg_v or tg_i params if all are undefined', function () {
             let params = {
               inventory: {
-                rating: undefined,
+                rating: null,
                 prodtype: undefined
               },
               visitor: {
                 ucat: undefined,
-                lastsearch: undefined,
+                lastsearch: null,
                 likes: undefined
               },
             };
@@ -853,7 +853,7 @@ describe('the rubicon adapter', function () {
                 prodtype: ['tech', 'mobile']
               },
               visitor: {
-                ucat: undefined,
+                ucat: null,
                 lastsearch: 'iphone',
                 likes: undefined
               },

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -818,6 +818,73 @@ describe('the rubicon adapter', function () {
           });
         });
 
+        describe('first party data', function () {
+          it('should not have any tg_v or tg_i params if all are undefined', function () {
+            let params = {
+              inventory: {
+                rating: undefined,
+                prodtype: undefined
+              },
+              visitor: {
+                ucat: undefined,
+                lastsearch: undefined,
+                likes: undefined
+              },
+            };
+            let undefinedKeys = ['tg_i.rating', 'tg_v.ucat', 'tg_v.likes', 'tg_v.lastsearch', 'tg_i.prodtype']
+
+            // Overwrite the bidder request params with the above ones
+            Object.assign(bidderRequest.bids[0].params, params);
+
+            // get the built request
+            let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+            let data = parseQuery(request.data);
+
+            // make sure that no tg_v or tg_i keys are present in the request
+            let matchingExp = RegExp('^tg_(i|v)\..*$')
+            Object.keys(data).forEach(key => {
+              expect(key).to.not.match(matchingExp);
+            });
+          });
+
+          it('should contain valid params when some are undefined', function () {
+            let params = {
+              inventory: {
+                rating: undefined,
+                prodtype: ['tech', 'mobile']
+              },
+              visitor: {
+                ucat: undefined,
+                lastsearch: 'iphone',
+                likes: undefined
+              },
+            };
+            let undefinedKeys = ['tg_i.rating', 'tg_v.ucat', 'tg_v.likes']
+            let expectedQuery = {
+              'tg_v.lastsearch': 'iphone',
+              'tg_i.prodtype': 'tech,mobile',
+            }
+
+            // Overwrite the bidder request params with the above ones
+            Object.assign(bidderRequest.bids[0].params, params);
+
+            // get the built request
+            let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+            let data = parseQuery(request.data);
+
+            // make sure none of the undefined keys are in query
+            undefinedKeys.forEach(key => {
+              expect(typeof data[key]).to.equal('undefined');
+            });
+
+            // make sure the expected and defined ones do show up still
+            Object.keys(expectedQuery).forEach(key => {
+              let value = expectedQuery[key];
+              expect(data[key]).to.equal(value);
+            });
+          });
+        });
+
         describe('singleRequest config', function () {
           it('should group all bid requests with the same site id', function () {
             sandbox.stub(Math, 'random').callsFake(() => 0.1);

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -831,7 +831,6 @@ describe('the rubicon adapter', function () {
                 likes: undefined
               },
             };
-            let undefinedKeys = ['tg_i.rating', 'tg_v.ucat', 'tg_v.likes', 'tg_v.lastsearch', 'tg_i.prodtype']
 
             // Overwrite the bidder request params with the above ones
             Object.assign(bidderRequest.bids[0].params, params);


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
rubiconBidAdapter - Checking FPD values are defined before toString() to prevent undefined errors
                                - Added two tests for this behavior
