### PR TITLE
add step to evaluate s2sconfig timeout

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1143,3 +1143,12 @@ export function convertTypes(types, params) {
   });
   return params;
 }
+
+export function evaluateTimeout(auctionTimeout, adapterTimeout, adapterName = 's2sConfig') {
+  if (auctionTimeout <= adapterTimeout) {
+    let newTimeout = Math.floor(0.75 * auctionTimeout);
+    exports.logInfo(`Detected auction timeout was smaller than the timeout set for ${adapterName}.  Adjusting ${adapterName} timeout to new value to compensate: ${newTimeout}`);
+    return newTimeout;
+  }
+  return adapterTimeout;
+}

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -915,4 +915,28 @@ describe('Utils', function () {
       }]);
     });
   });
+
+  describe('evaluateTimeout', function() {
+    let logInfoStub;
+    before(function() {
+      logInfoStub = sinon.stub(utils, 'logInfo');
+    });
+
+    after(function() {
+      logInfoStub.restore();
+    })
+
+    it('returns original timeout when auction timeout is higher', function() {
+      let auctionTimeout = 3500;
+      let adapterTimeout = 1000;
+      expect(utils.evaluateTimeout(auctionTimeout, adapterTimeout)).to.equal(adapterTimeout);
+    });
+
+    it('returns modified timeout when auction timeout is lower', function() {
+      let auctionTimeout = 1000;
+      let adapterTimeout = 1000;
+      expect(utils.evaluateTimeout(auctionTimeout, adapterTimeout)).to.equal(750);
+      expect(logInfoStub.calledOnce).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Added some logic to check the s2sconfig timeout value and set a new value if it's found to be larger than the auction's provided timeout.  The new timeout is set at 75% of the auction timeout (this can be changed).

Note - we set the value in the requestBids method as it's the last place where the timeout gets set (ie in the `timeout` field in the object config you pass in the `pbjs.requestBids` function).