### PR TITLE
update AJA adapter: support user sync by iframe

### DIFF
--- a/modules/ajaBidAdapter.js
+++ b/modules/ajaBidAdapter.js
@@ -93,16 +93,28 @@ export const spec = {
 
   getUserSyncs: function(syncOptions, serverResponses) {
     const syncs = [];
-    if (syncOptions.pixelEnabled && serverResponses.length) {
-      const bidderResponseBody = serverResponses[0].body;
-      if (bidderResponseBody.syncs) {
-        bidderResponseBody.syncs.forEach(sync => {
-          syncs.push({
-            type: 'image',
-            url: sync
-          });
+    if (!serverResponses.length) {
+      return syncs;
+    }
+
+    const bidderResponseBody = serverResponses[0].body;
+
+    if (syncOptions.pixelEnabled && bidderResponseBody.syncs) {
+      bidderResponseBody.syncs.forEach(sync => {
+        syncs.push({
+          type: 'image',
+          url: sync
         });
-      }
+      });
+    }
+
+    if (syncOptions.iframeEnabled && bidderResponseBody.sync_htmls) {
+      bidderResponseBody.sync_htmls.forEach(sync => {
+        syncs.push({
+          type: 'iframe',
+          url: sync
+        });
+      });
     }
 
     return syncs;

--- a/modules/ajaBidAdapter.md
+++ b/modules/ajaBidAdapter.md
@@ -13,40 +13,38 @@ Aja bid adapter supports Banner and Outstream Video.
 # Test Parameters
 ```
 var adUnits = [
-   // Banner adUnit
-   {
-       code: 'banner-div',
-       mediaTypes: {
-         banner: {
-           sizes: [
-             [300, 250]
-           ],
-         }
-       },
-       bids: [{
-         bidder: 'aja',
-         params: {
-           asi: 'szs4htFiR'
-         }
-       }]
-   },
-   // Video outstream adUnit
-   {
-     code: 'video-outstream',
-     mediaTypes: {
-       video: {
-         context: 'outstream',
-         playerSize: [300, 250]
-       }
-     },
-     bids: [
-       {
-         bidder: 'aja',
-         params: {
-           asi: 'Kp2O2tFig'
-         }
-       }
-     ]
-   }
+  // Banner adUnit
+  {
+    code: 'banner-div',
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [300, 250]
+        ],
+      }
+    },
+    bids: [{
+      bidder: 'aja',
+      params: {
+        asi: 'szs4htFiR'
+      }
+    }]
+  },
+  // Video outstream adUnit
+  {
+    code: 'video-outstream',
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        playerSize: [300, 250]
+      }
+    },
+    bids: [{
+      bidder: 'aja',
+      params: {
+        asi: 'Kp2O2tFig'
+      }
+    }]
+  }
 ];
 ```

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -148,7 +148,10 @@ describe('AjaAdapter', function () {
         'is_ad_return': true,
         'ad': { /* ad body */ },
         'syncs': [
-          'https://example.test/1'
+          'https://example.test/pixel/1'
+        ],
+        'sync_htmls': [
+          'https://example.test/iframe/1'
         ]
       }
     };
@@ -158,29 +161,53 @@ describe('AjaAdapter', function () {
         'is_ad_return': true,
         'ad': { /* ad body */ },
         'syncs': [
-          'https://example.test/2'
+          'https://example.test/pixel/2'
         ]
       }
     };
 
-    it('should use a sync url from first response', function () {
-      const syncs = spec.getUserSyncs({ pixelEnabled: true }, [bidResponse1, bidResponse2]);
+    it('should use a sync url from first response (pixel and iframe)', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, [bidResponse1, bidResponse2]);
       expect(syncs).to.deep.equal([
         {
           type: 'image',
-          url: 'https://example.test/1'
+          url: 'https://example.test/pixel/1'
+        },
+        {
+          type: 'iframe',
+          url: 'https://example.test/iframe/1'
         }
       ]);
     });
 
     it('handle empty response (e.g. timeout)', function () {
-      const syncs = spec.getUserSyncs({ pixelEnabled: true }, []);
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, []);
       expect(syncs).to.deep.equal([]);
     });
 
-    it('returns empty syncs when not enabled', function () {
-      const syncs = spec.getUserSyncs({ pixelEnabled: false }, [bidResponse1]);
+    it('returns empty syncs when not pixel enabled and not iframe enabled', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false, iframeEnabled: false }, [bidResponse1]);
       expect(syncs).to.deep.equal([]);
+    });
+
+    it('returns pixel syncs when pixel enabled and not iframe enabled', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: false }, [bidResponse1]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://example.test/pixel/1'
+        }
+      ]);
+    });
+
+    it('returns iframe syncs when not pixel enabled and iframe enabled', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false, iframeEnabled: true }, [bidResponse1]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'https://example.test/iframe/1'
+        }
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [×] Other

## Description of change

supporting user sync by iframe.

- contact email of the adapter’s maintainer: ssp_support@aja-kk.co.jp
- [×] official adapter submission