### PR TITLE
use unit id being sent instead of hard coded auid

### DIFF
--- a/modules/openxoutstreamBidAdapter.js
+++ b/modules/openxoutstreamBidAdapter.js
@@ -27,11 +27,13 @@ export const spec = {
       return [];
     }
     let requests = [];
-    requests.push(buildOXBannerRequest(bidRequests, bidderRequest));
+    bidRequests.forEach(bid => {
+      requests.push(buildOXBannerRequest(bid, bidderRequest));
+    })
     return requests;
   },
-  interpretResponse: function(serverResponse, serverRequest) {
-    return handleVastResponse(serverResponse, serverRequest.payload)
+  interpretResponse: function(bid, serverResponse) {
+    return handleVastResponse(bid, serverResponse.payload)
   },
 };
 
@@ -61,7 +63,7 @@ function getViewportDimensions(isIfr) {
   return `${width}x${height}`;
 }
 
-function buildCommonQueryParamsFromBids(bids, bidderRequest) {
+function buildCommonQueryParamsFromBids(bid, bidderRequest) {
   const isInIframe = utils.inIframe();
   let defaultParams;
   defaultParams = {
@@ -73,13 +75,13 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     tz: new Date().getTimezoneOffset(),
     tws: getViewportDimensions(isInIframe),
     be: 1,
-    bc: bids[0].params.bc || `${BIDDER_CONFIG}_${BIDDER_VERSION}`,
-    auid: bids[0].params.unit,
-    dddid: utils._map(bids, bid => bid.transactionId).join(','),
+    bc: bid.params.bc || `${BIDDER_CONFIG}_${BIDDER_VERSION}`,
+    auid: bid.params.unit,
+    dddid: bid.transactionId,
     openrtb: '%7B%22mimes%22%3A%5B%22video%2Fmp4%22%5D%7D',
     nocache: new Date().getTime(),
-    vht: bids[0].params.height || bids[0].sizes[0][1],
-    vwd: bids[0].params.width || bids[0].sizes[0][0]
+    vht: bid.params.height || bid.sizes[0][1],
+    vwd: bid.params.width || bid.sizes[0][0]
   };
 
   if (utils.deepAccess(bidderRequest, 'gdprConsent')) {
@@ -101,24 +103,28 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
   return defaultParams;
 }
 
-function buildOXBannerRequest(bids, bidderRequest) {
-  let queryParams = buildCommonQueryParamsFromBids(bids, bidderRequest);
-  queryParams.aus = utils._map(bids, bid => utils.parseSizesInput(bid.sizes).join(',')).join('|');
+function buildOXBannerRequest(bid, bidderRequest) {
+  let queryParams = buildCommonQueryParamsFromBids(bid, bidderRequest);
+  // let auids = utils._map(bids, bid => bid.params.unit)
+  // queryParams.aus = utils._map(bids, bid => utils.parseSizesInput(bid.sizes).join(',')).join('|');
 
-  if (bids.some(bid => bid.params.doNotTrack)) {
+  // if (auids.some(auid => auid)) {
+  //   queryParams.auid = auids.join(',');
+  // }
+  if (bid.params.doNotTrack) {
     queryParams.ns = 1;
   }
 
-  if (bids.some(bid => bid.params.coppa)) {
+  if (bid.params.coppa) {
     queryParams.tfcd = 1;
   }
 
-  let url = `https://${bids[0].params.delDomain}/v/1.0/avjp`
+  let url = `https://${bid.params.delDomain}/v/1.0/avjp`
   return {
     method: 'GET',
     url: url,
     data: queryParams,
-    payload: {'bids': bids}
+    payload: {'bid': bid}
   };
 }
 
@@ -137,7 +143,7 @@ function handleVastResponse(response, serverResponse) {
     const ymAdsScript = '<script type="text/javascript"> window.__ymAds =' + adResponseString + '</script>';
 
     let bidResponse = {};
-    bidResponse.requestId = serverResponse.bids[0].bidId;
+    bidResponse.requestId = serverResponse.bid.bidId;
     bidResponse.bidderCode = BIDDER_CODE;
     bidResponse.netRevenue = NET_REVENUE;
     bidResponse.currency = CURRENCY;

--- a/modules/openxoutstreamBidAdapter.js
+++ b/modules/openxoutstreamBidAdapter.js
@@ -20,10 +20,7 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: SUPPORTED_AD_TYPES,
   isBidRequestValid: function(bidRequest) {
-    if (bidRequest.params.delDomain) {
-      return !!bidRequest.params.unit || utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes.length') > 0;
-    }
-    return false;
+    return !!(bidRequest.params.delDomain && bidRequest.params.unit)
   },
   buildRequests: function(bidRequests, bidderRequest) {
     if (bidRequests.length === 0) {
@@ -36,12 +33,6 @@ export const spec = {
   interpretResponse: function(serverResponse, serverRequest) {
     return handleVastResponse(serverResponse, serverRequest.payload)
   },
-
-  transformBidParams: function(params, isOpenRtb) {
-    return utils.convertTypes({
-      'unit': 'string',
-    }, params);
-  }
 };
 
 function getViewportDimensions(isIfr) {
@@ -83,7 +74,7 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     tws: getViewportDimensions(isInIframe),
     be: 1,
     bc: bids[0].params.bc || `${BIDDER_CONFIG}_${BIDDER_VERSION}`,
-    auid: '540141567',
+    auid: bids[0].params.unit,
     dddid: utils._map(bids, bid => bid.transactionId).join(','),
     openrtb: '%7B%22mimes%22%3A%5B%22video%2Fmp4%22%5D%7D',
     nocache: new Date().getTime(),

--- a/modules/openxoutstreamBidAdapter.js
+++ b/modules/openxoutstreamBidAdapter.js
@@ -105,12 +105,8 @@ function buildCommonQueryParamsFromBids(bid, bidderRequest) {
 
 function buildOXBannerRequest(bid, bidderRequest) {
   let queryParams = buildCommonQueryParamsFromBids(bid, bidderRequest);
-  // let auids = utils._map(bids, bid => bid.params.unit)
-  // queryParams.aus = utils._map(bids, bid => utils.parseSizesInput(bid.sizes).join(',')).join('|');
+  queryParams.aus = utils.parseSizesInput(bid.sizes).join(',');
 
-  // if (auids.some(auid => auid)) {
-  //   queryParams.auid = auids.join(',');
-  // }
   if (bid.params.doNotTrack) {
     queryParams.ns = 1;
   }

--- a/modules/openxoutstreamBidAdapter.md
+++ b/modules/openxoutstreamBidAdapter.md
@@ -24,9 +24,8 @@ var adUnits = [
       {
         bidder: 'openxoutstream',
         params: {
-          unit: '53943996499',
+          unit: '540141567',
           delDomain: 'se-demo-d.openx.net',
-          publisher_page_url: 'yieldmo.com',
           width:  '300',
           height: '250',
         }

--- a/test/spec/modules/openxoutstreamBidAdapter_spec.js
+++ b/test/spec/modules/openxoutstreamBidAdapter_spec.js
@@ -147,9 +147,9 @@ describe('OpenXOutstreamAdapter', function () {
         };
         serverRequest = {
           payload: {
-            bids: [{
+            bid: {
               bidId: '2d36ac90d654af',
-            }],
+            },
           }
         };
       });

--- a/test/spec/modules/openxoutstreamBidAdapter_spec.js
+++ b/test/spec/modules/openxoutstreamBidAdapter_spec.js
@@ -44,28 +44,23 @@ describe('OpenXOutstreamAdapter', function () {
           bannerBid.params = {delDomain: 'test-delivery-domain'}
         });
 
-        it('should return false when there is no ad unit id and size', function () {
+        it('should return false if there is no adunit id and sizes are defined', function () {
+          bannerBid.mediaTypes.banner.sizes = [720, 90];
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
         });
 
-        it('should return true if there is an adunit id ', function () {
+        it('should return true if there is delivery domain and unit', function () {
           bannerBid.params.unit = '12345678';
           expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
         });
-
-        it('should return true if there is no adunit id and sizes are defined', function () {
-          bannerBid.mediaTypes.banner.sizes = [720, 90];
-          expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
-        });
-
-        it('should return false if no sizes are defined ', function () {
+        it('should return false if there is unit but no delivery domain', function () {
+          bannerBid.params = {unit: '12345678'};
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
         });
-
-        it('should return false if sizes empty ', function () {
-          bannerBid.mediaTypes.banner.sizes = [];
+        it('shoud return false if there is no delivery domain and no unit', function () {
+          bannerBid.params = {};
           expect(spec.isBidRequestValid(bannerBid)).to.equal(false);
-        });
+        })
       });
     });
   });
@@ -92,8 +87,26 @@ describe('OpenXOutstreamAdapter', function () {
       expect(request[0].method).to.equal('GET');
     });
 
-    it('should send ad unit ids when any are defined', function () {
+    it('should send ad unit ids, height, and width when any are defined', function () {
       const bidRequestsWithUnitIds = [{
+        'bidder': BIDDER,
+        'params': {
+          'unit': '540141567',
+          'height': '300',
+          'width': '250',
+          'delDomain': 'test-del-domain'
+        },
+        'adUnitCode': 'adunit-code',
+        sizes: [300, 250],
+        mediaTypes: {
+          banner: {
+            sizes: [[728, 90]]
+          }
+        },
+        'bidId': 'test-bid-id-2',
+        'bidderRequestId': 'test-bid-request-2',
+        'auctionId': 'test-auction-2'
+      }, {
         'bidder': BIDDER,
         'params': {
           'delDomain': 'test-del-domain'
@@ -108,24 +121,11 @@ describe('OpenXOutstreamAdapter', function () {
         'bidId': 'test-bid-id-1',
         'bidderRequestId': 'test-bid-request-1',
         'auctionId': 'test-auction-1'
-      }, {
-        'bidder': BIDDER,
-        'params': {
-          'unit': '540141567',
-          'delDomain': 'test-del-domain'
-        },
-        'adUnitCode': 'adunit-code',
-        mediaTypes: {
-          banner: {
-            sizes: [[728, 90]]
-          }
-        },
-        'bidId': 'test-bid-id-2',
-        'bidderRequestId': 'test-bid-request-2',
-        'auctionId': 'test-auction-2'
       }];
       const request = spec.buildRequests(bidRequestsWithUnitIds);
-      expect(request[0].data.auid).to.equal(`${bidRequestsWithUnitIds[1].params.unit}`);
+      expect(request[0].data.auid).to.equal(`${bidRequestsWithUnitIds[0].params.unit}`);
+      expect(request[0].data.vht).to.equal(`${bidRequestsWithUnitIds[0].params.height}`);
+      expect(request[0].data.vwd).to.equal(`${bidRequestsWithUnitIds[0].params.width}`);
     });
 
     describe('interpretResponse', function () {


### PR DESCRIPTION
- [x ] Other

## Description of change
uses unit bid param rather than hard coding unit Id. Updates some tests accordingly.
