### PR TITLE
Sonobi - Outstream Support

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -126,6 +126,8 @@ export const spec = {
           } else {
             mediaType = 'video';
           }
+        } else {
+          mediaType = 'video';
         }
       }
 

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -8,7 +8,7 @@ const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
 const PAGEVIEW_ID = generateUUID();
 const SONOBI_DIGITRUST_KEY = 'fhnS5drwmH';
-const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/outstream.js';
+const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/outstream_renderer.js';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -282,7 +282,7 @@ function newRenderer(adUnitCode, bid, rendererOptions = {}) {
     id: bid.aid,
     url: OUTSTREAM_REDNERER_URL,
     config: rendererOptions,
-    loaded: true,
+    loaded: false,
     adUnitCode
   });
 

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -168,7 +168,10 @@ export const spec = {
             bidRequest,
             'renderer.options'
           ));
-          let videoSize = deepAccess(bidRequest, 'mediaTypes.video.size');
+          let videoSize = deepAccess(bidRequest, 'params.sizes');
+          if(Array.isArray(videoSize) && videoSize[0]) {
+            videoSize = videoSize[0] // Only take the first size for outstream
+          }
           if(videoSize) {
             videoSize = videoSize.split('x');
             bids.width = Number(videoSize[0]);

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -169,13 +169,12 @@ export const spec = {
             'renderer.options'
           ));
           let videoSize = deepAccess(bidRequest, 'params.sizes');
-          if(Array.isArray(videoSize) && videoSize[0]) {
+          if(Array.isArray(videoSize) && Array.isArray(videoSize[0])) { // handle case of multiple sizes
             videoSize = videoSize[0] // Only take the first size for outstream
           }
           if(videoSize) {
-            videoSize = videoSize.split('x');
-            bids.width = Number(videoSize[0]);
-            bids.height = Number(videoSize[1]);
+            bids.width = videoSize[0];
+            bids.height = videoSize[1];
           }
 
         }

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -8,7 +8,7 @@ const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
 const PAGEVIEW_ID = generateUUID();
 const SONOBI_DIGITRUST_KEY = 'fhnS5drwmH';
-const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/outstream_renderer.js';
+const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/sbi_outstream_renderer.js';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -117,12 +117,11 @@ export const spec = {
       const bid = bidResponse.slots[slot];
       const bidId = _getBidIdFromTrinityKey(slot);
       const bidRequest = bidderRequest.bidderRequests.find(bid => bid.bidId === bidId);
-
       let mediaType = null;
-      if(bid.sbi_ct === 'video') {
+      if (bid.sbi_ct === 'video') {
         const context = deepAccess(bidRequest, 'mediaTypes.video.context');
-        if(context) {
-          if(context === 'outstream') {
+        if (context) {
+          if (context === 'outstream') {
             mediaType = 'outstream';
           } else {
             mediaType = 'video';
@@ -159,9 +158,7 @@ export const spec = {
           delete bids.ad;
           delete bids.width;
           delete bids.height;
-        }
-
-        if(mediaType === 'outstream' && bidRequest) {
+        } else if (mediaType === 'outstream' && bidRequest) {
           bids.mediaType = 'video';
           bids.vastUrl = createCreative(bidResponse.sbi_dc, bid.sbi_aid);
           bids.renderer = newRenderer(bidRequest.adUnitCode, bids, deepAccess(
@@ -169,14 +166,13 @@ export const spec = {
             'renderer.options'
           ));
           let videoSize = deepAccess(bidRequest, 'params.sizes');
-          if(Array.isArray(videoSize) && Array.isArray(videoSize[0])) { // handle case of multiple sizes
+          if (Array.isArray(videoSize) && Array.isArray(videoSize[0])) { // handle case of multiple sizes
             videoSize = videoSize[0] // Only take the first size for outstream
           }
-          if(videoSize) {
+          if (videoSize) {
             bids.width = videoSize[0];
             bids.height = videoSize[1];
           }
-
         }
         bidsReturned.push(bids);
       }

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -196,13 +196,11 @@ export const spec = {
 };
 
 function _findBidderRequest(bidderRequests, bidId) {
-
-  for(const bidderRequest of bidderRequests) {
-    if(bidderRequest.bidId === bidId) {
-      return bidderRequest
+  for (let i = 0; i < bidderRequests.length; i++) {
+    if (bidderRequests[i].bidId === bidId) {
+      return bidderRequests[i];
     }
   }
-
 }
 
 function _validateSize (bid) {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -119,15 +119,10 @@ export const spec = {
       const bidRequest = bidderRequest.bidderRequests.find(bid => bid.bidId === bidId);
       let mediaType = null;
       if (bid.sbi_ct === 'video') {
+        mediaType = 'video';
         const context = deepAccess(bidRequest, 'mediaTypes.video.context');
-        if (context) {
-          if (context === 'outstream') {
-            mediaType = 'outstream';
-          } else {
-            mediaType = 'video';
-          }
-        } else {
-          mediaType = 'video';
+        if (context === 'outstream') {
+          mediaType = 'outstream';
         }
       }
 

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory';
-import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess, logWarn, logMessage, getBidRequest } from '../src/utils';
+import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess, logWarn, logMessage } from '../src/utils';
 import { BANNER, VIDEO } from '../src/mediaTypes';
 import { config } from '../src/config';
 import { Renderer } from '../src/Renderer';

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -116,7 +116,7 @@ export const spec = {
     Object.keys(bidResponse.slots).forEach(slot => {
       const bid = bidResponse.slots[slot];
       const bidId = _getBidIdFromTrinityKey(slot);
-      const bidRequest = bidderRequest.bidderRequests.find(bid => bid.bidId === bidId);
+      const bidRequest = _findBidderRequest(bidderRequest.bidderRequests, bidId);
       let mediaType = null;
       if (bid.sbi_ct === 'video') {
         mediaType = 'video';
@@ -194,6 +194,16 @@ export const spec = {
     return syncs;
   }
 };
+
+function _findBidderRequest(bidderRequests, bidId) {
+
+  for(const bidderRequest of bidderRequests) {
+    if(bidderRequest.bidId === bidId) {
+      return bidderRequest
+    }
+  }
+
+}
 
 function _validateSize (bid) {
   if (bid.params.sizes) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -344,6 +344,20 @@ describe('SonobiBidAdapter', function () {
           'adUnitCode': 'adunit-code-3',
           'sizes': [[120, 600], [300, 600], [160, 600]],
           'bidId': '30b31c1838de1g'
+        },
+        {
+          'bidId': '30b31c1838de1zzzz',
+          'adUnitCode': 'outstream-dom-id',
+          bidder: 'sonobi',
+          mediaTypes: {
+            video: {
+              context: 'outstream'
+            }
+          },
+          params: {
+            placement_id: '92e95368e86639dbd86d',
+            sizes: [[640, 480]]
+          }
         }
       ]
     };
@@ -374,6 +388,17 @@ describe('SonobiBidAdapter', function () {
             'sbi_mouse': 1.07,
           },
           '/7780971/sparks_prebid_LB|30b31c1838de1g': {},
+          '30b31c1838de1zzzz': {
+            sbi_aid: 'force_1550072228_da1c5d030cb49150c5db8a2136175755',
+            sbi_apoc: 'premium',
+            sbi_ct: 'video',
+            sbi_curr: 'USD',
+            sbi_mouse: 1.25,
+            sbi_size: 'preroll',
+            'sbi_crid': 'somecrid',
+
+          }
+
         },
         'sbi_dc': 'mco-1-',
         'sbi_px': [{
@@ -404,13 +429,14 @@ describe('SonobiBidAdapter', function () {
         'cpm': 1.25,
         'width': 300,
         'height': 250,
-        'ad': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
+        'vastUrl': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
         'ttl': 500,
         'creativeId': '30292e432662bd5f86d90774b944b038',
         'netRevenue': true,
         'currency': 'USD',
         'dealId': 'dozerkey',
-        'aid': '30292e432662bd5f86d90774b944b038'
+        'aid': '30292e432662bd5f86d90774b944b038',
+        'mediaType': 'video'
       },
       {
         'requestId': '30b31c1838de1g',
@@ -423,6 +449,21 @@ describe('SonobiBidAdapter', function () {
         'netRevenue': true,
         'currency': 'USD',
         'aid': '30292e432662bd5f86d90774b944b038'
+      },
+      {
+        'requestId': '30b31c1838de1zzzz',
+        'cpm': 1.25,
+        'width': 640,
+        'height': 480,
+        'vastUrl': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
+        'ttl': 500,
+        'creativeId': 'somecrid',
+        'netRevenue': true,
+        'currency': 'USD',
+        'dealId': 'dozerkey',
+        'aid': 'force_1550072228_da1c5d030cb49150c5db8a2136175755',
+        'mediaType': 'video',
+        renderer: () => {}
       },
     ];
 
@@ -437,7 +478,12 @@ describe('SonobiBidAdapter', function () {
         expect(resp.netRevenue).to.equal(prebidResponse[i].netRevenue);
         expect(resp.currency).to.equal(prebidResponse[i].currency);
         expect(resp.aid).to.equal(prebidResponse[i].aid);
-        if (resp.mediaType === 'video') {
+        if (resp.mediaType === 'video' && resp.renderer) {
+          expect(resp.vastUrl.indexOf('vast.xml')).to.be.greaterThan(0);
+          expect(resp.width).to.equal(prebidResponse[i].width);
+          expect(resp.height).to.equal(prebidResponse[i].height);
+          expect(resp.renderer).to.be.ok;
+        } else if (resp.mediaType === 'video') {
           expect(resp.vastUrl.indexOf('vast.xml')).to.be.greaterThan(0);
           expect(resp.ad).to.be.undefined;
           expect(resp.width).to.be.undefined;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added support for outstream in sonobi adapter

- test parameters for validating outstream bids
```
var adUnits = [{
            code: 'div-gpt-ad-1460505748561-0',
            sizes: [[640, 480]],
            mediaTypes: {
                video: {
                    context: 'outstream'
                }
            },
            bids: [
                {
                    bidder: 'sonobi',
                    params: {
                        placement_id: '92e95368e86639dbd86d',
                        sizes: [[640,480]]
                    }
                }
            ]
        }];
```
- apex.prebid@sonobi.com
- [x] official adapter submission
