### PR TITLE
removing out console.log statements in ozoneBidAdapter test file

### DIFF
--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -424,17 +424,13 @@ describe('ozone Adapter', function () {
   describe('interpretResponse', function () {
     it('should build bid array', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      // console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      // console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
 
     it('should have all relevant fields', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      // console.log(['Request: ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      // console.log(['result[0]: ', result[0]]);
       const bid = result[0];
       expect(bid.cpm).to.equal(validResponse.body.seatbid[0].bid[0].cpm);
       expect(bid.width).to.equal(validResponse.body.seatbid[0].bid[0].width);
@@ -445,9 +441,7 @@ describe('ozone Adapter', function () {
       var validBidderRequestWithGdpr = validBidderRequest;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
-      // console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      // console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
   });

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -424,17 +424,17 @@ describe('ozone Adapter', function () {
   describe('interpretResponse', function () {
     it('should build bid array', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      console.log(['interpretResponse request  = ', request]);
+      // console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['interpretResponse result  = ', result]);
+      // console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
 
     it('should have all relevant fields', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      console.log(['Request: ', request]);
+      // console.log(['Request: ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['result[0]: ', result[0]]);
+      // console.log(['result[0]: ', result[0]]);
       const bid = result[0];
       expect(bid.cpm).to.equal(validResponse.body.seatbid[0].bid[0].cpm);
       expect(bid.width).to.equal(validResponse.body.seatbid[0].bid[0].width);
@@ -445,9 +445,9 @@ describe('ozone Adapter', function () {
       var validBidderRequestWithGdpr = validBidderRequest;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
-      console.log(['interpretResponse request  = ', request]);
+      // console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['interpretResponse result  = ', result]);
+      // console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Removing several `console.log` statements in the ozone test file to reduce the spam in console when running any `gulp` commands.