### PR TITLE
fix(unruly): avoid option request

### DIFF
--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -80,7 +80,7 @@ export const adapter = {
       bidRequests: validBidRequests,
       bidderRequest
     };
-    const options = { contentType: 'application/json' };
+    const options = { contentType: 'text/plain' };
 
     return {
       url,

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -107,10 +107,10 @@ describe('UnrulyAdapter', function () {
       const mockBidRequests = ['mockBid'];
       expect(adapter.buildRequests(mockBidRequests).method).to.equal('POST');
     });
-    it('should ensure contentType is `application/json`', function () {
+    it('should ensure contentType is `text/plain`', function () {
       const mockBidRequests = ['mockBid'];
       expect(adapter.buildRequests(mockBidRequests).options).to.deep.equal({
-        contentType: 'application/json'
+        contentType: 'text/plain'
       });
     });
     it('should return a server request with valid payload', function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Avoid making an OPTIONS request from Unruly adapter, to improve bid response time.