### PR TITLE
update circleci test to not auto-fix lint errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,4 +47,4 @@ jobs:
       # run tests!
       - run: 
           name: BrowserStack testing
-          command: gulp test --browserstack
+          command: gulp test --browserstack --nolintfix

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ function lint(done) {
     return file.eslint != null && file.eslint.fixed;
   }
   return gulp.src(['src/**/*.js', 'modules/**/*.js', 'test/**/*.js'], {base: './'})
-    .pipe(eslint({fix: true}))
+    .pipe(gulpif(argv.nolintfix, eslint(), eslint({fix: true})))
     .pipe(eslint.format('stylish'))
     .pipe(eslint.failAfterError())
     .pipe(gulpif(isFixed, gulp.dest('./')));


### PR DESCRIPTION
## Type of change
- [x] Build related changes
- [x] CI related changes


## Description of change
Adding logic to the `gulp lint` command to handle a `nolintifx` flag.  When passed on the `gulp` command, it will not automatically fix files that had a linting error and will report the error(s).

With this new flag, we will use it in the circleCi gulp test command in order to identify and fail the test if there are any lint errors.  


Currently, the lint errors are going under the radar during the circleCi test and are getting merged into `master`.  One recent example was with (#3593), where the unit tests had some spacing issues in some of the test objects.

## Other notes
For reference, these were the PRs that introduced the lint auto-fix:
#3412 (was closed due to bad commits)
#3416 (copy of above, with proper changes; was merged)