### PR TITLE
remove removeRequestId logic when getting bids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -1,7 +1,7 @@
 /** @module pbjs */
 
 import { getGlobal } from './prebidGlobal';
-import { flatten, uniques, isGptPubadsDefined, adUnitsFilter, removeRequestId, getLatestHighestCpmBid, isArrayOfNums } from './utils';
+import { flatten, uniques, isGptPubadsDefined, adUnitsFilter, getLatestHighestCpmBid, isArrayOfNums } from './utils';
 import { listenMessagesFromCreative } from './secureCreatives';
 import { userSync } from './userSync.js';
 import { loadScript } from './adloader';
@@ -184,7 +184,7 @@ function getBids(type) {
     .filter(bids => bids && bids[0] && bids[0].adUnitCode)
     .map(bids => {
       return {
-        [bids[0].adUnitCode]: { bids: bids.map(removeRequestId) }
+        [bids[0].adUnitCode]: { bids }
       };
     })
     .reduce((a, b) => Object.assign(a, b), {});
@@ -221,9 +221,7 @@ $$PREBID_GLOBAL$$.getBidResponses = function () {
 
 $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode = function (adUnitCode) {
   const bids = auctionManager.getBidsReceived().filter(bid => bid.adUnitCode === adUnitCode);
-  return {
-    bids: bids.map(removeRequestId)
-  };
+  return { bids };
 };
 
 /**
@@ -663,8 +661,7 @@ $$PREBID_GLOBAL$$.aliasBidder = function (bidderCode, alias) {
  * @return {Array<AdapterBidResponse>} A list of bids that have been rendered.
 */
 $$PREBID_GLOBAL$$.getAllWinningBids = function () {
-  return auctionManager.getAllWinningBids()
-    .map(removeRequestId);
+  return auctionManager.getAllWinningBids();
 };
 
 /**
@@ -673,8 +670,7 @@ $$PREBID_GLOBAL$$.getAllWinningBids = function () {
  */
 $$PREBID_GLOBAL$$.getAllPrebidWinningBids = function () {
   return auctionManager.getBidsReceived()
-    .filter(bid => bid.status === CONSTANTS.BID_STATUS.BID_TARGETING_SET)
-    .map(removeRequestId);
+    .filter(bid => bid.status === CONSTANTS.BID_STATUS.BID_TARGETING_SET);
 };
 
 /**
@@ -686,8 +682,7 @@ $$PREBID_GLOBAL$$.getAllPrebidWinningBids = function () {
  */
 $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
   let bidsReceived = getHighestCpmBidsFromBidPool(auctionManager.getBidsReceived(), getLatestHighestCpmBid);
-  return targeting.getWinningBids(adUnitCode, bidsReceived)
-    .map(removeRequestId);
+  return targeting.getWinningBids(adUnitCode, bidsReceived);
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1114,15 +1114,6 @@ export function deletePropertyFromObject(object, prop) {
 }
 
 /**
- * Delete requestId from external bid object.
- * @param {Object} bid
- * @return {Object} bid
- */
-export function removeRequestId(bid) {
-  return deletePropertyFromObject(bid, 'requestId');
-}
-
-/**
  * Checks input is integer or not
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
  * @param {*} value

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -340,6 +340,7 @@ export function getBidResponses() {
       'pbAg': '0.10',
       'size': '0x0',
       'auctionId': 123456,
+      'requestId': '1144e2f0de84363',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'triplelift',
         'hb_adid': '222bb26f9e8bd',
@@ -372,6 +373,7 @@ export function getBidResponses() {
       'size': '300x250',
       'alwaysUseBid': true,
       'auctionId': 123456,
+      'requestId': '4dccdc37746135',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'appnexus',
         'hb_adid': '233bcbee889d46d',
@@ -404,6 +406,7 @@ export function getBidResponses() {
       'size': '728x90',
       'alwaysUseBid': true,
       'auctionId': 123456,
+      'requestId': '392b5a6b05d648',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'appnexus',
         'hb_adid': '24bd938435ec3fc',
@@ -435,6 +438,7 @@ export function getBidResponses() {
       'pbAg': '0.50',
       'size': '300x250',
       'auctionId': 123456,
+      'requestId': '192c8c1df0f5d1d',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'pagescience',
         'hb_adid': '25bedd4813632d7',
@@ -465,6 +469,7 @@ export function getBidResponses() {
       'pbAg': '0.15',
       'size': '300x250',
       'auctionId': 654321,
+      'requestId': '135e89c039705da',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'brightcom',
         'hb_adid': '26e0795ab963896',
@@ -496,6 +501,7 @@ export function getBidResponses() {
       'pbAg': '0.50',
       'size': '300x250',
       'auctionId': 654321,
+      'requestId': '17dd1d869bed44e',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'brealtime',
         'hb_adid': '275bd666f5a5a5d',
@@ -528,6 +534,7 @@ export function getBidResponses() {
       'pbAg': '5.90',
       'size': '300x250',
       'auctionId': 654321,
+      'requestId': '6d11aa2d5b3659',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'pubmatic',
         'hb_adid': '28f4039c636b6a7',
@@ -558,6 +565,7 @@ export function getBidResponses() {
       'pbAg': '2.70',
       'size': '300x600',
       'auctionId': 654321,
+      'requestId': '96aff279720d39',
       'adserverTargeting': convertTargetingsFromOldToNew({
         'hb_bidder': 'rubicon',
         'hb_adid': '29019e2ab586a5a',
@@ -1062,6 +1070,7 @@ export function getBidResponsesFromAPI() {
           'pbAg': '0.15',
           'size': '300x250',
           'auctionId': 654321,
+          'requestId': '135e89c039705da',
           'adserverTargeting': convertTargetingsFromOldToNew({
             'hb_bidder': 'brightcom',
             'hb_adid': '26e0795ab963896',
@@ -1093,6 +1102,7 @@ export function getBidResponsesFromAPI() {
           'pbAg': '0.50',
           'size': '300x250',
           'auctionId': 654321,
+          'requestId': '17dd1d869bed44e',
           'adserverTargeting': convertTargetingsFromOldToNew({
             'hb_bidder': 'brealtime',
             'hb_adid': '275bd666f5a5a5d',
@@ -1125,6 +1135,7 @@ export function getBidResponsesFromAPI() {
           'pbAg': '5.90',
           'size': '300x250',
           'auctionId': 654321,
+          'requestId': '6d11aa2d5b3659',
           'adserverTargeting': convertTargetingsFromOldToNew({
             'hb_bidder': 'pubmatic',
             'hb_adid': '28f4039c636b6a7',
@@ -1155,6 +1166,7 @@ export function getBidResponsesFromAPI() {
           'pbAg': '2.70',
           'size': '300x600',
           'auctionId': 654321,
+          'requestId': '96aff279720d39',
           'adserverTargeting': convertTargetingsFromOldToNew({
             'hb_bidder': 'rubicon',
             'hb_adid': '29019e2ab586a5a',
@@ -1434,7 +1446,7 @@ export function getCurrencyRates() {
   };
 }
 
-export function createBidReceived({bidder, cpm, auctionId, responseTimestamp, adUnitCode, adId, status, ttl}) {
+export function createBidReceived({bidder, cpm, auctionId, responseTimestamp, adUnitCode, adId, status, ttl, requestId}) {
   let bid = {
     'bidderCode': bidder,
     'width': '300',
@@ -1448,6 +1460,7 @@ export function createBidReceived({bidder, cpm, auctionId, responseTimestamp, ad
     'requestTimestamp': 1454535718610,
     'responseTimestamp': responseTimestamp,
     'auctionId': auctionId,
+    'requestId': requestId,
     'timeToRespond': 123,
     'pbLg': '0.50',
     'pbMg': '0.50',

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2466,10 +2466,10 @@ describe('Unit: Prebid Module', function () {
 
     it('should return prebid auction winning bids', function () {
       let bidsReceived = [
-        createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1', status: 'targetingSet'}),
-        createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2'}),
-        createBidReceived({bidder: 'appnexus', cpm: 6, auctionId: 2, responseTimestamp: 102, adUnitCode: 'code-0', adId: 'adid-3'}),
-        createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 2, responseTimestamp: 103, adUnitCode: 'code-1', adId: 'adid-4'}),
+        createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1', status: 'targetingSet', requestId: 'reqid-1'}),
+        createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2', requestId: 'reqid-2'}),
+        createBidReceived({bidder: 'appnexus', cpm: 6, auctionId: 2, responseTimestamp: 102, adUnitCode: 'code-0', adId: 'adid-3', requestId: 'reqid-3'}),
+        createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 2, responseTimestamp: 103, adUnitCode: 'code-1', adId: 'adid-4', requestId: 'reqid-4'}),
       ];
       auctionManagerStub.returns(bidsReceived)
       let bids = $$PREBID_GLOBAL$$.getAllPrebidWinningBids();


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Fixes #3685

This PR removes the logic we had in place to remove the `requestId` field from the bid objects that were returned in the public API's various `getBids...` type functions.
 
### Context
Originally introduced in #1970, the `requestId`'s value for a long time was equal to the bid's `adId`; so it was unnecessary to have both included when one was just used internally.

However when #3440 was introduced, the `requestId` and `adId` held different responsibilities (see linked PR for details).  

At this point, both fields should be present when we're getting the bids from an auction.