### PR TITLE
fixed gumgums example params in readme

### DIFF
--- a/modules/gumgumBidAdapter.md
+++ b/modules/gumgumBidAdapter.md
@@ -21,7 +21,7 @@ var adUnits = [
         bidder: 'gumgum',
         params: {
           inSlot: '15901', // GumGum Slot ID given to the client,
-          bidFloor: 0.03 // CPM bid floor
+          bidfloor: 0.03 // CPM bid floor
         }
       }
     ]
@@ -33,7 +33,7 @@ var adUnits = [
         bidder: 'gumgum',
         params: {
           inScreen: 'dc9d6be1', // GumGum Zone ID given to the client
-          bidFloor: 0.03 // CPM bid floor
+          bidfloor: 0.03 // CPM bid floor
         }
       }
     ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Found a typo in the instructions for the gumgum adaptor.  The example adaptor in the readme used camelcase bidFloor when the actual adaptor code is looking for an all lowercase bidfloor.