### PR TITLE
Rubicon analytics fix bid response mapping

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -428,7 +428,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         break;
       case BIDDER_DONE:
         args.bids.forEach(bid => {
-          let cachedBid = cache.auctions[bid.auctionId].bids[bid.bidId || bid.adId];
+          let cachedBid = cache.auctions[bid.auctionId].bids[bid.bidId || bid.requestId];
           if (typeof bid.serverResponseTimeMs !== 'undefined') {
             cachedBid.serverLatencyMillis = bid.serverResponseTimeMs;
           }
@@ -445,11 +445,11 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         break;
       case BID_WON:
         let auctionCache = cache.auctions[args.auctionId];
-        auctionCache.bidsWon[args.adUnitCode] = args.adId;
+        auctionCache.bidsWon[args.adUnitCode] = args.requestId;
 
         // check if this BID_WON missed the boat, if so send by itself
         if (auctionCache.sent === true) {
-          sendMessage.call(this, args.auctionId, args.adId);
+          sendMessage.call(this, args.auctionId, args.requestId);
         } else if (Object.keys(auctionCache.bidsWon).reduce((memo, adUnitCode) => {
           // only send if we've received bidWon events for all adUnits in auction
           memo = memo && auctionCache.bidsWon[adUnitCode];
@@ -470,7 +470,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
       case BID_TIMEOUT:
         args.forEach(badBid => {
           let auctionCache = cache.auctions[badBid.auctionId];
-          let bid = auctionCache.bids[badBid.bidId || badBid.adId];
+          let bid = auctionCache.bids[badBid.bidId || badBid.requestId];
           bid.status = 'error';
           bid.error = {
             code: 'timeout-error'

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -408,7 +408,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
       case BID_RESPONSE:
         let bid = cache.auctions[args.auctionId].bids[args.requestId];
         if (!bid) {
-          utils.logError("Rubicon Anlytics Adapter Error: Could not find associated bid request for bid response with requestId: ", args.requestId);
+          utils.logError('Rubicon Anlytics Adapter Error: Could not find associated bid request for bid response with requestId: ', args.requestId);
           break;
         }
         bid.source = formatSource(bid.source || args.source);

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -407,6 +407,10 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         break;
       case BID_RESPONSE:
         let bid = cache.auctions[args.auctionId].bids[args.requestId];
+        if (!bid) {
+          utils.logError("Rubicon Anlytics Adapter Error: Could not find associated bid request for bid response with requestId: ", args.requestId);
+          break;
+        }
         bid.source = formatSource(bid.source || args.source);
         switch (args.getStatusCode()) {
           case GOOD:

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -406,7 +406,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         }, {}));
         break;
       case BID_RESPONSE:
-        let bid = cache.auctions[args.auctionId].bids[args.adId];
+        let bid = cache.auctions[args.auctionId].bids[args.requestId];
         bid.source = formatSource(bid.source || args.source);
         switch (args.getStatusCode()) {
           case GOOD:

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -40,7 +40,7 @@ const BID = {
   'mediaType': 'video',
   'statusMessage': 'Bid available',
   'bidId': '2ecff0db240757',
-  'adId': '2ecff0db240757',
+  'adId': 'fake_ad_id',
   'source': 'client',
   'requestId': '2ecff0db240757',
   'currency': 'USD',
@@ -80,7 +80,7 @@ const BID = {
 const BID2 = Object.assign({}, BID, {
   adUnitCode: '/19968336/header-bid-tag1',
   bidId: '3bd4ebb1c900e2',
-  adId: '3bd4ebb1c900e2',
+  adId: 'fake_ad_id',
   requestId: '3bd4ebb1c900e2',
   width: 728,
   height: 90,


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
We were mapping bid requests to bid responses by `args.bidId` <--> `args.adId`

This is not how Prebid Core does it.

If an adapter alters `adId` in the response, then it caused exceptions.

We now map by `args.bidId` <--> `args.requestId`

Which is how Prebid Core does it.
