### PR TITLE
update aja adaptor: forgot privacyLink for Native

### DIFF
--- a/modules/ajaBidAdapter.js
+++ b/modules/ajaBidAdapter.js
@@ -103,6 +103,7 @@ export const spec = {
           sponsoredBy: assets.sponsor,
           clickUrl: assets.lp_link,
           impressionTrackers: nativeAd.imps,
+          privacyLink: assets.adchoice_url,
         };
 
         if (assets.img_main !== undefined) {

--- a/modules/ajaBidAdapter.md
+++ b/modules/ajaBidAdapter.md
@@ -74,7 +74,11 @@ var adUnits = [
         icon: {
           required: false,
           sendId: false
-        }
+        },
+        privacyLink: {
+          required: true,
+          sendId: true
+        },
       }
     },
     bids: [{

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -210,7 +210,8 @@ describe('AjaAdapter', function () {
             'clickUrl': 'https://example.com/lp?k=v',
             'impressionTrackers': [
               'https://example.com/imp'
-            ]
+            ],
+            'privacyLink': 'https://aja-kk.co.jp/optout',
           }
         }
       ];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

add `privacyLink` field for native format.

```
privacyLink: {
  required: true,
  sendId: true
},
```
- contact email of the adapter’s maintainer ssp_support@aja-kk.co.jp
- [☓] official adapter submission
