### PR TITLE
Fix #3894 - update sizeConfig logic around multiformat bids

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -88,9 +88,9 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
 
   let results = {
     active: (
-      allMediaTypes.length > 1 || (allMediaTypes.length === 1 && allMediaTypes[0] !== 'banner')
+      allMediaTypes.every(type => type !== 'banner')
     ) || (
-      allMediaTypes[0] === 'banner' && deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
+      allMediaTypes.some(type => type === 'banner') && deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
         labels.length === 0 || (
           (!labelAll && (
             labels.some(label => maps.labels[label]) ||

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -66,13 +66,6 @@ describe('sizeMapping', function () {
       }
       return matchMediaOverride;
     });
-
-    sandbox.stub(window, 'matchMedia').callsFake((...args) => {
-      if (typeof matchMediaOverride === 'function') {
-        return matchMediaOverride.apply(window, args);
-      }
-      return matchMediaOverride;
-    });
   });
 
   afterEach(function () {
@@ -161,15 +154,14 @@ describe('sizeMapping', function () {
       });
     });
 
-    it('should filter all banner sizes but not disable adUnit if multiple mediaTypes are present', function () {
+    it('should filter all banner sizes and should disable the adUnit even if other mediaTypes are present', function () {
       matchMediaOverride = (str) => str === '(min-width: 0px) and (max-width: 767px)' ? {matches: true} : {matches: false};
-
       let status = resolveStatus(undefined, Object.assign({}, testSizes, {
         native: {
           type: 'image'
         }
       }), undefined, sizeConfig);
-      expect(status.active).to.equal(true);
+      expect(status.active).to.equal(false);
       expect(status.mediaTypes).to.deep.equal({
         banner: {
           sizes: []
@@ -210,12 +202,101 @@ describe('sizeMapping', function () {
       expect(status.mediaTypes).to.deep.equal(testSizes);
     });
 
+    it('should activate/decactivate adUnits/bidders based on labels with multiformat ads', function () {
+      matchMediaOverride = (str) => str === '(min-width: 768px) and (max-width: 1199px)' ? {matches: true} : {matches: false};
+
+      let multiFormatSizes = {
+        banner: {
+          sizes: [[728, 90], [300, 300]]
+        },
+        native: {
+          type: 'image'
+        },
+        video: {
+          context: 'outstream',
+          playerSize: [300, 300]
+        }
+      };
+
+      let status = resolveStatus({
+        labels: ['tablet', 'test'],
+        labelAll: true
+      }, multiFormatSizes, undefined, sizeConfigWithLabels);
+
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: [[728, 90]]
+        },
+        native: {
+          type: 'image'
+        },
+        video: {
+          context: 'outstream',
+          playerSize: [300, 300]
+        }
+      });
+
+      status = resolveStatus({
+        labels: ['tablet']
+      }, multiFormatSizes, undefined, sizeConfigWithLabels);
+
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: [[728, 90]]
+        },
+        native: {
+          type: 'image'
+        },
+        video: {
+          context: 'outstream',
+          playerSize: [300, 300]
+        }
+      });
+
+      multiFormatSizes.banner.sizes.splice(0, 1, [728, 80]);
+      status = resolveStatus({
+        labels: ['tablet']
+      }, multiFormatSizes, undefined, sizeConfigWithLabels);
+
+      expect(status.active).to.equal(false);
+      expect(status.mediaTypes).to.deep.equal({
+        banner: {
+          sizes: []
+        },
+        native: {
+          type: 'image'
+        },
+        video: {
+          context: 'outstream',
+          playerSize: [300, 300]
+        }
+      });
+
+      delete multiFormatSizes.banner;
+      status = resolveStatus({
+        labels: ['tablet']
+      }, multiFormatSizes, undefined, sizeConfigWithLabels);
+
+      expect(status.active).to.equal(true);
+      expect(status.mediaTypes).to.deep.equal({
+        native: {
+          type: 'image'
+        },
+        video: {
+          context: 'outstream',
+          playerSize: [300, 300]
+        }
+      });
+    });
+
     it('should active/deactivate adUnits/bidders based on requestBids labels', function () {
       let activeLabels = ['us-visitor', 'desktop', 'smart'];
 
       let status = resolveStatus({
-        labels: ['uk-visitor'],
-        activeLabels
+        labels: ['uk-visitor'], // from adunit
+        activeLabels // from requestBids.labels
       }, testSizes, undefined, sizeConfigWithLabels);
 
       expect(status.active).to.equal(false);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?


## Description of change
This PR is a fix for #3894 

It modifies the logic used by the sizeConfig when processing a multiformat bid.  

If the bid includes a `banner` `mediaType`, then the sizeConfig logic will be respected in that if the label rules don't pass or all the sizes are filtered out, the entire adUnit/bid (whichever is level is checked) will be removed from the request.  

If the bid does not include the `banner` type (even when the multiformat bid is just native + video), then sizeConfig logic is not applied.

## Other information
Docs PR: https://github.com/prebid/prebid.github.io/pull/1366