### PR TITLE
pass site.{} into prebid server request

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -257,10 +257,14 @@ function _appendSiteAppDevice(request) {
     request.app = config.getConfig('app');
     request.app.publisher = {id: _s2sConfig.accountId}
   } else {
-    request.site = {
-      publisher: { id: _s2sConfig.accountId },
-      page: utils.getTopWindowUrl()
+    if (typeof config.getConfig('site') === 'object') {
+      request.site = config.getConfig('site');
     }
+    if (!request.site) {
+      request.site = {};
+    }
+    request.site.publisher = {id: _s2sConfig.accountId}
+    request.site.page = utils.getTopWindowUrl()
   }
   if (typeof config.getConfig('device') === 'object') {
     request.device = config.getConfig('device');

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -632,6 +632,20 @@ describe('S2S Adapter', function () {
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
     });
 
+    it('adds site object to request', function () {
+      const _config = { s2sConfig: CONFIG,
+        site: { keywords: 'test.keywords' },
+      };
+
+      config.setConfig(_config);
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      const requestBid = JSON.parse(requests[0].requestBody);
+      expect(requestBid.site).to.exist.and.to.be.a('object');
+      expect(requestBid.site.publisher).to.exist.and.to.be.a('object');
+      expect(requestBid.site.page).to.exist.and.to.be.a('string');
+      expect(requestBid.site.keywords).to.exist.and.is.equal('test.keywords');
+    });
+
     it('adds appnexus aliases to request', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -634,7 +634,7 @@ describe('S2S Adapter', function () {
 
     it('adds site object to request', function () {
       const _config = { s2sConfig: CONFIG,
-        site: { keywords: 'test.keywords' },
+        site: { keywords: 'test.keywords_1, test.keywords_2' },
       };
 
       config.setConfig(_config);
@@ -643,7 +643,7 @@ describe('S2S Adapter', function () {
       expect(requestBid.site).to.exist.and.to.be.a('object');
       expect(requestBid.site.publisher).to.exist.and.to.be.a('object');
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
-      expect(requestBid.site.keywords).to.exist.and.is.equal('test.keywords');
+      expect(requestBid.site.keywords).to.exist.and.is.equal('test.keywords_1, test.keywords_2');
     });
 
     it('adds appnexus aliases to request', function () {


### PR DESCRIPTION
## Type of change
- [ ] Feature

## Description of change
Some publisher want to pass keywords to prebid server and current code only read pbjs.setConfig(app{}) not pbjs.setConfig(site{})
This code will pass the data in config.site to the prebid server request

## Other information
Prebid server is already able to read data passed in $.site.keywords
