### PR TITLE
Fix multi-bid adId in Criteo bid adapter

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -98,6 +98,7 @@ export const spec = {
         const bidId = bidRequest.bidId;
         const bid = {
           requestId: bidId,
+          adId: slot.bidId || utils.getUniqueIdentifierStr(),
           cpm: slot.cpm,
           currency: slot.currency,
           netRevenue: true,


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
A single bid request to the Criteo endpoint can generate as many bids as there is sizes. However, by default `adId` will be filled with the bid request's `bidId` field, so if we create multiple bids from the same bid request, they will share the same `adId`.

Because of this, Prebid will not know which bid to use once DFP asks for the creative for either of those bids, always taking the first one, which might not be the one that actually won the auction (see [auctionManager.findBidByAdId](https://github.com/prebid/Prebid.js/blob/7fe95d89464cbc95adf3446cd8e39bb499f2c321/src/auctionManager.js#L83-L85) used in [pbjs.renderAd](https://github.com/prebid/Prebid.js/blob/7fe95d89464cbc95adf3446cd8e39bb499f2c321/src/prebid.js#L235)).