### PR TITLE
Bug fix: Adding protocol to mapping file url

### DIFF
--- a/modules/categoryTranslation.js
+++ b/modules/categoryTranslation.js
@@ -17,7 +17,7 @@ import { ajax } from '../src/ajax';
 import { timestamp, logError, setDataInLocalStorage, getDataFromLocalStorage } from '../src/utils';
 import { addBidResponse } from '../src/auction';
 
-const DEFAULT_TRANSLATION_FILE_URL = '//cdn.jsdelivr.net/gh/prebid/category-mapping-file@1/freewheel-mapping.json';
+const DEFAULT_TRANSLATION_FILE_URL = 'https://cdn.jsdelivr.net/gh/prebid/category-mapping-file@1/freewheel-mapping.json';
 const DEFAULT_IAB_TO_FW_MAPPING_KEY = 'iabToFwMappingkey';
 const DEFAULT_IAB_TO_FW_MAPPING_KEY_PUB = 'iabToFwMappingkeyPub';
 const refreshInDays = 1;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

Translation module loads mapping file when it is included in the build. We follow url's to be protocol-less everywhere. As jsDelivr only supports https, non ssl pages were having cors errors. If you have included this module in your build and are not doing long form header bidding than it might not impact you in anyway.

Added protocol back with this PR