### PR TITLE
feat(unrulyBidAdapter): add getUserSyncs To legacy Unruly Adapter

### DIFF
--- a/integrationExamples/gpt/unruly_example.html
+++ b/integrationExamples/gpt/unruly_example.html
@@ -50,7 +50,11 @@
             });
             pbjs.setConfig({
                 "currency": {
-                    "adServerCurrency": "USD",
+                    "adServerCurrency": "USD"
+                },
+                "userSync": {
+                    "iframeEnabled": true,
+                    "enabledBidders": ['unruly']
                 }
             });
         });

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -95,6 +95,17 @@ export const adapter = {
     return isInvalidResponse
       ? noBidsResponse
       : buildPrebidResponseAndInstallRenderer(serverResponseBody.bids);
+  },
+
+  getUserSyncs: function(syncOptions) {
+    const syncs = []
+    if (syncOptions.iframeEnabled) {
+      syncs.push({
+        type: 'iframe',
+        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+      });
+    }
+    return syncs;
   }
 };
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -203,4 +203,21 @@ describe('UnrulyAdapter', () => {
       expect(supplyMode).to.equal('prebid');
     });
   });
+
+  describe('getUserSyncs', () => {
+    it('should push user sync iframe if enabled', () => {
+      const syncOptions = { iframeEnabled: true }
+      const syncs = adapter.getUserSyncs(syncOptions)
+      expect(syncs[0]).to.deep.equal({
+        type: 'iframe',
+        url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
+      })
+    })
+
+    it('should not push user sync iframe if not enabled', () => {
+      const syncOptions = { iframeEnabled: false }
+      const syncs = adapter.getUserSyncs(syncOptions)
+      expect(syncs).to.be.empty
+    })
+  })
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We are adding the user-sync function to our legacy adapter. We've also added the publisher configuration for user-syncing on our test page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
