### PR TITLE
Debug update and remove setConfig hook

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,10 +10,11 @@
 import { isValidPriceConfig } from './cpmBucketManager';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
-import { hook } from './hook';
-const utils = require('./utils');
 
-const DEFAULT_DEBUG = false;
+const utils = require('./utils');
+const CONSTANTS = require('./constants');
+
+const DEFAULT_DEBUG = utils.getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
 const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 const DEFAULT_ENABLE_SEND_ALL_BIDS = true;
@@ -231,7 +232,7 @@ export function newConfig() {
    * Sets configuration given an object containing key-value pairs and calls
    * listeners that were added by the `subscribe` function
    */
-  let setConfig = hook('async', function setConfig(options) {
+  function setConfig(options) {
     if (typeof options !== 'object') {
       utils.logError('setConfig options must be an object');
       return;
@@ -251,7 +252,7 @@ export function newConfig() {
     });
 
     callSubscribers(topicalConfig);
-  });
+  }
 
   /**
    * Sets configuration defaults which setConfig values can be applied on top of

--- a/src/config.js
+++ b/src/config.js
@@ -10,11 +10,12 @@
 import { isValidPriceConfig } from './cpmBucketManager';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
+import { parseQS } from './url';
 
 const utils = require('./utils');
 const CONSTANTS = require('./constants');
 
-const DEFAULT_DEBUG = utils.getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
+const DEFAULT_DEBUG = (parseQS(window.location.search)[CONSTANTS.DEBUG_MODE] || '').toUpperCase() === 'TRUE';
 const DEFAULT_BIDDER_TIMEOUT = 3000;
 const DEFAULT_PUBLISHER_DOMAIN = window.location.origin;
 const DEFAULT_ENABLE_SEND_ALL_BIDS = true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,6 @@ import includes from 'core-js/library/fn/array/includes';
 import { parse } from './url';
 const CONSTANTS = require('./constants');
 
-var _loggingChecked = false;
-
 var tArr = 'Array';
 var tStr = 'String';
 var tFn = 'Function';
@@ -354,12 +352,6 @@ export function hasConsoleLogger() {
 }
 
 export function debugTurnedOn() {
-  if (config.getConfig('debug') === false && _loggingChecked === false) {
-    const debug = getParameterByName(CONSTANTS.DEBUG_MODE).toUpperCase() === 'TRUE';
-    config.setConfig({ debug });
-    _loggingChecked = true;
-  }
-
   return !!config.getConfig('debug');
 }
 

--- a/test/spec/debugging_spec.js
+++ b/test/spec/debugging_spec.js
@@ -13,6 +13,7 @@ describe('bid overrides', function () {
 
   afterEach(function () {
     window.sessionStorage.clear();
+    config.resetConfig();
     sandbox.restore();
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
A re-submission of older an PR #3714 that was reverted from `master` via #3736.

Re-copying the description of the above ticket here for reference:

With the implementation of the new hooks library we added a `ready` functionality that would allow `async` hooks to be queued until the hooks were declared `ready` in `pbjs.processQueue`. This caused `config.setConfig` calls to be queued and `config.getConfigs` being called before `pbjs.processQueue` were not getting data (such as the call for printing prebid info in #3700). I updated the DEFAULT_DEBUG to be set immediately rather than relying on `config.setConfig` in the `utils` library, which I think makes a little more sense.

Also, the `pbjs.setConfig` hook was only being used for the `pre1api` module, which was removed in 2.0 so I think it's best we just remove the hook, which I've also done.

## Other information
Fixes #3700 and #3997