### PR TITLE
fixed bug with Firefox using the iframe's history instead of the top …

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -270,7 +270,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
           emitAdRenderFail(PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid);
         } else if (ad) {
-          doc.write(ad);
+          doc.open('text/html', doc.write(ad));
           doc.close();
           setRenderSize(doc, width, height);
           utils.callBurl(bid);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
The fix is for Firefox that does not handle properly the back button when using document.write, I added a document.open('text/html', document.write...) and now the back button and the history is not polluted by the iframe's document.write.

We had this issue on our sites with Firefox, version 60 to 65 (and maybe the next ones).

Source of the workaround : https://stackoverflow.com/questions/19624452/workaround-to-firefox-creating-new-history-after-each-document-write

