### PR TITLE
OpenXBidAdapter: add support for platform ids

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -8,7 +8,7 @@ import {parse} from 'src/url';
 const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'openx';
 const BIDDER_CONFIG = 'hb_pb';
-const BIDDER_VERSION = '2.1.4';
+const BIDDER_VERSION = '2.1.5';
 
 let shouldSendBoPixel = true;
 
@@ -20,11 +20,12 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: SUPPORTED_AD_TYPES,
   isBidRequestValid: function (bidRequest) {
-    if (utils.deepAccess(bidRequest, 'mediaTypes.banner') && bidRequest.params.delDomain) {
+    const hasDelDomainOrPlatform = bidRequest.params.delDomain || bidRequest.params.platform;
+    if (utils.deepAccess(bidRequest, 'mediaTypes.banner') && hasDelDomainOrPlatform) {
       return !!bidRequest.params.unit || utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes.length') > 0;
     }
 
-    return !!(bidRequest.params.unit && bidRequest.params.delDomain);
+    return !!(bidRequest.params.unit && hasDelDomainOrPlatform);
   },
   buildRequests: function (bidRequests, bidderRequest) {
     if (bidRequests.length === 0) {
@@ -206,6 +207,10 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     nocache: new Date().getTime()
   };
 
+  if (bids[0].params.platform) {
+    defaultParams.ph = bids[0].params.platform;
+  }
+
   if (utils.deepAccess(bidderRequest, 'gdprConsent')) {
     let gdprConsentConfig = bidderRequest.gdprConsent;
 
@@ -273,7 +278,10 @@ function buildOXBannerRequest(bids, bidderRequest) {
     queryParams.aumfs = customFloorsForAllBids.join(',');
   }
 
-  let url = `//${bids[0].params.delDomain}/w/1.0/arj`;
+  let url = queryParams.ph
+    ? `//u.openx.net/w/1.0/arj`
+    : `//${bids[0].params.delDomain}/w/1.0/arj`;
+
   return {
     method: 'GET',
     url: url,

--- a/modules/openxBidAdapter.md
+++ b/modules/openxBidAdapter.md
@@ -15,7 +15,7 @@ Module that connects to OpenX's demand sources
 
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
-| `delDomain` | required | String | OpenX delivery domain provided by your OpenX representative.  | "PUBLISHER-d.openx.net"
+| `delDomain` or `platform` | required | String | OpenX delivery domain or platform id provided by your OpenX representative.  | "PUBLISHER-d.openx.net" or "555not5a-real-plat-form-id0123456789"
 | `unit` | required | String | OpenX ad unit ID provided by your OpenX representative. | "1611023122"
 | `customParams` | optional | Object | User-defined targeting key-value pairs. customParams applies to a specific unit. | `{key1: "v1", key2: ["v2","v3"]}`
 | `customFloor` | optional | Number | Minimum price in USD. customFloor applies to a specific unit. For example, use the following value to set a $1.50 floor: 1.50 <br/><br/> **WARNING:**<br/> Misuse of this parameter can impact revenue | 1.50
@@ -49,7 +49,17 @@ var adUnits = [
             key2: ['v2', 'v3']
           },
         }
-      }
+      }, {
+         bidder: 'openx',
+         params: {
+           unit: '539439964',
+           platform: 'a3aece0c-9e80-4316-8deb-faf804779bd1',
+           customParams: {
+             key1: 'v1',
+             key2: ['v2', 'v3']
+           },
+         }
+       }
     ]
   },
   {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -279,16 +279,96 @@ describe('OpenxAdapter', function () {
       'bidderRequestId': 'test-bid-request-2',
       'auctionId': 'test-auction-2'
     }];
+    const bidRequestsWithPlatform = [{
+      'bidder': 'openx',
+      'params': {
+        'unit': '11',
+        'platform': '1cabba9e-cafe-3665-beef-f00f00f00f00',
+      },
+      'adUnitCode': '/adunit-code/test-path',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]]
+        }
+      },
+      'bidId': 'test-bid-id-1',
+      'bidderRequestId': 'test-bid-request-1',
+      'auctionId': 'test-auction-1'
+    }, {
+      'bidder': 'openx',
+      'params': {
+        'unit': '11',
+        'platform': '1cabba9e-cafe-3665-beef-f00f00f00f00',
+      },
+      'adUnitCode': '/adunit-code/test-path',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]]
+        }
+      },
+      'bidId': 'test-bid-id-1',
+      'bidderRequestId': 'test-bid-request-1',
+      'auctionId': 'test-auction-1'
+    }];
+    const bidRequestsWithPlatformAndDelDomain = [{
+      'bidder': 'openx',
+      'params': {
+        'unit': '11',
+        'delDomain': 'test-del-domain',
+        'platform': '1cabba9e-cafe-3665-beef-f00f00f00f00',
+      },
+      'adUnitCode': '/adunit-code/test-path',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]]
+        }
+      },
+      'bidId': 'test-bid-id-1',
+      'bidderRequestId': 'test-bid-request-1',
+      'auctionId': 'test-auction-1'
+    }, {
+      'bidder': 'openx',
+      'params': {
+        'unit': '11',
+        'delDomain': 'test-del-domain',
+        'platform': '1cabba9e-cafe-3665-beef-f00f00f00f00',
+      },
+      'adUnitCode': '/adunit-code/test-path',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]]
+        }
+      },
+      'bidId': 'test-bid-id-1',
+      'bidderRequestId': 'test-bid-request-1',
+      'auctionId': 'test-auction-1'
+    }];
 
     it('should send bid request to openx url via GET, with mediaType specified as banner', function () {
       const request = spec.buildRequests(bidRequestsWithMediaType);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaType[0].params.delDomain + URLBASE);
+      expect(request[0].data.ph).to.be.undefined;
       expect(request[0].method).to.equal('GET');
     });
 
     it('should send bid request to openx url via GET, with mediaTypes specified with banner type', function () {
       const request = spec.buildRequests(bidRequestsWithMediaTypes);
       expect(request[0].url).to.equal('//' + bidRequestsWithMediaTypes[0].params.delDomain + URLBASE);
+      expect(request[0].data.ph).to.be.undefined;
+      expect(request[0].method).to.equal('GET');
+    });
+
+    it('should send bid request to openx platform url via GET, if platform is present', function () {
+      const request = spec.buildRequests(bidRequestsWithPlatform);
+      expect(request[0].url).to.equal(`//u.openx.net${URLBASE}`);
+      expect(request[0].data.ph).to.equal(bidRequestsWithPlatform[0].params.platform);
+      expect(request[0].method).to.equal('GET');
+    });
+
+    it('should send bid request to openx platform url via GET, if both params present', function () {
+      const request = spec.buildRequests(bidRequestsWithPlatformAndDelDomain);
+      expect(request[0].url).to.equal(`//u.openx.net${URLBASE}`);
+      expect(request[0].data.ph).to.equal(bidRequestsWithPlatform[0].params.platform);
       expect(request[0].method).to.equal('GET');
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other
additional param to support a feature in openxBidAdapter
## Description of change
<!-- Describe the change proposed in this pull request -->
Users can now use either a delivery domain or a platform id provided by their OpenX representative.
<!-- For new bidder adapters, please provide the following -->


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
