### PR TITLE
adding Prebid.js version to request in quantcastBidAdapter

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -93,7 +93,7 @@ export const spec = {
         bidId: bid.bidId,
         gdprSignal: gdprConsent.gdprApplies ? 1 : 0,
         gdprConsent: gdprConsent.consentString,
-        prebidJsVersion: pbjs.version
+        prebidJsVersion: '$prebid.version$'
       };
 
       const data = JSON.stringify(requestData);

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
         });
       });
 
-      const gdprConsent = bidderRequest ? bidderRequest.gdprConsent : {};
+      const gdprConsent = (bidderRequest && bidderRequest.gdprConsent) ? bidderRequest.gdprConsent : {};
 
       // Request Data Format can be found at https://wiki.corp.qc/display/adinf/QCX
       const requestData = {
@@ -92,7 +92,8 @@ export const spec = {
         },
         bidId: bid.bidId,
         gdprSignal: gdprConsent.gdprApplies ? 1 : 0,
-        gdprConsent: gdprConsent.consentString
+        gdprConsent: gdprConsent.consentString,
+        prebidJsVersion: pbjs.version
       };
 
       const data = JSON.stringify(requestData);

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -120,7 +120,7 @@ describe('Quantcast adapter', function () {
         },
         bidId: '2f7b179d443f14',
         gdprSignal: 0,
-        prebidJsVersion: pbjs.version
+        prebidJsVersion: '$prebid.version$'
       };
 
       expect(requests[0].data).to.equal(JSON.stringify(expectedBidRequest));

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -119,7 +119,8 @@ describe('Quantcast adapter', function () {
           domain
         },
         bidId: '2f7b179d443f14',
-        gdprSignal: 0
+        gdprSignal: 0,
+        prebidJsVersion: pbjs.version
       };
 
       expect(requests[0].data).to.equal(JSON.stringify(expectedBidRequest));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

We would like to add a new field to the request containing the version of Prebid.js that was used to send it.



