### PR TITLE
initial setup of hook subscribe refactor

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -7,6 +7,7 @@
 import * as utils from '../src/utils';
 import { config } from '../src/config';
 import { gdprDataHandler } from '../src/adapterManager';
+// import { hookManager } from '../src/hook';
 import includes from 'core-js/library/fn/array/includes';
 import strIncludes from 'core-js/library/fn/string/includes';
 
@@ -376,6 +377,7 @@ export function setConfig(config) {
   }
   if (!addedConsentHook) {
     $$PREBID_GLOBAL$$.requestBids.before(requestBidsHook, 50);
+    // hookManager.subscribeHookFunc('requestBids', 'before', requestBidsHook, 50);
   }
   addedConsentHook = true;
 }

--- a/modules/currency.js
+++ b/modules/currency.js
@@ -3,7 +3,8 @@ import { STATUS } from '../src/constants';
 import { ajax } from '../src/ajax';
 import * as utils from '../src/utils';
 import { config } from '../src/config';
-import { hooks } from '../src/hook.js';
+// import { hooks } from '../src/hook.js';
+import { hookManager } from '../src/hook.js';
 
 const DEFAULT_CURRENCY_RATE_URL = 'https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=$$TODAY$$';
 const CURRENCY_RATE_PRECISION = 4;
@@ -122,7 +123,8 @@ function initCurrency(url) {
 
   utils.logInfo('Installing addBidResponse decorator for currency module', arguments);
 
-  hooks['addBidResponse'].before(addBidResponseHook, 100);
+  // hooks['addBidResponse'].before(addBidResponseHook, 100);
+  hookManager.subscribeHookFunc('addBidResponse', 'before', addBidResponseHook, 100);
 
   // call for the file if we haven't already
   if (needToCallForCurrencyFile) {
@@ -148,7 +150,8 @@ function initCurrency(url) {
 function resetCurrency() {
   utils.logInfo('Uninstalling addBidResponse decorator for currency module', arguments);
 
-  hooks['addBidResponse'].getHooks({hook: addBidResponseHook}).remove();
+  // hooks['addBidResponse'].getHooks({hook: addBidResponseHook}).remove();
+  hookManager.removeHook('addBidResponse', addBidResponseHook);
 
   adServerCurrency = 'USD';
   conversionCache = {};

--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -5,6 +5,7 @@
  */
 import * as utils from '../src/utils'
 import { config } from '../src/config';
+// import { hookManager } from '../src/hook';
 
 const COOKIE_NAME = '_pubcid';
 const DEFAULT_EXPIRES = 2628000; // 5-year worth of minutes
@@ -95,6 +96,7 @@ export function initPubcid() {
   if (utils.cookiesAreEnabled()) {
     if (!getCookie('_pubcid_optout')) {
       $$PREBID_GLOBAL$$.requestBids.before(requestBidHook);
+      // hookManager.subscribeHookFunc('requestBids', 'before', requestBidHook);
     }
   }
 }

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -7,6 +7,7 @@ import { nativeBidIsValid } from '../native';
 import { isValidVideoBid } from '../video';
 import CONSTANTS from '../constants.json';
 import events from '../events';
+import { hookManager } from '../hook';
 import includes from 'core-js/library/fn/array/includes';
 import { logWarn, logError, parseQueryStringParameters, delayExecution, parseSizesInput, getBidderRequest } from '../utils';
 
@@ -343,6 +344,12 @@ export function newBidder(spec) {
     }
     return true;
   }
+}
+
+hookManager.subscribeHookFunc('checkAdUnitSetup', 'before', quickTest, 5);
+function quickTest(fn, adUnits) {
+  console.log(`This is a hook... these are the adUnits object ${adUnits}`);
+  fn.call(this, adUnits);
 }
 
 // check that the bid has a width and height set

--- a/src/auction.js
+++ b/src/auction.js
@@ -55,7 +55,8 @@ import { getCacheUrl, store } from './videoCache';
 import { Renderer } from './Renderer';
 import { config } from './config';
 import { userSync } from './userSync';
-import { hook } from './hook';
+// import { hook } from './hook';
+import { hookManager } from './hook';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 import { OUTSTREAM } from './video';
@@ -318,7 +319,8 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels}) 
   }
 }
 
-export const addBidResponse = hook('async', function(adUnitCode, bid) {
+// export const addBidResponse = hook('async', function(adUnitCode, bid) {
+export const addBidResponse = hookManager.registerHook('async', function(adUnitCode, bid) {
   this.dispatch.call(this.bidderRequest, adUnitCode, bid);
 }, 'addBidResponse');
 
@@ -416,7 +418,8 @@ function tryAddVideoBid(auctionInstance, bidResponse, bidRequests, afterBidAdded
   }
 }
 
-const callPrebidCache = hook('async', function(auctionInstance, bidResponse, afterBidAdded, bidderRequest) {
+// const callPrebidCache = hook('async', function(auctionInstance, bidResponse, afterBidAdded, bidderRequest) {
+const callPrebidCache = hookManager.registerHook('async', function(auctionInstance, bidResponse, afterBidAdded, bidderRequest) {
   store([bidResponse], function (error, cacheIds) {
     if (error) {
       utils.logWarn(`Failed to save to the video cache: ${error}. Video bid must be discarded.`);

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,8 @@
 import { isValidPriceConfig } from './cpmBucketManager';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
-import { hook } from './hook';
+// import { hook } from './hook';
+import { hookManager } from './hook';
 const utils = require('./utils');
 
 const DEFAULT_DEBUG = false;
@@ -231,7 +232,8 @@ export function newConfig() {
    * Sets configuration given an object containing key-value pairs and calls
    * listeners that were added by the `subscribe` function
    */
-  let setConfig = hook('async', function setConfig(options) {
+  // let setConfig = hook('async', function setConfig(options) {
+  let setConfig = hookManager.registerHook('async', function setConfig(options) {
     if (typeof options !== 'object') {
       utils.logError('setConfig options must be an object');
       return;

--- a/src/hook.js
+++ b/src/hook.js
@@ -35,14 +35,12 @@ function createHookManager() {
    * Attempts to add a hook function onto a registered hook point.  If the hook point doesn't exist,
    * the hook function (and related information) will be stored in `listener` array so that it can be
    * loaded once the hook point has been registered.
-   * @param {*} alias
+   * @param {*} hookPoint
    * @param {*} type
    * @param {*} hookFn
    * @param {*} priority
    */
   function subscribeHookFunc (hookPoint, type, hookFn, priority) {
-    let test = hooks;
-    if (test) {}
     let hookPointType = typeof hookPoint;
 
     let doesHookPointExist;

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,5 +1,6 @@
 
 import funHooks from 'fun-hooks';
+import { logError } from './utils';
 
 export let hook = funHooks({
   ready: funHooks.SYNC | funHooks.ASYNC | funHooks.QUEUE
@@ -10,3 +11,104 @@ export let hook = funHooks({
  * @type {{}}
  */
 export const hooks = hook.hooks;
+
+function createHookManager() {
+  let listeners = [];
+
+  /**
+   * Creates a hook point and loads any previously stored hook functions that were trying to use this hook point.
+   * @param {*} type
+   * @param {*} baseFn
+   * @param {*} alias
+   */
+  function registerHook (type, baseFn, alias) {
+    let fn = hook(type, baseFn, alias);
+    if (alias === undefined) {
+      callSubscribers(baseFn);
+    } else {
+      callSubscribers(alias);
+    }
+    return fn;
+  }
+
+  /**
+   * Attempts to add a hook function onto a registered hook point.  If the hook point doesn't exist,
+   * the hook function (and related information) will be stored in `listener` array so that it can be
+   * loaded once the hook point has been registered.
+   * @param {*} alias
+   * @param {*} type
+   * @param {*} hookFn
+   * @param {*} priority
+   */
+  function subscribeHookFunc (hookPoint, type, hookFn, priority) {
+    let test = hooks;
+    if (test) {}
+    let hookPointType = typeof hookPoint;
+
+    let doesHookPointExist;
+    if (hookPointType === 'string') {
+      doesHookPointExist = !!(hooks[hookPoint]);
+    } else if (hookPointType === 'function') {
+      doesHookPointExist = !!(hookPoint.before);
+    } else {
+      logError('attempted to subscribe a hook function against an invalid hook point; the hook-point should be a function or a string');
+    }
+
+    if (!doesHookPointExist) {
+      listeners.push({hookPoint, type, hookFn, priority});
+    } else {
+      if (getHooks(hookPoint, {hook: hookFn}).length === 0) {
+        attachHook(hookPoint, type, hookFn, priority);
+      }
+    }
+  }
+
+  /**
+   * Get a particular hook or an array of all hooks.
+   * @param {*} hookPoint
+   * @param {*} options
+   */
+  function getHooks (hookPoint, options) {
+    let hookPointObj = (typeof hookPoint === 'function') ? hookPoint : hooks[hookPoint];
+    return hookPointObj.getHooks(options);
+  }
+
+  /**
+   * Remove a preivously attached hook function.
+   * @param {*} hookPoint
+   * @param {*} hookFn
+   */
+  function removeHook (hookPoint, hookFn) {
+    let targetHook = getHooks(hookPoint, {hook: hookFn});
+    targetHook.remove();
+  }
+
+  function callSubscribers(hookPoint) {
+    listeners.forEach(listener => {
+      if (listener.hookPoint === hookPoint) {
+        let {type, hookFn, priority} = listener;
+        attachHook(hookPoint, type, hookFn, priority);
+      }
+    })
+  }
+
+  function attachHook(hookPoint, type, hookFn, priority) {
+    let hookPointObj = (typeof hookPoint === 'function') ? hookPoint : hooks[hookPoint];
+
+    if (type === 'before') {
+      hookPointObj.before(hookFn, priority);
+    } else if (type === 'after') {
+      hookPointObj.after(hookFn, priority);
+    } else {
+      logError('Attempted to attach a hooked function with unknown type; use either \'before\' or \'after\'.');
+    }
+  }
+
+  return {
+    registerHook,
+    subscribeHookFunc,
+    getHooks,
+    removeHook
+  }
+}
+export const hookManager = createHookManager()

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -8,7 +8,7 @@ import { loadScript } from './adloader';
 import { config } from './config';
 import { auctionManager } from './auctionManager';
 import { targeting, getHighestCpmBidsFromBidPool } from './targeting';
-import { hook } from './hook';
+import { hook, hookManager } from './hook';
 import { sessionLoader } from './debugging';
 import includes from 'core-js/library/fn/array/includes';
 import { adunitCounter } from './adUnits';
@@ -69,7 +69,8 @@ function setRenderSize(doc, width, height) {
   }
 }
 
-const checkAdUnitSetup = hook('sync', function (adUnits) {
+const checkAdUnitSetup = hookManager.registerHook('sync', function(adUnits) {
+// const checkAdUnitSetup = hook('sync', function (adUnits) {
   adUnits.forEach((adUnit) => {
     const mediaTypes = adUnit.mediaTypes;
     const normalizedSize = utils.getAdUnitSizes(adUnit);
@@ -384,7 +385,8 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
  * @param {Array} requestOptions.labels
  * @alias module:pbjs.requestBids
  */
-$$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeout, adUnits, adUnitCodes, labels } = {}) {
+// $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeout, adUnits, adUnitCodes, labels } = {}) {
+$$PREBID_GLOBAL$$.requestBids = hookManager.registerHook('async', function ({ bidsBackHandler, timeout, adUnits, adUnitCodes, labels } = {}) {
   events.emit(REQUEST_BIDS);
   const cbTimeout = timeout || config.getConfig('bidderTimeout');
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;

--- a/src/video.js
+++ b/src/video.js
@@ -2,7 +2,8 @@ import adapterManager from './adapterManager';
 import { getBidRequest, deepAccess, logError } from './utils';
 import { config } from '../src/config';
 import includes from 'core-js/library/fn/array/includes';
-import { hook } from './hook';
+// import { hook } from './hook';
+import { hookManager } from './hook';
 
 const VIDEO_MEDIA_TYPE = 'video';
 export const OUTSTREAM = 'outstream';
@@ -42,7 +43,8 @@ export function isValidVideoBid(bid, bidRequests) {
   return checkVideoBidSetup(bid, bidRequest, videoMediaType, context);
 }
 
-const checkVideoBidSetup = hook('sync', function(bid, bidRequest, videoMediaType, context) {
+const checkVideoBidSetup = hookManager.registerHook('sync', function(bid, bidRequest, videoMediaType, context) {
+// const checkVideoBidSetup = hook('sync', function(bid, bidRequest, videoMediaType, context) {
   if (!bidRequest || (videoMediaType && context !== OUTSTREAM)) {
     // xml-only video bids require a prebid cache url
     if (!config.getConfig('cache.url') && bid.vastXml && !bid.vastUrl) {


### PR DESCRIPTION


## Type of change
- [x] Refactoring (no functional changes, no api changes)


## Description of change
Sample mock-up of a new API for the hooks logic using a subscribe methodology.  This is to address hook availability issues in the build file; specifically where attempting to attach a hook function in one file (such as bidderFactory) onto a hook point that hasn't be setup yet due to the load order of files in the build.  

This new logic will attempt to hold a function that was trying to register and will back-fill the attachment when the hook point is created.

A example of the logic working can be found in the new test hook setup in the bidderFactory.