### PR TITLE
MarsMedia analytic adapater to use PREBID_GLOBAL than hard-coded pbjs

### DIFF
--- a/modules/marsmediaAnalyticsAdapter.js
+++ b/modules/marsmediaAnalyticsAdapter.js
@@ -33,7 +33,7 @@ var marsmediaAnalyticsAdapter = Object.assign(adapter(
             success: function() {},
             error: function() {}
           },
-          JSON.stringify({act: 'prebid_analytics', params: events, 'pbjs': pbjs.getBidResponses(), ver: MARS_VERSION}),
+          JSON.stringify({act: 'prebid_analytics', params: events, 'pbjs': $$PREBID_GLOBAL$$.getBidResponses(), ver: MARS_VERSION}),
           {
             method: 'POST'
           }


### PR DESCRIPTION

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
MarsMedia analytic adapter to use PREBID_GLOBAL than hard-coded pbjs.
The adapter may not work if somebody sets namespace other than "pbjs" 
