### PR TITLE
support new type of user sync: html

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -321,13 +321,18 @@ export function newBidder(spec) {
       let syncs = spec.getUserSyncs({
         iframeEnabled: !!(config.getConfig('userSync.iframeEnabled') || (filterConfig && (filterConfig.iframe || filterConfig.all))),
         pixelEnabled: !!(config.getConfig('userSync.pixelEnabled') || (filterConfig && (filterConfig.image || filterConfig.all))),
+        htmlEnabled: !!(filterConfig && (filterConfig.html || filterConfig.all)),
       }, responses, gdprConsent);
       if (syncs) {
         if (!Array.isArray(syncs)) {
           syncs = [syncs];
         }
         syncs.forEach((sync) => {
-          userSync.registerSync(sync.type, spec.code, sync.url)
+          if (sync.url) {
+            userSync.registerSync(sync.type, spec.code, sync.url);
+          } else if (sync.html) {
+            userSync.registerSync(sync.type, spec.code, sync.html);
+          }
         });
       }
     }


### PR DESCRIPTION
## Type of change
- [×] Feature

## Description of change

### support new type of user sync
new type  is `html` 
target html is loaded by iframe.

publisher opt in `userSync.filterSettings.html` in config.

```js
pbjs.setConfig({
  userSync: {
    filterSettings: {
      html: {
        bidders: '*',
        filter: 'include'
      }
    }
  }
});
```

bidder update as follow

```js
getUserSyncs: function(syncOptions, serverResponses) {
  const syncs = [];
  if (syncOptions.htmlEnabaled) {
    syncs.push({
      type: 'html',
      html: '<script>hoge.sync();</script>'
    });
  }
  return syncs;
},

... any code
```

### document

> if this PR approved

TODO: