### PR TITLE
Update og:url param key

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -56,7 +56,7 @@ function _getBrowserParams() {
     ce: utils.cookiesAreEnabled(),
     dpr: topWindow.devicePixelRatio || 1,
     jcsi: JSON.stringify({ t: 0, rq: 8 }),
-    og_url: getOgURL()
+    ogu: getOgURL()
   }
 
   ns = getNetworkSpeed()


### PR DESCRIPTION
## Type of change
- [ ] Refactoring

## Description of change
Rename `og:url` key from `og_url` to `ogu`

- contact email of the adapter’s maintainer
- susan@gumgum.com

