### PR TITLE
Add buyer data to Index Exchange bid responses

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -77,6 +77,11 @@ function parseBid(rawBid, currency) {
   bid.currency = currency;
   bid.creativeId = rawBid.hasOwnProperty('crid') ? rawBid.crid : '-';
 
+  bid.meta = {};
+  bid.meta.networkId = utils.deepAccess(rawBid, 'ext.dspid');
+  bid.meta.brandId = utils.deepAccess(rawBid, 'ext.advbrandid');
+  bid.meta.brandName = utils.deepAccess(rawBid, 'ext.advbrand');
+
   return bid;
 }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -424,7 +424,12 @@ describe('IndexexchangeAdapter', function () {
           currency: 'USD',
           ttl: 35,
           netRevenue: true,
-          dealId: undefined
+          dealId: undefined,
+          meta: {
+            networkId: 50,
+            brandId: 303325,
+            brandName: 'OECTA'
+          }
         }
       ];
       const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE });
@@ -445,7 +450,12 @@ describe('IndexexchangeAdapter', function () {
           currency: 'USD',
           ttl: 35,
           netRevenue: true,
-          dealId: undefined
+          dealId: undefined,
+          meta: {
+            networkId: 50,
+            brandId: 303325,
+            brandName: 'OECTA'
+          }
         }
       ];
       const result = spec.interpretResponse({ body: bidResponse });
@@ -466,7 +476,12 @@ describe('IndexexchangeAdapter', function () {
           currency: 'JPY',
           ttl: 35,
           netRevenue: true,
-          dealId: undefined
+          dealId: undefined,
+          meta: {
+            networkId: 50,
+            brandId: 303325,
+            brandName: 'OECTA'
+          }
         }
       ];
       const result = spec.interpretResponse({ body: bidResponse });
@@ -487,7 +502,12 @@ describe('IndexexchangeAdapter', function () {
           currency: 'USD',
           ttl: 35,
           netRevenue: true,
-          dealId: 'deal'
+          dealId: 'deal',
+          meta: {
+            networkId: 50,
+            brandId: 303325,
+            brandName: 'OECTA'
+          }
         }
       ];
       const result = spec.interpretResponse({ body: bidResponse });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds buyer data to Index Exchange responses, following the format specified in https://github.com/prebid/Prebid.js/issues/3115.
We have already made this change to our fork, [here](https://github.com/guardian/Prebid.js/pull/80).

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
/cc @ix-prebid-support
