### PR TITLE
Fix multi bidder prebid server

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -461,7 +461,7 @@ const OPEN_RTB_PROTOCOL = {
       }
 
       // get bidder params in form { <bidder code>: {...params} }
-      const ext = adUnit.bids.reduce((acc, bid) => {
+      const ext = adUnit.bids.reduce((acc, bid, ind) => {
         const adapter = adapterManager.bidderRegistry[bid.bidder];
         if (adapter && adapter.getSpec().transformBidParams) {
           bid.params = adapter.getSpec().transformBidParams(bid.params, isOpenRtb());

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -466,7 +466,13 @@ const OPEN_RTB_PROTOCOL = {
         if (adapter && adapter.getSpec().transformBidParams) {
           bid.params = adapter.getSpec().transformBidParams(bid.params, isOpenRtb());
         }
-        acc[bid.bidder] = (_s2sConfig.adapterOptions && _s2sConfig.adapterOptions[bid.bidder]) ? Object.assign({}, bid.params, _s2sConfig.adapterOptions[bid.bidder]) : bid.params;
+        if (acc.hasOwnProperty(bid.bidder)) {
+          var aliasesBidder = bid.bidder + 'Alias_' + ind;
+          aliases[aliasesBidder] = bid.bidder;
+          acc[aliasesBidder] = (_s2sConfig.adapterOptions && _s2sConfig.adapterOptions[bid.bidder]) ? Object.assign({}, bid.params, _s2sConfig.adapterOptions[bid.bidder]) : bid.params;
+        } else {
+          acc[bid.bidder] = (_s2sConfig.adapterOptions && _s2sConfig.adapterOptions[bid.bidder]) ? Object.assign({}, bid.params, _s2sConfig.adapterOptions[bid.bidder]) : bid.params;
+        }
         return acc;
       }, {});
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -632,6 +632,37 @@ describe('S2S Adapter', function () {
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
     });
 
+    it('adds 2 appnexus bids to request', function () {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({s2sConfig: s2sConfig});
+
+      const aliasBidder = {
+        bidder: 'appnexus',
+        params: { placementId: '123456' }
+      };
+
+      const request = utils.deepClone(REQUEST);
+      request.ad_units[0].push(aliasBidder);
+
+      adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
+
+      const requestBid = JSON.parse(requests[0].requestBody);
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          aliases: {
+            'appnexusAlias_1': 'appnexus'
+          },
+          targeting: {
+            includebidderkeys: false,
+            includewinners: true
+          }
+        }
+      });
+    });
+
     it('adds appnexus aliases to request', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -644,7 +644,7 @@ describe('S2S Adapter', function () {
       };
 
       const request = utils.deepClone(REQUEST);
-      request.ad_units[0].push(aliasBidder);
+      request.ad_units[0].bids.push(aliasBidder);
 
       adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
 


### PR DESCRIPTION
Some bidders such as Pubmatic and Index are using a bid for each ad size as they don’t support multi-size. It is fine on client side except the fact that it will trigger 2 requests.
However, it is NOT working for Prebid server as only the last bid will be triggered server side.

As you can in the following test page, only the last Pubmatic bid (1410742@320x50) is sent to Prebid server and the first one is not present in the request (1410741@320x100):
https://jsfiddle.net/cbqzrjhx/

You can create an alias as a workaround and I have added this logic in the prebidBidServerBidAdapter to add an alias if the adUnit has multiple time the same bidder.

Thanks

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
