### PR TITLE
BUGFIX: Rubicon Video - pricegranularity param should be lowercase

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -151,7 +151,7 @@ export const spec = {
               includewinners: true,
               // includebidderkeys always false for openrtb
               includebidderkeys: false,
-              priceGranularity: getPriceGranularity(config)
+              pricegranularity: getPriceGranularity(config)
             }
           }
         }


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Prebid-Server expects price granularity param to be all lowercase,
Camel case causes it to not consider it.