### PR TITLE
Add 'hb_cache_host' and 'hb_cache_path' targeting for video bids when cache is set

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -48,7 +48,8 @@
  * @property {function(): void} callBids - sends requests to all adapters for bids
  */
 
-import { uniques, flatten, timestamp, adUnitsFilter, deepAccess, getBidRequest } from './utils';
+import { uniques, flatten, timestamp, adUnitsFilter, deepAccess, getBidRequest, getValue } from './utils';
+import { parse as parseURL } from './url';
 import { getPriceBucketString } from './cpmBucketManager';
 import { getNativeTargeting } from './native';
 import { getCacheUrl, store } from './videoCache';
@@ -505,6 +506,19 @@ function setupBidTargeting(bidObject, bidderRequest) {
 }
 
 export function getStandardBidderSettings(mediaType) {
+  // factory for key value objs
+  function createKeyVal(key, value) {
+    return {
+      key,
+      val: (typeof value === 'function')
+        ? function (bidResponse) {
+          return value(bidResponse);
+        }
+        : function (bidResponse) {
+          return getValue(bidResponse, value);
+        }
+    };
+  }
   // Use the config value 'mediaTypeGranularity' if it has been set for mediaType, else use 'priceGranularity'
   const mediaTypeGranularity = config.getConfig(`mediaTypePriceGranularity.${mediaType}`);
   const granularity = (typeof mediaType === 'string' && mediaTypeGranularity) ? ((typeof mediaTypeGranularity === 'string') ? mediaTypeGranularity : 'custom') : config.getConfig('priceGranularity');
@@ -514,68 +528,54 @@ export function getStandardBidderSettings(mediaType) {
     bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD] = {};
   }
   if (!bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING]) {
+    const TARGETING_KEYS = CONSTANTS.TARGETING_KEYS;
+
     bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING] = [
-      {
-        key: CONSTANTS.TARGETING_KEYS.BIDDER,
-        val: function (bidResponse) {
-          return bidResponse.bidderCode;
+      createKeyVal(TARGETING_KEYS.BIDDER, 'bidderCode'),
+      createKeyVal(TARGETING_KEYS.AD_ID, 'adId'),
+      createKeyVal(TARGETING_KEYS.PRICE_BUCKET, function(bidResponse) {
+        if (granularity === CONSTANTS.GRANULARITY_OPTIONS.AUTO) {
+          return bidResponse.pbAg;
+        } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.DENSE) {
+          return bidResponse.pbDg;
+        } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.LOW) {
+          return bidResponse.pbLg;
+        } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.MEDIUM) {
+          return bidResponse.pbMg;
+        } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.HIGH) {
+          return bidResponse.pbHg;
+        } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.CUSTOM) {
+          return bidResponse.pbCg;
         }
-      }, {
-        key: CONSTANTS.TARGETING_KEYS.AD_ID,
-        val: function (bidResponse) {
-          return bidResponse.adId;
-        }
-      }, {
-        key: CONSTANTS.TARGETING_KEYS.PRICE_BUCKET,
-        val: function (bidResponse) {
-          if (granularity === CONSTANTS.GRANULARITY_OPTIONS.AUTO) {
-            return bidResponse.pbAg;
-          } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.DENSE) {
-            return bidResponse.pbDg;
-          } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.LOW) {
-            return bidResponse.pbLg;
-          } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.MEDIUM) {
-            return bidResponse.pbMg;
-          } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.HIGH) {
-            return bidResponse.pbHg;
-          } else if (granularity === CONSTANTS.GRANULARITY_OPTIONS.CUSTOM) {
-            return bidResponse.pbCg;
-          }
-        }
-      }, {
-        key: CONSTANTS.TARGETING_KEYS.SIZE,
-        val: function (bidResponse) {
-          return bidResponse.size;
-        }
-      }, {
-        key: CONSTANTS.TARGETING_KEYS.DEAL,
-        val: function (bidResponse) {
-          return bidResponse.dealId;
-        }
-      },
-      {
-        key: CONSTANTS.TARGETING_KEYS.SOURCE,
-        val: function (bidResponse) {
-          return bidResponse.source;
-        }
-      },
-      {
-        key: CONSTANTS.TARGETING_KEYS.FORMAT,
-        val: function (bidResponse) {
-          return bidResponse.mediaType;
-        }
-      },
+      }),
+      createKeyVal(TARGETING_KEYS.SIZE, 'size'),
+      createKeyVal(TARGETING_KEYS.DEAL, 'dealId'),
+      createKeyVal(TARGETING_KEYS.SOURCE, 'source'),
+      createKeyVal(TARGETING_KEYS.FORMAT, 'mediaType'),
     ]
 
     if (mediaType === 'video') {
-      [CONSTANTS.TARGETING_KEYS.UUID, CONSTANTS.TARGETING_KEYS.CACHE_ID].forEach(item => {
-        bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push({
-          key: item,
-          val: function val(bidResponse) {
-            return bidResponse.videoCacheKey;
-          }
-        })
+      // Adding hb_uuid + hb_cache_id
+      [TARGETING_KEYS.UUID, TARGETING_KEYS.CACHE_ID].forEach(targetingKey => {
+        bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push(createKeyVal(targetingKey, 'videoCacheKey'));
       });
+
+      // Adding hb_cache_host + hb_cache_path
+      if (config.getConfig('cache.url')) {
+        const urlInfo = parseURL(config.getConfig('cache.url'));
+
+        bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push(createKeyVal(TARGETING_KEYS.CACHE_HOST, function(bidResponse) {
+          return utils.deepAccess(bidResponse, `adserverTargeting.${TARGETING_KEYS.CACHE_HOST}`)
+            ? bidResponse.adserverTargeting[TARGETING_KEYS.CACHE_HOST]
+            : urlInfo.hostname;
+        }));
+
+        bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push(createKeyVal(TARGETING_KEYS.CACHE_PATH, function(bidResponse) {
+          return utils.deepAccess(bidResponse, `adserverTargeting.${TARGETING_KEYS.CACHE_PATH}`)
+            ? bidResponse.adserverTargeting[TARGETING_KEYS.CACHE_PATH]
+            : urlInfo.pathname;
+        }));
+      }
     }
   }
   return bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD];

--- a/src/constants.json
+++ b/src/constants.json
@@ -64,7 +64,9 @@
     "SOURCE": "hb_source",
     "FORMAT": "hb_format",
     "UUID": "hb_uuid",
-    "CACHE_ID": "hb_cache_id"
+    "CACHE_ID": "hb_cache_id",
+    "CACHE_HOST": "hb_cache_host",
+    "CACHE_PATH": "hb_cache_path"
   },
   "NATIVE_KEYS": {
     "title": "hb_native_title",

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -142,6 +142,8 @@ describe('auctionmanager.js', function () {
       if (bid.mediaType === 'video') {
         expected[ CONSTANTS.TARGETING_KEYS.UUID ] = bid.videoCacheKey;
         expected[ CONSTANTS.TARGETING_KEYS.CACHE_ID ] = bid.videoCacheKey;
+        expected[ CONSTANTS.TARGETING_KEYS.CACHE_HOST ] = 'prebid.adnxs.com';
+        expected[ CONSTANTS.TARGETING_KEYS.CACHE_PATH ] = '/pbc/v1/cache';
       }
       if (!keys) {
         return expected;
@@ -167,6 +169,11 @@ describe('auctionmanager.js', function () {
     });
 
     it('No bidder level configuration defined - default for video', function () {
+      config.setConfig({
+        cache: {
+          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
+      });
       $$PREBID_GLOBAL$$.bidderSettings = {};
       let videoBid = utils.deepClone(bid);
       videoBid.mediaType = 'video';
@@ -229,6 +236,11 @@ describe('auctionmanager.js', function () {
     });
 
     it('Custom configuration for all bidders with video bid', function () {
+      config.setConfig({
+        cache: {
+          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
+      });
       let videoBid = utils.deepClone(bid);
       videoBid.mediaType = 'video';
       videoBid.videoCacheKey = 'abc123def';
@@ -288,6 +300,10 @@ describe('auctionmanager.js', function () {
       };
 
       let expected = getDefaultExpected(videoBid);
+      // Since we are effectively overwriting the bidderSettings above...
+      // we are not including the new host / path logic. So we will expect them to be gone.
+      delete expected['hb_cache_host'];
+      delete expected['hb_cache_path'];
       let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
       assert.deepEqual(response, expected);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
When setConfig.cache.url is defined, pass hb_cache_host to ad server. We need hb_cache_host set to trigger the new Prebid video cache redirector, and we may as well send hb_cache_path as well. Both host and path are parsed from the prebid config cache property: config.getConfig('cache.url').

Use case:

1. The new Prebid Video Cache Redirector is live and the ad server URL points to it
2. video adunit calls for AppNexus and Rubicon video
3. AppNexus returns VAST and caches it client-side
4. On client side caching, hb_cache_host isn't sent to ad server

The general idea is straight-forward: when cache.url is specified, parse it and add hb_cache_host and hb_cache_path to the targeting variables.

```
config.setConfig({
  cache: {
    url: 'https://prebid.adnxs.com/pbc/v1/cache'
  }
});
```