### PR TITLE
Updating Auction Init Pick for timestamp + Test update

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -289,7 +289,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
     switch (eventType) {
       case AUCTION_INIT:
         let cacheEntry = _pick(args, [
-          'auctionStart as timestamp',
+          'timestamp',
           'timeout'
         ]);
         cacheEntry.bids = {};

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -289,7 +289,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
     switch (eventType) {
       case AUCTION_INIT:
         let cacheEntry = _pick(args, [
-          'timestamp',
+          'auctionStart as timestamp',
           'timeout'
         ]);
         cacheEntry.bids = {};

--- a/src/auction.js
+++ b/src/auction.js
@@ -110,6 +110,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
   function getProperties() {
     return {
       auctionId: _auctionId,
+      timestamp: _auctionStart,
       auctionStart: _auctionStart,
       auctionEnd: _auctionEnd,
       auctionStatus: _auctionStatus,

--- a/src/auction.js
+++ b/src/auction.js
@@ -111,7 +111,6 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
     return {
       auctionId: _auctionId,
       timestamp: _auctionStart,
-      auctionStart: _auctionStart,
       auctionEnd: _auctionEnd,
       auctionStatus: _auctionStatus,
       adUnits: _adUnits,

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -106,9 +106,59 @@ const MOCK = {
     [BID2.adUnitCode]: BID2.adserverTargeting
   },
   AUCTION_INIT: {
-    'timestamp': 1519767010567,
     'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
-    'timeout': 3000
+    'auctionStart': 1519767010567,
+    'auctionStatus': 'inProgress',
+    'adUnits': [ {
+      'code': '/19968336/header-bid-tag1',
+      'sizes': [[640, 480]],
+      'bids': [ {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': 1001, 'siteId': 113932, 'zoneId': 535512
+        }
+      } ],
+      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
+    }
+    ],
+    'adUnitCodes': ['/19968336/header-bid-tag1'],
+    'bidderRequests': [ {
+      'bidderCode': 'rubicon',
+      'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+      'bidderRequestId': '1be65d7958826a',
+      'bids': [ {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': 1001, 'siteId': 113932, 'zoneId': 535512
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [[640, 480]]
+          }
+        },
+        'adUnitCode': '/19968336/header-bid-tag1',
+        'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+        'sizes': [[640, 480]],
+        'bidId': '2ecff0db240757',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'src': 'client',
+        'bidRequestsCount': 1
+      }
+      ],
+      'auctionStart': 1519767010567,
+      'timeout': 3000,
+      'refererInfo': {
+        'referer': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+      }
+    }
+    ],
+    'bidsReceived': [],
+    'winningBids': [],
+    'timeout': 3000,
+    'config': {
+      'accountId': 1001, 'endpoint': '//localhost:9999/event'
+    }
   },
   BID_REQUESTED: {
     'bidder': 'rubicon',

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -107,6 +107,7 @@ const MOCK = {
   },
   AUCTION_INIT: {
     'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+    'timestamp': 1519767010567,
     'auctionStart': 1519767010567,
     'auctionStatus': 'inProgress',
     'adUnits': [ {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -108,7 +108,6 @@ const MOCK = {
   AUCTION_INIT: {
     'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
     'timestamp': 1519767010567,
-    'auctionStart': 1519767010567,
     'auctionStatus': 'inProgress',
     'adUnits': [ {
       'code': '/19968336/header-bid-tag1',


### PR DESCRIPTION
## Type of change
- [X ] Bugfix

## Description of change

Commit:
https://github.com/prebid/Prebid.js/commit/de597ae6630031e08953c0a993bbb1539399ba47#diff-9a9e476b9246c1fdeb97faaf94fcbde2

https://github.com/prebid/Prebid.js/pull/3168

introduced an issue for the rubiconAnalyticsAdapter.

The old Auction Init args used to contain `timestamp` but that was changed to `auctionStart`.

This caused the adapter to send `null` values in certain areas.

This commit will fix this by altering the timestamp assignment, as well as updating the existing tests to contain a proper mock auction init.