### PR TITLE
fix deal targeting for cpm 0

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -35,18 +35,9 @@ export function getHighestCpmBidsFromBidPool(bidsReceived, highestCpmCallback) {
   // filter top bid for each bucket by bidder
   Object.keys(buckets).forEach(bucketKey => {
     let bidsByBidder = groupBy(buckets[bucketKey], 'bidderCode');
-    Object.keys(bidsByBidder).forEach(key => bids.push(bidsByBidder[key].reduce(highestCpmCallback, getEmptyBid())));
+    Object.keys(bidsByBidder).forEach(key => bids.push(bidsByBidder[key].reduce(highestCpmCallback)));
   });
   return bids;
-}
-
-function getEmptyBid(adUnitCode) {
-  return {
-    adUnitCode: adUnitCode,
-    cpm: 0,
-    adserverTargeting: {},
-    timeToRespond: 0
-  };
 }
 
 /**
@@ -222,7 +213,7 @@ export function newTargeting(auctionManager) {
       .filter(uniques)
       .map(adUnitCode => bidsReceived
         .filter(bid => bid.adUnitCode === adUnitCode ? bid : null)
-        .reduce(getHighestCpm, getEmptyBid(adUnitCode)));
+        .reduce(getHighestCpm));
   };
 
   /**


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Bids with cpm of 0 should still have deal targeting passed through.  Cleaned up the targeting a little bit and removed the "empty bid" logic.

## Other information
CPM issue referenced here: #3191 