### PR TITLE
yieldlabBidAdapter - Use Slot Size

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -81,8 +81,8 @@ export const spec = {
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
-          width: customsize[0],
-          height: customsize[1],
+          width: bidRequest.params.useSlotSize !== undefined ? primarysize[0] : customsize[0],
+          height: bidRequest.params.useSlotSize !== undefined ? primarysize[1] : customsize[1],
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,


### PR DESCRIPTION
Add a possibility to use the Prebid-AdSlot-Size in the bid-response instead of YieldLab-AdSlot-Size if you use a different.
This allows us a better deal-handling.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Code style update (formatting, local variables)

## Description of change
<!-- Describe the change proposed in this pull request -->
Add the bidder-param "useSlotSize" to use different Slot-Sizes between Prebid and YieldLab. This allows different AdType-Handling for the same slot-size (deals, ...).