### PR TITLE
Fix for #3908

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -71,7 +71,9 @@ module.exports = {
           if (fs.lstatSync(modulePath).isDirectory()) {
             modulePath = path.join(modulePath, 'index.js')
           }
-          memo[modulePath] = moduleName;
+          if ((externalModules.length > 0 && externalModules.includes(moduleName)) || externalModules.length === 0) {
+            memo[modulePath] = moduleName;
+          }
           return memo;
         }, {});
     } catch (err) {


### PR DESCRIPTION
## Type of change
- [x] Build related changes

## Description of change
Fix for #3908 
Recently many use cases have come across where we needed submodules for prebid. Example include
- user id module and various id systems
- long form module and supported long form ad servers
Also in future we would like to add other features as modules and not part of core. 

Until we have a new build system and fresh approach to modules this PR fixes #3908.

This fix returns the modules which are included in module.json or as command line arguments to gulp.src. 

Command 1: `gulp build --modules=appnexusBidAdapter,digiTrustIdSystem --analyze`
Result 
![Screen Shot 2019-06-18 at 2 48 01 PM](https://user-images.githubusercontent.com/7393273/59713243-ed34bd80-91dc-11e9-88d3-46d65aad7110.png)

Command 1: `gulp build --analyze`
Result 
![Screen Shot 2019-06-18 at 2 51 03 PM](https://user-images.githubusercontent.com/7393273/59713272-02115100-91dd-11e9-95d4-4957f1cb3a5e.png)


