### PR TITLE
Support of Instream/Outstream Video for the SmileWanted Adapter

### DIFF
--- a/modules/smilewantedBidAdapter.js
+++ b/modules/smilewantedBidAdapter.js
@@ -6,27 +6,42 @@ export const spec = {
   code: 'smilewanted',
   aliases: ['smile', 'sw'],
 
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {object} bid The bid to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     return !!(bid.params && bid.params.zoneId);
   },
 
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     return validBidRequests.map(bid => {
       var payload = {
         zoneId: bid.params.zoneId,
-        currencyCode: config.getConfig('currency.adServerCurrency'),
+        currencyCode: config.getConfig('currency.adServerCurrency') || 'EUR',
         bidfloor: bid.params.bidfloor || 0.0,
         tagId: bid.adUnitCode,
         sizes: bid.sizes.map(size => ({
           w: size[0],
           h: size[1]
         })),
-        pageDomain: utils.getTopWindowUrl(),
         transactionId: bid.transactionId,
         timeout: config.getConfig('bidderTimeout'),
         bidId: bid.bidId,
         prebidVersion: '$prebid.version$'
       };
+
+      if (bidderRequest && bidderRequest.refererInfo) {
+        payload.pageDomain = bidderRequest.refererInfo.referer || '';
+      }
 
       if (bidderRequest && bidderRequest.gdprConsent) {
         payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
@@ -41,6 +56,12 @@ export const spec = {
     });
   },
 
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     const bidResponses = [];
     var response = serverResponse.body;
@@ -56,7 +77,6 @@ export const spec = {
           currency: response.currency,
           netRevenue: response.isNetCpm,
           ttl: response.ttl,
-          referrer: utils.getTopWindowUrl(),
           adUrl: response.adUrl,
           ad: response.ad
         };
@@ -69,13 +89,22 @@ export const spec = {
     return bidResponses;
   },
 
+  /**
+   * User syncs.
+   *
+   * @param {*} syncOptions Publisher prebid configuration.
+   * @param {*} serverResponses A successful response from the server.
+   * @return {Syncs[]} An array of syncs that should be executed.
+   */
   getUserSyncs: function(syncOptions, serverResponses) {
     const syncs = []
     if (syncOptions.iframeEnabled && serverResponses.length > 0) {
-      syncs.push({
-        type: 'iframe',
-        url: serverResponses[0].body.cSyncUrl
-      });
+      if (serverResponses[0].body.cSyncUrl === 'https://csync.smilewanted.com') {
+        syncs.push({
+          type: 'iframe',
+          url: serverResponses[0].body.cSyncUrl
+        });
+      }
     }
     return syncs;
   }

--- a/modules/smilewantedBidAdapter.js
+++ b/modules/smilewantedBidAdapter.js
@@ -1,0 +1,84 @@
+import * as utils from '../src/utils';
+import { config } from '../src/config';
+import { registerBidder } from '../src/adapters/bidderFactory';
+
+export const spec = {
+  code: 'smilewanted',
+  aliases: ['smile', 'sw'],
+
+  isBidRequestValid: function(bid) {
+    return !!(bid.params && bid.params.zoneId);
+  },
+
+  buildRequests: function(validBidRequests, bidderRequest) {
+    return validBidRequests.map(bid => {
+      var payload = {
+        zoneId: bid.params.zoneId,
+        currencyCode: config.getConfig('currency.adServerCurrency'),
+        bidfloor: bid.params.bidfloor || 0.0,
+        tagId: bid.adUnitCode,
+        sizes: bid.sizes.map(size => ({
+          w: size[0],
+          h: size[1]
+        })),
+        pageDomain: utils.getTopWindowUrl(),
+        transactionId: bid.transactionId,
+        timeout: config.getConfig('bidderTimeout'),
+        bidId: bid.bidId,
+        prebidVersion: '$prebid.version$'
+      };
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+        payload.gdpr = bidderRequest.gdprConsent.gdprApplies; // we're handling the undefined case server side
+      }
+      var payloadString = JSON.stringify(payload);
+      return {
+        method: 'POST',
+        url: 'https://prebid.smilewanted.com',
+        data: payloadString,
+      };
+    });
+  },
+
+  interpretResponse: function(serverResponse, bidRequest) {
+    const bidResponses = [];
+    var response = serverResponse.body;
+    try {
+      if (response) {
+        const bidResponse = {
+          requestId: JSON.parse(bidRequest.data).bidId,
+          cpm: response.cpm,
+          width: response.width,
+          height: response.height,
+          creativeId: response.creativeId,
+          dealId: response.dealId,
+          currency: response.currency,
+          netRevenue: response.isNetCpm,
+          ttl: response.ttl,
+          referrer: utils.getTopWindowUrl(),
+          adUrl: response.adUrl,
+          ad: response.ad
+        };
+
+        bidResponses.push(bidResponse);
+      }
+    } catch (error) {
+      utils.logError('Error while parsing smilewanted response', error);
+    }
+    return bidResponses;
+  },
+
+  getUserSyncs: function(syncOptions, serverResponses) {
+    const syncs = []
+    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+      syncs.push({
+        type: 'iframe',
+        url: serverResponses[0].body.cSyncUrl
+      });
+    }
+    return syncs;
+  }
+}
+
+registerBidder(spec);

--- a/modules/smilewantedBidAdapter.md
+++ b/modules/smilewantedBidAdapter.md
@@ -13,6 +13,8 @@ To use us as a bidder you must have an account and an active "zoneId" on our Smi
 # Test Parameters
 
 ## Web
+
+### Display
 ```
     var adUnits = [
            {
@@ -28,4 +30,42 @@ To use us as a bidder you must have an account and an active "zoneId" on our Smi
                ]
            }
        ];
+```
+
+### Video Instream
+```
+    var videoAdUnit = {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            }
+        },
+        bids: [{
+            bidder: 'smilewanted',
+            params: {
+                zoneId: 2,
+            }
+        }]
+    };
+```
+
+### Video Outstream
+```
+    var videoAdUnit = {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'outstream'
+            }
+        },
+        bids: [{
+            bidder: 'smilewanted',
+            params: {
+                zoneId: 3,
+            }
+        }]
+    };
 ```

--- a/modules/smilewantedBidAdapter.md
+++ b/modules/smilewantedBidAdapter.md
@@ -1,0 +1,31 @@
+# Overview
+
+```
+Module Name: SmileWanted Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: maxime@smilewanted.com
+```
+
+# Description
+
+To use us as a bidder you must have an account and an active "zoneId" on our SmileWanted platform.
+
+# Test Parameters
+
+## Web
+```
+    var adUnits = [
+           {
+               code: 'test-div',
+               sizes: [[300, 250]],
+               bids: [
+                   {
+                       bidder: "smilewanted",
+                       params: {
+                            zoneId: 1
+                       }
+                   }
+               ]
+           }
+       ];
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "2.4.0",
+  "version": "2.5.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5909,7 +5909,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5930,12 +5931,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5950,17 +5953,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6077,7 +6083,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6089,6 +6096,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6103,6 +6111,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6110,12 +6119,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6134,6 +6145,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6214,7 +6226,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6226,6 +6239,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6311,7 +6325,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6347,6 +6362,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6366,6 +6382,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6409,12 +6426,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -5,62 +5,151 @@ import { config } from 'src/config';
 import * as utils from 'src/utils';
 import { requestBidsHook } from 'modules/consentManagement';
 
+const DISPLAY_REQUEST = [{
+  adUnitCode: 'sw_300x250',
+  bidId: '12345',
+  sizes: [
+    [300, 250],
+    [300, 200]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 1,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_DISPLAY = {
+  body: {
+    cpm: 3,
+    width: 300,
+    height: 250,
+    creativeId: 'crea_sw_1',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: '< --- sw script --- >',
+    cSyncUrl: 'https://csync.smilewanted.com'
+  }
+};
+
+const VIDEO_INSTREAM_REQUEST = [{
+  code: 'video1',
+  mediaTypes: {
+    video: {}
+  },
+  sizes: [
+    [640, 480]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 2,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_VIDEO_INSTREAM = {
+  body: {
+    cpm: 3,
+    width: 640,
+    height: 480,
+    creativeId: 'crea_sw_2',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: 'https://vast.smilewanted.com',
+    cSyncUrl: 'https://csync.smilewanted.com',
+    formatTypeSw: 'video_instream'
+  }
+};
+
+const VIDEO_OUTSTREAM_REQUEST = [{
+  code: 'video1',
+  mediaTypes: {
+    video: {}
+  },
+  sizes: [
+    [640, 480]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 3,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_VIDEO_OUTSTREAM = {
+  body: {
+    cpm: 3,
+    width: 640,
+    height: 480,
+    creativeId: 'crea_sw_3',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: 'https://vast.smilewanted.com',
+    cSyncUrl: 'https://csync.smilewanted.com',
+    OustreamTemplateUrl: 'https://prebid.smilewanted.com/scripts_outstream/infeed.js',
+    formatTypeSw: 'video_outstream'
+  }
+};
+
 // Default params with optional ones
 describe('smilewantedBidAdapterTests', function () {
-  var DEFAULT_PARAMS = [{
-    adUnitCode: 'sw_300x250',
-    bidId: '12345',
-    sizes: [
-      [300, 250],
-      [300, 200]
-    ],
-    bidder: 'smilewanted',
-    params: {
-      zoneId: '1234',
-      bidfloor: 2.50
-    },
-    requestId: 'request_abcd1234',
-    transactionId: 'trans_abcd1234'
-  }];
-
-  var BID_RESPONSE = {
-    body: {
-      cpm: 3,
-      width: 300,
-      height: 250,
-      creativeId: 'crea_sw_1',
-      currency: 'EUR',
-      isNetCpm: true,
-      ttl: 300,
-      adUrl: 'https://www.smilewanted.com',
-      ad: '< --- sw script --- >',
-      cSyncUrl: 'https://csync.smilewanted.com'
-    }
-  };
-
   it('SmileWanted - Verify build request', function () {
     config.setConfig({
       'currency': {
         'adServerCurrency': 'EUR'
       }
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS);
-    expect(request[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
-    expect(request[0]).to.have.property('method').and.to.equal('POST');
-    const requestContent = JSON.parse(request[0].data);
-    expect(requestContent).to.have.property('zoneId').and.to.equal('1234');
-    expect(requestContent).to.have.property('currencyCode').and.to.equal('EUR');
-    expect(requestContent).to.have.property('bidfloor').and.to.equal(2.50);
-    expect(requestContent).to.have.property('sizes');
-    expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(300);
-    expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(250);
-    expect(requestContent.sizes[1]).to.have.property('w').and.to.equal(300);
-    expect(requestContent.sizes[1]).to.have.property('h').and.to.equal(200);
-    expect(requestContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestDisplay = spec.buildRequests(DISPLAY_REQUEST);
+    expect(requestDisplay[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestDisplay[0]).to.have.property('method').and.to.equal('POST');
+    const requestDisplayContent = JSON.parse(requestDisplay[0].data);
+    expect(requestDisplayContent).to.have.property('zoneId').and.to.equal(1);
+    expect(requestDisplayContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestDisplayContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestDisplayContent).to.have.property('sizes');
+    expect(requestDisplayContent.sizes[0]).to.have.property('w').and.to.equal(300);
+    expect(requestDisplayContent.sizes[0]).to.have.property('h').and.to.equal(250);
+    expect(requestDisplayContent.sizes[1]).to.have.property('w').and.to.equal(300);
+    expect(requestDisplayContent.sizes[1]).to.have.property('h').and.to.equal(200);
+    expect(requestDisplayContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestVideoInstream = spec.buildRequests(VIDEO_INSTREAM_REQUEST);
+    expect(requestVideoInstream[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestVideoInstream[0]).to.have.property('method').and.to.equal('POST');
+    const requestVideoInstreamContent = JSON.parse(requestVideoInstream[0].data);
+    expect(requestVideoInstreamContent).to.have.property('zoneId').and.to.equal(2);
+    expect(requestVideoInstreamContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestVideoInstreamContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestVideoInstreamContent).to.have.property('sizes');
+    expect(requestVideoInstreamContent.sizes[0]).to.have.property('w').and.to.equal(640);
+    expect(requestVideoInstreamContent.sizes[0]).to.have.property('h').and.to.equal(480);
+    expect(requestVideoInstreamContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestVideoOutstream = spec.buildRequests(VIDEO_OUTSTREAM_REQUEST);
+    expect(requestVideoOutstream[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestVideoOutstream[0]).to.have.property('method').and.to.equal('POST');
+    const requestVideoOutstreamContent = JSON.parse(requestVideoOutstream[0].data);
+    expect(requestVideoOutstreamContent).to.have.property('zoneId').and.to.equal(3);
+    expect(requestVideoOutstreamContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestVideoOutstreamContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestVideoOutstreamContent).to.have.property('sizes');
+    expect(requestVideoOutstreamContent.sizes[0]).to.have.property('w').and.to.equal(640);
+    expect(requestVideoOutstreamContent.sizes[0]).to.have.property('h').and.to.equal(480);
+    expect(requestVideoOutstreamContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
   });
 
   it('SmileWanted - Verify build request with referrer', function () {
-    const request = spec.buildRequests(DEFAULT_PARAMS, {
+    const request = spec.buildRequests(DISPLAY_REQUEST, {
       refererInfo: {
         referer: 'http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html'
       }
@@ -87,7 +176,7 @@ describe('smilewantedBidAdapterTests', function () {
           allowAuctionWithoutConsent: true
         }
       });
-      const request = spec.buildRequests(DEFAULT_PARAMS, {
+      const request = spec.buildRequests(DISPLAY_REQUEST, {
         gdprConsent: {
           consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA',
           gdprApplies: true
@@ -110,7 +199,7 @@ describe('smilewantedBidAdapterTests', function () {
           allowAuctionWithoutConsent: true
         }
       });
-      const request = spec.buildRequests(DEFAULT_PARAMS, {
+      const request = spec.buildRequests(DISPLAY_REQUEST, {
         gdprConsent: {
           consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA'
         }
@@ -121,13 +210,12 @@ describe('smilewantedBidAdapterTests', function () {
     });
   });
 
-  it('SmileWanted - Verify parse response', function () {
-    const request = spec.buildRequests(DEFAULT_PARAMS);
-    const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
+  it('SmileWanted - Verify parse response - Display', function () {
+    const request = spec.buildRequests(DISPLAY_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_DISPLAY, request[0]);
     expect(bids).to.have.lengthOf(1);
     const bid = bids[0];
     expect(bid.cpm).to.equal(3);
-    expect(bid.adUrl).to.equal('https://www.smilewanted.com');
     expect(bid.ad).to.equal('< --- sw script --- >');
     expect(bid.width).to.equal(300);
     expect(bid.height).to.equal(250);
@@ -135,10 +223,56 @@ describe('smilewantedBidAdapterTests', function () {
     expect(bid.currency).to.equal('EUR');
     expect(bid.netRevenue).to.equal(true);
     expect(bid.ttl).to.equal(300);
-    expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
+    expect(bid.requestId).to.equal(DISPLAY_REQUEST[0].bidId);
 
     expect(function () {
-      spec.interpretResponse(BID_RESPONSE, {
+      spec.interpretResponse(BID_RESPONSE_DISPLAY, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
+  });
+
+  it('SmileWanted - Verify parse response - Video Instream', function () {
+    const request = spec.buildRequests(VIDEO_INSTREAM_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_VIDEO_INSTREAM, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3);
+    expect(bid.ad).to.equal(null);
+    expect(bid.vastUrl).to.equal('https://vast.smilewanted.com');
+    expect(bid.width).to.equal(640);
+    expect(bid.height).to.equal(480);
+    expect(bid.creativeId).to.equal('crea_sw_2');
+    expect(bid.currency).to.equal('EUR');
+    expect(bid.netRevenue).to.equal(true);
+    expect(bid.ttl).to.equal(300);
+    expect(bid.requestId).to.equal(VIDEO_INSTREAM_REQUEST[0].bidId);
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE_VIDEO_INSTREAM, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
+  });
+
+  it('SmileWanted - Verify parse response - Video Oustream', function () {
+    const request = spec.buildRequests(VIDEO_OUTSTREAM_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_VIDEO_OUTSTREAM, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3);
+    expect(bid.vastUrl).to.equal('https://vast.smilewanted.com');
+    expect(bid.renderer.url).to.equal('https://prebid.smilewanted.com/scripts_outstream/infeed.js');
+    expect(bid.width).to.equal(640);
+    expect(bid.height).to.equal(480);
+    expect(bid.creativeId).to.equal('crea_sw_3');
+    expect(bid.currency).to.equal('EUR');
+    expect(bid.netRevenue).to.equal(true);
+    expect(bid.ttl).to.equal(300);
+    expect(bid.requestId).to.equal(VIDEO_OUTSTREAM_REQUEST[0].bidId);
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE_VIDEO_OUTSTREAM, {
         data: 'invalid Json'
       })
     }).to.not.throw();
@@ -155,7 +289,7 @@ describe('smilewantedBidAdapterTests', function () {
   });
 
   it('SmileWanted - Verify if bid request valid', function () {
-    expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
+    expect(spec.isBidRequestValid(DISPLAY_REQUEST[0])).to.equal(true);
     expect(spec.isBidRequestValid({
       params: {
         zoneId: 1234
@@ -173,14 +307,14 @@ describe('smilewantedBidAdapterTests', function () {
   it('SmileWanted - Verify user sync', function () {
     var syncs = spec.getUserSyncs({
       iframeEnabled: true
-    }, [BID_RESPONSE]);
+    }, [BID_RESPONSE_DISPLAY]);
     expect(syncs).to.have.lengthOf(1);
     expect(syncs[0].type).to.equal('iframe');
     expect(syncs[0].url).to.equal('https://csync.smilewanted.com');
 
     syncs = spec.getUserSyncs({
       iframeEnabled: false
-    }, [BID_RESPONSE]);
+    }, [BID_RESPONSE_DISPLAY]);
     expect(syncs).to.have.lengthOf(0);
 
     syncs = spec.getUserSyncs({

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -56,8 +56,18 @@ describe('smilewantedBidAdapterTests', function () {
     expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(250);
     expect(requestContent.sizes[1]).to.have.property('w').and.to.equal(300);
     expect(requestContent.sizes[1]).to.have.property('h').and.to.equal(200);
-    expect(requestContent).to.have.property('pageDomain').and.to.equal(utils.getTopWindowUrl());
+    // expect(requestContent).to.have.property('pageDomain').and.to.equal('http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html');
     expect(requestContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+  });
+
+  it('SmileWanted - Verify build request with referrer', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS, {
+      refererInfo: {
+        referer: 'http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html'
+      }
+    });
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent).to.have.property('pageDomain').and.to.equal('http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html');
   });
 
   describe('gdpr tests', function () {
@@ -127,7 +137,6 @@ describe('smilewantedBidAdapterTests', function () {
     expect(bid.netRevenue).to.equal(true);
     expect(bid.ttl).to.equal(300);
     expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
-    expect(bid.referrer).to.equal(utils.getTopWindowUrl());
 
     expect(function () {
       spec.interpretResponse(BID_RESPONSE, {

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -1,0 +1,183 @@
+import { expect } from 'chai';
+import { spec } from 'modules/smilewantedBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config';
+import * as utils from 'src/utils';
+import { requestBidsHook } from 'modules/consentManagement';
+
+// Default params with optional ones
+describe('smilewantedBidAdapterTests', function () {
+  var DEFAULT_PARAMS = [{
+    adUnitCode: 'sw_300x250',
+    bidId: '12345',
+    sizes: [
+      [300, 250],
+      [300, 200]
+    ],
+    bidder: 'smilewanted',
+    params: {
+      zoneId: '1234',
+      bidfloor: 2.50
+    },
+    requestId: 'request_abcd1234',
+    transactionId: 'trans_abcd1234'
+  }];
+
+  var BID_RESPONSE = {
+    body: {
+      cpm: 3,
+      width: 300,
+      height: 250,
+      creativeId: 'crea_sw_1',
+      currency: 'EUR',
+      isNetCpm: true,
+      ttl: 300,
+      adUrl: 'https://www.smilewanted.com',
+      ad: '< --- sw script --- >',
+      cSyncUrl: 'https://csync.smilewanted.com'
+    }
+  };
+
+  it('SmileWanted - Verify build request', function () {
+    config.setConfig({
+      'currency': {
+        'adServerCurrency': 'EUR'
+      }
+    });
+    const request = spec.buildRequests(DEFAULT_PARAMS);
+    expect(request[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(request[0]).to.have.property('method').and.to.equal('POST');
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent).to.have.property('zoneId').and.to.equal('1234');
+    expect(requestContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestContent).to.have.property('sizes');
+    expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(300);
+    expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(250);
+    expect(requestContent.sizes[1]).to.have.property('w').and.to.equal(300);
+    expect(requestContent.sizes[1]).to.have.property('h').and.to.equal(200);
+    expect(requestContent).to.have.property('pageDomain').and.to.equal(utils.getTopWindowUrl());
+    expect(requestContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+  });
+
+  describe('gdpr tests', function () {
+    afterEach(function () {
+      config.resetConfig();
+      $$PREBID_GLOBAL$$.requestBids.removeAll();
+    });
+
+    it('SmileWanted - Verify build request with GDPR', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        },
+        consentManagement: {
+          cmp: 'iab',
+          consentRequired: true,
+          timeout: 1000,
+          allowAuctionWithoutConsent: true
+        }
+      });
+      const request = spec.buildRequests(DEFAULT_PARAMS, {
+        gdprConsent: {
+          consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA',
+          gdprApplies: true
+        }
+      });
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('gdpr').and.to.equal(true);
+      expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA');
+    });
+
+    it('SmileWanted - Verify build request with GDPR without gdprApplies', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        },
+        consentManagement: {
+          cmp: 'iab',
+          consentRequired: true,
+          timeout: 1000,
+          allowAuctionWithoutConsent: true
+        }
+      });
+      const request = spec.buildRequests(DEFAULT_PARAMS, {
+        gdprConsent: {
+          consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA'
+        }
+      });
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.not.have.property('gdpr');
+      expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA');
+    });
+  });
+
+  it('SmileWanted - Verify parse response', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS);
+    const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3);
+    expect(bid.adUrl).to.equal('https://www.smilewanted.com');
+    expect(bid.ad).to.equal('< --- sw script --- >');
+    expect(bid.width).to.equal(300);
+    expect(bid.height).to.equal(250);
+    expect(bid.creativeId).to.equal('crea_sw_1');
+    expect(bid.currency).to.equal('EUR');
+    expect(bid.netRevenue).to.equal(true);
+    expect(bid.ttl).to.equal(300);
+    expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
+    expect(bid.referrer).to.equal(utils.getTopWindowUrl());
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
+  });
+
+  it('SmileWanted - Verify bidder code', function () {
+    expect(spec.code).to.equal('smilewanted');
+  });
+
+  it('SmileWanted - Verify bidder aliases', function () {
+    expect(spec.aliases).to.have.lengthOf(2);
+    expect(spec.aliases[0]).to.equal('smile');
+    expect(spec.aliases[1]).to.equal('sw');
+  });
+
+  it('SmileWanted - Verify if bid request valid', function () {
+    expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
+    expect(spec.isBidRequestValid({
+      params: {
+        zoneId: 1234
+      }
+    })).to.equal(true);
+  });
+
+  it('SmileWanted - Verify if params(zoneId) is not passed', function () {
+    expect(spec.isBidRequestValid({})).to.equal(false);
+    expect(spec.isBidRequestValid({
+      params: {}
+    })).to.equal(false);
+  });
+
+  it('SmileWanted - Verify user sync', function () {
+    var syncs = spec.getUserSyncs({
+      iframeEnabled: true
+    }, [BID_RESPONSE]);
+    expect(syncs).to.have.lengthOf(1);
+    expect(syncs[0].type).to.equal('iframe');
+    expect(syncs[0].url).to.equal('https://csync.smilewanted.com');
+
+    syncs = spec.getUserSyncs({
+      iframeEnabled: false
+    }, [BID_RESPONSE]);
+    expect(syncs).to.have.lengthOf(0);
+
+    syncs = spec.getUserSyncs({
+      iframeEnabled: true
+    }, []);
+    expect(syncs).to.have.lengthOf(0);
+  });
+});

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -56,7 +56,6 @@ describe('smilewantedBidAdapterTests', function () {
     expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(250);
     expect(requestContent.sizes[1]).to.have.property('w').and.to.equal(300);
     expect(requestContent.sizes[1]).to.have.property('h').and.to.equal(200);
-    // expect(requestContent).to.have.property('pageDomain').and.to.equal('http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html');
     expect(requestContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
   });
 


### PR DESCRIPTION
This PR allows video support (Instream and Outstream) for the SmileWanted adapter.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

## Testing
### Video Instream
```
    var videoAdUnit = {
        code: 'video1',
        mediaTypes: {
            video: {
                playerSize: [640, 480],
                context: 'instream'
            }
        },
        bids: [{
            bidder: 'smilewanted',
            params: {
                zoneId: 2,
            }
        }]
    };
```

### Video Outstream
```
    var videoAdUnit = {
        code: 'video1',
        mediaTypes: {
            video: {
                playerSize: [640, 480],
                context: 'outstream'
            }
        },
        bids: [{
            bidder: 'smilewanted',
            params: {
                zoneId: 3,
            }
        }]
    };
```
