### PR TITLE
Adkernel adapters - admarkup html wrapping removed

### DIFF
--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils';
 import {registerBidder} from '../src/adapters/bidderFactory';
 import {BANNER, VIDEO} from '../src/mediaTypes';
 import includes from 'core-js/library/fn/array/includes';
+import {parse as parseUrl} from '../src/url';
 
 const DEFAULT_ADKERNEL_DSP_DOMAIN = 'tag.adkernel.com';
 const VIDEO_TARGETING = ['mimes', 'protocols', 'api'];
@@ -9,8 +10,8 @@ const DEFAULT_MIMES = ['video/mp4', 'video/webm', 'application/x-shockwave-flash
 const DEFAULT_PROTOCOLS = [2, 3, 5, 6];
 const DEFAULT_APIS = [1, 2];
 
-function isRtbDebugEnabled() {
-  return utils.getTopWindowLocation().href.indexOf('adk_debug=true') !== -1;
+function isRtbDebugEnabled(refInfo) {
+  return refInfo.referer.indexOf('adk_debug=true') !== -1;
 }
 
 function buildImp(bidRequest) {
@@ -18,14 +19,13 @@ function buildImp(bidRequest) {
     id: bidRequest.bidId,
     tagid: bidRequest.adUnitCode
   };
-  if (bidRequest.mediaType === BANNER || utils.deepAccess(bidRequest, `mediaTypes.banner`) ||
-    (bidRequest.mediaTypes === undefined && bidRequest.mediaType === undefined)) {
-    let sizes = canonicalizeSizesArray(bidRequest.sizes);
+  if (utils.deepAccess(bidRequest, `mediaTypes.banner`)) {
+    let sizes = canonicalizeSizesArray(bidRequest.mediaTypes.banner.sizes);
     imp.banner = {
       format: utils.parseSizesInput(sizes)
     }
-  } else if (bidRequest.mediaType === VIDEO || utils.deepAccess(bidRequest, `mediaTypes.video`)) {
-    let size = canonicalizeSizesArray(bidRequest.sizes)[0];
+  } else if (utils.deepAccess(bidRequest, `mediaTypes.video`)) {
+    let size = canonicalizeSizesArray(bidRequest.mediaTypes.video.playerSize)[0];
     imp.video = {
       w: size[0],
       h: size[1],
@@ -54,11 +54,11 @@ function canonicalizeSizesArray(sizes) {
   return sizes;
 }
 
-function buildRequestParams(tags, auctionId, transactionId, gdprConsent) {
+function buildRequestParams(tags, auctionId, transactionId, gdprConsent, refInfo) {
   let req = {
     id: auctionId,
     tid: transactionId,
-    site: buildSite(),
+    site: buildSite(refInfo),
     imp: tags
   };
 
@@ -74,13 +74,15 @@ function buildRequestParams(tags, auctionId, transactionId, gdprConsent) {
   return req;
 }
 
-function buildSite() {
-  let loc = utils.getTopWindowLocation();
+function buildSite(refInfo) {
+  let loc = parseUrl(refInfo.referer);
   let result = {
-    page: loc.href,
-    ref: utils.getTopWindowReferrer(),
-    secure: ~~(loc.protocol === 'https:')
+    page: `${loc.protocol}://${loc.hostname}${loc.pathname}`,
+    secure: ~~(loc.protocol === 'https')
   };
+  if (self === top && document.referrer) {
+    result.ref = document.referrer;
+  }
   let keywords = document.getElementsByTagName('meta')['keywords'];
   if (keywords && keywords.content) {
     result.keywords = keywords.content;
@@ -101,7 +103,7 @@ function buildBid(tag) {
     netRevenue: true
   };
   if (tag.tag) {
-    bid.ad = `<!DOCTYPE html><html><head><title></title><body style='margin:0px;padding:0px;'>${tag.tag}</body></head>`;
+    bid.ad = tag.tag;
     bid.mediaType = BANNER;
   } else if (tag.vast_url) {
     bid.vastUrl = tag.vast_url;
@@ -117,7 +119,7 @@ export const spec = {
 
   isBidRequestValid: function(bidRequest) {
     return 'params' in bidRequest && (typeof bidRequest.params.host === 'undefined' || typeof bidRequest.params.host === 'string') &&
-      typeof bidRequest.params.pubId === 'number';
+      typeof bidRequest.params.pubId === 'number' && 'mediaTypes' in bidRequest && ('banner' in bidRequest.mediaTypes || 'video' in bidRequest.mediaTypes);
   },
 
   buildRequests: function(bidRequests, bidderRequest) {
@@ -134,13 +136,14 @@ export const spec = {
     let auctionId = bidderRequest.auctionId;
     let gdprConsent = bidderRequest.gdprConsent;
     let transactionId = bidderRequest.transactionId;
+    let refererInfo = bidderRequest.refererInfo;
     let requests = [];
     Object.keys(dispatch).forEach(host => {
       Object.keys(dispatch[host]).forEach(pubId => {
-        let request = buildRequestParams(dispatch[host][pubId], auctionId, transactionId, gdprConsent);
+        let request = buildRequestParams(dispatch[host][pubId], auctionId, transactionId, gdprConsent, refererInfo);
         requests.push({
           method: 'POST',
-          url: `//${host}/tag?account=${pubId}&pb=1${isRtbDebugEnabled() ? '&debug=1' : ''}`,
+          url: `//${host}/tag?account=${pubId}&pb=1${isRtbDebugEnabled(refererInfo) ? '&debug=1' : ''}`,
           data: JSON.stringify(request)
         })
       });

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -3,7 +3,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes';
 import {registerBidder} from '../src/adapters/bidderFactory';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
-import {parse as parseUrl} from '../src/url'
+import {parse as parseUrl} from '../src/url';
 
 const VIDEO_TARGETING = ['mimes', 'minduration', 'maxduration', 'protocols',
   'startdelay', 'linearity', 'boxingallowed', 'playbackmethod', 'delivery',
@@ -20,7 +20,8 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bidRequest) {
     return 'params' in bidRequest && typeof bidRequest.params.host !== 'undefined' &&
-      'zoneId' in bidRequest.params && !isNaN(Number(bidRequest.params.zoneId));
+      'zoneId' in bidRequest.params && !isNaN(Number(bidRequest.params.zoneId)) &&
+      bidRequest.mediaTypes && (bidRequest.mediaTypes.banner || bidRequest.mediaTypes.video);
   },
   buildRequests: function(bidRequests, bidderRequest) {
     let impDispatch = dispatchImps(bidRequests, bidderRequest.refererInfo);
@@ -31,14 +32,9 @@ export const spec = {
       Object.keys(impDispatch[host]).forEach(zoneId => {
         const request = buildRtbRequest(impDispatch[host][zoneId], auctionId, gdprConsent, bidderRequest.refererInfo);
         requests.push({
-          method: 'GET',
-          url: `${window.location.protocol}//${host}/rtbg`,
-          data: {
-            zone: Number(zoneId),
-            ad_type: 'rtb',
-            v: VERSION,
-            r: JSON.stringify(request)
-          }
+          method: 'POST',
+          url: `${window.location.protocol}//${host}/hb?zone=${Number(zoneId)}&v=${VERSION}`,
+          data: JSON.stringify(request)
         });
       });
     });
@@ -50,7 +46,7 @@ export const spec = {
       return [];
     }
 
-    let rtbRequest = JSON.parse(request.data.r);
+    let rtbRequest = JSON.parse(request.data);
     let rtbImps = rtbRequest.imp;
     let rtbBids = response.seatbid
       .map(seatbid => seatbid.bid)
@@ -120,15 +116,14 @@ function buildImp(bidRequest, secure) {
     'tagid': bidRequest.adUnitCode
   };
 
-  if (bidRequest.mediaType === BANNER || utils.deepAccess(bidRequest, `mediaTypes.banner`) ||
-    (bidRequest.mediaTypes === undefined && bidRequest.mediaType === undefined)) {
-    let sizes = canonicalizeSizesArray(bidRequest.sizes);
+  if (utils.deepAccess(bidRequest, `mediaTypes.banner`)) {
+    let sizes = canonicalizeSizesArray(bidRequest.mediaTypes.banner.sizes);
     imp.banner = {
       format: sizes.map(s => ({'w': s[0], 'h': s[1]})),
       topframe: 0
     };
-  } else if (bidRequest.mediaType === VIDEO || utils.deepAccess(bidRequest, 'mediaTypes.video')) {
-    let size = canonicalizeSizesArray(bidRequest.sizes)[0];
+  } else if (utils.deepAccess(bidRequest, 'mediaTypes.video')) {
+    let size = canonicalizeSizesArray(bidRequest.mediaTypes.video.playerSize)[0];
     imp.video = {
       w: size[0],
       h: size[1]
@@ -222,9 +217,9 @@ function createSite(refInfo) {
  *  @param bid rtb Bid object
  */
 function formatAdMarkup(bid) {
-  var adm = bid.adm;
+  let adm = bid.adm;
   if ('nurl' in bid) {
     adm += utils.createTrackPixelHtml(`${bid.nurl}&px=1`);
   }
-  return `<!DOCTYPE html><html><head><title></title><body style='margin:0px;padding:0px;'>${adm}</body></head>`;
+  return adm;
 }

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {spec} from 'modules/adkernelAdnBidAdapter';
-import * as utils from 'src/utils';
 
 describe('AdkernelAdn adapter', function () {
   const bid1_pub1 = {
@@ -10,10 +9,15 @@ describe('AdkernelAdn adapter', function () {
       auctionId: '5c66da22-426a-4bac-b153-77360bef5337',
       bidId: 'bidid_1',
       params: {
-        pubId: 1
+        pubId: 1,
+        host: 'tag.adkernel.com'
+      },
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 200]]
+        }
       },
       adUnitCode: 'ad-unit-1',
-      sizes: [[300, 250], [300, 200]]
     },
     bid2_pub1 = {
       bidder: 'adkernelAdn',
@@ -25,7 +29,11 @@ describe('AdkernelAdn adapter', function () {
         pubId: 1
       },
       adUnitCode: 'ad-unit-2',
-      sizes: [300, 250]
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
     },
     bid1_pub2 = {
       bidder: 'adkernelAdn',
@@ -38,22 +46,30 @@ describe('AdkernelAdn adapter', function () {
         host: 'dps-test.com'
       },
       adUnitCode: 'ad-unit-2',
-      sizes: [[728, 90]]
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      }
     }, bid_video1 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact3',
       bidderRequestId: 'req1',
       auctionId: '5c66da22-426a-4bac-b153-77360bef5337',
       bidId: 'bidid_4',
-      mediaType: 'video',
-      sizes: [640, 300],
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [640, 300]
+        }
+      },
       adUnitCode: 'video_wrapper',
       params: {
         pubId: 7,
         video: {
-          mimes: ['video/mp4', 'video/webm', 'video/x-flv'],
-          api: [1, 2, 3, 4],
-          protocols: [1, 2, 3, 4, 5, 6]
+          mimes: ['video/mp4', 'video/webm'],
+          api: [1, 2],
+          protocols: [5, 6]
         }
       }
     }, bid_video2 = {
@@ -72,12 +88,7 @@ describe('AdkernelAdn adapter', function () {
 
       adUnitCode: 'video_wrapper2',
       params: {
-        pubId: 7,
-        video: {
-          mimes: ['video/mp4', 'video/webm', 'video/x-flv'],
-          api: [1, 2, 3, 4],
-          protocols: [1, 2, 3, 4, 5, 6]
-        }
+        pubId: 7
       }
     };
 
@@ -110,12 +121,26 @@ describe('AdkernelAdn adapter', function () {
       syncpages: ['https://dsp.adkernel.com/sync']
     };
 
-  describe('input parameters validation', function () {
-    it('empty request shouldn\'t generate exception', function () {
+  const defaultBidderRequest = {
+    bidderCode: 'adkernelAdn',
+    bids: [],
+    auctionStart: 1545836987704,
+    timeout: 3000,
+    refererInfo: {
+      referer: 'https://example.com/index.html',
+      reachedTop: true,
+      numIframes: 0,
+      stack: ['https://example.com/index.html']
+    },
+    start: 1545836987707
+  };
+
+  describe('input parameters validation', () => {
+    it('empty request shouldn\'t generate exception', () => {
       expect(spec.isBidRequestValid({bidderCode: 'adkernelAdn'
       })).to.be.equal(false);
     });
-    it('request without pubid should be ignored', function () {
+    it('request without pubid should be ignored', () => {
       expect(spec.isBidRequestValid({
         bidder: 'adkernelAdn',
         params: {},
@@ -123,7 +148,7 @@ describe('AdkernelAdn adapter', function () {
         sizes: [[300, 250]]
       })).to.be.equal(false);
     });
-    it('request with invalid pubid should be ignored', function () {
+    it('request with invalid pubid should be ignored', () => {
       expect(spec.isBidRequestValid({
         bidder: 'adkernelAdn',
         params: {
@@ -133,26 +158,42 @@ describe('AdkernelAdn adapter', function () {
         sizes: [[300, 250]]
       })).to.be.equal(false);
     });
+    it('request with totally invalid host should be ignored', () => {
+      expect(spec.isBidRequestValid({
+        bidder: 'adkernelAdn',
+        params: {
+          pubId: 1,
+          host: 1
+        },
+        placementCode: 'ad-unit-0',
+        sizes: [[300, 250]]
+      })).to.be.equal(false);
+    });
+    it('valid request should be accepted', () => {
+      expect(spec.isBidRequestValid({
+        bidder: 'adkernelAdn',
+        params: {
+          pubId: 1,
+          host: 'network.com'
+        },
+        placementCode: 'ad-unit-0',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 200]]
+          }
+        }
+      })).to.be.equal(true);
+    });
   });
 
-  function buildRequest(bidRequests, bidderRequest = {}) {
-    let mock = sinon.stub(utils, 'getTopWindowLocation').callsFake(() => {
-      return {
-        protocol: 'https:',
-        hostname: 'example.com',
-        host: 'example.com',
-        pathname: '/index.html',
-        href: 'https://example.com/index.html'
-      };
-    });
-
-    bidderRequest.auctionId = bidRequests[0].auctionId;
-    bidderRequest.transactionId = bidRequests[0].transactionId;
-    bidderRequest.bidderRequestId = bidRequests[0].bidderRequestId;
-
-    let pbRequests = spec.buildRequests(bidRequests, bidderRequest);
+  function buildRequest(bidRequests, bidderRequestAugments = {}) {
+    let fullBidderRequest = Object.assign(defaultBidderRequest, bidderRequestAugments);
+    fullBidderRequest.auctionId = bidRequests[0].auctionId;
+    fullBidderRequest.transactionId = bidRequests[0].transactionId;
+    fullBidderRequest.bidderRequestId = bidRequests[0].bidderRequestId;
+    fullBidderRequest.bids = bidRequests;
+    let pbRequests = spec.buildRequests(bidRequests, fullBidderRequest);
     let tagRequests = pbRequests.map(r => JSON.parse(r.data));
-    mock.restore();
 
     return [pbRequests, tagRequests];
   }
@@ -207,23 +248,31 @@ describe('AdkernelAdn adapter', function () {
     });
   });
 
-  describe('video request building', function () {
+  describe('video request building', () => {
     let [_, tagRequests] = buildRequest([bid_video1, bid_video2]);
     let tagRequest = tagRequests[0];
 
-    it('should have video object', function () {
+    it('should have video object', () => {
       expect(tagRequest.imp[0]).to.have.property('video');
       expect(tagRequest.imp[1]).to.have.property('video');
     });
-    it('should have tagid', function () {
+    it('should have tagid', () => {
       expect(tagRequest.imp[0]).to.have.property('tagid', 'video_wrapper');
       expect(tagRequest.imp[1]).to.have.property('tagid', 'video_wrapper2');
     });
-    it('should have size', function () {
+    it('should have size', () => {
       expect(tagRequest.imp[0].video).to.have.property('w', 640);
       expect(tagRequest.imp[0].video).to.have.property('h', 300);
       expect(tagRequest.imp[1].video).to.have.property('w', 1920);
       expect(tagRequest.imp[1].video).to.have.property('h', 1080);
+    });
+    it('should have video params', () => {
+      expect(tagRequest.imp[0].video).to.have.property('mimes');
+      expect(tagRequest.imp[0].video.mimes).to.be.eql(['video/mp4', 'video/webm']);
+      expect(tagRequest.imp[0].video).to.have.property('api');
+      expect(tagRequest.imp[0].video.api).to.be.eql([1, 2]);
+      expect(tagRequest.imp[0].video).to.have.property('protocols');
+      expect(tagRequest.imp[0].video.protocols).to.be.eql([5, 6]);
     });
   });
 

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -8,37 +8,61 @@ describe('Adkernel adapter', function () {
       bidId: 'Bid_01',
       params: {zoneId: 1, host: 'rtb.adkernel.com'},
       adUnitCode: 'ad-unit-1',
-      sizes: [[300, 250], [300, 200]]
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 200]]
+        }
+      }
     }, bid2_zone2 = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 2, host: 'rtb.adkernel.com'},
       adUnitCode: 'ad-unit-2',
-      sizes: [728, 90]
+      mediaTypes: {
+        banner: {
+          sizes: [728, 90]
+        }
+      }
     }, bid3_host2 = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 1, host: 'rtb-private.adkernel.com'},
       adUnitCode: 'ad-unit-2',
-      sizes: [[728, 90]]
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      }
     }, bid_without_zone = {
       bidder: 'adkernel',
       bidId: 'Bid_W',
       params: {host: 'rtb-private.adkernel.com'},
       adUnitCode: 'ad-unit-1',
-      sizes: [[728, 90]]
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      }
     }, bid_without_host = {
       bidder: 'adkernel',
       bidId: 'Bid_W',
       params: {zoneId: 1},
       adUnitCode: 'ad-unit-1',
-      sizes: [[728, 90]]
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      }
     }, bid_with_wrong_zoneId = {
       bidder: 'adkernel',
       bidId: 'Bid_02',
       params: {zoneId: 'wrong id', host: 'rtb.adkernel.com'},
       adUnitCode: 'ad-unit-2',
-      sizes: [[728, 90]]
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      }
     }, bid_video = {
       bidder: 'adkernel',
       transactionId: '866394b8-5d37-4d49-803e-f1bdb595f73e',
@@ -120,7 +144,7 @@ describe('Adkernel adapter', function () {
     let dntmock = sinon.stub(utils, 'getDNT').callsFake(() => dnt);
     let pbRequests = spec.buildRequests(bidRequests, bidderRequest);
     dntmock.restore();
-    let rtbRequests = pbRequests.map(r => JSON.parse(r.data.r));
+    let rtbRequests = pbRequests.map(r => JSON.parse(r.data));
     return [pbRequests, rtbRequests];
   }
 
@@ -246,8 +270,8 @@ describe('Adkernel adapter', function () {
     it('should issue a request for each zone', function () {
       let [pbRequests, _] = buildRequest([bid1_zone1, bid2_zone2]);
       expect(pbRequests).to.have.length(2);
-      expect(pbRequests[0].data.zone).to.be.equal(bid1_zone1.params.zoneId);
-      expect(pbRequests[1].data.zone).to.be.equal(bid2_zone2.params.zoneId);
+      expect(pbRequests[0].url).to.include(`zone=${bid1_zone1.params.zoneId}`);
+      expect(pbRequests[1].url).to.include(`zone=${bid2_zone2.params.zoneId}`);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other


## Description of change

* Removed admarkup html wrapping to make it uniform
* Removed deprecating functions usage

- denis@adkernel.com
- [x] official adapter submission
