### PR TITLE
ajaBidAdapter: handles empty responses in getUserSyncs

### DIFF
--- a/modules/ajaBidAdapter.js
+++ b/modules/ajaBidAdapter.js
@@ -93,7 +93,7 @@ export const spec = {
 
   getUserSyncs: function(syncOptions, serverResponses) {
     const syncs = [];
-    if (syncOptions.pixelEnabled) {
+    if (syncOptions.pixelEnabled && serverResponses.length) {
       const bidderResponseBody = serverResponses[0].body;
       if (bidderResponseBody.syncs) {
         bidderResponseBody.syncs.forEach(sync => {

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -141,4 +141,46 @@ describe('AjaAdapter', function () {
       expect(result.length).to.equal(0);
     });
   });
+
+  describe('getUserSyncs', function () {
+    const bidResponse1 = {
+      body: {
+        'is_ad_return': true,
+        'ad': { /* ad body */ },
+        'syncs': [
+          'https://example.test/1'
+        ]
+      }
+    };
+
+    const bidResponse2 = {
+      body: {
+        'is_ad_return': true,
+        'ad': { /* ad body */ },
+        'syncs': [
+          'https://example.test/2'
+        ]
+      }
+    };
+
+    it('should use a sync url from first response', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true }, [bidResponse1, bidResponse2]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://example.test/1'
+        }
+      ]);
+    });
+
+    it('handle empty response (e.g. timeout)', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true }, []);
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('returns empty syncs when not enabled', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false }, [bidResponse1]);
+      expect(syncs).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Bugfix

## Description of change

Bugfix for`getUserSyncs` in ajaBidAdapter.

That method doesn't consider an empty `serverResponses` that occurs when the bid request is timed out. So this error happens in userSync.

> Uncaught TypeError: Cannot read property 'body' of undefined
