### PR TITLE
New Adapter VMG

### DIFF
--- a/modules/vmgBidAdapter.js
+++ b/modules/vmgBidAdapter.js
@@ -24,10 +24,17 @@ export const spec = {
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     let bidRequests = [];
+    let referer = window.location.href;
+    try {
+      referer = typeof bidderRequest.refererInfo === 'undefined'
+        ? window.top.location.href
+        : bidderRequest.refererInfo.referer;
+    } catch (e) {}
+
     validBidRequests.forEach(function(validBidRequest) {
       bidRequests.push({
         adUnitCode: validBidRequest.adUnitCode,
-        referer: bidderRequest.refererInfo.referer,
+        referer: referer,
         bidId: validBidRequest.bidId
       });
     });

--- a/modules/vmgBidAdapter.js
+++ b/modules/vmgBidAdapter.js
@@ -1,0 +1,79 @@
+import {registerBidder} from '../src/adapters/bidderFactory';
+const BIDDER_CODE = 'vmg';
+const ENDPOINT = 'https://predict.vmg.nyc';
+
+export const spec = {
+  code: BIDDER_CODE,
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bidRequest) {
+    if (typeof bidRequest !== 'undefined') {
+      return true;
+    } else {
+      return false;
+    }
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    let bidRequests = [];
+    validBidRequests.forEach(function(validBidRequest) {
+      bidRequests.push({
+        adUnitCode: validBidRequest.adUnitCode,
+        referer: bidderRequest.refererInfo.referer,
+        bidId: validBidRequest.bidId
+      });
+    });
+
+    return {
+      method: 'POST',
+      url: ENDPOINT,
+      data: JSON.stringify(bidRequests)
+    };
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * Some required bid params are not needed for this so default
+   * values are used.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const validBids = JSON.parse(bidRequest.data);
+    let bidResponses = [];
+    if (typeof serverResponse.body !== 'undefined') {
+      const deals = serverResponse.body;
+      validBids.forEach(function(validBid) {
+        if (typeof deals[validBid.adUnitCode] !== 'undefined') {
+          const bidResponse = {
+            requestId: validBid.bidId,
+            ad: '<div></div>',
+            cpm: 0.01,
+            width: 0,
+            height: 0,
+            dealId: deals[validBid.adUnitCode],
+            ttl: 300,
+            creativeId: '1',
+            netRevenue: '0',
+            currency: 'USD'
+          };
+
+          bidResponses.push(bidResponse);
+        }
+      });
+    }
+
+    return bidResponses;
+  }
+}
+
+registerBidder(spec);

--- a/modules/vmgBidAdapter.md
+++ b/modules/vmgBidAdapter.md
@@ -1,0 +1,28 @@
+# Overview
+
+```
+Module Name: VMG Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: paul@vmgood.com
+```
+
+# Description
+
+Connects DFP to the VMG Predict engine.
+
+# Test Parameters
+```
+  var adUnits = [{
+    code: 'div-0',
+    mediaTypes: {
+      banner: {
+          sizes: sizes
+      }
+    },
+    bids: [
+      {
+        bidder: 'vmg'
+      }
+    ]
+  }];
+```

--- a/test/spec/modules/vmgBidAdapter_spec.js
+++ b/test/spec/modules/vmgBidAdapter_spec.js
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { spec } from 'modules/vmgBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('VmgAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  })
+
+  describe('isBidRequestValid', function () {
+    let bidRequest = {
+      adUnitCode: 'div-0',
+      auctionId: 'd69cdd3f-75e3-42dc-b313-e54c0a99c757',
+      bidId: '280e2eb8ac3891',
+      bidRequestsCount: 1,
+      bidder: 'vmg',
+      bidderRequestId: '14690d27b056c8',
+      mediaTypes: {
+        banner: {
+          sizes: [ [ 970, 250 ] ]
+        }
+      },
+      sizes: [ 970, 250 ],
+      src: 'client',
+      transactionId: 'af62f065-dfa7-4564-8cb2-d277dc6069f2'
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
+  })
+
+  describe('buildRequests', function () {
+    let validBidRequests = [
+      {
+        adUnitCode: 'div-0',
+        auctionId: 'd69cdd3f-75e3-42dc-b313-e54c0a99c757',
+        bidId: '280e2eb8ac3891',
+        bidRequestsCount: 1,
+        bidder: 'vmg',
+        bidderRequestId: '14690d27b056c8',
+        mediaTypes: {
+          banner: {
+            sizes: [ [ 970, 250 ] ]
+          }
+        },
+        sizes: [ 970, 250 ],
+        src: 'client',
+        transactionId: 'af62f065-dfa7-4564-8cb2-d277dc6069f2'
+      }
+    ];
+
+    let bidderRequest = {
+      auctionId: 'd69cdd3f-75e3-42dc-b313-e54c0a99c757',
+      auctionStart: 1549316149227,
+      bidderCode: 'vmg',
+      bidderRequestId: '14690d27b056c8',
+      refererInfo: {
+        canonicalUrl: undefined,
+        numIframes: 0,
+        reachedTop: true,
+        referer: 'https://vmg.nyc/public_assets/adapt/prebid.html',
+        stack: [ 'https://vmg.nyc/public_assets/adapt/prebid.html' ]
+      },
+      start: 1549316149229,
+      timeout: 1000
+    };
+
+    it('buildRequests fires', function () {
+      let request = spec.buildRequests(validBidRequests, bidderRequest);
+      expect(request).to.exist;
+      expect(request.method).to.equal('POST');
+      expect(request.data).to.exist;
+    });
+  })
+
+  describe('interpretResponse', function () {
+    let serverResponse = {};
+    serverResponse.body = {
+      'div-0': ['test']
+    };
+
+    var bidRequest = {
+      data: '[{"adUnitCode":"div-0","referer":"https://vmg.nyc/public_assets/adapt/prebid.html","bidId":"280e2eb8ac3891"}]',
+      method: 'POST',
+      url: 'https://predict.vmg.nyc'
+    };
+
+    it('interpresResponse fires', function () {
+      let bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses[0].dealId[0]).to.equal('test');
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adapter that allows VMG's publisher partners to connect DFP to the 'VMG Predict' Engine.
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'vmg'
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
paul@vmgood.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
