### PR TITLE
update node version for circleci to 10.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:10.9.0
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ prebid.requestBids({
     $ cd Prebid.js
     $ npm install
 
-*Note:* You need to have `NodeJS` 6.x or greater installed.
+*Note:* You need to have `NodeJS` 10.x or greater installed.
 
 *Note:* In the 1.24.0 release of Prebid.js we have transitioned to using gulp 4.0 from using gulp 3.9.1.  To compily with gulp's recommended setup for 4.0, you'll need to have `gulp-cli` installed globally prior to running the general `npm install`.  This shouldn't impact any other projects you may work on that use an earlier version of gulp in it's setup.
 


### PR DESCRIPTION
## Type of change
- [x] CI related changes


## Description of change
As a follow-up to #3966 we needed to update the version of node used by circleCi to at least 10.x (choose 10.9).  The upgrade was needed to support the use of the spread operator used by the karma 4 in its workflow.

Correlating this type of change, we're updating the version of node that's needed for the Prebid.js project (from 6.x to 10x) as documented in the `README.md`.