### PR TITLE
Add build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
+    "build": "gulp build",
     "test": "gulp test",
     "lint": "gulp lint"
   },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This removes the need to install gulp globally. Instead devs / buildsystems
can use the defined gulp dependency.

```bash
$ npm install
$ npm run build -- --modules=x,y,z
```

Otherwise you need to run

```bash
$ npm install
$ ./node_modules/.bin/gulp --modules=x,y,z
```