### PR TITLE
Fix for Quantum adapter empty size detection

### DIFF
--- a/modules/quantumBidAdapter.js
+++ b/modules/quantumBidAdapter.js
@@ -106,7 +106,7 @@ export const spec = {
       if (serverBody.cobj) {
         bid.cobj = serverBody.cobj;
       }
-      if (bidRequest.sizes) {
+      if (!utils.isEmpty(bidRequest.sizes)) {
         bid.width = bidRequest.sizes[0][0];
         bid.height = bidRequest.sizes[0][1];
       }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
For the 'native' mediatype, no size is sent for the bidRequest and Quantum's adapter fails to properly handle this case and throws an error in `interpretResponse()`.

- test parameters for validating bids
```
{
  code: "div-gpt-ad-native-0",
  mediaTypes: {
    native: {
      type: "image"
    }
  },
  bids: [
    {
      bidder: "quantum",
      params: {
        placementId: ANY_VALID_ID
      }
    }
  ]
}
```

## Other information
@sami-elasticad for official review