### PR TITLE
YIELDONE adapter - add timeout params to payload

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -22,6 +22,7 @@ export const spec = {
       const referrer = encodeURIComponent(utils.getTopWindowUrl());
       const bidId = bidRequest.bidId;
       const unitCode = bidRequest.adUnitCode;
+      const timeout = config.getConfig('bidderTimeout');
       const payload = {
         v: 'hb1',
         p: placementId,
@@ -29,6 +30,7 @@ export const spec = {
         r: referrer,
         uid: bidId,
         uc: unitCode,
+        tmax: timeout,
         t: 'i'
       };
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- addtimeout params to payload
  - `tmax` timeout setting by publisher or default value

contact email of the adapter’s maintainer y1dev@platform-one.co.jp
- [x]  official adapter submission