### PR TITLE
Removed deprecated priceType option (+tests)

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -30,13 +30,9 @@ export const spec = {
       config.getConfig(`currency.bidderCurrencyDefault.${BIDDER_CODE}`) ||
       config.getConfig('currency.adServerCurrency') ||
       DEFAULT_CUR;
-    let priceType = 'net';
     let reqId;
 
     bids.forEach(bid => {
-      if (bid.params.priceType === 'gross') {
-        priceType = 'gross';
-      }
       if (!bidsMap[bid.params.uid]) {
         bidsMap[bid.params.uid] = [bid];
         auids.push(bid.params.uid);
@@ -48,9 +44,8 @@ export const spec = {
 
     const payload = {
       u: utils.getTopWindowUrl(),
-      pt: priceType,
+      pt: 'net',
       auids: auids.join(','),
-      test: 1,
       r: reqId,
       cur: currency,
     };
@@ -75,7 +70,6 @@ export const spec = {
     serverResponse = serverResponse && serverResponse.body;
     const bidResponses = [];
     const bidsMap = bidRequest.bidsMap;
-    const priceType = bidRequest.data.pt;
     const currency = bidRequest.data.cur;
 
     let errorMessage;
@@ -87,7 +81,7 @@ export const spec = {
 
     if (!errorMessage && serverResponse.seatbid) {
       serverResponse.seatbid.forEach(respItem => {
-        _addBidResponse(_getBidFromResponse(respItem), bidsMap, priceType, currency, bidResponses);
+        _addBidResponse(_getBidFromResponse(respItem), bidsMap, currency, bidResponses);
       });
     }
     if (errorMessage) utils.logError(errorMessage);
@@ -123,7 +117,7 @@ function _getBidFromResponse(respItem) {
   return respItem && respItem.bid && respItem.bid[0];
 }
 
-function _addBidResponse(serverBid, bidsMap, priceType, currency, bidResponses) {
+function _addBidResponse(serverBid, bidsMap, currency, bidResponses) {
   if (!serverBid) return;
   let errorMessage;
   if (!serverBid.auid) errorMessage = LOG_ERROR_MESS.noAuid + JSON.stringify(serverBid);
@@ -139,7 +133,7 @@ function _addBidResponse(serverBid, bidsMap, priceType, currency, bidResponses) 
           height: serverBid.h,
           creativeId: serverBid.auid,
           currency: currency || DEFAULT_CUR,
-          netRevenue: priceType !== 'gross',
+          netRevenue: true,
           ttl: TIME_TO_LIVE,
           ad: serverBid.adm,
           dealId: serverBid.dealid

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -98,21 +98,8 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'EUR');
     });
 
-    it('pt parameter must be "gross" if params.priceType === "gross"', function () {
+    it('pt parameter must be "net" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
-      const request = spec.buildRequests(bidRequests);
-      const payload = request.data;
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
-      expect(payload).to.have.property('pt', 'gross');
-      expect(payload).to.have.property('auids', '903535,903536');
-      expect(payload).to.have.property('r', '22edbae2733bf6');
-      expect(payload).to.have.property('cur', 'EUR');
-      delete bidRequests[1].params.priceType;
-    });
-
-    it('pt parameter must be "net" or "gross"', function () {
-      bidRequests[1].params.priceType = 'some';
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.be.an('object');
@@ -123,6 +110,33 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'EUR');
       delete bidRequests[1].params.priceType;
     });
+
+    it('pt parameter must be "net" if params.priceType === "net"', function () {
+      bidRequests[1].params.priceType = 'net';
+      const request = spec.buildRequests(bidRequests);
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('pt', 'net');
+      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
+      expect(payload).to.have.property('cur', 'EUR');
+      delete bidRequests[1].params.priceType;
+    });
+
+    it('pt parameter must be "net" if params.priceType === "undefined"', function () {
+      bidRequests[1].params.priceType = 'undefined';
+      const request = spec.buildRequests(bidRequests);
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('pt', 'net');
+      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('r', '22edbae2733bf6');
+      expect(payload).to.have.property('cur', 'EUR');
+      delete bidRequests[1].params.priceType;
+    });
+
     it('should add currency from currency.bidderCurrencyDefault', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? 'JPY' : 'USD');
@@ -136,6 +150,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'JPY');
       getConfigStub.restore();
     });
+
     it('should add currency from currency.adServerCurrency', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? '' : 'USD');
@@ -149,6 +164,7 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('cur', 'USD');
       getConfigStub.restore();
     });
+
     it('if gdprConsent is present payload must have gdpr params', function () {
       const request = spec.buildRequests(bidRequests, {gdprConsent: {consentString: 'AAA', gdprApplies: true}});
       const payload = request.data;


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Removed deprecated priceType option (incl. test coverage). This option is not available anymore, change is backwards compatible.

- contact email of the adapter’s maintainer: evgenij.tovba@yoc.com
- [X] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/991
