### PR TITLE
Tests: ensure 12:00:00 hour part on fake timestamp

### DIFF
--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -34,7 +34,7 @@ describe('currency', function () {
   describe('setConfig', function () {
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-      clock = sinon.useFakeTimers(1047010195974);
+      clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
     });
 
     afterEach(function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, the currency unit tests are currently setting a fake timestamp to `1047010195974`, equivalent to `2003-03-07T04:09:55Z`. Tests that depend on this value fail on any machine with a TZ of UTC+12 to UTC-4, including the common timezone of UTC itself.

> AssertionError: expected 'https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=20030307' to equal 'https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=20030306'

The change in this PR winds the fake timestamp back to the equivalent of `2003-03-06T12:00:00Z` so the tests will pass with any TZ from UTC+12 to UTC-11.