### PR TITLE
Ensure transaction ID is always unique

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -347,10 +347,9 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
     const bidders = (s2sBidders) ? allBidders.filter(bidder => {
       return !includes(s2sBidders, bidder);
     }) : allBidders;
-
+    
     adUnit.transactionId = utils.generateUUID();
-   
-
+    
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
       const spec = adapter && adapter.getSpec && adapter.getSpec();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -348,9 +348,8 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
       return !includes(s2sBidders, bidder);
     }) : allBidders;
 
-    if (!adUnit.transactionId) {
-      adUnit.transactionId = utils.generateUUID();
-    }
+    adUnit.transactionId = utils.generateUUID();
+   
 
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -347,9 +347,9 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
     const bidders = (s2sBidders) ? allBidders.filter(bidder => {
       return !includes(s2sBidders, bidder);
     }) : allBidders;
-    
+		
     adUnit.transactionId = utils.generateUUID();
-    
+		
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
       const spec = adapter && adapter.getSpec && adapter.getSpec();

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -347,9 +347,9 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
     const bidders = (s2sBidders) ? allBidders.filter(bidder => {
       return !includes(s2sBidders, bidder);
     }) : allBidders;
-		
+
     adUnit.transactionId = utils.generateUUID();
-		
+
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
       const spec = adapter && adapter.getSpec && adapter.getSpec();

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1248,7 +1248,7 @@ describe('Unit: Prebid Module', function () {
         assert.ok(logMessageSpy.calledWith('No adUnits configured. No bids requested.'), 'expected message was logged');
       });
 
-      it('should attach transactionIds to ads (or pass through transactionId if it already exists)', function () {
+      it('should always attach new transactionIds to adUnits passed to requestBids', function () {
         $$PREBID_GLOBAL$$.requestBids({
           adUnits: [
             {
@@ -1263,7 +1263,8 @@ describe('Unit: Prebid Module', function () {
         });
 
         expect(auctionArgs.adUnits[0]).to.have.property('transactionId')
-          .and.to.equal('d0676a3c-ff32-45a5-af65-8175a8e7ddca');
+          .and.to.match(/[a-f0-9\-]{36}/i)
+          .and.not.to.equal('d0676a3c-ff32-45a5-af65-8175a8e7ddca');
         expect(auctionArgs.adUnits[1]).to.have.property('transactionId')
           .and.to.match(/[a-f0-9\-]{36}/i);
       });


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Transaction ID implicitly suggests that this is a unique identifier per transaction. However in the case of a refresh / re-use of an adunit the transaction ID remains the same causing undesirable bidding with certain SSPs.


