### PR TITLE
Fix #3813 move auctionEnd events so it always executes when auction completes

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -140,9 +140,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
       clearTimeout(_timer);
     }
 
-    // if (_auctionStatus !== AUCTION_COMPLETED) {
     if (_auctionEnd === undefined) {
-    // if (_callback != null) {
       let timedOutBidders = [];
       if (timedOut) {
         utils.logMessage(`Auction ${_auctionId} timedOut`);

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1,4 +1,4 @@
-import { getKeyValueTargetingPairs, auctionCallbacks } from 'src/auction';
+import { getKeyValueTargetingPairs, auctionCallbacks, AUCTION_COMPLETED } from 'src/auction';
 import CONSTANTS from 'src/constants.json';
 import { adjustBids } from 'src/auction';
 import * as auctionModule from 'src/auction';
@@ -783,7 +783,8 @@ describe('auctionmanager.js', function () {
         server.restore();
         events.emit.restore();
       });
-      it('should emit BID_TIMEOUT for timed out bids', function (done) {
+
+      it('should emit BID_TIMEOUT and AUCTION_END for timed out bids', function (done) {
         const spec1 = mockBidder(BIDDER_CODE, [bids[0]]);
         registerBidder(spec1);
         const spec2 = mockBidder(BIDDER_CODE1, [bids[1]]);
@@ -797,6 +798,12 @@ describe('auctionmanager.js', function () {
           const timedOutBids = bidTimeoutCall.args[1];
           assert.equal(timedOutBids.length, 1);
           assert.equal(timedOutBids[0].bidder, BIDDER_CODE1);
+
+          const auctionEndCall = eventsEmitSpy.withArgs(CONSTANTS.EVENTS.AUCTION_END).getCalls()[0];
+          const auctionProps = auctionEndCall.args[1];
+          assert.equal(auctionProps.adUnits, adUnits);
+          assert.equal(auctionProps.timeout, 20);
+          assert.equal(auctionProps.auctionStatus, AUCTION_COMPLETED)
           done();
         }
         auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: auctionCallback, cbTimeout: 20});


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes #3813.  

This change was made primarily to ensure that the auctionEnd event will always trigger even if the publisher didn't include a `bidsBackHandler` when making the `pbjs.requestBids()` call (as found while looking into the above issue).  

This change also ensures other actions taken after the auction finishes are always executed (such as calling timed out bidders, firing userSyncs, and changing the auctionStatus).