### PR TITLE
Sonobi - Added publisher common ID support to sonobi adapter.

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from 'src/adapters/bidderFactory';
-import { parseSizesInput, logError, generateUUID, isEmpty } from '../src/utils';
+import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess } from '../src/utils';
 import { BANNER, VIDEO } from '../src/mediaTypes';
 import { config } from '../src/config';
 
@@ -59,9 +59,10 @@ export const spec = {
       payload.us = config.getConfig('userSync').syncsPerBidder;
     }
 
-    if (validBidRequests[0].params.hfa) {
-      payload.hfa = validBidRequests[0].params.hfa;
+    if (deepAccess(validBidRequests[0], 'crumbs.pubcid') || deepAccess(validBidRequests[0], 'params.hfa')) {
+      payload.hfa = deepAccess(validBidRequests[0], 'params.hfa') ? deepAccess(validBidRequests[0], 'params.hfa') : `PRE-${deepAccess(validBidRequests[0], 'crumbs.pubcid')}`;
     }
+
     if (validBidRequests[0].params.referrer) {
       payload.ref = validBidRequests[0].params.referrer;
     }

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -236,6 +236,32 @@ describe('SonobiBidAdapter', function () {
       const bidRequests = spec.buildRequests([{params: {}}], bidderRequests)
       expect(bidRequests).to.equal(null);
     })
+
+    it('should return a properly formatted request with commonid as hfa', function () {
+      delete bidRequest[0].params.hfa;
+      delete bidRequest[1].params.hfa;
+      bidRequest[0].crumbs = {'pubcid': 'abcd-efg-0101'};
+      bidRequest[1].crumbs = {'pubcid': 'abcd-efg-0101'};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
+    })
+
+    it('should return a properly formatted request with hfa preferred over commonid', function () {
+      bidRequest[0].params.hfa = 'hfakey';
+      bidRequest[1].params.hfa = 'hfakey';
+      bidRequest[0].crumbs = {'pubcid': 'abcd-efg-0101'};
+      bidRequest[1].crumbs = {'pubcid': 'abcd-efg-0101'};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.hfa).to.equal('hfakey')
+    })
   })
 
   describe('.interpretResponse', function () {


### PR DESCRIPTION

## Type of change
- [x ] Feature

## Description of change
Added support for common ID support via crumbs.

- contact email of the adapter’s maintainer apex.prebid@sonobi.com
- [x] official adapter submission
