### PR TITLE
Add oRTB cur to PrebidServer Adapter

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -542,7 +542,7 @@ const OPEN_RTB_PROTOCOL = {
       request.cur = [adServerCur];
     } else if (Array.isArray(adServerCur) && adServerCur.length) {
       // if it's an array, get the first element
-      request.cur = adServerCur[0];
+      request.cur = [adServerCur[0]];
     }
 
     _appendSiteAppDevice(request);

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -541,8 +541,8 @@ const OPEN_RTB_PROTOCOL = {
       // if the value is a string, wrap it with an array
       request.cur = [adServerCur];
     } else if (Array.isArray(adServerCur) && adServerCur.length) {
-      // if it's an array, copy the first element
-      request.cur = adServerCur.slice(0, 1);
+      // if it's an array, get the first element
+      request.cur = adServerCur[0];
     }
 
     _appendSiteAppDevice(request);

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -533,6 +533,18 @@ const OPEN_RTB_PROTOCOL = {
       request.ext.prebid = Object.assign(request.ext.prebid, _s2sConfig.extPrebid);
     }
 
+    /**
+     * @type {(string[]|string|undefined)} - OpenRTB property 'cur', currencies available for bids
+     */
+    const adServerCur = config.getConfig('currency.adServerCurrency');
+    if (adServerCur && typeof adServerCur === 'string') {
+      // if the value is a string, wrap it with an array
+      request.cur = [adServerCur];
+    } else if (Array.isArray(adServerCur) && adServerCur.length) {
+      // if it's an array, copy the first element
+      request.cur = adServerCur.slice(0, 1);
+    }
+
     _appendSiteAppDevice(request);
 
     const digiTrust = _getDigiTrustQueryParams(bidRequests && bidRequests[0]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change
Added: **OpenRTB** property `cur` to Prebid Server Adapter.
Setting `currency.adServerCurrency` will now result in the openRTB JSON containing the obj property `cur: ["AAA"]`