### PR TITLE
Rad 2751/specify ad units set targeting for ast

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -260,16 +260,17 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit, customSlotMatching
 
 /**
  * Set query string targeting on all AST (AppNexus Seller Tag) ad units. Note that this function has to be called after all ad units on page are defined. For working example code, see [Using Prebid.js with AppNexus Publisher Ad Server](http://prebid.org/dev-docs/examples/use-prebid-with-appnexus-ad-server.html).
+ * @param  {(string|string[])} adUnitCode adUnitCode or array of adUnitCodes
  * @alias module:pbjs.setTargetingForAst
  */
-$$PREBID_GLOBAL$$.setTargetingForAst = function() {
+$$PREBID_GLOBAL$$.setTargetingForAst = function(adUnitCodes) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.setTargetingForAn', arguments);
   if (!targeting.isApntagDefined()) {
     utils.logError('window.apntag is not defined on the page');
     return;
   }
 
-  targeting.setTargetingForAst();
+  targeting.setTargetingForAst(adUnitCodes);
 
   // emit event
   events.emit(SET_TARGETING, targeting.getAllTargeting());

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -255,7 +255,7 @@ export function newTargeting(auctionManager) {
     let astTargeting = targeting.getAllTargeting(adUnitCodes);
 
     try {
-      targeting.resetPresetTargetingAST();
+      targeting.resetPresetTargetingAST(adUnitCodes);
     } catch (e) {
       utils.logError('unable to reset targeting for AST' + e)
     }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -248,10 +248,11 @@ export function newTargeting(auctionManager) {
   };
 
   /**
+   * @param  {(string|string[])} adUnitCode adUnitCode or array of adUnitCodes
    * Sets targeting for AST
    */
-  targeting.setTargetingForAst = function() {
-    let astTargeting = targeting.getAllTargeting();
+  targeting.setTargetingForAst = function(adUnitCodes) {
+    let astTargeting = targeting.getAllTargeting(adUnitCodes);
 
     try {
       targeting.resetPresetTargetingAST();

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -338,21 +338,8 @@ describe('targeting tests', function () {
       sandbox.restore();
     });
 
-    it('should set single addUnit code', function() {
-      let adUnitCode = 'testdiv-abc-ad-123456-0';
-      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
-        let mockTargeting = {};
-        mockTargeting.adUnitCode = {hb_bidder: 'appnexus'};
-        return mockTargeting;
-      });
-      targetingInstance.setTargetingForAst(adUnitCode);
-      expect(targetingInstance.getAllTargeting.called).to.equal(true);
-      expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
-      expect(window.apntag.setKeywords.called).to.equal(true);
-    });
-
-    it('should set array of addUnit codes', function() {
-      let adUnitCodes = ['testdiv1-abc-ad-123456-0', 'testdiv2-abc-ad-123456-0']
+    function mockGetAllTargeting(adUnitCodes) {
+      adUnitCodes = Array.isArray(adUnitCodes) ? adUnitCodes : Array(adUnitCodes);
       sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
         let mockTargeting = {};
         for (let i = 0; i < Object.keys(adUnitCodes).length; i++) {
@@ -361,6 +348,20 @@ describe('targeting tests', function () {
         }
         return mockTargeting;
       });
+    }
+
+    it('should set single addUnit code', function() {
+      let adUnitCode = 'testdiv-abc-ad-123456-0';
+      mockGetAllTargeting(adUnitCode);
+      targetingInstance.setTargetingForAst(adUnitCode);
+      expect(targetingInstance.getAllTargeting.called).to.equal(true);
+      expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
+      expect(window.apntag.setKeywords.called).to.equal(true);
+    });
+
+    it('should set array of addUnit codes', function() {
+      let adUnitCodes = ['testdiv1-abc-ad-123456-0', 'testdiv2-abc-ad-123456-0']
+      mockGetAllTargeting(adUnitCodes);
       targetingInstance.setTargetingForAst(adUnitCodes);
       expect(targetingInstance.getAllTargeting.called).to.equal(true);
       expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -338,21 +338,13 @@ describe('targeting tests', function () {
       sandbox.restore();
     });
 
-    function mockGetAllTargeting(adUnitCodes) {
-      adUnitCodes = Array.isArray(adUnitCodes) ? adUnitCodes : Array(adUnitCodes);
-      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
-        let mockTargeting = {};
-        for (let i = 0; i < Object.keys(adUnitCodes).length; i++) {
-          let key = Object.keys(adUnitCodes)[i];
-          mockTargeting[key] = {hb_bidder: 'appnexus'};
-        }
-        return mockTargeting;
-      });
-    }
-
     it('should set single addUnit code', function() {
       let adUnitCode = 'testdiv-abc-ad-123456-0';
-      mockGetAllTargeting(adUnitCode);
+      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
+        let mockTargeting = {};
+        mockTargeting.adUnitCode = {hb_bidder: 'appnexus'};
+        return mockTargeting;
+      });
       targetingInstance.setTargetingForAst(adUnitCode);
       expect(targetingInstance.getAllTargeting.called).to.equal(true);
       expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
@@ -361,7 +353,14 @@ describe('targeting tests', function () {
 
     it('should set array of addUnit codes', function() {
       let adUnitCodes = ['testdiv1-abc-ad-123456-0', 'testdiv2-abc-ad-123456-0']
-      mockGetAllTargeting(adUnitCodes);
+      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
+        let mockTargeting = {};
+        for (let i = 0; i < Object.keys(adUnitCodes).length; i++) {
+          let key = Object.keys(adUnitCodes)[i];
+          mockTargeting[key] = {hb_bidder: 'appnexus'};
+        }
+        return mockTargeting;
+      });
       targetingInstance.setTargetingForAst(adUnitCodes);
       expect(targetingInstance.getAllTargeting.called).to.equal(true);
       expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -328,11 +328,12 @@ describe('targeting tests', function () {
   });
 
   describe('setTargetingForAst', function () {
-    let sandbox;
+    let sandbox,
+      apnTagStub;
     beforeEach(function() {
       sandbox = sinon.createSandbox();
-      sandbox.stub(targetingInstance, 'resetPresetTargetingAST').callsFake(function() {});
-      sandbox.stub(window.apntag, 'setKeywords').callsFake(function() {});
+      sandbox.stub(targetingInstance, 'resetPresetTargetingAST');
+      apnTagStub = sandbox.stub(window.apntag, 'setKeywords');
     });
     afterEach(function () {
       sandbox.restore();
@@ -340,31 +341,29 @@ describe('targeting tests', function () {
 
     it('should set single addUnit code', function() {
       let adUnitCode = 'testdiv-abc-ad-123456-0';
-      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
-        let mockTargeting = {};
-        mockTargeting.adUnitCode = {hb_bidder: 'appnexus'};
-        return mockTargeting;
+      sandbox.stub(targetingInstance, 'getAllTargeting').returns({
+        'testdiv1-abc-ad-123456-0': {hb_bidder: 'appnexus'}
       });
       targetingInstance.setTargetingForAst(adUnitCode);
       expect(targetingInstance.getAllTargeting.called).to.equal(true);
       expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
-      expect(window.apntag.setKeywords.called).to.equal(true);
+      expect(apnTagStub.callCount).to.equal(1);
+      expect(apnTagStub.getCall(0).args[0]).to.deep.equal('testdiv1-abc-ad-123456-0');
+      expect(apnTagStub.getCall(0).args[1]).to.deep.equal({HB_BIDDER: 'appnexus'});
     });
 
     it('should set array of addUnit codes', function() {
       let adUnitCodes = ['testdiv1-abc-ad-123456-0', 'testdiv2-abc-ad-123456-0']
-      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
-        let mockTargeting = {};
-        for (let i = 0; i < Object.keys(adUnitCodes).length; i++) {
-          let key = Object.keys(adUnitCodes)[i];
-          mockTargeting[key] = {hb_bidder: 'appnexus'};
-        }
-        return mockTargeting;
+      sandbox.stub(targetingInstance, 'getAllTargeting').returns({
+        'testdiv1-abc-ad-123456-0': {hb_bidder: 'appnexus'},
+        'testdiv2-abc-ad-123456-0': {hb_bidder: 'appnexus'}
       });
       targetingInstance.setTargetingForAst(adUnitCodes);
       expect(targetingInstance.getAllTargeting.called).to.equal(true);
       expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
-      expect(window.apntag.setKeywords.called).to.equal(true);
+      expect(apnTagStub.callCount).to.equal(2);
+      expect(apnTagStub.getCall(1).args[0]).to.deep.equal('testdiv2-abc-ad-123456-0');
+      expect(apnTagStub.getCall(1).args[1]).to.deep.equal({HB_BIDDER: 'appnexus'});
     });
   });
 });

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -326,4 +326,45 @@ describe('targeting tests', function () {
       });
     });
   });
+
+  describe('setTargetingForAst', function () {
+    let sandbox;
+    beforeEach(function() {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(targetingInstance, 'resetPresetTargetingAST').callsFake(function() {});
+      sandbox.stub(window.apntag, 'setKeywords').callsFake(function() {});
+    });
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should set single addUnit code', function() {
+      let adUnitCode = 'testdiv-abc-ad-123456-0';
+      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
+        let mockTargeting = {};
+        mockTargeting.adUnitCode = {hb_bidder: 'appnexus'};
+        return mockTargeting;
+      });
+      targetingInstance.setTargetingForAst(adUnitCode);
+      expect(targetingInstance.getAllTargeting.called).to.equal(true);
+      expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
+      expect(window.apntag.setKeywords.called).to.equal(true);
+    });
+
+    it('should set array of addUnit codes', function() {
+      let adUnitCodes = ['testdiv1-abc-ad-123456-0', 'testdiv2-abc-ad-123456-0']
+      sandbox.stub(targetingInstance, 'getAllTargeting').callsFake(function() {
+        let mockTargeting = {};
+        for (let i = 0; i < Object.keys(adUnitCodes).length; i++) {
+          let key = Object.keys(adUnitCodes)[i];
+          mockTargeting[key] = {hb_bidder: 'appnexus'};
+        }
+        return mockTargeting;
+      });
+      targetingInstance.setTargetingForAst(adUnitCodes);
+      expect(targetingInstance.getAllTargeting.called).to.equal(true);
+      expect(targetingInstance.resetPresetTargetingAST.called).to.equal(true);
+      expect(window.apntag.setKeywords.called).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
-  Bugfix

## Description of change
Added Unit tests for setTargetingForAst()


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.


For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

