### PR TITLE
Add Unified ID support to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -294,15 +294,31 @@ function createVideoRequestData(bid, bidderRequest) {
       js: 1,
       geo: {}
     },
-    regs: {},
-    user: {},
+    regs: {
+      ext: {}
+    },
+    user: {
+      ext: {}
+    },
     cur: ['USD']
   };
 
   if (bidderRequest && bidderRequest.gdprConsent) {
     let { gdprApplies, consentString } = bidderRequest.gdprConsent;
-    payload.regs.ext = { gdpr: gdprApplies ? 1 : 0 };
-    payload.user.ext = { consent: consentString };
+    payload.regs.ext.gdpr = gdprApplies ? 1 : 0;
+    payload.user.ext.consent = consentString;
+  }
+
+  if (bid.userId && bid.userId.tdid) {
+    payload.user.ext.eids = [{
+      source: 'adserver.org',
+      uids: [{
+        id: bid.userId.tdid,
+        ext: {
+          rtiPartner: 'TDID'
+        }
+      }]
+    }];
   }
 
   return payload;
@@ -338,6 +354,10 @@ function createBannerRequestData(bids, bidderRequest) {
     let { gdprApplies, consentString } = bidderRequest.gdprConsent;
     payload.gdpr = gdprApplies ? 1 : 0;
     payload.gdprConsent = consentString;
+  }
+
+  if (bids[0] && bids[0].userId && bids[0].userId.tdid) {
+    payload.tdid = bids[0].userId.tdid;
   }
 
   return payload;

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -4,7 +4,7 @@ Module Name: Beachfront Bid Adapter
 
 Module Type: Bidder Adapter
 
-Maintainer: johnsalis@beachfront.com
+Maintainer: john@beachfront.com
 
 # Description
 

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec, VIDEO_ENDPOINT, BANNER_ENDPOINT, OUTSTREAM_SRC, DEFAULT_MIMES } from 'modules/beachfrontBidAdapter';
-import * as utils from 'src/utils';
 import { parse as parseUrl } from 'src/url';
 
 describe('BeachfrontAdapter', function () {
@@ -248,6 +247,24 @@ describe('BeachfrontAdapter', function () {
         expect(data.regs.ext.gdpr).to.equal(1);
         expect(data.user.ext.consent).to.equal(consentString);
       });
+
+      it('must add the Trade Desk User ID to the request', () => {
+        const tdid = '4321';
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { video: {} };
+        bidRequest.userId = { tdid };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.user.ext.eids[0]).to.deep.equal({
+          source: 'adserver.org',
+          uids: [{
+            id: tdid,
+            ext: {
+              rtiPartner: 'TDID'
+            }
+          }]
+        });
+      });
     });
 
     describe('for banner bids', function () {
@@ -367,6 +384,16 @@ describe('BeachfrontAdapter', function () {
         const data = requests[0].data;
         expect(data.gdpr).to.equal(1);
         expect(data.gdprConsent).to.equal(consentString);
+      });
+
+      it('must add the Trade Desk User ID to the request', () => {
+        const tdid = '4321';
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.userId = { tdid };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.tdid).to.equal(tdid);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Adds the Unified ID to Beachfront bid requests when the User ID Module is configured to pass it.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Relies on the new User ID Module.

#3424 
