### PR TITLE
Add bidfloor param to allow dynamic bid floor CPM

### DIFF
--- a/integrationExamples/gpt/pbjs_example_gpt.html
+++ b/integrationExamples/gpt/pbjs_example_gpt.html
@@ -418,7 +418,8 @@
                     {
                         bidder: 'gumgum',
                         params: {
-                            inScreen: 'ggumtest' // REQUIRED str Tracking Id
+                            inScreen: 'ggumtest', // REQUIRED str Tracking Id
+                            bidfloor: 0.01        // OPTIONAL number CPM bid
                         }
                     },
                     {

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -103,6 +103,12 @@ function isBidRequestValid (bid) {
       utils.logWarn(`[GumGum] No product selected for the placement ${adUnitCode}, please check your implementation.`);
       return false;
   }
+
+  if (params.bidfloor && !Number.isFinite(params.bidfloor)) {
+    utils.logWarn('[GumGum] bidfloor must be a Number');
+    return false;
+  }
+
   return true;
 }
 
@@ -125,6 +131,9 @@ function buildRequests (validBidRequests, bidderRequest) {
     const data = {}
     if (pageViewId) {
       data.pv = pageViewId
+    }
+    if (params.bidfloor) {
+      data.fp = params.bidfloor;
     }
     if (params.inScreen) {
       data.t = params.inScreen;

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -104,7 +104,7 @@ function isBidRequestValid (bid) {
       return false;
   }
 
-  if (params.bidfloor && !Number.isFinite(params.bidfloor)) {
+  if (params.bidfloor && !(typeof params.bidfloor === 'number' && isFinite(params.bidfloor))) {
     utils.logWarn('[GumGum] bidfloor must be a Number');
     return false;
   }

--- a/modules/gumgumBidAdapter.md
+++ b/modules/gumgumBidAdapter.md
@@ -20,7 +20,8 @@ var adUnits = [
       {
         bidder: 'gumgum',
         params: {
-          inSlot: '15901' // GumGum Slot ID given to the client
+          inSlot: '15901', // GumGum Slot ID given to the client,
+          bidFloor: 0.03 // CPM bid floor
         }
       }
     ]
@@ -31,7 +32,8 @@ var adUnits = [
       {
         bidder: 'gumgum',
         params: {
-          inScreen: 'dc9d6be1' // GumGum Zone ID given to the client
+          inScreen: 'dc9d6be1', // GumGum Zone ID given to the client
+          bidFloor: 0.03 // CPM bid floor
         }
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "1.36.0-pre",
+  "version": "1.37.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8614,12 +8614,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-opera-launcher/-/karma-opera-launcher-1.0.0.tgz",
       "integrity": "sha1-+lFihTGh0L6EstjcDX7iCfyP+Ro=",
-      "dev": true
-    },
-    "karma-requirejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-1.1.0.tgz",
-      "integrity": "sha1-/driy4fX68FvsCIok1ZNf+5Xh5g=",
       "dev": true
     },
     "karma-safari-launcher": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "1.37.0",
+  "version": "1.36.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8614,6 +8614,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-opera-launcher/-/karma-opera-launcher-1.0.0.tgz",
       "integrity": "sha1-+lFihTGh0L6EstjcDX7iCfyP+Ro=",
+      "dev": true
+    },
+    "karma-requirejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-1.1.0.tgz",
+      "integrity": "sha1-/driy4fX68FvsCIok1ZNf+5Xh5g=",
       "dev": true
     },
     "karma-safari-launcher": {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -17,7 +17,8 @@ describe('gumgumAdapter', function () {
     let bid = {
       'bidder': 'gumgum',
       'params': {
-        'inScreen': '10433394'
+        'inScreen': '10433394',
+        'bidfloor': 0.05
       },
       'adUnitCode': 'adunit-code',
       'sizes': [[300, 250], [300, 600], [1, 1]],
@@ -40,11 +41,21 @@ describe('gumgumAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', function () {
+    it('should return false when no unit type is specified', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
         'placementId': 0
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when bidfloor is not a number', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'inSlot': '789',
+        'bidfloor': '0.50'
       };
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adds support to allow user to specify a minimum bid floor price by adding an optional `bidfloor` param. If `bidfloor` is not specified, it will default to the values that are specified when setting up a GumGum publisher account.  