### PR TITLE
Fix #2781 - syncsPerBidder set to 0

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -152,7 +152,7 @@ export function newUserSync(userSyncDependencies) {
     if (!bidder) {
       return utils.logWarn(`Bidder is required for registering sync`);
     }
-    if (Number(numAdapterBids[bidder]) >= usConfig.syncsPerBidder) {
+    if (usConfig.syncsPerBidder !== 0 && Number(numAdapterBids[bidder]) >= usConfig.syncsPerBidder) {
       return utils.logWarn(`Number of user syncs exceeded for "${bidder}"`);
     }
 

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -135,7 +135,7 @@ describe('user sync', function () {
     expect(syncUsersSpy.called).to.be.true;
   });
 
-  it('should limit the sync per bidder', function () {
+  it('should limit the number of syncs per bidder', function () {
     const userSync = newTestUserSync({syncsPerBidder: 2});
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
     userSync.registerSync('image', 'testBidder', 'http://example.com/2');
@@ -146,6 +146,20 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(1)).to.not.be.null;
     expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2]/);
     expect(triggerPixelStub.getCall(2)).to.be.null;
+  });
+
+  it('should not limit the number of syncs per bidder when set to 0', function() {
+    const userSync = newTestUserSync({syncsPerBidder: 0});
+    userSync.registerSync('image', 'testBidder', 'http://example.com/1');
+    userSync.registerSync('image', 'testBidder', 'http://example.com/2');
+    userSync.registerSync('image', 'testBidder', 'http://example.com/3');
+    userSync.syncUsers();
+    expect(triggerPixelStub.getCall(0)).to.not.be.null;
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(1)).to.not.be.null;
+    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(2)).to.not.be.null;
+    expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
   });
 
   it('should balance out bidder requests', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes #2781 

This fix should allow unlimited number of syncs per bidder when the field is set to 0 (as per documentation).