### PR TITLE
Add adpod support to AppNexus adapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -593,7 +593,7 @@ function createAdPodRequest(tags, adPodBid) {
   let request = utils.fill(...tagToDuplicate, numberOfPlacements);
 
   if (requireExactDuration) {
-    const divider = numberOfPlacements / durationRangeSec.length;
+    const divider = Math.ceil(numberOfPlacements / durationRangeSec.length);
     const chunked = utils.chunk(request, divider);
 
     // each configured duration is set as min/maxduration for a subset of requests
@@ -611,8 +611,8 @@ function createAdPodRequest(tags, adPodBid) {
   return request;
 }
 
-function getAdPodPlacementNumber(videoParams, requireExactDuration) {
-  const { adPodDurationSec, durationRangeSec } = videoParams;
+function getAdPodPlacementNumber(videoParams) {
+  const { adPodDurationSec, durationRangeSec, requireExactDuration } = videoParams;
   const minAllowedDuration = utils.getMinValueFromArray(durationRangeSec);
   const numberOfPlacements = Math.floor(adPodDurationSec / minAllowedDuration);
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -360,11 +360,10 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === ADPOD) {
+      // TODO: uncomment and add to bid.meta after util function merged
+      // const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
       bid.meta = {
-        // after translation module/mapping file merged, set iabSubCatId
-        // let key = `${spec.code}_${mappingFileInfo.uniqueKey}`
-        // utils.getIabSubCategory(key, rtbBid.brand_category_id)
-        iabSubCatId: null
+        iabSubCatId: null,
       };
 
       bid.video = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -584,20 +584,20 @@ function hasAdPod(bid) {
  * maxduration video property according to requireExactDuration configuration
  */
 function createAdPodRequest(tags, adPodBid) {
-  const { durationRange, requireExactDuration } = adPodBid.mediaTypes.video;
+  const { durationRangeSec, requireExactDuration } = adPodBid.mediaTypes.video;
 
   const numberOfPlacements = getAdPodPlacementNumber(adPodBid.mediaTypes.video);
-  const maxDuration = utils.getMaxValueFromArray(durationRange);
+  const maxDuration = utils.getMaxValueFromArray(durationRangeSec);
 
   const tagToDuplicate = tags.filter(tag => tag.uuid === adPodBid.bidId);
   let request = utils.fill(...tagToDuplicate, numberOfPlacements);
 
   if (requireExactDuration) {
-    const divider = numberOfPlacements / durationRange.length;
+    const divider = numberOfPlacements / durationRangeSec.length;
     const chunked = utils.chunk(request, divider);
 
     // each configured duration is set as min/maxduration for a subset of requests
-    durationRange.forEach((duration, index) => {
+    durationRangeSec.forEach((duration, index) => {
       chunked[index].map(tag => {
         setVideoProperty(tag, 'minduration', duration);
         setVideoProperty(tag, 'maxduration', duration);
@@ -612,12 +612,12 @@ function createAdPodRequest(tags, adPodBid) {
 }
 
 function getAdPodPlacementNumber(videoParams, requireExactDuration) {
-  const { adPodDuration, durationRange } = videoParams;
-  const minAllowedDuration = utils.getMinValueFromArray(durationRange);
-  const numberOfPlacements = adPodDuration / minAllowedDuration;
+  const { adPodDurationSec, durationRangeSec } = videoParams;
+  const minAllowedDuration = utils.getMinValueFromArray(durationRangeSec);
+  const numberOfPlacements = adPodDurationSec / minAllowedDuration;
 
   return requireExactDuration
-    ? Math.max(numberOfPlacements, adPodDuration.length)
+    ? Math.max(numberOfPlacements, durationRangeSec.length)
     : numberOfPlacements;
 }
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -358,7 +358,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === 'adpod') {
       bid.meta = {
-        iabSubCatId: null // translate rtbBid.brand_category_id to iab when translation module ready
+        iabSubCatId: null // utils.getIabSubCategory('key', rtbBid.brand_category_id) after translation module/mapping file merged
       };
 
       bid.video = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -368,7 +368,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
       bid.video = {
         context: ADPOD,
-        durationSeconds: Math.ceil(rtbBid.rtb.video.duration_ms / 1000),
+        durationSeconds: Math.floor(rtbBid.rtb.video.duration_ms / 1000),
       };
     }
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -160,11 +160,14 @@ export const spec = {
       payload.referrer_detection = refererinfo;
     }
 
-    const adPodBid = find(bidRequests, hasAdPod);
-    if (adPodBid) {
-      const adPodTags = createAdPodRequest(tags, adPodBid);
-      const nonAdPodTags = payload.tags.filter(tag => tag.uuid !== adPodBid.bidId);
-      payload.tags = [...nonAdPodTags, ...adPodTags];
+    const hasAdPodBid = find(bidRequests, hasAdPod);
+    if (hasAdPodBid) {
+      bidRequests.filter(hasAdPod).forEach(adPodBid => {
+        const adPodTags = createAdPodRequest(tags, adPodBid);
+        // don't need the original adpod placement because it's in adPodTags
+        const nonPodTags = payload.tags.filter(tag => tag.uuid !== adPodBid.bidId);
+        payload.tags = [...nonPodTags, ...adPodTags];
+      });
     }
 
     const request = formatRequest(payload, bidderRequest);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -358,7 +358,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === 'adpod') {
       bid.meta = {
-        primaryCatId: rtbBid.brand_category_id
+        iabSubCatId: null // translate rtbBid.brand_category_id to iab when translation module ready
       };
 
       bid.video = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -327,6 +327,22 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       vastImpUrl: rtbBid.notify_url,
       ttl: 3600
     });
+
+    const videoContext = utils.deepAccess(
+      bidderRequest.bids[0],
+      'mediaTypes.video.context'
+    );
+    if (videoContext === 'adpod') {
+      bid.meta = {
+        primaryCatId: rtbBid.brand_category_id
+      };
+
+      bid.video = {
+        context: 'adpod',
+        durationSeconds: rtbBid.rtb.video.duration_ms / 1000,
+      };
+    }
+
     // This supports Outstream Video
     if (rtbBid.renderer_url) {
       const rendererOptions = utils.deepAccess(

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -119,6 +119,7 @@ export const spec = {
         version: '$prebid.version$'
       }
     };
+
     if (member > 0) {
       payload.member_id = member;
     }
@@ -128,6 +129,14 @@ export const spec = {
     }
     if (appIdObjBid) {
       payload.app = appIdObj;
+    }
+
+    const adPodBid = find(bidRequests, hasAdPod);
+    if (adPodBid) {
+      const numberOfPlacements = utils.getAdPodPlacementNumber(adPodBid.mediaTypes.video);
+      const maxDuration = utils.getAdPodMaxDuration(adPodBid.mediaTypes.video);
+      payload.tags = utils.fill(...tags, numberOfPlacements);
+      payload.tags.map(tag => setMaxDuration(tag, maxDuration));
     }
 
     if (debugObjParams.enabled) {
@@ -517,6 +526,19 @@ function hasAppId(bid) {
 
 function hasDebug(bid) {
   return !!bid.debug
+}
+
+function hasAdPod(bid) {
+  return (
+    bid.mediaTypes &&
+    bid.mediaTypes.video &&
+    bid.mediaTypes.video.context === 'adpod'
+  );
+}
+
+function setMaxDuration(tag, duration) {
+  if (utils.isEmpty(tag.video)) { tag.video = {}; }
+  tag.video.maxduration = duration;
 }
 
 function getRtbBid(tag) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -134,7 +134,7 @@ export const spec = {
     }
 
     if (config.getConfig('adpod.brandCategoryExclusion')) {
-      payload.brand_cat_uniqueness = true;
+      payload.brand_category_uniqueness = true;
     }
 
     if (debugObjParams.enabled) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1,7 +1,7 @@
 import { Renderer } from '../src/Renderer';
 import * as utils from '../src/utils';
 import { config } from '../src/config';
-import { registerBidder } from '../src/adapters/bidderFactory';
+import { registerBidder, getIabSubCategory } from '../src/adapters/bidderFactory';
 import { BANNER, NATIVE, VIDEO, ADPOD } from '../src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
@@ -360,10 +360,9 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === ADPOD) {
-      // TODO: uncomment and add to bid.meta after util function merged
-      // const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
+      const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
       bid.meta = {
-        iabSubCatId: null,
+        iabSubCatId
       };
 
       bid.video = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -355,11 +355,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       ttl: 3600
     });
 
-    // TODO: check bidRequest variable instead of [0]
-    const videoContext = utils.deepAccess(
-      bidderRequest.bids[0],
-      'mediaTypes.video.context'
-    );
+    const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === 'adpod') {
       bid.meta = {
         primaryCatId: rtbBid.brand_category_id

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -361,7 +361,10 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     if (videoContext === ADPOD) {
       bid.meta = {
-        iabSubCatId: null // utils.getIabSubCategory('key', rtbBid.brand_category_id) after translation module/mapping file merged
+        // after translation module/mapping file merged, set iabSubCatId
+        // let key = `${spec.code}_${mappingFileInfo.uniqueKey}`
+        // utils.getIabSubCategory(key, rtbBid.brand_category_id)
+        iabSubCatId: null
       };
 
       bid.video = {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1,5 +1,6 @@
 import { Renderer } from '../src/Renderer';
 import * as utils from '../src/utils';
+import { config } from '../src/config';
 import { registerBidder } from '../src/adapters/bidderFactory';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
@@ -134,6 +135,10 @@ export const spec = {
     const adPodBid = find(bidRequests, hasAdPod);
     if (adPodBid) {
       payload.tags = createAdPodRequest(tags, adPodBid);
+    }
+
+    if (config.getConfig('adpod.brandCategoryExclusion')) {
+      payload.brand_cat_uniqueness = true;
     }
 
     if (debugObjParams.enabled) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -2,7 +2,7 @@ import { Renderer } from '../src/Renderer';
 import * as utils from '../src/utils';
 import { config } from '../src/config';
 import { registerBidder } from '../src/adapters/bidderFactory';
-import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes';
+import { BANNER, NATIVE, VIDEO, ADPOD } from '../src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
@@ -359,13 +359,13 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     });
 
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
-    if (videoContext === 'adpod') {
+    if (videoContext === ADPOD) {
       bid.meta = {
         iabSubCatId: null // utils.getIabSubCategory('key', rtbBid.brand_category_id) after translation module/mapping file merged
       };
 
       bid.video = {
-        context: 'adpod',
+        context: ADPOD,
         durationSeconds: Math.ceil(rtbBid.rtb.video.duration_ms / 1000),
       };
     }
@@ -577,7 +577,7 @@ function hasAdPod(bid) {
   return (
     bid.mediaTypes &&
     bid.mediaTypes.video &&
-    bid.mediaTypes.video.context === 'adpod'
+    bid.mediaTypes.video.context === ADPOD
   );
 }
 

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -614,7 +614,7 @@ function createAdPodRequest(tags, adPodBid) {
 function getAdPodPlacementNumber(videoParams, requireExactDuration) {
   const { adPodDurationSec, durationRangeSec } = videoParams;
   const minAllowedDuration = utils.getMinValueFromArray(durationRangeSec);
-  const numberOfPlacements = adPodDurationSec / minAllowedDuration;
+  const numberOfPlacements = Math.floor(adPodDurationSec / minAllowedDuration);
 
   return requireExactDuration
     ? Math.max(numberOfPlacements, durationRangeSec.length)

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -366,7 +366,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
       bid.video = {
         context: 'adpod',
-        durationSeconds: rtbBid.rtb.video.duration_ms / 1000,
+        durationSeconds: Math.ceil(rtbBid.rtb.video.duration_ms / 1000),
       };
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1190,3 +1190,30 @@ export function convertTypes(types, params) {
 export function isArrayOfNums(val, size) {
   return (isArray(val)) && ((size) ? val.length === size : true) && (val.every(v => isInteger(v)));
 }
+
+/**
+ * Creates an array of n length and fills each item with the given value
+ */
+export function fill(value, length) {
+  let newArray = [];
+
+  for (let i = 0; i < length; i++) {
+    newArray.push(value);
+  }
+
+  return newArray;
+}
+
+/**
+ *
+ */
+export function getAdPodPlacementNumber(videoParams) {
+  return videoParams.adPodDuration / Math.min(...videoParams.durationRange);
+}
+
+/**
+ *
+ */
+export function getAdPodMaxDuration(videoParams) {
+  return Math.max(...videoParams.durationRange);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -986,7 +986,7 @@ export function getDefinedParams(object, params) {
  */
 export function isValidMediaTypes(mediaTypes) {
   const SUPPORTED_MEDIA_TYPES = ['banner', 'native', 'video'];
-  const SUPPORTED_STREAM_TYPES = ['instream', 'outstream'];
+  const SUPPORTED_STREAM_TYPES = ['instream', 'outstream', 'adpod'];
 
   const types = Object.keys(mediaTypes);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1205,6 +1205,26 @@ export function fill(value, length) {
   return newArray;
 }
 
+/**
+ * http://npm.im/chunk
+ * Returns an array with *size* chunks from given array
+ *
+ * Example:
+ * ['a', 'b', 'c', 'd', 'e'] chunked by 2 =>
+ * [['a', 'b'], ['c', 'd'], ['e']]
+ */
+export function chunk(array, size) {
+  let newArray = [];
+
+  for (let i = 0; i < Math.ceil(array.length / size); i++) {
+    let start = i * size;
+    let end = start + size;
+    newArray.push(array.slice(start, end));
+  }
+
+  return newArray;
+}
+
 export function getMinValueFromArray(array) {
   return Math.min(...array);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1198,22 +1198,17 @@ export function fill(value, length) {
   let newArray = [];
 
   for (let i = 0; i < length; i++) {
-    newArray.push(value);
+    let valueToPush = isPlainObject(value) ? deepClone(value) : value;
+    newArray.push(valueToPush);
   }
 
   return newArray;
 }
 
-/**
- *
- */
-export function getAdPodPlacementNumber(videoParams) {
-  return videoParams.adPodDuration / Math.min(...videoParams.durationRange);
+export function getMinValueFromArray(array) {
+  return Math.min(...array);
 }
 
-/**
- *
- */
-export function getAdPodMaxDuration(videoParams) {
-  return Math.max(...videoParams.durationRange);
+export function getMaxValueFromArray(array) {
+  return Math.max(...array);
 }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/appnexusBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
+import { config } from 'src/config';
 
 const ENDPOINT = '//ib.adnxs.com/ut/v3/prebid';
 
@@ -226,6 +227,21 @@ describe('AppNexusAdapter', function () {
 
       expect(tagsWith15.length).to.equal(10);
       expect(tagsWith30.length).to.equal(10);
+    });
+
+    it('adds brand_category_exclusion to request when set', function() {
+      let bidRequest = Object.assign({}, bidRequests[0]);
+      sinon
+        .stub(config, 'getConfig')
+        .withArgs('adpod.brandCategoryExclusion')
+        .returns(true);
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.brand_cat_uniqueness).to.equal(true);
+
+      config.getConfig.restore();
     });
 
     it('should attach native params to the request', function () {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/appnexusBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
-// TODO remove comment on merge
-// import * as bidderFactory from 'src/adapters/bidderFactory';
+import * as bidderFactory from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 import { config } from 'src/config';
 
@@ -600,15 +599,14 @@ describe('AppNexusAdapter', function () {
   })
 
   describe('interpretResponse', function () {
-    // TODO remove comments on merge
-    // let bfStub;
-    // before(function() {
-    //   bfStub = sinon.stub(bidderFactory, 'getIabSubCategory');
-    // });
+    let bfStub;
+    before(function() {
+      bfStub = sinon.stub(bidderFactory, 'getIabSubCategory');
+    });
 
-    // after(function() {
-    //   bfStub.restore();
-    // });
+    after(function() {
+      bfStub.restore();
+    });
 
     let response = {
       'version': '3.0.0',
@@ -759,8 +757,7 @@ describe('AppNexusAdapter', function () {
           }
         }]
       };
-      // TODO remove on merge
-      // bfStub.returns('1');
+      bfStub.returns('1');
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0].video.context).to.equal('adpod');

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -205,6 +205,29 @@ describe('AppNexusAdapter', function () {
       expect(payload2.tags[0].video.maxduration).to.equal(30);
     });
 
+    it('should round down adpod placements when numbers are uneven', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDurationSec: 123,
+              durationRangeSec: [45],
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.tags.length).to.equal(2);
+    });
+
     it('should duplicate adpod placements when requireExactDuration is set', function() {
       let bidRequest = Object.assign({},
         bidRequests[0],

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -197,6 +197,37 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].video.maxduration).to.equal(30);
     });
 
+    it('should duplicate adpod placements when requireExactDuration is set', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDuration: 300,
+              durationRange: [15, 30],
+              requireExactDuration: true,
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags.length).to.equal(20);
+
+      const tagsWith15 = payload.tags.filter(tag => tag.video.maxduration === 15);
+      const tagsWith30 = payload.tags.filter(tag => tag.video.maxduration === 30);
+
+      expect(tagsWith15.length).to.equal(10);
+      expect(tagsWith30.length).to.equal(10);
+    });
+
     it('should attach native params to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -270,6 +270,37 @@ describe('AppNexusAdapter', function () {
       expect(payload2tagsWith30.length).to.equal(5);
     });
 
+    it('should set durations for placements when requireExactDuration is set and numbers are uneven', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDurationSec: 105,
+              durationRangeSec: [15, 30, 60],
+              requireExactDuration: true,
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.tags.length).to.equal(7);
+
+      const tagsWith15 = payload.tags.filter(tag => tag.video.maxduration === 15);
+      const tagsWith30 = payload.tags.filter(tag => tag.video.maxduration === 30);
+      const tagsWith60 = payload.tags.filter(tag => tag.video.maxduration === 60);
+      expect(tagsWith15.length).to.equal(3);
+      expect(tagsWith30.length).to.equal(3);
+      expect(tagsWith60.length).to.equal(1);
+    });
+
     it('should break adpod request into batches', function() {
       let bidRequest = Object.assign({},
         bidRequests[0],

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -183,8 +183,8 @@ describe('AppNexusAdapter', function () {
             video: {
               context: 'adpod',
               playerSize: [640, 480],
-              adPodDuration: 300,
-              durationRange: [15, 30],
+              adPodDurationSec: 300,
+              durationRangeSec: [15, 30],
             }
           }
         }
@@ -216,8 +216,8 @@ describe('AppNexusAdapter', function () {
             video: {
               context: 'adpod',
               playerSize: [640, 480],
-              adPodDuration: 300,
-              durationRange: [15, 30],
+              adPodDurationSec: 300,
+              durationRangeSec: [15, 30],
               requireExactDuration: true,
             }
           }
@@ -258,8 +258,8 @@ describe('AppNexusAdapter', function () {
             video: {
               context: 'adpod',
               playerSize: [640, 480],
-              adPodDuration: 225,
-              durationRange: [5],
+              adPodDurationSec: 225,
+              durationRangeSec: [5],
             }
           }
         }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -341,7 +341,7 @@ describe('AppNexusAdapter', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
 
-      expect(payload.brand_cat_uniqueness).to.equal(true);
+      expect(payload.brand_category_uniqueness).to.equal(true);
 
       config.getConfig.restore();
     });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -617,6 +617,43 @@ describe('AppNexusAdapter', function () {
       expect(result[0]).to.have.property('mediaType', 'video');
     });
 
+    it('handles adpod responses', function () {
+      let response = {
+        'tags': [{
+          'uuid': '84ab500420319d',
+          'ads': [{
+            'ad_type': 'video',
+            'brand_category_id': 10,
+            'cpm': 0.500000,
+            'notify_url': 'imptracker.com',
+            'rtb': {
+              'video': {
+                'content': '<!-- Creative -->',
+                'duration_ms': 30000,
+              }
+            }
+          }]
+        }]
+      };
+
+      let bidderRequest = {
+        bids: [{
+          bidId: '84ab500420319d',
+          adUnitCode: 'code',
+          mediaTypes: {
+            video: {
+              context: 'adpod'
+            }
+          }
+        }]
+      };
+
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
+      expect(result[0].meta.primaryCatId).to.equal(10);
+      expect(result[0].video.context).to.equal('adpod');
+      expect(result[0].video.durationSeconds).to.equal(30);
+    });
+
     it('handles native responses', function () {
       let response1 = deepClone(response);
       response1.tags[0].ads[0].ad_type = 'native';

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/appnexusBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
+// TODO remove comment on merge
+// import * as bidderFactory from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 import { config } from 'src/config';
 
@@ -598,6 +600,16 @@ describe('AppNexusAdapter', function () {
   })
 
   describe('interpretResponse', function () {
+    // TODO remove comments on merge
+    // let bfStub;
+    // before(function() {
+    //   bfStub = sinon.stub(bidderFactory, 'getIabSubCategory');
+    // });
+
+    // after(function() {
+    //   bfStub.restore();
+    // });
+
     let response = {
       'version': '3.0.0',
       'tags': [
@@ -747,6 +759,8 @@ describe('AppNexusAdapter', function () {
           }
         }]
       };
+      // TODO remove on merge
+      // bfStub.returns('1');
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(result[0].video.context).to.equal('adpod');

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -171,6 +171,32 @@ describe('AppNexusAdapter', function () {
       });
     });
 
+    it('should duplicate adpod placements and set correct maxduration', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDuration: 300,
+              durationRange: [15, 30],
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags.length).to.equal(20);
+      expect(payload.tags[0]).to.deep.equal(payload.tags[1]);
+      expect(payload.tags[0].video.maxduration).to.equal(30);
+    });
+
     it('should attach native params to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -695,7 +695,6 @@ describe('AppNexusAdapter', function () {
       };
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
-      expect(result[0].meta.primaryCatId).to.equal(10);
       expect(result[0].video.context).to.equal('adpod');
       expect(result[0].video.durationSeconds).to.equal(30);
     });


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
- Adds support for 'adpod' video context to AppNexus adapter
- Duplicates tag objects for request
- Sets adpod-specific fields for response
- Supports new configuration `brandCategoryExclusion`

## Other information
This is for initial review/testing with other PRs related to #3379
