### PR TITLE
do not throw a warning of conversion after re-submitting bid post-con…

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -139,7 +139,7 @@ export function addBidResponseHook(adUnitCode, bid, fn) {
   }
 
   let bidder = bid.bidderCode || bid.bidder;
-  if (bidderCurrencyDefault[bidder]) {
+  if (bidderCurrencyDefault[bidder] && !bid.originalCurrency) {
     let currencyDefault = bidderCurrencyDefault[bidder];
     if (bid.currency && currencyDefault !== bid.currency) {
       utils.logWarn(`Currency default '${bidder}: ${currencyDefault}' ignored. adapter specified '${bid.currency}'`);


### PR DESCRIPTION
- [ x] Bugfix

When bid is converted from a source currency to that of adserver, the bid is re-submitted post-conversion. This however throws a warning of "overridden" currency which is incorrect. Unnecessary noise.