### PR TITLE
add logic to resize AST divs and iframes

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -6,11 +6,10 @@
 import events from './events';
 import { fireNativeTrackers } from './native';
 import { EVENTS } from './constants';
-import { isSlotMatchingAdUnitCode } from './utils';
+import { isSlotMatchingAdUnitCode, logWarn } from './utils';
 import { auctionManager } from './auctionManager';
 import find from 'core-js/library/fn/array/find';
 import { isRendererRequired, executeRenderer } from './Renderer';
-import { utils } from 'mocha';
 
 const BID_WON = EVENTS.BID_WON;
 
@@ -81,7 +80,7 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
       elementStyle.width = width + 'px';
       elementStyle.height = height + 'px';
     } else {
-      utils.logWarn(`Unable to locate matching page element for adUnitCode ${adUnitCode}.  Can't resize it to ad's dimensions.  Please review setup.`);
+      logWarn(`Unable to locate matching page element for adUnitCode ${adUnitCode}.  Can't resize it to ad's dimensions.  Please review setup.`);
     }
   });
 

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -105,8 +105,7 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
   }
 
   function getAstElementId(adUnitCode) {
-    let apn = window.apntag;
-    let astTagIds = apn.requests && apn.requests.tags && Object.keys(apn.requests.tags);
-    return astTagIds.length > 0 && find(astTagIds.filter(tagId => tagId === adUnitCode), tag => tag);
+    let astTag = window.apntag.getTag(adUnitCode);
+    return astTag && astTag.targetId;
   }
 }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -10,6 +10,7 @@ import { isSlotMatchingAdUnitCode } from './utils';
 import { auctionManager } from './auctionManager';
 import find from 'core-js/library/fn/array/find';
 import { isRendererRequired, executeRenderer } from './Renderer';
+import { utils } from 'mocha';
 
 const BID_WON = EVENTS.BID_WON;
 
@@ -74,12 +75,39 @@ function sendAdToCreative(adObject, remoteDomain, source) {
 function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
-    let elementStyle = getElementByAdUnit(elmType).style;
-    elementStyle.width = width + 'px';
-    elementStyle.height = height + 'px';
+    let element = getElementByAdUnit(elmType);
+    if (element) {
+      let elementStyle = element.style;
+      elementStyle.width = width + 'px';
+      elementStyle.height = height + 'px';
+    } else {
+      utils.logWarn(`Unable to locate matching page element for adUnitCode ${adUnitCode}.  Can't resize it to ad's dimensions.  Please review setup.`);
+    }
   });
+
   function getElementByAdUnit(elmType) {
-    return document.getElementById(find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot)
-      .getSlotElementId()).querySelector(elmType);
+    let id = getElementIdBasedOnAdServer(adUnitCode);
+    let parentDivEle = document.getElementById(id);
+    return parentDivEle && parentDivEle.querySelector(elmType);
+  }
+
+  function getElementIdBasedOnAdServer(adUnitCode) {
+    if (window.googletag) {
+      return getDfpElementId(adUnitCode)
+    } else if (window.apntag) {
+      return getAstElementId(adUnitCode)
+    } else {
+      return adUnitCode;
+    }
+  }
+
+  function getDfpElementId(adUnitCode) {
+    return find(window.googletag.pubads().getSlots().filter(isSlotMatchingAdUnitCode(adUnitCode)), slot => slot).getSlotElementId()
+  }
+
+  function getAstElementId(adUnitCode) {
+    let apn = window.apntag;
+    let astTagIds = apn.requests && apn.requests.tags && Object.keys(apn.requests.tags);
+    return astTagIds.length > 0 && find(astTagIds.filter(tagId => tagId === adUnitCode), tag => tag);
   }
 }


### PR DESCRIPTION
**NOTE** check with @mkendall07 first before merging.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
This change adds/fixes some of the logic used in the `resizeRemoteCreative` function.  The function will now:
- not only rely on GAM tags being present on the page; it will now support AST tags or a div that matches the value in the bid's adUnitCode*
- throw a warning message when it's unable to find the page element to resize instead of either silently failing or throwing an undefined exception.



* this back-up can be removed if desired.  I added it as a catch-all fallback instead of throwing an warning/error.