### PR TITLE
Rubicon adapter: Removed extraneous warning

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -581,7 +581,6 @@ function mapSizes(sizes) {
  */
 export function hasVideoMediaType(bidRequest) {
   if (typeof utils.deepAccess(bidRequest, 'params.video') === 'undefined' && Array.isArray(utils.deepAccess(bidRequest, 'params.sizes'))) {
-    utils.logWarn('Rubicon bid adapter Warning: no video params found, convert to banner with the bidder size id');
     return false;
   }
   return (bidRequest.mediaType === VIDEO || typeof utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`) !== 'undefined');

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -92,11 +92,9 @@ export const spec = {
     if (typeof bid.params !== 'object') {
       return false;
     }
-
     if (!/^\d+$/.test(bid.params.accountId)) {
       return false;
     }
-
     return !!bidType(bid, true);
   },
   /**


### PR DESCRIPTION
## Type of change
- [ X ] Other

## Description of change
Removed overly chatty warning on the Rubicon adapter that was firing on all non-video requests