### PR TITLE
update fun-hooks with fix checking if global Proxy is native

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "crypto-js": "^3.1.9-1",
     "dlv": "1.1.3",
     "dset": "2.0.1",
-    "fun-hooks": "^0.9.2",
+    "fun-hooks": "^0.9.5",
     "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2"
   }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Update `fun-hooks` to latest which includes a check for `Proxy.revocable` to determine if global `Proxy` object is native implementation or just some global that a third-party decided to create.

## Other information
fixes #4024

related fix in fun-hooks: https://github.com/snapwich/fun-hooks/commit/a9121c7115b4a98d475bc0adf8c6c8a58d3af96c and https://github.com/snapwich/fun-hooks/commit/db115652bc599e66aac56d791fbad08a1178afd7