### PR TITLE
change external-uid to camelcase

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -10,7 +10,7 @@ const BIDDER_CODE = 'appnexus';
 const URL = '//ib.adnxs.com/ut/v3/prebid';
 const VIDEO_TARGETING = ['id', 'mimes', 'minduration', 'maxduration',
   'startdelay', 'skippable', 'playback_method', 'frameworks'];
-const USER_PARAMS = ['age', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
+const USER_PARAMS = ['age', 'externalUid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
 const DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout'];
 const NATIVE_MAPPING = {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -157,7 +157,7 @@ describe('AppNexusAdapter', function () {
           params: {
             placementId: '10433394',
             user: {
-              external_uid: '123',
+              externalUid: '123',
               foobar: 'invalid'
             }
           }
@@ -169,7 +169,7 @@ describe('AppNexusAdapter', function () {
 
       expect(payload.user).to.exist;
       expect(payload.user).to.deep.equal({
-        external_uid: '123',
+        externalUid: '123',
       });
     });
 


### PR DESCRIPTION
## Type of change
-  Bugfix

## Description of change
change external user id to camel-case  from 'external_uid' to 'externalUid' since and object key cannot have underscore. 

- test parameters for validating bids
```
{
  bidder: 'apnexus',
  params: {
   user: {externalUid:'1234567890abcdefg',age:35,gender:1,language:'EN', segments:[1,2]}
  }
}
```

Tested the integration with adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

## Other information
Jira Link: https://jira.corp.appnexus.com/browse/RAD-2553