### PR TITLE
Fix user-sync iframes insertion bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -552,16 +552,18 @@ var hasOwn = function (objectToCheck, propertyToCheckFor) {
 exports.insertElement = function(elm, doc, target) {
   doc = doc || document;
   let elToAppend;
+  const head = doc.getElementsByTagName('head');
   if (target) {
     elToAppend = doc.getElementsByTagName(target);
   } else {
-    elToAppend = doc.getElementsByTagName('head');
+    elToAppend = head;
   }
   try {
     elToAppend = elToAppend.length ? elToAppend : doc.getElementsByTagName('body');
     if (elToAppend.length) {
       elToAppend = elToAppend[0];
-      elToAppend.insertBefore(elm, elToAppend.firstChild);
+      const refChild = head && head[0] === elToAppend ? null : elToAppend.firstChild;
+      return elToAppend.insertBefore(elm, refChild);
     }
   } catch (e) {}
 };

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -914,5 +914,14 @@ describe('Utils', function () {
         value: ['']
       }]);
     });
+
+    describe('insertElement', function () {
+      it('returns a node at bottom of head if no target is given', function () {
+        const toInsert = document.createElement('div');
+        const head = document.getElementsByTagName('head')[0];
+        const inserted = utils.insertElement(toInsert);
+        expect(inserted).to.equal(head.lastChild);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
According to the [documentation](http://prebid.org/dev-docs/publisher-api-reference.html#setConfig-Configure-User-Syncing), user-sync iframes should be inserted at the bottom of the head element, rather than at the top:
> When user syncs are run, regardless of whether they are invoked by the platform or by the page calling pbjs.triggerUserSyncs(), the queue entries are randomized and appended to the bottom of the HTML head tag. If there’s no head tag, then they’re appended to the end of the body tag.
