### PR TITLE
GumGum: adds tradedesk id param

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -75,6 +75,14 @@ function getWrapperCode(wrapper, data) {
   return wrapper.replace('AD_JSON', window.btoa(JSON.stringify(data)))
 }
 
+function _getTradeDeskIDParam(bidRequest) {
+  const unifiedIdObj = {};
+  if (bidRequest.userId && bidRequest.userId.tdid) {
+    unifiedIdObj.tdid = bidRequest.userId.tdid;
+  }
+  return unifiedIdObj;
+}
+
 // TODO: use getConfig()
 function _getDigiTrustQueryParams() {
   function getDigiTrustId () {
@@ -170,7 +178,7 @@ function buildRequests (validBidRequests, bidderRequest) {
       sizes: bidRequest.sizes,
       url: BID_ENDPOINT,
       method: 'GET',
-      data: Object.assign(data, _getBrowserParams(), _getDigiTrustQueryParams())
+      data: Object.assign(data, _getBrowserParams(), _getDigiTrustQueryParams(), _getTradeDeskIDParam(bidRequest))
     })
   });
   return bids;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -142,7 +142,7 @@ describe('gumgumAdapter', function () {
         const connection = window.navigator.connection;
         const downlink = connection.downlink || connection.bandwidth;
         expect(bidRequest.data).to.include.any.keys('ns');
-        expect(bidRequest.data.ns).to.eq(Math.round(downlink*1024));
+        expect(bidRequest.data.ns).to.eq(Math.round(downlink * 1024));
       }
     });
   })

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { spec } from 'modules/gumgumBidAdapter';
 
 const ENDPOINT = 'https://g2.gumgum.com/hbid/imp';
 
-describe.only('gumgumAdapter', function () {
+describe('gumgumAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { spec } from 'modules/gumgumBidAdapter';
 
 const ENDPOINT = 'https://g2.gumgum.com/hbid/imp';
 
-describe('gumgumAdapter', function () {
+describe.only('gumgumAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('inherited functions', function () {
@@ -80,6 +80,35 @@ describe('gumgumAdapter', function () {
       expect(request.method).to.equal('GET');
       expect(request.id).to.equal('30b31c1838de1e');
     });
+    it('should correctly set the request paramters depending on params field', function () {
+      const request = Object.assign({}, bidRequests[0]);
+      delete request.params;
+      request.params = {
+        'inScreen': '10433394',
+        'bidfloor': 0.05
+      };
+      const bidRequest = spec.buildRequests([request])[0];
+      expect(bidRequest.data.pi).to.equal(2);
+      expect(bidRequest.data).to.include.any.keys('t');
+      expect(bidRequest.data).to.include.any.keys('fp');
+    });
+    it('should correctly set the request paramters depending on params field', function () {
+      const request = Object.assign({}, bidRequests[0]);
+      delete request.params;
+      request.params = {
+        'ICV': '10433395'
+      };
+      const bidRequest = spec.buildRequests([request])[0];
+      expect(bidRequest.data.pi).to.equal(5);
+      expect(bidRequest.data).to.include.any.keys('ni');
+    });
+    it('should not add additional parameters depending on params field', function () {
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.data).to.not.include.any.keys('ni');
+      expect(request.data).to.not.include.any.keys('t');
+      expect(request.data).to.not.include.any.keys('eAdBuyId');
+      expect(request.data).to.not.include.any.keys('adBuyId');
+    });
     it('should add consent parameters if gdprConsent is present', function () {
       const gdprConsent = { consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==', gdprApplies: true };
       const fakeBidRequest = { gdprConsent: gdprConsent };
@@ -92,6 +121,29 @@ describe('gumgumAdapter', function () {
       const fakeBidRequest = { gdprConsent: gdprConsent };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
       expect(bidRequest.data).to.not.include.any.keys('gdprConsent')
+    });
+    it('should add a tdid parameter if request contains unified id from TradeDesk', function () {
+      const unifiedId = {
+        'userId': {
+          'tdid': 'tradedesk-id'
+        }
+      }
+      const request = Object.assign(unifiedId, bidRequests[0]);
+      const bidRequest = spec.buildRequests([request])[0];
+      expect(bidRequest.data.tdid).to.eq(unifiedId.userId.tdid);
+    });
+    it('should not add a tdid parameter if unified id is not found', function () {
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.data).to.not.include.any.keys('tdid');
+    });
+    it('should send ns parameter if browser contains navigator.connection property', function () {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      if (window.navigator) {
+        const connection = window.navigator.connection;
+        const downlink = connection.downlink || connection.bandwidth;
+        expect(bidRequest.data).to.include.any.keys('ns');
+        expect(bidRequest.data.ns).to.eq(Math.round(downlink*1024));
+      }
     });
   })
 

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -138,11 +138,13 @@ describe('gumgumAdapter', function () {
     });
     it('should send ns parameter if browser contains navigator.connection property', function () {
       const bidRequest = spec.buildRequests(bidRequests)[0];
-      if (window.navigator) {
-        const connection = window.navigator.connection;
+      const connection = window.navigator && window.navigator.connection;
+      if (connection) {
         const downlink = connection.downlink || connection.bandwidth;
         expect(bidRequest.data).to.include.any.keys('ns');
         expect(bidRequest.data.ns).to.eq(Math.round(downlink * 1024));
+      } else {
+        expect(bidRequest.data).to.not.include.any.keys('ns');
       }
     });
   })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This adds support for the Unified/TradeDesk id from Prebid's user id module
