### PR TITLE
Bid caching flag

### DIFF
--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -57,9 +57,6 @@ export function newAuctionManager() {
   };
 
   auctionManager.getBidsReceived = function() {
-    // As of now, an old bid which is not used in auction 1 can be used in auction n.
-    // To prevent this, bid.ttl (time to live) will be added to this logic and bid pool will also be added
-    // As of now none of the adapters are sending back bid.ttl
     return _auctions.map((auction) => {
       if (auction.getAuctionStatus() === AUCTION_COMPLETED) {
         return auction.getBidsReceived();

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 const DEFAULT_ENABLE_SEND_ALL_BIDS = true;
 const DEFAULT_DISABLE_AJAX_TIMEOUT = false;
+const DEFAULT_BID_CACHE = true;
 
 const DEFAULT_TIMEOUTBUFFER = 400;
 
@@ -131,6 +132,14 @@ export function newConfig() {
       },
       set enableSendAllBids(val) {
         this._sendAllBids = val;
+      },
+
+      _useBidCache: DEFAULT_BID_CACHE,
+      get useBidCache() {
+        return this._useBidCache;
+      },
+      set useBidderCache(val) {
+        this._useBidCache = val;
       },
 
       _bidderSequence: DEFAULT_BIDDER_SEQUENCE,

--- a/src/config.js
+++ b/src/config.js
@@ -138,7 +138,7 @@ export function newConfig() {
       get useBidCache() {
         return this._useBidCache;
       },
-      set useBidderCache(val) {
+      set useBidCache(val) {
         this._useBidCache = val;
       },
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -396,6 +396,7 @@ $$PREBID_GLOBAL$$.requestBids = createHook('asyncSeries', function ({ bidsBackHa
   }
 
   const auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout, labels});
+  adUnitCodes.forEach(code => targeting.setLatestAuctionForAdUnit(code, auction.getAuctionId()));
   auction.callBids();
   return auction;
 });

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -53,6 +53,11 @@ export function getHighestCpmBidsFromBidPool(bidsReceived, highestCpmCallback) {
 
 export function newTargeting(auctionManager) {
   let targeting = {};
+  let latestAuctionForAdUnit = {};
+
+  targeting.setLatestAuctionForAdUnit = function(adUnitCode, auctionId) {
+    latestAuctionForAdUnit[adUnitCode] = auctionId;
+  };
 
   targeting.resetPresetTargeting = function(adUnitCode) {
     if (isGptPubadsDefined()) {
@@ -191,7 +196,13 @@ export function newTargeting(auctionManager) {
   }
 
   function getBidsReceived() {
-    const bidsReceived = auctionManager.getBidsReceived()
+    let bidsReceived = auctionManager.getBidsReceived();
+
+    if (!config.getConfig('useBidCache')) {
+      bidsReceived = bidsReceived.filter(bid => latestAuctionForAdUnit[bid.adUnitCode] === bid.auctionId)
+    }
+
+    bidsReceived = bidsReceived
       .filter(bid => bid.mediaType !== 'banner' || sizeSupported([bid.width, bid.height]))
       .filter(filters.isUnusedBid)
       .filter(filters.isBidNotExpired)

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -100,14 +100,21 @@ const bid3 = {
 describe('targeting tests', function () {
   let sandbox;
   let enableSendAllBids = false;
+  let useBidCache;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
+
+    useBidCache = true;
+    // enableSendAllBids = false;
 
     let origGetConfig = config.getConfig;
     sandbox.stub(config, 'getConfig').callsFake(function (key) {
       if (key === 'enableSendAllBids') {
         return enableSendAllBids;
+      }
+      if (key === 'useBidCache') {
+        return useBidCache;
       }
       return origGetConfig.apply(config, arguments);
     });
@@ -220,6 +227,30 @@ describe('targeting tests', function () {
         expect(bids.length).to.equal(2);
         expect(bids[0].adId).to.equal('adid-1');
         expect(bids[1].adId).to.equal('adid-2');
+      });
+
+      it('should honor useBidCache', function() {
+        useBidCache = true;
+
+        auctionManagerStub.returns([
+          createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1'}),
+          createBidReceived({bidder: 'appnexus', cpm: 5, auctionId: 2, responseTimestamp: 102, adUnitCode: 'code-0', adId: 'adid-2'}),
+        ]);
+
+        let adUnitCodes = ['code-0'];
+        targetingInstance.setLatestAuctionForAdUnit('code-0', 2);
+
+        let bids = targetingInstance.getWinningBids(adUnitCodes);
+
+        expect(bids.length).to.equal(1);
+        expect(bids[0].adId).to.equal('adid-1');
+
+        useBidCache = false;
+
+        bids = targetingInstance.getWinningBids(adUnitCodes);
+
+        expect(bids.length).to.equal(1);
+        expect(bids[0].adId).to.equal('adid-2');
       });
 
       it('should not use rendered bid to get winning bid', function () {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1361,6 +1361,29 @@ describe('Unit: Prebid Module', function () {
           .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
+      it('should notify targeting of the latest auction for each adUnit', function () {
+        let latestStub = sinon.stub(targeting, 'setLatestAuctionForAdUnit');
+        let getAuctionStub = sinon.stub(auction, 'getAuctionId').returns(2);
+
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'test1',
+              bids: []
+            }, {
+              code: 'test2',
+              bids: []
+            }
+          ]
+        });
+
+        expect(latestStub.firstCall.calledWith('test1', 2)).to.equal(true);
+        expect(latestStub.secondCall.calledWith('test2', 2)).to.equal(true);
+
+        latestStub.restore();
+        getAuctionStub.restore();
+      });
+
       it('should execute callback immediately if adUnits is empty', function () {
         var bidsBackHandler = function bidsBackHandlerCallback() {};
         var spyExecuteCallback = sinon.spy(bidsBackHandler);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This adds a new flag, `useBidCache`, for disabling [bid caching](http://prebid.org/dev-docs/faq.html#does-prebidjs-cache-bids).  The default for `useBidCache` is true.

```javascript
// disable bid caching
pbjs.setConfig({
  useBidCache: false
});
```

## Other information
Documentation pull-request here: https://github.com/prebid/prebid.github.io/pull/1069

fixes #2992 