### PR TITLE
Stub adloader across the board to prevent requests going out

### DIFF
--- a/test/mocks/adloaderStub.js
+++ b/test/mocks/adloaderStub.js
@@ -1,0 +1,22 @@
+const adloader = require('src/adloader');
+
+let sandbox;
+
+export let loadScript;
+export let loadExternalScript;
+export let loadScriptStub;
+export let loadExternalScriptStub;
+
+beforeEach(function() {
+  sandbox = sinon.sandbox.create();
+  loadScript = adloader.loadScript;
+  loadExternalScript = adloader.loadExternalScript;
+  loadScriptStub = sandbox.stub(adloader, 'loadScript').callsFake((...args) => {
+    args[1]();
+  });
+  loadExternalScriptStub = sandbox.stub(adloader, 'loadExternalScript');
+});
+
+afterEach(function() {
+  sandbox.restore();
+});

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -1,5 +1,5 @@
 import * as utils from 'src/utils';
-import * as adLoader from 'src/adloader';
+import * as adLoader from 'test/mocks/adloaderStub';
 
 describe('adLoader', function () {
   let utilsinsertElementStub;

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -9,7 +9,6 @@ import * as store from 'src/videoCache';
 import * as ajaxLib from 'src/ajax';
 import find from 'core-js/library/fn/array/find';
 
-const adloader = require('../../src/adloader');
 var assert = require('assert');
 
 /* use this method to test individual files instead of the whole prebid.js project */
@@ -551,7 +550,6 @@ describe('auctionmanager.js', function () {
     });
 
     describe('when auction timeout is 3000', function () {
-      let loadScriptStub;
       before(function () {
         makeRequestsStub.returns(TEST_BID_REQS);
       });
@@ -567,17 +565,12 @@ describe('auctionmanager.js', function () {
         createAuctionStub = sinon.stub(auctionModule, 'newAuction');
         createAuctionStub.returns(auction);
 
-        loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-          args[1]();
-        });
-
         spec = mockBidder(BIDDER_CODE, bids);
         registerBidder(spec);
       });
 
       afterEach(function () {
         auctionModule.newAuction.restore();
-        loadScriptStub.restore();
       });
 
       function checkPbDg(cpm, expected, msg) {
@@ -673,7 +666,6 @@ describe('auctionmanager.js', function () {
     });
 
     describe('when auction timeout is 20', function () {
-      let loadScriptStub;
       let eventsEmitSpy;
       let getBidderRequestStub;
 
@@ -697,10 +689,6 @@ describe('auctionmanager.js', function () {
         createAuctionStub = sinon.stub(auctionModule, 'newAuction');
         createAuctionStub.returns(auction);
 
-        loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-          args[1]();
-        });
-
         spec = mockBidder(BIDDER_CODE, [bids[0]]);
         registerBidder(spec);
 
@@ -722,7 +710,6 @@ describe('auctionmanager.js', function () {
       });
       afterEach(function () {
         auctionModule.newAuction.restore();
-        loadScriptStub.restore();
         events.emit.restore();
         getBidderRequestStub.restore();
       });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -4,21 +4,9 @@ import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
-const adloader = require('src/adloader');
 
 describe('AppNexusAdapter', function () {
   const adapter = newBidder(spec);
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -1,21 +1,9 @@
 import { expect } from 'chai';
 import { spec, VIDEO_ENDPOINT, BANNER_ENDPOINT, OUTSTREAM_SRC, DEFAULT_MIMES } from 'modules/beachfrontBidAdapter';
 import * as utils from 'src/utils';
-const adloader = require('src/adloader');
 
 describe('BeachfrontAdapter', function () {
   let bidRequests;
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
 
   beforeEach(function () {
     bidRequests = [

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -1,21 +1,9 @@
 import { expect } from 'chai';
 import { spec, internals } from 'modules/rockyouBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
-const adloader = require('src/adloader');
 
 describe('RockYouAdapter', function () {
   const adapter = newBidder(spec);
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
 
   describe('bid validator', function () {
     it('rejects a bid that is missing the placementId', function () {

--- a/test/spec/modules/vubleBidAdapter_spec.js
+++ b/test/spec/modules/vubleBidAdapter_spec.js
@@ -3,21 +3,8 @@
 import {expect} from 'chai';
 import {spec as adapter} from 'modules/vubleBidAdapter';
 import * as utils from 'src/utils';
-const adloader = require('../../../src/adloader');
 
 describe('VubleAdapter', function () {
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
-
   describe('Check methods existance', function () {
     it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');

--- a/test/spec/modules/xhbBidAdapter_spec.js
+++ b/test/spec/modules/xhbBidAdapter_spec.js
@@ -4,21 +4,9 @@ import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
-const adloader = require('../../../src/adloader');
 
 describe('xhbAdapter', function () {
   const adapter = newBidder(spec);
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {

--- a/test/spec/modules/zedoBidAdapter_spec.js
+++ b/test/spec/modules/zedoBidAdapter_spec.js
@@ -1,20 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/zedoBidAdapter';
-const adloader = require('src/adloader');
 
 describe('The ZEDO bidding adapter', function () {
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
-
-  after(function() {
-    loadScriptStub.restore();
-  });
-
   describe('isBidRequestValid', function () {
     it('should return false when given an invalid bid', function () {
       const bid = {

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { Renderer } from 'src/Renderer';
-const adloader = require('../../src/adloader');
 
 describe('Renderer: A renderer installed on a bid response', function () {
   let testRenderer1;
@@ -8,13 +7,7 @@ describe('Renderer: A renderer installed on a bid response', function () {
   let spyRenderFn;
   let spyEventHandler;
 
-  let loadScriptStub;
-
   beforeEach(function () {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-
     testRenderer1 = Renderer.install({
       url: 'https://httpbin.org/post',
       config: { test: 'config1' },
@@ -28,10 +21,6 @@ describe('Renderer: A renderer installed on a bid response', function () {
 
     spyRenderFn = sinon.spy();
     spyEventHandler = sinon.spy();
-  });
-
-  afterEach(function () {
-    loadScriptStub.restore();
   });
 
   it('is an instance of Renderer', function () {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -11,7 +11,6 @@ import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 var s2sTesting = require('../../../../modules/s2sTesting');
 var events = require('../../../../src/events');
-const adloader = require('../../../../src/adloader');
 
 const CONFIG = {
   enabled: true,
@@ -39,7 +38,6 @@ var rubiconAdapterMock = {
   bidder: 'rubicon',
   callBids: sinon.stub()
 };
-let loadScriptStub;
 
 describe('adapterManager tests', function () {
   let orgAppnexusAdapter;
@@ -51,9 +49,6 @@ describe('adapterManager tests', function () {
     orgAdequantAdapter = AdapterManager.bidderRegistry['adequant'];
     orgPrebidServerAdapter = AdapterManager.bidderRegistry['prebidServer'];
     orgRubiconAdapter = AdapterManager.bidderRegistry['rubicon'];
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
   });
 
   after(function () {
@@ -61,7 +56,6 @@ describe('adapterManager tests', function () {
     AdapterManager.bidderRegistry['adequant'] = orgAdequantAdapter;
     AdapterManager.bidderRegistry['prebidServer'] = orgPrebidServerAdapter;
     AdapterManager.bidderRegistry['rubicon'] = orgRubiconAdapter;
-    loadScriptStub.restore();
     config.setConfig({s2sConfig: { enabled: false }});
   });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -7,7 +7,6 @@ import { userSync } from 'src/userSync'
 import * as utils from 'src/utils';
 import { config } from 'src/config';
 
-const adloader = require('src/adloader');
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
   bids: [
@@ -35,13 +34,6 @@ describe('bidders created by newBidder', function () {
   let bidder;
   let addBidResponseStub;
   let doneStub;
-  let loadScriptStub;
-
-  before(function() {
-    loadScriptStub = sinon.stub(adloader, 'loadScript').callsFake((...args) => {
-      args[1]();
-    });
-  });
 
   beforeEach(function () {
     spec = {
@@ -54,10 +46,6 @@ describe('bidders created by newBidder', function () {
 
     addBidResponseStub = sinon.stub();
     doneStub = sinon.stub();
-  });
-
-  after(function() {
-    loadScriptStub.restore();
   });
 
   describe('when the ajax response is irrelevant', function () {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -26,7 +26,7 @@ var prebid = require('src/prebid');
 var utils = require('src/utils');
 // var bidmanager = require('src/bidmanager');
 var bidfactory = require('src/bidfactory');
-var adloader = require('src/adloader');
+var adloader = require('test/mocks/adloaderStub');
 var adaptermanager = require('src/adaptermanager');
 var events = require('src/events');
 var adserver = require('src/adserver');
@@ -1633,14 +1633,12 @@ describe('Unit: Prebid Module', function () {
 
   describe('loadScript', function () {
     it('should call adloader.loadScript', function () {
-      const loadScriptSpy = sinon.spy(adloader, 'loadScript');
       const tagSrc = '';
       const callback = Function;
       const useCache = false;
 
       $$PREBID_GLOBAL$$.loadScript(tagSrc, callback, useCache);
-      assert.ok(loadScriptSpy.calledWith(tagSrc, callback, useCache), 'called adloader.loadScript');
-      adloader.loadScript.restore();
+      assert.ok(adloader.loadScriptStub.calledWith(tagSrc, callback, useCache), 'called adloader.loadScript');
     });
   });
 

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -1,4 +1,5 @@
 require('test/helpers/prebidGlobal.js');
+require('test/mocks/adloaderStub.js');
 
 var testsContext = require.context('.', true, /_spec$/);
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Pulled out the adloader stubbing into a global mock so that it is stubbed by default.  Modules that need to use the actual adloader implementation (like adloader_spec.js) can access the original through the mock module.