### PR TITLE
adformOpenRTB adapter: size targeting using aspect ratios

### DIFF
--- a/modules/adformOpenRTBBidAdapter.js
+++ b/modules/adformOpenRTBBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
           let wmin, hmin, w, h;
           let aRatios = bidParams.aspect_ratios;
 
-          if (aRatios) {
+          if (aRatios && aRatios[0]) {
             aRatios = aRatios[0];
             wmin = aRatios.min_width || 0;
             hmin = aRatios.ratio_height * wmin / aRatios.ratio_width | 0;

--- a/modules/adformOpenRTBBidAdapter.js
+++ b/modules/adformOpenRTBBidAdapter.js
@@ -66,11 +66,28 @@ export const spec = {
         };
         if (props) {
           asset.id = props.id;
+          let wmin, hmin, w, h;
+          let aRatios = bidParams.aspect_ratios;
+
+          if (aRatios) {
+            aRatios = aRatios[0];
+            wmin = aRatios.min_width || 0;
+            hmin = aRatios.ratio_height * wmin / aRatios.ratio_width | 0;
+          }
+
+          if (bidParams.sizes) {
+            const sizes = flatten(bidParams.sizes);
+            w = sizes[0];
+            h = sizes[1];
+          }
+
           asset[props.name] = {
             len: bidParams.len,
-            wmin: bidParams.sizes && bidParams.sizes[0],
-            hmin: bidParams.sizes && bidParams.sizes[1],
-            type: props.type
+            type: props.type,
+            wmin,
+            hmin,
+            w,
+            h
           };
 
           return asset;
@@ -170,4 +187,8 @@ function setOnAny(collection, key) {
       return result;
     }
   }
+}
+
+function flatten(arr) {
+  return [].concat(...arr);
 }

--- a/test/spec/modules/adformOpenRTBBidAdapter_spec.js
+++ b/test/spec/modules/adformOpenRTBBidAdapter_spec.js
@@ -320,6 +320,23 @@ describe('AdformOpenRTB adapter', function () {
             assert.equal(assets[1].img.wmin, 10);
             assert.equal(assets[1].img.hmin, 25);
           });
+
+          it('should not throw error if aspect_ratios config is not defined', function () {
+            const validBidRequests = [{
+              bidId: 'bidId',
+              params: { siteId: 'siteId', mid: 1000 },
+              nativeParams: {
+                image: {
+                  aspect_ratios: []
+                },
+                icon: {
+                  aspect_ratios: []
+                }
+              }
+            }];
+
+            assert.doesNotThrow(() => spec.buildRequests(validBidRequests, { refererInfo: { referer: 'page' } }));
+          });
         });
 
         it('should expect any dimensions if min_width not passed', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Pass `aspect_ratios` config to adserver.

- contact email of the adapter’s maintainer
Scope.FL.Scripts@adform.com
- [x] official adapter submission
