### PR TITLE
Adding Remaining Native Parameters from AppNexus Native response

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -27,7 +27,9 @@ const NATIVE_MAPPING = {
     minimumParams: { sizes: [{}] },
   },
   sponsoredBy: 'sponsored_by',
-  privacyLink: 'privacy_link'
+  privacyLink: 'privacy_link',
+  sale: 'saleprice',
+  clickLabel: 'displayurl'
 };
 const SOURCE = 'pbjs';
 
@@ -338,10 +340,18 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       rating: nativeAd.rating,
       sponsoredBy: nativeAd.sponsored,
       privacyLink: nativeAd.privacy_link,
+      address: nativeAd.address,
+      downloads: nativeAd.downloads,
+      likes: nativeAd.likes,
+      phone: nativeAd.phone,
+      price: nativeAd.price,
+      sale: nativeAd.saleprice,
       clickUrl: nativeAd.link.url,
+      clickLabel: nativeAd.displayurl,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,
       javascriptTrackers: nativeAd.javascript_trackers,
+      video: nativeAd.video.content
     };
     if (nativeAd.main_img) {
       bid['native'].image = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -28,8 +28,8 @@ const NATIVE_MAPPING = {
   },
   sponsoredBy: 'sponsored_by',
   privacyLink: 'privacy_link',
-  sale: 'saleprice',
-  clickLabel: 'displayurl'
+  salePrice: 'saleprice',
+  displayUrl: 'displayurl'
 };
 const SOURCE = 'pbjs';
 
@@ -345,13 +345,12 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       likes: nativeAd.likes,
       phone: nativeAd.phone,
       price: nativeAd.price,
-      sale: nativeAd.saleprice,
+      salePrice: nativeAd.saleprice,
       clickUrl: nativeAd.link.url,
-      clickLabel: nativeAd.displayurl,
+      displayUrl: nativeAd.displayurl,
       clickTrackers: nativeAd.link.click_trackers,
       impressionTrackers: nativeAd.impression_trackers,
-      javascriptTrackers: nativeAd.javascript_trackers,
-      video: nativeAd.video.content
+      javascriptTrackers: nativeAd.javascript_trackers
     };
     if (nativeAd.main_img) {
       bid['native'].image = {

--- a/src/constants.json
+++ b/src/constants.json
@@ -74,7 +74,7 @@
     "image": "hb_native_image",
     "icon": "hb_native_icon",
     "clickUrl": "hb_native_linkurl",
-    "clickLabel": "hb_native_linklabel",
+    "displayUrl": "hb_native_displayurl",
     "cta": "hb_native_cta",
     "rating": "hb_native_rating",
     "address": "hb_native_address",
@@ -82,8 +82,7 @@
     "likes": "hb_native_likes",
     "phone": "hb_native_phone",
     "price": "hb_native_price",
-    "sale": "hb_native_sale",
-    "video": "hb_native_video"
+    "salePrice": "hb_native_saleprice"
   },
   "S2S" : {
     "SRC" : "s2s",

--- a/src/constants.json
+++ b/src/constants.json
@@ -74,8 +74,16 @@
     "image": "hb_native_image",
     "icon": "hb_native_icon",
     "clickUrl": "hb_native_linkurl",
+    "clickLabel": "hb_native_linklabel",
     "cta": "hb_native_cta",
-    "rating": "hb_native_rating"
+    "rating": "hb_native_rating",
+    "address": "hb_native_address",
+    "downloads": "hb_native_downloads",
+    "likes": "hb_native_likes",
+    "phone": "hb_native_phone",
+    "price": "hb_native_price",
+    "sale": "hb_native_sale",
+    "video": "hb_native_video"
   },
   "S2S" : {
     "SRC" : "s2s",

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -577,9 +577,6 @@ describe('AppNexusAdapter', function () {
         'saleprice': 'FREE',
         'phone': '1234567890',
         'address': '28 W 23rd St, New York, NY 10010',
-        'video': {
-          'content': '<!-- VAST Creative -->'
-        },
         'privacy_link': 'http://appnexus.com/?url=privacy_url'
       };
       let bidderRequest = {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -185,14 +185,13 @@ describe('AppNexusAdapter', function () {
             rating: {required: true},
             sponsoredBy: {required: true},
             privacyLink: {required: true},
-            clickLabel: {required: true},
+            displayUrl: {required: true},
             address: {required: true},
             downloads: {required: true},
             likes: {required: true},
             phone: {required: true},
             price: {required: true},
-            sale: {required: true},
-            video: {required: true}
+            salePrice: {required: true}
           }
         }
       );
@@ -215,8 +214,7 @@ describe('AppNexusAdapter', function () {
         likes: {required: true},
         phone: {required: true},
         price: {required: true},
-        saleprice: {required: true},
-        video: {required: true}
+        saleprice: {required: true}
       });
     });
 

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -184,7 +184,15 @@ describe('AppNexusAdapter', function () {
             cta: {required: false},
             rating: {required: true},
             sponsoredBy: {required: true},
-            privacyLink: {required: true}
+            privacyLink: {required: true},
+            clickLabel: {required: true},
+            address: {required: true},
+            downloads: {required: true},
+            likes: {required: true},
+            phone: {required: true},
+            price: {required: true},
+            sale: {required: true},
+            video: {required: true}
           }
         }
       );
@@ -200,7 +208,15 @@ describe('AppNexusAdapter', function () {
         ctatext: {required: false},
         rating: {required: true},
         sponsored_by: {required: true},
-        privacy_link: {required: true}
+        privacy_link: {required: true},
+        displayurl: {required: true},
+        address: {required: true},
+        downloads: {required: true},
+        likes: {required: true},
+        phone: {required: true},
+        price: {required: true},
+        saleprice: {required: true},
+        video: {required: true}
       });
     });
 
@@ -536,6 +552,7 @@ describe('AppNexusAdapter', function () {
       response1.tags[0].ads[0].rtb.native = {
         'title': 'Native Creative',
         'desc': 'Cool description great stuff',
+        'desc2': 'Additional body text',
         'ctatext': 'Do it',
         'sponsored': 'AppNexus',
         'icon': {
@@ -554,6 +571,18 @@ describe('AppNexusAdapter', function () {
           'click_trackers': ['http://nym1-ib.adnxs.com/click']
         },
         'impression_trackers': ['http://example.com'],
+        'rating': '5',
+        'displayurl': 'http://AppNexus.com/?url=display_url',
+        'likes': '38908320',
+        'downloads': '874983',
+        'price': '9.99',
+        'saleprice': 'FREE',
+        'phone': '1234567890',
+        'address': '28 W 23rd St, New York, NY 10010',
+        'video': {
+          'content': '<!-- VAST Creative -->'
+        },
+        'privacy_link': 'http://appnexus.com/?url=privacy_url'
       };
       let bidderRequest = {
         bids: [{


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds support for the following native parameters to prebid.js and the AppNexus adaptor:
- displayUrl
- address
- downloads
- likes
- phone
- price
- salePrice

Example implementation
```
var adUnits = [{
  code: 'div-id',
  mediaTypes: {
	  native: {
                displayUrl: {
                    required: true
                },
                address: {
                    required: true
                },
                downloads: {
                    required: true
                },
                likes: {
                    required: true
                },
                phone: {
                    required: true
                },
                price: {
                    required: true
                },
                salePrice: {
                    required: true
                }
	  }
  },
  bids: [...]
}];
```