### PR TITLE
Return mediaType:video in unruly adapter

### DIFF
--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -29,7 +29,8 @@ const serverResponseToBid = (bid, rendererInstance) => ({
   creativeId: bid.bidId,
   ttl: 360,
   currency: 'USD',
-  renderer: rendererInstance
+  renderer: rendererInstance,
+  mediaType: VIDEO
 });
 
 const buildPrebidResponseAndInstallRenderer = bids =>

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -146,7 +146,8 @@ describe('UnrulyAdapter', function () {
           creativeId: 'mockBidId',
           ttl: 360,
           currency: 'USD',
-          renderer: fakeRenderer
+          renderer: fakeRenderer,
+          mediaType: 'video'
         }
       ])
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
Changes unruly's bid responses to state mediaType: 'video' instead of 'banner'. 

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
   "bidder": "unruly",
    "params": {
        "siteId": 1081534,
        "targetingUUID": "6f15e139-5f18-49a1-b52f-87e5e69ee65e",
    }
}
```

- Bid Adapter Maintainer:  ryan.chou@ucfunnel.com

@RyanChouTw 