### PR TITLE
reject invalid values in adpod adunit

### DIFF
--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -256,8 +256,8 @@ export function checkAdUnitSetupHook(fn, adUnits) {
       let errMsg = `Detected missing or incorrectly setup fields for an adpod adUnit.  Please review the following fields of adUnitCode: ${adUnit.code}.  This adUnit will be removed from the auction.`;
 
       let playerSize = !!(videoConfig.playerSize && utils.isArrayOfNums(videoConfig.playerSize));
-      let adPodDurationSec = !!(videoConfig.adPodDurationSec && utils.isNumber(videoConfig.adPodDurationSec));
-      let durationRangeSec = !!(videoConfig.durationRangeSec && utils.isArrayOfNums(videoConfig.durationRangeSec));
+      let adPodDurationSec = !!(videoConfig.adPodDurationSec && utils.isNumber(videoConfig.adPodDurationSec) && videoConfig.adPodDurationSec > 0);
+      let durationRangeSec = !!(videoConfig.durationRangeSec && utils.isArrayOfNums(videoConfig.durationRangeSec) && videoConfig.durationRangeSec.every(range => range > 0));
 
       if (!playerSize || !adPodDurationSec || !durationRangeSec) {
         errMsg += (!playerSize) ? '\nmediaTypes.video.playerSize' : '';

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -689,6 +689,32 @@ describe('adpod.js', function () {
       expect(logWarnStub.calledOnce).to.equal(true);
     });
 
+    it('removes an incorrectly setup adpod adunit - required fields are using invalid values', function() {
+      let adUnits = [{
+        code: 'test1',
+        mediaTypes: {
+          video: {
+            context: ADPOD,
+            durationRangeSec: [-5, 15, 30, 45],
+            adPodDurationSec: 300
+          }
+        }
+      }];
+
+      checkAdUnitSetupHook(callbackFn, adUnits);
+
+      expect(results).to.deep.equal([]);
+      expect(logWarnStub.calledOnce).to.equal(true);
+
+      adUnits[0].mediaTypes.video.durationRangeSec = [15, 30, 45];
+      adUnits[0].mediaTypes.video.adPodDurationSec = 0;
+
+      checkAdUnitSetupHook(callbackFn, adUnits);
+
+      expect(results).to.deep.equal([]);
+      expect(logWarnStub.calledTwice).to.equal(true);
+    });
+
     it('removes an incorrectly setup adpod adunit - attempting to use multi-format adUnit', function() {
       let adUnits = [{
         code: 'multi_test1',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This PR fixes some bugs that were found related to the adpod adUnit config.  

It will now reject the adUnit if:
* the `adPodDurationSec` field is less than or equal to `0`
* any of the values in the `durationRageSec` array is less than or equal to `0`