### PR TITLE
Digitrust submodule

### DIFF
--- a/integrationExamples/gpt/digitrust_Full.html
+++ b/integrationExamples/gpt/digitrust_Full.html
@@ -1,13 +1,12 @@
 <html>
 <head>
-    <title>Simple DigiTrust Prebid - No Framework</title>
-
+    <title>Full DigiTrust Prebid Sample</title>
     <script>
-        (function (window, document) {
+        (function(window, document) {
             if (!window.__cmp) {
-                window.__cmp = (function () {
+                window.__cmp = (function() {
                     var listen = window.attachEvent || window.addEventListener;
-                    listen('message', function (event) {
+                    listen('message', function(event) {
                         window.__cmp.receiveMessage(event);
                     }, false);
 
@@ -26,7 +25,7 @@
                     addLocatorFrame();
 
                     var commandQueue = [];
-                    var cmp = function (command, parameter, callback) {
+                    var cmp = function(command, parameter, callback) {
                         if (command === 'ping') {
                             if (callback) {
                                 callback({
@@ -43,7 +42,7 @@
                         }
                     };
                     cmp.commandQueue = commandQueue;
-                    cmp.receiveMessage = function (event) {
+                    cmp.receiveMessage = function(event) {
                         var data = event && event.data && event.data.__cmpCall;
                         if (data) {
                             commandQueue.push({
@@ -85,7 +84,7 @@
         var adUnits = [
             {
                 code: 'test-div',
-                sizes: [[300, 250], [300, 600], [728, 90]],
+                sizes: [[300,250],[300,600],[728,90]],
                 bids: [
                     {
                         bidder: 'rubicon',
@@ -107,11 +106,11 @@
     <script>
         var googletag = googletag || {};
         googletag.cmd = googletag.cmd || [];
-        googletag.cmd.push(function () {
+        googletag.cmd.push(function() {
             googletag.pubads().disableInitialLoad();
         });
 
-        pbjs.que.push(function () {
+        pbjs.que.push(function() {
             pbjs.setConfig({
                 debug: true,
                 consentManagement: {
@@ -119,7 +118,7 @@
                     timeout: 1000,
                     allowAuctionWithoutConsent: true
                 },
-                usersync: {
+               usersync: {
                     userIds: [{
                         name: "digitrust",
                         params: {
@@ -147,8 +146,7 @@
                                 }
                                 else {
                                     console.error('Digitrust init failed');
-                                }
-                            }
+                                }                            }
                         },
                         storage: {
                             type: "html5",
@@ -167,15 +165,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
+            googletag.cmd.push(function() {
+                pbjs.que.push(function() {
                     pbjs.setTargetingForGPTAsync();
                     googletag.pubads().refresh();
                 });
             });
         }
 
-        setTimeout(function () {
+        setTimeout(function() {
             sendAdserverRequest();
         }, FAILSAFE_TIMEOUT);
     </script>
@@ -194,8 +192,8 @@
     </script>
 
     <script>
-        googletag.cmd.push(function () {
-            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250], [300, 600]], 'test-div').addService(googletag.pubads());
+        googletag.cmd.push(function() {
+            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250],[300,600]], 'test-div').addService(googletag.pubads());
             googletag.pubads().enableSingleRequest();
             googletag.enableServices();
         });
@@ -203,12 +201,14 @@
 </head>
 
 <body>
-    <h2>DigiTrust Prebid Sample - No Framework</h2>
+    <h2>DigiTrust Prebid Full Sample</h2>
+
 
     <p>
         This sample shows the simplest integration path for using DigiTrust ID with Prebid.
         You can use DigiTrust ID without integrating the entire DigiTrust suite.
     </p>
+
     <div id="idDiv"></div>
 
     <div id='test-div'>
@@ -216,5 +216,7 @@
             googletag.cmd.push(function () { googletag.display('test-div'); });
         </script>
     </div>
+    <script src="https://cdn.digitru.st/prod/1/digitrust.min.js"></script>
+
 </body>
-</html>
+</html >

--- a/integrationExamples/gpt/digitrust_Simple.html
+++ b/integrationExamples/gpt/digitrust_Simple.html
@@ -126,6 +126,10 @@
                                 site: 'example_site_id'
                             },
                             callback: function (digiTrustResult) {
+                                // This callback can be used by publisher page to react to error conditions
+                                // Or pass the DigiTrust ID on.
+                                // If the Prebid userId system already has a managed copy of the DigiTrust ID
+                                // this callback will not be invoked.
                                 if (digiTrustResult.success) {
                                     console.log('Success in Digitrust init');
                                     if (digiTrustResult.identity && digiTrustResult.identity.id != null) {
@@ -194,6 +198,12 @@
 
 <body>
 <h2>DigiTrust Prebid Sample - No Framework</h2>
+
+
+<p>
+    This sample shows the simplest integration path for using DigiTrust ID with Prebid.
+    You can use DigiTrust ID without integrating the entire DigiTrust suite.
+</p>
 
 <div id='test-div'>
     <script>

--- a/integrationExamples/gpt/digitrust_Simple.html
+++ b/integrationExamples/gpt/digitrust_Simple.html
@@ -1,0 +1,204 @@
+<html>
+<head>
+    <script>
+        (function(window, document) {
+            if (!window.__cmp) {
+                window.__cmp = (function() {
+                    var listen = window.attachEvent || window.addEventListener;
+                    listen('message', function(event) {
+                        window.__cmp.receiveMessage(event);
+                    }, false);
+
+                    function addLocatorFrame() {
+                        if (!window.frames['__cmpLocator']) {
+                            if (document.body) {
+                                var frame = document.createElement('iframe');
+                                frame.style.display = 'none';
+                                frame.name = '__cmpLocator';
+                                document.body.appendChild(frame);
+                            } else {
+                                setTimeout(addLocatorFrame, 5);
+                            }
+                        }
+                    }
+                    addLocatorFrame();
+
+                    var commandQueue = [];
+                    var cmp = function(command, parameter, callback) {
+                        if (command === 'ping') {
+                            if (callback) {
+                                callback({
+                                    gdprAppliesGlobally: !!(window.__cmp && window.__cmp.config && window.__cmp.config.storeConsentGlobally),
+                                    cmpLoaded: false
+                                });
+                            }
+                        } else {
+                            commandQueue.push({
+                                command: command,
+                                parameter: parameter,
+                                callback: callback
+                            });
+                        }
+                    };
+                    cmp.commandQueue = commandQueue;
+                    cmp.receiveMessage = function(event) {
+                        var data = event && event.data && event.data.__cmpCall;
+                        if (data) {
+                            commandQueue.push({
+                                callId: data.callId,
+                                command: data.command,
+                                parameter: data.parameter,
+                                event: event
+                            });
+                        }
+                    };
+                    cmp.config = {
+                        //
+                        // Modify config values here
+                        //
+                        // globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
+                        // customPurposeListLocation: './purposes.json',
+                        // globalConsentLocation: './portal.html',
+                        // storeConsentGlobally: false,
+                        // storePublisherData: false,
+                        logging: 'debug'//,
+                        // localization: {},
+                        // forceLocale: 'en-us'
+                    };
+                    return cmp;
+                }());
+                var t = document.createElement('script');
+                t.async = false;
+                t.src = 'http://acdn.adnxs.com/cmp/cmp.bundle.js';
+                var tag = document.getElementsByTagName('head')[0];
+                tag.appendChild(t);
+            }
+        })(window, document);
+        // window.__cmp('showConsentTool');
+    </script>
+
+    <script>
+        var FAILSAFE_TIMEOUT = 2000;
+
+        var adUnits = [
+            {
+                code: 'test-div',
+                sizes: [[300,250],[300,600],[728,90]],
+                bids: [
+                    {
+                        bidder: 'rubicon',
+                        params: {
+                            accountId: '1001',
+                            siteId: '113932',
+                            zoneId: '535510'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+    </script>
+    <script src="../../build/dev/prebid.js" async></script>
+
+    <script>
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function() {
+            googletag.pubads().disableInitialLoad();
+        });
+
+        pbjs.que.push(function() {
+            pbjs.setConfig({
+                debug: true,
+                consentManagement: {
+                    cmpApi: 'iab',
+                    timeout: 1000,
+                    allowAuctionWithoutConsent: true
+                },
+               usersync: {
+                    userIds: [{
+                        name: "digitrust",
+                        params: {
+                            init: {
+                                member: 'example_member_id',
+                                site: 'example_site_id'
+                            },
+                            callback: function (digiTrustResult) {
+                                if (digiTrustResult.success) {
+                                    console.log('Success in Digitrust init');
+                                    if (digiTrustResult.identity && digiTrustResult.identity.id != null) {
+                                        console.log('DigiTrust Id (encrypted): ' + digiTrustResult.identity.id);
+                                    }
+                                    else {
+                                        console.error('Digitrust gave success, but no identity returned');
+                                    }
+                                }
+                                else {
+                                    console.error('Digitrust init failed');
+                                }
+                            }
+                        },
+                        storage: {
+                            type: "html5",
+                            name: "pbjsdigitrust",
+                            expires: 60
+                        }
+                    }]
+                }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest
+            });
+        });
+
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent) return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function() {
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+
+        setTimeout(function() {
+            sendAdserverRequest();
+        }, FAILSAFE_TIMEOUT);
+    </script>
+
+    <script>
+        (function () {
+            var gads = document.createElement('script');
+            gads.async = true;
+            gads.type = 'text/javascript';
+            var useSSL = 'https:' == document.location.protocol;
+            gads.src = (useSSL ? 'https:' : 'http:') +
+                '//www.googletagservices.com/tag/js/gpt.js';
+            var node = document.getElementsByTagName('script')[0];
+            node.parentNode.insertBefore(gads, node);
+        })();
+    </script>
+
+    <script>
+        googletag.cmd.push(function() {
+            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250],[300,600]], 'test-div').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+</head>
+
+<body>
+<h2>DigiTrust Prebid Sample - No Framework</h2>
+
+<div id='test-div'>
+    <script>
+        googletag.cmd.push(function() { googletag.display('test-div'); });
+    </script>
+</div>
+</body>
+</html>

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -36,7 +36,7 @@ function isPresent() {
 var noop = function () {
 };
 
-const MAX_RETRIES = 4;
+const MAX_RETRIES = 2;
 const DT_ID_SVC = 'https://prebid.digitru.st/id/v1';
 
 var isFunc = function (fn) {

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -1,0 +1,225 @@
+/**
+ * This module adds DigiTrust ID support to the User ID module
+ * The {@link module:modules/userId} module is required
+ * If the full DigiTrust Id library is included the standard functions
+ * will be invoked to obtain the user's DigiTrust Id.
+ * When the full library is not included this will fall back to the
+ * DigiTrust Identity API and generate a mock DigiTrust object.
+ * @module modules/digiTrustIdSystem
+ * @requires module:modules/userId
+ */
+
+import { config } from 'src/config';
+import * as utils from '../src/utils'
+import { ajax } from 'src/ajax';
+import { getGlobal } from 'src/prebidGlobal';
+
+/**
+ * Checks to see if the DigiTrust framework is initialized.
+ * @function
+ */
+function isInitialized() {
+  if (window.DigiTrust == null) {
+    return false;
+  }
+  return DigiTrust.isClient; // this is set to true after init
+}
+
+let retries = 0;
+let retryId = 0;
+var isMock = false;
+var noop = function () {
+};
+
+const MAX_RETRIES = 4;
+const DT_ID_SVC = 'https://cdn-cf.digitru.st/id/v1';
+
+var isFunc = function (fn) {
+  return typeof (fn) === 'function';
+}
+
+function callApi(options) {
+  ajax(
+    DT_ID_SVC,
+    {
+      success: options.success,
+      error: options.fail
+    },
+    null,
+    {
+      method: 'GET'
+    }
+  );
+}
+
+/**
+ * Encode the Id per DigiTrust lib
+ * @param {any} id
+ */
+function encId(id) {
+  try {
+    if (typeof (id) !== 'string') {
+      id = JSON.stringify(id);
+    }
+    return encodeURIComponent(btoa(id));
+  } catch (ex) {
+    return id;
+  }
+}
+
+/**
+ * Writes the Identity into the expected DigiTrust cookie
+ * @param {any} id
+ */
+function writeDigiId(id) {
+  var key = 'DigiTrust.v1.identity';
+  var date = new Date();
+  date.setTime(date.getTime() + 604800000);
+  var exp = 'expires=' + date.toUTCString();
+  document.cookie = key + '=' + encId(id) + '; ' + exp + '; path=/;';
+}
+
+/**
+ * Set up a mock DigiTrust object
+ *
+ */
+function initMockDigitrust() {
+  isMock = true;
+  var _savedId = null; // closure variable for storing Id to avoid additional requests
+  var mock = {
+    isClient: true,
+    isMock: true,
+    getUser: function (obj, callback) {
+      var cb = callback || noop;
+      if (_savedId != null) {
+        cb(_savedId);
+        return;
+      }
+
+      var opts = {
+        success: function (respText, result) {
+          var idResult = {
+            success: true
+          }
+          try {
+            writeDigiId(respText);
+            idResult.identity = JSON.parse(respText);
+            _savedId = idResult;
+          } catch (ex) {
+            idResult.success = false;
+          }
+          cb(idResult);
+        },
+        fail: function (statusErr, result) {
+          utils.logError('DigiTrustId API error: ' + statusErr);
+        }
+      }
+
+      callApi(opts);
+    }
+  }
+
+  if (window) {
+    window.DigiTrust = mock;
+  }
+}
+
+/*
+ * Internal implementation to get the Id and trigger callback
+ */
+function getDigiTrustId(data, consentData, syncDelay, callback) {
+  if (!isInitialized()) {
+    if (retries >= MAX_RETRIES) {
+      utils.logInfo('DigiTrust framework timeout. Fallback to API and mock.');
+      initMockDigitrust();
+    } else {
+      // use expanding envelope
+      if (retryId != 0) {
+        clearTimeout(retryId);
+      }
+
+      retryId = setTimeout(function () {
+        getDigiTrustId(data, consentData, syncDelay, callback);
+      }, 100 * (1 + retries++));
+      return;
+    }
+  }
+
+  var executeIdRequest = function (data, callback) {
+    DigiTrust.getUser({ member: 'prebid' }, function (idResult) {
+      var exp = (data && data.storage && data.storage.expires) || 60;
+      var rslt = {
+        data: null,
+        expires: exp
+      };
+      if (idResult && idResult.success && idResult.identity) {
+        if (isMock) {
+          // plug in the mock ID
+        }
+
+        if (isFunc(callback)) {
+          rslt.data = idResult.identity;
+          callback(rslt);
+        }
+      } else {
+        // failed
+        if (isFunc(callback)) {
+          rslt.err = 'Failure getting id';
+          callback(rslt);
+        }
+      }
+    });
+  }
+
+  executeIdRequest(data, callback);
+}
+
+function initializeDigiTrust(config) {
+  var dt = window.DigiTrust;
+  if (dt && !dt.isClient && config != null) {
+    dt.initialize(config.init, config.callback);
+  } else if (dt == null) {
+    // Assume we are already on a delay and DigiTrust is not on page
+    initMockDigitrust();
+  }
+}
+
+var testHook = {};
+
+/**
+ * Exposes the test hook object by attaching to the digitrustIdModule.
+ * This method is called in the unit tests to surface internals.
+ */
+function surfaceTestHook() {
+  digitrustIdModule['_testHook'] = testHook;
+}
+
+testHook.exposeLoader = exposeLoader;
+testHook.initMockDigitrust = initMockDigitrust;
+
+
+
+/** @type {Submodule} */
+export const digiTrustIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: 'digiTrust',
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{pubcid:string}}
+   */
+  decode: function (idData) {
+    try {
+      return { 'digitrustid': idData };
+    } catch (e) {
+      utils.logError('DigiTrust ID submodule decode error');
+    }
+  },
+  getId: getDigiTrustId,
+  init: initializeDigiTrust,
+  _testInit: surfaceTestHook
+};

--- a/modules/digiTrustIdSystem.md
+++ b/modules/digiTrustIdSystem.md
@@ -6,21 +6,6 @@ The DigiTrust Id integration for Prebid may be used with or without the full
 DigiTrust library. This is an optional module that must be used in conjunction
 with the userId module.
 
-The full DigiTrust integration requires the DigiTrust package be included.
-DigiTrust may be initialized in the standard manner or through the params
-object. 
-
-You can use npm or reference the script on the cdn.
-
-npm install digitrust
-
-or
-
-<script src="https://cdn.digitru.st/prod/1.5.20/digitrust.min.js"></script>
-
-Please note that version 1.5.20 or better is required.
-
-
 See the [Prebid Integration Guide for DigiTrust](https://github.com/digi-trust/dt-cdn/wiki/Prebid-Integration-for-DigiTrust-Id)
 and the [DigiTrust wiki](https://github.com/digi-trust/dt-cdn/wiki)
 for further instructions.
@@ -39,17 +24,13 @@ for further instructions.
 								site: 'example_site_id'
 							},
 							callback: function (digiTrustResult) {
+							// This callback method is optional
 								if (digiTrustResult.success) {
-									console.log('Success in Digitrust init');
-									if (digiTrustResult.identity && digiTrustResult.identity.id != null) {
-										console.log('DigiTrust Id (encrypted): ' + digiTrustResult.identity.id);
-									}
-									else {
-										console.error('Digitrust gave success, but no identity returned');
-									}
+									// Success in Digitrust init;
+									// 'DigiTrust Id (encrypted): ' + digiTrustResult.identity.id;
 								}
 								else {
-									console.error('Digitrust init failed');
+									// Digitrust init failed
 								}
 							}
 						},
@@ -70,5 +51,104 @@ for further instructions.
 ```
 
 
+## Building Prebid with DigiTrust Support
+Your Prebid build must include the modules for both **userId** and **digitrustIdLoader**. Follow the build instructions for Prebid as
+explained in the top level README.md file of the Prebid source tree.
 
+ex: $ gulp build --modules=userId,digitrustIdLoader
+
+### Step by step Prebid build instructions for DigiTrust 
+
+1. Download the Prebid source from [Prebid Git Repo](https://github.com/prebid/Prebid.js)
+2. Set up your environment as outlined in the [Readme File](https://github.com/prebid/Prebid.js/blob/master/README.md#Build)
+3. Execute the build command either with all modules or with the `userId` and `digitrustIdLoader` modules.
+   ```
+   $ gulp build --modules=userId,digitrustIdLoader
+   ```
+4. (Optional) Concatenate the DigiTrust source code to the end of your `prebid.js` file for a single source distribution.
+5. Upload the resulting source file to your CDN.
+
+
+## Deploying Prebid with DigiTrust ID support
+**Precondition:** You must be a DigiTrust member and have registered through the [DigiTrust Signup Process](http://www.digitru.st/signup/).
+Your assigned publisher ID will be required in the configuration settings for all deployment scenarios.
+
+There are three supported approaches to deploying the Prebid-integrated DigiTrust package:
+
+* "Bare bones" deployment using only the integrated DigiTrust module code.
+* Full DigiTrust with CDN referenced DigiTrust.js library.
+* Full DigiTrust packaged with Prebid or site js.
+
+### Bare Bones Deployment
+
+This deployment results in the smallest Javascript package and is the simplest deployment. 
+It is appropriate for testing or deployments where simplicity is key. This approach
+utilizes the REST API for ID generation. While there is less Javascript in use,
+the user may experience more network requests than the scenarios that include the full
+DigiTrust library.
+
+1. Build your Prebid package as above, skipping step 4.
+2. Add the DigiTrust initializer section to your Prebid initialization object as below, 
+   using your Member ID and Site ID.
+3. Add a reference to your Prebid package and the initialization code on all pages you wish
+   to utilize Prebid with integrated DigiTrust ID.
+
+
+
+
+### Full DigiTrust with CDN referenced DigiTrust library
+
+Both "Full DigiTrust" deployments will result in a larger initial Javascript payload.
+The end user may experience fewer overall network requests as the encrypted and anonymous
+DigiTrust ID can often be generated fully in client-side code. Utilizing the CDN reference
+to the official DigiTrust distribution insures you will be running the latest version of the library.
+
+The Full DigiTrust deployment is designed to work with both new DigiTrust with Prebid deployments, and with
+Prebid deployments by existing DigiTrust members. This allows you to migrate your code more slowly
+without losing DigiTrust support in the process.
+
+1. Deploy your built copy of `prebid.js` to your CDN.
+2. On each page reference both your `prebid.js` and a copy of the **DigiTrust** library. 
+   This may either be a copy downloaded from the [DigiTrust CDN](https://cdn.digitru.st/prod/1/digitrust.min.js) to your CDN, 
+   or directly referenced from the URL https://cdn.digitru.st/prod/1/digitrust.min.js. These may be added to the page in any order.
+3. Add a configuration section for Prebid that includes the `usersync` settings and the `digitrust` settings.
+
+### Full DigiTrust packaged with Prebid
+
+
+1. Deploy your built copy of `prebid.js` to your CDN. Be sure to perform *Step 4* of the build to concatenate or 
+   integrate the full DigiTrust library code with your Prebid package.
+2. On each page reference your `prebid.js`
+3. Add a configuration section for Prebid that includes the `usersync` settings and the `digitrust` settings. 
+   This code may also be appended to your Prebid package or placed in other initialization methods.
+
+
+
+## Parameter Descriptions for the `usersync` Configuration Section
+The below parameters apply only to the DigiTrust ID integration.
+
+{: .table .table-bordered .table-striped }
+| Param under usersync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | ID value for the DigiTrust module - `"digitrust"` | `"digitrust"` |
+| params | Required | Object | Details for DigiTrust initialization. | |
+| params.init | Required | Object | Initialization parameters, including the DigiTrust Publisher ID and Site ID. |  |
+| params.init.member | Required | String | DigiTrust Publisher Id | "A897dTzB" |
+| params.init.site | Required | String | DigiTrust Site Id | "MM2123" |
+| params.callback | Optional | Function | Callback method to fire after initialization of the DigiTrust framework. The argument indicates failure and success and the identity object upon success. |  |
+| storage | Required | Object | The publisher must specify the local storage in which to store the results of the call to get the user ID. This can be either cookie or HTML5 storage. | |
+| storage.type | Required | String | This is where the results of the user ID will be stored. The recommended method is `localStorage` by specifying `html5`. | `"html5"` |
+| storage.name | Required | String | The name of the cookie or html5 local storage where the user ID will be stored. | `"pbjsdigitrust"` |
+| storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. Default is 30 for UnifiedId and 1825 for PubCommonID | `365` |
+| value | Optional | Object | Used only if the page has a separate mechanism for storing the Unified ID. The value is an object containing the values to be sent to the adapters. In this scenario, no URL is called and nothing is added to local storage | `{"tdid": "D6885E90-2A7A-4E0F-87CB-7734ED1B99A3"}` |
+
+
+
+## Further Reading
+
++ [DigiTrust Home Page](http://digitru.st)
+
++ [DigiTrust integration guide](https://github.com/digi-trust/dt-cdn/wiki/Integration-Guide)
+
++ [DigiTrust ID Encryption](https://github.com/digi-trust/dt-cdn/wiki/ID-encryption)
 

--- a/modules/digiTrustIdSystem.md
+++ b/modules/digiTrustIdSystem.md
@@ -1,0 +1,74 @@
+## DigiTrust Universal Id Integration
+
+Setup
+-----
+The DigiTrust Id integration for Prebid may be used with or without the full
+DigiTrust library. This is an optional module that must be used in conjunction
+with the userId module.
+
+The full DigiTrust integration requires the DigiTrust package be included.
+DigiTrust may be initialized in the standard manner or through the params
+object. 
+
+You can use npm or reference the script on the cdn.
+
+npm install digitrust
+
+or
+
+<script src="https://cdn.digitru.st/prod/1.5.20/digitrust.min.js"></script>
+
+Please note that version 1.5.20 or better is required.
+
+
+See the [Prebid Integration Guide for DigiTrust](https://github.com/digi-trust/dt-cdn/wiki/Prebid-Integration-for-DigiTrust-Id)
+and the [DigiTrust wiki](https://github.com/digi-trust/dt-cdn/wiki)
+for further instructions.
+
+
+## Example Prebid Configuration for Digitrust Id
+```
+        pbjs.que.push(function() {
+            pbjs.setConfig({
+                usersync: {
+                    userIds: [{
+						name: "digitrust",
+						params: {
+							init: {
+								member: 'example_member_id',
+								site: 'example_site_id'
+							},
+							callback: function (digiTrustResult) {
+								if (digiTrustResult.success) {
+									console.log('Success in Digitrust init');
+									if (digiTrustResult.identity && digiTrustResult.identity.id != null) {
+										console.log('DigiTrust Id (encrypted): ' + digiTrustResult.identity.id);
+									}
+									else {
+										console.error('Digitrust gave success, but no identity returned');
+									}
+								}
+								else {
+									console.error('Digitrust init failed');
+								}
+							}
+						},
+						storage: {
+							type: "html5",
+							name: "pbjsdigitrust",
+							expires: 60
+						}
+					}]
+                }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest
+            });
+        });
+
+```
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -6074,8 +6074,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6099,15 +6098,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6124,22 +6121,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6270,8 +6264,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6285,7 +6278,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6302,7 +6294,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6311,15 +6302,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6340,7 +6329,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6429,8 +6417,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6444,7 +6431,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6540,8 +6526,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6583,7 +6568,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6605,7 +6589,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6654,15 +6637,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6074,7 +6074,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6098,13 +6099,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6121,19 +6124,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6264,7 +6270,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6278,6 +6285,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6294,6 +6302,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6302,13 +6311,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6329,6 +6340,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6417,7 +6429,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6431,6 +6444,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6526,7 +6540,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6568,6 +6583,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6589,6 +6605,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6637,13 +6654,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This adds DigiTrust support to the updated userId system.

## Type of change
- [X ] Feature

## Description of change
This is an update to add DigiTrust Id support to the new userId module for Prebid. This change eliminates the loader and instead uses the "attachIdSystem" method to link in DigiTrust Id submodule to the userId system.

## Other information
Previous changes to documentation remains valid.
