### PR TITLE
Fix event firing on native click

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -144,6 +144,7 @@ export function fireNativeTrackers(message, adObject) {
   }
 
   (trackers || []).forEach(triggerPixel);
+  return message.action;
 }
 
 /**

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -52,7 +52,9 @@ function receiveMessage(ev) {
         return;
       }
 
-      fireNativeTrackers(data, adObject);
+      const trackerType = fireNativeTrackers(data, adObject);
+      if (trackerType === 'click') { return; }
+
       auctionManager.addWinningBid(adObject);
       events.emit(BID_WON, adObject);
     }

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -85,7 +85,8 @@ describe('native.js', function () {
   });
 
   it('fires click trackers', function () {
-    fireNativeTrackers({ action: 'click' }, bid);
+    const trackerType = fireNativeTrackers({ action: 'click' }, bid);
+    expect(trackerType).to.equal('click');
     sinon.assert.calledOnce(triggerPixelStub);
     sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
   });


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Fixes bug where `BID_WON` event was firing when a native click track message was received. The `BID_WON` event for a native ad will still fire when the 'Prebid Native' message is received when the ad initially loads, but won't happen again for clicks fired from that ad