### PR TITLE
getCpmInNewCurrency to use current value of bid.cpm and bid.currency

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -180,12 +180,9 @@ export function addBidResponseHook(fn, adUnitCode, bid) {
     bid.currency = 'USD';
   }
 
-  let fromCurrency = bid.currency;
-  let cpm = bid.cpm;
-
   // used for analytics
   bid.getCpmInNewCurrency = function(toCurrency) {
-    return (parseFloat(cpm) * getCurrencyConversion(fromCurrency, toCurrency)).toFixed(3);
+    return (parseFloat(this.cpm) * getCurrencyConversion(this.currency, toCurrency)).toFixed(3);
   };
 
   // execute immediately if the bid is already in the desired currency

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -191,6 +191,34 @@ describe('currency', function () {
       expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('100.000');
     });
 
+    it('uses rates specified in json when provided and consider boosted bid', function () {
+      setConfig({
+        adServerCurrency: 'USD',
+        rates: {
+          USD: {
+            JPY: 100
+          }
+        }
+      });
+
+      var bid = { cpm: 100, currency: 'JPY', bidder: 'rubicon' };
+      var innerBid;
+
+      addBidResponseHook(function(adCodeId, bid) {
+        innerBid = bid;
+      }, 'elementId', bid);
+
+      expect(innerBid.cpm).to.equal('1.0000');
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('100.000');
+
+      // Boosting the bid now
+      innerBid.cpm *= 10;
+      expect(innerBid.cpm).to.equal(10.0000);
+      expect(typeof innerBid.getCpmInNewCurrency).to.equal('function');
+      expect(innerBid.getCpmInNewCurrency('JPY')).to.equal('1000.000');
+    });
+
     it('uses default rates when currency file fails to load', function () {
       setConfig({});
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix for #3837 

## Description of change
bid.getCpmInNewCurrency should use the latest value of bid.cpm and bid.currency as we allow publishers to update the value of bid.cpm (using bidAdjustment and bidResponse event) hence the bid.getCpmInNewCurrency API should return the bid.cpm equivalent value in the requested currency. 

#3837 