### PR TITLE
Adding mediaType param to parseSizes in order to ALWAYS get the corre…

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -111,7 +111,7 @@ export const spec = {
       bidRequest.startTime = new Date().getTime();
 
       let params = bidRequest.params;
-      let size = parseSizes(bidRequest);
+      let size = parseSizes(bidRequest, 'video');
 
       let data = {
         page_url: _getPageUrl(bidRequest, bidderRequest),
@@ -306,7 +306,7 @@ export const spec = {
     const params = bidRequest.params;
 
     // use rubicon sizes if provided, otherwise adUnit.sizes
-    const parsedSizes = parseSizes(bidRequest);
+    const parsedSizes = parseSizes(bidRequest, 'banner');
 
     const [latitude, longitude] = params.latLong || [];
 
@@ -529,9 +529,9 @@ function _renderCreative(script, impId) {
 </html>`;
 }
 
-function parseSizes(bid) {
+function parseSizes(bid, mediaType) {
   let params = bid.params;
-  if (hasVideoMediaType(bid)) {
+  if (mediaType === 'video') {
     let size = [];
     if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
@@ -624,7 +624,7 @@ function bidType(bid, log = false) {
       return undefined;
     }
   }
-  if (parseSizes(bid).length > 0) {
+  if (parseSizes(bid, 'banner').length > 0) {
     if (log && validVideo === false) {
       utils.logWarn('Rubicon bid adapter Warning: invalid video requested for adUnit, continuing with banner request.');
     }


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
- When requesting a multi format ad unit to rubicon. Video will only be used if the ad unit has the necessary video params for the exchange:
```
1. adUnit.mediaTypes.video.context is either 'instream' or 'outstream'
2. if instream: params.video.size_id is defined
```
- If these checks fail, but banner mediaType is also in the adUnit, then Rubicon proceeds with a banner request. (see https://github.com/prebid/Prebid.js/pull/3037)

- This change of logic was not brought into the `parseSizes` function, thus, when the above scenario DID occur, the adapter sent a banner request, but built the sizes thinking it was a video media type.

* This change will fix this scenario

Since the mediaType is known before actually ever entering parseSizes, we can just pass it in
