### PR TITLE
only set mediaTypes.banner.sizes from sizes if mediaTypes doesn't exist.

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -65,20 +65,18 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
   let maps = evaluateSizeConfig(configs);
 
   if (!isPlainObject(mediaTypes)) {
-    mediaTypes = {};
+    // add support for deprecated adUnit.sizes by creating correct banner mediaTypes if they don't already exist
+    if (sizes) {
+      mediaTypes = {
+        banner: {
+          sizes
+        }
+      };
+    } else {
+      mediaTypes = {};
+    }
   } else {
     mediaTypes = deepClone(mediaTypes);
-  }
-
-  // add support for deprecated adUnit.sizes by creating correct banner mediaTypes if they don't already exist
-  if (sizes) {
-    if (!mediaTypes.banner) {
-      mediaTypes.banner = {
-        sizes
-      }
-    } else if (!mediaTypes.banner.sizes) {
-      mediaTypes.banner.sizes = sizes;
-    }
   }
 
   let oldSizes = deepAccess(mediaTypes, 'banner.sizes');


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes #3269.  The issue is when `mediaTypes.video.playerSize` is set then `adUnits.sizes` is set [here](https://github.com/prebid/Prebid.js/blob/master/src/adaptermanager.js#L284).  Since sizeMapping still supports `adUnit.sizes` it will set `adUnit.mediaTypes.banner.sizes` if it doesn't already exist, which is a bug if `adUnit.sizes` was set from the video sizes.  So to fix this, this pull-request only sets `adUnit.mediaTypes.banner.sizes` from `adUnit.sizes` if `adUnit.mediaTypes` doesn't exist.