### PR TITLE
Sonobi Adapter - Support UnifiedId/tradedesk from user id module

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -78,6 +78,12 @@ export const spec = {
       payload.hfa = `PRE-${validBidRequests[0].crumbs.pubcid}`;
     }
 
+    if (deepAccess(validBidRequests[0], 'userId.tdid')) {
+      payload.tdid = validBidRequests[0].userId.tdid
+    } else if (deepAccess(validBidRequests[0], 'crumbs.tdid')) {
+      payload.tdid = validBidRequests[0].crumbs.tdid
+    }
+
     if (validBidRequests[0].params.referrer) {
       payload.ref = validBidRequests[0].params.referrer;
     }

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -80,8 +80,6 @@ export const spec = {
 
     if (deepAccess(validBidRequests[0], 'userId.tdid')) {
       payload.tdid = validBidRequests[0].userId.tdid;
-    } else if (deepAccess(validBidRequests[0], 'crumbs.tdid')) {
-      payload.tdid = validBidRequests[0].crumbs.tdid;
     }
 
     if (validBidRequests[0].params.referrer) {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -79,9 +79,9 @@ export const spec = {
     }
 
     if (deepAccess(validBidRequests[0], 'userId.tdid')) {
-      payload.tdid = validBidRequests[0].userId.tdid
+      payload.tdid = validBidRequests[0].userId.tdid;
     } else if (deepAccess(validBidRequests[0], 'crumbs.tdid')) {
-      payload.tdid = validBidRequests[0].crumbs.tdid
+      payload.tdid = validBidRequests[0].crumbs.tdid;
     }
 
     if (validBidRequests[0].params.referrer) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -290,11 +290,11 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].params.hfa;
       bidRequest[0].crumbs = {'pubcid': 'abcd-efg-0101'};
       bidRequest[1].crumbs = {'pubcid': 'abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
-      expect(bidRequests.method).to.equal('GET')
-      expect(bidRequests.data.ref).not.to.be.empty
-      expect(bidRequests.data.s).not.to.be.empty
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
       expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
     });
 
@@ -303,11 +303,11 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].params.hfa;
       bidRequest[0].userId = {'pubcid': 'abcd-efg-0101'};
       bidRequest[1].userId = {'pubcid': 'abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
-      expect(bidRequests.method).to.equal('GET')
-      expect(bidRequests.data.ref).not.to.be.empty
-      expect(bidRequests.data.s).not.to.be.empty
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
       expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
       delete bidRequest[0].userId;
       delete bidRequest[1].userId;
@@ -318,11 +318,11 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].params.tdid;
       bidRequest[0].crumbs = {'tdid': 'td-abcd-efg-0101'};
       bidRequest[1].crumbs = {'tdid': 'td-abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
-      expect(bidRequests.method).to.equal('GET')
-      expect(bidRequests.data.ref).not.to.be.empty
-      expect(bidRequests.data.s).not.to.be.empty
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
       expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
     });
 
@@ -331,11 +331,11 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].params.tdid;
       bidRequest[0].userId = {'tdid': 'td-abcd-efg-0101'};
       bidRequest[1].userId = {'tdid': 'td-abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
-      expect(bidRequests.method).to.equal('GET')
-      expect(bidRequests.data.ref).not.to.be.empty
-      expect(bidRequests.data.s).not.to.be.empty
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
       expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
     })
 

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -313,19 +313,6 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].userId;
     })
 
-    it('should return a properly formatted request with unified id as tdid', function () {
-      delete bidRequest[0].params.tdid;
-      delete bidRequest[1].params.tdid;
-      bidRequest[0].crumbs = {'tdid': 'td-abcd-efg-0101'};
-      bidRequest[1].crumbs = {'tdid': 'td-abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
-      expect(bidRequests.method).to.equal('GET');
-      expect(bidRequests.data.ref).not.to.be.empty;
-      expect(bidRequests.data.s).not.to.be.empty;
-      expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
-    });
-
     it('should return a properly formatted request with unified id from User ID as tdid', function () {
       delete bidRequest[0].params.tdid;
       delete bidRequest[1].params.tdid;

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -314,8 +314,8 @@ describe('SonobiBidAdapter', function () {
     })
 
     it('should return a properly formatted request with unified id as tdid', function () {
-      delete bidRequest[0].params.hfa;
-      delete bidRequest[1].params.hfa;
+      delete bidRequest[0].params.tdid;
+      delete bidRequest[1].params.tdid;
       bidRequest[0].crumbs = {'tdid': 'td-abcd-efg-0101'};
       bidRequest[1].crumbs = {'tdid': 'td-abcd-efg-0101'};
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
@@ -327,8 +327,8 @@ describe('SonobiBidAdapter', function () {
     });
 
     it('should return a properly formatted request with unified id from User ID as tdid', function () {
-      delete bidRequest[0].params.hfa;
-      delete bidRequest[1].params.hfa;
+      delete bidRequest[0].params.tdid;
+      delete bidRequest[1].params.tdid;
       bidRequest[0].userId = {'tdid': 'td-abcd-efg-0101'};
       bidRequest[1].userId = {'tdid': 'td-abcd-efg-0101'};
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -296,7 +296,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.ref).not.to.be.empty
       expect(bidRequests.data.s).not.to.be.empty
       expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
-    })
+    });
 
     it('should return a properly formatted request with commonid from User ID as hfa', function () {
       delete bidRequest[0].params.hfa;
@@ -311,6 +311,32 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
       delete bidRequest[0].userId;
       delete bidRequest[1].userId;
+    })
+
+    it('should return a properly formatted request with unified id as tdid', function () {
+      delete bidRequest[0].params.hfa;
+      delete bidRequest[1].params.hfa;
+      bidRequest[0].crumbs = {'tdid': 'td-abcd-efg-0101'};
+      bidRequest[1].crumbs = {'tdid': 'td-abcd-efg-0101'};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
+    });
+
+    it('should return a properly formatted request with unified id from User ID as tdid', function () {
+      delete bidRequest[0].params.hfa;
+      delete bidRequest[1].params.hfa;
+      bidRequest[0].userId = {'tdid': 'td-abcd-efg-0101'};
+      bidRequest[1].userId = {'tdid': 'td-abcd-efg-0101'};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
     })
 
     it('should return a properly formatted request with hfa preferred over commonid', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added Sonobi Adapter support for Unified/Tradedesk ID

- apex.prebid@sonobi.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1258