### PR TITLE
Use referer detection module in Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -1,11 +1,13 @@
 import * as utils from 'src/utils';
+import { parse as parseUrl } from 'src/url';
+import { config } from 'src/config';
 import { registerBidder } from 'src/adapters/bidderFactory';
 import { Renderer } from 'src/Renderer';
 import { VIDEO, BANNER } from 'src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
-const ADAPTER_VERSION = '1.3';
+const ADAPTER_VERSION = '1.4';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 
@@ -237,6 +239,19 @@ function isBannerBidValid(bid) {
   return isBannerBid(bid) && getBannerBidParam(bid, 'appId') && getBannerBidParam(bid, 'bidfloor');
 }
 
+function getTopWindowLocation(bidderRequest) {
+  let url = bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer;
+  return parseUrl(config.getConfig('pageUrl') || url, { decodeSearchAsString: true });
+}
+
+function getTopWindowReferrer() {
+  try {
+    return window.top.document.referrer;
+  } catch (e) {
+    return '';
+  }
+}
+
 function getVideoTargetingParams(bid) {
   return Object.keys(Object(bid.params.video))
     .filter(param => includes(VIDEO_TARGETING, param))
@@ -252,7 +267,7 @@ function createVideoRequestData(bid, bidderRequest) {
   let video = getVideoTargetingParams(bid);
   let appId = getVideoBidParam(bid, 'appId');
   let bidfloor = getVideoBidParam(bid, 'bidfloor');
-  let topLocation = utils.getTopWindowLocation();
+  let topLocation = getTopWindowLocation(bidderRequest);
   let payload = {
     isPrebid: true,
     appId: appId,
@@ -294,8 +309,8 @@ function createVideoRequestData(bid, bidderRequest) {
 }
 
 function createBannerRequestData(bids, bidderRequest) {
-  let topLocation = utils.getTopWindowLocation();
-  let referrer = utils.getTopWindowReferrer();
+  let topLocation = getTopWindowLocation(bidderRequest);
+  let topReferrer = getTopWindowReferrer();
   let slots = bids.map(bid => {
     return {
       slot: bid.adUnitCode,
@@ -309,8 +324,8 @@ function createBannerRequestData(bids, bidderRequest) {
     page: topLocation.href,
     domain: topLocation.hostname,
     search: topLocation.search,
-    secure: topLocation.protocol === 'https:' ? 1 : 0,
-    referrer: referrer,
+    secure: topLocation.protocol.indexOf('https') === 0 ? 1 : 0,
+    referrer: topReferrer,
     ua: navigator.userAgent,
     deviceOs: getOsVersion(),
     isMobile: isMobile() ? 1 : 0,

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec, VIDEO_ENDPOINT, BANNER_ENDPOINT, OUTSTREAM_SRC, DEFAULT_MIMES } from 'modules/beachfrontBidAdapter';
 import * as utils from 'src/utils';
+import { parse as parseUrl } from 'src/url';
 
 describe('BeachfrontAdapter', function () {
   let bidRequests;
@@ -150,9 +151,14 @@ describe('BeachfrontAdapter', function () {
             playerSize: [ width, height ]
           }
         };
-        const requests = spec.buildRequests([ bidRequest ]);
+        const topLocation = parseUrl('http://www.example.com?foo=bar', { decodeSearchAsString: true });
+        const bidderRequest = {
+          refererInfo: {
+            referer: topLocation.href
+          }
+        };
+        const requests = spec.buildRequests([ bidRequest ], bidderRequest);
         const data = requests[0].data;
-        const topLocation = utils.getTopWindowLocation();
         expect(data.isPrebid).to.equal(true);
         expect(data.appId).to.equal(bidRequest.params.appId);
         expect(data.domain).to.equal(document.location.hostname);
@@ -270,9 +276,14 @@ describe('BeachfrontAdapter', function () {
             sizes: [ width, height ]
           }
         };
-        const requests = spec.buildRequests([ bidRequest ]);
+        const topLocation = parseUrl('http://www.example.com?foo=bar', { decodeSearchAsString: true });
+        const bidderRequest = {
+          refererInfo: {
+            referer: topLocation.href
+          }
+        };
+        const requests = spec.buildRequests([ bidRequest ], bidderRequest);
         const data = requests[0].data;
-        const topLocation = utils.getTopWindowLocation();
         expect(data.slots).to.deep.equal([
           {
             slot: bidRequest.adUnitCode,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Updates the Beachfront adapter to use the referer detection module, and the publisher page url from the config.