### PR TITLE
add support for userSyncLimit field in s2sConfig

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -100,6 +100,11 @@ function queueSync(bidderCodes, gdprConsent) {
     account: _s2sConfig.accountId
   };
 
+  let userSyncLimit = _s2sConfig.userSyncLimit;
+  if (utils.isNumber(userSyncLimit) && userSyncLimit > 0) {
+    payload['limit'] = userSyncLimit;
+  }
+
   if (gdprConsent) {
     // only populate gdpr field if we know CMP returned consent information (ie didn't timeout or have an error)
     if (typeof gdprConsent.consentString !== 'undefined') {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -738,6 +738,48 @@ describe('S2S Adapter', function () {
         value: ['buzz']
       }]);
     });
+
+    it('adds limit to the cookie_sync request if userSyncLimit is greater than 0', function () {
+      let cookieSyncConfig = utils.deepClone(CONFIG);
+      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
+      cookieSyncConfig.userSyncLimit = 1;
+
+      config.setConfig({ s2sConfig: cookieSyncConfig });
+
+      let bidRequest = utils.deepClone(BID_REQUESTS);
+      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
+      let requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.bidders).to.contain('appnexus').and.to.have.lengthOf(1);
+      expect(requestBid.account).is.equal('1');
+      expect(requestBid.limit).is.equal(1);
+    });
+
+    it('does not add limit to cooke_sync request if userSyncLimit is missing or 0', function () {
+      let cookieSyncConfig = utils.deepClone(CONFIG);
+      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
+      config.setConfig({ s2sConfig: cookieSyncConfig });
+
+      let bidRequest = utils.deepClone(BID_REQUESTS);
+      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
+      let requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.bidders).to.contain('appnexus').and.to.have.lengthOf(1);
+      expect(requestBid.account).is.equal('1');
+      expect(requestBid.limit).is.undefined;
+
+      cookieSyncConfig.userSyncLimit = 0;
+      config.resetConfig();
+      config.setConfig({ s2sConfig: cookieSyncConfig });
+
+      bidRequest = utils.deepClone(BID_REQUESTS);
+      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
+      requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.bidders).to.contain('appnexus').and.to.have.lengthOf(1);
+      expect(requestBid.account).is.equal('1');
+      expect(requestBid.limit).is.undefined;
+    });
   });
 
   describe('response handler', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Fixes #3367

Adds support for a new `s2sConfig` field named `userSyncLimit`.  It accepts a positive number that's meant to represent the number of syncs that PBS will execute.  

This field gets added to the `cookie_sync` request under the field `limit`.

## Other information
Docs PR:
https://github.com/prebid/prebid.github.io/pull/1060
