### PR TITLE
change matching url

### DIFF
--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -112,7 +112,7 @@ export const spec = {
     // });
     syncs.push({
       type: 'iframe',
-      url: 'http://ads.betweendigital.com/sspmatch-iframe'
+      url: '//ads.betweendigital.com/sspmatch-iframe'
     });
     return syncs;
   }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Changed protocol in matching url from 'http://' to '//'.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
khaylov@betweenx.com

- [x] official adapter submission
