### PR TITLE
Add Eslint rules to throw error when importing other modules from within modules directory.

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  "rules": {
+    // This rule restricts import of other modules within the module directory
+    // and also ensures use of relative path when importing from src/
+    "no-restricted-imports": ["error", {
+      "patterns": ["./*", "src/*"]
+    }],
+    // Needed to support CommonJS style require statements.
+    "no-restricted-modules": ["error", {
+      "patterns": ["./*", "src/*"]
+    }]
+  }
+}
+

--- a/modules/prebidServerBidAdapter/.eslintrc.js
+++ b/modules/prebidServerBidAdapter/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "rules": {
+    "no-restricted-imports": "off",
+    "no-restricted-modules": "off"
+  }
+}

--- a/modules/userId/.eslintrc.js
+++ b/modules/userId/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "rules": {
+    "no-restricted-imports": "off",
+    "no-restricted-modules": "off"
+  }
+}


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change

Related to https://github.com/prebid/Prebid.js/issues/3964.