### PR TITLE
fix hb_cache_id for adpod bids

### DIFF
--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -132,6 +132,7 @@ function attachPriceIndustryDurationKeyToBid(bid, brandCategoryExclusion) {
   }
   bid.adserverTargeting[TARGETING_KEY_PB_CAT_DUR] = pcd;
   bid.adserverTargeting[TARGETING_KEY_CACHE_ID] = initialCacheKey;
+  bid.videoCacheKey = initialCacheKey;
   bid.customCacheKey = `${pcd}_${initialCacheKey}`;
 }
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -139,7 +139,10 @@ describe('auctionmanager.js', function () {
       expected[ CONSTANTS.TARGETING_KEYS.SIZE ] = bid.getSize();
       expected[ CONSTANTS.TARGETING_KEYS.SOURCE ] = bid.source;
       expected[ CONSTANTS.TARGETING_KEYS.FORMAT ] = bid.mediaType;
-
+      if (bid.mediaType === 'video') {
+        expected[ CONSTANTS.TARGETING_KEYS.UUID ] = bid.videoCacheKey;
+        expected[ CONSTANTS.TARGETING_KEYS.CACHE_ID ] = bid.videoCacheKey;
+      }
       if (!keys) {
         return expected;
       }
@@ -157,8 +160,20 @@ describe('auctionmanager.js', function () {
     });
 
     it('No bidder level configuration defined - default', function () {
-      var expected = getDefaultExpected(bid);
-      var response = getKeyValueTargetingPairs(bid.bidderCode, bid, CONSTANTS.GRANULARITY_OPTIONS.MEDIUM);
+      $$PREBID_GLOBAL$$.bidderSettings = {};
+      let expected = getDefaultExpected(bid);
+      let response = getKeyValueTargetingPairs(bid.bidderCode, bid);
+      assert.deepEqual(response, expected);
+    });
+
+    it('No bidder level configuration defined - default for video', function () {
+      $$PREBID_GLOBAL$$.bidderSettings = {};
+      let videoBid = utils.deepClone(bid);
+      videoBid.mediaType = 'video';
+      videoBid.videoCacheKey = 'abc123def';
+
+      let expected = getDefaultExpected(videoBid);
+      let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
       assert.deepEqual(response, expected);
     });
 
@@ -210,6 +225,70 @@ describe('auctionmanager.js', function () {
       expected[CONSTANTS.TARGETING_KEYS.PRICE_BUCKET] = bid.pbHg;
 
       var response = getKeyValueTargetingPairs(bid.bidderCode, bid);
+      assert.deepEqual(response, expected);
+    });
+
+    it('Custom configuration for all bidders with video bid', function () {
+      let videoBid = utils.deepClone(bid);
+      videoBid.mediaType = 'video';
+      videoBid.videoCacheKey = 'abc123def';
+
+      $$PREBID_GLOBAL$$.bidderSettings =
+      {
+        standard: {
+          adserverTargeting: [
+            {
+              key: CONSTANTS.TARGETING_KEYS.BIDDER,
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+            }, {
+              key: CONSTANTS.TARGETING_KEYS.AD_ID,
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+            }, {
+              key: CONSTANTS.TARGETING_KEYS.PRICE_BUCKET,
+              val: function (bidResponse) {
+                return bidResponse.pbMg;
+              }
+            }, {
+              key: CONSTANTS.TARGETING_KEYS.SIZE,
+              val: function (bidResponse) {
+                return bidResponse.size;
+              }
+            },
+            {
+              key: CONSTANTS.TARGETING_KEYS.SOURCE,
+              val: function (bidResponse) {
+                return bidResponse.source;
+              }
+            },
+            {
+              key: CONSTANTS.TARGETING_KEYS.FORMAT,
+              val: function (bidResponse) {
+                return bidResponse.mediaType;
+              }
+            },
+            {
+              key: CONSTANTS.TARGETING_KEYS.UUID,
+              val: function (bidResponse) {
+                return bidResponse.videoCacheKey;
+              }
+            },
+            {
+              key: CONSTANTS.TARGETING_KEYS.CACHE_ID,
+              val: function (bidResponse) {
+                return bidResponse.videoCacheKey;
+              }
+            }
+          ]
+
+        }
+      };
+
+      let expected = getDefaultExpected(videoBid);
+      let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
       assert.deepEqual(response, expected);
     });
 

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -150,11 +150,13 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^5\.00_test_15s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('5.00_test_15s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
       expect(auctionBids[1].adId).to.equal(bidResponse2.adId);
       expect(auctionBids[1].customCacheKey).to.exist.and.to.match(/^12\.00_value_15s_.*/);
       expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('12.00_value_15s');
       expect(auctionBids[1].adserverTargeting.hb_cache_id).to.exist;
       expect(auctionBids[1].adserverTargeting.hb_cache_id).to.equal(auctionBids[0].adserverTargeting.hb_cache_id);
+      expect(auctionBids[1].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id);
     });
 
     it('should send prebid cache call once bid queue is full', function () {
@@ -220,10 +222,12 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^10\.00_airline_30s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('10.00_airline_30s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
       expect(auctionBids[1].adId).to.equal('adId234');
       expect(auctionBids[1].customCacheKey).to.exist.and.to.match(/^15\.00_airline_30s_.*/);
       expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('15.00_airline_30s');
       expect(auctionBids[1].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[1].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
     });
 
     it('should send prebid cache call after set period of time (even if queue is not full)', function () {
@@ -276,6 +280,7 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^15\.00_airline_30s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('15.00_airline_30s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
     });
 
     it('should execute multiple prebid cache calls when number of bids exceeds queue size', function () {
@@ -360,14 +365,17 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^15\.00_airline_15s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('15.00_airline_15s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
       expect(auctionBids[1].adId).to.equal('multi_ad2');
       expect(auctionBids[1].customCacheKey).to.exist.and.to.match(/^15\.00_news_15s_.*/);
       expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('15.00_news_15s');
       expect(auctionBids[1].adserverTargeting.hb_cache_id).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id);
+      expect(auctionBids[1].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
       expect(auctionBids[2].adId).to.equal('multi_ad3');
       expect(auctionBids[2].customCacheKey).to.exist.and.to.match(/^10\.00_sports_15s_.*/);
       expect(auctionBids[2].adserverTargeting.hb_pb_cat_dur).to.equal('10.00_sports_15s');
       expect(auctionBids[2].adserverTargeting.hb_cache_id).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id);
+      expect(auctionBids[2].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
     });
 
     it('should cache the bids with a shortened custom key when adpod.brandCategoryExclusion is false', function() {
@@ -436,10 +444,12 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^10\.00_15s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('10.00_15s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
       expect(auctionBids[1].adId).to.equal('nocat_ad2');
       expect(auctionBids[1].customCacheKey).to.exist.and.to.match(/^15\.00_15s_.*/);
       expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('15.00_15s');
       expect(auctionBids[1].adserverTargeting.hb_cache_id).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id);
+      expect(auctionBids[1].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
     });
 
     it('should not add bid to auction when config adpod.brandCategoryExclusion is true but bid is missing adServerCatId', function() {
@@ -564,6 +574,7 @@ describe('adpod.js', function () {
       expect(auctionBids[0].customCacheKey).to.exist.and.to.match(/^5\.00_tech_45s_.*/);
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('5.00_tech_45s');
       expect(auctionBids[0].adserverTargeting.hb_cache_id).to.exist;
+      expect(auctionBids[0].videoCacheKey).to.exist.and.to.equal(auctionBids[0].adserverTargeting.hb_cache_id)
     });
 
     it('should not add bids to auction if PBC returns an error', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
In the `adpod` module, we're now populating the `bid.videoCacheKey` property in the bid object to ensure the `hb_cache_id` targeting key value is setup properly.

Also updated/added some unit tests to properly reflect the change of logic in the standard keys generated for video bids.

#### Context for the change
When #3528 was merged, it introduced a change that made the two targeting cache keys `hb_uuid` and `hb_cache_id` to be considered part of the standard set of adserver targeting keys (for video bids).  The values for these keys were populated by reading the `bid.videoCacheKey`.

With the adpod logic, we were generating our own key values for the `hb_cache_id` key - but we were not populating the `bid.videoCacheKey` (since there's different logic used for adpod bids when they're passed to the adserver and we assumed at the time it wasn't needed for the bid).  

As a result of the above - when the logic [here](https://github.com/prebid/Prebid.js/blob/master/src/auction.js#L504) ran, it overwrote the bid's `adserverTargeting.hb_cache_id` with an `undefined` because of the missing `bid.videoCacheKey`.  

The fix addresses the problem by populating the expected field in the bid when it's processed by the adpod module.

A note related to [this](https://github.com/prebid/Prebid.js/blob/master/modules/adpod.js#L134) line of code - we're keeping this value here as a backup in the case the publisher sets the `pbjs.bidderSettings.standard` property and doesn't setup the overwrite for the `hb_cache_id` key.  