### PR TITLE
Add instream & outstream video support to Criteo adapter

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -255,7 +255,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       }
       if (hasVideoMediaType(bidRequest)) {
         const video = {
-          playersize: getVideoSizes(bidRequest),
+          playersizes: getVideoSizes(bidRequest),
           mimes: bidRequest.mediaTypes.video.mimes,
           protocols: bidRequest.mediaTypes.video.protocols,
           maxduration: bidRequest.mediaTypes.video.maxduration,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -304,8 +304,16 @@ function getBannerSizes(bidRequest) {
   return parseSizes(utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes);
 }
 
+function parseSize(size) {
+  return size[0] + 'x' + size[1];
+}
+
 function parseSizes(sizes) {
-  return sizes.map(size => size[0] + 'x' + size[1]);
+  if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])
+    return sizes.map(size => parseSize(size));
+  }
+
+  return [parseSize(sizes)]; // or a single one ? (ie. [728,90])
 }
 
 function hasVideoMediaType(bidRequest) {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -255,7 +255,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       }
       if (hasVideoMediaType(bidRequest)) {
         const video = {
-          playerSizes: getVideoSizes(bidRequest),
+          playersize: getVideoSizes(bidRequest),
           mimes: bidRequest.mediaTypes.video.mimes,
           protocols: bidRequest.mediaTypes.video.protocols,
           maxduration: bidRequest.mediaTypes.video.maxduration,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,11 +1,12 @@
 import { loadExternalScript } from '../src/adloader';
 import { registerBidder } from '../src/adapters/bidderFactory';
+import { config } from '../src/config';
+import { BANNER, VIDEO } from '../src/mediaTypes';
 import { parse } from '../src/url';
 import * as utils from '../src/utils';
 import find from 'core-js/library/fn/array/find';
 import JSEncrypt from 'jsencrypt/bin/jsencrypt';
 import sha256 from 'crypto-js/sha256';
-import { config } from '../src/config';
 
 const ADAPTER_VERSION = 19;
 const BIDDER_CODE = 'criteo';
@@ -30,14 +31,25 @@ OmOSj0/qnYTAYCu0cR5LiyWG79KlIgUyMbp92ulGg24gAyGrVn4+v/4c53WlOEUp
 /** @type {BidderSpec} */
 export const spec = {
   code: BIDDER_CODE,
+  supportedMediaTypes: [ BANNER, VIDEO ],
 
   /**
    * @param {object} bid
    * @return {boolean}
    */
-  isBidRequestValid: bid => (
-    !!(bid && bid.params && (bid.params.zoneId || bid.params.networkId))
-  ),
+  isBidRequestValid: (bid) => {
+    // either one of zoneId or networkId should be set
+    if (!(bid && bid.params && (bid.params.zoneId || bid.params.networkId))) {
+      return false;
+    }
+
+    // video media types requires some mandatory params
+    if (hasVideoMediaType(bid) && (!hasValidVideoMediaType(bid) || !hasValidVideoParams(bid))) {
+      return false;
+    }
+
+    return true;
+  },
 
   /**
    * @param {BidRequest[]} bidRequests
@@ -112,6 +124,9 @@ export const spec = {
         }
         if (slot.native) {
           bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
+        } else if (slot.video) {
+          bid.vastUrl = slot.creative;
+          bid.mediaType = VIDEO;
         } else {
           bid.ad = slot.creative;
         }
@@ -225,7 +240,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
         impid: bidRequest.adUnitCode,
         transactionid: bidRequest.transactionId,
         auctionId: bidRequest.auctionId,
-        sizes: bidRequest.sizes.map(size => size[0] + 'x' + size[1]),
+        sizes: getBannerSizes(bidRequest),
       };
       if (bidRequest.params.zoneId) {
         slot.zoneid = bidRequest.params.zoneId;
@@ -235,6 +250,23 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       }
       if (bidRequest.params.nativeCallback) {
         slot.native = true;
+      }
+      if (hasVideoMediaType(bidRequest)) {
+        const video = {
+          playerSizes: getVideoSizes(bidRequest),
+          mimes: bidRequest.mediaTypes.video.mimes,
+          protocols: bidRequest.mediaTypes.video.protocols,
+          maxduration: bidRequest.mediaTypes.video.maxduration,
+          api: bidRequest.mediaTypes.video.api
+        }
+
+        video.skip = bidRequest.params.video.skip;
+        video.placement = bidRequest.params.video.placement;
+        video.minduration = bidRequest.params.video.minduration;
+        video.playbackmethod = bidRequest.params.video.playbackmethod;
+        video.startdelay = bidRequest.params.video.startdelay;
+
+        slot.video = video;
       }
       return slot;
     }),
@@ -260,6 +292,55 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
     }
   }
   return request;
+}
+
+function getVideoSizes(bidRequest) {
+  return parseSizes(utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize'));
+}
+
+function getBannerSizes(bidRequest) {
+  return parseSizes(utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes);
+}
+
+function parseSizes(sizes) {
+  return sizes.map(size => size[0] + 'x' + size[1]);
+}
+
+function hasVideoMediaType(bidRequest) {
+  if (typeof utils.deepAccess(bidRequest, 'params.video') !== 'object') {
+    return false;
+  }
+  return (typeof utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`) !== 'undefined');
+}
+
+function hasValidVideoMediaType(bidRequest) {
+  let isValid = true;
+
+  var requiredParams = ['mimes', 'playerSize', 'maxduration', 'protocols', 'api'];
+
+  requiredParams.forEach(function(param) {
+    if (utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}.` + param) === undefined) {
+      isValid = false;
+      utils.logError('Criteo Bid Adapter: mediaTypes.video.' + param + ' is required');
+    }
+  });
+
+  return isValid;
+}
+
+function hasValidVideoParams(bidRequest) {
+  let isValid = true;
+
+  var requiredParams = ['skip', 'placement', 'playbackmethod'];
+
+  requiredParams.forEach(function(param) {
+    if (utils.deepAccess(bidRequest, 'params.video.' + param) === undefined) {
+      isValid = false;
+      utils.logError('Criteo Bid Adapter: params.video.' + param + ' is required');
+    }
+  });
+
+  return isValid;
 }
 
 /**

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -127,7 +127,7 @@ export const spec = {
         if (slot.native) {
           bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
         } else if (slot.video) {
-          bid.vastUrl = slot.creative;
+          bid.vastUrl = slot.displayurl;
           bid.mediaType = VIDEO;
         } else {
           bid.ad = slot.creative;

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -7,7 +7,7 @@ import JSEncrypt from 'jsencrypt/bin/jsencrypt';
 import sha256 from 'crypto-js/sha256';
 import { config } from '../src/config';
 
-const ADAPTER_VERSION = 17;
+const ADAPTER_VERSION = 19;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -522,7 +522,7 @@ describe('The Criteo bidding adapter', function () {
           sizes: [[728, 90]],
           mediaTypes: {
             video: {
-              playerSize: [[640, 480]],
+              playerSize: [640, 480],
               mimes: ['video/mp4', 'video/x-flv'],
               maxduration: 30,
               api: [1, 2],
@@ -547,6 +547,50 @@ describe('The Criteo bidding adapter', function () {
       const ortbRequest = request.data;
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
       expect(ortbRequest.slots[0].video.playersize).to.deep.equal(['640x480']);
+      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
+      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
+      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
+      expect(ortbRequest.slots[0].video.skip).to.equal(1);
+      expect(ortbRequest.slots[0].video.minduration).to.equal(5);
+      expect(ortbRequest.slots[0].video.startdelay).to.equal(5);
+      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([1, 3]);
+      expect(ortbRequest.slots[0].video.placement).to.equal(2);
+    });
+
+    it('should properly build a video request with more than one player size', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          mediaTypes: {
+            video: {
+              playerSize: [[640, 480], [800, 600]],
+              mimes: ['video/mp4', 'video/x-flv'],
+              maxduration: 30,
+              api: [1, 2],
+              protocols: [2, 3]
+            }
+          },
+          params: {
+            zoneId: 123,
+            video: {
+              skip: 1,
+              minduration: 5,
+              startdelay: 5,
+              playbackmethod: [1, 3],
+              placement: 2
+            }
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
+      expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+      expect(ortbRequest.slots[0].video.playersize).to.deep.equal(['640x480', '800x600']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
       expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
       expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -426,10 +426,13 @@ describe('The Criteo bidding adapter', function () {
       expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
+      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
+      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
       expect(ortbRequest.slots[0].video.skip).to.equal(1);
       expect(ortbRequest.slots[0].video.minduration).to.equal(5);
       expect(ortbRequest.slots[0].video.startdelay).to.equal(5);
-      expect(ortbRequest.slots[0].video.playerSizes).to.deep.equal(['640x480']);
       expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([1, 3]);
       expect(ortbRequest.slots[0].video.placement).to.equal(2);
     });

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -53,6 +53,191 @@ describe('The Criteo bidding adapter', function () {
       const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equal(true);
     });
+
+    it('should return true when given a valid video bid request', function () {
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(true);
+    });
+
+    it('should return false when given an invalid video bid request', function () {
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1
+          }
+        },
+      })).to.equal(false);
+    });
   });
 
   describe('buildRequests', function () {
@@ -118,7 +303,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[300, 250], [728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [728, 90]]
+            }
+          },
           params: {
             networkId: 456,
           },
@@ -203,6 +392,46 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.gdprConsent.consentData).to.equal(undefined);
       expect(ortbRequest.gdprConsent.gdprApplies).to.equal(undefined);
       expect(ortbRequest.gdprConsent.consentGiven).to.equal(undefined);
+    });
+
+    it('should properly build a video request', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          mediaTypes: {
+            video: {
+              playerSize: [[640, 480]],
+              mimes: ['video/mp4', 'video/x-flv'],
+              maxduration: 30,
+              api: [1, 2],
+              protocols: [2, 3]
+            }
+          },
+          params: {
+            zoneId: 123,
+            video: {
+              skip: 1,
+              minduration: 5,
+              startdelay: 5,
+              playbackmethod: [1, 3],
+              placement: 2
+            }
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
+      expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].video.skip).to.equal(1);
+      expect(ortbRequest.slots[0].video.minduration).to.equal(5);
+      expect(ortbRequest.slots[0].video.startdelay).to.equal(5);
+      expect(ortbRequest.slots[0].video.playerSizes).to.deep.equal(['640x480']);
+      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([1, 3]);
+      expect(ortbRequest.slots[0].video.placement).to.equal(2);
     });
 
     it('should properly build a request with ceh', function () {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -702,7 +702,7 @@ describe('The Criteo bidding adapter', function () {
             impid: 'test-requestId',
             bidId: 'abc123',
             cpm: 1.23,
-            creative: 'test-ad',
+            displayurl: 'http://test-ad',
             width: 728,
             height: 90,
             zoneid: 123,
@@ -724,7 +724,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].requestId).to.equal('test-bidId');
       expect(bids[0].adId).to.equal('abc123');
       expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].vastUrl).to.equal('test-ad');
+      expect(bids[0].vastUrl).to.equal('http://test-ad');
       expect(bids[0].mediaType).to.equal(VIDEO);
     });
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -59,6 +59,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
@@ -75,6 +76,28 @@ describe('The Criteo bidding adapter', function () {
           }
         },
       })).to.equal(true);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 2,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(true);
     });
 
     it('should return false when given an invalid video bid request', function () {
@@ -82,6 +105,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
             maxduration: 30,
@@ -102,6 +126,94 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 2,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'adpod',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+          video: {
+            skip: 1,
+            placement: 1,
+            playbackmethod: 1
+          }
+        },
+      })).to.equal(false);
+
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             protocols: [5, 6],
             maxduration: 30,
@@ -122,6 +234,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             maxduration: 30,
@@ -142,6 +255,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
@@ -162,6 +276,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
@@ -182,6 +297,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
@@ -202,6 +318,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],
@@ -222,6 +339,7 @@ describe('The Criteo bidding adapter', function () {
         bidder: 'criteo',
         mediaTypes: {
           video: {
+            context: 'instream',
             mimes: ['video/mpeg'],
             playerSize: [640, 480],
             protocols: [5, 6],

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -546,7 +546,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
-      expect(ortbRequest.slots[0].video.playersize).to.deep.equal(['640x480']);
+      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
       expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
       expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
@@ -590,7 +590,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
-      expect(ortbRequest.slots[0].video.playersize).to.deep.equal(['640x480', '800x600']);
+      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480', '800x600']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
       expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
       expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { createBid } from 'src/bidfactory';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils';
 import { config } from '../../../src/config';
+import { VIDEO } from '../../../src/mediaTypes';
 
 describe('The Criteo bidding adapter', function () {
   beforeEach(function () {
@@ -545,6 +546,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+      expect(ortbRequest.slots[0].video.playersize).to.deep.equal(['640x480']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
       expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
       expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
@@ -647,6 +649,39 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].ad).to.equal('test-ad');
       expect(bids[0].width).to.equal(728);
       expect(bids[0].height).to.equal(90);
+    });
+
+    it('should properly parse a bid responsewith with a video', function () {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            bidId: 'abc123',
+            cpm: 1.23,
+            creative: 'test-ad',
+            width: 728,
+            height: 90,
+            zoneid: 123,
+            video: true
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: 123,
+          },
+        }]
+      };
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('test-bidId');
+      expect(bids[0].adId).to.equal('abc123');
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].vastUrl).to.equal('test-ad');
+      expect(bids[0].mediaType).to.equal(VIDEO);
     });
 
     it('should properly parse a bid responsewith with a zoneId passed as a string', function () {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
We'd like to add the support for instream & outstream videos in our adapter.

Here's a sample of addUnit for an instream video query.
```
var videoAdUnit = {
    code: 'div-Test-DirectBidder-Video',
    mediaTypes: {
      video: {
        context: "instream",
        mimes: ["video/mp4","application/javascript"],
        maxduration: 30,
        api: [1, 2],
        playerSize: [640,480],
        protocols: [2, 3, 5, 6]
      }
    },
    bids: [
      {
        bidder: 'criteo',
        params: {
          zoneId: 1424176,
          video: {
            skip: 0,
            playbackmethod: 1,
            placement: 1
          }
        }
      }
    ]
  };
```

PR for documentation is available here : https://github.com/prebid/prebid.github.io/pull/1414