### PR TITLE
Quantcast adapter onTimeout

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -167,10 +167,10 @@ export const spec = {
   },
   onTimeout(timeoutData) {
     const url = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
-    const data = {
+    const params = {
       mode: 'no-cors'
     };
-    fetch(url, data);
+    fetch(url, params);
   }
 };
 

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -1,4 +1,5 @@
 import * as utils from 'src/utils';
+import { ajax } from 'src/ajax';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'quantcast';
@@ -160,10 +161,7 @@ export const spec = {
   },
   onTimeout(timeoutData) {
     const url = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
-    const params = {
-      mode: 'no-cors'
-    };
-    fetch(url, params);
+    ajax(url, null, null);
   }
 };
 

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -4,7 +4,8 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 const BIDDER_CODE = 'quantcast';
 const DEFAULT_BID_FLOOR = 0.0000000001;
 
-export const QUANTCAST_DOMAIN = 'qcx.quantserve.com';
+// export const QUANTCAST_DOMAIN = 'qcx.quantserve.com';
+export const QUANTCAST_DOMAIN = 'localhost';
 export const QUANTCAST_TEST_DOMAIN = 's2s-canary.quantserve.com';
 export const QUANTCAST_NET_REVENUE = true;
 export const QUANTCAST_TEST_PUBLISHER = 'test-publisher';
@@ -69,7 +70,7 @@ export const spec = {
         });
       });
 
-      const gdprConsent = bidderRequest ? bidderRequest.gdprConsent : {};
+      const gdprConsent = (bidderRequest && bidderRequest.gdprConsent) ? bidderRequest.gdprConsent : {};
 
       // Request Data Format can be found at https://wiki.corp.qc/display/adinf/QCX
       const requestData = {
@@ -101,6 +102,12 @@ export const spec = {
         ? QUANTCAST_TEST_DOMAIN
         : QUANTCAST_DOMAIN;
       const url = `${QUANTCAST_PROTOCOL}://${qcDomain}:${QUANTCAST_PORT}/qchb`;
+
+      if (qcDomain !== QUANTCAST_TEST_DOMAIN) {
+        for (var i = 0; i < 20000; i += 1) {
+          console.log('xxxxxxxxxx');
+        }
+      }
 
       return {
         data,
@@ -157,6 +164,13 @@ export const spec = {
     });
 
     return bidResponsesList;
+  },
+  onTimeout(timeoutData) {
+    const url = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
+    const data = {
+      mode: 'no-cors'
+    };
+    fetch(url, data);
   }
 };
 

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -102,12 +102,6 @@ export const spec = {
         : QUANTCAST_DOMAIN;
       const url = `${QUANTCAST_PROTOCOL}://${qcDomain}:${QUANTCAST_PORT}/qchb`;
 
-      if (qcDomain !== QUANTCAST_TEST_DOMAIN) {
-        for (var i = 0; i < 20000; i += 1) {
-          console.log('xxxxxxxxxx');
-        }
-      }
-
       return {
         data,
         method: 'POST',

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -4,8 +4,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 const BIDDER_CODE = 'quantcast';
 const DEFAULT_BID_FLOOR = 0.0000000001;
 
-// export const QUANTCAST_DOMAIN = 'qcx.quantserve.com';
-export const QUANTCAST_DOMAIN = 'localhost';
+export const QUANTCAST_DOMAIN = 'qcx.quantserve.com';
 export const QUANTCAST_TEST_DOMAIN = 's2s-canary.quantserve.com';
 export const QUANTCAST_NET_REVENUE = true;
 export const QUANTCAST_TEST_PUBLISHER = 'test-publisher';

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import * as utils from 'src/utils';
 import { expect } from 'chai';
-import { stub } from 'sinon';
+import { stub, sandbox } from 'sinon';
 import {
   QUANTCAST_DOMAIN,
   QUANTCAST_TEST_DOMAIN,
@@ -215,7 +215,9 @@ describe('Quantcast adapter', function () {
 
   describe('`onTimeout`', function() {
     it('makes a request to the notify endpoint', function() {
-      const fetchStub = stub(window, 'fetch').callsFake(function() {});
+      // const fetchStub = stub(window, 'fetch').callsFake(function() {});
+      const sinonSandbox = sandbox.create();
+      const fetchStub = sinonSandbox.stub(window, 'fetch').callsFake(function() {});
       const timeoutData = {
         bidder: 'quantcast'
       };
@@ -226,6 +228,7 @@ describe('Quantcast adapter', function () {
       };
       fetchStub.withArgs(expectedUrl, expectedParams).calledOnce.should.be.true;
       fetchStub.restore();
+      sinonSandbox.restore();
     });
   });
 });

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -221,10 +221,10 @@ describe('Quantcast adapter', function () {
       };
       qcSpec.onTimeout(timeoutData);
       const expectedUrl = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
-      const expectedData = {
+      const expectedParams = {
         mode: 'no-cors'
       };
-      fetchStub.withArgs(expectedUrl, expectedData).calledOnce.should.be.true;
+      fetchStub.withArgs(expectedUrl, expectedParams).calledOnce.should.be.true;
       fetchStub.restore();
     });
   });

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -13,6 +13,7 @@ import {
 } from '../../../modules/quantcastBidAdapter';
 import { newBidder } from '../../../src/adapters/bidderFactory';
 import { parse } from 'src/url';
+import * as ajax from 'src/ajax';
 
 describe('Quantcast adapter', function () {
   const quantcastAdapter = newBidder(qcSpec);
@@ -215,19 +216,15 @@ describe('Quantcast adapter', function () {
 
   describe('`onTimeout`', function() {
     it('makes a request to the notify endpoint', function() {
-      // const fetchStub = stub(window, 'fetch').callsFake(function() {});
       const sinonSandbox = sandbox.create();
-      const fetchStub = sinonSandbox.stub(window, 'fetch').callsFake(function() {});
+      const ajaxStub = sinonSandbox.stub(ajax, 'ajax').callsFake(function() {});
       const timeoutData = {
         bidder: 'quantcast'
       };
       qcSpec.onTimeout(timeoutData);
       const expectedUrl = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
-      const expectedParams = {
-        mode: 'no-cors'
-      };
-      fetchStub.withArgs(expectedUrl, expectedParams).calledOnce.should.be.true;
-      fetchStub.restore();
+      ajaxStub.withArgs(expectedUrl, null, null).calledOnce.should.be.true;
+      ajaxStub.restore();
       sinonSandbox.restore();
     });
   });

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -1,5 +1,6 @@
 import * as utils from 'src/utils';
 import { expect } from 'chai';
+import { stub } from 'sinon';
 import {
   QUANTCAST_DOMAIN,
   QUANTCAST_TEST_DOMAIN,
@@ -209,6 +210,22 @@ describe('Quantcast adapter', function () {
       const interpretedResponse = qcSpec.interpretResponse(response);
 
       expect(interpretedResponse.length).to.equal(0);
+    });
+  });
+
+  describe('`onTimeout`', function() {
+    it('makes a request to the notify endpoint', function() {
+      const fetchStub = stub(window, 'fetch').callsFake(function() {});
+      const timeoutData = {
+        bidder: 'quantcast'
+      };
+      qcSpec.onTimeout(timeoutData);
+      const expectedUrl = `${QUANTCAST_PROTOCOL}://${QUANTCAST_DOMAIN}:${QUANTCAST_PORT}/qchb_notify?type=timeout`;
+      const expectedData = {
+        mode: 'no-cors'
+      };
+      fetchStub.withArgs(expectedUrl, expectedData).calledOnce.should.be.true;
+      fetchStub.restore();
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature
 
## Description of change
<!-- Describe the change proposed in this pull request -->
Adding onTimeout function to Quantcast's adapter. It should hit one of our endpoints so that we can log the number of timeouts.

