### PR TITLE
Add support for bidderRequest.refererInfo in Adhese Adapter

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -18,16 +18,15 @@ export const spec = {
     if (validBidRequests.length === 0) {
       return null;
     }
-    const gdprConsent = bidderRequest.gdprConsent;
-    const refererInfo = bidderRequest.refererInfo;
+    const { gdprConsent, refererInfo } = bidderRequest;
 
     const account = getAccount(validBidRequests);
     const targets = validBidRequests.map(bid => bid.params.data).reduce(mergeTargets, {});
-    const gdprParams = (gdprConsent && gdprConsent.consentString) ? [ 'xt' + gdprConsent.consentString ] : [];
-    const refererParams = (refererInfo && refererInfo.referer) ? [ 'xf' + base64urlEncode(refererInfo.referer) ] : [];
+    const gdprParams = (gdprConsent && gdprConsent.consentString) ? [`xt${gdprConsent.consentString}`] : [];
+    const refererParams = (refererInfo && refererInfo.referer) ? [`xf${base64urlEncode(refererInfo.referer)}`] : [];
     const targetsParams = Object.keys(targets).map(targetCode => targetCode + targets[targetCode].join(';'));
     const slotsParams = validBidRequests.map(bid => 'sl' + bidToSlotName(bid));
-    const params = [...slotsParams, ...targetsParams, ...gdprParams, ...refererParams].map(s => '/' + s).join('');
+    const params = [...slotsParams, ...targetsParams, ...gdprParams, ...refererParams].map(s => `/${s}`).join('');
     const cacheBuster = '?t=' + new Date().getTime();
     const uri = 'https://ads-' + account + '.adhese.com/json' + params + cacheBuster;
 
@@ -170,7 +169,7 @@ function getAdDetails(ad) {
 }
 
 function base64urlEncode(s) {
-  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '');
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 registerBidder(spec);

--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -18,13 +18,16 @@ export const spec = {
     if (validBidRequests.length === 0) {
       return null;
     }
+    const gdprConsent = bidderRequest.gdprConsent;
+    const refererInfo = bidderRequest.refererInfo;
 
     const account = getAccount(validBidRequests);
     const targets = validBidRequests.map(bid => bid.params.data).reduce(mergeTargets, {});
-    const gdprParams = (bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString) ? [ 'xt' + bidderRequest.gdprConsent.consentString ] : [];
+    const gdprParams = (gdprConsent && gdprConsent.consentString) ? [ 'xt' + gdprConsent.consentString ] : [];
+    const refererParams = (refererInfo && refererInfo.referer) ? [ 'xf' + base64urlEncode(refererInfo.referer) ] : [];
     const targetsParams = Object.keys(targets).map(targetCode => targetCode + targets[targetCode].join(';'));
     const slotsParams = validBidRequests.map(bid => 'sl' + bidToSlotName(bid));
-    const params = [...slotsParams, ...targetsParams, ...gdprParams].map(s => '/' + s).join('');
+    const params = [...slotsParams, ...targetsParams, ...gdprParams, ...refererParams].map(s => '/' + s).join('');
     const cacheBuster = '?t=' + new Date().getTime();
     const uri = 'https://ads-' + account + '.adhese.com/json' + params + cacheBuster;
 
@@ -164,6 +167,10 @@ function getAdDetails(ad) {
     }
   }
   return { creativeId: creativeId, dealId: dealId };
+}
+
+function base64urlEncode(s) {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '');
 }
 
 registerBidder(spec);

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -64,6 +64,9 @@ describe('AdheseAdapter', function () {
       gdprConsent: {
         gdprApplies: true,
         consentString: 'CONSENT_STRING'
+      },
+      refererInfo: {
+        referer: 'http://prebid.org/dev-docs/subjects?_d=1'
       }
     };
 
@@ -89,6 +92,12 @@ describe('AdheseAdapter', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
       expect(req.url).to.contain('/xtCONSENT_STRING');
+    });
+
+    it('should include referer param in base64url format', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(req.url).to.contain('/xfaHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ');
     });
 
     it('should include bids', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

Add support for `bidderRequest.refererInfo` in Adhese Adapter.
Send the referer url (if available) to the Adhese backend as a request parameter.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
