### PR TITLE
use custom bind where non-standard mootools bind could cause issues

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -169,7 +169,7 @@ function doAllSyncs(bidders) {
 
   const thisSync = bidders.pop();
   if (thisSync.no_cookie) {
-    doBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, doAllSyncs.bind(null, bidders));
+    doBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, utils.bind.call(doAllSyncs, null, bidders));
   } else {
     doAllSyncs(bidders);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "2.2.0",
+  "version": "2.3.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3038,7 +3038,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -3463,7 +3463,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -4590,7 +4590,7 @@
     "engine.io": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
-      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+      "integrity": "sha1-tgKBw1SEpw7gNR6g6/+D7IyVIqI=",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -4604,7 +4604,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4620,7 +4620,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -4640,7 +4640,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5333,7 +5333,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -5846,7 +5846,7 @@
     "flatted": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "integrity": "sha1-VRIrZTbqSWtLRIk+4mCBQdENmRY=",
       "dev": true
     },
     "flush-write-stream": {
@@ -6602,9 +6602,9 @@
       }
     },
     "fun-hooks": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/fun-hooks/-/fun-hooks-0.6.6.tgz",
-      "integrity": "sha512-Q+UdtGIpteY7Wd6z4T9MZ4GlqHtrRY1gCk+XuLyRxqgLsCaPKOOBY7EKJRFlXm1oQoNIrg2b7W55dEN55O8FBA=="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fun-hooks/-/fun-hooks-0.7.3.tgz",
+      "integrity": "sha512-AbufOkCqXQCFgQ6TDagpp1tBCrTw2G59ez2EtSFTTbtHEv9EX8xIV5A6Jparf2bxS4QoHIMEEvC1jFd2B4pBkA=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7343,7 +7343,7 @@
     "gulp-connect": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-5.7.0.tgz",
-      "integrity": "sha512-8tRcC6wgXMLakpPw9M7GRJIhxkYdgZsXwn7n56BA2bQYGLR9NOPhMzx7js+qYDy6vhNkbApGKURjAw1FjY4pNA==",
+      "integrity": "sha1-fpJfXkw06/7fnzGFdpZuj+iEDVo=",
       "dev": true,
       "requires": {
         "ansi-colors": "^2.0.5",
@@ -7360,7 +7360,7 @@
         "ansi-colors": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-2.0.5.tgz",
-          "integrity": "sha512-yAdfUZ+c2wetVNIFsNRn44THW+Lty6S5TwMpUfLA/UaGhiXbBv/F8E60/1hMLd0cnF/CDoWH8vzVaI5bAcHCjw==",
+          "integrity": "sha1-XaN4Jf7z51872kf3YNZL/RDhXhA=",
           "dev": true
         }
       }
@@ -8105,7 +8105,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -9094,7 +9094,7 @@
     "karma": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.4.tgz",
-      "integrity": "sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==",
+      "integrity": "sha1-OJDKlyKxDR0UtybhM1kxRVeISZ4=",
       "dev": true,
       "requires": {
         "bluebird": "^3.3.0",
@@ -9130,7 +9130,7 @@
         "mime": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+          "integrity": "sha1-4FH9iBNYWF8yed8zP+aU2gvP/dY=",
           "dev": true
         },
         "rimraf": {
@@ -9803,7 +9803,7 @@
     "log4js": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
-      "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+      "integrity": "sha1-5srO2Uln7uuc45n5+GgqSysoyP8=",
       "dev": true,
       "requires": {
         "circular-json": "^0.5.5",
@@ -9816,7 +9816,7 @@
         "circular-json": {
           "version": "0.5.9",
           "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-          "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
+          "integrity": "sha1-kydjroj0996teg0JyKUaR0OlOx0=",
           "dev": true
         },
         "debug": {
@@ -10337,7 +10337,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -10373,7 +10373,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -10981,7 +10981,7 @@
     "opn": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "integrity": "sha1-y1Reeqt4VivrEao7+rxwQuF2EDU=",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -10999,7 +10999,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -12591,7 +12591,7 @@
     "rfdc": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
-      "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
+      "integrity": "sha1-5uctdPXcOd6PU49l4Aw2wYAY40k=",
       "dev": true
     },
     "right-align": {
@@ -13046,7 +13046,7 @@
     "socket.io": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "integrity": "sha1-oGnF/qvuPmshSnW0DOBlLhz7mYA=",
       "dev": true,
       "requires": {
         "debug": "~3.1.0",
@@ -13060,7 +13060,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -13083,7 +13083,7 @@
     "socket.io-client": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "integrity": "sha1-3LOBA0NqtFeN2wJmOK4vIbYjZx8=",
       "dev": true,
       "requires": {
         "backo2": "1.0.2",
@@ -13105,7 +13105,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -13121,7 +13121,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -13133,7 +13133,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -13271,7 +13271,7 @@
     },
     "split": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
@@ -13399,7 +13399,7 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
@@ -14267,7 +14267,7 @@
       "dependencies": {
         "bluebird": {
           "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
           "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
           "dev": true
         }
@@ -14368,7 +14368,7 @@
     "useragent": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "integrity": "sha1-IX+UOtVAyyEoZYqyP8lg9qiMmXI=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.x",
@@ -15045,7 +15045,7 @@
     },
     "webpack-dev-middleware": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
       "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
     "crypto-js": "^3.1.9-1",
-    "fun-hooks": "^0.6.6",
+    "fun-hooks": "^0.7.1",
     "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
     "crypto-js": "^3.1.9-1",
-    "fun-hooks": "^0.6.5",
+    "fun-hooks": "^0.6.6",
     "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2"
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -157,7 +157,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
 
         const adUnitCodes = _adUnitCodes;
         const bids = _bidsReceived
-          .filter(adUnitsFilter.bind(this, adUnitCodes))
+          .filter(utils.bind.call(adUnitsFilter, this, adUnitCodes))
           .reduce(groupByPlacement, {});
         _callback.apply($$PREBID_GLOBAL$$, [bids, timedOut]);
       } catch (e) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -172,7 +172,7 @@ $$PREBID_GLOBAL$$.getAdserverTargeting = function (adUnitCode) {
 
 function getBids(type) {
   const responses = auctionManager[type]()
-    .filter(adUnitsFilter.bind(this, auctionManager.getAdUnitCodes()));
+    .filter(utils.bind.call(adUnitsFilter, this, auctionManager.getAdUnitCodes()));
 
   // find the last auction id to get responses for most recent auction only
   const currentAuctionId = auctionManager.getLastAuctionId();

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,9 +45,9 @@ export let bind = function(a, b) { return b; }.bind(null, 1, uniqueRef)() === un
   ? Function.prototype.bind
   : function(bind) {
     var self = this;
-    var args = rest(arguments, 1);
+    var args = Array.prototype.slice.call(arguments, 1);
     return function() {
-      return self.apply(bind, args.concat(rest(arguments)));
+      return self.apply(bind, args.concat(Array.prototype.slice.call(arguments)));
     };
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,17 @@ export const internal = {
   logInfo
 };
 
+var uniqueRef = {};
+export let bind = function(a, b) { return b; }.bind(null, 1, uniqueRef)() === uniqueRef
+  ? Function.prototype.bind
+  : function(bind) {
+    var self = this;
+    var args = rest(arguments, 1);
+    return function() {
+      return self.apply(bind, args.concat(rest(arguments)));
+    };
+  };
+
 /*
  *   Substitutes into a string from a given map using the token
  *   Usage


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
https://github.com/snapwich/fun-hooks/issues/1 highlighted an issue where MooTools with the compatibility layer being present on the page [can cause non-standard behavior](https://mootools.lighthouseapp.com/projects/2706/tickets/822-google-chrome-3-breaks-functionprototypebind-due-to-built-in-function-of-same-name) with `Function.prototype.bind`

Not really a bug in Prebid.js, but probably worth avoiding if we can (as it could still cause issues with Prebid.js installs).  This pull-request updates incompatible usages of `bind` to use our custom `utils.bind` which will be either `Function.prototype.bind` if the incompatible MooTools `bind` is not detected, or our custom implementation of the `bind` function if it _is_ detected.  Also updates `fun-hooks` dependency to use version with similar fix.