### PR TITLE
Audience Network: update advert HTML

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -18,7 +18,7 @@ const ttl = 600;
 const videoTtl = 3600;
 const platver = '$prebid.version$';
 const platform = '241394079772386';
-const adapterver = '1.1.0';
+const adapterver = '1.2.0';
 
 /**
  * Does this bid request contain valid parameters?
@@ -138,11 +138,34 @@ const isTestmode = () => Boolean(
 const createAdHtml = (placementId, format, bidId) => {
   const nativeStyle = format === 'native' ? '<script>window.onload=function(){if(parent){var o=document.getElementsByTagName("head")[0];var s=parent.document.getElementsByTagName("style");for(var i=0;i<s.length;i++)o.appendChild(s[i].cloneNode(true));}}</script>' : '';
   const nativeContainer = format === 'native' ? '<div class="thirdPartyRoot"><a class="fbAdLink"><div class="fbAdMedia thirdPartyMediaClass"></div><div class="fbAdSubtitle thirdPartySubtitleClass"></div><div class="fbDefaultNativeAdWrapper"><div class="fbAdCallToAction thirdPartyCallToActionClass"></div><div class="fbAdTitle thirdPartyTitleClass"></div></div></a></div>' : '';
-  return `<html><head>${nativeStyle}</head><body><div style="display:none;position:relative;">
-<script type='text/javascript'>var data = {placementid:'${placementId}',format:'${format}',bidid:'${bidId}',onAdLoaded:function(e){console.log('Audience Network [${placementId}] ad loaded');e.style.display = 'block';},onAdError:function(c,m){console.log('Audience Network [${placementId}] error (' + c + ') ' + m);}};
-(function(a,b,c){var d='https://www.facebook.com',e='https://connect.facebook.net/en_US/fbadnw55.js',f={iframeLoaded:true,xhrLoaded:true},g=a.data,h=function(){if(Date.now){return Date.now();}else return +new Date();},i=function(aa){var ba=d+'/audience_network/client_event',ca={cb:h(),event_name:'ADNW_ADERROR',ad_pivot_type:'audience_network_mobile_web',sdk_version:'5.5.web',app_id:g.placementid.split('_')[0],publisher_id:g.placementid.split('_')[1],error_message:aa},da=[];for(var ea in ca)da.push(encodeURIComponent(ea)+'='+encodeURIComponent(ca[ea]));var fa=ba+'?'+da.join('&'),ga=new XMLHttpRequest();ga.open('GET',fa,true);ga.send();if(g.onAdError)g.onAdError('1000','Internal error.');},j=function(){if(b.currentScript){return b.currentScript;}else{var aa=b.getElementsByTagName('script');return aa[aa.length-1];}},k=function(aa){try{return aa.document.referrer;}catch(ba){}return '';},l=function(){var aa=a,ba=[aa];try{while(aa!==aa.parent&&aa.parent.document)ba.push(aa=aa.parent);}catch(ca){}return ba.reverse();},m=function(){var aa=l();for(var ba=0;ba<aa.length;ba++){var ca=aa[ba],da=ca.ADNW||{};ca.ADNW=da;if(!ca.ADNW)continue;return da.v55=da.v55||{ads:[],window:ca};}throw new Error('no_writable_global');},n=function(aa){var ba=aa.indexOf('/',aa.indexOf('://')+3);if(ba===-1)return aa;return aa.substring(0,ba);},o=function(aa){return aa.location.href||k(aa);},p=function(aa){if(aa.sdkLoaded)return;var ba=aa.window.document,ca=ba.createElement('iframe');ca.name='fbadnw';ca.style.display='none';ba.body.appendChild(ca);var da=ca.contentDocument.createElement('script');da.src=e;da.async=true;ca.contentDocument.body.appendChild(da);aa.sdkLoaded=true;},q=function(aa){var ba=/^https?:\\/\\/www\\.google(\\.com?)?\\.\\w{2,3}$/;return !!aa.match(ba);},r=function(aa){return !!aa.match(/cdn\\.ampproject\\.org$/);},s=function(){var aa=c.ancestorOrigins||[],ba=aa[aa.length-1]||c.origin,ca=aa[aa.length-2]||c.origin;if(q(ba)&&r(ca)){return n(ca);}else return n(ba);},t=function(aa){try{return JSON.parse(aa);}catch(ba){i(ba.message);throw ba;}},u=function(aa,ba,ca){if(!aa.iframe){var da=ca.createElement('iframe');da.src=d+'/audiencenetwork/iframe/';da.style.display='none';ca.body.appendChild(da);aa.iframe=da;aa.iframeAppendedTime=h();aa.iframeData={};}ba.iframe=aa.iframe;ba.iframeData=aa.iframeData;ba.tagJsIframeAppendedTime=aa.iframeAppendedTime||0;},v=function(aa){var ba=d+'/audiencenetwork/xhr/?sdk=5.5.web';for(var ca in aa)if(typeof aa[ca]!=='function')ba+='&'+ca+'='+encodeURIComponent(aa[ca]);var da=new XMLHttpRequest();da.open('GET',ba,true);da.withCredentials=true;da.onreadystatechange=function(){if(da.readyState===4){var ea=t(da.response);aa.events.push({name:'xhrLoaded',source:aa.iframe.contentWindow,data:ea,postMessageTimestamp:h(),receivedTimestamp:h()});}};da.send();},w=function(aa,ba){var ca=d+'/audiencenetwork/xhriframe/?sdk=5.5.web';for(var da in ba)if(typeof ba[da]!=='function')ca+='&'+da+'='+encodeURIComponent(ba[da]);var ea=b.createElement('iframe');ea.src=ca;ea.style.display='none';b.body.appendChild(ea);ba.iframe=ea;ba.iframeData={};ba.tagJsIframeAppendedTime=h();},x=function(aa){var ba=function(event){try{var da=event.data;if(da.name in f)aa.events.push({name:da.name,source:event.source,data:da.data});}catch(ea){}},ca=aa.iframe.contentWindow.parent;ca.addEventListener('message',ba,false);},y=function(aa){if(aa.context&&aa.context.sourceUrl)return true;try{return !!JSON.parse(decodeURI(aa.name)).ampcontextVersion;}catch(ba){return false;}},z=function(aa){var ba=h(),ca=l()[0],da=j().parentElement,ea=ca!=a.top,fa=ca.$sf&&ca.$sf.ext,ga=o(ca),ha=m();p(ha);var ia={amp:y(ca),events:[],tagJsInitTime:ba,rootElement:da,iframe:null,tagJsIframeAppendedTime:ha.iframeAppendedTime||0,url:ga,domain:s(),channel:n(o(ca)),width:screen.width,height:screen.height,pixelratio:a.devicePixelRatio,placementindex:ha.ads.length,crossdomain:ea,safeframe:!!fa,placementid:g.placementid,format:g.format||'300x250',testmode:!!g.testmode,onAdLoaded:g.onAdLoaded,onAdError:g.onAdError};if(g.bidid)ia.bidid=g.bidid;if(ea){w(ha,ia);}else{u(ha,ia,ca.document);v(ia);}; x(ia);ia.rootElement.dataset.placementid=ia.placementid;ha.ads.push(ia);};try{z();}catch(aa){i(aa.message||aa);throw aa;}})(window,document,location);
-</script>
-${nativeContainer}</div></body></html>`;
+  return `<html>
+  <head>${nativeStyle}</head>
+  <body>
+    <div style="display:none;position:relative;">
+      <script type="text/javascript" src="https://connect.facebook.net/en_US/fbadnw60-tag.js" async></script>
+      <script type="text/javascript">
+        window.ADNW = window.ADNW || {};
+        window.ADNW.v60 = window.ADNW.v60 || {};
+        window.ADNW.v60.slots = window.ADNW.v60.slots || [];
+        window.ADNW.v60.slots.push({
+          rootElement: document.currentScript.parentElement,
+          placementid: '${placementId}',
+          format: '${format}',
+          bidid: '${bidId}',
+          testmode: false,
+          onAdLoaded: function(rootElement) {
+            console.log('Audience Network [${placementId}] ad loaded');
+            rootElement.style.display = 'block';
+          },
+          onAdError: function(errorCode, errorMessage) {
+            console.log('Audience Network [${placementId}] error (' + errorCode + ') ' + errorMessage);
+          }
+        });
+      </script>
+      ${nativeContainer}
+    </div>
+  </body>
+</html>`;
 };
 
 /**

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -19,7 +19,7 @@ const placementId = 'test-placement-id';
 const playerwidth = 320;
 const playerheight = 180;
 const requestId = 'test-request-id';
-const debug = 'adapterver=1.1.0&platform=241394079772386&platver=$prebid.version$&cb=test-uuid';
+const debug = 'adapterver=1.2.0&platform=241394079772386&platver=$prebid.version$&cb=test-uuid';
 const pageUrl = encodeURIComponent(utils.getTopWindowUrl());
 
 describe('AudienceNetwork adapter', function () {
@@ -241,7 +241,9 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.width).to.equal(300);
       expect(bidResponse.height).to.equal(250);
       expect(bidResponse.ad)
-        .to.contain(`placementid:'${placementId}',format:'native',bidid:'test-bid-id'`, 'ad missing parameters')
+        .to.contain(`placementid: '${placementId}',`)
+        .and.to.contain(`format: 'native',`)
+        .and.to.contain(`bidid: 'test-bid-id',`)
         .and.to.contain('getElementsByTagName("style")', 'ad missing native styles')
         .and.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad missing native container');
       expect(bidResponse.ttl).to.equal(600);
@@ -280,7 +282,9 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.width).to.equal(300);
       expect(bidResponse.height).to.equal(250);
       expect(bidResponse.ad)
-        .to.contain(`placementid:'${placementId}',format:'300x250',bidid:'test-bid-id'`, 'ad missing parameters')
+        .to.contain(`placementid: '${placementId}',`)
+        .and.to.contain(`format: '300x250',`)
+        .and.to.contain(`bidid: 'test-bid-id',`)
         .and.not.to.contain('getElementsByTagName("style")', 'ad should not contain native styles')
         .and.not.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad should not contain native container');
       expect(bidResponse.ttl).to.equal(600);
@@ -361,7 +365,10 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponseNative.requestId).to.equal(requestId);
       expect(bidResponseNative.width).to.equal(300);
       expect(bidResponseNative.height).to.equal(250);
-      expect(bidResponseNative.ad).to.contain(`placementid:'${placementIdNative}',format:'native',bidid:'test-bid-id-native'`, 'ad missing parameters');
+      expect(bidResponseNative.ad)
+        .to.contain(`placementid: '${placementIdNative}',`)
+        .and.to.contain(`format: 'native',`)
+        .and.to.contain(`bidid: 'test-bid-id-native',`);
       expect(bidResponseNative.ttl).to.equal(600);
       expect(bidResponseNative.creativeId).to.equal(placementIdNative);
       expect(bidResponseNative.netRevenue).to.equal(true);
@@ -375,7 +382,10 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponseIab.requestId).to.equal(requestId);
       expect(bidResponseIab.width).to.equal(300);
       expect(bidResponseIab.height).to.equal(250);
-      expect(bidResponseIab.ad).to.contain(`placementid:'${placementIdIab}',format:'300x250',bidid:'test-bid-id-iab'`, 'ad missing parameters');
+      expect(bidResponseIab.ad)
+        .to.contain(`placementid: '${placementIdIab}',`)
+        .and.to.contain(`format: '300x250',`)
+        .and.to.contain(`bidid: 'test-bid-id-iab',`);
       expect(bidResponseIab.ttl).to.equal(600);
       expect(bidResponseIab.creativeId).to.equal(placementIdIab);
       expect(bidResponseIab.netRevenue).to.equal(true);
@@ -462,7 +472,10 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponseNative.ttl).to.equal(600);
       expect(bidResponseNative.width).to.equal(300);
       expect(bidResponseNative.height).to.equal(250);
-      expect(bidResponseNative.ad).to.contain(`placementid:'${nativePlacementId}',format:'native',bidid:'${nativeBidId}'`);
+      expect(bidResponseNative.ad)
+        .to.contain(`placementid: '${nativePlacementId}',`)
+        .and.to.contain(`format: 'native',`)
+        .and.to.contain(`bidid: '${nativeBidId}',`);
     });
 
     it('mixture of valid native bid and error in response', function () {
@@ -490,7 +503,9 @@ describe('AudienceNetwork adapter', function () {
       expect(bidResponse.width).to.equal(300);
       expect(bidResponse.height).to.equal(250);
       expect(bidResponse.ad)
-        .to.contain(`placementid:'${placementId}',format:'native',bidid:'test-bid-id'`, 'ad missing parameters')
+        .to.contain(`placementid: '${placementId}',`)
+        .and.to.contain(`format: 'native',`)
+        .and.to.contain(`bidid: 'test-bid-id',`)
         .and.to.contain('getElementsByTagName("style")', 'ad missing native styles')
         .and.to.contain('<div class="thirdPartyRoot"><a class="fbAdLink">', 'ad missing native container');
       expect(bidResponse.ttl).to.equal(600);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Hello, this PR contains a small update to the Audience Network advert HTML (from version 55 to 60).

This work was commissioned and paid for by Facebook.