### PR TITLE
allow endpoint configuration for rdn adapter

### DIFF
--- a/modules/rdnBidAdapter.js
+++ b/modules/rdnBidAdapter.js
@@ -1,6 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory'
 import * as utils from '../src/utils'
 import { BANNER } from '../src/mediaTypes'
+import { config } from '../src/config'
 
 const BIDDER_CODE = 'rdn'
 const ENDPOINT = 'https://s-bid.rmp.rakuten.co.jp/h'
@@ -14,7 +15,7 @@ export const spec = {
       const params = bid.params
       bidRequests.push({
         method: 'GET',
-        url: ENDPOINT,
+        url: config.getConfig('rdn.endpoint') || ENDPOINT,
         data: {
           bi: bid.bidId,
           t: params.adSpotId,

--- a/test/spec/modules/rdnBidAdapter_spec.js
+++ b/test/spec/modules/rdnBidAdapter_spec.js
@@ -2,10 +2,20 @@ import { expect } from 'chai'
 import * as utils from 'src/utils'
 import { spec } from 'modules/rdnBidAdapter'
 import { newBidder } from 'src/adapters/bidderFactory'
+import {config} from '../../../src/config';
 
 describe('rdnBidAdapter', function() {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://s-bid.rmp.rakuten.co.jp/h';
+  let sandbox;
+
+  beforeEach(function() {
+    config.resetConfig();
+  });
+
+  afterEach(function () {
+    config.resetConfig();
+  });
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {
@@ -52,6 +62,16 @@ describe('rdnBidAdapter', function() {
       const request = spec.buildRequests(bidRequests)[0];
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('GET')
+    })
+
+    it('allows url override', () => {
+      config.setConfig({
+        rdn: {
+          endpoint: '//test.rakuten.com'
+        }
+      });
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.url).to.equal('//test.rakuten.com');
     })
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added a configuration option `rdn.endpoint` for setting the endpoint of the rdnBidAdapter.