### PR TITLE
[Native] Add privacyIcon for native add

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -72,6 +72,7 @@
     "body": "hb_native_body",
     "body2": "hb_native_body2",
     "privacyLink": "hb_native_privacy",
+    "privacyIcon": "hb_native_privicon",
     "sponsoredBy": "hb_native_brand",
     "image": "hb_native_image",
     "icon": "hb_native_icon",


### PR DESCRIPTION
Privacy icon can be provided by some bidders, adding this field allows
publisher to render privacy link with provided icon on it

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Privacy icon can be provided by some bidders, adding this field allows
publisher to render privacy link with provided icon on it

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/1280

