### PR TITLE
Adjust TTL for MANTIS adapter

### DIFF
--- a/modules/mantisBidAdapter.js
+++ b/modules/mantisBidAdapter.js
@@ -252,7 +252,7 @@ const spec = {
         width: ad.width,
         height: ad.height,
         ad: ad.html,
-        ttl: 86400,
+        ttl: ad.ttl || serverResponse.body.ttl || 86400,
         creativeId: ad.view,
         netRevenue: true,
         currency: 'USD'

--- a/modules/mantisBidAdapter.js
+++ b/modules/mantisBidAdapter.js
@@ -168,7 +168,7 @@ function buildMantisUrl(path, data, domain) {
     tz: new Date().getTimezoneOffset(),
     buster: new Date().getTime(),
     secure: isSecure(),
-    version: 8
+    version: 9
   };
   if (!inIframe() || isAmp()) {
     params.mobile = !isAmp() && isDesktop(true) ? 'false' : 'true';

--- a/test/spec/modules/mantisBidAdapter_spec.js
+++ b/test/spec/modules/mantisBidAdapter_spec.js
@@ -128,6 +128,81 @@ describe('MantisAdapter', function () {
   });
 
   describe('interpretResponse', function () {
+    it('use ad ttl if provided', function () {
+      let response = {
+        body: {
+          ttl: 360,
+          uuid: 'uuid',
+          ads: [
+            {
+              bid: 'bid',
+              cpm: 1,
+              view: 'view',
+              width: 300,
+              ttl: 250,
+              height: 250,
+              html: '<!-- Creative -->'
+            }
+          ]
+        }
+      };
+
+      let expectedResponse = [
+        {
+          requestId: 'bid',
+          cpm: 1,
+          width: 300,
+          height: 250,
+          ttl: 250,
+          ad: '<!-- Creative -->',
+          creativeId: 'view',
+          netRevenue: true,
+          currency: 'USD'
+        }
+      ];
+      let bidderRequest;
+
+      let result = spec.interpretResponse(response, {bidderRequest});
+      expect(result[0]).to.deep.equal(expectedResponse[0]);
+    });
+
+    it('use global ttl if provded', function () {
+      let response = {
+        body: {
+          ttl: 360,
+          uuid: 'uuid',
+          ads: [
+            {
+              bid: 'bid',
+              cpm: 1,
+              view: 'view',
+              width: 300,
+              height: 250,
+              html: '<!-- Creative -->'
+            }
+          ]
+        }
+      };
+
+      let expectedResponse = [
+        {
+          requestId: 'bid',
+          cpm: 1,
+          width: 300,
+          height: 250,
+          ttl: 360,
+          ad: '<!-- Creative -->',
+          creativeId: 'view',
+          netRevenue: true,
+          currency: 'USD'
+        }
+      ];
+      let bidderRequest;
+
+      let result = spec.interpretResponse(response, {bidderRequest});
+      expect(result[0]).to.deep.equal(expectedResponse[0]);
+    });
+
     it('display ads returned', function () {
       let response = {
         body: {


### PR DESCRIPTION
Existing adapter has incorrect TTL of 24 hours hard coded, change will allow for TTL overriding by server response at bid or global level