### PR TITLE
Add finteza analytics adapter

### DIFF
--- a/modules/fintezaAnalyticsAdapter.js
+++ b/modules/fintezaAnalyticsAdapter.js
@@ -1,0 +1,408 @@
+import { ajax } from '../src/ajax';
+import adapter from '../src/AnalyticsAdapter';
+import adapterManager from '../src/adapterManager';
+import * as utils from '../src/utils';
+import { parse as parseURL } from '../src/url';
+
+const CONSTANTS = require('../src/constants.json');
+
+const ANALYTICS_TYPE = 'endpoint';
+const FINTEZA_HOST = 'https://content.mql5.com/tr';
+const BID_REQUEST_TRACK = 'Bid Request %BIDDER%';
+const BID_RESPONSE_TRACK = 'Bid Response %BIDDER%';
+const BID_TIMEOUT_TRACK = 'Bid Timeout %BIDDER%';
+const BID_WON_TRACK = 'Bid Won %BIDDER%';
+
+const FIRST_VISIT_DATE = '_fz_fvdt';
+const SESSION_ID = '_fz_ssn';
+const SESSION_DURATION = 30 * 60 * 1000;
+const SESSION_RAND_PART = 9;
+const TRACK_TIME_KEY = '_fz_tr';
+
+function getPageInfo() {
+  const pageInfo = {
+    domain: window.location.hostname,
+  }
+
+  if (document.referrer) {
+    pageInfo.referrerDomain = parseURL(document.referrer).hostname;
+  }
+
+  return pageInfo;
+}
+
+function initFirstVisit() {
+  let now;
+  let visitDate;
+  let cookies;
+
+  try {
+    cookies = parseCookies(document.cookie);
+  } catch (a) {
+    cookies = {};
+  }
+
+  visitDate = cookies[ FIRST_VISIT_DATE ];
+
+  if (!visitDate) {
+    now = new Date();
+
+    visitDate = parseInt(now.getTime() / 1000, 10);
+
+    now.setFullYear(now.getFullYear() + 20);
+
+    try {
+      document.cookie = FIRST_VISIT_DATE + '=' + visitDate + '; path=/; expires=' + now.toUTCString();
+    } catch (e) {}
+  }
+
+  return visitDate;
+}
+
+function trim(string) {
+  if (string.trim) {
+    return string.trim();
+  }
+  return string.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+}
+
+function parseCookies(cookie) {
+  let values = {};
+  let arr, item;
+  let param, value;
+  let i, j;
+
+  if (!cookie) {
+    return {};
+  }
+
+  arr = cookie.split(';');
+
+  for (i = 0, j = arr.length; i < j; i++) {
+    item = arr[ i ];
+    if (!item) {
+      continue;
+    }
+
+    param = item.split('=');
+    if (param.length <= 1) {
+      continue;
+    }
+
+    value = decodeURIComponent(param[0]);
+    value = trim(value);
+
+    values[value] = decodeURIComponent(param[1]);
+  }
+
+  return values;
+}
+
+function getRandAsStr(digits) {
+  let str = '';
+  let rand = 0;
+  let i;
+
+  digits = digits || 4;
+
+  for (i = 0; i < digits; i++) {
+    rand = (Math.random() * 10) >>> 0;
+    str += '' + rand;
+  }
+
+  return str;
+}
+
+function getSessionBegin(session) {
+  if (!session || (typeof session !== 'string')) {
+    return 0;
+  }
+
+  const len = session.length;
+  if (len && len <= SESSION_RAND_PART) {
+    return 0;
+  }
+
+  const timestamp = session.substring(0, len - SESSION_RAND_PART);
+
+  return parseInt(timestamp, 10);
+}
+
+function initSession() {
+  const now = new Date();
+  const expires = new Date(now.getTime() + SESSION_DURATION);
+  const timestamp = Math.floor(now.getTime() / 1000);
+  let begin = 0;
+  let cookies;
+  let sessionId;
+  let sessionDuration;
+  let isNew = false;
+
+  try {
+    cookies = parseCookies(document.cookie);
+  } catch (a) {
+    cookies = {};
+  }
+
+  sessionId = cookies[ SESSION_ID ];
+
+  if (!sessionId ||
+      !checkSessionByExpires() ||
+      !checkSessionByReferer() ||
+      !checkSessionByDay()) {
+    sessionId = '' + timestamp + getRandAsStr(SESSION_RAND_PART);
+    begin = timestamp;
+
+    isNew = true;
+  } else {
+    begin = getSessionBegin(sessionId);
+  }
+
+  if (begin > 0) {
+    sessionDuration = Math.floor(timestamp - begin);
+  } else {
+    sessionDuration = -1;
+  }
+
+  try {
+    document.cookie = SESSION_ID + '=' + sessionId + '; path=/; expires=' + expires.toUTCString();
+  } catch (e) {}
+
+  return {
+    isNew: isNew,
+    id: sessionId,
+    duration: sessionDuration
+  };
+}
+
+function checkSessionByExpires() {
+  const timestamp = getTrackRequestLastTime();
+  const now = new Date().getTime();
+
+  if (now > timestamp + SESSION_DURATION) {
+    return false;
+  }
+  return true;
+}
+
+function checkSessionByReferer() {
+  const referrer = fntzAnalyticsAdapter.context.pageInfo.referrerDomain;
+  const domain = fntzAnalyticsAdapter.context.pageInfo.domain;
+
+  return referrer === '' || domain === referrer;
+}
+
+function checkSessionByDay() {
+  let last = getTrackRequestLastTime();
+  if (last) {
+    last = new Date(last);
+    const now = new Date();
+
+    return last.getUTCDate() === now.getUTCDate() &&
+      last.getUTCMonth() === now.getUTCMonth() &&
+      last.getUTCFullYear() === now.getUTCFullYear();
+  }
+
+  return false;
+}
+
+function saveTrackRequestTime() {
+  const now = new Date().getTime();
+  const expires = new Date(now + SESSION_DURATION);
+
+  try {
+    if (window.localStorage) {
+      window.localStorage.setItem(TRACK_TIME_KEY, now.toString());
+    } else {
+      document.cookie = TRACK_TIME_KEY + '=' + now + '; path=/; expires=' + expires.toUTCString();
+    }
+  } catch (a) {}
+}
+
+function getTrackRequestLastTime() {
+  let cookie;
+
+  try {
+    if (window.localStorage) {
+      return parseInt(
+        window.localStorage.getItem(TRACK_TIME_KEY) || 0,
+        10,
+      );
+    }
+
+    cookie = parseCookies(document.cookie);
+    if (cookie) {
+      cookie = cookie[ TRACK_TIME_KEY ];
+      if (cookie) {
+        return parseInt(cookie, 10);
+      }
+    }
+  } catch (e) {}
+
+  return 0;
+}
+
+function getAntiCacheParam() {
+  const date = new Date();
+  const rand = (Math.random() * 99999 + 1) >>> 0;
+
+  return ([ date.getTime(), rand ].join(''));
+}
+
+function replaceBidder(str, bidder) {
+  let _str = str;
+  _str = _str.replace(/\%bidder\%/, bidder.toLowerCase());
+  _str = _str.replace(/\%BIDDER\%/, bidder.toUpperCase());
+  _str = _str.replace(/\%Bidder\%/, bidder.charAt(0).toUpperCase() + bidder.slice(1).toLowerCase());
+
+  return _str;
+}
+
+function prepareBidRequestedParams(args) {
+  return [{
+    event: encodeURIComponent(replaceBidder(fntzAnalyticsAdapter.context.bidRequestTrack, args.bidderCode)),
+    ref: encodeURIComponent(window.location.href),
+  }];
+}
+
+function prepareBidResponseParams(args) {
+  return [{
+    event: encodeURIComponent(replaceBidder(fntzAnalyticsAdapter.context.bidResponseTrack, args.bidderCode)),
+    c1_value: args.timeToRespond,
+    c1_unit: 'ms',
+    c2_value: args.cpm,
+    c2_unit: 'usd',
+  }];
+}
+
+function prepareBidWonParams(args) {
+  return [{
+    event: encodeURIComponent(replaceBidder(fntzAnalyticsAdapter.context.bidWonTrack, args.bidderCode)),
+    c1_value: args.cpm,
+    c1_unit: 'usd',
+  }];
+}
+
+function prepareBidTimeoutParams(args) {
+  return args.map(function(bid) {
+    return {
+      event: encodeURIComponent(replaceBidder(fntzAnalyticsAdapter.context.bidTimeoutTrack, bid.bidder)),
+      c1_value: bid.timeout,
+      c1_unit: 'ms',
+    };
+  })
+}
+
+function prepareTrackData(evtype, args) {
+  let prepareParams = null;
+
+  switch (evtype) {
+    case CONSTANTS.EVENTS.BID_REQUESTED:
+      prepareParams = prepareBidRequestedParams;
+      break;
+    case CONSTANTS.EVENTS.BID_RESPONSE:
+      prepareParams = prepareBidResponseParams;
+      break;
+    case CONSTANTS.EVENTS.BID_WON:
+      prepareParams = prepareBidWonParams;
+      break;
+    case CONSTANTS.EVENTS.BID_TIMEOUT:
+      prepareParams = prepareBidTimeoutParams;
+      break;
+  }
+
+  if (!prepareParams) { return null; }
+
+  const data = prepareParams(args);
+
+  if (!data) { return null; }
+
+  const session = initSession();
+
+  return data.map(d => {
+    const trackData = Object.assign(d, {
+      id: fntzAnalyticsAdapter.context.id,
+      ref: encodeURIComponent(window.location.href),
+      title: encodeURIComponent(document.title),
+      scr_res: fntzAnalyticsAdapter.context.screenResolution,
+      fv_date: fntzAnalyticsAdapter.context.firstVisit,
+      ac: getAntiCacheParam(),
+    })
+
+    if (session.id) {
+      trackData.ssn = session.id;
+    }
+    if (session.isNew) {
+      session.isNew = false;
+      trackData.ssn_start = 1;
+    }
+    trackData.ssn_dr = session.duration;
+
+    return trackData;
+  });
+}
+
+function sendTrackRequest(trackData) {
+  try {
+    ajax(
+      fntzAnalyticsAdapter.context.host,
+      null, // Callback
+      trackData,
+      {
+        method: 'GET',
+        contentType: 'application/x-www-form-urlencoded',
+        // preflight: true,
+      },
+    );
+    saveTrackRequestTime();
+  } catch (err) {
+    utils.logError('Error on send data: ', err);
+  }
+}
+
+const fntzAnalyticsAdapter = Object.assign(
+  adapter({
+    FINTEZA_HOST,
+    ANALYTICS_TYPE
+  }),
+  {
+    track({ eventType, args }) {
+      if (typeof args !== 'undefined') {
+        const trackData = prepareTrackData(eventType, args);
+        if (!trackData) { return; }
+
+        trackData.forEach(sendTrackRequest);
+      }
+    }
+  }
+);
+
+fntzAnalyticsAdapter.originEnableAnalytics = fntzAnalyticsAdapter.enableAnalytics;
+
+fntzAnalyticsAdapter.enableAnalytics = function (config) {
+  if (!config.options.id) {
+    utils.logError('Client ID (id) option is not defined. Analytics won\'t work');
+    return;
+  }
+
+  fntzAnalyticsAdapter.context = {
+    host: config.options.host || FINTEZA_HOST,
+    id: config.options.id,
+    bidRequestTrack: config.options.bidRequestTrack || BID_REQUEST_TRACK,
+    bidResponseTrack: config.options.bidResponseTrack || BID_RESPONSE_TRACK,
+    bidTimeoutTrack: config.options.bidTimeoutTrack || BID_TIMEOUT_TRACK,
+    bidWonTrack: config.options.bidWonTrack || BID_WON_TRACK,
+    firstVisit: initFirstVisit(),
+    screenResolution: `${window.screen.width}x${window.screen.height}`,
+    pageInfo: getPageInfo(),
+  };
+
+  fntzAnalyticsAdapter.originEnableAnalytics(config);
+};
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: fntzAnalyticsAdapter,
+  code: 'finteza'
+});
+
+export default fntzAnalyticsAdapter;

--- a/modules/fintezaAnalyticsAdapter.js
+++ b/modules/fintezaAnalyticsAdapter.js
@@ -231,11 +231,9 @@ function getTrackRequestLastTime() {
     }
 
     cookie = parseCookies(document.cookie);
+    cookie = cookie[ TRACK_TIME_KEY ];
     if (cookie) {
-      cookie = cookie[ TRACK_TIME_KEY ];
-      if (cookie) {
-        return parseInt(cookie, 10);
-      }
+      return parseInt(cookie, 10);
     }
   } catch (e) {}
 

--- a/modules/fintezaAnalyticsAdapter.md
+++ b/modules/fintezaAnalyticsAdapter.md
@@ -1,0 +1,28 @@
+# Overview
+
+```
+Module Name:  Finteza Analytics Adapter
+Module Type:  Analytics Adapter
+Maintainer: renat@finteza.com
+```
+
+# Description
+
+The Finteza adapter for integration with Prebid is an analytics tool for publishers who use the Header Bidding technology. The adapter tracks auction opening, offer sending to advertisers, receipt of bids by the publisher and auction winner selection. All tracks are sent to Finteza and enable visual advertiser quality evaluation: how many offers partners accept, what prices they provide, how fast they respond and how often their bids win.
+
+For more information, visit the [official Finteza website](https://www.finteza.com/).
+
+# Test Parameters
+
+```
+{
+  provider: 'finteza',
+  options: {
+    id:               'xxxxx', // Client ID (required)
+    bidRequestTrack:  'Bid Request %BIDDER%',
+    bidResponseTrack: 'Bid Response %BIDDER%',
+    bidTimeoutTrack:  'Bid Timeout %BIDDER%',
+    bidWonTrack:      'Bid Won %BIDDER%'
+  }
+}
+```

--- a/modules/fintezaAnalyticsAdapter.md
+++ b/modules/fintezaAnalyticsAdapter.md
@@ -18,7 +18,7 @@ For more information, visit the [official Finteza website](https://www.finteza.c
 {
   provider: 'finteza',
   options: {
-    id:               'xxxxx', // Client ID (required)
+    id:               'xxxxx', // Website ID (required)
     bidRequestTrack:  'Bid Request %BIDDER%',
     bidResponseTrack: 'Bid Response %BIDDER%',
     bidTimeoutTrack:  'Bid Timeout %BIDDER%',

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -77,10 +77,10 @@ describe('finteza analytics adapter', function () {
         const url = parseURL(requests[0].url);
 
         expect(url.protocol).to.equal('https');
-        expect(url.host).to.equal('content.mql5.com');
+        expect(url.hostname).to.equal('content.mql5.com');
         expect(url.pathname).to.equal('/tr');
         expect(url.search.id).to.equal(clientId);
-        expect(url.search.event).to.equal(encodeURIComponent(`Bid Request ${bidderCode.toUpperCase()}`));
+        expect(decodeURIComponent(url.search.event)).to.equal(`Bid Request ${bidderCode.toUpperCase()}`);
 
         sinon.assert.callCount(fntzAnalyticsAdapter.track, 1);
       });
@@ -118,10 +118,10 @@ describe('finteza analytics adapter', function () {
         const url = parseURL(requests[0].url);
 
         expect(url.protocol).to.equal('https');
-        expect(url.host).to.equal('content.mql5.com');
+        expect(url.hostname).to.equal('content.mql5.com');
         expect(url.pathname).to.equal('/tr');
         expect(url.search.id).to.equal(clientId);
-        expect(url.search.event).to.equal(encodeURIComponent(`Bid Response ${bidderCode.toLowerCase()}`));
+        expect(decodeURIComponent(url.search.event)).to.equal(`Bid Response ${bidderCode.toLowerCase()}`);
         expect(url.search.c1_value).to.equal(String(timeToRespond));
         expect(url.search.c1_unit).to.equal('ms');
         expect(url.search.c2_value).to.equal(String(cpm));
@@ -158,10 +158,10 @@ describe('finteza analytics adapter', function () {
         const url = parseURL(requests[0].url);
 
         expect(url.protocol).to.equal('https');
-        expect(url.host).to.equal('content.mql5.com');
+        expect(url.hostname).to.equal('content.mql5.com');
         expect(url.pathname).to.equal('/tr');
         expect(url.search.id).to.equal(clientId);
-        expect(url.search.event).to.equal(encodeURIComponent(`Bid Won ${bidderCode.toUpperCase()}`));
+        expect(decodeURIComponent(url.search.event)).to.equal(`Bid Won ${bidderCode.toUpperCase()}`);
         expect(url.search.c1_value).to.equal(String(cpm));
         expect(url.search.c1_unit).to.equal('usd');
 
@@ -195,10 +195,10 @@ describe('finteza analytics adapter', function () {
         const url = parseURL(requests[0].url);
 
         expect(url.protocol).to.equal('https');
-        expect(url.host).to.equal('content.mql5.com');
+        expect(url.hostname).to.equal('content.mql5.com');
         expect(url.pathname).to.equal('/tr');
         expect(url.search.id).to.equal(clientId);
-        expect(url.search.event).to.equal(encodeURIComponent(`Bid Timeout Bidder789`));
+        expect(decodeURIComponent(url.search.event)).to.equal(`Bid Timeout Bidder789`);
         expect(url.search.c1_value).to.equal(String(timeout));
         expect(url.search.c1_unit).to.equal('ms');
 

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -1,0 +1,209 @@
+import fntzAnalyticsAdapter from 'modules/fintezaAnalyticsAdapter';
+import includes from 'core-js/library/fn/array/includes';
+import { expect } from 'chai';
+import { parse as parseURL } from 'src/url';
+let adapterManager = require('src/adapterManager').default;
+let events = require('src/events');
+let constants = require('src/constants.json');
+
+describe('finteza analytics adapter', function () {
+  const clientId = 'fntz-client-32145';
+
+  let xhr;
+  let requests;
+
+  beforeEach(function () {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = request => { requests.push(request) };
+    sinon.stub(events, 'getEvents').returns([]);
+    sinon.spy(fntzAnalyticsAdapter, 'track');
+
+    adapterManager.registerAnalyticsAdapter({
+      code: 'finteza',
+      adapter: fntzAnalyticsAdapter
+    });
+
+    adapterManager.enableAnalytics({
+      provider: 'finteza',
+      options: {
+        id: clientId, // Client ID (required)
+        bidRequestTrack: 'Bid Request %BIDDER%',
+        bidResponseTrack: 'Bid Response %bidder%',
+        bidTimeoutTrack: 'Bid Timeout %Bidder%',
+        bidWonTrack: 'Bid Won %BIDDER%',
+      }
+    });
+  });
+
+  afterEach(function () {
+    xhr.restore();
+    events.getEvents.restore();
+    fntzAnalyticsAdapter.track.restore();
+    fntzAnalyticsAdapter.disableAnalytics();
+  });
+
+  describe('track', () => {
+    describe('bid request', () => {
+      it('builds and sends data', function () {
+        const bidderCode = 'Bidder789';
+        const pauctionId = '5018eb39-f900-4370-b71e-3bb5b48d324f';
+
+        const bidRequest = {
+          bidderCode: bidderCode,
+          auctionId: pauctionId,
+          bidderRequestId: '1a6fc81528d0f6',
+          bids: [{
+            bidder: bidderCode,
+            placementCode: 'container-1',
+            bidId: '208750227436c1',
+            bidderRequestId: '1a6fc81528d0f6',
+            auctionId: pauctionId,
+            startTime: 1509369418389,
+            sizes: [[300, 250]],
+          }],
+          auctionStart: 1509369418387,
+          timeout: 3000,
+          start: 1509369418389
+        };
+
+        // Emit the events with the "real" arguments
+        events.emit(constants.EVENTS.BID_REQUESTED, bidRequest);
+
+        expect(requests.length).to.equal(1);
+
+        expect(requests[0].method).to.equal('GET');
+
+        const url = parseURL(requests[0].url);
+
+        expect(url.protocol).to.equal('https');
+        expect(url.host).to.equal('content.mql5.com');
+        expect(url.pathname).to.equal('/tr');
+        expect(url.search.id).to.equal(clientId);
+        expect(url.search.event).to.equal(encodeURIComponent(`Bid Request ${bidderCode.toUpperCase()}`));
+
+        sinon.assert.callCount(fntzAnalyticsAdapter.track, 1);
+      });
+    });
+
+    describe('bid response', () => {
+      it('builds and sends data', function () {
+        const bidderCode = 'Bidder789';
+        const pauctionId = '5018eb39-f900-4370-b71e-3bb5b48d324f';
+
+        const timeToRespond = 443;
+        const cpm = 0.015;
+
+        const bidResponse = {
+          bidderCode: bidderCode,
+          adId: '208750227436c1',
+          cpm: cpm,
+          auctionId: pauctionId,
+          responseTimestamp: 1509369418832,
+          requestTimestamp: 1509369418389,
+          bidder: bidderCode,
+          timeToRespond: timeToRespond,
+          size: '300x250',
+          width: 300,
+          height: 250,
+        };
+
+        // Emit the events with the "real" arguments
+        events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
+
+        expect(requests.length).to.equal(1);
+
+        expect(requests[0].method).to.equal('GET');
+
+        const url = parseURL(requests[0].url);
+
+        expect(url.protocol).to.equal('https');
+        expect(url.host).to.equal('content.mql5.com');
+        expect(url.pathname).to.equal('/tr');
+        expect(url.search.id).to.equal(clientId);
+        expect(url.search.event).to.equal(encodeURIComponent(`Bid Response ${bidderCode.toLowerCase()}`));
+        expect(url.search.c1_value).to.equal(String(timeToRespond));
+        expect(url.search.c1_unit).to.equal('ms');
+        expect(url.search.c2_value).to.equal(String(cpm));
+        expect(url.search.c2_unit).to.equal('usd');
+
+        sinon.assert.callCount(fntzAnalyticsAdapter.track, 1);
+      });
+    });
+
+    describe('bid won', () => {
+      it('builds and sends data', function () {
+        const bidderCode = 'Bidder789';
+        const pauctionId = '5018eb39-f900-4370-b71e-3bb5b48d324f';
+
+        const cpm = 0.015;
+
+        const bidWon = {
+          bidderCode: bidderCode,
+          cpm: cpm,
+          adId: 'adIdData',
+          ad: 'adContent',
+          auctionId: pauctionId,
+          width: 300,
+          height: 250
+        }
+
+        // Emit the events with the "real" arguments
+        events.emit(constants.EVENTS.BID_WON, bidWon);
+
+        expect(requests.length).to.equal(1);
+
+        expect(requests[0].method).to.equal('GET');
+
+        const url = parseURL(requests[0].url);
+
+        expect(url.protocol).to.equal('https');
+        expect(url.host).to.equal('content.mql5.com');
+        expect(url.pathname).to.equal('/tr');
+        expect(url.search.id).to.equal(clientId);
+        expect(url.search.event).to.equal(encodeURIComponent(`Bid Won ${bidderCode.toUpperCase()}`));
+        expect(url.search.c1_value).to.equal(String(cpm));
+        expect(url.search.c1_unit).to.equal('usd');
+
+        sinon.assert.callCount(fntzAnalyticsAdapter.track, 1);
+      });
+    });
+
+    describe('bid timeout', () => {
+      it('builds and sends data', function () {
+        const bidderCode = 'biDDer789';
+        const pauctionId = '5018eb39-f900-4370-b71e-3bb5b48d324f';
+
+        const timeout = 2540;
+
+        const bidTimeout = [
+          {
+            bidId: '208750227436c1',
+            bidder: bidderCode,
+            auctionId: pauctionId,
+            timeout: timeout,
+          }
+        ];
+
+        // Emit the events with the "real" arguments
+        events.emit(constants.EVENTS.BID_TIMEOUT, bidTimeout);
+
+        expect(requests.length).to.equal(1);
+
+        expect(requests[0].method).to.equal('GET');
+
+        const url = parseURL(requests[0].url);
+
+        expect(url.protocol).to.equal('https');
+        expect(url.host).to.equal('content.mql5.com');
+        expect(url.pathname).to.equal('/tr');
+        expect(url.search.id).to.equal(clientId);
+        expect(url.search.event).to.equal(encodeURIComponent(`Bid Timeout Bidder789`));
+        expect(url.search.c1_value).to.equal(String(timeout));
+        expect(url.search.c1_unit).to.equal('ms');
+
+        sinon.assert.callCount(fntzAnalyticsAdapter.track, 1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Finteza Analytics Adapter

The Finteza adapter for integration with Prebid is an analytics tool for publishers who use the Header Bidding technology. The adapter tracks auction opening, offer sending to advertisers, receipt of bids by the publisher and auction winner selection. All tracks are sent to Finteza and enable visual advertiser quality evaluation: how many offers partners accept, what prices they provide, how fast they respond and how often their bids win.

For more information, visit the [official Finteza website](https://www.finteza.com/).