### PR TITLE
BidPhysics bid adapter - remove unused alias

### DIFF
--- a/modules/bidphysicsBidAdapter.js
+++ b/modules/bidphysicsBidAdapter.js
@@ -10,7 +10,7 @@ const DEFAULT_NET_REVENUE = true;
 
 export const spec = {
   code: 'bidphysics',
-  aliases: ['yieldlift', 'padsquad'],
+  aliases: ['yieldlift'],
   supportedMediaTypes: [BANNER],
 
   isBidRequestValid: function (bid) {


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Removed `padsquad` alias since it was never used.
