### PR TITLE
update targeting's getBidsReceived to not include adpod bids

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -1,8 +1,9 @@
-import { uniques, isGptPubadsDefined, getHighestCpm, getOldestHighestCpmBid, groupBy, isAdUnitCodeMatchingSlot, timestamp } from './utils';
+import { uniques, isGptPubadsDefined, getHighestCpm, getOldestHighestCpmBid, groupBy, isAdUnitCodeMatchingSlot, timestamp, deepAccess } from './utils';
 import { config } from './config';
 import { NATIVE_TARGETING_KEYS } from './native';
 import { auctionManager } from './auctionManager';
 import { sizeSupported } from './sizeMapping';
+import { ADPOD } from './mediaTypes';
 import includes from 'core-js/library/fn/array/includes';
 
 const utils = require('./utils.js');
@@ -220,6 +221,7 @@ export function newTargeting(auctionManager) {
     }
 
     bidsReceived = bidsReceived
+      .filter(bid => deepAccess(bid, 'video.context') !== ADPOD)
       .filter(bid => bid.mediaType !== 'banner' || sizeSupported([bid.width, bid.height]))
       .filter(filters.isUnusedBid)
       .filter(filters.isBidNotExpired)

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -179,6 +179,17 @@ describe('targeting tests', function () {
       // expect the winning CPM to be equal to the sendAllBidCPM
       expect(targeting['/123456/header-bid-tag-0'][CONSTANTS.TARGETING_KEYS.PRICE_BUCKET + '_rubicon']).to.deep.equal(targeting['/123456/header-bid-tag-0'][CONSTANTS.TARGETING_KEYS.PRICE_BUCKET]);
     });
+
+    it('does not include adpod type bids in the getBidsReceived results', function () {
+      let adpodBid = utils.deepClone(bid1);
+      adpodBid.video = { context: 'adpod', durationSeconds: 15, durationBucket: 15 };
+      adpodBid.cpm = 5;
+      bidsReceived.push(adpodBid);
+
+      const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+      expect(targeting['/123456/header-bid-tag-0']).to.contain.keys('hb_deal', 'hb_adid', 'hb_bidder');
+      expect(targeting['/123456/header-bid-tag-0']['hb_adid']).to.equal(bid1.adId);
+    });
   }); // end getAllTargeting tests
 
   describe('getAllTargeting without bids return empty object', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Small change to the `getBidsReceived` function in targeting to not include `adpod` type bids when determining the winning bids or getting the targeting keys for auctions with other bid types.  

Winning 'adpod' type bids should be selected/handled by the corresponding `<...>AdserverVideo` module file.  