### PR TITLE
calling for currency file even when default rates are specified

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -57,7 +57,7 @@ export function setConfig(config) {
   if (typeof config.rates === 'object') {
     currencyRates.conversions = config.rates;
     currencyRatesLoaded = true;
-    needToCallForCurrencyFile=false; // don't call if rates are already specified
+    needToCallForCurrencyFile = false; // don't call if rates are already specified
   }
 
   if (typeof config.defaultRates === 'object') {
@@ -126,7 +126,7 @@ function initCurrency(url) {
 
   // call for the file if we haven't already
   if (needToCallForCurrencyFile) {
-    needToCallForCurrencyFile=false;
+    needToCallForCurrencyFile = false;
     ajax(url,
       {
         success: function (response) {

--- a/modules/currency.js
+++ b/modules/currency.js
@@ -11,6 +11,7 @@ const CURRENCY_RATE_PRECISION = 4;
 var bidResponseQueue = [];
 var conversionCache = {};
 var currencyRatesLoaded = false;
+var needToCallForCurrencyFile = true;
 var adServerCurrency = 'USD';
 
 export var currencySupportEnabled = false;
@@ -56,6 +57,7 @@ export function setConfig(config) {
   if (typeof config.rates === 'object') {
     currencyRates.conversions = config.rates;
     currencyRatesLoaded = true;
+    needToCallForCurrencyFile=false; // don't call if rates are already specified
   }
 
   if (typeof config.defaultRates === 'object') {
@@ -122,7 +124,9 @@ function initCurrency(url) {
 
   hooks['addBidResponse'].addHook(addBidResponseHook, 100);
 
-  if (!currencyRates.conversions) {
+  // call for the file if we haven't already
+  if (needToCallForCurrencyFile) {
+    needToCallForCurrencyFile=false;
     ajax(url,
       {
         success: function (response) {
@@ -150,6 +154,7 @@ function resetCurrency() {
   conversionCache = {};
   currencySupportEnabled = false;
   currencyRatesLoaded = false;
+  needToCallForCurrencyFile = true;
   currencyRates = {};
   bidderCurrencyDefault = {};
 }

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -64,6 +64,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       expect(fakeCurrencyFileServer.requests[0].url).to.equal('https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=20030306');
 
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
+
       // date macro should not modify 'conversionRateFile' if TOKEN is not found
       setConfig({
         'adServerCurrency': 'JPY',
@@ -72,6 +75,9 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       expect(fakeCurrencyFileServer.requests[1].url).to.equal('http://test.net/currency.json?date=foobar');
 
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
+
       // date macro should replace $$TODAY$$ with date for 'conversionRateFile' is configured
       setConfig({
         'adServerCurrency': 'JPY',
@@ -79,6 +85,9 @@ describe('currency', function () {
       });
       fakeCurrencyFileServer.respond();
       expect(fakeCurrencyFileServer.requests[2].url).to.equal('http://test.net/currency.json?date=20030306');
+
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
 
       // MULTIPLE TOKENS used in a url is not supported. Only the TOKEN at left-most position is REPLACED
       setConfig({
@@ -220,6 +229,7 @@ describe('currency', function () {
 
     it('should result in NO_BID when currency support is not enabled and fromCurrency is not USD', function () {
       setConfig({});
+
       var bid = { 'cpm': 1, 'currency': 'GBP' };
       var innerBid;
       addBidResponseHook('elementId', bid, function(adCodeId, bid) {
@@ -241,6 +251,9 @@ describe('currency', function () {
     });
 
     it('should result in NO_BID when fromCurrency is not supported in file', function () {
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
+
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
       setConfig({ 'adServerCurrency': 'JPY' });
       fakeCurrencyFileServer.respond();

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -55,6 +55,33 @@ describe('currency', function () {
       expect(currencySupportEnabled).to.equal(true);
     });
 
+    it('currency file is called even when default rates are specified', function() {
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
+
+      // DO NOT SET DEFAULT RATES, currency file should be requested
+      setConfig({
+        'adServerCurrency': 'JPY'
+      });
+      fakeCurrencyFileServer.respond();
+      expect(fakeCurrencyFileServer.requests.length).to.equal(1);
+      expect(fakeCurrencyFileServer.requests[0].url).to.equal('https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=20030306');
+
+      // RESET to request currency file (specifically url value for this test)
+      setConfig({ 'adServerCurrency': undefined });
+
+      // SET DEFAULT RATES, currency file should STILL be requested
+      setConfig({
+        'adServerCurrency': 'JPY',
+        'defaultRates': {
+          'GBP': { 'CNY': 66, 'JPY': 132, 'USD': 264 },
+          'USD': { 'CNY': 60, 'GBP': 120, 'JPY': 240 }
+        } });
+      fakeCurrencyFileServer.respond();
+      expect(fakeCurrencyFileServer.requests.length).to.equal(2);
+      expect(fakeCurrencyFileServer.requests[1].url).to.equal('https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=20030306');
+    });
+
     it('date macro token $$TODAY$$ is replaced by current date (formatted as yyyymmdd)', function () {
       // RESET to request currency file (specifically url value for this test)
       setConfig({ 'adServerCurrency': undefined });
@@ -251,7 +278,7 @@ describe('currency', function () {
     });
 
     it('should result in NO_BID when fromCurrency is not supported in file', function () {
-      // RESET to request currency file (specifically url value for this test)
+      // RESET to request currency file
       setConfig({ 'adServerCurrency': undefined });
 
       fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
We introduced a bug with the last release of currency module -- when the `defaultRates` parameter is specified, no call is made to obtain the latest rates.

With this config:
```
      pbjs.setConfig({
        "currency": {
                "adServerCurrency": "UNK",
                "defaultRates": { "USD": { "UNK": 50 }}
            }
      });
```
Expected results are that a call should go out to jsdelivr to pull the currency file.

Actual results: it doesn't currently with 1.37+.
