### PR TITLE
Kargo migration to localstorage alternatives

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -73,53 +73,13 @@ export const spec = {
   },
 
   // PRIVATE
-  _readCookie(name) {
-    let nameEquals = `${name}=`;
-    let cookies = document.cookie.split(';');
-
-    for (let i = 0; i < cookies.length; i++) {
-      let cookie = cookies[i];
-      while (cookie.charAt(0) === ' ') {
-        cookie = cookie.substring(1, cookie.length);
-      }
-
-      if (cookie.indexOf(nameEquals) === 0) {
-        return cookie.substring(nameEquals.length, cookie.length);
-      }
-    }
-
-    return null;
-  },
-
-  _getCrbIds() {
+  _getCrb() {
     try {
-      const crb = JSON.parse(decodeURIComponent(spec._readCookie('krg_crb')));
-      let syncIds = {};
-
-      if (crb && crb.v) {
-        let vParsed = JSON.parse(atob(crb.v));
-
-        if (vParsed && vParsed.syncIds) {
-          syncIds = vParsed.syncIds;
-        }
+      const crb = JSON.parse(atob(spec._getLocalStorageSafely('krg_crb')));
+      if (crb) {
+        return crb;
       }
-
-      return syncIds;
-    } catch (e) {
       return {};
-    }
-  },
-
-  _getUid() {
-    try {
-      const uid = JSON.parse(decodeURIComponent(spec._readCookie('krg_uid')));
-      let vData = {};
-
-      if (uid && uid.v) {
-        vData = uid.v;
-      }
-
-      return vData;
     } catch (e) {
       return {};
     }
@@ -156,20 +116,18 @@ export const spec = {
   },
 
   _getUserIds() {
-    const uid = spec._getUid();
-    const crbIds = spec._getCrbIds();
-
+    const crb = spec._getCrb();
     return {
-      kargoID: uid.userId,
-      clientID: uid.clientId,
-      crbIDs: crbIds,
-      optOut: uid.optOut
+      kargoID: crb.userId,
+      clientID: crb.clientId,
+      crbIDs: crb.syncIds || {},
+      optOut: crb.optOut
     };
   },
 
   _getClientId() {
-    const uid = spec._getUid();
-    return uid.clientId;
+    const crb = spec._getCrb();
+    return crb.clientId;
   },
 
   _getAllMetadata() {
@@ -177,7 +135,7 @@ export const spec = {
       userIDs: spec._getUserIds(),
       krux: spec._getKrux(),
       pageURL: window.location.href,
-      rawCRB: spec._readCookie('krg_crb')
+      rawCRB: spec._getLocalStorageSafely('krg_crb')
     };
   },
 

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -73,16 +73,53 @@ export const spec = {
   },
 
   // PRIVATE
-  _getCrb() {
+  _readCookie(name) {
+    let nameEquals = `${name}=`;
+    let cookies = document.cookie.split(';');
+
+    for (let i = 0; i < cookies.length; i++) {
+      let cookie = cookies[i];
+      while (cookie.charAt(0) === ' ') {
+        cookie = cookie.substring(1, cookie.length);
+      }
+
+      if (cookie.indexOf(nameEquals) === 0) {
+        return cookie.substring(nameEquals.length, cookie.length);
+      }
+    }
+
+    return null;
+  },
+
+  _getCrbFromCookie() {
     try {
-      const crb = JSON.parse(atob(spec._getLocalStorageSafely('krg_crb')));
-      if (crb) {
-        return crb;
+      const crb = JSON.parse(decodeURIComponent(spec._readCookie('krg_crb')));
+      if (crb && crb.v) {
+        let vParsed = JSON.parse(atob(crb.v));
+        if (vParsed) {
+          return vParsed;
+        }
       }
       return {};
     } catch (e) {
       return {};
     }
+  },
+
+  _getCrbFromLocalStorage() {
+    try {
+      return JSON.parse(atob(spec._getLocalStorageSafely('krg_crb')));
+    } catch (e) {
+      return {};
+    }
+  },
+
+  _getCrb() {
+    let localStorageCrb = spec._getCrbFromLocalStorage();
+    if (Object.keys(localStorageCrb).length) {
+      return localStorageCrb;
+    }
+    return spec._getCrbFromCookie();
   },
 
   _getKruxUserId() {
@@ -135,7 +172,8 @@ export const spec = {
       userIDs: spec._getUserIds(),
       krux: spec._getKrux(),
       pageURL: window.location.href,
-      rawCRB: spec._getLocalStorageSafely('krg_crb')
+      rawCRB: spec._readCookie('krg_crb'),
+      rawCRBLocalStorage: spec._getLocalStorageSafely('krg_crb')
     };
   },
 

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -138,8 +138,15 @@ describe('kargo adapter tests', function () {
       return 'eyJzeW5jSWRzIjp7IjIiOiI4MmZhMjU1NS01OTY5LTQ2MTQtYjRjZS00ZGNmMTA4MGU5ZjkiLCIxNiI6IlZveElrOEFvSnowQUFFZENleUFBQUFDMiY1MDIiLCIyMyI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjI0IjoiVm94SWs4QW9KejBBQUVkQ2V5QUFBQUMyJjUwMiIsIjI1IjoiNWVlMjQxMzgtNWUwMy00YjlkLWE5NTMtMzhlODMzZjI4NDlmIiwiMl84MCI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjJfOTMiOiI1ZWUyNDEzOC01ZTAzLTRiOWQtYTk1My0zOGU4MzNmMjg0OWYifSwidXNlcklkIjoiNWYxMDg4MzEtMzAyZC0xMWU3LWJmNmItNDU5NWFjZDNiZjZjIiwiY2xpZW50SWQiOiIyNDEwZDhmMi1jMTExLTQ4MTEtODhhNS03YjVlMTkwZTQ3NWYiLCJvcHRPdXQiOmZhbHNlLCJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9';
     }
 
-    function initializeKrgCrb() {
-      setLocalStorageItem('krg_crb', getKrgCrb());
+    function getKrgCrbOldStyle() {
+      return '%7B%22v%22%3A%22eyJzeW5jSWRzIjp7IjIiOiI4MmZhMjU1NS01OTY5LTQ2MTQtYjRjZS00ZGNmMTA4MGU5ZjkiLCIxNiI6IlZveElrOEFvSnowQUFFZENleUFBQUFDMiY1MDIiLCIyMyI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjI0IjoiVm94SWs4QW9KejBBQUVkQ2V5QUFBQUMyJjUwMiIsIjI1IjoiNWVlMjQxMzgtNWUwMy00YjlkLWE5NTMtMzhlODMzZjI4NDlmIiwiMl84MCI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjJfOTMiOiI1ZWUyNDEzOC01ZTAzLTRiOWQtYTk1My0zOGU4MzNmMjg0OWYifSwidXNlcklkIjoiNWYxMDg4MzEtMzAyZC0xMWU3LWJmNmItNDU5NWFjZDNiZjZjIiwiY2xpZW50SWQiOiIyNDEwZDhmMi1jMTExLTQ4MTEtODhhNS03YjVlMTkwZTQ3NWYiLCJvcHRPdXQiOmZhbHNlLCJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9%22%7D';
+    }
+
+    function initializeKrgCrb(cookieOnly) {
+      if (!cookieOnly) {
+        setLocalStorageItem('krg_crb', getKrgCrb());
+      }
+      setCookie('krg_crb', getKrgCrbOldStyle());
     }
 
     function getInvalidKrgCrbType1() {
@@ -150,23 +157,51 @@ describe('kargo adapter tests', function () {
       setLocalStorageItem('krg_crb', getInvalidKrgCrbType1());
     }
 
+    function initializeInvalidKrgCrbType1Cookie() {
+      setCookie('krg_crb', getInvalidKrgCrbType1());
+    }
+
     function getInvalidKrgCrbType2() {
       return 'Ly8v';
+    }
+
+    function getInvalidKrgCrbType2OldStyle() {
+      return '%7B%22v%22%3A%22%26%26%26%26%26%26%22%7D';
     }
 
     function initializeInvalidKrgCrbType2() {
       setLocalStorageItem('krg_crb', getInvalidKrgCrbType2());
     }
 
+    function initializeInvalidKrgCrbType2Cookie() {
+      setCookie('krg_crb', getInvalidKrgCrbType2OldStyle());
+    }
+
+    function getInvalidKrgCrbType3OldStyle() {
+      return '%7B%22v%22%3A%22Ly8v%22%7D';
+    }
+
+    function initializeInvalidKrgCrbType3Cookie() {
+      setCookie('krg_crb', getInvalidKrgCrbType3OldStyle());
+    }
+
     function getEmptyKrgCrb() {
       return 'eyJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9';
+    }
+
+    function getEmptyKrgCrbOldStyle() {
+      return '%7B%22v%22%3A%22eyJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9%22%7D';
     }
 
     function initializeEmptyKrgCrb() {
       setLocalStorageItem('krg_crb', getEmptyKrgCrb());
     }
 
-    function getExpectedKrakenParams(excludeUserIds, excludeKrux, expectedRawCRB) {
+    function initializeEmptyKrgCrbCookie() {
+      setCookie('krg_crb', getEmptyKrgCrbOldStyle());
+    }
+
+    function getExpectedKrakenParams(excludeUserIds, excludeKrux, expectedRawCRB, expectedRawCRBCookie) {
       var base = {
         timeout: 200,
         currency: 'USD',
@@ -206,7 +241,8 @@ describe('kargo adapter tests', function () {
           ]
         },
         pageURL: window.location.href,
-        rawCRB: expectedRawCRB
+        rawCRB: expectedRawCRBCookie,
+        rawCRBLocalStorage: expectedRawCRB
       };
 
       if (excludeUserIds === true) {
@@ -237,41 +273,70 @@ describe('kargo adapter tests', function () {
       expect(krakenParams).to.deep.equal(expected);
     }
 
-    it('works when all params and cookies are correctly set', function() {
+    it('works when all params and localstorage and cookies are correctly set', function() {
       initializeKruxUser();
       initializeKruxSegments();
       initializeKrgCrb();
-      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
+      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb(), getKrgCrbOldStyle()));
+    });
+
+    it('works when all params and cookies are correctly set but no localstorage', function() {
+      initializeKruxUser();
+      initializeKruxSegments();
+      initializeKrgCrb(true);
+      testBuildRequests(getExpectedKrakenParams(undefined, undefined, null, getKrgCrbOldStyle()));
     });
 
     it('gracefully handles nothing being set', function() {
-      testBuildRequests(getExpectedKrakenParams(true, true, null));
+      testBuildRequests(getExpectedKrakenParams(true, true, null, null));
     });
 
     it('gracefully handles browsers without localStorage', function() {
       simulateNoLocalStorage();
-      testBuildRequests(getExpectedKrakenParams(true, true, null));
+      testBuildRequests(getExpectedKrakenParams(true, true, null, null));
     });
 
     it('handles empty yet valid Kargo CRB', function() {
       initializeKruxUser();
       initializeKruxSegments();
       initializeEmptyKrgCrb();
-      testBuildRequests(getExpectedKrakenParams(true, undefined, getEmptyKrgCrb()));
+      initializeEmptyKrgCrbCookie();
+      testBuildRequests(getExpectedKrakenParams(true, undefined, getEmptyKrgCrb(), getEmptyKrgCrbOldStyle()));
     });
 
     it('handles broken Kargo CRBs where base64 encoding is invalid', function() {
       initializeKruxUser();
       initializeKruxSegments();
       initializeInvalidKrgCrbType1();
-      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType1()));
+      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType1(), null));
+    });
+
+    it('handles broken Kargo CRBs where top level JSON is invalid on cookie', function() {
+      initializeKruxUser();
+      initializeKruxSegments();
+      initializeInvalidKrgCrbType1Cookie();
+      testBuildRequests(getExpectedKrakenParams(true, undefined, null, getInvalidKrgCrbType1()));
     });
 
     it('handles broken Kargo CRBs where decoded JSON is invalid', function() {
       initializeKruxUser();
       initializeKruxSegments();
       initializeInvalidKrgCrbType2();
-      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType2()));
+      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType2(), null));
+    });
+
+    it('handles broken Kargo CRBs where inner base 64 is invalid on cookie', function() {
+      initializeKruxUser();
+      initializeKruxSegments();
+      initializeInvalidKrgCrbType2Cookie();
+      testBuildRequests(getExpectedKrakenParams(true, undefined, null, getInvalidKrgCrbType2OldStyle()));
+    });
+
+    it('handles broken Kargo CRBs where inner JSON is invalid on cookie', function() {
+      initializeKruxUser();
+      initializeKruxSegments();
+      initializeInvalidKrgCrbType3Cookie();
+      testBuildRequests(getExpectedKrakenParams(true, undefined, null, getInvalidKrgCrbType3OldStyle()));
     });
 
     it('handles a non-existant currency object on the config', function() {
@@ -279,7 +344,7 @@ describe('kargo adapter tests', function () {
       initializeKruxUser();
       initializeKruxSegments();
       initializeKrgCrb();
-      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
+      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb(), getKrgCrbOldStyle()));
     });
 
     it('handles no ad server currency being set on the currency object in the config', function() {
@@ -287,7 +352,7 @@ describe('kargo adapter tests', function () {
       initializeKruxUser();
       initializeKruxSegments();
       initializeKrgCrb();
-      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
+      testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb(), getKrgCrbOldStyle()));
     });
   });
 

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -134,20 +134,12 @@ describe('kargo adapter tests', function () {
       setLocalStorageItem('kxkar_segs', 'qv9v984dy,rpx2gy365,qrd5u4axv,rnub9nmtd,reha00jnu');
     }
 
-    function initializeKrgUid() {
-      setCookie('krg_uid', '%7B%22v%22%3A%7B%22userId%22%3A%225f108831-302d-11e7-bf6b-4595acd3bf6c%22%2C%22clientId%22%3A%222410d8f2-c111-4811-88a5-7b5e190e475f%22%2C%22optOut%22%3Afalse%7D%7D');
-    }
-
     function getKrgCrb() {
-      return '%7B%22v%22%3A%22eyJzeW5jSWRzIjp7IjIiOiI4MmZhMjU1NS01OTY5LTQ2MTQtYjRjZS00ZGNmMTA4MGU5ZjkiLCIxNiI6IlZveElrOEFvSnowQUFFZENleUFBQUFDMiY1MDIiLCIyMyI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjI0IjoiVm94SWs4QW9KejBBQUVkQ2V5QUFBQUMyJjUwMiIsIjI1IjoiNWVlMjQxMzgtNWUwMy00YjlkLWE5NTMtMzhlODMzZjI4NDlmIiwiMl84MCI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjJfOTMiOiI1ZWUyNDEzOC01ZTAzLTRiOWQtYTk1My0zOGU4MzNmMjg0OWYifSwiZXhwaXJlVGltZSI6MTQ5NzQ0OTM4MjY2OCwibGFzdFN5bmNlZEF0IjoxNDk3MzYyOTc5MDEyfQ%3D%3D%22%7D';
+      return 'eyJzeW5jSWRzIjp7IjIiOiI4MmZhMjU1NS01OTY5LTQ2MTQtYjRjZS00ZGNmMTA4MGU5ZjkiLCIxNiI6IlZveElrOEFvSnowQUFFZENleUFBQUFDMiY1MDIiLCIyMyI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjI0IjoiVm94SWs4QW9KejBBQUVkQ2V5QUFBQUMyJjUwMiIsIjI1IjoiNWVlMjQxMzgtNWUwMy00YjlkLWE5NTMtMzhlODMzZjI4NDlmIiwiMl84MCI6ImQyYTg1NWE1LTFiMWMtNDMwMC05NDBlLWE3MDhmYTFmMWJkZSIsIjJfOTMiOiI1ZWUyNDEzOC01ZTAzLTRiOWQtYTk1My0zOGU4MzNmMjg0OWYifSwidXNlcklkIjoiNWYxMDg4MzEtMzAyZC0xMWU3LWJmNmItNDU5NWFjZDNiZjZjIiwiY2xpZW50SWQiOiIyNDEwZDhmMi1jMTExLTQ4MTEtODhhNS03YjVlMTkwZTQ3NWYiLCJvcHRPdXQiOmZhbHNlLCJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9';
     }
 
     function initializeKrgCrb() {
-      setCookie('krg_crb', getKrgCrb());
-    }
-
-    function initializeInvalidKrgUid() {
-      setCookie('krg_uid', 'invalid-krg-uid');
+      setLocalStorageItem('krg_crb', getKrgCrb());
     }
 
     function getInvalidKrgCrbType1() {
@@ -155,35 +147,23 @@ describe('kargo adapter tests', function () {
     }
 
     function initializeInvalidKrgCrbType1() {
-      setCookie('krg_crb', getInvalidKrgCrbType1());
+      setLocalStorageItem('krg_crb', getInvalidKrgCrbType1());
     }
 
     function getInvalidKrgCrbType2() {
-      return '%7B%22v%22%3A%22%26%26%26%26%26%26%22%7D';
+      return 'Ly8v';
     }
 
     function initializeInvalidKrgCrbType2() {
-      setCookie('krg_crb', getInvalidKrgCrbType2());
-    }
-
-    function getInvalidKrgCrbType3() {
-      return '%7B%22v%22%3A%22Ly8v%22%7D';
-    }
-
-    function initializeInvalidKrgCrbType3() {
-      setCookie('krg_crb', getInvalidKrgCrbType3());
-    }
-
-    function initializeEmptyKrgUid() {
-      setCookie('krg_uid', '%7B%7D');
+      setLocalStorageItem('krg_crb', getInvalidKrgCrbType2());
     }
 
     function getEmptyKrgCrb() {
-      return '%7B%22v%22%3A%22eyJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9%22%7D';
+      return 'eyJleHBpcmVUaW1lIjoxNDk3NDQ5MzgyNjY4LCJsYXN0U3luY2VkQXQiOjE0OTczNjI5NzkwMTJ9';
     }
 
     function initializeEmptyKrgCrb() {
-      setCookie('krg_crb', getEmptyKrgCrb());
+      setLocalStorageItem('krg_crb', getEmptyKrgCrb());
     }
 
     function getExpectedKrakenParams(excludeUserIds, excludeKrux, expectedRawCRB) {
@@ -233,16 +213,6 @@ describe('kargo adapter tests', function () {
         base.userIDs = {
           crbIDs: {}
         };
-      } else if (excludeUserIds) {
-        if (excludeUserIds.uid) {
-          delete base.userIDs.kargoID;
-          delete base.userIDs.clientID;
-          delete base.userIDs.optOut;
-        }
-
-        if (excludeUserIds.crb) {
-          base.userIDs.crbIDs = {};
-        }
       }
 
       if (excludeKrux) {
@@ -270,7 +240,6 @@ describe('kargo adapter tests', function () {
     it('works when all params and cookies are correctly set', function() {
       initializeKruxUser();
       initializeKruxSegments();
-      initializeKrgUid();
       initializeKrgCrb();
       testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
     });
@@ -281,56 +250,34 @@ describe('kargo adapter tests', function () {
 
     it('gracefully handles browsers without localStorage', function() {
       simulateNoLocalStorage();
-      initializeKrgUid();
-      initializeKrgCrb();
-      testBuildRequests(getExpectedKrakenParams(false, true, getKrgCrb()));
+      testBuildRequests(getExpectedKrakenParams(true, true, null));
     });
 
-    it('handles empty yet valid Kargo CRBs and UIDs', function() {
+    it('handles empty yet valid Kargo CRB', function() {
       initializeKruxUser();
       initializeKruxSegments();
-      initializeEmptyKrgUid();
       initializeEmptyKrgCrb();
       testBuildRequests(getExpectedKrakenParams(true, undefined, getEmptyKrgCrb()));
     });
 
-    it('handles broken Kargo UIDs', function() {
+    it('handles broken Kargo CRBs where base64 encoding is invalid', function() {
       initializeKruxUser();
       initializeKruxSegments();
-      initializeInvalidKrgUid();
-      initializeKrgCrb();
-      testBuildRequests(getExpectedKrakenParams({uid: true}, undefined, getKrgCrb()));
-    });
-
-    it('handles broken Kargo CRBs where top level JSON is invalid', function() {
-      initializeKruxUser();
-      initializeKruxSegments();
-      initializeKrgUid();
       initializeInvalidKrgCrbType1();
-      testBuildRequests(getExpectedKrakenParams({crb: true}, undefined, getInvalidKrgCrbType1()));
+      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType1()));
     });
 
-    it('handles broken Kargo CRBs where inner base 64 is invalid', function() {
+    it('handles broken Kargo CRBs where decoded JSON is invalid', function() {
       initializeKruxUser();
       initializeKruxSegments();
-      initializeKrgUid();
       initializeInvalidKrgCrbType2();
-      testBuildRequests(getExpectedKrakenParams({crb: true}, undefined, getInvalidKrgCrbType2()));
-    });
-
-    it('handles broken Kargo CRBs where inner JSON is invalid', function() {
-      initializeKruxUser();
-      initializeKruxSegments();
-      initializeKrgUid();
-      initializeInvalidKrgCrbType3();
-      testBuildRequests(getExpectedKrakenParams({crb: true}, undefined, getInvalidKrgCrbType3()));
+      testBuildRequests(getExpectedKrakenParams(true, undefined, getInvalidKrgCrbType2()));
     });
 
     it('handles a non-existant currency object on the config', function() {
       simulateNoCurrencyObject();
       initializeKruxUser();
       initializeKruxSegments();
-      initializeKrgUid();
       initializeKrgCrb();
       testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
     });
@@ -339,7 +286,6 @@ describe('kargo adapter tests', function () {
       simulateNoAdServerCurrency();
       initializeKruxUser();
       initializeKruxSegments();
-      initializeKrgUid();
       initializeKrgCrb();
       testBuildRequests(getExpectedKrakenParams(undefined, undefined, getKrgCrb()));
     });
@@ -429,10 +375,10 @@ describe('kargo adapter tests', function () {
 
   describe('user sync handler', function() {
     const clientId = '74c81cbb-7d07-46d9-be9b-68ccb291c949';
-    var shouldSimulateOutdatedBrowser, uid, isActuallyOutdatedBrowser;
+    var shouldSimulateOutdatedBrowser, crb, isActuallyOutdatedBrowser;
 
     beforeEach(() => {
-      uid = {};
+      crb = {};
       shouldSimulateOutdatedBrowser = false;
       isActuallyOutdatedBrowser = false;
 
@@ -455,8 +401,8 @@ describe('kargo adapter tests', function () {
         });
       }
 
-      sandbox.stub(spec, '_getUid').callsFake(function() {
-        return uid;
+      sandbox.stub(spec, '_getCrb').callsFake(function() {
+        return crb;
       });
     });
 
@@ -469,7 +415,7 @@ describe('kargo adapter tests', function () {
     }
 
     function turnOnClientId() {
-      uid.clientId = clientId;
+      crb.clientId = clientId;
     }
 
     function simulateOutdatedBrowser() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
We want to pull our information from localstorage primarily and fall back to cookies. This is due to improvements across our ecosystem and various Apple ITP updates on the horizon.
