### PR TITLE
[RFC] Support for a Custom Bid Adapter

### DIFF
--- a/modules/customBidAdapter.js
+++ b/modules/customBidAdapter.js
@@ -1,0 +1,54 @@
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { BANNER, NATIVE, VIDEO } from 'src/mediaTypes';
+
+const BIDDER_CODE = 'customBidAdapter';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   * If there is no 'isBidRequestValid' handler, the bid is considered valid .
+   *
+   * @param {object} bid The bid to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    const { handlers = {} } = bid;
+    return typeof handlers.isBidRequestValid === 'function' ? handlers.isBidRequestValid(bid) : true;
+  },
+
+  /**
+   * Make a request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server.
+   * @param {object}  bidderRequest The Bidder Request associated to the requests.
+   * @return [ServerRequest] Info describing the requests to the server.
+   */
+  buildRequests: function (bidRequests, bidderRequest) {
+    const { handlers = {} } = bidderRequest;
+    if (typeof handlers.buildRequests !== 'function') return [];
+    return handlers.buildRequests(bidRequests, bidRequest).filter(isPromise);
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @param {ServerRequest} serverRequest The server request
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, serverRequest) {
+    const { handlers = {} } = bidderRequest;
+    if (typeof handlers.interpretResponse !== 'function') return [];
+    return handlers.interpretResponse(serverResponse, serverRequest);
+  },
+
+};
+
+function isPromise(obj) {
+  return typeof obj === 'object' && obj.then && typeof obj.then === 'function';
+}
+
+registerBidder(spec);


### PR DESCRIPTION
This proposal offers the ability for a publisher to use Prebid as a global controller both for official bidders and third-parties that are not compatible with prebid.

For instance, a publisher wants to monetize a slot using its Prebid bidders (let's said appnexus, rubicon, improve ...) AND its others bidders (a9, various networks, proprietary ad sever, ...).

In order to achieve that goal, the publishers must recreate a custom logic to handle all requests (prebid + others), to wait for all responses (or timeout) and to decide who is the winner.

Dealing with 2 timeout managers or gather all responses into one array is so painful, I think using Prebid as a global controller is great feature and offers many possibilities.

I propose to add a custom bid adapter.
This adapter will fake the request/response behavior by allowing the publisher to use its custom logic to generate requests and responses. The publisher has to provide 2 handlers in order to use the existing Prebid logic (timeout management, wining decision, no response, Prebid events ...).


The publisher will use the custom bid adapter like bellow. He can add as many custom logics as he wants by using aliases.
```
pbjs.aliasBidder('customBidAdapter', 'my-ad-server');
pbjs.bidderSettings = {
    standard: {},
    'my-ad-server': {
        handlers: {
            buildRequests: myCustomHandlerToBuildRequests,
            interpretResponse: myCustomHandlerToInterpretResponses,
        }
    }
};
```

In conclusion, Publishers that still want to use networks or bidders that not have a Prebid adapter have the ability to add them easily by adding the bidder tag in the page, and updating the Prebid configuration as they already do for a new Prebid Bidder.

I pushed a PR in order to illustrate the changes needed.
If you are okay to add it to Prebid, I will update the PR to be compatible with the code requirements.