### PR TITLE
Use actual global object name in log message

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -58,7 +58,7 @@ const defaultParamConstants = {
  */
 export default function buildDfpVideoUrl(options) {
   if (!options.params && !options.url) {
-    logError(`A params object or a url is required to use pbjs.adServers.dfp.buildVideoUrl`);
+    logError(`A params object or a url is required to use $$PREBID_GLOBAL$$.adServers.dfp.buildVideoUrl`);
     return;
   }
 

--- a/src/video.js
+++ b/src/video.js
@@ -48,7 +48,7 @@ export const checkVideoBidSetup = hook('sync', function(bid, bidRequest, videoMe
     if (!config.getConfig('cache.url') && bid.vastXml && !bid.vastUrl) {
       logError(`
         This bid contains only vastXml and will not work when a prebid cache url is not specified.
-        Try enabling prebid cache with pbjs.setConfig({ cache: {url: "..."} });
+        Try enabling prebid cache with $$PREBID_GLOBAL$$.setConfig({ cache: {url: "..."} });
       `);
       return false;
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The global Prebid.js object name can be something other than 'pbjs'. Update this log message to reference the specified prebid global object name.
