### PR TITLE
Bugfix: Adhese bid adapter user sync

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -52,16 +52,19 @@ export const spec = {
       .map(item => adResponse(item.bid, item.ad));
   },
 
-  getUserSyncs: function(syncOptions, serverResponse, gdprConsent) {
-    const account = serverResponse.account || '';
-    if (syncOptions.iframeEnabled) {
-      let syncurl = USER_SYNC_BASE_URL + '?account=' + account;
-      if (gdprConsent) {
-        syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
-        syncurl += '&consentString=' + encodeURIComponent(gdprConsent.consentString || '');
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent) {
+    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+      const account = serverResponses[0].account;
+      if (account) {
+        let syncurl = USER_SYNC_BASE_URL + '?account=' + account;
+        if (gdprConsent) {
+          syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+          syncurl += '&consentString=' + encodeURIComponent(gdprConsent.consentString || '');
+        }
+        return [{type: 'iframe', url: syncurl}];
       }
-      return [{ type: 'iframe', url: syncurl }];
     }
+    return [];
   }
 };
 

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -25,18 +25,24 @@ let bidWithParams = function(data) {
 
 describe('AdheseAdapter', function () {
   describe('getUserSyncs', function () {
-    const serverResponse = {
+    const serverResponses = [{
       account: 'demo'
-    };
+    }];
     const gdprConsent = {
       gdprApplies: true,
       consentString: 'CONSENT_STRING'
     };
     it('should return empty when iframe disallowed', function () {
-      expect(spec.getUserSyncs({ iframeEnabled: false }, serverResponse, gdprConsent)).to.be.empty;
+      expect(spec.getUserSyncs({ iframeEnabled: false }, serverResponses, gdprConsent)).to.be.empty;
+    });
+    it('should return empty when no serverResponses present', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [], gdprConsent)).to.be.empty;
+    });
+    it('should return empty when no account info present in the response', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [{}], gdprConsent)).to.be.empty;
     });
     it('should return usersync url when iframe allowed', function () {
-      expect(spec.getUserSyncs({ iframeEnabled: true }, serverResponse, gdprConsent)).to.deep.equal([{ type: 'iframe', url: 'https://user-sync.adhese.com/iframe/user_sync.html?account=demo&gdpr=1&consentString=CONSENT_STRING' }]);
+      expect(spec.getUserSyncs({ iframeEnabled: true }, serverResponses, gdprConsent)).to.deep.equal([{ type: 'iframe', url: 'https://user-sync.adhese.com/iframe/user_sync.html?account=demo&gdpr=1&consentString=CONSENT_STRING' }]);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

We assumed an incorrect type of the 2nd parameter (serverResponses) in `getUserSyncs` function. Should be an `array`, we assumed `object`. This commit fixes this bug and the tests.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
