### PR TITLE
feat(unruly-bid-adapter): use bidResponse siteId when configuring the renderer

### DIFF
--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -6,7 +6,7 @@ import { VIDEO } from '../src/mediaTypes'
 function configureUniversalTag (exchangeRenderer) {
   parent.window.unruly = parent.window.unruly || {};
   parent.window.unruly['native'] = parent.window.unruly['native'] || {};
-  parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || exchangeRenderer.siteId;
+  parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || exchangeRenderer.config.siteId;
   parent.window.unruly['native'].supplyMode = 'prebid';
 }
 

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -4,6 +4,9 @@ import { registerBidder } from '../src/adapters/bidderFactory'
 import { VIDEO } from '../src/mediaTypes'
 
 function configureUniversalTag (exchangeRenderer) {
+  if (!exchangeRenderer.config) throw new Error('UnrulyBidAdapter: Missing renderer config.')
+  if (!exchangeRenderer.config.siteId) throw new Error('UnrulyBidAdapter: Missing renderer siteId.')
+
   parent.window.unruly = parent.window.unruly || {};
   parent.window.unruly['native'] = parent.window.unruly['native'] || {};
   parent.window.unruly['native'].siteId = parent.window.unruly['native'].siteId || exchangeRenderer.config.siteId;

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -38,9 +38,18 @@ const serverResponseToBid = (bid, rendererInstance) => ({
 
 const buildPrebidResponseAndInstallRenderer = bids =>
   bids
-    .filter(serverBid => !!utils.deepAccess(serverBid, 'ext.renderer'))
+    .filter(serverBid => {
+      const hasConfig = !!utils.deepAccess(serverBid, 'ext.renderer.config');
+      const hasSiteId = !!utils.deepAccess(serverBid, 'ext.renderer.config.siteId');
+
+      if (!hasConfig) utils.logError(new Error('UnrulyBidAdapter: Missing renderer config.'));
+      if (!hasSiteId) utils.logError(new Error('UnrulyBidAdapter: Missing renderer siteId.'));
+
+      return hasSiteId
+    })
     .map(serverBid => {
       const exchangeRenderer = utils.deepAccess(serverBid, 'ext.renderer');
+
       configureUniversalTag(exchangeRenderer);
       configureRendererQueue();
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -182,6 +182,37 @@ describe('UnrulyAdapter', function () {
       sinon.assert.calledWithExactly(fakeRenderer.setRender, sinon.match.func)
     });
 
+    it('should throw if bidResponse renderer config is not available', function () {
+      expect(Renderer.install.called).to.be.false;
+      expect(fakeRenderer.setRender.called).to.be.false;
+
+      const mockReturnedBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
+      const mockRenderer = {
+        url: 'value: mockRendererURL'
+      };
+      mockReturnedBid.ext.renderer = mockRenderer;
+      const mockServerResponse = createExchangeResponse(mockReturnedBid);
+
+      expect(() => adapter.interpretResponse(mockServerResponse))
+        .to.throw('UnrulyBidAdapter: Missing renderer config.');
+    });
+
+    it('should throw if siteId is not available', function () {
+      expect(Renderer.install.called).to.be.false;
+      expect(fakeRenderer.setRender.called).to.be.false;
+
+      const mockReturnedBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
+      const mockRenderer = {
+        url: 'value: mockRendererURL',
+        config: {}
+      };
+      mockReturnedBid.ext.renderer = mockRenderer;
+      const mockServerResponse = createExchangeResponse(mockReturnedBid);
+
+      expect(() => adapter.interpretResponse(mockServerResponse))
+        .to.throw('UnrulyBidAdapter: Missing renderer siteId.');
+    });
+
     it('bid is placed on the bid queue when render is called', function () {
       const exchangeBid = createOutStreamExchangeBid({ adUnitCode: 'video', vastUrl: 'value: vastUrl' });
       const exchangeResponse = createExchangeResponse(exchangeBid);
@@ -200,7 +231,7 @@ describe('UnrulyAdapter', function () {
       expect(sentRendererConfig.vastUrl).to.equal('value: vastUrl');
       expect(sentRendererConfig.renderer).to.equal(fakeRenderer);
       expect(sentRendererConfig.adUnitCode).to.equal('video')
-    })
+    });
 
     it('should ensure that renderer is placed in Prebid supply mode', function () {
       const mockExchangeBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
@@ -246,13 +277,13 @@ describe('UnrulyAdapter', function () {
       type: 'iframe',
       url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html'
     })
-  })
+  });
 
   it('should append consent params if gdpr does apply and consent is given', () => {
     const mockConsent = {
       gdprApplies: true,
       consentString: 'hello'
-    }
+    };
     const response = {}
     const syncOptions = { iframeEnabled: true }
     const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
@@ -260,14 +291,14 @@ describe('UnrulyAdapter', function () {
       type: 'iframe',
       url: 'https://video.unrulymedia.com/iframes/third-party-iframes.html?gdpr=1&gdpr_consent=hello'
     })
-  })
+  });
 
   it('should append consent param if gdpr applies and no consent is given', () => {
     const mockConsent = {
       gdprApplies: true,
       consentString: {}
-    }
-    const response = {}
+    };
+    const response = {};
     const syncOptions = { iframeEnabled: true }
     const syncs = adapter.getUserSyncs(syncOptions, response, mockConsent)
     expect(syncs[0]).to.deep.equal({

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -18,7 +18,10 @@ describe('UnrulyAdapter', function () {
         'statusCode': statusCode,
         'renderer': {
           'id': 'unruly_inarticle',
-          'config': {},
+          'config': {
+            'siteId': 123456,
+            'targetingUUID': 'xxx-yyy-zzz'
+          },
           'url': 'https://video.unrulymedia.com/native/prebid-loader.js'
         },
         'adUnitCode': adUnitCode
@@ -157,7 +160,13 @@ describe('UnrulyAdapter', function () {
       expect(fakeRenderer.setRender.called).to.be.false;
 
       const mockReturnedBid = createOutStreamExchangeBid({adUnitCode: 'video1', bidId: 'mockBidId'});
-      const mockRenderer = { url: 'value: mockRendererURL' };
+      const mockRenderer = {
+        url: 'value: mockRendererURL',
+        config: {
+          siteId: 123456,
+          targetingUUID: 'xxx-yyy-zzz'
+        }
+      };
       mockReturnedBid.ext.renderer = mockRenderer;
       const mockServerResponse = createExchangeResponse(mockReturnedBid);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Ensure that the Unruly Bid Adapter can be used on sites where the Unruly Universal Tag has not been configured separately. This is a backwards-compatible change and it doesn't require any actions on Publisher's side.
