### PR TITLE
change in Aardvark adapter to handle additional data 

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -124,6 +124,10 @@ export const spec = {
         bidResponse.dealId = rawBid.dealId
       }
 
+      if (rawBid.hasOwnProperty('ex')) {
+        bidResponse.ex = rawBid.ex;
+      }
+
       switch (rawBid.media) {
         case 'banner':
           bidResponse.ad = rawBid.adm + utils.createTrackPixelHtml(decodeURIComponent(rawBid.nurl));

--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -25,7 +25,7 @@ export const spec = {
     var auctionCodes = [];
     var requests = [];
     var requestsMap = {};
-    var referer = utils.getTopWindowUrl();
+    var referer = bidderRequest.refererInfo.referer;
     var pageCategories = [];
 
     // This reference to window.top can cause issues when loaded in an iframe if not protected with a try/catch.

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -219,6 +219,7 @@ describe('aardvarkAdapterTest', function () {
             cid: '1abgs362e0x48a8',
             adm: '</tag2>',
             ttl: 200,
+            ex: 'extraproperty'
           }
         ],
         headers: {}
@@ -234,6 +235,7 @@ describe('aardvarkAdapterTest', function () {
       expect(result[0].currency).to.equal('USD');
       expect(result[0].ttl).to.equal(200);
       expect(result[0].dealId).to.equal('dealing');
+      expect(result[0].ex).to.be.undefined;
       expect(result[0].ad).to.not.be.undefined;
 
       expect(result[1].requestId).to.equal('1abgs362e0x48a8');
@@ -243,6 +245,7 @@ describe('aardvarkAdapterTest', function () {
       expect(result[1].currency).to.equal('USD');
       expect(result[1].ttl).to.equal(200);
       expect(result[1].ad).to.not.be.undefined;
+      expect(result[1].ex).to.equal('extraproperty');
     });
 
     it('should handle nobid responses', function () {

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -54,21 +54,27 @@ describe('aardvarkAdapterTest', function () {
       auctionId: 'e97cafd0-ebfc-4f5c-b7c9-baa0fd335a4a'
     }];
 
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'http://example.com'
+      }
+    };
+
     it('should use HTTP GET method', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
     it('should call the correct bidRequest url', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].url).to.match(new RegExp('^\/\/adzone.pub.com/xiby/TdAx_RAZd/aardvark\?'));
     });
 
     it('should have correct data', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(1);
       expect(requests[0].data.version).to.equal(1);
       expect(requests[0].data.jsonp).to.equal(false);
@@ -108,22 +114,28 @@ describe('aardvarkAdapterTest', function () {
       auctionId: 'e97cafd0-ebfc-4f5c-b7c9-baa0fd335a4a'
     }];
 
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'http://example.com'
+      }
+    };
+
     it('should use HTTP GET method', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       requests.forEach(function(requestItem) {
         expect(requestItem.method).to.equal('GET');
       });
     });
 
     it('should call the correct bidRequest urls for each auction', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests[0].url).to.match(new RegExp('^\/\/bidder.rtk.io/Toby/TdAx/aardvark\?'));
       expect(requests[0].data.categories.length).to.equal(2);
       expect(requests[1].url).to.match(new RegExp('^\/\/adzone.pub.com/xiby/RAZd/aardvark\?'));
     });
 
     it('should have correct data', function () {
-      const requests = spec.buildRequests(bidRequests);
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests.length).to.equal(2);
       expect(requests[0].data.version).to.equal(1);
       expect(requests[0].data.jsonp).to.equal(false);
@@ -157,6 +169,9 @@ describe('aardvarkAdapterTest', function () {
       gdprConsent: {
         consentString: 'awefasdfwefasdfasd',
         gdprApplies: true
+      },
+      refererInfo: {
+        referer: 'http://example.com'
       }
     };
 
@@ -184,7 +199,10 @@ describe('aardvarkAdapterTest', function () {
     }];
 
     const bidderRequest = {
-      gdprConsent: undefined
+      gdprConsent: undefined,
+      refererInfo: {
+        referer: 'http://example.com'
+      }
     };
 
     it('should transmit correct data', function () {


### PR DESCRIPTION
## Type of change
- [ x ] Refactoring (no functional changes, no api changes)

## Description of change
Aardvark will send, together with the bid data, an optional `ex` property that may contain some useful information. We want to pass it together with the bid. 

Also, we removed `utils.getTopWindowUrl()` function calls and refactored the code and the tests to use `refererInfo.referer'. 

- contact email of the adapter’s maintainer
chris@rtk.io

- [x] official adapter submission 
