### PR TITLE
bugfix for Firefox for some ads that use document.write

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -270,6 +270,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
           emitAdRenderFail(PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid);
         } else if (ad) {
+          doc.open('text/html', 'replace');
           doc.write(ad);
           doc.close();
           setRenderSize(doc, width, height);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1040,6 +1040,7 @@ describe('Unit: Prebid Module', function () {
       });
       adResponse.ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
       $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      assert.ok(doc.open, 'open method called');
       assert.ok(doc.write.calledWith(adResponse.ad), 'ad was written to doc');
       assert.ok(doc.close.called, 'close method called');
     });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -990,6 +990,7 @@ describe('Unit: Prebid Module', function () {
 
     beforeEach(function () {
       doc = {
+        open: sinon.spy(),
         write: sinon.spy(),
         close: sinon.spy(),
         defaultView: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
This is a fix targeted for Firefox that creates an entry in history after a document.write. It means that when an ad uses document.write (as we see in a lot of ads on our 30 M users network), the user has to click the "back" button twice to go back. The bug is 17 years old (https://bugzilla.mozilla.org/show_bug.cgi?id=148794) and the workaround is described here for example : https://stackoverflow.com/questions/19624452/workaround-to-firefox-creating-new-history-after-each-document-write/32677679#32677679 .

