### PR TITLE
Fixing DigiTrust Markdown Table in digiTrustIdSystem.md file

### DIFF
--- a/modules/digiTrustIdSystem.md
+++ b/modules/digiTrustIdSystem.md
@@ -127,7 +127,6 @@ without losing DigiTrust support in the process.
 ## Parameter Descriptions for the `usersync` Configuration Section
 The below parameters apply only to the DigiTrust ID integration.
 
-{: .table .table-bordered .table-striped }
 | Param under usersync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Required | String | ID value for the DigiTrust module - `"digitrust"` | `"digitrust"` |


### PR DESCRIPTION


## Type of change
- [X] Other : Documentation table was broken, fixing it.

## Description of change
Fixing DigiTrust Markdown Table in digiTrustIdSystem.md file