### PR TITLE
fix two issues related to hb_uuid and hb_cache_id targeting keys

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -159,10 +159,10 @@ function getCustParams(bid, options) {
   const optCustParams = deepAccess(options, 'params.cust_params');
   let customParams = Object.assign({},
     allTargetingData,
-    adserverTargeting,
     { hb_uuid: bid && bid.videoCacheKey },
     // hb_uuid will be deprecated and replaced by hb_cache_id
     { hb_cache_id: bid && bid.videoCacheKey },
+    adserverTargeting,
     optCustParams,
   );
   return encodeURIComponent(formatQS(customParams));

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -159,9 +159,6 @@ function getCustParams(bid, options) {
   const optCustParams = deepAccess(options, 'params.cust_params');
   let customParams = Object.assign({},
     allTargetingData,
-    { hb_uuid: bid && bid.videoCacheKey },
-    // hb_uuid will be deprecated and replaced by hb_cache_id
-    { hb_cache_id: bid && bid.videoCacheKey },
     adserverTargeting,
     optCustParams,
   );

--- a/src/auction.js
+++ b/src/auction.js
@@ -431,11 +431,6 @@ const callPrebidCache = hook('async', function(auctionInstance, bidResponse, aft
         doCallbacksIfTimedout(auctionInstance, bidResponse);
       } else {
         bidResponse.videoCacheKey = cacheIds[0].uuid;
-        let cacheTargetKeys = {
-          hb_uuid: cacheIds[0].uuid,
-          hb_cache_id: cacheIds[0].uuid
-        };
-        bidResponse.adserverTargeting = Object.assign(bidResponse.adserverTargeting || {}, cacheTargetKeys);
 
         if (!bidResponse.vastUrl) {
           bidResponse.vastUrl = getCacheUrl(bidResponse.videoCacheKey);
@@ -502,8 +497,14 @@ function setupBidTargeting(bidObject) {
     keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject);
   }
 
+  let cacheTargetKeys = {};
+  if (bidObject.videoCacheKey) {
+    cacheTargetKeys.hb_uuid = bidObject.videoCacheKey;
+    cacheTargetKeys.hb_cache_id = bidObject.videoCacheKey;
+  }
+
   // use any targeting provided as defaults, otherwise just set from getKeyValueTargetingPairs
-  bidObject.adserverTargeting = Object.assign(bidObject.adserverTargeting || {}, keyValues);
+  bidObject.adserverTargeting = Object.assign(bidObject.adserverTargeting || {}, cacheTargetKeys, keyValues);
 }
 
 export function getStandardBidderSettings(mediaType) {

--- a/src/auction.js
+++ b/src/auction.js
@@ -386,7 +386,9 @@ export function doCallbacksIfTimedout(auctionInstance, bidResponse) {
 
 // Add a bid to the auction.
 export function addBidToAuction(auctionInstance, bidResponse) {
-  setupBidTargeting(bidResponse);
+  let bidderRequests = auctionInstance.getBidRequests();
+  let bidderRequest = find(bidderRequests, bidderRequest => bidderRequest.bidderCode === bidResponse.bidderCode);
+  setupBidTargeting(bidResponse, bidderRequest);
 
   events.emit(CONSTANTS.EVENTS.BID_RESPONSE, bidResponse);
   auctionInstance.addBidReceived(bidResponse);
@@ -491,9 +493,10 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   return bidObject;
 }
 
-function setupBidTargeting(bidObject) {
+function setupBidTargeting(bidObject, bidderRequest) {
   let keyValues;
   if (bidObject.bidderCode && (bidObject.cpm > 0 || bidObject.dealId)) {
+    let bidReq = find(bidderRequest.bids, bid => bid.adUnitCode === bidObject.adUnitCode);
     keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject, bidReq);
   }
 

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -10,7 +10,10 @@ import { targeting } from 'src/targeting';
 
 const bid = {
   videoCacheKey: 'abc',
-  adserverTargeting: { },
+  adserverTargeting: {
+    hb_uuid: 'abc',
+    hb_cache_id: 'abc',
+  },
 };
 
 describe('The DFP video support module', function () {
@@ -40,7 +43,7 @@ describe('The DFP video support module', function () {
   });
 
   it('can take an adserver url as a parameter', function () {
-    const bidCopy = Object.assign({ }, bid);
+    const bidCopy = utils.deepClone(bid);
     bidCopy.vastUrl = 'vastUrl.example';
 
     const url = parse(buildDfpVideoUrl({
@@ -90,10 +93,10 @@ describe('The DFP video support module', function () {
   });
 
   it('should include the cache key and adserver targeting in cust_params', function () {
-    const bidCopy = Object.assign({ }, bid);
-    bidCopy.adserverTargeting = {
+    const bidCopy = utils.deepClone(bid);
+    bidCopy.adserverTargeting = Object.assign(bidCopy.adserverTargeting, {
       hb_adid: 'ad_id',
-    };
+    });
 
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
@@ -160,10 +163,10 @@ describe('The DFP video support module', function () {
         }
       });
 
-      const bidCopy = Object.assign({ }, bid);
-      bidCopy.adserverTargeting = {
+      const bidCopy = utils.deepClone(bid);
+      bidCopy.adserverTargeting = Object.assign(bidCopy.adserverTargeting, {
         hb_adid: 'ad_id',
-      };
+      });
 
       const url = parse(buildDfpVideoUrl({
         adUnit: adUnitsCopy,
@@ -184,10 +187,10 @@ describe('The DFP video support module', function () {
   });
 
   it('should merge the user-provided cust_params with the default ones', function () {
-    const bidCopy = Object.assign({ }, bid);
-    bidCopy.adserverTargeting = {
+    const bidCopy = utils.deepClone(bid);
+    bidCopy.adserverTargeting = Object.assign(bidCopy.adserverTargeting, {
       hb_adid: 'ad_id',
-    };
+    });
 
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
@@ -207,10 +210,10 @@ describe('The DFP video support module', function () {
   });
 
   it('should merge the user-provided cust-params with the default ones when using url object', function () {
-    const bidCopy = Object.assign({ }, bid);
-    bidCopy.adserverTargeting = {
+    const bidCopy = utils.deepClone(bid);
+    bidCopy.adserverTargeting = Object.assign(bidCopy.adserverTargeting, {
       hb_adid: 'ad_id',
-    };
+    });
 
     const url = parse(buildDfpVideoUrl({
       adUnit: adUnit,
@@ -229,7 +232,7 @@ describe('The DFP video support module', function () {
   });
 
   it('should not overwrite an existing description_url for object input and cache disabled', function () {
-    const bidCopy = Object.assign({}, bid);
+    const bidCopy = utils.deepClone(bid);
     bidCopy.vastUrl = 'vastUrl.example';
 
     const url = parse(buildDfpVideoUrl({


### PR DESCRIPTION
## Type of change
- [x] Bugfix

**NOTE** This is the re-submission of #3568 (which was reverted due to a last minute code conflict that came when #3573 was merged to `master`).

## Description of change
This PR incorporates some fixes related to the `hb_uuid` and `hb_cache_id` targeting keys.

Some issues that were fixed:
- due to the order in which the code was executed, the `bid.adserverTargeting.hb_uuid` and `bid.adserverTargeting.hb_cache_id` fields weren't properly populated with the bid's `videoCacheKey` after it came back from Prebid Cache.  This caused other functions that pulled the targeting keys (like `pbjs.getAdserverTargetingForAdUnitCode()`) to be missing this information when it was otherwise expected to be there.

- a consequence to the above issue, when the publisher tried to overwrite the values for these keys in the `pbjs.bidderSettings` feature - the overwrites wouldn't work because the `bid.videoCacheKey` wasn't populated at the time these `bidderSettings` values were used.

The changes in this PR addresses the above issues through mainly moving the code around to populate the `bid.adserverTargeting` object once we know the bid is complete (ie back from prebid cache for that use-case).

Note - removed the `dfpAdServerVideo` code since it's now redundant.