### PR TITLE
Update PubMatic Examples

### DIFF
--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -25,7 +25,7 @@ var adUnits = [
       bidder: 'pubmatic',
       params: {
         publisherId: '156209',               // required
-        adSlot: 'pubmatic_test2@300x250',    // required
+        adSlot: 'pubmatic_test2',            // required
         pmzoneid: 'zone1, zone11',           // optional
         lat: '40.712775',                    // optional
         lon: '-74.005973',                   // optional
@@ -33,7 +33,7 @@ var adUnits = [
         kadpageurl: 'www.test.com',          // optional							
         gender: 'M',                         // optional
         kadfloor: '0.50',                    // optional
-        currency: 'AUD'                      // optional (Value configured only in the 1st adunit will be passed on. < br/> Values if present in subsequent adunits, will be ignored.)
+        currency: 'AUD',                     // optional (Value configured only in the 1st adunit will be passed on. < br/> Values if present in subsequent adunits, will be ignored.)
         dctr: 'key1=123|key2=345',            // optional (Value configured only in the 1st adunit will be passed on. < br/> Values if present in subsequent adunits, will be ignored.)
         bcat: ['IAB1-5', 'IAB1-7']                // Optional: Blocked IAB Categories. (Values from all slots will be combined and only unique values will be passed. An array of strings only. Each category should be a string of a length of more than 3 characters.)
       }
@@ -55,8 +55,8 @@ var adVideoAdUnits = [
     bids: [{
       bidder: 'pubmatic',
       params: {
-        publisherId: '351',                     // required
-        adSlot: '1363568@300x250',              // required
+        publisherId: '156209',                  // required
+        adSlot: 'pubmatic_video1',              // required
         video: {
           mimes: ['video/mp4','video/x-flv'],   // required
           skippable: true,                      // optional


### PR DESCRIPTION
Update PubMatic banner and video examples to use adSlot without appended size

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Update PubMatic banner and video examples to use adSlot without appended size

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->