### PR TITLE
Send url value when replacing image and icons types

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -157,12 +157,7 @@ export function getNativeTargeting(bid, bidReq) {
 
   Object.keys(bid['native']).forEach(asset => {
     const key = CONSTANTS.NATIVE_KEYS[asset];
-    let value = bid['native'][asset];
-
-    // native image-type assets can be a string or an object with a url prop
-    if (typeof value === 'object' && value.url) {
-      value = value.url;
-    }
+    let value = getAssetValue(bid['native'][asset]);
 
     const sendPlaceholder = deepAccess(
       bidReq,
@@ -195,10 +190,22 @@ export function getAssetMessage(data, adObject) {
 
   data.assets.forEach(asset => {
     const key = getKeyByValue(CONSTANTS.NATIVE_KEYS, asset);
-    const value = adObject.native[key];
+    const value = getAssetValue(adObject.native[key]);
 
     message.assets.push({ key, value });
   });
 
   return message;
+}
+
+/**
+ * Native assets can be a string or an object with a url prop. Returns the value
+ * appropriate for sending in adserver targeting or placeholder replacement.
+ */
+function getAssetValue(value) {
+  if (typeof value === 'object' && value.url) {
+    return value.url;
+  }
+
+  return value;
 }

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -9,6 +9,16 @@ const bid = {
     title: 'Native Creative',
     body: 'Cool description great stuff',
     cta: 'Do it',
+    image: {
+      url: 'http://cdn.example.com/p/creative-image/image.png',
+      height: 83,
+      width: 127
+    },
+    icon: {
+      url: 'http://cdn.example.com/p/creative-image/icon.jpg',
+      height: 742,
+      width: 989
+    },
     sponsoredBy: 'AppNexus',
     clickUrl: 'https://www.link.example',
     clickTrackers: ['https://tracker.example'],
@@ -96,15 +106,19 @@ describe('native.js', function () {
       message: 'Prebid Native',
       action: 'assetRequest',
       adId: '123',
-      assets: ['hb_native_body', 'hb_native_linkurl'],
+      assets: ['hb_native_body', 'hb_native_image', 'hb_native_linkurl'],
     };
 
     const message = getAssetMessage(messageRequest, bid);
 
-    expect(message.assets.length).to.equal(2);
+    expect(message.assets.length).to.equal(3);
     expect(message.assets).to.deep.include({
       key: 'body',
       value: bid.native.body
+    });
+    expect(message.assets).to.deep.include({
+      key: 'image',
+      value: bid.native.image.url
     });
     expect(message.assets).to.deep.include({
       key: 'clickUrl',


### PR DESCRIPTION
## Type of change
- Bugfix

## Description of change
Fixes bug where `image` and `icon` native asset types were being sent as objects when `sendId` is configured. This PR fixes that to send the url fields of those objects instead of the entire object, which matches the value types sent in adserver targeting.

## Other information
Fixes #3607