### PR TITLE
fix how native sizes are passed in AppNexus adapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -19,13 +19,11 @@ const NATIVE_MAPPING = {
   cta: 'ctatext',
   image: {
     serverName: 'main_image',
-    requiredParams: { required: true },
-    minimumParams: { sizes: [{}] },
+    requiredParams: { required: true }
   },
   icon: {
     serverName: 'icon',
-    requiredParams: { required: true },
-    minimumParams: { sizes: [{}] },
+    requiredParams: { required: true }
   },
   sponsoredBy: 'sponsored_by',
   privacyLink: 'privacy_link',
@@ -675,18 +673,12 @@ function buildNativeRequest(params) {
     const requiredParams = NATIVE_MAPPING[key] && NATIVE_MAPPING[key].requiredParams;
     request[requestKey] = Object.assign({}, requiredParams, params[key]);
 
-    // minimum params are passed if no non-required params given on adunit
-    const minimumParams = NATIVE_MAPPING[key] && NATIVE_MAPPING[key].minimumParams;
-
-    if (requiredParams && minimumParams) {
-      // subtract required keys from adunit keys
-      const adunitKeys = Object.keys(params[key]);
-      const requiredKeys = Object.keys(requiredParams);
-      const remaining = adunitKeys.filter(key => !includes(requiredKeys, key));
-
-      // if none are left over, the minimum params needs to be sent
-      if (remaining.length === 0) {
-        request[requestKey] = Object.assign({}, request[requestKey], minimumParams);
+    // convert the sizes of image/icon assets to proper format (if needed)
+    const isImageAsset = !!(requestKey === NATIVE_MAPPING.image.serverName || requestKey === NATIVE_MAPPING.icon.serverName);
+    if (isImageAsset && request[requestKey].sizes) {
+      let sizes = request[requestKey].sizes;
+      if (utils.isArrayOfNums(sizes) || (utils.isArray(sizes) && sizes.length > 0 && sizes.every(sz => utils.isArrayOfNums(sz)))) {
+        request[requestKey].sizes = transformSizes(request[requestKey].sizes);
       }
     }
   });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -354,7 +354,8 @@ describe('AppNexusAdapter', function () {
             title: {required: true},
             body: {required: true},
             body2: {required: true},
-            image: {required: true, sizes: [{ width: 100, height: 100 }]},
+            image: {required: true, sizes: [100, 100]},
+            icon: {required: true},
             cta: {required: false},
             rating: {required: true},
             sponsoredBy: {required: true},
@@ -378,6 +379,7 @@ describe('AppNexusAdapter', function () {
         description: {required: true},
         desc2: {required: true},
         main_image: {required: true, sizes: [{ width: 100, height: 100 }]},
+        icon: {required: true},
         ctatext: {required: false},
         rating: {required: true},
         sponsored_by: {required: true},
@@ -389,57 +391,6 @@ describe('AppNexusAdapter', function () {
         phone: {required: true},
         price: {required: true},
         saleprice: {required: true}
-      });
-    });
-
-    it('sets minimum native asset params when not provided on adunit', function () {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
-          mediaType: 'native',
-          nativeParams: {
-            image: {required: true},
-          }
-        }
-      );
-
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-
-      expect(payload.tags[0].native.layouts[0]).to.deep.equal({
-        main_image: {required: true, sizes: [{}]},
-      });
-    });
-
-    it('does not overwrite native ad unit params with mimimum params', function () {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
-          mediaType: 'native',
-          nativeParams: {
-            image: {
-              aspect_ratios: [{
-                min_width: 100,
-                ratio_width: 2,
-                ratio_height: 3,
-              }]
-            }
-          }
-        }
-      );
-
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-
-      expect(payload.tags[0].native.layouts[0]).to.deep.equal({
-        main_image: {
-          required: true,
-          aspect_ratios: [{
-            min_width: 100,
-            ratio_width: 2,
-            ratio_height: 3,
-          }]
-        },
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This PR fixes a bug with how native sizes were passed into the UT request for the appNexusBidAdapter.  

Previously the sizes for `native.image` and `native.icon` were passed as is into the request (ie `sizes: [150, 100]` was left in this state).

The UT needs these sizes converted to an object notation like the following: 
`sizes: [{width: 150, height: 100}]`

With the changes, if we detect that someone passes the array of sizes (or an array of multiple array sizes), we'll convert the value to the proper format.

Additionally, I removed the `minimumParams` logic for the `sizes` as this was deemed unnecessary per further internal conversation.  If there are no sizes supplied for a native asset, we do not need to pass an empty object array in the UT request; we can just not include the field and it would work.