### PR TITLE
Add beachfront bidder params to set outstream player settings

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -7,7 +7,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
-const ADAPTER_VERSION = '1.4';
+const ADAPTER_VERSION = '1.5';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 
@@ -143,21 +143,20 @@ function createRenderer(bidRequest) {
     loaded: false
   });
 
-  renderer.setRender(outstreamRender);
-
-  return renderer;
-}
-
-function outstreamRender(bid) {
-  bid.renderer.push(() => {
-    window.Beachfront.Player(bid.adUnitCode, {
-      ad_tag_url: bid.vastUrl,
-      width: bid.width,
-      height: bid.height,
-      expand_in_view: false,
-      collapse_on_complete: true
+  renderer.setRender(bid => {
+    bid.renderer.push(() => {
+      window.Beachfront.Player(bid.adUnitCode, {
+        adTagUrl: bid.vastUrl,
+        width: bid.width,
+        height: bid.height,
+        expandInView: getPlayerBidParam(bidRequest, 'expandInView', false),
+        collapseOnComplete: getPlayerBidParam(bidRequest, 'collapseOnComplete', true),
+        progressColor: getPlayerBidParam(bidRequest, 'progressColor')
+      });
     });
   });
+
+  return renderer;
 }
 
 function getFirstSize(sizes) {
@@ -229,6 +228,11 @@ function getVideoBidParam(bid, key) {
 
 function getBannerBidParam(bid, key) {
   return utils.deepAccess(bid, 'params.banner.' + key) || utils.deepAccess(bid, 'params.' + key);
+}
+
+function getPlayerBidParam(bid, key, defaultValue) {
+  let param = utils.deepAccess(bid, 'params.player.' + key);
+  return param === undefined ? defaultValue : param;
 }
 
 function isVideoBidValid(bid) {

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -86,3 +86,35 @@ Module that connects to Beachfront's demand sources
         }
     ];
 ```
+
+# Outstream Player Params Example
+```javascript
+    var adUnits = [
+        {
+            code: 'test-video-outstream',
+            mediaTypes: {
+                video: {
+                    context: 'outstream',
+                    playerSize: [ 640, 360 ]
+                }
+            },
+            bids: [
+                {
+                    bidder: 'beachfront',
+                    params: {
+                        video: {
+                            bidfloor: 0.01,
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+                            mimes: [ 'video/mp4', 'application/javascript' ]
+                        },
+                        player: {
+                            progressColor: '#50A8FA',
+                            expandInView: false,
+                            collapseOnComplete: true
+                        }
+                    }
+                }
+            ]
+        }
+    ];
+```


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds bidder params to pass player settings for the outstream renderer.

```javascript
{
  bidder: 'beachfront',
  params: {
    bidfloor: 0.01,
    appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
    player: {
      collapseOnComplete: false
    }
  }
}
```

PR for docs:
prebid/prebid.github.io#1334
