### PR TITLE
Update Conversant adapter's support for video playerSize

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -4,7 +4,7 @@ import { BANNER, VIDEO } from 'src/mediaTypes';
 
 const BIDDER_CODE = 'conversant';
 const URL = '//web.hb.ad.cpe.dotomi.com/s2s/header/24';
-const VERSION = '2.2.3';
+const VERSION = '2.2.4';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -62,8 +62,6 @@ export const spec = {
       siteId = utils.getBidIdParameter('site_id', bid.params);
       requestId = bid.auctionId;
 
-      let format = convertSizes(bid.sizes);
-
       const imp = {
         id: bid.bidId,
         secure: secure,
@@ -72,29 +70,31 @@ export const spec = {
         displaymanagerver: VERSION
       };
 
-      copyOptProperty(bid.params, 'tag_id', imp, 'tagid');
+      copyOptProperty(bid.params.tag_id, imp, 'tagid');
 
       if (isVideoRequest(bid)) {
-        if (bid.mediaTypes.video.playerSize) {
-          format = convertSizes(bid.mediaTypes.video.playerSize);
+        const videoData = utils.deepAccess(bid, 'mediaTypes.video') || {};
+        const format = convertSizes(videoData.playerSize || bid.sizes);
+        const video = {};
+
+        if (format && format[0]) {
+          copyOptProperty(format[0].w, video, 'w');
+          copyOptProperty(format[0].h, video, 'h');
         }
 
-        const video = {
-          w: format[0].w,
-          h: format[0].h
-        };
-
-        copyOptProperty(bid.params, 'position', video, 'pos');
-        copyOptProperty(bid.params, 'mimes', video);
-        copyOptProperty(bid.params, 'maxduration', video);
-        copyOptProperty(bid.params, 'protocols', video);
-        copyOptProperty(bid.params, 'api', video);
+        copyOptProperty(bid.params.position, video, 'pos');
+        copyOptProperty(bid.params.mimes || videoData.mimes, video, 'mimes');
+        copyOptProperty(bid.params.maxduration, video, 'maxduration');
+        copyOptProperty(bid.params.protocols || videoData.protocols, video, 'protocols');
+        copyOptProperty(bid.params.api || videoData.api, video, 'api');
 
         imp.video = video;
       } else {
+        const bannerData = utils.deepAccess(bid, 'mediaTypes.banner') || {};
+        const format = convertSizes(bannerData.sizes || bid.sizes);
         const banner = {format: format};
 
-        copyOptProperty(bid.params, 'position', banner, 'pos');
+        copyOptProperty(bid.params.position, banner, 'pos');
 
         imp.banner = banner;
       }
@@ -253,11 +253,12 @@ function getDevice() {
  */
 function convertSizes(bidSizes) {
   let format;
-
-  if (bidSizes.length === 2 && typeof bidSizes[0] === 'number' && typeof bidSizes[1] === 'number') {
-    format = [{w: bidSizes[0], h: bidSizes[1]}];
-  } else {
-    format = utils._map(bidSizes, d => { return {w: d[0], h: d[1]}; });
+  if (Array.isArray(bidSizes)) {
+    if (bidSizes.length === 2 && typeof bidSizes[0] === 'number' && typeof bidSizes[1] === 'number') {
+      format = [{w: bidSizes[0], h: bidSizes[1]}];
+    } else {
+      format = utils._map(bidSizes, d => { return {w: d[0], h: d[1]}; });
+    }
   }
 
   return format;
@@ -276,16 +277,13 @@ function isVideoRequest(bid) {
 /**
  * Copy property if exists from src to dst
  *
- * @param {object} src
- * @param {string} srcName
- * @param {object} dst
- * @param {string} [dstName] - Optional. If not specified then srcName is used.
+ * @param {object} src - source object
+ * @param {object} dst - destination object
+ * @param {string} dstName - destination property name
  */
-function copyOptProperty(src, srcName, dst, dstName) {
-  dstName = dstName || srcName;
-  const obj = utils.getBidIdParameter(srcName, src);
-  if (obj !== '') {
-    dst[dstName] = obj;
+function copyOptProperty(src, dst, dstName) {
+  if (src) {
+    dst[dstName] = src;
   }
 }
 

--- a/modules/conversantBidAdapter.md
+++ b/modules/conversantBidAdapter.md
@@ -22,7 +22,6 @@ var adUnits = [
         }]
     },{
         code: 'video-test-div',
-        sizes: [640, 480],
         mediaTypes: {
             video: {
                 context: 'instream',
@@ -32,7 +31,7 @@ var adUnits = [
         bids: [{
             bidder: "conversant",
             params: {
-                site_id: '88563',
+                site_id: '108060',
                 api: [2],
                 protocols: [1, 2],
                 mimes: ['video/mp4']

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -8,6 +8,7 @@ describe('Conversant adapter tests', function() {
   const siteId = '108060';
 
   const bidRequests = [
+    // banner with single size
     {
       bidder: 'conversant',
       params: {
@@ -23,19 +24,27 @@ describe('Conversant adapter tests', function() {
       bidId: 'bid000',
       bidderRequestId: '117d765b87bed38',
       auctionId: 'req000'
-    }, {
+    },
+    // banner with sizes in mediaTypes.banner.sizes
+    {
       bidder: 'conversant',
       params: {
         site_id: siteId,
         secure: false
       },
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90], [468, 60]]
+        }
+      },
       placementCode: 'pcode001',
       transactionId: 'tx001',
-      sizes: [[468, 60]],
       bidId: 'bid001',
       bidderRequestId: '117d765b87bed38',
       auctionId: 'req000'
-    }, {
+    },
+    // banner with tag id and position
+    {
       bidder: 'conversant',
       params: {
         site_id: siteId,
@@ -49,7 +58,9 @@ describe('Conversant adapter tests', function() {
       bidId: 'bid002',
       bidderRequestId: '117d765b87bed38',
       auctionId: 'req000'
-    }, {
+    },
+    // video with single size
+    {
       bidder: 'conversant',
       params: {
         site_id: siteId,
@@ -68,6 +79,47 @@ describe('Conversant adapter tests', function() {
       transactionId: 'tx003',
       sizes: [640, 480],
       bidId: 'bid003',
+      bidderRequestId: '117d765b87bed38',
+      auctionId: 'req000'
+    },
+    // video with playerSize
+    {
+      bidder: 'conversant',
+      params: {
+        site_id: siteId,
+        maxduration: 30,
+        api: [2, 3]
+      },
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [1024, 768],
+          api: [1, 2],
+          protocols: [1, 2, 3],
+          mimes: ['video/mp4', 'video/x-flv']
+        }
+      },
+      placementCode: 'pcode004',
+      transactionId: 'tx004',
+      bidId: 'bid004',
+      bidderRequestId: '117d765b87bed38',
+      auctionId: 'req000'
+    },
+    // video without sizes
+    {
+      bidder: 'conversant',
+      params: {
+        site_id: siteId
+      },
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          mimes: ['video/mp4', 'video/x-flv']
+        }
+      },
+      placementCode: 'pcode005',
+      transactionId: 'tx005',
+      bidId: 'bid005',
       bidderRequestId: '117d765b87bed38',
       auctionId: 'req000'
     }];
@@ -129,6 +181,8 @@ describe('Conversant adapter tests', function() {
     expect(spec.isBidRequestValid(bidRequests[1])).to.be.true;
     expect(spec.isBidRequestValid(bidRequests[2])).to.be.true;
     expect(spec.isBidRequestValid(bidRequests[3])).to.be.true;
+    expect(spec.isBidRequestValid(bidRequests[4])).to.be.true;
+    expect(spec.isBidRequestValid(bidRequests[5])).to.be.true;
 
     const simpleVideo = JSON.parse(JSON.stringify(bidRequests[3]));
     simpleVideo.params.site_id = 123;
@@ -151,7 +205,7 @@ describe('Conversant adapter tests', function() {
     expect(payload).to.have.property('id', 'req000');
     expect(payload).to.have.property('at', 1);
     expect(payload).to.have.property('imp');
-    expect(payload.imp).to.be.an('array').with.lengthOf(4);
+    expect(payload.imp).to.be.an('array').with.lengthOf(6);
 
     expect(payload.imp[0]).to.have.property('id', 'bid000');
     expect(payload.imp[0]).to.have.property('secure', 0);
@@ -169,18 +223,18 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[1]).to.have.property('secure', 0);
     expect(payload.imp[1]).to.have.property('bidfloor', 0);
     expect(payload.imp[1]).to.have.property('displaymanager', 'Prebid.js');
-    expect(payload.imp[0]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
+    expect(payload.imp[1]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
     expect(payload.imp[1]).to.not.have.property('tagid');
     expect(payload.imp[1]).to.have.property('banner');
     expect(payload.imp[1].banner).to.not.have.property('pos');
     expect(payload.imp[1].banner).to.have.property('format');
-    expect(payload.imp[1].banner.format).to.deep.equal([{w: 468, h: 60}]);
+    expect(payload.imp[1].banner.format).to.deep.equal([{w: 728, h: 90}, {w: 468, h: 60}]);
 
     expect(payload.imp[2]).to.have.property('id', 'bid002');
     expect(payload.imp[2]).to.have.property('secure', 0);
     expect(payload.imp[2]).to.have.property('bidfloor', 0);
     expect(payload.imp[2]).to.have.property('displaymanager', 'Prebid.js');
-    expect(payload.imp[0]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
+    expect(payload.imp[2]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
     expect(payload.imp[2]).to.have.property('banner');
     expect(payload.imp[2].banner).to.have.property('pos', 2);
     expect(payload.imp[2].banner).to.have.property('format');
@@ -190,7 +244,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[3]).to.have.property('secure', 0);
     expect(payload.imp[3]).to.have.property('bidfloor', 0);
     expect(payload.imp[3]).to.have.property('displaymanager', 'Prebid.js');
-    expect(payload.imp[0]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
+    expect(payload.imp[3]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
     expect(payload.imp[3]).to.not.have.property('tagid');
     expect(payload.imp[3]).to.have.property('video');
     expect(payload.imp[3].video).to.not.have.property('pos');
@@ -204,6 +258,42 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[3].video.api).to.deep.equal([2]);
     expect(payload.imp[3].video).to.have.property('maxduration', 30);
     expect(payload.imp[3]).to.not.have.property('banner');
+
+    expect(payload.imp[4]).to.have.property('id', 'bid004');
+    expect(payload.imp[4]).to.have.property('secure', 0);
+    expect(payload.imp[4]).to.have.property('bidfloor', 0);
+    expect(payload.imp[4]).to.have.property('displaymanager', 'Prebid.js');
+    expect(payload.imp[4]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
+    expect(payload.imp[4]).to.not.have.property('tagid');
+    expect(payload.imp[4]).to.have.property('video');
+    expect(payload.imp[4].video).to.not.have.property('pos');
+    expect(payload.imp[4].video).to.have.property('w', 1024);
+    expect(payload.imp[4].video).to.have.property('h', 768);
+    expect(payload.imp[4].video).to.have.property('mimes');
+    expect(payload.imp[4].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+    expect(payload.imp[4].video).to.have.property('protocols');
+    expect(payload.imp[4].video.protocols).to.deep.equal([1, 2, 3]);
+    expect(payload.imp[4].video).to.have.property('api');
+    expect(payload.imp[4].video.api).to.deep.equal([2, 3]);
+    expect(payload.imp[4].video).to.have.property('maxduration', 30);
+    expect(payload.imp[4]).to.not.have.property('banner');
+
+    expect(payload.imp[5]).to.have.property('id', 'bid005');
+    expect(payload.imp[5]).to.have.property('secure', 0);
+    expect(payload.imp[5]).to.have.property('bidfloor', 0);
+    expect(payload.imp[5]).to.have.property('displaymanager', 'Prebid.js');
+    expect(payload.imp[5]).to.have.property('displaymanagerver').that.matches(/^\d+\.\d+\.\d+$/);
+    expect(payload.imp[5]).to.not.have.property('tagid');
+    expect(payload.imp[5]).to.have.property('video');
+    expect(payload.imp[5].video).to.not.have.property('pos');
+    expect(payload.imp[5].video).to.not.have.property('w');
+    expect(payload.imp[5].video).to.not.have.property('h');
+    expect(payload.imp[5].video).to.have.property('mimes');
+    expect(payload.imp[5].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+    expect(payload.imp[5].video).to.not.have.property('protocols');
+    expect(payload.imp[5].video).to.not.have.property('api');
+    expect(payload.imp[5].video).to.not.have.property('maxduration');
+    expect(payload.imp[5]).to.not.have.property('banner');
 
     expect(payload).to.have.property('site');
     expect(payload.site).to.have.property('id', siteId);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add support for mediaTypes.video.playerSize, and also support video requests that have no sizes.

- contact email of the adapter’s maintainer
pyang@conversantmedia.com

- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
