### PR TITLE
TripleLift adapter: Always use secure endpoint

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory';
 import * as utils from '../src/utils';
 
 const BIDDER_CODE = 'triplelift';
-const STR_ENDPOINT = document.location.protocol + '//tlx.3lift.com/header/auction?';
+const STR_ENDPOINT = 'https://tlx.3lift.com/header/auction?';
 let gdprApplies = true;
 let consentString = null;
 

--- a/modules/tripleliftBidAdapter.md
+++ b/modules/tripleliftBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name:  Triplelift Bid Adapter
 Module Type:  Bidder Adapter
-Maintainer: bzellman@triplelift.com
+Maintainer: csmith+wrapper@triplelift.com
 ```
 
 # Description

--- a/modules/tripleliftBidAdapter.md
+++ b/modules/tripleliftBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name:  Triplelift Bid Adapter
 Module Type:  Bidder Adapter
-Maintainer: csmith+wrapper@triplelift.com
+Maintainer: csmith+s2s@triplelift.com
 ```
 
 # Description

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { newBidder } from 'src/adapters/bidderFactory';
 import { deepClone } from 'src/utils';
 import prebid from '../../../package.json';
 
-const ENDPOINT = document.location.protocol + '//tlx.3lift.com/header/auction?';
+const ENDPOINT = 'https://tlx.3lift.com/header/auction?';
 
 describe('triplelift adapter', function () {
   const adapter = newBidder(tripleliftAdapterSpec);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Update to always secure

`const STR_ENDPOINT = document.location.protocol + '//tlx.3lift.com/header/auction?';`
to
`const STR_ENDPOINT = 'https://tlx.3lift.com/header/auction?';`


