### PR TITLE
add renderer param in appnexus adapter request

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -538,6 +538,10 @@ function bidToTag(bid) {
       .forEach(param => tag.video[param] = bid.params.video[param]);
   }
 
+  if (bid.renderer) {
+    tag.video = Object.assign({}, tag.video, {custom_renderer_present: true});
+  }
+
   if (
     (utils.isEmpty(bid.mediaType) && utils.isEmpty(bid.mediaTypes)) ||
     (bid.mediaType === BANNER || (bid.mediaTypes && bid.mediaTypes[BANNER]))

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -150,6 +150,48 @@ describe('AppNexusAdapter', function () {
       });
     });
 
+    it('should add video property when adUnit includes a renderer', function () {
+      const videoData = {
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            mimes: ['video/mp4']
+          }
+        },
+        params: {
+          placementId: '10433394',
+          video: {
+            skippable: true,
+            playback_method: ['auto_play_sound_off']
+          }
+        }
+      };
+
+      let bidRequest1 = deepClone(bidRequests[0]);
+      bidRequest1 = Object.assign({}, bidRequest1, videoData, {
+        renderer: {
+          url: 'http://test.renderer.url',
+          render: function () {}
+        }
+      });
+
+      let bidRequest2 = deepClone(bidRequests[0]);
+      bidRequest2.adUnitCode = 'adUnit_code_2';
+      bidRequest2 = Object.assign({}, bidRequest2, videoData);
+
+      const request = spec.buildRequests([bidRequest1, bidRequest2]);
+      const payload = JSON.parse(request.data);
+      expect(payload.tags[0].video).to.deep.equal({
+        skippable: true,
+        playback_method: ['auto_play_sound_off'],
+        custom_renderer_present: true
+      });
+      expect(payload.tags[1].video).to.deep.equal({
+        skippable: true,
+        playback_method: ['auto_play_sound_off']
+      });
+    });
+
     it('should attach valid user params to the tag', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds a new field to the UT request for the appNexusBidAdapter if there is a `renderer` object defined in the corresponding adUnit.

The new field is titled `custom_renderer_present`.  It uses a boolean value that only needs to be populated when the condition is `true`.  Leaving the field out of the request, it will be treated as `false` when the UT request is processed.