### PR TITLE
Encode native targeting params for DFP support.

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -174,11 +174,11 @@ export function getNativeTargeting(bid) {
       value = value.url;
     }
 
-    // encode fields as they might contain invalid DFP key-value values
-    // such as `=` or `!`.
-    value = encodeURIComponent(value);
-
     if (key) {
+      // encode fields as they might contain invalid DFP key-value values
+      // such as `=` or `!`.
+      value = encodeURIComponent(value);
+
       keyValues[key] = value;
     }
   });

--- a/src/native.js
+++ b/src/native.js
@@ -115,13 +115,24 @@ export function nativeBidIsValid(bid, bidRequests) {
  * message should contain an `action` set to 'click'.
  *
  * // Native creative template example usage
- * <a href="%%CLICK_URL_UNESC%%%%PATTERN:hb_native_linkurl%%"
+ * <a class='js-native-link' href=''
  *    target="_blank"
- *    onclick="fireTrackers('click')">
- *    %%PATTERN:hb_native_title%%
+ *    onclick="fireTrackers('click')"
+ *    id="native-title">
  * </a>
  *
  * <script>
+ *   var linkUrl = '%%PATTERN:hb_native_linkurl%%';
+ *   linkUrl = '%%CLICK_URL_UNESC%%' + decodeURIComponent(linkUrl);
+ *   var links = document.getElementsByClassName('js-native-link');
+ *   for (var i = 0; i < links.length; i++) {
+ *     links[i].href = linkUrl;
+ *   };
+ *
+ *   var titleText = '%%PATTERN:hb_native_title%%';
+ *   titleText = decodeURIComponent(titleText);
+ *   document.getElementById('native-title').innerHTML = titleText;
+ *
  *   function fireTrackers(action) {
  *     var message = {message: 'Prebid Native', adId: '%%PATTERN:hb_adid%%'};
  *     if (action === 'click') {message.action = 'click';} // fires click trackers
@@ -162,6 +173,10 @@ export function getNativeTargeting(bid) {
     if (typeof value === 'object' && value.url) {
       value = value.url;
     }
+
+    // encode fields as they might contain invalid DFP key-value values
+    // such as `=` or `!`.
+    value = encodeURIComponent(value);
 
     if (key) {
       keyValues[key] = value;

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -6,10 +6,10 @@ const utils = require('src/utils');
 const bid = {
   native: {
     title: 'Native Creative',
-    body: 'Cool description great stuff',
+    body: 'Cool description great stuff!',
     cta: 'Do it',
     sponsoredBy: 'AppNexus',
-    clickUrl: 'https://www.link.example',
+    clickUrl: 'https://www.link.example?param=value',
     clickTrackers: ['https://tracker.example'],
     impressionTrackers: ['https://impression.example'],
     javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>'
@@ -32,9 +32,12 @@ describe('native.js', function () {
 
   it('gets native targeting keys', function () {
     const targeting = getNativeTargeting(bid);
-    expect(targeting[CONSTANTS.NATIVE_KEYS.title]).to.equal(bid.native.title);
-    expect(targeting[CONSTANTS.NATIVE_KEYS.body]).to.equal(bid.native.body);
-    expect(targeting[CONSTANTS.NATIVE_KEYS.clickUrl]).to.equal(bid.native.clickUrl);
+    const title = decodeURIComponent(targeting[CONSTANTS.NATIVE_KEYS.title]);
+    const body = decodeURIComponent(targeting[CONSTANTS.NATIVE_KEYS.body]);
+    const linkurl = decodeURIComponent(targeting[CONSTANTS.NATIVE_KEYS.clickUrl]);
+    expect(title).to.equal(bid.native.title);
+    expect(body).to.equal(bid.native.body);
+    expect(linkurl).to.equal(bid.native.clickUrl);
   });
 
   it('fires impression trackers', function () {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Fixes #3155

Encodes all native targeting params sent to DFP. The DFP native creative then needs to decode each value. Without encoding the values never make it through DFP to the creative.

This is a breaking change, however I'm unaware of how existing code works for anyone using DFP. If this is a concern, we can add a configuration parameter to toggle this, or at least note this in the changelog.