### PR TITLE
fix lint errors in ozoneBidAdapter unit tests

### DIFF
--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -73,7 +73,7 @@ var validBidRequestsWithNonBannerMediaTypes = [
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
     params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, ozoneData: {'networkID': '3048', 'dfpSiteID': 'd.thesun', 'sectionID': 'homepage', 'path': '/', 'sec_id': 'null', 'sec': 'sec', 'topics': 'null', 'kw': 'null', 'aid': 'null', 'search': 'null', 'article_type': 'null', 'hide_ads': '', 'article_slug': 'null'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
-    mediaTypes: {video:{info:'dummy data'}, native:{info:'dummy data'}},
+    mediaTypes: {video: {info: 'dummy data'}, native: {info: 'dummy data'}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
 ];
@@ -580,7 +580,7 @@ describe('ozone Adapter', function () {
       expect(result).to.be.empty;
     });
     it('should fail ok if seatbid is not an array', function () {
-      const result = spec.interpretResponse({'body':{'seatbid':'nothing_here'}}, {});
+      const result = spec.interpretResponse({'body': {'seatbid': 'nothing_here'}}, {});
       expect(result).to.be.an('array');
       expect(result).to.be.empty;
     });
@@ -596,5 +596,4 @@ describe('ozone Adapter', function () {
       expect(result).to.be.empty;
     });
   });
-
 });


### PR DESCRIPTION


## Type of change
- [x] Code style update (formatting, local variables)


## Description of change
When #3593 was merged, it had some lint errors in the unit test code that got into `master`.  

These errors were missed during the circleCI test due to the auto-fix logic of the `gulp lint` command; this is being fixed in #3623 

This PR fixes the lint errors in `master` so it's clean again.
CC: @afsheenb