### PR TITLE
Safeframe resize fix 

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -81,7 +81,7 @@ export function _sendAdToCreative(adObject, remoteDomain, source) {
 
 function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
-  ['div', 'iframe'].forEach(elmType => {
+  ['div:last-child', 'div:last-child iframe'].forEach(elmType => {
     let element = getElementByAdUnit(elmType);
     if (element) {
       let elementStyle = element.style;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This PR fixes resizing issue in case of banner safeframe. https://github.com/prebid/prebid-universal-creative/issues/66

When you refresh the ad unit, dfp loads a new div for the creative and marks old div as `to be removed`. Prebid core was resizing the div which will be removed once rendering is complete.

<img width="1242" alt="Screen Shot 2019-07-10 at 4 19 05 PM" src="https://user-images.githubusercontent.com/7393273/61073475-870a1780-a3e3-11e9-8a30-de25df5253d2.png">

Tested with DFP and APAS. 

## Other information
@benjaminclot 
