### PR TITLE
aardvark tdid support

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -27,6 +27,7 @@ export const spec = {
     var requestsMap = {};
     var referer = bidderRequest.refererInfo.referer;
     var pageCategories = [];
+    var tdId = '';
 
     // This reference to window.top can cause issues when loaded in an iframe if not protected with a try/catch.
     try {
@@ -34,6 +35,10 @@ export const spec = {
         pageCategories = window.top.rtkcategories;
       }
     } catch (e) {}
+
+    if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.tdid'))) {
+      tdId = validBidRequests[0].userId.tdid;
+    }
 
     utils._each(validBidRequests, function(b) {
       var rMap = requestsMap[b.params.ai];
@@ -47,6 +52,10 @@ export const spec = {
           },
           endpoint: DEFAULT_ENDPOINT
         };
+
+        if (tdId) {
+          rMap.payload.tdid = tdId;
+        }
 
         if (pageCategories && pageCategories.length) {
           rMap.payload.categories = pageCategories.slice(0);

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -37,7 +37,8 @@ describe('aardvarkAdapterTest', function () {
       sizes: [300, 250],
       bidId: '1abgs362e0x48a8',
       bidderRequestId: '70deaff71c281d',
-      auctionId: '5c66da22-426a-4bac-b153-77360bef5337'
+      auctionId: '5c66da22-426a-4bac-b153-77360bef5337',
+      userId: { tdid: 'eff98622-b5fd-44fa-9a49-6e846922d532' }
     },
     {
       bidder: 'aardvark',
@@ -81,6 +82,13 @@ describe('aardvarkAdapterTest', function () {
       expect(requests[0].data.TdAx).to.equal('1abgs362e0x48a8');
       expect(requests[0].data.rtkreferer).to.not.be.undefined;
       expect(requests[0].data.RAZd).to.equal('22aidtbx5eabd9');
+    });
+
+    it('should have tdid, it is available in bidRequest', function () {
+      const requests = spec.buildRequests(bidRequests);
+      requests.forEach(function (requestItem) {
+        expect(requestItem.data.tdid).to.equal('eff98622-b5fd-44fa-9a49-6e846922d532');
+      });
     });
   });
 
@@ -147,6 +155,13 @@ describe('aardvarkAdapterTest', function () {
       expect(requests[1].data.TdAx).to.be.undefined;
       expect(requests[1].data.rtkreferer).to.not.be.undefined;
       expect(requests[1].data.RAZd).to.equal('22aidtbx5eabd9');
+    });
+
+    it('should have no tdid, it is not available in bidRequest', function () {
+      const requests = spec.buildRequests(bidRequests);
+      requests.forEach(function (requestItem) {
+        expect(requestItem.data.tdid).to.be.undefined;
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Add support for unifiedId, from userId module by reading `validBidRequests[0].userId.tdid` param in `buildRequests()` method of `aardvarkBidAdapter`.
- Bumped up test coverage percentage of `aardvarkBidAdapter`, by covering function `getUserSyncs()`.

- contact email of the adapter’s maintainer: chris@rtk.io
- [x] official adapter submission
