### PR TITLE
Adding native parameters: body2, rating, privacyLink

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -13,6 +13,7 @@ const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'langua
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
 const NATIVE_MAPPING = {
   body: 'description',
+  body2: 'desc2',
   cta: 'ctatext',
   image: {
     serverName: 'main_image',
@@ -25,6 +26,7 @@ const NATIVE_MAPPING = {
     minimumParams: { sizes: [{}] },
   },
   sponsoredBy: 'sponsored_by',
+  privacyLink: 'privacy_link'
 };
 const SOURCE = 'pbjs';
 
@@ -283,8 +285,11 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     bid[NATIVE] = {
       title: nativeAd.title,
       body: nativeAd.desc,
+      body2: nativeAd.desc2,
       cta: nativeAd.ctatext,
+      rating: nativeAd.rating,
       sponsoredBy: nativeAd.sponsored,
+      privacyLink: nativeAd.privacy_link,
       clickUrl: nativeAd.link.url,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,

--- a/src/constants.json
+++ b/src/constants.json
@@ -67,11 +67,14 @@
   "NATIVE_KEYS": {
     "title": "hb_native_title",
     "body": "hb_native_body",
+    "body2": "hb_native_body2",
+    "privacyLink": "hb_native_privacy",
     "sponsoredBy": "hb_native_brand",
     "image": "hb_native_image",
     "icon": "hb_native_icon",
     "clickUrl": "hb_native_linkurl",
-    "cta": "hb_native_cta"
+    "cta": "hb_native_cta",
+    "rating": "hb_native_rating"
   },
   "S2S" : {
     "SRC" : "s2s",

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -179,9 +179,12 @@ describe('AppNexusAdapter', function () {
           nativeParams: {
             title: {required: true},
             body: {required: true},
+            body2: {required: true},
             image: {required: true, sizes: [{ width: 100, height: 100 }]},
             cta: {required: false},
-            sponsoredBy: {required: true}
+            rating: {required: true},
+            sponsoredBy: {required: true},
+            privacyLink: {required: true}
           }
         }
       );
@@ -192,9 +195,12 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].native.layouts[0]).to.deep.equal({
         title: {required: true},
         description: {required: true},
+        desc2: {required: true},
         main_image: {required: true, sizes: [{ width: 100, height: 100 }]},
         ctatext: {required: false},
-        sponsored_by: {required: true}
+        rating: {required: true},
+        sponsored_by: {required: true},
+        privacy_link: {required: true}
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds support for `body2` `rating`, and `privacyLink` to prebid.js and the AppNexus adaptor.

- Example implementation
```
var adUnits = [{
  code: 'div-id',
  mediaTypes: {
	  native: {
		  body2: {
			  required: true
		  },
		  rating: {
			  required: true
		  },
		  privacyLink: {
			  required: false
		  }
	  }
  },
  bids: [...]
}];
```