### PR TITLE
update placementId to be number instead of string

### DIFF
--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -41,7 +41,7 @@
               {
                 bidder: 'appnexus',
                 params: {
-                   placementId: '13144370'
+                   placementId: 13144370
                 }
               }
             ]


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Appnexus' prebid-server endpoint expects placementId to be a number instead of a string.