### PR TITLE
fix spacing in gulp lint command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,10 +80,10 @@ function lint(done) {
   if (argv.nolint) {
     return done();
   }
-  const isFixed = function(file){
+  const isFixed = function(file) {
     return file.eslint != null && file.eslint.fixed;
   }
-  return gulp.src(['src/**/*.js', 'modules/**/*.js', 'test/**/*.js'],{base: './'})
+  return gulp.src(['src/**/*.js', 'modules/**/*.js', 'test/**/*.js'], {base: './'})
     .pipe(eslint({fix: true}))
     .pipe(eslint.format('stylish'))
     .pipe(eslint.failAfterError())


### PR DESCRIPTION
## Type of change
- [x] Code style update (formatting, local variables)

## Description of change
Fix the small formatting problem introduced from #3416 in the `gulp lint` command.