### PR TITLE
PubCommonId - Add support for localStorage

### DIFF
--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -6,12 +6,112 @@
 import * as utils from '../src/utils'
 import { config } from '../src/config';
 
-const COOKIE_NAME = '_pubcid';
-const DEFAULT_EXPIRES = 2628000; // 5-year worth of minutes
+const ID_NAME = '_pubcid';
+const DEFAULT_EXPIRES = 525600; // 1-year worth of minutes
 const PUB_COMMON = 'PublisherCommonId';
+const EXP_SUFFIX = '_exp';
+const COOKIE = 'cookie';
+const LOCAL_STORAGE = 'html5';
 
 var pubcidEnabled = true;
 var interval = DEFAULT_EXPIRES;
+var typeEnabled = {cookie: true, html5: true};
+
+/**
+ * Set an item in the storage with expiry time.
+ * @param {string} key Key of the item to be stored
+ * @param {string} val Value of the item to be stored
+ * @param {number} expires Expiry time in minutes
+ */
+
+export function setStorageItem(key, val, expires) {
+  try {
+    if (expires !== undefined && expires != null) {
+      const expStr = (new Date(Date.now() + (expires * 60 * 1000))).toUTCString();
+      localStorage.setItem(key + EXP_SUFFIX, expStr);
+    }
+
+    localStorage.setItem(key, val);
+  } catch (e) {
+    utils.logMessage(e);
+  }
+}
+
+/**
+ * Retrieve an item from storage if it exists and hasn't expired.
+ * @param {string} key Key of the item.
+ * @returns {string|null} Value of the item.
+ */
+export function getStorageItem(key) {
+  let val = null;
+
+  try {
+    const expVal = localStorage.getItem(key + EXP_SUFFIX);
+
+    if (!expVal) {
+      // If there is no expiry time, then just return the item
+      val = localStorage.getItem(key);
+    } else {
+      // Only return the item if it hasn't expired yet.
+      // Otherwise delete the item.
+      const expDate = new Date(expVal);
+      const isValid = (expDate.getTime() - Date.now()) > 0;
+      if (isValid) {
+        val = localStorage.getItem(key);
+      } else {
+        removeStorageItem(key);
+      }
+    }
+  } catch (e) {
+    utils.logMessage(e);
+  }
+
+  return val;
+}
+
+/**
+ * Remove an item from storage
+ * @param {string} key Key of the item to be removed
+ */
+export function removeStorageItem(key) {
+  try {
+    localStorage.removeItem(key + EXP_SUFFIX);
+    localStorage.removeItem(key);
+  } catch (e) {
+    utils.logMessage(e);
+  }
+}
+
+/**
+ * Read a value by checking cookies first and then local storage.
+ * @param {string} name Name of the item
+ * @returns {string|null} a string if item exists
+ */
+function readValue(name) {
+  const cookieValue = typeEnabled[COOKIE] ? getCookie(name) : null;
+
+  if (cookieValue) { return cookieValue; }
+
+  const storageValue = typeEnabled[LOCAL_STORAGE] ? getStorageItem(name) : null;
+  return storageValue;
+}
+
+/**
+ * Write a value to both cookies and local storage
+ * @param {string} name Name of the item
+ * @param {string} value Value to be stored
+ * @param {number} expInterval Expiry time in minutes
+ */
+function writeValue(name, value, expInterval) {
+  if (name && value) {
+    if (typeEnabled[COOKIE]) {
+      setCookie(name, value, expInterval);
+    }
+    if (typeEnabled[LOCAL_STORAGE]) {
+      setStorageItem(name, value, expInterval);
+    }
+  }
+}
 
 export function isPubcidEnabled() { return pubcidEnabled; }
 export function getExpInterval() { return interval; }
@@ -38,11 +138,22 @@ export function requestBidHook(next, config) {
     pubcid = window[PUB_COMMON].getId();
     utils.logMessage(PUB_COMMON + ': pubcid = ' + pubcid);
   } else {
-    // Otherwise get the existing cookie or create a new id
-    pubcid = getCookie(COOKIE_NAME) || utils.generateUUID();
+    // Otherwise get the existing cookie
+    pubcid = readValue(ID_NAME);
 
-    // Update the cookie with the latest expiration date
-    setCookie(COOKIE_NAME, pubcid, interval);
+    if (pubcid === 'undefined' || pubcid === 'null') { pubcid = null; }
+
+    if (!pubcid) {
+      pubcid = utils.generateUUID();
+      // Update the cookie/storage with the latest expiration date
+      writeValue(ID_NAME, pubcid, interval);
+      // Only return pubcid if it is saved successfully
+      pubcid = readValue(ID_NAME);
+    } else {
+      // Update the cookie/storage with the latest expiration date
+      writeValue(ID_NAME, pubcid, interval);
+    }
+
     utils.logMessage('pbjs: pubcid = ' + pubcid);
   }
 
@@ -68,8 +179,11 @@ export function setCookie(name, value, expires) {
 
 // Helper to read a cookie
 export function getCookie(name) {
-  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
-  return m ? decodeURIComponent(m[2]) : null;
+  if (name && window.document.cookie) {
+    let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
+    return m ? decodeURIComponent(m[2]) : null;
+  }
+  return null;
 }
 
 /**
@@ -78,12 +192,16 @@ export function getCookie(name) {
  * @param {number} expInterval Expiration interval of the cookie in minutes.
  */
 
-export function setConfig({ enable = true, expInterval = DEFAULT_EXPIRES } = {}) {
+export function setConfig({ enable = true, expInterval = DEFAULT_EXPIRES, type = 'cookie,html5' } = {}) {
   pubcidEnabled = enable;
   interval = parseInt(expInterval, 10);
   if (isNaN(interval)) {
     interval = DEFAULT_EXPIRES;
   }
+  typeEnabled = type.split(',').reduce((obj, str, idx) => {
+    obj[str.trim()] = true;
+    return obj;
+  }, {});
 }
 
 /**
@@ -92,8 +210,8 @@ export function setConfig({ enable = true, expInterval = DEFAULT_EXPIRES } = {})
 export function initPubcid() {
   config.getConfig('pubcid', config => setConfig(config.pubcid));
 
-  if (utils.cookiesAreEnabled()) {
-    if (!getCookie('_pubcid_optout')) {
+  if (utils.cookiesAreEnabled() || utils.hasLocalStorage()) {
+    if (!readValue('_pubcid_optout')) {
       $$PREBID_GLOBAL$$.requestBids.before(requestBidHook);
     }
   }

--- a/modules/pubCommonId.md
+++ b/modules/pubCommonId.md
@@ -1,0 +1,37 @@
+## Publisher Common ID Example Configuration
+
+When the module is included, it's automatically enabled and saves an id to both cookie and local storage with an expiration time of 1 year.  
+
+Example of disabling publisher common id.
+
+```
+pbjs.setConfig(
+	pubcid: {
+		enable: false
+	}
+);
+```
+
+Example of setting expiration interval to 30 days.  The interval is expressed in minutes.
+
+```
+pbjs.setConfig(
+	pubcid: {
+		expInterval: 43200
+	}
+);
+```
+
+Example of using local storage only and setting expiration interval to 30 days.
+
+```
+pbjs.setConfig(
+	pubcid: {
+		expInterval: 43200,
+		type: 'html5'
+	}
+);
+```
+
+
+

--- a/test/spec/modules/pubCommonId_spec.js
+++ b/test/spec/modules/pubCommonId_spec.js
@@ -5,7 +5,10 @@ import {
   setConfig,
   isPubcidEnabled,
   getExpInterval,
-  initPubcid } from 'modules/pubCommonId';
+  initPubcid,
+  setStorageItem,
+  getStorageItem,
+  removeStorageItem } from 'modules/pubCommonId';
 import { getAdUnits } from 'test/fixtures/fixtures';
 import * as auctionModule from 'src/auction';
 import { registerBidder } from 'src/adapters/bidderFactory';
@@ -14,16 +17,28 @@ import * as utils from 'src/utils';
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 
-const COOKIE_NAME = '_pubcid';
+const ID_NAME = '_pubcid';
+const EXP = '_exp';
 const TIMEOUT = 2000;
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89a-f][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function cleanUp() {
+  window.document.cookie = ID_NAME + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+  localStorage.removeItem(ID_NAME);
+  localStorage.removeItem(ID_NAME + EXP);
+}
 
 describe('Publisher Common ID', function () {
   afterEach(function () {
     $$PREBID_GLOBAL$$.requestBids.removeAll();
   });
   describe('Decorate adUnits', function () {
-    before(function() {
-      window.document.cookie = COOKIE_NAME + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    beforeEach(function() {
+      cleanUp();
+    });
+    afterEach(function() {
+      cleanUp();
     });
 
     it('Check same cookie', function () {
@@ -31,12 +46,12 @@ describe('Publisher Common ID', function () {
       let adUnits2 = getAdUnits();
       let innerAdUnits1;
       let innerAdUnits2;
-      let pubcid = getCookie(COOKIE_NAME);
+      let pubcid = getCookie(ID_NAME);
 
       expect(pubcid).to.be.null; // there should be no cookie initially
 
       requestBidHook((config) => { innerAdUnits1 = config.adUnits }, {adUnits: adUnits1});
-      pubcid = getCookie(COOKIE_NAME); // cookies is created after requestbidHook
+      pubcid = getCookie(ID_NAME); // cookies is created after requestbidHook
 
       innerAdUnits1.forEach((unit) => {
         unit.bids.forEach((bid) => {
@@ -44,6 +59,11 @@ describe('Publisher Common ID', function () {
           expect(bid.crumbs.pubcid).to.equal(pubcid);
         });
       });
+
+      // verify local storage
+      expect(localStorage.getItem(ID_NAME)).to.be.equal(pubcid);
+
+      // verify same pubcid is preserved
       requestBidHook((config) => { innerAdUnits2 = config.adUnits }, {adUnits: adUnits2});
       assert.deepEqual(innerAdUnits1, innerAdUnits2);
     });
@@ -57,8 +77,9 @@ describe('Publisher Common ID', function () {
       let pubcid2;
 
       requestBidHook((config) => { innerAdUnits1 = config.adUnits }, {adUnits: adUnits1});
-      pubcid1 = getCookie(COOKIE_NAME); // get first cookie
-      setCookie(COOKIE_NAME, '', -1); // erase cookie
+      pubcid1 = getCookie(ID_NAME); // get first cookie
+      setCookie(ID_NAME, '', -1); // erase cookie
+      removeStorageItem(ID_NAME); // remove storage
 
       innerAdUnits1.forEach((unit) => {
         unit.bids.forEach((bid) => {
@@ -68,7 +89,7 @@ describe('Publisher Common ID', function () {
       });
 
       requestBidHook((config) => { innerAdUnits2 = config.adUnits }, {adUnits: adUnits2});
-      pubcid2 = getCookie(COOKIE_NAME); // get second cookie
+      pubcid2 = getCookie(ID_NAME); // get second cookie
 
       innerAdUnits2.forEach((unit) => {
         unit.bids.forEach((bid) => {
@@ -85,7 +106,7 @@ describe('Publisher Common ID', function () {
       let innerAdUnits;
       let pubcid = utils.generateUUID();
 
-      setCookie(COOKIE_NAME, pubcid, 600);
+      setCookie(ID_NAME, pubcid, 600);
       requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
       innerAdUnits.forEach((unit) => {
         unit.bids.forEach((bid) => {
@@ -94,16 +115,63 @@ describe('Publisher Common ID', function () {
         });
       });
     });
+
+    it('Replicate cookie to storage', function() {
+      let adUnits = getAdUnits();
+      let innerAdUnits;
+      let pubcid = utils.generateUUID();
+
+      setCookie(ID_NAME, pubcid, 600);
+      requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(getStorageItem(ID_NAME)).to.equal(pubcid);
+    });
+
+    it('Replicate storage to cookie', function() {
+      let adUnits = getAdUnits();
+      let innerAdUnits;
+      let pubcid = utils.generateUUID();
+
+      setStorageItem(ID_NAME, pubcid, 600);
+      requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(getCookie(ID_NAME)).to.equal(pubcid);
+    });
+
+    it('Cookie only', function() {
+      setConfig({type: 'cookie'});
+      let adUnits = getAdUnits();
+      let innerAdUnits;
+
+      requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(getCookie(ID_NAME)).to.match(uuidPattern);
+      expect(getStorageItem(ID_NAME)).to.be.null;
+    });
+
+    it('Storage only', function() {
+      setConfig({type: 'html5'});
+      let adUnits = getAdUnits();
+      let innerAdUnits;
+
+      requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(getCookie(ID_NAME)).to.be.null;
+      expect(getStorageItem(ID_NAME)).to.match(uuidPattern);
+    });
   });
 
   describe('Configuration', function () {
+    beforeEach(() => { cleanUp(); });
+    afterEach(() => { cleanUp(); });
+
     it('empty config', function () {
       // this should work as usual
       setConfig({});
       let adUnits = getAdUnits();
       let innerAdUnits;
       requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
-      let pubcid = getCookie(COOKIE_NAME);
+      let pubcid = getCookie(ID_NAME);
       innerAdUnits.forEach((unit) => {
         unit.bids.forEach((bid) => {
           expect(bid).to.have.deep.nested.property('crumbs.pubcid');
@@ -114,13 +182,12 @@ describe('Publisher Common ID', function () {
 
     it('disable', function () {
       setConfig({enable: false});
-      setCookie(COOKIE_NAME, '', -1); // erase cookie
       let adUnits = getAdUnits();
       let unmodified = getAdUnits();
       let innerAdUnits;
       expect(isPubcidEnabled()).to.be.false;
       requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
-      expect(getCookie(COOKIE_NAME)).to.be.null;
+      expect(getCookie(ID_NAME)).to.be.null;
       assert.deepEqual(innerAdUnits, unmodified);
       setConfig({enable: true}); // reset
       requestBidHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
@@ -133,7 +200,6 @@ describe('Publisher Common ID', function () {
 
     it('change expiration time', function () {
       setConfig({expInterval: 100});
-      setCookie(COOKIE_NAME, '', -1); // erase cookie
       expect(getExpInterval()).to.equal(100);
       let adUnits = getAdUnits();
       let innerAdUnits;
@@ -190,6 +256,46 @@ describe('Publisher Common ID', function () {
           expect(bid).to.have.deep.nested.property('crumbs.pubcid');
         });
       });
+    });
+  });
+
+  describe('Storage item functions', () => {
+    beforeEach(() => { cleanUp(); });
+    afterEach(() => { cleanUp(); });
+
+    it('Test set', () => {
+      const key = ID_NAME;
+      const val = 'test-set-value';
+      // Set item in localStorage
+      const now = Date.now();
+      setStorageItem(key, val, 100);
+      // Check both item and expiry time are stored
+      const expVal = localStorage.getItem(key + EXP);
+      const storedVal = localStorage.getItem(key);
+      // Verify expiry
+      expect(expVal).to.not.be.null;
+      const expDate = new Date(expVal);
+      expect((expDate.getTime() - now) / 1000).to.be.closeTo(100 * 60, 5);
+      // Verify value
+      expect(storedVal).to.equal(val);
+    });
+
+    it('Test get and remove', () => {
+      const key = ID_NAME;
+      const val = 'test-get-remove';
+      setStorageItem(key, val, 10);
+      expect(getStorageItem(key)).to.equal(val);
+      removeStorageItem(key);
+      expect(getStorageItem(key)).to.be.null;
+    });
+
+    it('Test expiry', () => {
+      const key = ID_NAME;
+      const val = 'test-expiry';
+      setStorageItem(key, val, -1);
+      expect(localStorage.getItem(key)).to.equal(val);
+      expect(getStorageItem(key)).to.be.null;
+      expect(localStorage.getItem(key)).to.be.null;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Enable PubCommonId module to store id in localStorage.  This is for publishers that have not yet switch to the new user id module.  As a transition aid, the pubcid is written both as a cookie and also to the localStorage.  Cookie values, if present, will be copied into localStorage.  Otherwise a new id will be generated and written to both locations.  

The default expiration time has also been reduced to 1 year.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
pyang@conversantmedia.com

- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1217

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
