### PR TITLE
Triplelift - update creativeId

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -113,11 +113,11 @@ function _buildResponseObject(bidderRequest, bid) {
   let width = bid.width || 1;
   let height = bid.height || 1;
   let dealId = bid.deal_id || '';
-  let creativeId = bid.imp_id;
+  let creativeId = bid.crid;
 
   if (bid.cpm != 0 && bid.ad) {
     bidResponse = {
-      requestId: bidderRequest.bids[creativeId].bidId,
+      requestId: bidderRequest.bids[bid.imp_id].bidId,
       cpm: bid.cpm,
       width: width,
       height: height,

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -113,7 +113,7 @@ function _buildResponseObject(bidderRequest, bid) {
   let width = bid.width || 1;
   let height = bid.height || 1;
   let dealId = bid.deal_id || '';
-  let creativeId = bid.crid;
+  let creativeId = bid.crid || '';
 
   if (bid.cpm != 0 && bid.ad) {
     bidResponse = {

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -17,7 +17,7 @@ export const tripleliftAdapterSpec = {
 
   buildRequests: function(bidRequests, bidderRequest) {
     let tlCall = STR_ENDPOINT;
-    let referrer = utils.getTopWindowUrl();
+    let referrer = bidderRequest.refererInfo.referer;
     let data = _buildPostBody(bidRequests);
 
     tlCall = utils.tryAppendQueryString(tlCall, 'lib', 'prebid');

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -17,12 +17,15 @@ export const tripleliftAdapterSpec = {
 
   buildRequests: function(bidRequests, bidderRequest) {
     let tlCall = STR_ENDPOINT;
-    let referrer = bidderRequest.refererInfo.referer;
     let data = _buildPostBody(bidRequests);
 
     tlCall = utils.tryAppendQueryString(tlCall, 'lib', 'prebid');
     tlCall = utils.tryAppendQueryString(tlCall, 'v', '$prebid.version$');
-    tlCall = utils.tryAppendQueryString(tlCall, 'referrer', referrer);
+
+    if (bidderRequest && bidderRequest.refererInfo) {
+      let referrer = bidderRequest.refererInfo.referer;
+      tlCall = utils.tryAppendQueryString(tlCall, 'referrer', referrer);
+    }
 
     if (bidderRequest && bidderRequest.timeout) {
       tlCall = utils.tryAppendQueryString(tlCall, 'tmax', bidderRequest.timeout);

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -68,19 +68,42 @@ describe('triplelift adapter', function () {
       }
     ];
 
+    let bidderRequest = {
+      bidderCode: 'triplelift',
+      auctionId: 'a7ebcd1d-66ff-4b5c-a82c-6a21a6ee5a18',
+      bidderRequestId: '5c55612f99bc11',
+      bids: [
+        {
+          imp_id: 0,
+          cpm: 1.062,
+          width: 300,
+          height: 250,
+          ad: 'ad-markup',
+          iurl: 'https://s.adroll.com/a/IYR/N36/IYRN366MFVDITBAGNNT5U6.jpg'
+        }
+      ],
+      gdprConsent: {
+        consentString: 'BOONm0NOONma-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVOQ6gEaY',
+        gdprApplies: true
+      },
+      refererInfo: {
+        referer: 'http://.examplereferer.com'
+      }
+    };
+
     it('exists and is an object', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request).to.exist.and.to.be.a('object');
     });
 
     it('should only parse sizes that are of the proper length and format', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].banner.format).to.have.length(2);
       expect(request.data.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
     it('should be a post request and populate the payload', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.exist;
       expect(payload.imp[0].tagid).to.equal('12345');
@@ -89,13 +112,16 @@ describe('triplelift adapter', function () {
     });
 
     it('should return a query string for TL call', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const url = request.url;
       expect(url).to.exist;
       expect(url).to.be.a('string');
       expect(url).to.match(/(?:tlx.3lift.com\/header\/auction)/)
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
+      expect(url).to.match(/(?:referrer)/);
+      expect(url).to.match(/(?:gdpr)/);
+      expect(url).to.match(/(?:cmp_cs)/);
     })
   });
 
@@ -131,6 +157,9 @@ describe('triplelift adapter', function () {
       gdprConsent: {
         consentString: 'BOONm0NOONma-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVOQ6gEaY',
         gdprApplies: true
+      },
+      refererInfo: {
+        referer: 'http://.examplereferer.com'
       }
     };
 
@@ -202,6 +231,9 @@ describe('triplelift adapter', function () {
         gdprConsent: {
           consentString: 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY',
           gdprApplies: true
+        },
+        refererInfo: {
+          referer: 'http://.examplereferer.com'
         }
       };
       let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -83,23 +83,23 @@ describe('triplelift adapter', function () {
         }
       ],
       refererInfo: {
-        referer: 'http://.examplereferer.com'
+        referer: 'http://examplereferer.com'
       }
     };
 
     it('exists and is an object', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
       expect(request).to.exist.and.to.be.a('object');
     });
 
     it('should only parse sizes that are of the proper length and format', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
       expect(request.data.imp[0].banner.format).to.have.length(2);
       expect(request.data.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
     it('should be a post request and populate the payload', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
       const payload = request.data;
       expect(payload).to.exist;
       expect(payload.imp[0].tagid).to.equal('12345');
@@ -108,7 +108,7 @@ describe('triplelift adapter', function () {
     });
 
     it('should return a query string for TL call', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
       const url = request.url;
       expect(url).to.exist;
       expect(url).to.be.a('string');
@@ -149,7 +149,7 @@ describe('triplelift adapter', function () {
         }
       ],
       refererInfo: {
-        referer: 'http://.examplereferer.com'
+        referer: 'http://examplereferer.com'
       }
     };
 
@@ -219,7 +219,7 @@ describe('triplelift adapter', function () {
           }
         ],
         refererInfo: {
-          referer: 'http://.examplereferer.com'
+          referer: 'http://examplereferer.com'
         }
       };
       let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -96,8 +96,6 @@ describe('triplelift adapter', function () {
       expect(url).to.match(/(?:tlx.3lift.com\/header\/auction)/)
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
-      // expect(url).to.match(/(?:fe=)/) //
-      expect(url).to.match(/(?:referrer)/)
     })
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -82,10 +82,6 @@ describe('triplelift adapter', function () {
           iurl: 'https://s.adroll.com/a/IYR/N36/IYRN366MFVDITBAGNNT5U6.jpg'
         }
       ],
-      gdprConsent: {
-        consentString: 'BOONm0NOONma-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVOQ6gEaY',
-        gdprApplies: true
-      },
       refererInfo: {
         referer: 'http://.examplereferer.com'
       }
@@ -152,10 +148,6 @@ describe('triplelift adapter', function () {
           iurl: 'https://s.adroll.com/a/IYR/N36/IYRN366MFVDITBAGNNT5U6.jpg'
         }
       ],
-      gdprConsent: {
-        consentString: 'BOONm0NOONma-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVOQ6gEaY',
-        gdprApplies: true
-      },
       refererInfo: {
         referer: 'http://.examplereferer.com'
       }
@@ -226,10 +218,6 @@ describe('triplelift adapter', function () {
             iurl: 'https://s.adroll.com/a/IYR/N36/IYRN366MFVDITBAGNNT5U6.jpg'
           }
         ],
-        gdprConsent: {
-          consentString: 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY',
-          gdprApplies: true
-        },
         refererInfo: {
           referer: 'http://.examplereferer.com'
         }

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -84,22 +84,26 @@ describe('triplelift adapter', function () {
       ],
       refererInfo: {
         referer: 'http://examplereferer.com'
+      },
+      gdprConsent: {
+        consentString: 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY',
+        gdprApplies: true
       }
     };
 
     it('exists and is an object', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request).to.exist.and.to.be.a('object');
     });
 
     it('should only parse sizes that are of the proper length and format', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].banner.format).to.have.length(2);
       expect(request.data.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
     it('should be a post request and populate the payload', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.exist;
       expect(payload.imp[0].tagid).to.equal('12345');
@@ -108,14 +112,14 @@ describe('triplelift adapter', function () {
     });
 
     it('should return a query string for TL call', function () {
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {bidderRequest});
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const url = request.url;
       expect(url).to.exist;
       expect(url).to.be.a('string');
       expect(url).to.match(/(?:tlx.3lift.com\/header\/auction)/)
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
-      // expect(url).to.match(/(?:referrer)/);
+      expect(url).to.match(/(?:referrer)/);
     });
   });
 
@@ -150,6 +154,10 @@ describe('triplelift adapter', function () {
       ],
       refererInfo: {
         referer: 'http://examplereferer.com'
+      },
+      gdprConsent: {
+        consentString: 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY',
+        gdprApplies: true
       }
     };
 
@@ -220,6 +228,10 @@ describe('triplelift adapter', function () {
         ],
         refererInfo: {
           referer: 'http://examplereferer.com'
+        },
+        gdprConsent: {
+          consentString: 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY',
+          gdprApplies: true
         }
       };
       let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -115,7 +115,7 @@ describe('triplelift adapter', function () {
       expect(url).to.match(/(?:tlx.3lift.com\/header\/auction)/)
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
-      expect(url).to.match(/(?:referrer)/);
+      // expect(url).to.match(/(?:referrer)/);
     });
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -120,9 +120,7 @@ describe('triplelift adapter', function () {
       expect(url).to.match(/(?:lib=prebid)/)
       expect(url).to.match(/(?:prebid.version)/)
       expect(url).to.match(/(?:referrer)/);
-      expect(url).to.match(/(?:gdpr)/);
-      expect(url).to.match(/(?:cmp_cs)/);
-    })
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
update the creative id to be a Triplelift specific id rather than the SRA impression id or an empty string if not present. 

- contact email of the adapter’s maintainer
bzellman@triplelift.com

