### PR TITLE
Added MediaFuse Lift alias to Orbitsoft adapter

### DIFF
--- a/modules/orbitsoftBidAdapter.js
+++ b/modules/orbitsoftBidAdapter.js
@@ -25,7 +25,7 @@ let styleParamsMap = {
 };
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['oas', '152media'], // short code and customer aliases
+  aliases: ['oas', 'mediafuseLift'], // short code and customer aliases
   isBidRequestValid: function (bid) {
     switch (true) {
       case !('params' in bid):


### PR DESCRIPTION
We'd like to add MediaFuse Lift (_mediafuseLift_) alias to Orbitsoft adapter. Dev-docs will be submitted as well. Thank you.