### PR TITLE
Add new s2s config option

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -186,7 +186,7 @@ function doAllSyncs(bidders) {
  * @param {function} done an exit callback; to signify this pixel has either: finished rendering or something went wrong
  */
 function doPreBidderSync(type, url, bidder, done) {
-  if (typeof _s2sConfig.syncUrlModifier[bidder] === 'function') {
+  if (_s2sConfig.syncUrlModifier && typeof _s2sConfig.syncUrlModifier[bidder] === 'function') {
     const newSyncUrl = _s2sConfig.syncUrlModifier[bidder](type, url, bidder);
     doBidderSync(type, newSyncUrl, bidder, done)
   } else {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -53,7 +53,8 @@ const s2sDefaultConfig = {
   timeout: 1000,
   maxBids: 1,
   adapter: 'prebidServer',
-  adapterOptions: {}
+  adapterOptions: {},
+  syncUrlModifier: {}
 };
 
 config.setDefaults({
@@ -170,9 +171,26 @@ function doAllSyncs(bidders) {
 
   const thisSync = bidders.pop();
   if (thisSync.no_cookie) {
-    doBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, utils.bind.call(doAllSyncs, null, bidders));
+    doPreBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, utils.bind.call(doAllSyncs, null, bidders));
   } else {
     doAllSyncs(bidders);
+  }
+}
+
+/**
+ * Modify the cookie sync url from prebid server to add new params.
+ *
+ * @param {string} type the type of sync, "image", "redirect", "iframe"
+ * @param {string} url the url to sync
+ * @param {string} bidder name of bidder doing sync for
+ * @param {function} done an exit callback; to signify this pixel has either: finished rendering or something went wrong
+ */
+function doPreBidderSync(type, url, bidder, done) {
+  if (typeof _s2sConfig.syncUrlModifier[bidder] === 'function') {
+    const newSyncUrl = _s2sConfig.syncUrlModifier[bidder](type, url, bidder);
+    doBidderSync(type, newSyncUrl, bidder, done)
+  } else {
+    doBidderSync(type, url, bidder, done)
   }
 }
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1460,5 +1460,16 @@ describe('S2S Adapter', function () {
         }
       })
     });
+
+    it('should set syncUrlModifier', function () {
+      config.setConfig({
+        s2sConfig: {
+          syncUrlModifier: {
+            appnexus: () => {}
+          }
+        }
+      });
+      expect(typeof config.getConfig('s2sConfig').syncUrlModifier.appnexus).to.equal('function')
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding a new option in the s2s configuration, which allow bidder to modify the sync url before the actual call to the sync endpoint.  This enable bidder to have customization over the url, and also enable them to add custom params
<!-- For new bidder adapters, please provide the following -->
- new s2s configuration options
```
{
  bidders: ['33across'],
  adapter: 'prebidServer',
  syncEndpoint: 'http://www.mylocal.com:8000/cookie_sync',
  syncUrlModifier: {
    '33across': function(type, url, bidder) {
      const publisherId = '00000123231231'
      url += `&ri=${publisherId}`;

      return url
    }
  }
}
```

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1216