### PR TITLE
update userSync messaging for re-fire to not be warning

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -152,7 +152,7 @@ export function newUserSync(userSyncDependencies) {
    */
   publicApi.registerSync = (type, bidder, url) => {
     if (hasFiredBidder.has(bidder)) {
-      return utils.logWarn(`already registered syncs for "${bidder}"`);
+      return utils.logMessage(`already fired syncs for "${bidder}", ignoring registerSync call`);
     }
     if (!usConfig.syncEnabled || !utils.isArray(queue[type])) {
       return utils.logWarn(`User sync type "${type}" not supported`);


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Update the messaging in `registerSync` to message attempts to re-fire bidder syncs as a message notification as opposed to the current warning. Not firing syncs more than once per bidder is expected behavior.

## Other information
Related to #4027
