### PR TITLE
Add External Id support to the Yieldlab bidder

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -77,6 +77,7 @@ export const spec = {
       if (matchedBid) {
         const primarysize = bidRequest.sizes.length === 2 && !utils.isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0]
         const customsize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : primarysize
+        const extId = bidRequest.params.extId !== undefined ? '&id=' + bidRequest.params.extId : ''
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
@@ -88,11 +89,12 @@ export const spec = {
           netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
-          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}"></script>`
+          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}"></script>`
         }
+
         if (isVideo(bidRequest)) {
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}`
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}`
         }
 
         bidResponses.push(bidResponse)

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -25,7 +25,8 @@ Module that connects to Yieldlab's demand sources
                        targeting: {
                            key1: "value1",
                            key2: "value2"
-                       }
+                       },
+                       extId: "abc"
                    }
                }]
            }, {

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -11,7 +11,8 @@ const REQUEST = {
     'targeting': {
       'key1': 'value1',
       'key2': 'value2'
-    }
+    },
+    'extId': 'abc'
   },
   'bidderRequestId': '143346cf0f1731',
   'auctionId': '2e41f65424c87c',
@@ -104,6 +105,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].ttl).to.equal(300)
       expect(result[0].referrer).to.equal('')
       expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].ad).to.include('&id=abc')
     })
 
     it('should get correct bid response when passing more than one size', function () {
@@ -127,6 +129,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].ttl).to.equal(300)
       expect(result[0].referrer).to.equal('')
       expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].ad).to.include('&id=abc')
     })
 
     it('should add vastUrl when type is video', function () {
@@ -143,6 +146,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].cpm).to.equal(0.01)
       expect(result[0].mediaType).to.equal('video')
       expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].vastUrl).to.include('&id=abc')
     })
   })
 })


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on prebid.org?
Corresponding PR: https://github.com/prebid/prebid.github.io/pull/1178

## Description of change
- Add support for External Id
The External Id is a dynamic reporting dimension, that can be passed through Yieldlab's adtag via the "id"-parameter. E.g.  https://ad.yieldlab.net/d/1111/2222/728x90?ts=123456789&id=abc

- contact email of the adapter’s maintainer
solutions@yieldlab.de
- [x] official adapter submission