### PR TITLE
AOL Adapter: Perform requests over https by default.

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -29,17 +29,18 @@ const SYNC_TYPES = {
   }
 };
 
-const pubapiTemplate = template`//${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'};misc=${'misc'};${'dynamicParams'}`;
-const nexageBaseApiTemplate = template`//${'host'}/bidRequest?`;
+const pubapiTemplate = template`${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'};misc=${'misc'};${'dynamicParams'}`;
+const nexageBaseApiTemplate = template`${'host'}/bidRequest?`;
 const nexageGetApiTemplate = template`dcn=${'dcn'}&pos=${'pos'}&cmd=bid${'dynamicParams'}`;
 const MP_SERVER_MAP = {
   us: 'adserver-us.adtech.advertising.com',
   eu: 'adserver-eu.adtech.advertising.com',
   as: 'adserver-as.adtech.advertising.com'
 };
-const NEXAGE_SERVER = 'hb.nexage.com';
+const NEXAGE_SERVER = 'c2shb.ssp.yahoo.com';
 const ONE_DISPLAY_TTL = 60;
 const ONE_MOBILE_TTL = 3600;
+const DEFAULT_PROTO = 'https';
 
 const NUMERIC_VALUES = {
   TRUE: 1,
@@ -198,7 +199,7 @@ export const spec = {
     // Set region param, used by AOL analytics.
     params.region = regionParam;
 
-    return pubapiTemplate({
+    return this.applyProtocol(pubapiTemplate({
       host: server,
       network: params.network,
       placement: parseInt(params.placement),
@@ -207,7 +208,7 @@ export const spec = {
       alias: params.alias || utils.getUniqueIdentifierStr(),
       misc: new Date().getTime(), // cache busting
       dynamicParams: this.formatMarketplaceDynamicParams(params, consentData)
-    });
+    }));
   },
   buildOneMobileGetUrl(bid, consentData) {
     let {dcn, pos, ext} = bid.params;
@@ -219,9 +220,20 @@ export const spec = {
     return nexageApi;
   },
   buildOneMobileBaseUrl(bid) {
-    return nexageBaseApiTemplate({
+    return this.applyProtocol(nexageBaseApiTemplate({
       host: bid.params.host || NEXAGE_SERVER
-    });
+    }));
+  },
+  applyProtocol(url) {
+    if (/^https?:\/\//i.test(url)) {
+      return url;
+    }
+    switch (url.indexOf('//')) {
+      case 0:
+        return `${DEFAULT_PROTO}:${url}`;
+      default:
+        return `${DEFAULT_PROTO}://${url}`;
+    }
   },
   formatMarketplaceDynamicParams(params = {}, consentData) {
     let queryParams = {};

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -228,12 +228,7 @@ export const spec = {
     if (/^https?:\/\//i.test(url)) {
       return url;
     }
-    switch (url.indexOf('//')) {
-      case 0:
-        return `${DEFAULT_PROTO}:${url}`;
-      default:
-        return `${DEFAULT_PROTO}://${url}`;
-    }
+    return (url.indexOf('//') === 0) ? `${DEFAULT_PROTO}:${url}` : `${DEFAULT_PROTO}://${url}`;
   },
   formatMarketplaceDynamicParams(params = {}, consentData) {
     let queryParams = {};

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -76,8 +76,8 @@ let getPixels = () => {
 };
 
 describe('AolAdapter', function () {
-  const MARKETPLACE_URL = '//adserver-us.adtech.advertising.com/pubapi/3.0/';
-  const NEXAGE_URL = '//hb.nexage.com/bidRequest?';
+  const MARKETPLACE_URL = 'https://adserver-us.adtech.advertising.com/pubapi/3.0/';
+  const NEXAGE_URL = 'https://c2shb.ssp.yahoo.com/bidRequest?';
   const ONE_DISPLAY_TTL = 60;
   const ONE_MOBILE_TTL = 3600;
 
@@ -152,7 +152,7 @@ describe('AolAdapter', function () {
       it('should return request for Marketplace endpoint', function () {
         let bidRequest = getDefaultBidRequest();
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain(MARKETPLACE_URL);
+        expect(request.url.indexOf(MARKETPLACE_URL)).to.equal(0);
       });
 
       it('should return request for Marketplace via onedisplay bidder code', function () {
@@ -164,7 +164,7 @@ describe('AolAdapter', function () {
         });
 
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain(MARKETPLACE_URL);
+        expect(request.url.indexOf(MARKETPLACE_URL)).to.equal(0);
       });
 
       it('should return Marketplace request via onedisplay bidder code when' +
@@ -178,7 +178,7 @@ describe('AolAdapter', function () {
         });
 
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain(MARKETPLACE_URL);
+        expect(request.url.indexOf(MARKETPLACE_URL)).to.equal(0);
       });
 
       it('should return Marketplace request via onedisplay bidder code when' +
@@ -192,7 +192,7 @@ describe('AolAdapter', function () {
         });
 
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain(MARKETPLACE_URL);
+        expect(request.url.indexOf(MARKETPLACE_URL)).to.equal(0);
       });
 
       it('should not resolve endpoint for onedisplay bidder code ' +
@@ -218,10 +218,37 @@ describe('AolAdapter', function () {
           }
         });
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain('adserver-eu.adtech.advertising.com/pubapi/3.0/');
+        expect(request.url.indexOf('https://adserver-eu.adtech.advertising.com/pubapi/3.0/'))
+          .to.equal(0);
       });
 
-      it('should return Marketplace URL for eu region when server option is present', function () {
+      it('should return insecure MP URL if insecure server option is present', function () {
+        let bidRequest = createCustomBidRequest({
+          params: {
+            placement: 1234567,
+            network: '9599.1',
+            server: 'http://adserver-eu.adtech.advertising.com'
+          }
+        });
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url.indexOf('http://adserver-eu.adtech.advertising.com/pubapi/3.0/'))
+          .to.equal(0);
+      });
+
+      it('should return a secure MP URL if relative proto server option is present', function () {
+        let bidRequest = createCustomBidRequest({
+          params: {
+            placement: 1234567,
+            network: '9599.1',
+            server: '//adserver-eu.adtech.advertising.com'
+          }
+        });
+        let [request] = spec.buildRequests(bidRequest.bids);
+        expect(request.url.indexOf('https://adserver-eu.adtech.advertising.com/pubapi/3.0/'))
+          .to.equal(0);
+      });
+
+      it('should return a secure MP URL when server option without protocol is present', function () {
         let bidRequest = createCustomBidRequest({
           params: {
             placement: 1234567,
@@ -230,7 +257,8 @@ describe('AolAdapter', function () {
           }
         });
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain('adserver-eu.adtech.advertising.com/pubapi/3.0/');
+        expect(request.url.indexOf('https://adserver-eu.adtech.advertising.com/pubapi/3.0/'))
+          .to.equal(0);
       });
 
       it('should return default Marketplace URL in case of unknown region config option', function () {
@@ -242,7 +270,7 @@ describe('AolAdapter', function () {
           }
         });
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain(MARKETPLACE_URL);
+        expect(request.url.indexOf(MARKETPLACE_URL)).to.equal(0);
       });
 
       it('should return url with pubapi bid option', function () {
@@ -358,13 +386,13 @@ describe('AolAdapter', function () {
 
       it('should return One Mobile url with different host when host option is present', function () {
         let bidParams = Object.assign({
-          host: 'qa-hb.nexage.com'
+          host: 'http://qa-hb.nexage.com'
         }, getNexageGetBidParams());
         let bidRequest = createCustomBidRequest({
           params: bidParams
         });
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain('qa-hb.nexage.com/bidRequest?');
+        expect(request.url).to.contain('http://qa-hb.nexage.com/bidRequest?');
       });
 
       it('should return One Mobile url when One Mobile and Marketplace params are present', function () {
@@ -431,7 +459,7 @@ describe('AolAdapter', function () {
           }
         });
         let [request] = spec.buildRequests(bidRequest.bids);
-        expect(request.url).to.contain('hb.nexage.com/bidRequest?dcn=54321123&pos=footer-2324&cmd=bid' +
+        expect(request.url).to.equal('https://c2shb.ssp.yahoo.com/bidRequest?dcn=54321123&pos=footer-2324&cmd=bid' +
           '&param1=val1&param2=val2&param3=val3&param4=val4');
       });
 
@@ -455,7 +483,7 @@ describe('AolAdapter', function () {
       });
 
       it('should not return request object for One Mobile POST endpoint' +
-        'if required parameterers are missed', () => {
+        'if required parameters are missed', () => {
         let bidRequest = createCustomBidRequest({
           params: {
             imp: []


### PR DESCRIPTION
## Type of change
- Other

## Description of change
Update hostname to use go-forwards domain
Perform requests over HTTPS by default. 

- [x] official adapter submission

