### PR TITLE
Add gdpr_consented_providers for google gdpr

### DIFF
--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -252,6 +252,10 @@ export const spec = {
       }
     }
 
+    if (currentBidRequest.params.gdpr_consented_providers) {
+      requestParams._fw_gdpr_consented_providers = currentBidRequest.params.gdpr_consented_providers;
+    }
+
     var vastParams = currentBidRequest.params.vastUrlParams;
     if (typeof vastParams === 'object') {
       for (var key in vastParams) {

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -46,6 +46,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
         'bidder': 'freewheel-ssp',
         'params': {
           'zoneId': '277225',
+          'gdpr_consented_providers': '123,345',
           'vastUrlParams': {'ownerId': 'kombRJ'}
         },
         'adUnitCode': 'adunit-code',
@@ -71,6 +72,7 @@ describe('freewheel-ssp BidAdapter Test', function () {
       expect(payload.playerSize).to.equal('300x600');
       expect(payload._fw_gdpr).to.equal(true);
       expect(payload._fw_gdpr_consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
+      expect(payload._fw_gdpr_consented_providers).to.equal('123,345');
     });
 
     it('sends bid request to ENDPOINT via GET', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->
Add a parameter gdpr_consented_providers for google gdpr solution.
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
xfchen@freewheel.tv
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
