### PR TITLE
YIELDONE adapter - add outstream video renderer

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -7,8 +7,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes';
 const BIDDER_CODE = 'yieldone';
 const ENDPOINT_URL = '//y.one.impact-ad.jp/h_bid';
 const USER_SYNC_URL = '//y.one.impact-ad.jp/push_sync';
-// TODO: have to change this debug url
-const VIDEO_PLAYER_URL = '//webdemo.dac.co.jp/kusapan/hb/video/render/dac-video-prebid.js';
+const VIDEO_PLAYER_URL = '//img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -36,15 +36,15 @@ export const spec = {
       };
 
       const videoMediaType = utils.deepAccess(bidRequest, 'mediaTypes.video');
-      if (bidRequest.mediaType === VIDEO || videoMediaType) {
+      if ((utils.isEmpty(bidRequest.mediaType) && utils.isEmpty(bidRequest.mediaTypes)) ||
+      (bidRequest.mediaType === BANNER || (bidRequest.mediaTypes && bidRequest.mediaTypes[BANNER]))) {
+        const sizes = utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
+        payload.sz = utils.parseSizesInput(sizes).join(',');
+      } else if (bidRequest.mediaType === VIDEO || videoMediaType) {
         const sizes = utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') || bidRequest.sizes;
         const size = utils.parseSizesInput(sizes)[0];
         payload.w = size.split('x')[0];
         payload.h = size.split('x')[1];
-      } else if ((utils.isEmpty(bidRequest.mediaType) && utils.isEmpty(bidRequest.mediaTypes)) ||
-      (bidRequest.mediaType === BANNER || (bidRequest.mediaTypes && bidRequest.mediaTypes[BANNER]))) {
-        const sizes = utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
-        payload.sz = utils.parseSizesInput(sizes).join(',');
       }
 
       return {

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -190,7 +190,8 @@ describe('yieldoneBidAdapter', function() {
         'ttl': 3000,
         'referrer': '',
         'mediaType': 'video',
-        'vastXml': '<!-- vast -->'
+        'vastXml': '<!-- vast -->',
+        'renderer': ''
       }];
       let result = spec.interpretResponse(serverResponseVideo, bidRequestVideo[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { newBidder } from 'src/adapters/bidderFactory';
 
 const ENDPOINT = '//y.one.impact-ad.jp/h_bid';
 const USER_SYNC_URL = '//y.one.impact-ad.jp/push_sync';
+const VIDEO_PLAYER_URL = '//img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 
 describe('yieldoneBidAdapter', function() {
   const adapter = newBidder(spec);
@@ -191,11 +192,16 @@ describe('yieldoneBidAdapter', function() {
         'referrer': '',
         'mediaType': 'video',
         'vastXml': '<!-- vast -->',
-        'renderer': ''
+        'renderer': {
+          id: '23beaa6af6cdde',
+          url: VIDEO_PLAYER_URL
+        }
       }];
       let result = spec.interpretResponse(serverResponseVideo, bidRequestVideo[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
       expect(result[0].mediaType).to.equal(expectedResponse[0].mediaType);
+      expect(result[0].renderer.id).to.equal(expectedResponse[0].renderer.id);
+      expect(result[0].renderer.url).to.equal(expectedResponse[0].renderer.url);
     });
 
     it('handles empty bid response', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- add outstream video renderer
- change to prioritize the size of banner instead of video

contact email of the adapter’s maintainer y1dev@platform-one.co.jp
- [x]  official adapter submission