### PR TITLE
Use aliases in userSync endpoint for PrebidServerAdapter

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -687,7 +687,10 @@ export function PrebidServer() {
 
     if (_s2sConfig && _s2sConfig.syncEndpoint) {
       let consent = (Array.isArray(bidRequests) && bidRequests.length > 0) ? bidRequests[0].gdprConsent : undefined;
-      queueSync(_s2sConfig.bidders, consent);
+      let syncBidders = _s2sConfig.bidders.map((bidder) => adaptermanager.aliasRegistry[bidder] || bidder);
+
+      syncBidders = syncBidders.filter((bidder, index) => (syncBidders.indexOf(bidder) === index));
+      queueSync(syncBidders, consent);
     }
 
     const request = protocolAdapter().buildRequest(s2sBidRequest, bidRequests, adUnitsWithSizes);


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This is just a quick approach for issue #3628  regarding the problem with the aliases and the syncEndpoint for PrebidServerAdapter. Has yet to be properly tested, but this way we can discuss about the approach.


## Other information
Issue: #3628 
