### PR TITLE
add default sizes value for appnexus native requests

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -508,6 +508,9 @@ function bidToTag(bid) {
 
   if (bid.mediaType === NATIVE || utils.deepAccess(bid, `mediaTypes.${NATIVE}`)) {
     tag.ad_types.push(NATIVE);
+    if (tag.sizes.length === 0) {
+      tag.sizes = transformSizes([1, 1]);
+    }
 
     if (bid.nativeParams) {
       const nativeRequest = buildNativeRequest(bid.nativeParams);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -443,6 +443,30 @@ describe('AppNexusAdapter', function () {
       });
     });
 
+    it('should always populated tags[].sizes with 1,1 for native if otherwise not defined', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          mediaType: 'native',
+          nativeParams: {
+            image: { required: true }
+          }
+        }
+      );
+      bidRequest.sizes = [[150, 100], [300, 250]];
+
+      let request = spec.buildRequests([bidRequest]);
+      let payload = JSON.parse(request.data);
+      expect(payload.tags[0].sizes).to.deep.equal([{width: 150, height: 100}, {width: 300, height: 250}]);
+
+      delete bidRequest.sizes;
+
+      request = spec.buildRequests([bidRequest]);
+      payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].sizes).to.deep.equal([{width: 1, height: 1}]);
+    });
+
     it('should convert keyword params to proper form and attaches to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -913,7 +913,7 @@ describe('adapterManager tests', function () {
         setSizeConfig([]);
       });
 
-      it('should not filter bids w/ no labels', function () {
+      it('should not filter banner bids w/ no labels', function () {
         let bidRequests = adapterManager.makeBidRequests(
           adUnits,
           Date.now(),
@@ -931,6 +931,85 @@ describe('adapterManager tests', function () {
         expect(appnexusBidRequests.bids.length).to.equal(2);
         expect(appnexusBidRequests.bids[0].sizes).to.deep.equal(find(adUnits, adUnit => adUnit.code === appnexusBidRequests.bids[0].adUnitCode).sizes);
         expect(appnexusBidRequests.bids[1].sizes).to.deep.equal(find(adUnits, adUnit => adUnit.code === appnexusBidRequests.bids[1].adUnitCode).sizes);
+      });
+
+      it('should not filter video bids', function () {
+        setSizeConfig([{
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'sizesSupported': [
+            [728, 90],
+            [300, 250]
+          ],
+          'labels': ['tablet', 'phone']
+        }]);
+
+        let videoAdUnits = [{
+          code: 'test_video',
+          mediaTypes: {
+            video: {
+              playerSize: [300, 300],
+              context: 'outstream'
+            }
+          },
+          bids: [{
+            bidder: 'appnexus',
+            params: {
+              placementId: 13232385,
+              video: {
+                skippable: true,
+                playback_method: ['auto_play_sound_off']
+              }
+            }
+          }]
+        }];
+        let bidRequests = adapterManager.makeBidRequests(
+          videoAdUnits,
+          Date.now(),
+          utils.getUniqueIdentifierStr(),
+          function callback() {},
+          []
+        );
+        expect(bidRequests[0].bids[0].sizes).to.deep.equal([300, 300]);
+      });
+
+      it('should not filter native bids', function () {
+        setSizeConfig([{
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'sizesSupported': [
+            [728, 90],
+            [300, 250]
+          ],
+          'labels': ['tablet', 'phone']
+        }]);
+
+        let nativeAdUnits = [{
+          code: 'test_native',
+          sizes: [[1, 1]],
+          mediaTypes: {
+            native: {
+              title: { required: true },
+              body: { required: false },
+              image: { required: true },
+              icon: { required: false },
+              sponsoredBy: { required: true },
+              clickUrl: { required: true },
+            },
+          },
+          bids: [
+            {
+              bidder: 'appnexus',
+              params: { placementId: 13232354 }
+            },
+          ]
+        }];
+        let bidRequests = adapterManager.makeBidRequests(
+          nativeAdUnits,
+          Date.now(),
+          utils.getUniqueIdentifierStr(),
+          function callback() {},
+          []
+        );
+        expect(bidRequests[0].bids[0].sizes).to.deep.equal([]);
       });
 
       it('should filter sizes using size config', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This change adds a 1x1 default size for native placements in the UT request when the `sizes` field is otherwise empty. 

### Context
When sending bid requests to the UT endpoint that target a multi-format placement (eg banner + native), depending on the setup of the adUnit - the `sizes` information is not included into the request.  

One example happens when you're only requesting for a native bid against a multi-format placement; since `sizes` aren't typically associated with native bids - the `sizes` field is left empty.  

When sizes information is empty but it's expected, the UT request returns an `{error: parse}` response.

The `[1, 1]` size is commonly associated for native requests, so it was recommended to set this size to address the error returned by this type of situation.