### PR TITLE
Allow root configs when building with analytics

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -11,6 +11,7 @@ const gutil = require('gulp-util');
 const MODULE_PATH = './modules';
 const BUILD_PATH = './build/dist';
 const DEV_PATH = './build/dev';
+const ANALYTICS_PATH = '../analytics';
 
 
 // get only subdirectories that contain package.json with 'main' property
@@ -126,16 +127,34 @@ module.exports = {
    * Invoke with gulp <task> --analytics
    * Returns an array of source files for inclusion in build process
    */
-  getAnalyticsSources: function(directory) {
+  getAnalyticsSources: function() {
     if (!argv.analytics) {return [];} // empty arrays won't affect a standard build
 
-    const directoryContents = fs.readdirSync(directory);
+    const directoryContents = fs.readdirSync(ANALYTICS_PATH);
     return directoryContents
-      .filter(file => isModuleDirectory(path.join(directory, file)))
+      .filter(file => isModuleDirectory(path.join(ANALYTICS_PATH, file)))
       .map(moduleDirectory => {
-        const module = require(path.join(directory, moduleDirectory, MANIFEST));
-        return path.join(directory, moduleDirectory, module.main);
+        const module = require(path.join(ANALYTICS_PATH, moduleDirectory, MANIFEST));
+        return path.join(ANALYTICS_PATH, moduleDirectory, module.main);
       });
+  },
+
+  /*
+   * Returns the babel options object necessary for allowing analytics packages
+   * to have their own configs. Gets added to prebid's webpack config with the
+   * flag --analytics
+   */
+  getAnalyticsOptions: function() {
+    let options;
+
+    if (argv.analytics) {
+      // https://babeljs.io/docs/en/options#babelrcroots
+      options = {
+        babelrcRoots: ['.', ANALYTICS_PATH],
+      }
+    }
+
+    return options;
   },
 
   createEnd2EndTestReport : function(targetDestinationDir) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,6 @@ var jsEscape = require('gulp-js-escape');
 var prebid = require('./package.json');
 var dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
 var banner = '/* <%= prebid.name %> v<%= prebid.version %>\n' + dateString + ' */\n';
-var analyticsDirectory = '../analytics';
 var port = 9999;
 
 // these modules must be explicitly listed in --modules to be included in the build, won't be part of "all" modules
@@ -135,7 +134,7 @@ function makeDevpackPkg() {
   cloned.devtool = 'source-map';
   var externalModules = helpers.getArgModules();
 
-  const analyticsSources = helpers.getAnalyticsSources(analyticsDirectory);
+  const analyticsSources = helpers.getAnalyticsSources();
   const moduleSources = helpers.getModulePaths(externalModules);
 
   return gulp.src([].concat(moduleSources, analyticsSources, 'src/prebid.js'))
@@ -147,12 +146,11 @@ function makeDevpackPkg() {
 
 function makeWebpackPkg() {
   var cloned = _.cloneDeep(webpackConfig);
-
   delete cloned.devtool;
 
   var externalModules = helpers.getArgModules();
 
-  const analyticsSources = helpers.getAnalyticsSources(analyticsDirectory);
+  const analyticsSources = helpers.getAnalyticsSources();
   const moduleSources = helpers.getModulePaths(externalModules);
 
   return gulp.src([].concat(moduleSources, analyticsSources, 'src/prebid.js'))

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -28,6 +28,7 @@ module.exports = {
         use: [
           {
             loader: 'babel-loader',
+            options: helpers.getAnalyticsOptions(),
           }
         ]
       },


### PR DESCRIPTION
## Type of change
- Build related changes

## Description of change
Babel 6.x and 7.x load configuration files [differently](https://babeljs.io/docs/en/config-files#6x-vs-7x-babelrc-loading). This PR fixes an issue when building with `--analytics` caused by that difference by setting the [`babelrcRoots` ](https://babeljs.io/docs/en/options#babelrcroots) when that flag is invoked. This allows analytic packages included in the build to use their own babel configuration file.