### PR TITLE
smartadserverBidAdapter.js - make bid.params.domain optional

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -16,7 +16,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return !!(bid.params && bid.params.siteId && bid.params.pageId && bid.params.formatId && bid.params.domain);
+    return !!(bid.params && bid.params.siteId && bid.params.pageId && bid.params.formatId);
   },
   /**
    * Make a server request from the list of BidRequests.
@@ -63,7 +63,7 @@ export const spec = {
       var payloadString = JSON.stringify(payload);
       return {
         method: 'POST',
-        url: bid.params.domain + '/prebid/v1',
+        url: (bid.params.domain !== undefined ? bid.params.domain : 'https://prg.smartadserver.com') + '/prebid/v1',
         data: payloadString,
       };
     });


### PR DESCRIPTION
https://prg.smartadserver.com is the standard domain for smartadserver. This update makes the "bid.params.domain"-parameter optional.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Code style update (formatting, local variables)

## Description of change
<!-- Describe the change proposed in this pull request -->
