### PR TITLE
appnexus adapter support empty keyvalues in bidder params

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -178,6 +178,14 @@ export const spec = {
       params.use_pmt_rule = (typeof params.usePaymentRule === 'boolean') ? params.usePaymentRule : false;
       if (params.usePaymentRule) { delete params.usePaymentRule; }
 
+      if (utils.isArray(params.keywords) && params.keywords.length > 0) {
+        params.keywords.forEach(function(keyPairObj) {
+          if (utils.isArray(keyPairObj.value) && keyPairObj.value.length > 0 && keyPairObj.value[0] === '') {
+            delete keyPairObj.value;
+          }
+        });
+      }
+
       Object.keys(params).forEach(paramKey => {
         let convertedKey = utils.convertCamelToUnderscore(paramKey);
         if (convertedKey !== paramKey) {
@@ -345,7 +353,16 @@ function bidToTag(bid) {
     tag.external_imp_id = bid.params.externalImpId;
   }
   if (!utils.isEmpty(bid.params.keywords)) {
-    tag.keywords = utils.transformBidderParamKeywords(bid.params.keywords);
+    let keywords = utils.transformBidderParamKeywords(bid.params.keywords);
+
+    if (keywords.length > 0) {
+      keywords.forEach(function(keyPairObj) {
+        if (utils.isArray(keyPairObj.value) && keyPairObj.value.length > 0 && keyPairObj.value[0] === '') {
+          delete keyPairObj.value;
+        }
+      });
+    }
+    tag.keywords = keywords;
   }
 
   if (bid.mediaType === NATIVE || utils.deepAccess(bid, `mediaTypes.${NATIVE}`)) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -178,9 +178,9 @@ export const spec = {
       params.use_pmt_rule = (typeof params.usePaymentRule === 'boolean') ? params.usePaymentRule : false;
       if (params.usePaymentRule) { delete params.usePaymentRule; }
 
-      if (utils.isArray(params.keywords) && params.keywords.length > 0) {
+      if (utils.isPopulatedArray(params.keywords)) {
         params.keywords.forEach(function(keyPairObj) {
-          if (utils.isArray(keyPairObj.value) && keyPairObj.value.length > 0 && keyPairObj.value[0] === '') {
+          if (utils.isPopulatedArray(keyPairObj.value) && keyPairObj.value[0] === '') {
             delete keyPairObj.value;
           }
         });
@@ -357,7 +357,7 @@ function bidToTag(bid) {
 
     if (keywords.length > 0) {
       keywords.forEach(function(keyPairObj) {
-        if (utils.isArray(keyPairObj.value) && keyPairObj.value.length > 0 && keyPairObj.value[0] === '') {
+        if (utils.isPopulatedArray(keyPairObj.value) && keyPairObj.value[0] === '') {
           delete keyPairObj.value;
         }
       });

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -178,12 +178,8 @@ export const spec = {
       params.use_pmt_rule = (typeof params.usePaymentRule === 'boolean') ? params.usePaymentRule : false;
       if (params.usePaymentRule) { delete params.usePaymentRule; }
 
-      if (utils.isPopulatedArray(params.keywords)) {
-        params.keywords.forEach(function(keyPairObj) {
-          if (utils.isPopulatedArray(keyPairObj.value) && keyPairObj.value[0] === '') {
-            delete keyPairObj.value;
-          }
-        });
+      if (isPopulatedArray(params.keywords)) {
+        params.keywords.forEach(deleteValues);
       }
 
       Object.keys(params).forEach(paramKey => {
@@ -196,6 +192,16 @@ export const spec = {
     }
 
     return params;
+  }
+}
+
+function isPopulatedArray(arr) {
+  return !!(utils.isArray(arr) && arr.length > 0);
+}
+
+function deleteValues(keyPairObj) {
+  if (isPopulatedArray(keyPairObj.value) && keyPairObj.value[0] === '') {
+    delete keyPairObj.value;
   }
 }
 
@@ -356,11 +362,7 @@ function bidToTag(bid) {
     let keywords = utils.transformBidderParamKeywords(bid.params.keywords);
 
     if (keywords.length > 0) {
-      keywords.forEach(function(keyPairObj) {
-        if (utils.isPopulatedArray(keyPairObj.value) && keyPairObj.value[0] === '') {
-          delete keyPairObj.value;
-        }
-      });
+      keywords.forEach(deleteValues);
     }
     tag.keywords = keywords;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -439,10 +439,6 @@ exports.isBoolean = function(object) {
   return exports.isA(object, tBoolean);
 }
 
-exports.isPopulatedArray = function(arr) {
-  return !!(exports.isArray(arr) && arr.length > 0);
-}
-
 /**
  * Return if the object is "empty";
  * this includes falsey, no keys, or no items at indices

--- a/src/utils.js
+++ b/src/utils.js
@@ -1086,7 +1086,7 @@ export function transformBidderParamKeywords(keywords, paramName = 'keywords') {
       let values = [];
       exports._each(v, (val) => {
         val = exports.getValueString(paramName + '.' + k, val);
-        if (val) { values.push(val); }
+        if (val || val === '') { values.push(val); }
       });
       v = values;
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -439,6 +439,10 @@ exports.isBoolean = function(object) {
   return exports.isA(object, tBoolean);
 }
 
+exports.isPopulatedArray = function(arr) {
+  return !!(exports.isArray(arr) && arr.length > 0);
+}
+
 /**
  * Return if the object is "empty";
  * this includes falsey, no keys, or no items at indices

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -261,6 +261,8 @@ describe('AppNexusAdapter', function () {
               singleArrNum: [5],
               multiValMixed: ['value1', 2, 'value3'],
               singleValNum: 123,
+              emptyStr: '',
+              emptyArr: [''],
               badValue: {'foo': 'bar'} // should be dropped
             }
           }
@@ -285,6 +287,10 @@ describe('AppNexusAdapter', function () {
       }, {
         'key': 'singleValNum',
         'value': ['123']
+      }, {
+        'key': 'emptyStr'
+      }, {
+        'key': 'emptyArr'
       }]);
     });
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -846,4 +846,73 @@ describe('Utils', function () {
       expect(sizes).to.deep.equal([[300, 250], [300, 600]]);
     });
   });
+
+  describe('transformBidderParamKeywords', function () {
+    it('returns an array of objects when keyvalue is an array', function () {
+      let keywords = {
+        genre: ['rock', 'pop']
+      };
+      let result = utils.transformBidderParamKeywords(keywords);
+      expect(result).to.deep.equal([{
+        key: 'genre',
+        value: ['rock', 'pop']
+      }]);
+    });
+
+    it('returns an array of objects when keyvalue is a string', function () {
+      let keywords = {
+        genre: 'opera'
+      };
+      let result = utils.transformBidderParamKeywords(keywords);
+      expect(result).to.deep.equal([{
+        key: 'genre',
+        value: ['opera']
+      }]);
+    });
+
+    it('returns an array of objects when keyvalue is a number', function () {
+      let keywords = {
+        age: 15
+      };
+      let result = utils.transformBidderParamKeywords(keywords);
+      expect(result).to.deep.equal([{
+        key: 'age',
+        value: ['15']
+      }]);
+    });
+
+    it('returns an array of objects when using multiple keys with values of differing types', function () {
+      let keywords = {
+        genre: 'classical',
+        mix: ['1', 2, '3', 4],
+        age: 10
+      };
+      let result = utils.transformBidderParamKeywords(keywords);
+      expect(result).to.deep.equal([{
+        key: 'genre',
+        value: ['classical']
+      }, {
+        key: 'mix',
+        value: ['1', '2', '3', '4']
+      }, {
+        key: 'age',
+        value: ['10']
+      }]);
+    });
+
+    it('returns an array of objects when the keyvalue uses an empty string', function() {
+      let keywords = {
+        test: [''],
+        test2: ''
+      };
+      let result = utils.transformBidderParamKeywords(keywords);
+      expect(result).to.deep.equal([{
+        key: 'test',
+        value: ['']
+      }, {
+        key: 'test2',
+        value: ['']
+      }]);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
This change allows the appenxus bidder param `keywords` to accept an empty keyvalue and subsequently pass just the `key` param to the adserver.

In terms of setup, the bidder param would just use an empty string as the value; examples below:
```
params: {
  placementId: 13144370,
  keywords: {
    mykeyword: [''],
  }
}
```
or 
```
params: {
  placementId: 13144370,
  keywords: {
    mykeyword: '',
  }
}
```

Based on the above, the `tags[...].keywords` object in the ut request would look like the following:
```
[{
  key: 'mykeyword'
}]
```

A similar structure would be used in the request to PBS for the `imp[...].ext.appnexus.keywords` object.