### PR TITLE
Send placeholders for configured native assets

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -488,7 +488,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   // if there is any key value pairs to map do here
   var keyValues;
   if (bidObject.bidderCode && (bidObject.cpm > 0 || bidObject.dealId)) {
-    keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject);
+    keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject, bidReq);
   }
 
   // use any targeting provided as defaults, otherwise just set from getKeyValueTargetingPairs
@@ -563,7 +563,7 @@ export function getStandardBidderSettings(mediaType) {
   return bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD];
 }
 
-export function getKeyValueTargetingPairs(bidderCode, custBidObj) {
+export function getKeyValueTargetingPairs(bidderCode, custBidObj, bidReq) {
   if (!custBidObj) {
     return {};
   }
@@ -586,7 +586,7 @@ export function getKeyValueTargetingPairs(bidderCode, custBidObj) {
 
   // set native key value targeting
   if (custBidObj['native']) {
-    keyValues = Object.assign({}, keyValues, getNativeTargeting(custBidObj));
+    keyValues = Object.assign({}, keyValues, getNativeTargeting(custBidObj, bidReq));
   }
 
   return keyValues;

--- a/src/native.js
+++ b/src/native.js
@@ -180,3 +180,33 @@ export function getNativeTargeting(bid, bidReq) {
 
   return keyValues;
 }
+
+/**
+ *
+ */
+export function getAssetMessage(data, adObject) {
+  const message = {
+    message: 'gotLink',
+    adId: data.adId,
+    assets: [],
+  };
+
+  data.assets.forEach(nativeKey => {
+    const key = getNativeField(nativeKey);
+    const value = adObject.native[key];
+    message.assets.push({ key, value });
+  });
+
+  return message;
+}
+
+/**
+ *
+ */
+function getNativeField(key) {
+  for (let i in CONSTANTS.NATIVE_KEYS) {
+    if (CONSTANTS.NATIVE_KEYS[i] === key) {
+      return i;
+    }
+  }
+}

--- a/src/native.js
+++ b/src/native.js
@@ -1,4 +1,4 @@
-import { deepAccess, getBidRequest, logError, triggerPixel, insertHtmlIntoIframe } from './utils';
+import { deepAccess, getBidRequest, getKeyByValue, insertHtmlIntoIframe, logError, triggerPixel } from './utils';
 import includes from 'core-js/library/fn/array/includes';
 
 const CONSTANTS = require('./constants.json');
@@ -182,31 +182,22 @@ export function getNativeTargeting(bid, bidReq) {
 }
 
 /**
- *
+ * Constructs a message object containing asset values for each of the
+ * requested data keys.
  */
 export function getAssetMessage(data, adObject) {
   const message = {
-    message: 'gotLink',
+    message: 'assetResponse',
     adId: data.adId,
     assets: [],
   };
 
-  data.assets.forEach(nativeKey => {
-    const key = getNativeField(nativeKey);
+  data.assets.forEach(asset => {
+    const key = getKeyByValue(CONSTANTS.NATIVE_KEYS, asset);
     const value = adObject.native[key];
+
     message.assets.push({ key, value });
   });
 
   return message;
-}
-
-/**
- *
- */
-function getNativeField(key) {
-  for (let i in CONSTANTS.NATIVE_KEYS) {
-    if (CONSTANTS.NATIVE_KEYS[i] === key) {
-      return i;
-    }
-  }
 }

--- a/src/native.js
+++ b/src/native.js
@@ -151,7 +151,7 @@ export function fireNativeTrackers(message, adObject) {
  * @param {Object} bid
  * @return {Object} targeting
  */
-export function getNativeTargeting(bid) {
+export function getNativeTargeting(bid, bidReq) {
   let keyValues = {};
 
   Object.keys(bid['native']).forEach(asset => {
@@ -161,6 +161,16 @@ export function getNativeTargeting(bid) {
     // native image-type assets can be a string or an object with a url prop
     if (typeof value === 'object' && value.url) {
       value = value.url;
+    }
+
+    const sendPlaceholder = deepAccess(
+      bidReq,
+      `mediaTypes.native.${asset}.usePlaceholder`
+    );
+
+    if (sendPlaceholder) {
+      const placeholder = `${key}:${bid.adId}`;
+      value = placeholder;
     }
 
     if (key && value) {

--- a/src/native.js
+++ b/src/native.js
@@ -165,7 +165,7 @@ export function getNativeTargeting(bid, bidReq) {
 
     const sendPlaceholder = deepAccess(
       bidReq,
-      `mediaTypes.native.${asset}.usePlaceholder`
+      `mediaTypes.native.${asset}.sendId`
     );
 
     if (sendPlaceholder) {

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -4,7 +4,7 @@
  */
 
 import events from './events';
-import { fireNativeTrackers } from './native';
+import { fireNativeTrackers, getAssetMessage } from './native';
 import { EVENTS } from './constants';
 import { isSlotMatchingAdUnitCode, logWarn, replaceAuctionPrice } from './utils';
 import { auctionManager } from './auctionManager';
@@ -46,6 +46,12 @@ function receiveMessage(ev) {
     //   adId: '%%PATTERN:hb_adid%%'
     // }), '*');
     if (data.message === 'Prebid Native') {
+      if (data.action === 'requestAssets') {
+        const message = getAssetMessage(data, adObject);
+        ev.source.postMessage(JSON.stringify(message), ev.origin);
+        return;
+      }
+
       fireNativeTrackers(data, adObject);
       auctionManager.addWinningBid(adObject);
       events.emit(BID_WON, adObject);

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -46,7 +46,7 @@ function receiveMessage(ev) {
     //   adId: '%%PATTERN:hb_adid%%'
     // }), '*');
     if (data.message === 'Prebid Native') {
-      if (data.action === 'requestAssets') {
+      if (data.action === 'assetRequest') {
         const message = getAssetMessage(data, adObject);
         ev.source.postMessage(JSON.stringify(message), ev.origin);
         return;

--- a/src/utils.js
+++ b/src/utils.js
@@ -772,6 +772,19 @@ export function getValue(obj, key) {
   return obj[key];
 }
 
+/**
+ * Get the key of an object for a given value
+ */
+export function getKeyByValue(obj, value) {
+  for (let prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      if (obj[prop] === value) {
+        return prop;
+      }
+    }
+  }
+}
+
 export function getBidderCodes(adUnits = $$PREBID_GLOBAL$$.adUnits) {
   // this could memoize adUnits
   return adUnits.map(unit => unit.bids.map(bid => bid.bidder)

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -55,8 +55,8 @@ describe('native.js', function () {
     const bidRequest = {
       mediaTypes: {
         native: {
-          body: { usePlaceholder: true },
-          clickUrl: { usePlaceholder: true },
+          body: { sendId: true },
+          clickUrl: { sendId: true },
         }
       }
     };

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -93,13 +93,22 @@ describe('native.js', function () {
   it('creates native asset message', function() {
     const messageRequest = {
       message: 'Prebid Native',
-      action: 'requestAssets',
+      action: 'assetRequest',
       adId: '123',
       assets: ['hb_native_body', 'hb_native_linkurl'],
     };
 
     const message = getAssetMessage(messageRequest, bid);
+
     expect(message.assets.length).to.equal(2);
+    expect(message.assets).to.deep.include({
+      key: 'body',
+      value: bid.native.body
+    });
+    expect(message.assets).to.deep.include({
+      key: 'clickUrl',
+      value: bid.native.clickUrl
+    });
   });
 });
 

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -4,6 +4,7 @@ import CONSTANTS from 'src/constants.json';
 const utils = require('src/utils');
 
 const bid = {
+  adId: '123',
   native: {
     title: 'Native Creative',
     body: 'Cool description great stuff',
@@ -48,6 +49,22 @@ describe('native.js', function () {
     expect(targeting[CONSTANTS.NATIVE_KEYS.title]).to.equal(bid.native.title);
     expect(targeting[CONSTANTS.NATIVE_KEYS.body]).to.equal(bid.native.body);
     expect(targeting[CONSTANTS.NATIVE_KEYS.clickUrl]).to.equal(bid.native.clickUrl);
+  });
+
+  it('sends placeholders for configured assets', function () {
+    const bidRequest = {
+      mediaTypes: {
+        native: {
+          body: { usePlaceholder: true },
+          clickUrl: { usePlaceholder: true },
+        }
+      }
+    };
+    const targeting = getNativeTargeting(bid, bidRequest);
+
+    expect(targeting[CONSTANTS.NATIVE_KEYS.title]).to.equal(bid.native.title);
+    expect(targeting[CONSTANTS.NATIVE_KEYS.body]).to.equal('hb_native_body:123');
+    expect(targeting[CONSTANTS.NATIVE_KEYS.clickUrl]).to.equal('hb_native_linkurl:123');
   });
 
   it('should only include native targeting keys with values', function () {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { fireNativeTrackers, getNativeTargeting, nativeBidIsValid } from 'src/native';
+import { fireNativeTrackers, getNativeTargeting, nativeBidIsValid, getAssetMessage } from 'src/native';
 import CONSTANTS from 'src/constants.json';
 const utils = require('src/utils');
 
@@ -88,6 +88,18 @@ describe('native.js', function () {
     fireNativeTrackers({ action: 'click' }, bid);
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
+  });
+
+  it('creates native asset message', function() {
+    const messageRequest = {
+      message: 'Prebid Native',
+      action: 'requestAssets',
+      adId: '123',
+      assets: ['hb_native_body', 'hb_native_linkurl'],
+    };
+
+    const message = getAssetMessage(messageRequest, bid);
+    expect(message.assets.length).to.equal(2);
   });
 });
 


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Transmitting some types of native assets via querystring parameters can cause issues. For example, large strings may exceed an adserver's url call limit, and special characters can get mangled. This PR introduces a configuration option to send placeholder values in adserver targeting, instead of asset values. The native creative template can then replace the placeholder values with the actual values through a postmessage request to Prebid ([a PR to the native functionality in prebid-universal-creative](https://github.com/prebid/prebid-universal-creative/pull/56) will do this automatically).

Given the configuration:
```JavaScript
pbjs.addAdUnits({
  code: slot.code,

  mediaTypes: {
    native: {
      body: {
        required: false,
        sendId: true
      },
      clickUrl: {
        required: true,
        sendId: true
      },
    },
  },

  bids: [...]
});
```

The `body` and `clickUrl` assets will be sent as placeholder values `hb_native_body:<adId>` and `hb_native_linkurl:<adId>`. All other native assets will be sent normally.