### PR TITLE
fix orbidder pathing and test

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -1,6 +1,6 @@
-import {detectReferer} from 'src/refererDetection';
-import {ajax} from 'src/ajax';
-import {registerBidder} from 'src/adapters/bidderFactory';
+import {detectReferer} from '../src/refererDetection';
+import {ajax} from '../src/ajax';
+import {registerBidder} from '../src/adapters/bidderFactory';
 
 export const spec = {
   code: 'orbidder',
@@ -70,7 +70,11 @@ export const spec = {
     const getRefererInfo = detectReferer(window);
     const refererInfo = getRefererInfo();
     winObj.pageUrl = refererInfo.referer;
-    ajax(`${this.orbidderHost}/win`, null, JSON.stringify(winObj));
+    spec.ajaxCall(`${this.orbidderHost}/win`, JSON.stringify(winObj));
+  },
+
+  ajaxCall(endpoint, data) {
+    ajax(endpoint, null, data);
   }
 };
 

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import {spec} from 'modules/orbidderBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
-import * as ajax from 'src/ajax';
 
 describe('orbidderBidAdapter', () => {
   const adapter = newBidder(spec);
@@ -117,7 +116,7 @@ describe('orbidderBidAdapter', () => {
     };
 
     beforeEach(() => {
-      ajaxStub = sinon.stub(ajax, 'ajax');
+      ajaxStub = sinon.stub(spec, 'ajaxCall');
     });
 
     afterEach(() => {
@@ -129,7 +128,7 @@ describe('orbidderBidAdapter', () => {
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0].indexOf('https://')).to.equal(0);
       expect(ajaxStub.firstCall.args[0]).to.equal(`${spec.orbidderHost}/win`);
-      expect(ajaxStub.firstCall.args[2]).to.equal(JSON.stringify(winObj));
+      expect(ajaxStub.firstCall.args[1]).to.equal(JSON.stringify(winObj));
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix


## Description of change
Fix include paths to be relative.  Fix test to not rely on stubbing ajax module (which doesn't work quite correctly with sinon and es6).
