### PR TITLE
Add new alias for Adtelligent adapter

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -12,6 +12,7 @@ const DISPLAY = 'display';
 
 export const spec = {
   code: BIDDER_CODE,
+  aliases: ['onefiftytwomediaBidAdapter'],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {
     return bid && bid.params && bid.params.aid;

--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -12,7 +12,7 @@ const DISPLAY = 'display';
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['onefiftytwomediaBidAdapter'],
+  aliases: ['onefiftytwomedia'],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {
     return bid && bid.params && bid.params.aid;


### PR DESCRIPTION
## Type of change
- [x] New alias for bidder adapter Adtelligent

## Description of change
New alias for bidder adapter Adtelligent


- [x] official adapter submission
- contact email of the adapter’s maintainer g.moroz@adtelligent.com
- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/1037

