### PR TITLE
AdLive: filter passbacks

### DIFF
--- a/modules/adliveBidAdapter.js
+++ b/modules/adliveBidAdapter.js
@@ -44,17 +44,19 @@ export const spec = {
       const bidResponses = [];
 
       utils._each(response, function(bidResponse) {
-        bidResponses.push({
-          requestId: bidRequest.bidId,
-          cpm: bidResponse.is_passback ? 0 : bidResponse.price,
-          width: bidResponse.size[0],
-          height: bidResponse.size[1],
-          creativeId: bidResponse.hash,
-          currency: CURRENCY,
-          netRevenue: false,
-          ttl: TIME_TO_LIVE,
-          ad: bidResponse.content
-        });
+        if (!bidResponse.is_passback) {
+          bidResponses.push({
+            requestId: bidRequest.bidId,
+            cpm: bidResponse.price,
+            width: bidResponse.size[0],
+            height: bidResponse.size[1],
+            creativeId: bidResponse.hash,
+            currency: CURRENCY,
+            netRevenue: false,
+            ttl: TIME_TO_LIVE,
+            ad: bidResponse.content
+          });
+        }
       });
 
       return bidResponses;

--- a/test/spec/modules/adliveBidAdapter_spec.js
+++ b/test/spec/modules/adliveBidAdapter_spec.js
@@ -73,15 +73,6 @@ describe('adliveBidAdapterTests', function() {
     };
     let bids = spec.interpretResponse(serverResponse, bidRequestData.bids[0]);
 
-    expect(bids).to.have.lengthOf(1);
-
-    let bid = bids[0];
-
-    expect(bid.creativeId).to.equal('1e100887dd614b0909bf6c49ba7f69fdd1360437');
-    expect(bid.ad).to.equal('Ad html passback');
-    expect(bid.cpm).to.equal(0);
-    expect(bid.width).to.equal(300);
-    expect(bid.height).to.equal(250);
-    expect(bid.currency).to.equal('USD');
+    expect(bids).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Bid responses from backend with is_passback=1 will be ignored
