### PR TITLE
add nolint command line option, similar to notest

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,10 @@ function escapePostbidConfig() {
 };
 escapePostbidConfig.displayName = 'escape-postbid-config';
 
-function lint() {
+function lint(done) {
+  if (argv.nolint) {
+    return done();
+  }
   return gulp.src(['src/**/*.js', 'modules/**/*.js', 'test/**/*.js'])
     .pipe(eslint())
     .pipe(eslint.format('stylish'))


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This `--nolint` options is rather useful when debugging as `debugger` statements make the lint fail and kill the build.

## Other information
Cherry-picked from #3145
