### PR TITLE
Add a check against the size config when setting targeting

### DIFF
--- a/src/adaptermanager.js
+++ b/src/adaptermanager.js
@@ -1,7 +1,7 @@
 /** @module adaptermanger */
 
 import { flatten, getBidderCodes, getDefinedParams, shuffle, timestamp } from './utils';
-import { resolveStatus } from './sizeMapping';
+import { getLabels, resolveStatus } from './sizeMapping';
 import { processNativeAdUnitParams, nativeAdapters } from './native';
 import { newBidder } from './adapters/bidderFactory';
 import { ajaxBuilder } from 'src/ajax';
@@ -33,19 +33,6 @@ var _analyticsRegistry = {};
  * @property {Array<string>} labels the labels listed on the bidder or adUnit
  * @property {Array<string>} activeLabels the labels specified as being active by requestBids
  */
-
-/**
- * Returns object describing the status of labels on the adUnit or bidder along with labels passed into requestBids
- * @param bidOrAdUnit the bidder or adUnit to get label info on
- * @param activeLabels the labels passed to requestBids
- * @returns {LabelDescriptor}
- */
-function getLabels(bidOrAdUnit, activeLabels) {
-  if (bidOrAdUnit.labelAll) {
-    return {labelAll: true, labels: bidOrAdUnit.labelAll, activeLabels};
-  }
-  return {labelAll: false, labels: bidOrAdUnit.labelAny, activeLabels};
-}
 
 function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels, src}) {
   return adUnits.reduce((result, adUnit) => {

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -25,6 +25,33 @@ export function setSizeConfig(config) {
 config.getConfig('sizeConfig', config => setSizeConfig(config.sizeConfig));
 
 /**
+ * Returns object describing the status of labels on the adUnit or bidder along with labels passed into requestBids
+ * @param bidOrAdUnit the bidder or adUnit to get label info on
+ * @param activeLabels the labels passed to requestBids
+ * @returns {LabelDescriptor}
+ */
+export function getLabels(bidOrAdUnit, activeLabels) {
+  if (bidOrAdUnit.labelAll) {
+    return {labelAll: true, labels: bidOrAdUnit.labelAll, activeLabels};
+  }
+  return {labelAll: false, labels: bidOrAdUnit.labelAny, activeLabels};
+}
+
+/**
+ * Determines whether a single size is valid given configured sizes
+ * @param {Array} size [width, height]
+ * @param {Array<SizeConfig>} configs
+ * @returns {boolean}
+ */
+export function sizeSupported(size, configs = sizeConfig) {
+  let maps = evaluateSizeConfig(configs);
+  if (!maps.shouldFilter) {
+    return true;
+  }
+  return !!maps.sizesSupported[size];
+}
+
+/**
  * Resolves the unique set of the union of all sizes and labels that are active from a SizeConfig.mediaQuery match
  * @param {Array<string>} labels Labels specified on adUnit or bidder
  * @param {boolean} labelAll if true, all labels must match to be enabled

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -2,6 +2,7 @@ import { uniques, isGptPubadsDefined, getHighestCpm, getOldestHighestCpmBid, gro
 import { config } from './config';
 import { NATIVE_TARGETING_KEYS } from './native';
 import { auctionManager } from './auctionManager';
+import { sizeSupported } from './sizeMapping';
 import includes from 'core-js/library/fn/array/includes';
 
 const utils = require('./utils.js');
@@ -198,6 +199,7 @@ export function newTargeting(auctionManager) {
 
   function getBidsReceived() {
     const bidsReceived = auctionManager.getBidsReceived()
+      .filter(bid => bid.mediaType !== 'banner' || sizeSupported([bid.width, bid.height]))
       .filter(isUnusedBid)
       .filter(exports.isBidNotExpired)
     ;

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { resolveStatus, setSizeConfig } from 'src/sizeMapping';
+import { resolveStatus, setSizeConfig, sizeSupported } from 'src/sizeMapping';
 import includes from 'core-js/library/fn/array/includes';
 
 let utils = require('src/utils');
@@ -75,6 +75,13 @@ describe('sizeMapping', function () {
   });
 
   describe('when handling sizes', function () {
+    it('should allow us to validate a single size', function() {
+      matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
+
+      expect(sizeSupported([300, 250])).to.equal(true);
+      expect(sizeSupported([80, 80])).to.equal(false);
+    });
+
     it('should log a warning when mediaQuery property missing from sizeConfig', function () {
       let errorConfig = deepClone(sizeConfig);
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Add an extra check for size configs when setting targeting so that a cached bid that was valid cannot be used if it has become invalid by the screen changing size since last auction.

## Other information
fixes #2861
