### PR TITLE
fix bidTimeout event (#3583)

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -252,7 +252,7 @@ adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTi
   return bidRequests;
 };
 
-adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks, requestBidsTimeout) => {
+adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks, requestBidsTimeout, onTimelyResponse) => {
   if (!bidRequests.length) {
     utils.logWarn('callBids executed with no bidRequests.  Were they filtered by labels or sizing?');
     return;
@@ -323,7 +323,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done
     } : undefined);
-    adapter.callBids(bidRequest, addBidResponse.bind(bidRequest), doneCb.bind(bidRequest), ajax);
+    adapter.callBids(bidRequest, addBidResponse.bind(bidRequest), doneCb.bind(bidRequest), ajax, onTimelyResponse);
   });
 }
 

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -168,7 +168,7 @@ export function newBidder(spec) {
       return Object.freeze(spec);
     },
     registerSyncs,
-    callBids: function(bidderRequest, addBidResponse, done, ajax) {
+    callBids: function(bidderRequest, addBidResponse, done, ajax, onTimelyResponse) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
       }
@@ -267,6 +267,8 @@ export function newBidder(spec) {
         // If the adapter code fails, no bids should be added. After all the bids have been added, make
         // sure to call the `onResponse` function so that we're one step closer to calling done().
         function onSuccess(response, responseObj) {
+          onTimelyResponse(spec.code);
+
           try {
             response = JSON.parse(response);
           } catch (e) { /* response might not be JSON... that's ok. */ }
@@ -316,6 +318,8 @@ export function newBidder(spec) {
         // If the server responds with an error, there's not much we can do. Log it, and make sure to
         // call onResponse() so that we're one step closer to calling done().
         function onFailure(err) {
+          onTimelyResponse(spec.code);
+
           logError(`Server call for ${spec.code} failed: ${err}. Continuing without bids.`);
           onResponse();
         }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -614,17 +614,15 @@ describe('auctionmanager.js', function () {
 
     before(function () {
       makeRequestsStub = sinon.stub(adapterManager, 'makeBidRequests');
-
-      ajaxStub = sinon.stub(ajaxLib, 'ajaxBuilder').callsFake(mockAjaxBuilder);
     });
 
     after(function () {
-      ajaxStub.restore();
       adapterManager.makeBidRequests.restore();
     });
 
     describe('when auction timeout is 3000', function () {
       before(function () {
+        ajaxStub = sinon.stub(ajaxLib, 'ajaxBuilder').callsFake(mockAjaxBuilder);
         makeRequestsStub.returns(TEST_BID_REQS);
       });
       beforeEach(function () {
@@ -645,6 +643,10 @@ describe('auctionmanager.js', function () {
 
       afterEach(function () {
         auctionModule.newAuction.restore();
+      });
+
+      after(function () {
+        ajaxStub.restore();
       });
 
       function checkPbDg(cpm, expected, msg) {
@@ -741,6 +743,7 @@ describe('auctionmanager.js', function () {
 
     describe('when auction timeout is 20', function () {
       let eventsEmitSpy;
+      let server;
 
       before(function () {
         bids = [mockBid(), mockBid({ bidderCode: BIDDER_CODE1 })];
@@ -750,6 +753,8 @@ describe('auctionmanager.js', function () {
       });
 
       beforeEach(function () {
+        server = sinon.createFakeServer();
+
         adUnits = [{
           code: ADUNIT_CODE,
           bids: [
@@ -758,35 +763,72 @@ describe('auctionmanager.js', function () {
         }];
         adUnitCodes = [ADUNIT_CODE];
 
-        auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: 20});
-        createAuctionStub = sinon.stub(auctionModule, 'newAuction');
-        createAuctionStub.returns(auction);
-
-        spec = mockBidder(BIDDER_CODE, [bids[0]]);
-        registerBidder(spec);
-
-        // Timeout is checked when bid is received. If that bid is the only one
-        // auction is waiting for, timeout is not emitted, so we need to add a
-        // second bidder to get timeout event.
-        let spec1 = mockBidder(BIDDER_CODE1, [bids[1]]);
-        registerBidder(spec1);
-
         eventsEmitSpy = sinon.spy(events, 'emit');
-
-        // make all timestamp calls 5 minutes apart
-        let callCount = 0;
-        sinon.stub(utils, 'timestamp').callsFake(function() {
-          return new Date().getTime() + (callCount++ * 1000 * 60 * 5);
-        });
       });
       afterEach(function () {
-        auctionModule.newAuction.restore();
+        server.restore();
         events.emit.restore();
-        utils.timestamp.restore();
       });
-      it('should emit BID_TIMEOUT for timed out bids', function () {
+      it('should emit BID_TIMEOUT for timed out bids', function (done) {
+        const spec1 = mockBidder(BIDDER_CODE, [bids[0]]);
+        registerBidder(spec1);
+        const spec2 = mockBidder(BIDDER_CODE1, [bids[1]]);
+        registerBidder(spec2);
+
+        function respondToRequest(requestIndex) {
+          server.requests[requestIndex].respond(200, {}, 'response body');
+        }
+        function auctionCallback() {
+          const bidTimeoutCall = eventsEmitSpy.withArgs(CONSTANTS.EVENTS.BID_TIMEOUT).getCalls()[0];
+          const timedOutBids = bidTimeoutCall.args[1];
+          assert.equal(timedOutBids.length, 1);
+          assert.equal(timedOutBids[0].bidder, BIDDER_CODE1);
+          done();
+        }
+        auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: auctionCallback, cbTimeout: 20});
+
         auction.callBids();
-        assert.ok(eventsEmitSpy.calledWith(CONSTANTS.EVENTS.BID_TIMEOUT), 'emitted events BID_TIMEOUT');
+        respondToRequest(0);
+      });
+      it('should NOT emit BID_TIMEOUT when all bidders responded in time', function (done) {
+        const spec1 = mockBidder(BIDDER_CODE, [bids[0]]);
+        registerBidder(spec1);
+        const spec2 = mockBidder(BIDDER_CODE1, [bids[1]]);
+        registerBidder(spec2);
+
+        function respondToRequest(requestIndex) {
+          server.requests[requestIndex].respond(200, {}, 'response body');
+        }
+        function auctionCallback() {
+          assert.ok(eventsEmitSpy.withArgs(CONSTANTS.EVENTS.BID_TIMEOUT).notCalled, 'did not emit event BID_TIMEOUT');
+          done();
+        }
+        auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: auctionCallback, cbTimeout: 20});
+
+        auction.callBids();
+        respondToRequest(0);
+        respondToRequest(1);
+      });
+      it('should NOT emit BID_TIMEOUT for bidders which responded in time but with an empty bid', function (done) {
+        const spec1 = mockBidder(BIDDER_CODE, []);
+        registerBidder(spec1);
+        const spec2 = mockBidder(BIDDER_CODE1, []);
+        registerBidder(spec2);
+
+        function respondToRequest(requestIndex) {
+          server.requests[requestIndex].respond(200, {}, 'response body');
+        }
+        function auctionCallback() {
+          const bidTimeoutCall = eventsEmitSpy.withArgs(CONSTANTS.EVENTS.BID_TIMEOUT).getCalls()[0];
+          const timedOutBids = bidTimeoutCall.args[1];
+          assert.equal(timedOutBids.length, 1);
+          assert.equal(timedOutBids[0].bidder, BIDDER_CODE1);
+          done();
+        }
+        auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: auctionCallback, cbTimeout: 20});
+
+        auction.callBids();
+        respondToRequest(0);
       });
     });
   });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -29,6 +29,10 @@ const MOCK_BIDS_REQUEST = {
   ]
 }
 
+function onTimelyResponseStub() {
+
+}
+
 describe('bidders created by newBidder', function () {
   let spec;
   let bidder;
@@ -67,7 +71,7 @@ describe('bidders created by newBidder', function () {
       spec.getUserSyncs.returns([]);
 
       bidder.callBids({});
-      bidder.callBids({ bids: 'nothing useful' }, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids({ bids: 'nothing useful' }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.called).to.equal(false);
@@ -81,7 +85,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -95,7 +99,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(false);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -109,7 +113,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.onSecondCall().returns(false);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -123,7 +127,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.called).to.equal(false);
     });
@@ -139,7 +143,7 @@ describe('bidders created by newBidder', function () {
         data: data
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(url);
@@ -164,7 +168,7 @@ describe('bidders created by newBidder', function () {
         options: options
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(url);
@@ -187,7 +191,7 @@ describe('bidders created by newBidder', function () {
         data: data
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(`${url}?arg=2&`);
@@ -211,7 +215,7 @@ describe('bidders created by newBidder', function () {
         options: opt
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(`${url}?arg=2&`);
@@ -240,7 +244,7 @@ describe('bidders created by newBidder', function () {
         }
       ]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(ajaxStub.calledTwice).to.equal(true);
     });
@@ -253,7 +257,7 @@ describe('bidders created by newBidder', function () {
       spec.interpretResponse.returns([]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(addBidResponseStub.callCount).to.equal(0);
     });
@@ -293,7 +297,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(spec.interpretResponse.calledOnce).to.equal(true);
       const response = spec.interpretResponse.firstCall.args[0]
@@ -325,7 +329,7 @@ describe('bidders created by newBidder', function () {
       ]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(spec.interpretResponse.calledTwice).to.equal(true);
       expect(doneStub.calledOnce).to.equal(true);
@@ -356,7 +360,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(addBidResponseStub.calledOnce).to.equal(true);
       expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -375,7 +379,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(spec.getUserSyncs.calledOnce).to.equal(true);
       expect(spec.getUserSyncs.firstCall.args[1].length).to.equal(1);
@@ -394,7 +398,7 @@ describe('bidders created by newBidder', function () {
         url: 'usersync.com'
       }]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(userSyncStub.called).to.equal(true);
       expect(userSyncStub.firstCall.args[0]).to.equal('iframe');
@@ -423,7 +427,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
@@ -453,7 +457,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
@@ -485,7 +489,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(spec.interpretResponse.called).to.equal(false);
       expect(doneStub.calledOnce).to.equal(true);
@@ -503,7 +507,7 @@ describe('bidders created by newBidder', function () {
       spec.interpretResponse.returns([]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(addBidResponseStub.callCount).to.equal(0);
       expect(doneStub.calledOnce).to.equal(true);
@@ -520,7 +524,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
       expect(spec.getUserSyncs.calledOnce).to.equal(true);
       expect(spec.getUserSyncs.firstCall.args[1]).to.deep.equal([]);
@@ -666,7 +670,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -703,7 +707,7 @@ describe('validate bid response: ', function () {
 
     const bidder = newBidder(spec);
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
     expect(addBidResponseStub.calledOnce).to.equal(false);
     expect(logErrorSpy.callCount).to.equal(1);
@@ -736,7 +740,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -768,7 +772,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
In Prebid 2.x the BID_TIMEOUT event was emitted for bidders which responded in time but yielded no bids. This is now fixed - a bidder which responded in time is considered a timely bidder, even if it responded with no bids.

This fixes #3583 . 

**NOTE**: When a bidder responds, we assume that it responded to all its bid requests in the auction. This might not be 100% desired behaviour, but it was the behaviour in 1.x so I decided to keep it this way.

**NOTE2**: Even an error response is considered a timely response.