### PR TITLE
new no bid event and no bids available from auction

### DIFF
--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -11,6 +11,7 @@ const {
     BID_REQUESTED,
     BID_TIMEOUT,
     BID_RESPONSE,
+    NO_BID,
     BID_WON,
     BID_ADJUSTMENT,
     BIDDER_DONE,
@@ -100,6 +101,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
       _handlers = {
         [BID_REQUESTED]: args => this.enqueue({ eventType: BID_REQUESTED, args }),
         [BID_RESPONSE]: args => this.enqueue({ eventType: BID_RESPONSE, args }),
+        [NO_BID]: args => this.enqueue({ eventType: NO_BID, args }),
         [BID_TIMEOUT]: args => this.enqueue({ eventType: BID_TIMEOUT, args }),
         [BID_WON]: args => this.enqueue({ eventType: BID_WON, args }),
         [BID_ADJUSTMENT]: args => this.enqueue({ eventType: BID_ADJUSTMENT, args }),

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -176,7 +176,7 @@ export function newBidder(spec) {
       // After all the responses have come back, call done() and
       // register any required usersync pixels.
       const responses = [];
-      function afterAllResponses(bids) {
+      function afterAllResponses() {
         done();
         events.emit(CONSTANTS.EVENTS.BIDDER_DONE, bidderRequest);
         registerSyncs(responses, bidderRequest.gdprConsent);

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -39,15 +39,20 @@ export function newAuctionManager() {
     } else {
       utils.logWarn(`Auction not found when adding winning bid`);
     }
-  }
+  };
 
   auctionManager.getAllWinningBids = function() {
     return _auctions.map(auction => auction.getWinningBids())
       .reduce(flatten, []);
-  }
+  };
 
   auctionManager.getBidsRequested = function() {
     return _auctions.map(auction => auction.getBidRequests())
+      .reduce(flatten, []);
+  };
+
+  auctionManager.getNoBids = function() {
+    return _auctions.map(auction => auction.getNoBids())
       .reduce(flatten, []);
   };
 

--- a/src/constants.json
+++ b/src/constants.json
@@ -30,6 +30,7 @@
     "BID_TIMEOUT": "bidTimeout",
     "BID_REQUESTED": "bidRequested",
     "BID_RESPONSE": "bidResponse",
+    "NO_BID": "noBid",
     "BID_WON": "bidWon",
     "BIDDER_DONE": "bidderDone",
     "SET_TARGETING": "setTargeting",

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -114,15 +114,8 @@ $$PREBID_GLOBAL$$.getAdserverTargeting = function (adUnitCode) {
   return targeting.getAllTargeting(adUnitCode);
 };
 
-/**
- * This function returns the bid responses at the given moment.
- * @alias module:pbjs.getBidResponses
- * @return {Object}            map | object that contains the bidResponses
- */
-
-$$PREBID_GLOBAL$$.getBidResponses = function () {
-  utils.logInfo('Invoking $$PREBID_GLOBAL$$.getBidResponses', arguments);
-  const responses = auctionManager.getBidsReceived()
+function getBids(type) {
+  const responses = auctionManager[type]()
     .filter(adUnitsFilter.bind(this, auctionManager.getAdUnitCodes()));
 
   // find the last auction id to get responses for most recent auction only
@@ -139,6 +132,28 @@ $$PREBID_GLOBAL$$.getBidResponses = function () {
       };
     })
     .reduce((a, b) => Object.assign(a, b), {});
+}
+
+/**
+ * This function returns the bids requests involved in an auction but not bid on
+ * @alias module:pbjs.getNoBids
+ * @return {Object}            map | object that contains the bidRequests
+ */
+
+$$PREBID_GLOBAL$$.getNoBids = function () {
+  utils.logInfo('Invoking $$PREBID_GLOBAL$$.getNoBids', arguments);
+  return getBids('getNoBids');
+};
+
+/**
+ * This function returns the bid responses at the given moment.
+ * @alias module:pbjs.getBidResponses
+ * @return {Object}            map | object that contains the bidResponses
+ */
+
+$$PREBID_GLOBAL$$.getBidResponses = function () {
+  utils.logInfo('Invoking $$PREBID_GLOBAL$$.getBidResponses', arguments);
+  return getBids('getBidsReceived');
 };
 
 /**

--- a/test/spec/api_spec.js
+++ b/test/spec/api_spec.js
@@ -39,6 +39,10 @@ describe('Publisher API', function () {
       assert.isFunction($$PREBID_GLOBAL$$.getBidResponses);
     });
 
+    it('should have function $$PREBID_GLOBAL$$.getBidResponses', function () {
+      assert.isFunction($$PREBID_GLOBAL$$.getNoBids);
+    });
+
     it('should have function $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode', function () {
       assert.isFunction($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode);
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
Added the a new event `NO_BID` which is fired for analytics and anything else interested in bidders not bidding.  Since no bid is created when not bidding, the `NO_BID` event sends the bid request that the bidder was notified of but decided not to respond to.  The auction also keeps track of these bid requests that resulted in no bid and makes them available through a new API call `pbjs.getNoBids()`, this is primarily for the updated debug snippet in https://github.com/prebid/prebid.github.io/pull/1030

Also added a fix for a potential bug with the new done callback refactoring.  The updated logic was relying on counting which can be problematic (for instance, if one bidder calls done more than once that could potentially end the auction early).  New logic only ends auction if done has been heard from each bidder with a bidderRequest.

## Other information
fixes #2640 and is a replacement solution for #3022

