### PR TITLE
update spec to alias older bidder code that can serve video ads

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1,5 +1,5 @@
 import * as utils from '../src/utils';
-import { BANNER } from '../src/mediaTypes';
+import { BANNER, VIDEO } from '../src/mediaTypes';
 import { config } from '../src/config';
 import isArray from 'core-js/library/fn/array/is-array';
 import isInteger from 'core-js/library/fn/number/is-integer';
@@ -8,7 +8,7 @@ import { registerBidder } from '../src/adapters/bidderFactory';
 const BIDDER_CODE = 'ix';
 const BANNER_SECURE_BID_URL = 'https://as-sec.casalemedia.com/cygnus';
 const BANNER_INSECURE_BID_URL = 'http://as.casalemedia.com/cygnus';
-const SUPPORTED_AD_TYPES = [BANNER];
+const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const ENDPOINT_VERSION = 7.2;
 const CENT_TO_DOLLAR_FACTOR = 100;
 const TIME_TO_LIVE = 35;
@@ -137,6 +137,7 @@ export const spec = {
 
   code: BIDDER_CODE,
   supportedMediaTypes: SUPPORTED_AD_TYPES,
+  aliases: ['indexExchange'],
 
   /**
    * Determines whether or not the given bid request is valid.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Index Exchange is able to support video ads for prebid versions 0.34.8 and older, but not for the most recent prebid versions.

Index Exchange at one point switched over to a new bidder code: 'ix'.  This caused the new versions of prebid to think that the old bidder code: 'indexExchange' is invalid.  This causes the bidder code: 'ix' to be incompatible with video-ads, while bidder code: 'indexExchange' is compatible at prebid.js version 0.34.8.  This PR just modifies the 'ixBidAdapter.js' file's `spec` object to also include `alias: 'indexExchange'`.

Previous to this change, the video bids for 'ix' would be filtered out during the pbjs.requestBids() function where 'ix' was a bidder that did not have 'video' as a `spec.supportedMediaTypes` causing `bidderEligible` to be false.  This is a bug because Index Exchange is capable of serving video ads for the older prebid versions 0.34.8 and older.
