### PR TITLE
Add buyer data to Pubmatic bid responses

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -976,6 +976,17 @@ export const spec = {
                 newBid['dealChannel'] = dealChannelValues[bid.ext.deal_channel] || null;
               }
 
+              newBid.meta = {};
+              if (bid.ext && bid.ext.dspid) {
+                newBid.meta.networkId = bid.ext.dspid;
+              }
+              if (bid.ext && bid.ext.advid) {
+                newBid.meta.buyerId = bid.ext.advid;
+              }
+              if (bid.adomain && bid.adomain.length > 0) {
+                newBid.meta.clickUrl = bid.adomain[0];
+              }
+
               bidResponses.push(newBid);
             });
         });

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -281,10 +281,13 @@ describe('PubMatic adapter', function () {
             'impid': '22bddb28db77d',
             'price': 1.3,
             'adm': 'image3.pubmatic.com Layer based creative',
+            'adomain': ['blackrock.com'],
             'h': 250,
             'w': 300,
             'ext': {
-              'deal_channel': 6
+              'deal_channel': 6,
+              'advid': 976,
+              'dspid': 123
             }
           }]
         }, {
@@ -293,10 +296,13 @@ describe('PubMatic adapter', function () {
             'impid': '22bddb28db77e',
             'price': 1.7,
             'adm': 'image3.pubmatic.com Layer based creative',
+            'adomain': ['hivehome.com'],
             'h': 250,
             'w': 300,
             'ext': {
-              'deal_channel': 5
+              'deal_channel': 5,
+              'advid': 832,
+              'dspid': 422
             }
           }]
         }]
@@ -1323,6 +1329,9 @@ describe('PubMatic adapter', function () {
         expect(response[0].currency).to.equal('USD');
         expect(response[0].netRevenue).to.equal(false);
         expect(response[0].ttl).to.equal(300);
+        expect(response[0].meta.networkId).to.equal(123);
+        expect(response[0].meta.buyerId).to.equal(976);
+        expect(response[0].meta.clickUrl).to.equal('blackrock.com');
         expect(response[0].referrer).to.include(data.site.ref);
         expect(response[0].ad).to.equal(bidResponses.body.seatbid[0].bid[0].adm);
 
@@ -1339,6 +1348,9 @@ describe('PubMatic adapter', function () {
         expect(response[1].currency).to.equal('USD');
         expect(response[1].netRevenue).to.equal(false);
         expect(response[1].ttl).to.equal(300);
+        expect(response[1].meta.networkId).to.equal(422);
+        expect(response[1].meta.buyerId).to.equal(832);
+        expect(response[1].meta.clickUrl).to.equal('hivehome.com');
         expect(response[1].referrer).to.include(data.site.ref);
         expect(response[1].ad).to.equal(bidResponses.body.seatbid[1].bid[0].adm);
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds buyer data to Pubmatic responses, following the format specified in #3115.
We have already made this change to our fork, [here](https://github.com/guardian/Prebid.js/pull/85).

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
/cc @PubMatic-OpenWrap
