### PR TITLE
Fix issue with limited browser `const` support triggered by code in the Sharethrough Adapter

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -348,7 +348,7 @@ export function setConfig(config) {
     allowAuction = DEFAULT_ALLOW_AUCTION_WO_CONSENT;
     utils.logInfo(`consentManagement config did not specify allowAuctionWithoutConsent.  Using system default setting (${DEFAULT_ALLOW_AUCTION_WO_CONSENT}).`);
   }
-
+  utils.logInfo('consentManagement module has been activated...');
   $$PREBID_GLOBAL$$.requestBids.addHook(requestBidsHook, 50);
 }
 config.getConfig('consentManagement', config => setConfig(config.consentManagement));

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -23,7 +23,7 @@ describe('consentManagement', function () {
         expect(userCMP).to.be.equal('iab');
         expect(consentTimeout).to.be.equal(10000);
         expect(allowAuction).to.be.true;
-        sinon.assert.callCount(utils.logInfo, 3);
+        sinon.assert.callCount(utils.logInfo, 4);
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Fixes browser compatibility issue with Sharethrough Adapter. Replaces the hardcoding of `const` with `var`

A `const` in a string literal like this won't be correctly transpiled
by babel, so we'll be limited by the browser support matrix for
`const`.

- jbecker@sharethrough.com / pubgrowth.engineering@sharethrough.com
- [ x] official adapter submission

