### PR TITLE
Ensure width and height are integers

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -419,10 +419,9 @@ export function getIabSubCategory(bidderCode, category) {
 
 // check that the bid has a width and height set
 function validBidSize(adUnitCode, bid, bidRequests) {
-  bid.width = parseInt(bid.width, 10) || 0;
-  bid.height = parseInt(bid.height, 10) || 0;
-
-  if (bid.width && bid.height) {
+  if ((bid.width || parseInt(bid.width, 10) === 0) && (bid.height || parseInt(bid.height === 0)) {
+    bid.width = parseInt(width, 10);
+    bid.height = parseInt(height, 10);
     return true;
   }
 

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -420,8 +420,8 @@ export function getIabSubCategory(bidderCode, category) {
 // check that the bid has a width and height set
 function validBidSize(adUnitCode, bid, bidRequests) {
   if ((bid.width || parseInt(bid.width, 10) === 0) && (bid.height || parseInt(bid.height, 10) === 0)) {
-    bid.width = parseInt(width, 10);
-    bid.height = parseInt(height, 10);
+    bid.width = parseInt(bid.width, 10);
+    bid.height = parseInt(bid.height, 10);
     return true;
   }
 

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -421,7 +421,7 @@ export function getIabSubCategory(bidderCode, category) {
 function validBidSize(adUnitCode, bid, bidRequests) {
   bid.width = parseInt(bid.width, 10) || 0;
   bid.height = parseInt(bid.height, 10) || 0;
-  
+
   if (bid.width && bid.height) {
     return true;
   }

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -419,7 +419,7 @@ export function getIabSubCategory(bidderCode, category) {
 
 // check that the bid has a width and height set
 function validBidSize(adUnitCode, bid, bidRequests) {
-  if ((bid.width || parseInt(bid.width, 10) === 0) && (bid.height || parseInt(bid.height === 0)) {
+  if ((bid.width || parseInt(bid.width, 10) === 0) && (bid.height || parseInt(bid.height, 10) === 0)) {
     bid.width = parseInt(width, 10);
     bid.height = parseInt(height, 10);
     return true;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -436,7 +436,7 @@ function validBidSize(adUnitCode, bid, bidRequests) {
   if (parsedSizes.length === 1) {
     const [ width, height ] = parsedSizes[0].split('x');
     bid.width = parseInt(width, 10);
-    bid.height = parsrInt(height, 10);
+    bid.height = parseInt(height, 10);
     return true;
   }
 

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -419,7 +419,10 @@ export function getIabSubCategory(bidderCode, category) {
 
 // check that the bid has a width and height set
 function validBidSize(adUnitCode, bid, bidRequests) {
-  if ((bid.width || bid.width === 0) && (bid.height || bid.height === 0)) {
+  bid.width = parseInt(bid.width, 10) || 0;
+  bid.height = parseInt(bid.height, 10) || 0;
+  
+  if (bid.width && bid.height) {
     return true;
   }
 
@@ -432,8 +435,8 @@ function validBidSize(adUnitCode, bid, bidRequests) {
   // response that does not explicitly set width or height
   if (parsedSizes.length === 1) {
     const [ width, height ] = parsedSizes[0].split('x');
-    bid.width = width;
-    bid.height = height;
+    bid.width = parseInt(width, 10);
+    bid.height = parsrInt(height, 10);
     return true;
   }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Some bid responses return width and height as strings. Let's follow the docs and ensure that they indeed are integers, avoiding some strict comparison surprises.