### PR TITLE
Apply matchMedia to the top frame

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,5 +1,5 @@
 import { config } from './config';
-import {logWarn, isPlainObject, deepAccess, deepClone} from './utils';
+import {logWarn, isPlainObject, deepAccess, deepClone, getWindowTop} from './utils';
 import includes from 'core-js/library/fn/array/includes';
 
 let sizeConfig = [];
@@ -123,7 +123,17 @@ function evaluateSizeConfig(configs) {
       typeof config === 'object' &&
       typeof config.mediaQuery === 'string'
     ) {
-      if (matchMedia(config.mediaQuery).matches) {
+      let ruleMatch = false;
+
+      try {
+        ruleMatch = getWindowTop().matchMedia(config.mediaQuery).matches;
+      } catch (e) {
+        logWarn('Unfriendly iFrame blocks sizeConfig from being correctly evaluated');
+
+        ruleMatch = matchMedia(config.mediaQuery).matches;
+      }
+
+      if (ruleMatch) {
         if (Array.isArray(config.sizesSupported)) {
           results.shouldFilter = true;
         }

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -60,6 +60,13 @@ describe('sizeMapping', function () {
 
     matchMediaOverride = {matches: false};
 
+    sandbox.stub(utils.getWindowTop(), 'matchMedia').callsFake((...args) => {
+      if (typeof matchMediaOverride === 'function') {
+        return matchMediaOverride.apply(utils.getWindowTop(), args);
+      }
+      return matchMediaOverride;
+    });
+
     sandbox.stub(window, 'matchMedia').callsFake((...args) => {
       if (typeof matchMediaOverride === 'function') {
         return matchMediaOverride.apply(window, args);


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
In case Prebid.js is called from within an iFrame, matchMedia should be applied to window.top, not the containing iFrame.
This PR falls back to the legacy behavior in case of unfriendly iFrames.