### PR TITLE
add console message when number of adunits exceeds point

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -70,6 +70,11 @@ function setRenderSize(doc, width, height) {
 }
 
 export const checkAdUnitSetup = hook('sync', function (adUnits) {
+  let adUnitsLen = adUnits.length;
+  if (adUnitsLen > 15) {
+    utils.logInfo(`Current auction contains ${adUnitsLen} adUnits.`);
+  }
+
   adUnits.forEach((adUnit) => {
     const mediaTypes = adUnit.mediaTypes;
     const normalizedSize = utils.getAdUnitSizes(adUnit);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -70,11 +70,6 @@ function setRenderSize(doc, width, height) {
 }
 
 export const checkAdUnitSetup = hook('sync', function (adUnits) {
-  let adUnitsLen = adUnits.length;
-  if (adUnitsLen > 15) {
-    utils.logInfo(`Current auction contains ${adUnitsLen} adUnits.`);
-  }
-
   adUnits.forEach((adUnit) => {
     const mediaTypes = adUnit.mediaTypes;
     const normalizedSize = utils.getAdUnitSizes(adUnit);
@@ -474,6 +469,12 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
   }
 
   const auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout, labels});
+
+  let adUnitsLen = adUnits.length;
+  if (adUnitsLen > 15) {
+    utils.logInfo(`Current auction ${auction.getAuctionId()} contains ${adUnitsLen} adUnits.`, adUnits);
+  }
+
   adUnitCodes.forEach(code => targeting.setLatestAuctionForAdUnit(code, auction.getAuctionId()));
   auction.callBids();
   return auction;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds a console message when the number of `adUnit`s for an auction exceeds a certain amount (currently set to 15).  This is to help notify publishers of their setup and to potentially review it if the number seems incorrect or too high.