### PR TITLE
clear latest auction units

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -474,7 +474,10 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
     utils.logInfo(`Current auction ${auction.getAuctionId()} contains ${adUnitsLen} adUnits.`, adUnits);
   }
 
-  targeting.clearLatestAuctionKeys();
+  if (!config.getConfig('useBidCache')) {
+    targeting.clearLatestAuctionKeys();
+  }
+
   adUnitCodes.forEach(code => targeting.setLatestAuctionForAdUnit(code, auction.getAuctionId()));
   auction.callBids();
   return auction;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -474,6 +474,7 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
     utils.logInfo(`Current auction ${auction.getAuctionId()} contains ${adUnitsLen} adUnits.`, adUnits);
   }
 
+  targeting.clearLatestAuctionKeys();
   adUnitCodes.forEach(code => targeting.setLatestAuctionForAdUnit(code, auction.getAuctionId()));
   auction.callBids();
   return auction;

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -60,6 +60,10 @@ export function newTargeting(auctionManager) {
     latestAuctionForAdUnit[adUnitCode] = auctionId;
   };
 
+  targeting.clearLatestAuctionKeys = function() {
+    latestAuctionForAdUnit = {};
+  };
+
   targeting.resetPresetTargeting = function(adUnitCode) {
     if (isGptPubadsDefined()) {
       const adUnitCodes = getAdUnitCodes(adUnitCode);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1396,6 +1396,7 @@ describe('Unit: Prebid Module', function () {
 
       it('should notify targeting of the latest auction for each adUnit', function () {
         let latestStub = sinon.stub(targeting, 'setLatestAuctionForAdUnit');
+        let clearLatestAuctionKeysStub = sinon.stub(targeting, 'clearLatestAuctionKeys');
         let getAuctionStub = sinon.stub(auction, 'getAuctionId').returns(2);
 
         $$PREBID_GLOBAL$$.requestBids({
@@ -1409,6 +1410,8 @@ describe('Unit: Prebid Module', function () {
             }
           ]
         });
+
+        assert(clearLatestAuctionKeysStub.called)
 
         expect(latestStub.firstCall.calledWith('test1', 2)).to.equal(true);
         expect(latestStub.secondCall.calledWith('test2', 2)).to.equal(true);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1398,6 +1398,7 @@ describe('Unit: Prebid Module', function () {
         let latestStub = sinon.stub(targeting, 'setLatestAuctionForAdUnit');
         let clearLatestAuctionKeysStub = sinon.stub(targeting, 'clearLatestAuctionKeys');
         let getAuctionStub = sinon.stub(auction, 'getAuctionId').returns(2);
+        let getConfig = sinon.stub(configObj, 'getConfig').returns(false);
 
         $$PREBID_GLOBAL$$.requestBids({
           adUnits: [
@@ -1418,6 +1419,7 @@ describe('Unit: Prebid Module', function () {
 
         latestStub.restore();
         getAuctionStub.restore();
+        getConfig.restore();
       });
 
       it('should execute callback immediately if adUnits is empty', function () {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

If `useBidCache` flag is set to false, we have to use only the bids from the latest auction while setting the targeting keys. 

Currently even if the flag is set to false, it will use the bids from the previous actions because `latestAuctionForAdUnit ` object stores latest auction for all the adUnits, even the ones for which the bids are requested for previous auctions. and that is being used to filter bids while setting targeting.

so these changes while setting the latest auction ids for each placement on new auctions, it will remove the auction ids for the adUnits from previous auctions.
