### PR TITLE
feat(unrulyBidAdapter): add userSync functionality

### DIFF
--- a/integrationExamples/gpt/unruly_example.html
+++ b/integrationExamples/gpt/unruly_example.html
@@ -55,6 +55,10 @@
             pbjs.setConfig({
                 "currency": {
                     "adServerCurrency": "USD",
+                },
+                "userSync": {
+                    "iframeEnabled": true,
+                    "enabledBidders": ['unruly']
                 }
             });
         });

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -95,6 +95,17 @@ export const adapter = {
     return isInvalidResponse
       ? noBidsResponse
       : buildPrebidResponseAndInstallRenderer(serverResponseBody.bids);
+  },
+
+  getUserSyncs: function(syncOptions) {
+    const syncs = []
+    if (syncOptions.iframeEnabled) {
+      syncs.push({
+        type: 'iframe',
+        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+      });
+    }
+    return syncs;
   }
 };
 

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -97,7 +97,7 @@ export const adapter = {
       : buildPrebidResponseAndInstallRenderer(serverResponseBody.bids);
   },
 
-  getUserSyncs: function(syncOptions, {}, gdprConsent) {
+  getUserSyncs: function(syncOptions, response, gdprConsent) {
     let params = '';
     if (gdprConsent && 'gdprApplies' in gdprConsent) {
       if (gdprConsent.gdprApplies && typeof gdprConsent.consentString === 'string') {

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -97,12 +97,21 @@ export const adapter = {
       : buildPrebidResponseAndInstallRenderer(serverResponseBody.bids);
   },
 
-  getUserSyncs: function(syncOptions) {
+  getUserSyncs: function(syncOptions, {}, gdprConsent) {
+    let params = '';
+    if (gdprConsent && 'gdprApplies' in gdprConsent) {
+      if (gdprConsent.gdprApplies && typeof gdprConsent.consentString === 'string') {
+        params += `?gdpr=1&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        params += `?gdpr=0`;
+      }
+    }
+
     const syncs = []
     if (syncOptions.iframeEnabled) {
       syncs.push({
         type: 'iframe',
-        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html' + params
       });
     }
     return syncs;

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -207,7 +207,7 @@ describe('UnrulyAdapter', () => {
   describe('getUserSyncs', () => {
     it('should push user sync iframe if enabled', () => {
       const syncOptions = { iframeEnabled: true }
-      const syncs = adapter.getUserSyncs(syncOptions)
+      const syncs = adapter.getUserSyncs(syncOptions, {}, {})
       expect(syncs[0]).to.deep.equal({
         type: 'iframe',
         url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
@@ -216,8 +216,44 @@ describe('UnrulyAdapter', () => {
 
     it('should not push user sync iframe if not enabled', () => {
       const syncOptions = { iframeEnabled: false }
-      const syncs = adapter.getUserSyncs(syncOptions);
+      const syncs = adapter.getUserSyncs(syncOptions, {}, {});
       expect(syncs).to.be.empty;
     });
   });
+
+  it('should not append consent params if gdpr does not apply', () => {
+    const mockConsent = {}
+    const syncOptions = { iframeEnabled: true }
+    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    expect(syncs[0]).to.deep.equal({
+      type: 'iframe',
+      url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+    })
+  })
+
+  it('should append consent params if gdpr does apply and consent is given', () => {
+    const mockConsent = {
+      gdprApplies: true,
+      consentString: 'hello'
+    }
+    const syncOptions = { iframeEnabled: true }
+    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    expect(syncs[0]).to.deep.equal({
+      type: 'iframe',
+      url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html?gdpr=1&gdpr_consent=hello'
+    })
+  })
+
+  it('should append consent param if gdpr applies and no consent is given', () => {
+    const mockConsent = {
+      gdprApplies: true,
+      consentString: {}
+    }
+    const syncOptions = { iframeEnabled: true }
+    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    expect(syncs[0]).to.deep.equal({
+      type: 'iframe',
+      url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html?gdpr=0'
+    })
+  })
 });

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -203,4 +203,21 @@ describe('UnrulyAdapter', () => {
       expect(supplyMode).to.equal('prebid');
     });
   });
+
+  describe('getUserSyncs', () => {
+    it('should push user sync iframe if enabled', () => {
+      const syncOptions = { iframeEnabled: true }
+      const syncs = adapter.getUserSyncs(syncOptions)
+      expect(syncs[0]).to.deep.equal({
+        type: 'iframe',
+        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+      });
+    })
+
+    it('should not push user sync iframe if not enabled', () => {
+      const syncOptions = { iframeEnabled: false }
+      const syncs = adapter.getUserSyncs(syncOptions);
+      expect(syncs).to.be.empty;
+    });
+  });
 });

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -206,8 +206,10 @@ describe('UnrulyAdapter', () => {
 
   describe('getUserSyncs', () => {
     it('should push user sync iframe if enabled', () => {
+      const mockConsent = {}
+      const response = {}
       const syncOptions = { iframeEnabled: true }
-      const syncs = adapter.getUserSyncs(syncOptions, {}, {})
+      const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
       expect(syncs[0]).to.deep.equal({
         type: 'iframe',
         url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
@@ -215,16 +217,19 @@ describe('UnrulyAdapter', () => {
     })
 
     it('should not push user sync iframe if not enabled', () => {
+      const mockConsent = {}
+      const response = {}
       const syncOptions = { iframeEnabled: false }
-      const syncs = adapter.getUserSyncs(syncOptions, {}, {});
+      const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent);
       expect(syncs).to.be.empty;
     });
   });
 
   it('should not append consent params if gdpr does not apply', () => {
     const mockConsent = {}
+    const response = {}
     const syncOptions = { iframeEnabled: true }
-    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
     expect(syncs[0]).to.deep.equal({
       type: 'iframe',
       url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
@@ -236,8 +241,9 @@ describe('UnrulyAdapter', () => {
       gdprApplies: true,
       consentString: 'hello'
     }
+    const response = {}
     const syncOptions = { iframeEnabled: true }
-    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
     expect(syncs[0]).to.deep.equal({
       type: 'iframe',
       url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html?gdpr=1&gdpr_consent=hello'
@@ -249,8 +255,9 @@ describe('UnrulyAdapter', () => {
       gdprApplies: true,
       consentString: {}
     }
+    const response = {}
     const syncOptions = { iframeEnabled: true }
-    const syncs = adapter.getUserSyncs(syncOptions, {}, mockConsent)
+    const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
     expect(syncs[0]).to.deep.equal({
       type: 'iframe',
       url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html?gdpr=0'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We are adding the user-sync function to our adapter. We'e also added the publisher configuration for user-syncing on our test page.
<!-- For new bidder adapters, please provide the following -->

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
