### PR TITLE
AppNexus debug auction via cookie

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -11,6 +11,7 @@ const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
 const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
+const DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout'];
 const NATIVE_MAPPING = {
   body: 'description',
   cta: 'ctatext',
@@ -77,6 +78,25 @@ export const spec = {
       };
     }
 
+    let debugObj = {};
+    let debugObjParams = {};
+    const debugCookieName = 'apn_prebid_debug';
+    const debugCookie = getCookie(debugCookieName) || null;
+    if (debugCookie) {
+      try {
+        debugObj = JSON.parse(debugCookie);
+      } catch (e) {
+        utils.logError('AppNexus Debug Auction Cookie Error:\n\n' + e);
+      }
+    }
+    if (debugObj && debugObj.enabled) {
+      Object.keys(debugObj)
+        .filter(param => includes(DEBUG_PARAMS, param))
+        .forEach(param => {
+          debugObjParams[param] = debugObj[param];
+        });
+    }
+
     const memberIdBid = find(bidRequests, hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
 
@@ -97,6 +117,11 @@ export const spec = {
     }
     if (appIdObjBid) {
       payload.app = appIdObj;
+    }
+
+    if (debugObjParams.enabled) {
+      payload.debug = debugObjParams;
+      utils.logInfo('AppNexus Debug Auction Settings:\n\n' + JSON.stringify(debugObjParams, null, 4));
     }
 
     if (bidderRequest && bidderRequest.gdprConsent) {
@@ -154,6 +179,22 @@ export const spec = {
         }
       });
     }
+
+    if (serverResponse.debug && serverResponse.debug.debug_info) {
+      let debugHeader = 'AppNexus Debug Auction for Prebid\n\n'
+      let debugText = debugHeader + serverResponse.debug.debug_info
+      debugText = debugText
+        .replace(/(<td>|<th>)/gm, '\t') // Tables
+        .replace(/(<\/td>|<\/th>)/gm, '\n') // Tables
+        .replace(/^<br>/gm, '') // Remove leading <br>
+        .replace(/(<br>\n|<br>)/gm, '\n') // <br>
+        .replace(/<h1>(.*)<\/h1>/gm, '\n\n===== $1 =====\n\n') // Header H1
+        .replace(/<h[2-6]>(.*)<\/h[2-6]>/gm, '\n\n*** $1 ***\n\n') // Headers
+        .replace(/(<([^>]+)>)/igm, ''); // Remove any other tags
+      utils.logMessage('https://console.appnexus.com/docs/understanding-the-debug-auction');
+      utils.logMessage(debugText);
+    }
+
     return bids;
   },
 
@@ -448,6 +489,11 @@ function hasAppId(bid) {
     return !!bid.params.app.id
   }
   return !!bid.params.app
+}
+
+function getCookie(name) {
+  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
+  return m ? decodeURIComponent(m[2]) : null;
 }
 
 function getRtbBid(tag) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,6 +498,10 @@ function hasAppId(bid) {
   return !!bid.params.app
 }
 
+function hasDebug(bid) {
+  return !!bid.debug
+}
+
 function getRtbBid(tag) {
   return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
 }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,11 +498,6 @@ function hasAppId(bid) {
   return !!bid.params.app
 }
 
-function getCookie(name) {
-  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
-  return m ? decodeURIComponent(m[2]) : null;
-}
-
 function getRtbBid(tag) {
   return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
 }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -81,14 +81,21 @@ export const spec = {
     let debugObj = {};
     let debugObjParams = {};
     const debugCookieName = 'apn_prebid_debug';
-    const debugCookie = getCookie(debugCookieName) || null;
+    const debugCookie = utils.getCookie(debugCookieName) || null;
+
     if (debugCookie) {
       try {
         debugObj = JSON.parse(debugCookie);
       } catch (e) {
         utils.logError('AppNexus Debug Auction Cookie Error:\n\n' + e);
       }
+    } else {
+      const debugBidRequest = find(bidRequests, hasDebug);
+      if (debugBidRequest && debugBidRequest.debug) {
+        debugObj = debugBidRequest.debug;
+      }
     }
+
     if (debugObj && debugObj.enabled) {
       Object.keys(debugObj)
         .filter(param => includes(DEBUG_PARAMS, param))

--- a/src/utils.js
+++ b/src/utils.js
@@ -844,6 +844,11 @@ export function cookiesAreEnabled() {
   return window.document.cookie.indexOf('prebid.cookieTest') != -1;
 }
 
+export function getCookie(name) {
+  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
+  return m ? decodeURIComponent(m[2]) : null;
+}
+
 /**
  * Given a function, return a function which only executes the original after
  * it's been called numRequiredCalls times.


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
The following feature enhancement adds in the ability for a publisher or developer to request an AppNexus debug auction in the response back from AppNexus alongside any bids.

This feature can be enabled by doing the following:

1) Adding the `pbjs_debug=true` query string parameter.
2) By setting an `apn_prebid_debug` cookie with a JSON string. For example:

```
{ "enabled": true, "dongle": "QWERTY", "debug_timeout": 1000, "member_id": 958 }
```

*Sample Console Log:*

```
Running member 958 debug using no permissions
Impbus 4280.bm-impbus.prod.nym2:8001
	Header Referer: http://example.com?pbjs_debug=true&ast_debug=true&ast_dongle=sss
	Site Domain: example.com
1772142023491463321 - Predicted engagement_rate_id: 2 (view) imps 54.87%
1772142023491463321 - Predicted engagement_rate_id: 3 (view_over_total) imps 51.57%
1772142023491463321 - Predicted engagement_rate_id: 8 (predicted_100pv1s_display_view_rate) imps 47.06%
```