### PR TITLE
update conversant bid adapter to use video playerSize instead of sizes

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
       siteId = utils.getBidIdParameter('site_id', bid.params);
       requestId = bid.auctionId;
 
-      const format = convertSizes(bid.sizes);
+      let format = convertSizes(bid.sizes);
 
       const imp = {
         id: bid.bidId,
@@ -75,6 +75,10 @@ export const spec = {
       copyOptProperty(bid.params, 'tag_id', imp, 'tagid');
 
       if (isVideoRequest(bid)) {
+        if (bid.mediaTypes.video.playerSize) {
+          format = convertSizes(bid.mediaTypes.video.playerSize);
+        }
+
         const video = {
           w: format[0].w,
           h: format[0].h

--- a/modules/conversantBidAdapter.md
+++ b/modules/conversantBidAdapter.md
@@ -25,7 +25,8 @@ var adUnits = [
         sizes: [640, 480],
         mediaTypes: {
             video: {
-                context: 'instream'
+                context: 'instream',
+                playerSize: [640, 480]
             }
         },
         bids: [{

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -60,7 +60,8 @@ describe('Conversant adapter tests', function() {
       },
       mediaTypes: {
         video: {
-          context: 'instream'
+          context: 'instream',
+          playerSize: [632, 499],
         }
       },
       placementCode: 'pcode003',
@@ -193,8 +194,8 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[3]).to.not.have.property('tagid');
     expect(payload.imp[3]).to.have.property('video');
     expect(payload.imp[3].video).to.not.have.property('pos');
-    expect(payload.imp[3].video).to.have.property('w', 640);
-    expect(payload.imp[3].video).to.have.property('h', 480);
+    expect(payload.imp[3].video).to.have.property('w', 632);
+    expect(payload.imp[3].video).to.have.property('h', 499);
     expect(payload.imp[3].video).to.have.property('mimes');
     expect(payload.imp[3].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
     expect(payload.imp[3].video).to.have.property('protocols');
@@ -254,8 +255,8 @@ describe('Conversant adapter tests', function() {
     expect(bid).to.have.property('currency', 'USD');
     expect(bid).to.have.property('cpm', 3.99);
     expect(bid).to.have.property('creativeId', '1003');
-    expect(bid).to.have.property('width', 640);
-    expect(bid).to.have.property('height', 480);
+    expect(bid).to.have.property('width', 632);
+    expect(bid).to.have.property('height', 499);
     expect(bid).to.have.property('vastUrl', 'markup003');
     expect(bid).to.have.property('mediaType', 'video');
     expect(bid).to.have.property('ttl', 300);


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Updates conversant bid adapter to use mediaTypes.video.playerSize to determine the size of the video, instead of using sizes if the playerSize is given. If playerSize is not given, it will default to using sizes in order to not change current behavior.

Per the Prebid documents, the preference is to use mediaTypes.banner.sizes for display ads for 1.0 and later. 


- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
