### PR TITLE
rename buyer to dspx

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -2,12 +2,12 @@ import * as utils from 'src/utils';
 import {config} from 'src/config';
 import {registerBidder} from 'src/adapters/bidderFactory';
 
-const BIDDER_CODE = 'buyer';
+const BIDDER_CODE = 'dspx';
 const ENDPOINT_URL = 'https://buyer.dspx.tv/request/';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['buyer'],
+  aliases: ['dspx'],
   isBidRequestValid: function(bid) {
     return !!(bid.params.placement);
   },

--- a/modules/dspxBidAdapter.md
+++ b/modules/dspxBidAdapter.md
@@ -1,14 +1,14 @@
 # Overview
 
 ```
-Module Name: Buyer Bidder Adapter
+Module Name: Dspx Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: avj83@list.ru
+Maintainer: prebid@dspx.tv
 ```
 
 # Description
 
-Buyer adapter for Prebid.js 1.0
+Dspx adapter for Prebid.js 1.0
 
 # Test Parameters
 ```
@@ -25,9 +25,9 @@ Buyer adapter for Prebid.js 1.0
             },
             bids: [
                 {
-                    bidder: "buyer",
+                    bidder: "dspx",
                     params: {
-                        placement: '12345',
+                        placement: '101',
                         pfilter: {
                             floorprice: 1000000, // EUR * 1,000,000
                             private_auction: 1, // Is private auction?  0  - no, 1 - yes
@@ -60,9 +60,9 @@ Buyer adapter for Prebid.js 1.0
             },
             bids: [
                 {
-                    bidder: "buyer",
+                    bidder: "dspx",
                     params: {
-                        placement: 67890
+                        placement: 101
                     }
                 }
             ]

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
-import { spec } from 'modules/buyerBidAdapter';
+import { spec } from 'modules/dspxBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT_URL = 'https://buyer.dspx.tv/request/';
 
-describe('buyerAdapter', function () {
+describe('dspxAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('isBidRequestValid', function () {
     let bid = {
-      'bidder': 'buyer',
+      'bidder': 'dspx',
       'params': {
         'placement': '6682',
         'pfilter': {
@@ -42,7 +42,7 @@ describe('buyerAdapter', function () {
 
   describe('buildRequests', function () {
     let bidRequests = [{
-      'bidder': 'buyer',
+      'bidder': 'dspx',
       'params': {
         'placement': '6682',
         'pfilter': {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ x] Other

## Description of change
Rename adapter's name to `dspx` (inc. relevant code)  and  Maintainer's email

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'dspx',
  params: {
       placement: 101
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer  prebid@dspx.tv
- [x ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
