### PR TITLE
GumGum adapter: push first indexed value in sizes array to bidResponses.height and width

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -175,7 +175,7 @@ function buildRequests (validBidRequests, bidderRequest) {
       tId: transactionId,
       pi: data.pi,
       selector: params.selector,
-      sizes: bidRequest.sizes,
+      sizes: bidRequest.sizes || bidRequest.mediatype[banner].sizes,
       url: BID_ENDPOINT,
       method: 'GET',
       data: Object.assign(data, _getBrowserParams(), _getDigiTrustQueryParams(), _getTradeDeskIDParam(bidRequest))

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -221,7 +221,7 @@ function interpretResponse (serverResponse, bidRequest) {
   let [width, height] = sizes[0].split('x')
 
   // return 1x1 when breakout expected
-  if ((product === 2 || product === 5) && includes(sizes, '1x1')) {
+  if (product === 5 && includes(sizes, '1x1')) {
     width = '1'
     height = '1'
   }

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -245,8 +245,8 @@ describe('gumgumAdapter', function () {
         'thms': 10000
       }
       let result = spec.interpretResponse({ body: inscreenServerResponse }, inscreenBidRequest);
-      expect(result[0].width).to.equal('1');
-      expect(result[0].height).to.equal('1');
+      expect(result[0].width).to.equal(inscreenBidRequest.sizes[0][0].toString());
+      expect(result[0].height).to.equal(inscreenBidRequest.sizes[0][1].toString());
     })
   })
   describe('getUserSyncs', function () {


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
This pull request will change GumGum's bid adapter to return the width and height of the first indexed value in the sizes array. This change will allow our adapter to dynamically populate the ad size of our bid response to match the request size that the publisher sends us.



For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
CC: @susyt 
