### PR TITLE
remove console log statement in logicadBidAdapter unit tests

### DIFF
--- a/test/spec/modules/logicadBidAdapter_spec.js
+++ b/test/spec/modules/logicadBidAdapter_spec.js
@@ -108,7 +108,7 @@ describe('LogicadAdapter', function () {
     it('should perform usersync', function () {
       let syncs = spec.getUserSyncs({pixelEnabled: false}, [serverResponse]);
       expect(syncs).to.have.length(0);
-      console.log(serverResponse);
+
       syncs = spec.getUserSyncs({pixelEnabled: true}, [serverResponse]);
       expect(syncs).to.have.length(1);
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
In the `logicadBidAdapter_spec.js` file, there was a rogue `console.log` statement in one of the unit tests.  This PR removes the statement so it's not present in the console output whenever we run the unit tests or make a build.

CC: @logicad 