### PR TITLE
override default fun-hooks module configuration

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -2,7 +2,8 @@
 import funHooks from 'fun-hooks/no-eval';
 
 export let hook = funHooks({
-  ready: funHooks.SYNC | funHooks.ASYNC | funHooks.QUEUE
+  ready: funHooks.SYNC | funHooks.ASYNC | funHooks.QUEUE,
+  ...$$PREBID_GLOBAL$$.hookSettings
 });
 
 export const getHook = hook.get;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Possibility to overwrite default fun-hooks module configuration used by Prebid.js while importing them.

Need to change default ``useProxy`` value of fun-hooks configuration https://www.npmjs.com/package/fun-hooks#configuration in some cases.

Example: 
```
$$PREBID_GLOBAL$$.hookSettings = {
  useProxy: false
}
```