### PR TITLE
Update VIS.X bid adapter

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -25,6 +25,8 @@ export const spec = {
   buildRequests: function(validBidRequests, bidderRequest) {
     const auids = [];
     const bidsMap = {};
+    const slotsMapByUid = {};
+    const sizeMap = {};
     const bids = validBidRequests || [];
     const currency =
       config.getConfig(`currency.bidderCurrencyDefault.${BIDDER_CODE}`) ||
@@ -33,21 +35,46 @@ export const spec = {
     let reqId;
 
     bids.forEach(bid => {
-      if (!bidsMap[bid.params.uid]) {
-        bidsMap[bid.params.uid] = [bid];
-        auids.push(bid.params.uid);
-      } else {
-        bidsMap[bid.params.uid].push(bid);
-      }
       reqId = bid.bidderRequestId;
+      const {params: {uid}, adUnitCode} = bid;
+      auids.push(uid);
+      const sizesId = utils.parseSizesInput(bid.sizes);
+
+      if (!slotsMapByUid[uid]) {
+        slotsMapByUid[uid] = {};
+      }
+      const slotsMap = slotsMapByUid[uid];
+      if (!slotsMap[adUnitCode]) {
+        slotsMap[adUnitCode] = {adUnitCode, bids: [bid], parents: []};
+      } else {
+        slotsMap[adUnitCode].bids.push(bid);
+      }
+      const slot = slotsMap[adUnitCode];
+
+      sizesId.forEach((sizeId) => {
+        sizeMap[sizeId] = true;
+        if (!bidsMap[uid]) {
+          bidsMap[uid] = {};
+        }
+
+        if (!bidsMap[uid][sizeId]) {
+          bidsMap[uid][sizeId] = [slot];
+        } else {
+          bidsMap[uid][sizeId].push(slot);
+        }
+        slot.parents.push({parent: bidsMap[uid], key: sizeId, uid});
+      });
     });
 
     const payload = {
       u: utils.getTopWindowUrl(),
       pt: 'net',
       auids: auids.join(','),
+      sizes: utils.getKeys(sizeMap).join(','),
       r: reqId,
       cur: currency,
+      wrapperType: 'Prebid_js',
+      wrapperVersion: '$prebid.version$'
     };
 
     if (bidderRequest && bidderRequest.gdprConsent) {
@@ -69,6 +96,7 @@ export const spec = {
   interpretResponse: function(serverResponse, bidRequest) {
     serverResponse = serverResponse && serverResponse.body;
     const bidResponses = [];
+    const bidsWithoutSizeMatching = [];
     const bidsMap = bidRequest.bidsMap;
     const currency = bidRequest.data.cur;
 
@@ -81,7 +109,10 @@ export const spec = {
 
     if (!errorMessage && serverResponse.seatbid) {
       serverResponse.seatbid.forEach(respItem => {
-        _addBidResponse(_getBidFromResponse(respItem), bidsMap, currency, bidResponses);
+        _addBidResponse(_getBidFromResponse(respItem), bidsMap, currency, bidResponses, bidsWithoutSizeMatching);
+      });
+      bidsWithoutSizeMatching.forEach(serverBid => {
+        _addBidResponse(serverBid, bidsMap, currency, bidResponses);
       });
     }
     if (errorMessage) utils.logError(errorMessage);
@@ -117,7 +148,7 @@ function _getBidFromResponse(respItem) {
   return respItem && respItem.bid && respItem.bid[0];
 }
 
-function _addBidResponse(serverBid, bidsMap, currency, bidResponses) {
+function _addBidResponse(serverBid, bidsMap, currency, bidResponses, bidsWithoutSizeMatching) {
   if (!serverBid) return;
   let errorMessage;
   if (!serverBid.auid) errorMessage = LOG_ERROR_MESS.noAuid + JSON.stringify(serverBid);
@@ -125,9 +156,14 @@ function _addBidResponse(serverBid, bidsMap, currency, bidResponses) {
   else {
     const awaitingBids = bidsMap[serverBid.auid];
     if (awaitingBids) {
-      awaitingBids.forEach(bid => {
-        const bidResponse = {
+      const sizeId = bidsWithoutSizeMatching ? `${serverBid.w}x${serverBid.h}` : Object.keys(awaitingBids)[0];
+      if (awaitingBids[sizeId]) {
+        const slot = awaitingBids[sizeId][0];
+
+        const bid = slot.bids.shift();
+        bidResponses.push({
           requestId: bid.bidId,
+          bidderCode: spec.code,
           cpm: serverBid.price,
           width: serverBid.w,
           height: serverBid.h,
@@ -137,9 +173,25 @@ function _addBidResponse(serverBid, bidsMap, currency, bidResponses) {
           ttl: TIME_TO_LIVE,
           ad: serverBid.adm,
           dealId: serverBid.dealid
-        };
-        bidResponses.push(bidResponse);
-      });
+        });
+
+        if (!slot.bids.length) {
+          slot.parents.forEach(({parent, key, uid}) => {
+            const index = parent[key].indexOf(slot);
+            if (index > -1) {
+              parent[key].splice(index, 1);
+            }
+            if (!parent[key].length) {
+              delete parent[key];
+              if (!utils.getKeys(parent).length) {
+                delete bidsMap[uid];
+              }
+            }
+          });
+        }
+      } else {
+        bidsWithoutSizeMatching && bidsWithoutSizeMatching.push(serverBid);
+      }
     } else {
       errorMessage = LOG_ERROR_MESS.noPlacementCode + serverBid.auid;
     }

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -58,7 +58,7 @@ describe('VisxAdapter', function () {
           'uid': '903535'
         },
         'adUnitCode': 'adunit-code-2',
-        'sizes': [[728, 90]],
+        'sizes': [[728, 90], [300, 250]],
         'bidId': '3150ccb55da321',
         'bidderRequestId': '22edbae2733bf6',
         'auctionId': '1d1a030790a475',
@@ -83,17 +83,19 @@ describe('VisxAdapter', function () {
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535');
+      expect(payload).to.have.property('sizes', '300x250,300x600');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'EUR');
     });
 
-    it('auids must not be duplicated', function () {
+    it('sizes must not be duplicated', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = request.data;
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'EUR');
     });
@@ -105,12 +107,12 @@ describe('VisxAdapter', function () {
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'EUR');
       delete bidRequests[1].params.priceType;
     });
-
     it('pt parameter must be "net" if params.priceType === "net"', function () {
       bidRequests[1].params.priceType = 'net';
       const request = spec.buildRequests(bidRequests);
@@ -118,7 +120,8 @@ describe('VisxAdapter', function () {
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'EUR');
       delete bidRequests[1].params.priceType;
@@ -131,7 +134,8 @@ describe('VisxAdapter', function () {
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'EUR');
       delete bidRequests[1].params.priceType;
@@ -145,7 +149,8 @@ describe('VisxAdapter', function () {
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'JPY');
       getConfigStub.restore();
@@ -159,7 +164,8 @@ describe('VisxAdapter', function () {
       expect(payload).to.be.an('object');
       expect(payload).to.have.property('u').that.is.a('string');
       expect(payload).to.have.property('pt', 'net');
-      expect(payload).to.have.property('auids', '903535,903536');
+      expect(payload).to.have.property('auids', '903535,903535,903536');
+      expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
       expect(payload).to.have.property('r', '22edbae2733bf6');
       expect(payload).to.have.property('cur', 'USD');
       getConfigStub.restore();
@@ -193,9 +199,10 @@ describe('VisxAdapter', function () {
   describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300}], 'seat': '1'},
-      {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 90, 'w': 728}], 'seat': '1'},
-      {'bid': [{'price': 0, 'auid': 903536, 'h': 250, 'w': 300}], 'seat': '1'},
-      {'bid': [{'price': 0, 'adm': '<div>test content 4</div>', 'h': 250, 'w': 300}], 'seat': '1'},
+      {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300}], 'seat': '1'},
+      {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728}], 'seat': '1'},
+      {'bid': [{'price': 0, 'auid': 903537, 'h': 250, 'w': 300}], 'seat': '1'},
+      {'bid': [{'price': 0, 'adm': '<div>test content 5</div>', 'h': 250, 'w': 300}], 'seat': '1'},
       undefined,
       {'bid': [], 'seat': '1'},
       {'seat': '1'},
@@ -225,6 +232,7 @@ describe('VisxAdapter', function () {
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
+          'bidderCode': 'visx',
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
@@ -281,18 +289,7 @@ describe('VisxAdapter', function () {
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
-          'currency': 'EUR',
-          'netRevenue': true,
-          'ttl': 360,
-        },
-        {
-          'requestId': '5703af74d0472a',
-          'cpm': 1.15,
-          'creativeId': 903535,
-          'dealId': undefined,
-          'width': 300,
-          'height': 250,
-          'ad': '<div>test content 1</div>',
+          'bidderCode': 'visx',
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
@@ -302,16 +299,30 @@ describe('VisxAdapter', function () {
           'cpm': 0.5,
           'creativeId': 903536,
           'dealId': undefined,
+          'width': 300,
+          'height': 600,
+          'ad': '<div>test content 2</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '5703af74d0472a',
+          'cpm': 0.15,
+          'creativeId': 903535,
+          'dealId': undefined,
           'width': 728,
           'height': 90,
-          'ad': '<div>test content 2</div>',
+          'ad': '<div>test content 3</div>',
+          'bidderCode': 'visx',
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
         }
       ];
 
-      const result = spec.interpretResponse({'body': {'seatbid': [responses[0], responses[1]]}}, request);
+      const result = spec.interpretResponse({'body': {'seatbid': responses.slice(0, 3)}}, request);
       expect(result).to.deep.equal(expectedResponse);
     });
 
@@ -340,6 +351,7 @@ describe('VisxAdapter', function () {
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
+          'bidderCode': 'visx',
           'currency': 'JPY',
           'netRevenue': true,
           'ttl': 360,
@@ -356,7 +368,7 @@ describe('VisxAdapter', function () {
         {
           'bidder': 'visx',
           'params': {
-            'uid': '903536'
+            'uid': '903537'
           },
           'adUnitCode': 'adunit-code-1',
           'sizes': [[300, 250], [300, 600]],
@@ -388,8 +400,220 @@ describe('VisxAdapter', function () {
         }
       ];
       const request = spec.buildRequests(bidRequests);
-      const result = spec.interpretResponse({'body': {'seatbid': responses.slice(2)}}, request);
+      const result = spec.interpretResponse({'body': {'seatbid': responses.slice(3)}}, request);
       expect(result.length).to.equal(0);
+    });
+
+    it('complicated case', function () {
+      const fullResponse = [
+        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300}], 'seat': '1'},
+        {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728}], 'seat': '1'},
+        {'bid': [{'price': 0.15, 'adm': '<div>test content 4</div>', 'auid': 903535, 'h': 600, 'w': 300}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 5</div>', 'auid': 903536, 'h': 600, 'w': 350}], 'seat': '1'},
+      ];
+      const bidRequests = [
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '2164be6358b9',
+          'bidderRequestId': '106efe3247',
+          'auctionId': '32a1f276cb87cb8',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '326bde7fbf69',
+          'bidderRequestId': '106efe3247',
+          'auctionId': '32a1f276cb87cb8',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903536'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '4e111f1b66e4',
+          'bidderRequestId': '106efe3247',
+          'auctionId': '32a1f276cb87cb8',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-2',
+          'sizes': [[728, 90]],
+          'bidId': '26d6f897b516',
+          'bidderRequestId': '106efe3247',
+          'auctionId': '32a1f276cb87cb8',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903536'
+          },
+          'adUnitCode': 'adunit-code-2',
+          'sizes': [[728, 90]],
+          'bidId': '1751cd90161',
+          'bidderRequestId': '106efe3247',
+          'auctionId': '32a1f276cb87cb8',
+        }
+      ];
+      const request = spec.buildRequests(bidRequests);
+      const expectedResponse = [
+        {
+          'requestId': '2164be6358b9',
+          'cpm': 1.15,
+          'creativeId': 903535,
+          'dealId': undefined,
+          'width': 300,
+          'height': 250,
+          'ad': '<div>test content 1</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '4e111f1b66e4',
+          'cpm': 0.5,
+          'creativeId': 903536,
+          'dealId': undefined,
+          'width': 300,
+          'height': 600,
+          'ad': '<div>test content 2</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '26d6f897b516',
+          'cpm': 0.15,
+          'creativeId': 903535,
+          'dealId': undefined,
+          'width': 728,
+          'height': 90,
+          'ad': '<div>test content 3</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '326bde7fbf69',
+          'cpm': 0.15,
+          'creativeId': 903535,
+          'dealId': undefined,
+          'width': 300,
+          'height': 600,
+          'ad': '<div>test content 4</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '1751cd90161',
+          'cpm': 0.5,
+          'creativeId': 903536,
+          'dealId': undefined,
+          'width': 350,
+          'height': 600,
+          'ad': '<div>test content 5</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        }
+      ];
+
+      const result = spec.interpretResponse({'body': {'seatbid': fullResponse}}, request);
+      expect(result).to.deep.equal(expectedResponse);
+    });
+
+    it('dublicate uids and sizes in one slot', function () {
+      const fullResponse = [
+        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903535, 'h': 250, 'w': 300}], 'seat': '1'},
+      ];
+      const bidRequests = [
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '5126e301f4be',
+          'bidderRequestId': '171c5405a390',
+          'auctionId': '35bcbc0f7e79c',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '57b2ebe70e16',
+          'bidderRequestId': '171c5405a390',
+          'auctionId': '35bcbc0f7e79c',
+        },
+        {
+          'bidder': 'visx',
+          'params': {
+            'uid': '903535'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '225fcd44b18c',
+          'bidderRequestId': '171c5405a390',
+          'auctionId': '35bcbc0f7e79c',
+        }
+      ];
+      const request = spec.buildRequests(bidRequests);
+      const expectedResponse = [
+        {
+          'requestId': '5126e301f4be',
+          'cpm': 1.15,
+          'creativeId': 903535,
+          'dealId': undefined,
+          'width': 300,
+          'height': 250,
+          'ad': '<div>test content 1</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        },
+        {
+          'requestId': '57b2ebe70e16',
+          'cpm': 0.5,
+          'creativeId': 903535,
+          'dealId': undefined,
+          'width': 300,
+          'height': 250,
+          'ad': '<div>test content 2</div>',
+          'bidderCode': 'visx',
+          'currency': 'EUR',
+          'netRevenue': true,
+          'ttl': 360,
+        }
+      ];
+
+      const result = spec.interpretResponse({'body': {'seatbid': fullResponse}}, request);
+      expect(result).to.deep.equal(expectedResponse);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->
Sometimes publishers use the same SSP ad unit ID for several 'physical' ad slots. So we allowed duplicated AUs in requests. Also now we will check that one response from SSP would not be duplicated on in the adapter.
<!-- For new bidder adapters, please provide the following -->

- mikhail.kuryshev@yoc.com
- [X] official adapter submission
