### PR TITLE
OpenX Bid Adapter: video support for platform IDs

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -296,8 +296,10 @@ function buildOXBannerRequest(bids, bidderRequest) {
 }
 
 function buildOXVideoRequest(bid, bidderRequest) {
-  let url = `//${bid.params.delDomain}/v/1.0/avjp`;
   let oxVideoParams = generateVideoParameters(bid, bidderRequest);
+  let url = oxVideoParams.ph
+    ? `//u.openx.net/v/1.0/avjp`
+    : `//${bid.params.delDomain}/v/1.0/avjp`;
   return {
     method: 'GET',
     url: url,

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -179,57 +179,106 @@ describe('OpenxAdapter', function () {
     });
 
     describe('when request is for a video ad', function () {
-      const videoBidWithMediaTypes = {
-        bidder: 'openx',
-        params: {
-          unit: '12345678',
-          delDomain: 'test-del-domain'
-        },
-        adUnitCode: 'adunit-code',
-        mediaTypes: {
-          video: {
-            playerSize: [640, 480]
-          }
-        },
-        bidId: '30b31c1838de1e',
-        bidderRequestId: '22edbae2733bf6',
-        auctionId: '1d1a030790a475',
-        transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e'
-      };
+      describe('and request config uses mediaTypes', () => {
+        const videoBidWithMediaTypes = {
+          bidder: 'openx',
+          params: {
+            unit: '12345678',
+            delDomain: 'test-del-domain'
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            video: {
+              playerSize: [640, 480]
+            }
+          },
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e'
+        };
+        it('should return true when required params found', function () {
+          expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(true);
+        });
 
-      const videoBidWithMediaType = {
-        'bidder': 'openx',
-        'params': {
-          'unit': '12345678',
-          'delDomain': 'test-del-domain'
-        },
-        'adUnitCode': 'adunit-code',
-        'mediaType': 'video',
-        'sizes': [640, 480],
-        'bidId': '30b31c1838de1e',
-        'bidderRequestId': '22edbae2733bf6',
-        'auctionId': '1d1a030790a475',
-        'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
-      };
-      it('should return true when required params found', function () {
-        expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(true);
+        it('should return false when required params are not passed', function () {
+          let videoBidWithMediaTypes = Object.assign({}, videoBidWithMediaTypes);
+          videoBidWithMediaTypes.params = {};
+          expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(false);
+        });
+        it('should send bid request to openx url via GET, with mediaType specified as video', function () {
+          const request = spec.buildRequests([videoBidWithMediaTypes]);
+          expect(request[0].url).to.equal(`//${videoBidWithMediaTypes.params.delDomain}${URLBASEVIDEO}`);
+          expect(request[0].data.ph).to.be.undefined;
+          expect(request[0].method).to.equal('GET');
+        });
       });
+      describe('and request config uses both delDomain and platform', () => {
+        const videoBidWithDelDomainAndPlatform = {
+          bidder: 'openx',
+          params: {
+            unit: '12345678',
+            delDomain: 'test-del-domain',
+            platform: '1cabba9e-cafe-3665-beef-f00f00f00f00',
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            video: {
+              playerSize: [640, 480]
+            }
+          },
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e'
+        };
+        it('should return true when required params found', function () {
+          expect(spec.isBidRequestValid(videoBidWithDelDomainAndPlatform)).to.equal(true);
+        });
 
-      it('should return false when required params are not passed', function () {
-        let videoBidWithMediaTypes = Object.assign({}, videoBidWithMediaTypes);
-        videoBidWithMediaTypes.params = {};
-        expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(false);
+        it('should return false when required params are not passed', function () {
+          let videoBidWithMediaTypes = Object.assign({}, videoBidWithDelDomainAndPlatform);
+          videoBidWithMediaTypes.params = {};
+          expect(spec.isBidRequestValid(videoBidWithMediaTypes)).to.equal(false);
+        });
+        it('should send bid request to openx url via GET, with mediaType specified as video', function () {
+          const request = spec.buildRequests([videoBidWithDelDomainAndPlatform]);
+          expect(request[0].url).to.equal(`//u.openx.net${URLBASEVIDEO}`);
+          expect(request[0].data.ph).to.equal(videoBidWithDelDomainAndPlatform.params.platform);
+          expect(request[0].method).to.equal('GET');
+        });
       });
+      describe('and request config uses mediaType', () => {
+        const videoBidWithMediaType = {
+          'bidder': 'openx',
+          'params': {
+            'unit': '12345678',
+            'delDomain': 'test-del-domain'
+          },
+          'adUnitCode': 'adunit-code',
+          'mediaType': 'video',
+          'sizes': [640, 480],
+          'bidId': '30b31c1838de1e',
+          'bidderRequestId': '22edbae2733bf6',
+          'auctionId': '1d1a030790a475',
+          'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+        };
+        it('should return true when required params found', function () {
+          expect(spec.isBidRequestValid(videoBidWithMediaType)).to.equal(true);
+        });
 
-      it('should return true when required params found', function () {
-        expect(spec.isBidRequestValid(videoBidWithMediaType)).to.equal(true);
-      });
-
-      it('should return false when required params are not passed', function () {
-        let videoBidWithMediaType = Object.assign({}, videoBidWithMediaType);
-        delete videoBidWithMediaType.params;
-        videoBidWithMediaType.params = {};
-        expect(spec.isBidRequestValid(videoBidWithMediaType)).to.equal(false);
+        it('should return false when required params are not passed', function () {
+          let videoBidWithMediaType = Object.assign({}, videoBidWithMediaType);
+          delete videoBidWithMediaType.params;
+          videoBidWithMediaType.params = {};
+          expect(spec.isBidRequestValid(videoBidWithMediaType)).to.equal(false);
+        });
+        it('should send bid request to openx url via GET, with mediaType specified as video', function () {
+          const request = spec.buildRequests([videoBidWithMediaType]);
+          expect(request[0].url).to.equal(`//${videoBidWithMediaType.params.delDomain}${URLBASEVIDEO}`);
+          expect(request[0].data.ph).to.be.undefined;
+          expect(request[0].method).to.equal('GET');
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
OpenX Bid Adapter: video support for platform IDs
related to #3282, but expanding the requests support to also include video
<!-- Describe the change proposed in this pull request -->

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
prebid/prebid.github.io#1033

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
