### PR TITLE
Fixes #3197 - call auctionDone() when 'No valid bid requests returned for auction'

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -196,6 +196,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
 
     if (bidRequests.length < 1) {
       utils.logWarn('No valid bid requests returned for auction');
+      auctionDone();
     } else {
       let call = {
         bidRequests,

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1194,6 +1194,39 @@ describe('Unit: Prebid Module', function () {
   })
 
   describe('requestBids', function () {
+    let sandbox;
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+    afterEach(function () {
+      sandbox.restore();
+    });
+    describe('bidRequests is empty', function () {
+      it('should log warning message and execute callback if bidRequests is empty', function () {
+        let bidsBackHandler = function bidsBackHandlerCallback() {};
+        let spyExecuteCallback = sinon.spy(bidsBackHandler);
+        let logWarnSpy = sandbox.spy(utils, 'logWarn');
+
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'test1',
+              bids: [],
+            }, {
+              code: 'test2',
+              bids: [],
+            }
+          ],
+          bidsBackHandler: spyExecuteCallback
+        });
+
+        assert.ok(logWarnSpy.calledWith('No valid bid requests returned for auction'), 'expected warning message was logged');
+        assert.ok(spyExecuteCallback.calledOnce, 'callback executed when bidRequests is empty');
+      });
+    });
+  });
+
+  describe('requestBids', function () {
     let xhr;
     let requests;
 


### PR DESCRIPTION
call auctionDone() when 'No valid bid requests returned for auction'

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
When 'No valid bid requests returned for auction' we do call `auctionDone()` to have `bidsBackHandler` gets called.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#3197 