### PR TITLE
Add HTML5 video support param to bid requests

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -12,12 +12,13 @@ export const sharethroughAdapterSpec = {
   buildRequests: (bidRequests, bidderRequest) => {
     return bidRequests.map(bid => {
       let query = {
-        bidId: bid.bidId,
         placement_key: bid.params.pkey,
-        hbVersion: '$prebid.version$',
-        strVersion: VERSION,
+        bidId: bid.bidId,
+        consent_required: false,
+        instant_play_capable: canAutoPlayHTML5Video(),
         hbSource: 'prebid',
-        consent_required: false
+        hbVersion: '$prebid.version$',
+        strVersion: VERSION
       };
 
       if (bidderRequest && bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString) {
@@ -146,6 +147,27 @@ function b64EncodeUnicode(str) {
       function toSolidBytes(match, p1) {
         return String.fromCharCode('0x' + p1);
       }));
+}
+
+function canAutoPlayHTML5Video() {
+  var userAgent = navigator.userAgent;
+  if (!userAgent) return false;
+
+  var isAndroid = /Android/i.test(userAgent);
+  var isiOS = /iPhone|iPad|iPod/i.test(userAgent);
+  var chromeVersion = parseInt((/Chrome\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+  var chromeiOSVersion = parseInt((/CriOS\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+  var safariVersion = parseInt((/Version\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+
+  if (
+    (isAndroid && chromeVersion >= 53) ||
+    (isiOS && (safariVersion >= 10 || chromeiOSVersion >= 53)) ||
+    !(isAndroid || isiOS)
+  ) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 registerBidder(sharethroughAdapterSpec);

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -150,14 +150,14 @@ function b64EncodeUnicode(str) {
 }
 
 function canAutoPlayHTML5Video() {
-  var userAgent = navigator.userAgent;
+  const userAgent = navigator.userAgent;
   if (!userAgent) return false;
 
-  var isAndroid = /Android/i.test(userAgent);
-  var isiOS = /iPhone|iPad|iPod/i.test(userAgent);
-  var chromeVersion = parseInt((/Chrome\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
-  var chromeiOSVersion = parseInt((/CriOS\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
-  var safariVersion = parseInt((/Version\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+  const isAndroid = /Android/i.test(userAgent);
+  const isiOS = /iPhone|iPad|iPod/i.test(userAgent);
+  const chromeVersion = parseInt((/Chrome\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+  const chromeiOSVersion = parseInt((/CriOS\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
+  const safariVersion = parseInt((/Version\/([0-9]+)/.exec(userAgent) || [0, 0])[1]);
 
   if (
     (isAndroid && chromeVersion >= 53) ||


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Sharethrough's adapter has been updated to include a parameter sent to our ad server that helps ensure the delivery of HTML5 video demand when available and allowed.

- mduran@sharethrough.com
- [x] official adapter submission