### PR TITLE
Rubicon skip video request in mutlti format when video is not setup

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -580,7 +580,7 @@ function mapSizes(sizes) {
  * @returns {boolean}
  */
 export function hasVideoMediaType(bidRequest) {
-  if (typeof utils.deepAccess(bid, 'params.video') === 'undefined' && Array.isArray(bidRequest.params.sizes)) {
+  if (typeof utils.deepAccess(bidRequest, 'params.video') === 'undefined' && Array.isArray(bidRequest.params.sizes)) {
     utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id ');
     return false;
   }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -531,7 +531,7 @@ function _renderCreative(script, impId) {
 
 function parseSizes(bid) {
   let params = bid.params;
-  if (hasVideoMediaType(bid)) {
+  if (hasVideoMediaTypeOrParams(bid)) {
     let size = [];
     if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
@@ -579,8 +579,12 @@ function mapSizes(sizes) {
  * @param {BidRequest} bidRequest
  * @returns {boolean}
  */
-export function hasVideoMediaType(bidRequest) {
-  return bidRequest.mediaType === VIDEO || typeof utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`) !== 'undefined';
+export function hasVideoMediaTypeOrParams(bidRequest) {
+  if (typeof utils.deepAccess(bid, 'params.video') === 'undefined' && Array.isArray(bidRequest.params.sizes)) {
+    utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id ');
+    return false;
+  }
+  return (bidRequest.mediaType === VIDEO || typeof utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`) !== 'undefined');
 }
 
 /**
@@ -591,7 +595,7 @@ export function hasVideoMediaType(bidRequest) {
  */
 function bidType(bid, log = false) {
   let validVideo;
-  if (hasVideoMediaType(bid)) {
+  if (hasVideoMediaTypeOrParams(bid)) {
     validVideo = true;
 
     if (utils.deepAccess(bid, `mediaTypes.${VIDEO}.context`) === 'instream' || bid.mediaType === VIDEO) {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -580,7 +580,7 @@ function mapSizes(sizes) {
  * @returns {boolean}
  */
 export function hasVideoMediaType(bidRequest) {
-  if (typeof utils.deepAccess(bidRequest, 'params.video') === 'undefined' && Array.isArray(bidRequest.params.sizes)) {
+  if (typeof utils.deepAccess(bidRequest, 'params.video') === 'undefined' && Array.isArray(utils.deepAccess(bidRequest, 'params.sizes'))) {
     utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id ');
     return false;
   }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -581,7 +581,7 @@ function mapSizes(sizes) {
  */
 export function hasVideoMediaType(bidRequest) {
   if (typeof utils.deepAccess(bidRequest, 'params.video') === 'undefined' && Array.isArray(utils.deepAccess(bidRequest, 'params.sizes'))) {
-    utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id ');
+    utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id');
     return false;
   }
   return (bidRequest.mediaType === VIDEO || typeof utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`) !== 'undefined');

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -531,7 +531,7 @@ function _renderCreative(script, impId) {
 
 function parseSizes(bid) {
   let params = bid.params;
-  if (hasVideoMediaTypeOrParams(bid)) {
+  if (hasVideoMediaType(bid)) {
     let size = [];
     if (params.video && params.video.playerWidth && params.video.playerHeight) {
       size = [
@@ -579,7 +579,7 @@ function mapSizes(sizes) {
  * @param {BidRequest} bidRequest
  * @returns {boolean}
  */
-export function hasVideoMediaTypeOrParams(bidRequest) {
+export function hasVideoMediaType(bidRequest) {
   if (typeof utils.deepAccess(bid, 'params.video') === 'undefined' && Array.isArray(bidRequest.params.sizes)) {
     utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id ');
     return false;
@@ -595,7 +595,7 @@ export function hasVideoMediaTypeOrParams(bidRequest) {
  */
 function bidType(bid, log = false) {
   let validVideo;
-  if (hasVideoMediaTypeOrParams(bid)) {
+  if (hasVideoMediaType(bid)) {
     validVideo = true;
 
     if (utils.deepAccess(bid, `mediaTypes.${VIDEO}.context`) === 'instream' || bid.mediaType === VIDEO) {


### PR DESCRIPTION
<!--
Creating a test in case of multi format when publisher wants to monetise display not video
-->

## Type of change
- [ ] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
I have some clients wanted to displayed banner on same slot monetise via outstream for other partners. We should look at bid.param.sizes and if present when video is not present then override for making a banner request.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
