### PR TITLE
added setTargeting code for custom key-value pairs to ozone adapter

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -1,5 +1,5 @@
-import * as utils from '../src/utils';
-import { registerBidder } from '../src/adapters/bidderFactory';
+import * as utils from 'src/utils';
+import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'ozone';
 
@@ -70,26 +70,38 @@ export const spec = {
    * @returns {*}
    */
   interpretResponse(serverResponse, request) {
-    utils.logInfo('ozone interpretResponse version 2018-12-05 16:46');
+    utils.logInfo('ozone interpretResponse', serverResponse, request);
     serverResponse = serverResponse.body || {};
+    _ozoneInternal.serverResponseId = serverResponse.id; /* this is sent to the ads request as requestId */
     if (serverResponse.seatbid) {
       if (utils.isArray(serverResponse.seatbid)) {
+        // check - does the auction ID match the one in the request?
+        utils.logInfo('checking auction ID: ', _ozoneInternal.auctionId, request.bidderRequest.auctionId);
         // serverResponse seems good, let's get the list of bids from the request object:
         let arrRequestBids = request.bidderRequest.bids;
         // build up a list of winners, one for each bidId in arrBidIds
         let arrWinners = [];
         for (let i = 0; i < arrRequestBids.length; i++) {
-          let winner = ozoneGetWinnerForRequestBid(arrRequestBids[i], serverResponse.seatbid);
-          if (winner !== null) {
+          let thisBid = arrRequestBids[i];
+          let {seat: winningSeat, bid: winningBid} = ozoneGetWinnerForRequestBid(thisBid, serverResponse.seatbid);
+          utils.logInfo('adding all bids to _ozoneInternal for key: ', thisBid.bidId);
+          _ozoneInternal.responses[thisBid.bidId] = ozoneGetAllBidsForBidId(thisBid.bidId, serverResponse.seatbid);
+          _ozoneInternal.winners[thisBid.bidId] = {'seat': winningSeat, 'bid': winningBid};
+          if (winningBid !== null) {
             const {defaultWidth, defaultHeight} = defaultSize(arrRequestBids[i]);
-            winner = ozoneAddStandardProperties(winner, defaultWidth, defaultHeight);
-            arrWinners.push(winner);
+            winningBid = ozoneAddStandardProperties(winningBid, defaultWidth, defaultHeight);
+            // utils.logInfo(['adding allBids to winningBid object for key: ', thisBid.bidId]);
+            // winningBid['allBids'] = ozoneGetAllBidsForBidId(thisBid.bidId, serverResponse.seatbid);
+            utils.logInfo('winner is', winningBid);
+            arrWinners.push(winningBid);
+            utils.logInfo('arrWinners is', arrWinners);
+            utils.logInfo('_ozoneInternal is', _ozoneInternal);
           }
         }
         let winnersClean = arrWinners.filter(w => {
           return (w.bidId); // will be cast to boolean
         });
-        utils.logInfo(['going to return winnersClean:', winnersClean]);
+        utils.logInfo('going to return winnersClean:', winnersClean);
         return winnersClean;
       } else {
         return [];
@@ -99,23 +111,15 @@ export const spec = {
     }
   },
   buildRequests(validBidRequests, bidderRequest) {
-    let ozoneRequest = validBidRequests[0].params;
+    utils.logInfo('validBidRequests', validBidRequests, 'bidderRequest', bidderRequest);
+    utils.logInfo('buildRequests setting auctionId', bidderRequest.auctionId);
+    _ozoneInternal.auctionId = bidderRequest.auctionId;
+    let htmlParams = validBidRequests[0].params; // the html page config params will be included in each element
+    let ozoneRequest = {}; // we only want to set specific properties on this, not validBidRequests[0].params
     ozoneRequest['id'] = utils.generateUUID();
     ozoneRequest['auctionId'] = bidderRequest['auctionId'];
 
-    if (bidderRequest.hasOwnProperty('placementId')) {
-      bidderRequest.placementId = (bidderRequest.placementId).toString();
-    }
-    if (bidderRequest.hasOwnProperty('siteId')) {
-      bidderRequest.siteId = (bidderRequest.siteId).toString();
-    }
-    if (bidderRequest.hasOwnProperty('publisherId')) {
-      bidderRequest.publisherId = (bidderRequest.publisherId).toString();
-    }
-
-    // if (!ozoneRequest.test) {
     delete ozoneRequest.test; // don't allow test to be set in the config - ONLY use $_GET['pbjs_debug']
-    // }
     if (bidderRequest.gdprConsent) {
       ozoneRequest.regs = {};
       ozoneRequest.regs.ext = {};
@@ -127,7 +131,7 @@ export const spec = {
     let tosendtags = validBidRequests.map(ozoneBidRequest => {
       var obj = {};
       obj.id = ozoneBidRequest.bidId;
-      obj.tagid = String(ozoneBidRequest.params.ozoneid);
+      obj.tagid = (ozoneBidRequest.params.placementId).toString();
       obj.secure = window.location.protocol === 'https:' ? 1 : 0;
       obj.banner = {
         topframe: 1,
@@ -137,14 +141,8 @@ export const spec = {
           return {w: s[0], h: s[1]};
         })
       };
-      if (ozoneBidRequest.params.hasOwnProperty('customData')) {
-        obj.customData = ozoneBidRequest.params.customData;
-      }
-      if (ozoneBidRequest.params.hasOwnProperty('ozoneData')) {
-        obj.ozoneData = ozoneBidRequest.params.ozoneData;
-      }
-      if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
-        obj.lotameData = ozoneBidRequest.params.lotameData;
+      if (ozoneBidRequest.params.hasOwnProperty('placementId')) {
+        obj.placementId = (ozoneBidRequest.params.placementId).toString();
       }
       if (ozoneBidRequest.params.hasOwnProperty('publisherId')) {
         obj.publisherId = (ozoneBidRequest.params.publisherId).toString();
@@ -152,11 +150,22 @@ export const spec = {
       if (ozoneBidRequest.params.hasOwnProperty('siteId')) {
         obj.siteId = (ozoneBidRequest.params.siteId).toString();
       }
-      obj.ext = {'prebid': {'storedrequest': {'id': (ozoneBidRequest.params.placementId).toString()}}};
+      // build the imp['ext'] object
+      obj.ext = {'prebid': {'storedrequest': {'id': (ozoneBidRequest.params.placementId).toString()}}, 'ozone':{}};
+      if (ozoneBidRequest.params.hasOwnProperty('customData')) {
+        obj.ext.ozone.customData = ozoneBidRequest.params.customData;
+      }
+      if (ozoneBidRequest.params.hasOwnProperty('ozoneData')) {
+        obj.ext.ozone.ozoneData = ozoneBidRequest.params.ozoneData;
+      }
+      if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
+        obj.ext.ozone.lotameData = ozoneBidRequest.params.lotameData;
+      }
       return obj;
     });
     ozoneRequest.imp = tosendtags;
-    ozoneRequest.site = {'publisher': {'id': ozoneRequest.publisherId}, 'page': document.location.href};
+    ozoneRequest.source = {'tid': bidderRequest.auctionId};
+    ozoneRequest.site = {'publisher': {'id': htmlParams.publisherId}, 'page': document.location.href};
     ozoneRequest.test = parseInt(getTestQuerystringValue()); // will be 1 or 0
     var ret = {
       method: 'POST',
@@ -164,7 +173,7 @@ export const spec = {
       data: JSON.stringify(ozoneRequest),
       bidderRequest: bidderRequest
     };
-    utils.logInfo(['buildRequests going to return', ret]);
+    utils.logInfo('buildRequests going to return', ret);
     return ret;
   },
 
@@ -223,6 +232,7 @@ export function defaultSize(thebidObj) {
  */
 export function ozoneGetWinnerForRequestBid(requestBid, serverResponseSeatBid) {
   let thisBidWinner = null;
+  let winningSeat = null;
   for (let j = 0; j < serverResponseSeatBid.length; j++) {
     let theseBids = serverResponseSeatBid[j].bid;
     let thisSeat = serverResponseSeatBid[j].seat;
@@ -230,12 +240,36 @@ export function ozoneGetWinnerForRequestBid(requestBid, serverResponseSeatBid) {
       if (theseBids[k].impid === requestBid.bidId) { // we've found a matching server response bid for this request bid
         if ((thisBidWinner == null) || (thisBidWinner.price < theseBids[k].price)) {
           thisBidWinner = theseBids[k];
-          thisBidWinner.seat = thisSeat; // we need to add this here - it's the name of the winning bidder, not guaranteed to be available in the bid object.
+          winningSeat = thisSeat;
+          break;
         }
       }
     }
   }
-  return thisBidWinner;
+  return {'seat': winningSeat, 'bid': thisBidWinner};
+}
+
+/**
+ * Get a list of all the bids, for this bidId
+ * @param matchBidId
+ * @param serverResponseSeatBid
+ * @returns {} = {ozone:{obj}, appnexus:{obj}, ... }
+ */
+export function ozoneGetAllBidsForBidId(matchBidId, serverResponseSeatBid) {
+  utils.logInfo('ozoneGetAllBidsForBidId - starting, with: ', matchBidId, serverResponseSeatBid);
+  let objBids = {};
+  for (let j = 0; j < serverResponseSeatBid.length; j++) {
+    let theseBids = serverResponseSeatBid[j].bid;
+    let thisSeat = serverResponseSeatBid[j].seat;
+    for (let k = 0; k < theseBids.length; k++) {
+      if (theseBids[k].impid === matchBidId) { // we've found a matching server response bid for the request bid we're looking for
+        utils.logInfo('ozoneGetAllBidsForBidId - found matching bid: ', matchBidId, theseBids[k]);
+        objBids[thisSeat] = theseBids[k];
+      }
+    }
+  }
+  utils.logInfo('ozoneGetAllBidsForBidId - going to return: ', objBids);
+  return objBids;
 }
 
 /**
@@ -273,5 +307,39 @@ export function getTestQuerystringValue() {
   }
   return 0;
 }
+
+// listeners:
+// http://prebid.org/dev-docs/publisher-api-reference.html
+// this is called immediately after the standard targeting has been set.
+// We will now try to add custom targeting data - auction ID and all losing bidders.
+// we will use this instead of having to use in the html page: pbjs.bidderSettings = { ozone: { ... } } - see http://prebid.org/dev-docs/publisher-api-reference.html
+pbjs.onEvent('setTargeting', function(arrData) {
+  utils.logInfo('In the setTargeting event handler. Adding custom k/v to the ad request. _ozoneInternal = ', _ozoneInternal);
+  /*
+  In order to add a custom key/value pair you fundamentally need to do one thing:
+  Set new targeting for this key by calling setTargeting() on each window.googletag.pubads().getSlots() array.
+  */
+  // iterate over the slot objects, adding custom targeting parameters
+  window.googletag.pubads().getSlots().forEach(function (slot) {
+    let thisAdId = slot.getTargetingMap().hb_adid;
+    let ozoneResponse = _ozoneInternal.responses[thisAdId]; /* The key is bidid - always found in responses & matches back to the request. */
+	Object.keys(ozoneResponse).forEach(function(bidderName, index, ar2) {
+	     slot.setTargeting('oz_' + bidderName , bidderName);
+	     slot.setTargeting('oz_' + bidderName + '_pb', ozoneResponse[bidderName].price);
+	     slot.setTargeting('oz_' + bidderName + '_crid', ozoneResponse[bidderName].crid);
+	     slot.setTargeting('oz_' + bidderName + '_adv', ozoneResponse[bidderName].adomain);
+	     slot.setTargeting('oz_' + bidderName + '_imp_id', ozoneResponse[bidderName].impid);
+	   });
+	   let objWinner = _ozoneInternal.winners[thisAdId];
+	   slot.setTargeting('oz_auc_id', _ozoneInternal.auctionId); /* from request.auctionId */
+	   slot.setTargeting('oz_winner', objWinner.seat);
+	   slot.setTargeting('oz_winner_auc_id', objWinner.bid.id);
+	   slot.setTargeting('oz_winner_imp_id', objWinner.bid.impid);
+	   slot.setTargeting('oz_response_id', _ozoneInternal.serverResponseId);
+  });
+});
+
+// declare a variable to hold data about the responses & auction ID which we will use in our setTargeting event handler
+var _ozoneInternal = { 'responses': {}, 'winners': {}, 'auctionId': 'not_set', 'serverResponseId': 'not_set' }; // this will hold the response from ozone server call. We use this data to send non-winning bidders to the ad request
 
 registerBidder(spec);

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -323,19 +323,19 @@ pbjs.onEvent('setTargeting', function(arrData) {
   window.googletag.pubads().getSlots().forEach(function (slot) {
     let thisAdId = slot.getTargetingMap().hb_adid;
     let ozoneResponse = _ozoneInternal.responses[thisAdId]; /* The key is bidid - always found in responses & matches back to the request. */
-	Object.keys(ozoneResponse).forEach(function(bidderName, index, ar2) {
-	     slot.setTargeting('oz_' + bidderName , bidderName);
-	     slot.setTargeting('oz_' + bidderName + '_pb', ozoneResponse[bidderName].price);
-	     slot.setTargeting('oz_' + bidderName + '_crid', ozoneResponse[bidderName].crid);
-	     slot.setTargeting('oz_' + bidderName + '_adv', ozoneResponse[bidderName].adomain);
-	     slot.setTargeting('oz_' + bidderName + '_imp_id', ozoneResponse[bidderName].impid);
-	   });
-	   let objWinner = _ozoneInternal.winners[thisAdId];
-	   slot.setTargeting('oz_auc_id', _ozoneInternal.auctionId); /* from request.auctionId */
-	   slot.setTargeting('oz_winner', objWinner.seat);
-	   slot.setTargeting('oz_winner_auc_id', objWinner.bid.id);
-	   slot.setTargeting('oz_winner_imp_id', objWinner.bid.impid);
-	   slot.setTargeting('oz_response_id', _ozoneInternal.serverResponseId);
+  Object.keys(ozoneResponse).forEach(function(bidderName, index, ar2) {
+       slot.setTargeting('oz_' + bidderName , bidderName);
+       slot.setTargeting('oz_' + bidderName + '_pb', ozoneResponse[bidderName].price);
+       slot.setTargeting('oz_' + bidderName + '_crid', ozoneResponse[bidderName].crid);
+       slot.setTargeting('oz_' + bidderName + '_adv', ozoneResponse[bidderName].adomain);
+       slot.setTargeting('oz_' + bidderName + '_imp_id', ozoneResponse[bidderName].impid);
+     });
+     let objWinner = _ozoneInternal.winners[thisAdId];
+     slot.setTargeting('oz_auc_id', _ozoneInternal.auctionId); /* from request.auctionId */
+     slot.setTargeting('oz_winner', objWinner.seat);
+     slot.setTargeting('oz_winner_auc_id', objWinner.bid.id);
+     slot.setTargeting('oz_winner_imp_id', objWinner.bid.impid);
+     slot.setTargeting('oz_response_id', _ozoneInternal.serverResponseId);
   });
 });
 

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -2,8 +2,13 @@ import { expect } from 'chai';
 import { spec } from 'modules/ozoneBidAdapter';
 
 const OZONEURI = 'https://elb.the-ozone-project.com/openrtb2/auction';
+// const OZONEURI = 'https://www.1in39.co.uk/openrtb2/auction';
 const BIDDER_CODE = 'ozone';
+/*
 
+NOTE - use firefox console to deep copy the objects to use here
+
+ */
 var validBidRequests = [
   {
     adUnitCode: 'div-gpt-ad-1460505748561-0',
@@ -15,6 +20,34 @@ var validBidRequests = [
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
     params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, ozoneData: {'networkID': '3048', 'dfpSiteID': 'd.thesun', 'sectionID': 'homepage', 'path': '/', 'sec_id': 'null', 'sec': 'sec', 'topics': 'null', 'kw': 'null', 'aid': 'null', 'search': 'null', 'article_type': 'null', 'hide_ads': '', 'article_slug': 'null'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  }
+];
+var validBidRequestsNoSizes = [
+  {
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff8',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, ozoneData: {'networkID': '3048', 'dfpSiteID': 'd.thesun', 'sectionID': 'homepage', 'path': '/', 'sec_id': 'null', 'sec': 'sec', 'topics': 'null', 'kw': 'null', 'aid': 'null', 'search': 'null', 'article_type': 'null', 'hide_ads': '', 'article_slug': 'null'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  }
+];
+
+var validBidRequestsWithMediaTypes = [
+  {
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff8',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, ozoneData: {'networkID': '3048', 'dfpSiteID': 'd.thesun', 'sectionID': 'homepage', 'path': '/', 'sec_id': 'null', 'sec': 'sec', 'topics': 'null', 'kw': 'null', 'aid': 'null', 'search': 'null', 'article_type': 'null', 'hide_ads': '', 'article_slug': 'null'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    mediaTypes: {banner: {sizes: [[300, 250], [300, 600]]}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
 ];
@@ -95,242 +128,6 @@ var validResponse = {
     }
   },
   'headers': {}
-}
-
-var validResponse2Ads2Bidders = {
-  'body': {
-    'id': '81fab647-f3e4-4262-a618-231c0dfbba19',
-    'seatbid': [
-      {
-        'bid': [
-          {
-            'id': '2528653442263849051',
-            'impid': '246ecf3443c17e8',
-            'price': 0.25493,
-            'adm': '<script src="http://ams1-ib.adnxs.com/ab?referrer=http%3A%2F%2Ftpdads.com%2Fadaptortest.html&e=wqT_3QLhCOhhBAAAAwDWAAUBCIXUnuAFEMnNkbjJuLa0Zhj_lofznozw9HIqNgniOzHrxVDQPxHiOzHrxVDQPxkAAAkCACERGwApEQkAMQkZsAAAMNz46AY4-01A-01IAlD-84g5WN_0aGAAaLrQggF4uZAFgAEBigEDVVNEkgUG8HKYAawCoAH6AagBAbABALgBAsABBMgBAtABANgBAOABAPABAIoCkwF1ZignYScsIDI4OTU5NDAsIDE1NDQwMDYxNDkpO3VmKCdyJywgMTE5NjgzNTgyLCAxNTQ0MDA2MTQ5KTt1ZignYycsIDI1NDg5MTQ5Rh4AKGcnLCA2ODE1MzEyRh0AIGknLCA5NTE0OTp2APCBkgKhAiE5MGFpRGdqOTNaTU1FUDd6aURrWUFDRGY5R2d3QURnQVFBUkktMDFRM1Bqb0JsZ0FZUF9fX184UGFBQndBWGdCZ0FFQmlBRUJrQUVCbUFFQm9BRUJxQUVCc0FFQXVRRjFxdzFzbXBuSlA4RUJDLWV2MDlKUTBEX0pBUUFBQQEDqFBBXzJRRjcydUd2eVJycFAtQUJ3b2s2OVFITnpFdy1tQUlBb0FJQXRRSUEBLwR2UQkI6HdBSUJ5QUlCMEFJQjJBSUI0QUlBNkFJQS1BSUFnQU1Ca0FNQW1BTUJvZ01YQ0w2MnpRTVFBaGdCTFFBAUfIeUIyUmxabUYxYkhTb0FfM2Rrd3k2QXdsQlRWTXhPalF4TmpUZ0E2SUOaAmEhMkJVb3JnNiQBNDNfUm9JQVFvQURHYW1aAQKIbkpQem9KUVUxVE1UbzBNVFkwUUtJQ1NYdmE0YV9KR3VrX1UJfAUBAFcdDPBI2AIA4AKyrkzqAiJodHRwOi8vdHBkYWRzLmNvbS9hZGFwdG9ydGVzdC5odG1s8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWQy4WACBMRUFGX05BTUUBHQweChpDMh0A8JlBU1RfTU9ESUZJRUQSAIADAIgDAZADAJgDFKADAaoDAMADrALIAwDYAwDgAwDoAwD4AwOABACSBAkvb3BlbnJ0YjKYBACiBAw4MS4xNTAuMC4xMTGoBACyBAwIABAAGAAgADAAOAC4BADABADIBADSBA45OTc5I0FNUzE6NDE2NNoEAggB4AQA8AT-84g5iAUBmAUAoAX_____BQOwAaoFJDgxZmFiNjQ3LWYzZTQtNDI2Mi1hNjE4LTIzMWMwZGZiYmExOcAFAMkFaboU8D_SBQkJCQxwAADYBQHgBQHwBQH6BQQIABAAkAYAmAYAuAYAwQYJIyTwP8gGANoGFgoQCRA0AAAAAAAAAAAAABAAGAA.&s=301f133a55b6a9caf890b863f956de2b60ed2b53&pp=${AUCTION_PRICE}"></script>',
-            'adid': '119683582',
-            'adomain': [
-              'appnexus.com'
-            ],
-            'iurl': 'http://ams1-ib.adnxs.com/cr?id=119683582',
-            'cid': '9979',
-            'crid': '119683582',
-            'w': 300,
-            'h': 250,
-            'ext': {
-              'prebid': {
-                'type': 'banner'
-              },
-              'bidder': {
-                'appnexus': {
-                  'brand_id': 1,
-                  'auction_id': 7379387427817023000,
-                  'bidder_id': 2,
-                  'bid_ad_type': 0
-                }
-              }
-            }
-          },
-          {
-            'id': '452175203342206024',
-            'impid': '371102c16611c18',
-            'price': 0.25493,
-            'adm': '<script src="http://ams1-ib.adnxs.com/ab?referrer=http%3A%2F%2Ftpdads.com%2Fadaptortest.html&e=wqT_3QLhCOhhBAAAAwDWAAUBCIXUnuAFEOL4g7z--eidUxj_lofznozw9HIqNgniOzHrxVDQPxHiOzHrxVDQPxkAAAkCACERGwApEQkAMQkZsAAAMNz46AY4-01A-01IAlCQlKc5WN_0aGAAaLrQggF4uZAFgAEBigEDVVNEkgUG8HKYAcoHoAH6AagBAbABALgBAsABBMgBAtABANgBAOABAPABAIoCkwF1ZignYScsIDI4OTU5NDAsIDE1NDQwMDYxNDkpO3VmKCdyJywgMTIwMTc5MjE2LCAxNTQ0MDA2MTQ5KTt1ZignYycsIDI2MDQzMTE1Rh4AKGcnLCA2OTgxNzg5Rh0AIGknLCA5NTE0OTp2APCBkgKhAiFWMFljZ0FqcnhiVU1FSkNVcHprWUFDRGY5R2d3QURnQVFBUkktMDFRM1Bqb0JsZ0FZUF9fX184UGFBQndBWGdCZ0FFQmlBRUJrQUVCbUFFQm9BRUJxQUVCc0FFQXVRRjFxdzFzbXBuSlA4RUJDLWV2MDlKUTBEX0pBUUFBQQEDqFBBXzJRRjcydUd2eVJycFAtQUJ3b2s2OVFITnpFdy1tQUlBb0FJQXRRSUEBLwR2UQkI6HdBSUJ5QUlCMEFJQjJBSUI0QUlBNkFJQS1BSUFnQU1Ca0FNQW1BTUJvZ01YQ05xTzl3TVFBaGdCTFFBAUfIeUIyUmxabUYxYkhTb0EtdkZ0UXk2QXdsQlRWTXhPalF4TmpUZ0E2SUOaAmEhSWhYaGdRNiQBNDNfUm9JQVFvQURHYW1aAQKIbkpQem9KUVUxVE1UbzBNVFkwUUtJQ1NYdmE0YV9KR3VrX1UJfAUBAFcdDPBI2AIA4AKyrkzqAiJodHRwOi8vdHBkYWRzLmNvbS9hZGFwdG9ydGVzdC5odG1s8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWQy4WACBMRUFGX05BTUUBHQweChpDMh0A8JlBU1RfTU9ESUZJRUQSAIADAIgDAZADAJgDFKADAaoDAMADrALIAwDYAwDgAwDoAwD4AwOABACSBAkvb3BlbnJ0YjKYBACiBAw4MS4xNTAuMC4xMTGoBACyBAwIABAAGAAgADAAOAC4BADABADIBADSBA45OTc5I0FNUzE6NDE2NNoEAggB4AQA8ASQlKc5iAUBmAUAoAX_____BQOwAaoFJDgxZmFiNjQ3LWYzZTQtNDI2Mi1hNjE4LTIzMWMwZGZiYmExOcAFAMkFaboU8D_SBQkJCQxwAADYBQHgBQHwBQH6BQQIABAAkAYAmAYAuAYAwQYJIyTwP8gGANoGFgoQCRA0AAAAAAAAAAAAABAAGAA.&s=47aa373759af2f4d3ae5f41b8813da8d2a80dbf1&pp=${AUCTION_PRICE}"></script>',
-            'adid': '120179216',
-            'adomain': [
-              'appnexus.com'
-            ],
-            'iurl': 'http://ams1-ib.adnxs.com/cr?id=120179216',
-            'cid': '9979',
-            'crid': '120179216',
-            'w': 970,
-            'h': 250,
-            'ext': {
-              'prebid': {
-                'type': 'banner'
-              },
-              'bidder': {
-                'appnexus': {
-                  'brand_id': 1,
-                  'auction_id': 5997567442111495000,
-                  'bidder_id': 2,
-                  'bid_ad_type': 0
-                }
-              }
-            }
-          }
-        ],
-        'seat': 'appnexus'
-      },
-      {
-        'bid': [
-          {
-            'id': '6253a6e7-dccf-4674-a1ab-a267fceb88f1',
-            'impid': '246ecf3443c17e8',
-            'price': 0.01,
-            'adm': '<div id="beacon_9436" style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://rtb-xa.openx.net/win/prebid?p=FIRST&t=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA&ph=a3aece0c-9e80-4316-8deb-faf804779bd1"/></div><a href="http://sademo-d.openx.net/w/1.0/rc?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA" target="_blank">\n  <img src="http://ox-i.sademo.servedbyopenx.com/a3a/a3aece0c-9e80-4316-8deb-faf804779bd1/80e/80eeedd896f54edfa01c82fdb6a372b7.jpg" height="250" width="300" border="0" alt=""/>\n</a>\n<div id="beacon_9165" style="position: absolute; left: 0px; top: 0px; visibility: hidden;">\n  <img src="http://sademo-d.openx.net/w/1.0/rr?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA"/>\n</div>\n<iframe src="https://us-u.openx.net/w/1.0/pd?plm=6&ph=a3aece0c-9e80-4316-8deb-faf804779bd1" width="0" height="0" style="display:none;"></iframe>',
-            'crid': '538137718',
-            'w': 300,
-            'h': 250,
-            'ext': {
-              'prebid': {
-                'type': 'banner'
-              }
-            }
-          },
-          {
-            'id': '5023e9fd-9aa6-4e23-a747-9ebe84886b66',
-            'impid': '371102c16611c18',
-            'price': 0.01,
-            'adm': '<div id="beacon_9450" style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://rtb-xa.openx.net/win/prebid?p=FIRST&t=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA&ph=a3aece0c-9e80-4316-8deb-faf804779bd1"/></div><a href="http://sademo-d.openx.net/w/1.0/rc?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA" target="_blank">\n  <img src="http://ox-i.sademo.servedbyopenx.com/a3a/a3aece0c-9e80-4316-8deb-faf804779bd1/0c8/0c8dd68f50234093bc08b7339ee0093d.jpg" height="90" width="728" border="0" alt=""/>\n</a>\n<div id="beacon_9308" style="position: absolute; left: 0px; top: 0px; visibility: hidden;">\n  <img src="http://sademo-d.openx.net/w/1.0/rr?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA"/>\n</div>\n<iframe src="https://us-u.openx.net/w/1.0/pd?plm=6&ph=a3aece0c-9e80-4316-8deb-faf804779bd1" width="0" height="0" style="display:none;"></iframe>',
-            'crid': '538137717',
-            'w': 728,
-            'h': 90,
-            'ext': {
-              'prebid': {
-                'type': 'banner'
-              }
-            }
-          }
-        ],
-        'seat': 'openx'
-      }
-    ],
-    'ext': {
-      'responsetimemillis': {
-        'appnexus': 21,
-        'openx': 123
-      }
-    }
-  },
-  'headers': {}
-}
-
-var validRequest2Ads2Bidders = {
-  'method': 'POST',
-  'url': 'https://elb.the-ozone-project.com/openrtb2/auction',
-  'data': '{"publisherId":"OZONENUK0001","siteId":"4204204201","placementId":"0420420421","id":"81fab647-f3e4-4262-a618-231c0dfbba19","auctionId":"d44d384b-7dd8-49bb-8dab-164fae1d6555","imp":[{"id":"246ecf3443c17e8","tagid":"undefined","secure":0,"banner":{"topframe":1,"w":300,"h":250,"format":[{"w":300,"h":250},{"w":300,"h":600}]},"publisherId":"OZONENUK0001","siteId":"4204204201","ext":{"prebid":{"storedrequest":{"id":"0420420421"}}}},{"id":"371102c16611c18","tagid":"undefined","secure":0,"banner":{"topframe":1,"w":728,"h":90,"format":[{"w":728,"h":90},{"w":970,"h":250}]},"publisherId":"OZONENUK0001","siteId":"4204204201","ext":{"prebid":{"storedrequest":{"id":"0420420421"}}}}]}',
-  'bidderRequest': {
-    'bidderCode': 'ozone',
-    'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
-    'bidderRequestId': '10ad92670f58ba8',
-    'bids': [
-      {
-        'bidder': 'ozone',
-        'params': {
-          'publisherId': 'OZONENUK0001',
-          'siteId': '4204204201',
-          'placementId': '0420420421',
-          'id': '81fab647-f3e4-4262-a618-231c0dfbba19',
-          'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
-          'imp': [
-            {
-              'id': '246ecf3443c17e8',
-              'tagid': 'undefined',
-              'secure': 0,
-              'banner': {
-                'topframe': 1,
-                'w': 300,
-                'h': 250,
-                'format': [
-                  {
-                    'w': 300,
-                    'h': 250
-                  },
-                  {
-                    'w': 300,
-                    'h': 600
-                  }
-                ]
-              },
-              'publisherId': 'OZONENUK0001',
-              'siteId': '4204204201',
-              'ext': {
-                'prebid': {
-                  'storedrequest': {
-                    'id': '0420420421'
-                  }
-                }
-              }
-            },
-            {
-              'id': '371102c16611c18',
-              'tagid': 'undefined',
-              'secure': 0,
-              'banner': {
-                'topframe': 1,
-                'w': 728,
-                'h': 90,
-                'format': [
-                  {
-                    'w': 728,
-                    'h': 90
-                  },
-                  {
-                    'w': 970,
-                    'h': 250
-                  }
-                ]
-              },
-              'publisherId': 'OZONENUK0001',
-              'siteId': '4204204201',
-              'ext': {
-                'prebid': {
-                  'storedrequest': {
-                    'id': '0420420421'
-                  }
-                }
-              }
-            }
-          ]
-        },
-        'adUnitCode': 'mpu',
-        'transactionId': '05c75220-47e6-4f1a-9e17-07c60fae2cc9',
-        'sizes': [
-          [
-            300,
-            250
-          ],
-          [
-            300,
-            600
-          ]
-        ],
-        'bidId': '246ecf3443c17e8',
-        'bidderRequestId': '10ad92670f58ba8',
-        'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
-        'bidRequestsCount': 1
-      },
-      {
-        'bidder': 'ozone',
-        'params': {
-          'publisherId': 'OZONENUK0001',
-          'siteId': '4204204201',
-          'placementId': '0420420421'
-        },
-        'adUnitCode': 'leaderboard',
-        'transactionId': 'f109a297-88a8-4806-a455-079574f76271',
-        'sizes': [
-          [
-            728,
-            90
-          ],
-          [
-            970,
-            250
-          ]
-        ],
-        'bidId': '371102c16611c18',
-        'bidderRequestId': '10ad92670f58ba8',
-        'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
-        'bidRequestsCount': 1
-      }
-    ],
-    'auctionStart': 1544006146957,
-    'timeout': 3000,
-    'start': 1544006146960,
-    'doneCbCallCount': 1
-  }
 }
 
 describe('ozone Adapter', function () {
@@ -441,6 +238,18 @@ describe('ozone Adapter', function () {
 
     it('should not validate missing publisherId', function () {
       expect(spec.isBidRequestValid(xMissingPublisher)).to.equal(false);
+    });
+
+    var xMissingSiteId = {
+      bidder: BIDDER_CODE,
+      params: {
+        publisherId: '9876abcd12-3',
+        placementId: '1234567890',
+      }
+    };
+
+    it('should not validate missing sitetId', function () {
+      expect(spec.isBidRequestValid(xMissingSiteId)).to.equal(false);
     });
 
     var xBadPublisherTooShort = {
@@ -651,31 +460,28 @@ describe('ozone Adapter', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
       expect(request.bidderRequest.bids[0].bidder).to.equal(BIDDER_CODE);
     });
+
+    it('handles mediaTypes element correctly', function () {
+      const request = spec.buildRequests(validBidRequestsWithMediaTypes, validBidderRequest);
+      expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
+    });
+
+    it('should not crash when there is no sizes element at all', function () {
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest);
+      expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
+    });
   });
 
   describe('interpretResponse', function () {
-    // new test to verify the interpretresponse code works properly with responses of [ [bidder 1, bidder 1], [bidder 2, bidder 2] ]
-    it('should return 2 appnexus winning bids', function () {
-      const result = spec.interpretResponse(validResponse2Ads2Bidders, validRequest2Ads2Bidders);
-      console.log(['interpretResponse result  = ', result]);
-      expect(result.length).to.equal(2);
-      expect(result[0].seat).to.equal('appnexus');
-      expect(result[1].seat).to.equal('appnexus');
-    });
-
     it('should build bid array', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
 
     it('should have all relevant fields', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
-      console.log(['Request: ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['result[0]: ', result[0]]);
       const bid = result[0];
       expect(bid.cpm).to.equal(validResponse.body.seatbid[0].bid[0].cpm);
       expect(bid.width).to.equal(validResponse.body.seatbid[0].bid[0].width);
@@ -686,9 +492,7 @@ describe('ozone Adapter', function () {
       var validBidderRequestWithGdpr = validBidderRequest;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
-      console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
-      console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
   });

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -3,11 +3,7 @@ import { spec } from 'modules/ozoneBidAdapter';
 
 const OZONEURI = 'https://elb.the-ozone-project.com/openrtb2/auction';
 const BIDDER_CODE = 'ozone';
-/*
 
-NOTE - use firefox console to deep copy the objects to use here
-
- */
 var validBidRequests = [
   {
     adUnitCode: 'div-gpt-ad-1460505748561-0',
@@ -99,6 +95,242 @@ var validResponse = {
     }
   },
   'headers': {}
+}
+
+var validResponse2Ads2Bidders = {
+  'body': {
+    'id': '81fab647-f3e4-4262-a618-231c0dfbba19',
+    'seatbid': [
+      {
+        'bid': [
+          {
+            'id': '2528653442263849051',
+            'impid': '246ecf3443c17e8',
+            'price': 0.25493,
+            'adm': '<script src="http://ams1-ib.adnxs.com/ab?referrer=http%3A%2F%2Ftpdads.com%2Fadaptortest.html&e=wqT_3QLhCOhhBAAAAwDWAAUBCIXUnuAFEMnNkbjJuLa0Zhj_lofznozw9HIqNgniOzHrxVDQPxHiOzHrxVDQPxkAAAkCACERGwApEQkAMQkZsAAAMNz46AY4-01A-01IAlD-84g5WN_0aGAAaLrQggF4uZAFgAEBigEDVVNEkgUG8HKYAawCoAH6AagBAbABALgBAsABBMgBAtABANgBAOABAPABAIoCkwF1ZignYScsIDI4OTU5NDAsIDE1NDQwMDYxNDkpO3VmKCdyJywgMTE5NjgzNTgyLCAxNTQ0MDA2MTQ5KTt1ZignYycsIDI1NDg5MTQ5Rh4AKGcnLCA2ODE1MzEyRh0AIGknLCA5NTE0OTp2APCBkgKhAiE5MGFpRGdqOTNaTU1FUDd6aURrWUFDRGY5R2d3QURnQVFBUkktMDFRM1Bqb0JsZ0FZUF9fX184UGFBQndBWGdCZ0FFQmlBRUJrQUVCbUFFQm9BRUJxQUVCc0FFQXVRRjFxdzFzbXBuSlA4RUJDLWV2MDlKUTBEX0pBUUFBQQEDqFBBXzJRRjcydUd2eVJycFAtQUJ3b2s2OVFITnpFdy1tQUlBb0FJQXRRSUEBLwR2UQkI6HdBSUJ5QUlCMEFJQjJBSUI0QUlBNkFJQS1BSUFnQU1Ca0FNQW1BTUJvZ01YQ0w2MnpRTVFBaGdCTFFBAUfIeUIyUmxabUYxYkhTb0FfM2Rrd3k2QXdsQlRWTXhPalF4TmpUZ0E2SUOaAmEhMkJVb3JnNiQBNDNfUm9JQVFvQURHYW1aAQKIbkpQem9KUVUxVE1UbzBNVFkwUUtJQ1NYdmE0YV9KR3VrX1UJfAUBAFcdDPBI2AIA4AKyrkzqAiJodHRwOi8vdHBkYWRzLmNvbS9hZGFwdG9ydGVzdC5odG1s8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWQy4WACBMRUFGX05BTUUBHQweChpDMh0A8JlBU1RfTU9ESUZJRUQSAIADAIgDAZADAJgDFKADAaoDAMADrALIAwDYAwDgAwDoAwD4AwOABACSBAkvb3BlbnJ0YjKYBACiBAw4MS4xNTAuMC4xMTGoBACyBAwIABAAGAAgADAAOAC4BADABADIBADSBA45OTc5I0FNUzE6NDE2NNoEAggB4AQA8AT-84g5iAUBmAUAoAX_____BQOwAaoFJDgxZmFiNjQ3LWYzZTQtNDI2Mi1hNjE4LTIzMWMwZGZiYmExOcAFAMkFaboU8D_SBQkJCQxwAADYBQHgBQHwBQH6BQQIABAAkAYAmAYAuAYAwQYJIyTwP8gGANoGFgoQCRA0AAAAAAAAAAAAABAAGAA.&s=301f133a55b6a9caf890b863f956de2b60ed2b53&pp=${AUCTION_PRICE}"></script>',
+            'adid': '119683582',
+            'adomain': [
+              'appnexus.com'
+            ],
+            'iurl': 'http://ams1-ib.adnxs.com/cr?id=119683582',
+            'cid': '9979',
+            'crid': '119683582',
+            'w': 300,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'appnexus': {
+                  'brand_id': 1,
+                  'auction_id': 7379387427817023000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            }
+          },
+          {
+            'id': '452175203342206024',
+            'impid': '371102c16611c18',
+            'price': 0.25493,
+            'adm': '<script src="http://ams1-ib.adnxs.com/ab?referrer=http%3A%2F%2Ftpdads.com%2Fadaptortest.html&e=wqT_3QLhCOhhBAAAAwDWAAUBCIXUnuAFEOL4g7z--eidUxj_lofznozw9HIqNgniOzHrxVDQPxHiOzHrxVDQPxkAAAkCACERGwApEQkAMQkZsAAAMNz46AY4-01A-01IAlCQlKc5WN_0aGAAaLrQggF4uZAFgAEBigEDVVNEkgUG8HKYAcoHoAH6AagBAbABALgBAsABBMgBAtABANgBAOABAPABAIoCkwF1ZignYScsIDI4OTU5NDAsIDE1NDQwMDYxNDkpO3VmKCdyJywgMTIwMTc5MjE2LCAxNTQ0MDA2MTQ5KTt1ZignYycsIDI2MDQzMTE1Rh4AKGcnLCA2OTgxNzg5Rh0AIGknLCA5NTE0OTp2APCBkgKhAiFWMFljZ0FqcnhiVU1FSkNVcHprWUFDRGY5R2d3QURnQVFBUkktMDFRM1Bqb0JsZ0FZUF9fX184UGFBQndBWGdCZ0FFQmlBRUJrQUVCbUFFQm9BRUJxQUVCc0FFQXVRRjFxdzFzbXBuSlA4RUJDLWV2MDlKUTBEX0pBUUFBQQEDqFBBXzJRRjcydUd2eVJycFAtQUJ3b2s2OVFITnpFdy1tQUlBb0FJQXRRSUEBLwR2UQkI6HdBSUJ5QUlCMEFJQjJBSUI0QUlBNkFJQS1BSUFnQU1Ca0FNQW1BTUJvZ01YQ05xTzl3TVFBaGdCTFFBAUfIeUIyUmxabUYxYkhTb0EtdkZ0UXk2QXdsQlRWTXhPalF4TmpUZ0E2SUOaAmEhSWhYaGdRNiQBNDNfUm9JQVFvQURHYW1aAQKIbkpQem9KUVUxVE1UbzBNVFkwUUtJQ1NYdmE0YV9KR3VrX1UJfAUBAFcdDPBI2AIA4AKyrkzqAiJodHRwOi8vdHBkYWRzLmNvbS9hZGFwdG9ydGVzdC5odG1s8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWQy4WACBMRUFGX05BTUUBHQweChpDMh0A8JlBU1RfTU9ESUZJRUQSAIADAIgDAZADAJgDFKADAaoDAMADrALIAwDYAwDgAwDoAwD4AwOABACSBAkvb3BlbnJ0YjKYBACiBAw4MS4xNTAuMC4xMTGoBACyBAwIABAAGAAgADAAOAC4BADABADIBADSBA45OTc5I0FNUzE6NDE2NNoEAggB4AQA8ASQlKc5iAUBmAUAoAX_____BQOwAaoFJDgxZmFiNjQ3LWYzZTQtNDI2Mi1hNjE4LTIzMWMwZGZiYmExOcAFAMkFaboU8D_SBQkJCQxwAADYBQHgBQHwBQH6BQQIABAAkAYAmAYAuAYAwQYJIyTwP8gGANoGFgoQCRA0AAAAAAAAAAAAABAAGAA.&s=47aa373759af2f4d3ae5f41b8813da8d2a80dbf1&pp=${AUCTION_PRICE}"></script>',
+            'adid': '120179216',
+            'adomain': [
+              'appnexus.com'
+            ],
+            'iurl': 'http://ams1-ib.adnxs.com/cr?id=120179216',
+            'cid': '9979',
+            'crid': '120179216',
+            'w': 970,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'appnexus': {
+                  'brand_id': 1,
+                  'auction_id': 5997567442111495000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            }
+          }
+        ],
+        'seat': 'appnexus'
+      },
+      {
+        'bid': [
+          {
+            'id': '6253a6e7-dccf-4674-a1ab-a267fceb88f1',
+            'impid': '246ecf3443c17e8',
+            'price': 0.01,
+            'adm': '<div id="beacon_9436" style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://rtb-xa.openx.net/win/prebid?p=FIRST&t=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA&ph=a3aece0c-9e80-4316-8deb-faf804779bd1"/></div><a href="http://sademo-d.openx.net/w/1.0/rc?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA" target="_blank">\n  <img src="http://ox-i.sademo.servedbyopenx.com/a3a/a3aece0c-9e80-4316-8deb-faf804779bd1/80e/80eeedd896f54edfa01c82fdb6a372b7.jpg" height="250" width="300" border="0" alt=""/>\n</a>\n<div id="beacon_9165" style="position: absolute; left: 0px; top: 0px; visibility: hidden;">\n  <img src="http://sademo-d.openx.net/w/1.0/rr?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGAo4QmpDbUdNRVFNHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFuiZ-sz7udPTxAEWndyjsYDmrtS8AQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFuzRmoEEFqD03YAEFQIcFPQDFNgEABUEFQoWFCYURQoAAAA"/>\n</div>\n<iframe src="https://us-u.openx.net/w/1.0/pd?plm=6&ph=a3aece0c-9e80-4316-8deb-faf804779bd1" width="0" height="0" style="display:none;"></iframe>',
+            'crid': '538137718',
+            'w': 300,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              }
+            }
+          },
+          {
+            'id': '5023e9fd-9aa6-4e23-a747-9ebe84886b66',
+            'impid': '371102c16611c18',
+            'price': 0.01,
+            'adm': '<div id="beacon_9450" style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://rtb-xa.openx.net/win/prebid?p=FIRST&t=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA&ph=a3aece0c-9e80-4316-8deb-faf804779bd1"/></div><a href="http://sademo-d.openx.net/w/1.0/rc?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA" target="_blank">\n  <img src="http://ox-i.sademo.servedbyopenx.com/a3a/a3aece0c-9e80-4316-8deb-faf804779bd1/0c8/0c8dd68f50234093bc08b7339ee0093d.jpg" height="90" width="728" border="0" alt=""/>\n</a>\n<div id="beacon_9308" style="position: absolute; left: 0px; top: 0px; visibility: hidden;">\n  <img src="http://sademo-d.openx.net/w/1.0/rr?ts=2DAABBgABAAECAAIBAAsAAgAAAJgcGApTWGY4Y0YwcUxmHBbDzL3fk8q5rDQW7fLe5MrihOfrAQAcFsa4sqqz__SjoAEWs9K8t6_QsLixAQAWhqi9wAsVBgAsHBUCABwVAgAAHCbu-ZiDBBUEFQQm6vmYgwQW3OCegATWFAAcJsSqn4AEFrLVtYAEFurRmoEEFqD03YAEFQIcFLQBFLALABUEFQoWFCYURQoAAAA"/>\n</div>\n<iframe src="https://us-u.openx.net/w/1.0/pd?plm=6&ph=a3aece0c-9e80-4316-8deb-faf804779bd1" width="0" height="0" style="display:none;"></iframe>',
+            'crid': '538137717',
+            'w': 728,
+            'h': 90,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              }
+            }
+          }
+        ],
+        'seat': 'openx'
+      }
+    ],
+    'ext': {
+      'responsetimemillis': {
+        'appnexus': 21,
+        'openx': 123
+      }
+    }
+  },
+  'headers': {}
+}
+
+var validRequest2Ads2Bidders = {
+  'method': 'POST',
+  'url': 'https://elb.the-ozone-project.com/openrtb2/auction',
+  'data': '{"publisherId":"OZONENUK0001","siteId":"4204204201","placementId":"0420420421","id":"81fab647-f3e4-4262-a618-231c0dfbba19","auctionId":"d44d384b-7dd8-49bb-8dab-164fae1d6555","imp":[{"id":"246ecf3443c17e8","tagid":"undefined","secure":0,"banner":{"topframe":1,"w":300,"h":250,"format":[{"w":300,"h":250},{"w":300,"h":600}]},"publisherId":"OZONENUK0001","siteId":"4204204201","ext":{"prebid":{"storedrequest":{"id":"0420420421"}}}},{"id":"371102c16611c18","tagid":"undefined","secure":0,"banner":{"topframe":1,"w":728,"h":90,"format":[{"w":728,"h":90},{"w":970,"h":250}]},"publisherId":"OZONENUK0001","siteId":"4204204201","ext":{"prebid":{"storedrequest":{"id":"0420420421"}}}}]}',
+  'bidderRequest': {
+    'bidderCode': 'ozone',
+    'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
+    'bidderRequestId': '10ad92670f58ba8',
+    'bids': [
+      {
+        'bidder': 'ozone',
+        'params': {
+          'publisherId': 'OZONENUK0001',
+          'siteId': '4204204201',
+          'placementId': '0420420421',
+          'id': '81fab647-f3e4-4262-a618-231c0dfbba19',
+          'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
+          'imp': [
+            {
+              'id': '246ecf3443c17e8',
+              'tagid': 'undefined',
+              'secure': 0,
+              'banner': {
+                'topframe': 1,
+                'w': 300,
+                'h': 250,
+                'format': [
+                  {
+                    'w': 300,
+                    'h': 250
+                  },
+                  {
+                    'w': 300,
+                    'h': 600
+                  }
+                ]
+              },
+              'publisherId': 'OZONENUK0001',
+              'siteId': '4204204201',
+              'ext': {
+                'prebid': {
+                  'storedrequest': {
+                    'id': '0420420421'
+                  }
+                }
+              }
+            },
+            {
+              'id': '371102c16611c18',
+              'tagid': 'undefined',
+              'secure': 0,
+              'banner': {
+                'topframe': 1,
+                'w': 728,
+                'h': 90,
+                'format': [
+                  {
+                    'w': 728,
+                    'h': 90
+                  },
+                  {
+                    'w': 970,
+                    'h': 250
+                  }
+                ]
+              },
+              'publisherId': 'OZONENUK0001',
+              'siteId': '4204204201',
+              'ext': {
+                'prebid': {
+                  'storedrequest': {
+                    'id': '0420420421'
+                  }
+                }
+              }
+            }
+          ]
+        },
+        'adUnitCode': 'mpu',
+        'transactionId': '05c75220-47e6-4f1a-9e17-07c60fae2cc9',
+        'sizes': [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ],
+        'bidId': '246ecf3443c17e8',
+        'bidderRequestId': '10ad92670f58ba8',
+        'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
+        'bidRequestsCount': 1
+      },
+      {
+        'bidder': 'ozone',
+        'params': {
+          'publisherId': 'OZONENUK0001',
+          'siteId': '4204204201',
+          'placementId': '0420420421'
+        },
+        'adUnitCode': 'leaderboard',
+        'transactionId': 'f109a297-88a8-4806-a455-079574f76271',
+        'sizes': [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            250
+          ]
+        ],
+        'bidId': '371102c16611c18',
+        'bidderRequestId': '10ad92670f58ba8',
+        'auctionId': 'd44d384b-7dd8-49bb-8dab-164fae1d6555',
+        'bidRequestsCount': 1
+      }
+    ],
+    'auctionStart': 1544006146957,
+    'timeout': 3000,
+    'start': 1544006146960,
+    'doneCbCallCount': 1
+  }
 }
 
 describe('ozone Adapter', function () {
@@ -422,15 +654,28 @@ describe('ozone Adapter', function () {
   });
 
   describe('interpretResponse', function () {
+    // new test to verify the interpretresponse code works properly with responses of [ [bidder 1, bidder 1], [bidder 2, bidder 2] ]
+    it('should return 2 appnexus winning bids', function () {
+      const result = spec.interpretResponse(validResponse2Ads2Bidders, validRequest2Ads2Bidders);
+      console.log(['interpretResponse result  = ', result]);
+      expect(result.length).to.equal(2);
+      expect(result[0].seat).to.equal('appnexus');
+      expect(result[1].seat).to.equal('appnexus');
+    });
+
     it('should build bid array', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
+      console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
 
     it('should have all relevant fields', function () {
       const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      console.log(['Request: ', request]);
       const result = spec.interpretResponse(validResponse, request);
+      console.log(['result[0]: ', result[0]]);
       const bid = result[0];
       expect(bid.cpm).to.equal(validResponse.body.seatbid[0].bid[0].cpm);
       expect(bid.width).to.equal(validResponse.body.seatbid[0].bid[0].width);
@@ -441,7 +686,9 @@ describe('ozone Adapter', function () {
       var validBidderRequestWithGdpr = validBidderRequest;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
+      console.log(['interpretResponse request  = ', request]);
       const result = spec.interpretResponse(validResponse, request);
+      console.log(['interpretResponse result  = ', result]);
       expect(result.length).to.equal(1);
     });
   });


### PR DESCRIPTION
## Type of change
- [X] Feature


## Description of change
* Added support for custom key-value pairs in setTargeting;
* Move customData, lotameData and and ozoneData objects from top-level object into a separate ext.ozone object



