### PR TITLE
Do not load external js if renderer defined on adUnit

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -211,6 +211,7 @@ function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
     url: rtbBid.renderer_url,
     config: rendererOptions,
     loaded: false,
+    adUnitCode
   });
 
   try {
@@ -238,6 +239,7 @@ function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
  * @return Bid
  */
 function newBid(serverBid, rtbBid, bidderRequest) {
+  const bidRequest = utils.getBidRequest(serverBid.uuid, [bidderRequest]);
   const bid = {
     requestId: serverBid.uuid,
     cpm: rtbBid.cpm,
@@ -246,6 +248,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     currency: 'USD',
     netRevenue: true,
     ttl: 300,
+    adUnitCode: bidRequest.adUnitCode,
     appnexus: {
       buyerMemberId: rtbBid.buyer_member_id,
       dealPriority: rtbBid.deal_priority,

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -463,12 +463,18 @@ describe('AppNexusAdapter', function () {
           'currency': 'USD',
           'ttl': 300,
           'netRevenue': true,
+          'adUnitCode': 'code',
           'appnexus': {
             'buyerMemberId': 958
           }
         }
       ];
-      let bidderRequest;
+      let bidderRequest = {
+        bids: [{
+          bidId: '3db3773286ee59',
+          adUnitCode: 'code'
+        }]
+      }
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
@@ -505,7 +511,12 @@ describe('AppNexusAdapter', function () {
           }]
         }]
       };
-      let bidderRequest;
+      let bidderRequest = {
+        bids: [{
+          bidId: '84ab500420319d',
+          adUnitCode: 'code'
+        }]
+      }
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0]).to.have.property('vastUrl');
@@ -538,7 +549,12 @@ describe('AppNexusAdapter', function () {
         },
         'impression_trackers': ['http://example.com'],
       };
-      let bidderRequest;
+      let bidderRequest = {
+        bids: [{
+          bidId: '3db3773286ee59',
+          adUnitCode: 'code'
+        }]
+      }
 
       let result = spec.interpretResponse({ body: response1 }, {bidderRequest});
       expect(result[0].native.title).to.equal('Native Creative');
@@ -554,6 +570,7 @@ describe('AppNexusAdapter', function () {
 
       const bidderRequest = {
         bids: [{
+          bidId: '3db3773286ee59',
           renderer: {
             options: {
               adText: 'configured'
@@ -573,7 +590,12 @@ describe('AppNexusAdapter', function () {
       responseWithDeal.tags[0].ads[0].deal_priority = 'high';
       responseWithDeal.tags[0].ads[0].deal_code = '123';
 
-      let bidderRequest;
+      let bidderRequest = {
+        bids: [{
+          bidId: '3db3773286ee59',
+          adUnitCode: 'code'
+        }]
+      }
       let result = spec.interpretResponse({ body: responseWithDeal }, {bidderRequest});
       expect(Object.keys(result[0].appnexus)).to.include.members(['buyerMemberId', 'dealPriority', 'dealCode']);
     });

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -1,96 +1,131 @@
 import { expect } from 'chai';
 import { Renderer } from 'src/Renderer';
+import * as utils from 'src/utils';
 
-describe('Renderer: A renderer installed on a bid response', function () {
-  let testRenderer1;
-  let testRenderer2;
-  let spyRenderFn;
-  let spyEventHandler;
+describe('Renderer', function () {
+  describe('Renderer: A renderer installed on a bid response', function () {
+    let testRenderer1;
+    let testRenderer2;
+    let spyRenderFn;
+    let spyEventHandler;
 
-  beforeEach(function () {
-    testRenderer1 = Renderer.install({
-      url: 'https://httpbin.org/post',
-      config: { test: 'config1' },
-      id: 1
-    });
-    testRenderer2 = Renderer.install({
-      url: 'https://httpbin.org/post',
-      config: { test: 'config2' },
-      id: 2
-    });
+    beforeEach(function () {
+      testRenderer1 = Renderer.install({
+        url: 'https://httpbin.org/post',
+        config: { test: 'config1' },
+        id: 1
+      });
+      testRenderer2 = Renderer.install({
+        url: 'https://httpbin.org/post',
+        config: { test: 'config2' },
+        id: 2
+      });
 
-    spyRenderFn = sinon.spy();
-    spyEventHandler = sinon.spy();
-  });
-
-  it('is an instance of Renderer', function () {
-    expect(testRenderer1 instanceof Renderer).to.equal(true);
-  });
-
-  it('has expected properties ', function () {
-    expect(testRenderer1.url).to.equal('https://httpbin.org/post');
-    expect(testRenderer1.config).to.deep.equal({ test: 'config1' });
-    expect(testRenderer1.id).to.equal(1);
-  });
-
-  it('returns config from getConfig method', function () {
-    expect(testRenderer1.getConfig()).to.deep.equal({ test: 'config1' });
-    expect(testRenderer2.getConfig()).to.deep.equal({ test: 'config2' });
-  });
-
-  it('sets a render function with setRender method', function () {
-    testRenderer1.setRender(spyRenderFn);
-    expect(typeof testRenderer1.render).to.equal('function');
-    testRenderer1.render();
-    expect(spyRenderFn.called).to.equal(true);
-  });
-
-  it('sets event handlers with setEventHandlers method and handles events with installed handlers', function () {
-    testRenderer1.setEventHandlers({
-      testEvent: spyEventHandler
+      spyRenderFn = sinon.spy();
+      spyEventHandler = sinon.spy();
     });
 
-    expect(testRenderer1.handlers).to.deep.equal({
-      testEvent: spyEventHandler
+    it('is an instance of Renderer', function () {
+      expect(testRenderer1 instanceof Renderer).to.equal(true);
     });
 
-    testRenderer1.handleVideoEvent({ id: 1, eventName: 'testEvent' });
-    expect(spyEventHandler.called).to.equal(true);
+    it('has expected properties ', function () {
+      expect(testRenderer1.url).to.equal('https://httpbin.org/post');
+      expect(testRenderer1.config).to.deep.equal({ test: 'config1' });
+      expect(testRenderer1.id).to.equal(1);
+    });
+
+    it('returns config from getConfig method', function () {
+      expect(testRenderer1.getConfig()).to.deep.equal({ test: 'config1' });
+      expect(testRenderer2.getConfig()).to.deep.equal({ test: 'config2' });
+    });
+
+    it('sets a render function with setRender method', function () {
+      testRenderer1.setRender(spyRenderFn);
+      expect(typeof testRenderer1.render).to.equal('function');
+      testRenderer1.render();
+      expect(spyRenderFn.called).to.equal(true);
+    });
+
+    it('sets event handlers with setEventHandlers method and handles events with installed handlers', function () {
+      testRenderer1.setEventHandlers({
+        testEvent: spyEventHandler
+      });
+
+      expect(testRenderer1.handlers).to.deep.equal({
+        testEvent: spyEventHandler
+      });
+
+      testRenderer1.handleVideoEvent({ id: 1, eventName: 'testEvent' });
+      expect(spyEventHandler.called).to.equal(true);
+    });
+
+    it('pushes commands to queue if renderer is not loaded', function () {
+      testRenderer1.loaded = false;
+      testRenderer1.push(spyRenderFn);
+      expect(testRenderer1.cmd.length).to.equal(1);
+
+      // clear queue for next tests
+      testRenderer1.cmd = [];
+    });
+
+    it('fires commands immediately if the renderer is loaded', function () {
+      const func = sinon.spy();
+
+      testRenderer1.loaded = true;
+      testRenderer1.push(func);
+
+      expect(testRenderer1.cmd.length).to.equal(0);
+
+      sinon.assert.calledOnce(func);
+    });
+
+    it('processes queue by calling each function in queue', function () {
+      testRenderer1.loaded = false;
+      const func1 = sinon.spy();
+      const func2 = sinon.spy();
+
+      testRenderer1.push(func1);
+      testRenderer1.push(func2);
+      expect(testRenderer1.cmd.length).to.equal(2);
+
+      testRenderer1.process();
+
+      sinon.assert.calledOnce(func1);
+      sinon.assert.calledOnce(func2);
+      expect(testRenderer1.cmd.length).to.equal(0);
+    });
   });
 
-  it('pushes commands to queue if renderer is not loaded', function () {
-    testRenderer1.loaded = false;
-    testRenderer1.push(spyRenderFn);
-    expect(testRenderer1.cmd.length).to.equal(1);
+  describe('3rd party renderer', function () {
+    let adUnitsOld;
+    let utilsSpy;
+    before(function () {
+      adUnitsOld = $$PREBID_GLOBAL$$.adUnits;
+      utilsSpy = sinon.spy(utils, 'logWarn');
+    });
 
-    // clear queue for next tests
-    testRenderer1.cmd = [];
-  });
+    after(function() {
+      $$PREBID_GLOBAL$$.adUnits = adUnitsOld;
+      utilsSpy.restore();
+    });
 
-  it('fires commands immediately if the renderer is loaded', function () {
-    const func = sinon.spy();
+    it('should not load renderer and log warn message', function() {
+      $$PREBID_GLOBAL$$.adUnits = [{
+        code: 'video1',
+        renderer: {
+          url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+          render: sinon.spy()
+        }
+      }]
 
-    testRenderer1.loaded = true;
-    testRenderer1.push(func);
-
-    expect(testRenderer1.cmd.length).to.equal(0);
-
-    sinon.assert.calledOnce(func);
-  });
-
-  it('processes queue by calling each function in queue', function () {
-    testRenderer1.loaded = false;
-    const func1 = sinon.spy();
-    const func2 = sinon.spy();
-
-    testRenderer1.push(func1);
-    testRenderer1.push(func2);
-    expect(testRenderer1.cmd.length).to.equal(2);
-
-    testRenderer1.process();
-
-    sinon.assert.calledOnce(func1);
-    sinon.assert.calledOnce(func2);
-    expect(testRenderer1.cmd.length).to.equal(0);
+      let testRenderer = Renderer.install({
+        url: 'https://httpbin.org/post',
+        config: { test: 'config1' },
+        id: 1,
+        adUnitCode: 'video1'
+      });
+      expect(utilsSpy.callCount).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
### Do not merge

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes https://github.com/prebid/Prebid.js/issues/2805, Delaying loading of external js for winning bid will be done in a separate PR. This one just fixes a bug.

If renderer is defined on adUnit level, Renderer module will not load external js returned by bid. As of now 12 adapters are using Renderer. We need to update those if this approach is fine.