### PR TITLE
Appnexus Adapter: Adding privacy_supported flag

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -686,6 +686,10 @@ function buildNativeRequest(params) {
         request[requestKey].sizes = transformSizes(request[requestKey].sizes);
       }
     }
+
+    if (requestKey === NATIVE_MAPPING.privacyLink) {
+      request.privacy_supported = true;
+    }
   });
 
   return request;

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -432,7 +432,8 @@ describe('AppNexusAdapter', function () {
         likes: {required: true},
         phone: {required: true},
         price: {required: true},
-        saleprice: {required: true}
+        saleprice: {required: true},
+        privacy_supported: true
       });
     });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds privacy_supported flag to appnexus request payload when `mediaTypes.native.privacyLink` is added on ad unit