### PR TITLE
Fix requestId field

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -389,7 +389,7 @@ const LEGACY_PROTOCOL = {
           if (bidObj.deal_id) {
             bidObject.dealId = bidObj.deal_id;
           }
-          bidObject.requestId = bidRequest.bidId;
+          bidObject.requestId = bidRequest.bidId || bidRequest.bid_Id;
           bidObject.creativeId = bidObj.creative_id;
 
           // TODO: Remove when prebid-server returns ttl, currency and netRevenue
@@ -576,7 +576,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.width = bid.w;
           bidObject.height = bid.h;
           if (bid.dealid) { bidObject.dealId = bid.dealid; }
-          bidObject.requestId = bidRequest.bidId;
+          bidObject.requestId = bidRequest.bidId || bidRequest.bid_Id;
           bidObject.creative_id = bid.crid;
           bidObject.creativeId = bid.crid;
           if (bid.burl) { bidObject.burl = bid.burl; }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -389,7 +389,7 @@ const LEGACY_PROTOCOL = {
           if (bidObj.deal_id) {
             bidObject.dealId = bidObj.deal_id;
           }
-          bidObject.requestId = bidObj.bid_id;
+          bidObject.requestId = bidRequest.bidId;
           bidObject.creativeId = bidObj.creative_id;
 
           // TODO: Remove when prebid-server returns ttl, currency and netRevenue
@@ -576,7 +576,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.width = bid.w;
           bidObject.height = bid.h;
           if (bid.dealid) { bidObject.dealId = bid.dealid; }
-          bidObject.requestId = bid.id;
+          bidObject.requestId = bidRequest.bidId;
           bidObject.creative_id = bid.crid;
           bidObject.creativeId = bid.crid;
           if (bid.burl) { bidObject.burl = bid.burl; }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -844,6 +844,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('statusMessage', 'Bid available');
       expect(response).to.have.property('cpm', 0.5);
       expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('requestId', '123');
       expect(response).to.not.have.property('videoCacheKey');
       expect(response).to.have.property('cache_id', '7654321');
       expect(response).to.have.property('cache_url', 'http://www.test.com/cache?uuid=7654321');
@@ -862,6 +863,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('statusMessage', 'Bid available');
       expect(response).to.have.property('cpm', 0.5);
       expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('requestId', '123');
       expect(response).to.have.property('videoCacheKey', 'video_cache_id');
       expect(response).to.have.property('cache_id', 'video_cache_id');
       expect(response).to.have.property('cache_url', 'video_cache_url');
@@ -1015,6 +1017,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('statusMessage', 'Bid available');
       expect(response).to.have.property('bidderCode', 'appnexus');
       expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('requestId', '123');
       expect(response).to.have.property('cpm', 0.5);
     });
 
@@ -1035,6 +1038,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('mediaType', 'video');
       expect(response).to.have.property('bidderCode', 'appnexus');
       expect(response).to.have.property('adId', '123');
+      expect(response).to.have.property('requestId', '123');
       expect(response).to.have.property('cpm', 10);
     });
 


### PR DESCRIPTION
after the commit (https://github.com/prebid/Prebid.js/pull/3411/files), Rubicon is no more seeing event for Server side requests.
This is due to the requestId not correctly set up as it should be the associatedBidRequest bidid not the bid response bid id.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
