### PR TITLE
Only set native targeting if value exists.

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -147,7 +147,7 @@ export function fireNativeTrackers(message, adObject) {
 }
 
 /**
- * Gets native targeting key-value paris
+ * Gets native targeting key-value pairs
  * @param {Object} bid
  * @return {Object} targeting
  */
@@ -163,7 +163,7 @@ export function getNativeTargeting(bid) {
       value = value.url;
     }
 
-    if (key) {
+    if (key && value) {
       keyValues[key] = value;
     }
   });

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -16,6 +16,19 @@ const bid = {
   }
 };
 
+const bidWithUndefinedFields = {
+  native: {
+    title: 'Native Creative',
+    body: undefined,
+    cta: undefined,
+    sponsoredBy: 'AppNexus',
+    clickUrl: 'https://www.link.example',
+    clickTrackers: ['https://tracker.example'],
+    impressionTrackers: ['https://impression.example'],
+    javascriptTrackers: '<script src=\"http://www.foobar.js\"></script>'
+  }
+};
+
 describe('native.js', function () {
   let triggerPixelStub;
   let insertHtmlIntoIframeStub;
@@ -35,6 +48,16 @@ describe('native.js', function () {
     expect(targeting[CONSTANTS.NATIVE_KEYS.title]).to.equal(bid.native.title);
     expect(targeting[CONSTANTS.NATIVE_KEYS.body]).to.equal(bid.native.body);
     expect(targeting[CONSTANTS.NATIVE_KEYS.clickUrl]).to.equal(bid.native.clickUrl);
+  });
+
+  it('should only include native targeting keys with values', function () {
+    const targeting = getNativeTargeting(bidWithUndefinedFields);
+
+    expect(Object.keys(targeting)).to.deep.equal([
+      CONSTANTS.NATIVE_KEYS.title,
+      CONSTANTS.NATIVE_KEYS.sponsoredBy,
+      CONSTANTS.NATIVE_KEYS.clickUrl
+    ]);
   });
 
   it('fires impression trackers', function () {


### PR DESCRIPTION

## Type of change
- [X ] Bugfix

## Description of change

With an appnexus test placementId, we get native bid responses without a body or cta set. These are then passed as KVPs to DFP as `undefined`.  For example: `hb_native_brand=AppNexus&hb_native_cta=undefined&hb_native_body=undefined`. Since there is a limit on the length of a URL sent to DFP, this PR does not set keys without valid values.

I've assumed that `false` is not a valid value, based on the context of the fields.
