### PR TITLE
fix: secure kargoBidAdapter against wrong Array extensions

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -76,8 +76,8 @@ export const spec = {
     let nameEquals = `${name}=`;
     let cookies = document.cookie.split(';');
 
-    for (let key in cookies) {
-      let cookie = cookies[key];
+    for (let i = 0; i < cookies.length; i++) {
+      let cookie = cookies[i];
       while (cookie.charAt(0) === ' ') {
         cookie = cookie.substring(1, cookie.length);
       }


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Currently, kargo adapter uses `for(let n in array)` loop which is fine, but in case someone does a nasty thing of extending `Array.prototype` it will crash as keys will represent new fields in the prototype, so the following lines will try to read `charAt` of `undefined`. Unfortunately, we found quite a few external codebases that do override that prototype.

Change is to simply use `for(let n = 0; n < array.length; n++)` loop as bulletproof version.

