### PR TITLE
allow globalVarName as babel plugin option

### DIFF
--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -2,17 +2,17 @@
 let t = require('@babel/core').types;
 let prebid = require('../package.json');
 
-let replace = {
-  '$prebid.version$': prebid.version,
-  '$$PREBID_GLOBAL$$': prebid.globalVarName,
-  '$$REPO_AND_VERSION$$': `${prebid.repository.url.split('/')[3]}_prebid_${prebid.version}`
-};
+module.exports = function(api, options) {
+  let replace = {
+    '$prebid.version$': prebid.version,
+    '$$PREBID_GLOBAL$$': options.globalVarName || prebid.globalVarName,
+    '$$REPO_AND_VERSION$$': `${prebid.repository.url.split('/')[3]}_prebid_${prebid.version}`
+  };
 
-let identifierToStringLiteral = [
-  '$$REPO_AND_VERSION$$'
-];
+  let identifierToStringLiteral = [
+    '$$REPO_AND_VERSION$$'
+  ];
 
-module.exports = function() {
   return {
     visitor: {
       StringLiteral(path) {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Right now when using Prebid.js directly from npm there is no easy way to pass the `globalVarName` to the babel plugin to change from `pbjs`.  This adds an option to the plugin to pass `globalVarName`.

Issue stems from #3479
