### PR TITLE
Quantcast Adapter: Added optional dealId parameter to bid response.

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -182,7 +182,7 @@ export const spec = {
     }
 
     const bidResponsesList = response.bids.map(bid => {
-      const { ad, cpm, width, height, creativeId, currency, videoUrl } = bid;
+      const { ad, cpm, width, height, creativeId, currency, videoUrl, dealId } = bid;
 
       const result = {
         requestId: response.requestId,
@@ -199,6 +199,10 @@ export const spec = {
       if (videoUrl !== undefined && videoUrl) {
         result['vastUrl'] = videoUrl;
         result['mediaType'] = 'video';
+      }
+
+      if (dealId !== undefined && dealId) {
+        result['dealId'] = dealId;
       }
 
       return result;

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -305,6 +305,26 @@ describe('Quantcast adapter', function () {
       expect(interpretedResponse[0]).to.deep.equal(expectedResponse);
     });
 
+    it('should include dealId in bid response', function () {
+      response.body.bids[0].dealId = 'test-dealid';
+      const expectedResponse = {
+        requestId: 'erlangcluster@qa-rtb002.us-ec.adtech.com-11417780270886458',
+        cpm: 4.5,
+        width: 300,
+        height: 250,
+        ad:
+          '<!DOCTYPE html><div style="height: 250; width: 300; display: table-cell; vertical-align: middle;"><div style="width: 300px; margin-left: auto; margin-right: auto;"><script src="https://adserver.adtechus.com/addyn/3.0/5399.1/2394397/0/-1/QUANTCAST;size=300x250;target=_blank;alias=;kvp36=;sub1=;kvl=;kvc=;kvs=300x250;kvi=;kva=;sub2=;rdclick=http://exch.quantserve.com/r?a=;labels=_qc.clk,_click.adserver.rtb,_click.rand.;rtbip=;rtbdata2=;redirecturl2=" type="text/javascript"></script><img src="https://exch.quantserve.com/pixel/p_12345.gif?media=ad&p=&r=&rand=&labels=_qc.imp,_imp.adserver.rtb&rtbip=&rtbdata2=" style="display: none;" border="0" height="1" width="1" alt="Quantcast"/></div></div>',
+        ttl: QUANTCAST_TTL,
+        creativeId: 1001,
+        netRevenue: QUANTCAST_NET_REVENUE,
+        currency: 'USD',
+        dealId: 'test-dealid'
+      };
+      const interpretedResponse = qcSpec.interpretResponse(response);
+
+      expect(interpretedResponse[0]).to.deep.equal(expectedResponse);
+    });
+
     it('should get correct bid response for instream video', function() {
       const expectedResponse = {
         requestId: 'erlangcluster@qa-rtb002.us-ec.adtech.com-11417780270886458',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add support for dealId in bid response from Quantcast.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
