### PR TITLE
Fix #3939 - update firefox specific code in renderAd function

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -327,7 +327,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         } else if (ad) {
           // will check if browser is firefox and below version 67, if so execute special doc.open()
           // for details see: https://github.com/prebid/Prebid.js/pull/3524
-          // TODO remove this browser specific code at later date
+          // TODO remove this browser specific code at later date (when Firefox < 67 usage is mostly gone)
           if (navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox/') > -1) {
             const firefoxVerRegx = /firefox\/([\d\.]+)/;
             let firefoxVer = navigator.userAgent.toLowerCase().match(firefoxVerRegx)[1]; // grabs the text in the 1st matching group

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -325,7 +325,16 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
           emitAdRenderFail(PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid);
         } else if (ad) {
-          doc.open('text/html', 'replace');
+          // will check if browser is firefox and below version 67, if so execute special doc.open()
+          // for details see: https://github.com/prebid/Prebid.js/pull/3524
+          // TODO remove this browser specific code at later date
+          if (navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox/') > -1) {
+            const firefoxVerRegx = /firefox\/([\d\.]+)/;
+            let firefoxVer = navigator.userAgent.toLowerCase().match(firefoxVerRegx)[1]; // grabs the text in the 1st matching group
+            if (firefoxVer && parseInt(firefoxVer, 10) < 67) {
+              doc.open('text/html', 'replace');
+            }
+          }
           doc.write(ad);
           doc.close();
           setRenderSize(doc, width, height);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -990,7 +990,6 @@ describe('Unit: Prebid Module', function () {
 
     beforeEach(function () {
       doc = {
-        open: sinon.spy(),
         write: sinon.spy(),
         close: sinon.spy(),
         defaultView: {
@@ -1041,7 +1040,6 @@ describe('Unit: Prebid Module', function () {
       });
       adResponse.ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
       $$PREBID_GLOBAL$$.renderAd(doc, bidId);
-      assert.ok(doc.open, 'open method called');
       assert.ok(doc.write.calledWith(adResponse.ad), 'ad was written to doc');
       assert.ok(doc.close.called, 'close method called');
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This change updates the firefox specific logic in the `renderAd` function to only run if the user is using a version of Firefox below 67 (since Mozilla fixed the original bug in 67.0).



Additional references relevant to this overall change:
- original Prebid.js issue that added the firefox specific code - https://github.com/prebid/Prebid.js/pull/3524
- Mozilla issue that was noted on the above issue - https://bugzilla.mozilla.org/show_bug.cgi?id=148794
- Actual Mozilla issue (was linked in the Mozilla issue above) that contained the fix, release in Firefox 67.0 - https://bugzilla.mozilla.org/show_bug.cgi?id=1489308