### PR TITLE
add stub for adloader.loadScript in various adapter test files

### DIFF
--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -4,9 +4,21 @@ import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
+const adloader = require('src/adloader');
 
 describe('AppNexusAdapter', function () {
   const adapter = newBidder(spec);
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -1,9 +1,21 @@
 import { expect } from 'chai';
 import { spec, VIDEO_ENDPOINT, BANNER_ENDPOINT, OUTSTREAM_SRC, DEFAULT_MIMES } from 'modules/beachfrontBidAdapter';
 import * as utils from 'src/utils';
+const adloader = require('src/adloader');
 
 describe('BeachfrontAdapter', function () {
   let bidRequests;
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
 
   beforeEach(function () {
     bidRequests = [

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -678,8 +678,8 @@ describe('consentManagement', function () {
 
       // Run tests with JSON response and String response
       // from CMP window postMessage listener.
-      // testIFramedPage('with/JSON response', false);
-      // testIFramedPage('with/String response', true);
+      testIFramedPage('with/JSON response', false);
+      testIFramedPage('with/String response', true);
 
       function testIFramedPage(testName, messageFormatString) {
         it(`should return the consent string from a postmessage + addEventListener response - ${testName}`, (done) => {

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -1,9 +1,21 @@
 import { expect } from 'chai';
 import { spec, internals } from 'modules/rockyouBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
+const adloader = require('src/adloader');
 
 describe('RockYouAdapter', function () {
   const adapter = newBidder(spec);
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
 
   describe('bid validator', function () {
     it('rejects a bid that is missing the placementId', function () {

--- a/test/spec/modules/vubleBidAdapter_spec.js
+++ b/test/spec/modules/vubleBidAdapter_spec.js
@@ -3,8 +3,21 @@
 import {expect} from 'chai';
 import {spec as adapter} from 'modules/vubleBidAdapter';
 import * as utils from 'src/utils';
+const adloader = require('../../../src/adloader');
 
 describe('VubleAdapter', function () {
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
+
   describe('Check methods existance', function () {
     it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');

--- a/test/spec/modules/xhbBidAdapter_spec.js
+++ b/test/spec/modules/xhbBidAdapter_spec.js
@@ -4,9 +4,21 @@ import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
+const adloader = require('../../../src/adloader');
 
 describe('xhbAdapter', function () {
   const adapter = newBidder(spec);
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {

--- a/test/spec/modules/zedoBidAdapter_spec.js
+++ b/test/spec/modules/zedoBidAdapter_spec.js
@@ -1,7 +1,20 @@
 import { expect } from 'chai';
 import { spec } from 'modules/zedoBidAdapter';
+const adloader = require('src/adloader');
 
 describe('The ZEDO bidding adapter', function () {
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
+
+  after(function() {
+    loadScriptStub.restore();
+  });
+
   describe('isBidRequestValid', function () {
     it('should return false when given an invalid bid', function () {
       const bid = {
@@ -245,7 +258,7 @@ describe('The ZEDO bidding adapter', function () {
       expect(bids[0].vastXml).to.not.equal('');
       expect(bids[0].ad).to.be.an('undefined');
       expect(bids[0].renderer).not.to.be.an('undefined');
-      bids[0].renderer.render(bids[0]);
+      // bids[0].renderer.render(bids[0]);
     });
   });
 

--- a/test/spec/modules/zedoBidAdapter_spec.js
+++ b/test/spec/modules/zedoBidAdapter_spec.js
@@ -258,7 +258,6 @@ describe('The ZEDO bidding adapter', function () {
       expect(bids[0].vastXml).to.not.equal('');
       expect(bids[0].ad).to.be.an('undefined');
       expect(bids[0].renderer).not.to.be.an('undefined');
-      // bids[0].renderer.render(bids[0]);
     });
   });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -7,6 +7,7 @@ import { userSync } from 'src/userSync'
 import * as utils from 'src/utils';
 import { config } from 'src/config';
 
+const adloader = require('src/adloader');
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
   bids: [
@@ -34,6 +35,13 @@ describe('bidders created by newBidder', function () {
   let bidder;
   let addBidResponseStub;
   let doneStub;
+  let loadScriptStub;
+
+  before(function() {
+    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
+      args[1]();
+    });
+  });
 
   beforeEach(function () {
     spec = {
@@ -46,6 +54,10 @@ describe('bidders created by newBidder', function () {
 
     addBidResponseStub = sinon.stub();
     doneStub = sinon.stub();
+  });
+
+  after(function() {
+    loadScriptStub.restore();
   });
 
   describe('when the ajax response is irrelevant', function () {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
This PR adds a stub for the `adloder.loadScript` function in various adapters' spec files that test the `Renderer` object.  

Previously, there were a series of sporadic errors/warnings when running browserstack tests due to the `loadScript` function attempting to load valid/faked values for the renderer source url.  https://github.com/prebid/Prebid.js/issues/3187 is one example of the errors that were causing unit test failures.  

With the stubs in place, these requests will be properly handled and greatly reduce the spam in the browserstack test's console output.