### PR TITLE
DFP Module: init customparams as empty object

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -161,7 +161,7 @@ export function buildAdpodVideoUrl({code, params, callback} = {}) {
       [adpodUtils.TARGETING_KEY_PB_CAT_DUR]: undefined,
       [adpodUtils.TARGETING_KEY_CACHE_ID]: undefined
     }
-    let customParams;
+    let customParams = {};
     if (targeting[code]) {
       customParams = targeting[code].reduce((acc, curValue) => {
         if (Object.keys(curValue)[0] === adpodUtils.TARGETING_KEY_PB_CAT_DUR) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
formatQS function expects object. If adpod module returns empty targeting object, we were passing undefined. This PR fixes the bug by initializing customParams with empty object