### PR TITLE
Adding support of Instream/Outstream Video for the SmileWanted Adapter

### DIFF
--- a/modules/smilewantedBidAdapter.md
+++ b/modules/smilewantedBidAdapter.md
@@ -13,6 +13,8 @@ To use us as a bidder you must have an account and an active "zoneId" on our Smi
 # Test Parameters
 
 ## Web
+
+### Display
 ```
     var adUnits = [
            {
@@ -28,4 +30,42 @@ To use us as a bidder you must have an account and an active "zoneId" on our Smi
                ]
            }
        ];
+```
+
+### Video Instream
+```
+    var videoAdUnit = {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            }
+        },
+        bids: [{
+            bidder: 'smilewanted',
+            params: {
+                zoneId: 2,
+            }
+        }]
+    };
+```
+
+### Video Outstream
+```
+    var videoAdUnit = {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'outstream'
+            }
+        },
+        bids: [{
+            bidder: 'smilewanted',
+            params: {
+                zoneId: 3,
+            }
+        }]
+    };
 ```

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -5,62 +5,151 @@ import { config } from 'src/config';
 import * as utils from 'src/utils';
 import { requestBidsHook } from 'modules/consentManagement';
 
+const DISPLAY_REQUEST = [{
+  adUnitCode: 'sw_300x250',
+  bidId: '12345',
+  sizes: [
+    [300, 250],
+    [300, 200]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 1,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_DISPLAY = {
+  body: {
+    cpm: 3,
+    width: 300,
+    height: 250,
+    creativeId: 'crea_sw_1',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: '< --- sw script --- >',
+    cSyncUrl: 'https://csync.smilewanted.com'
+  }
+};
+
+const VIDEO_INSTREAM_REQUEST = [{
+  code: 'video1',
+  mediaTypes: {
+    video: {}
+  },
+  sizes: [
+    [640, 480]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 2,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_VIDEO_INSTREAM = {
+  body: {
+    cpm: 3,
+    width: 640,
+    height: 480,
+    creativeId: 'crea_sw_2',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: 'https://vast.smilewanted.com',
+    cSyncUrl: 'https://csync.smilewanted.com',
+    formatTypeSw: 'video_instream'
+  }
+};
+
+const VIDEO_OUTSTREAM_REQUEST = [{
+  code: 'video1',
+  mediaTypes: {
+    video: {}
+  },
+  sizes: [
+    [640, 480]
+  ],
+  bidder: 'smilewanted',
+  params: {
+    zoneId: 3,
+    bidfloor: 2.50
+  },
+  requestId: 'request_abcd1234',
+  transactionId: 'trans_abcd1234'
+}];
+
+const BID_RESPONSE_VIDEO_OUTSTREAM = {
+  body: {
+    cpm: 3,
+    width: 640,
+    height: 480,
+    creativeId: 'crea_sw_3',
+    currency: 'EUR',
+    isNetCpm: true,
+    ttl: 300,
+    ad: 'https://vast.smilewanted.com',
+    cSyncUrl: 'https://csync.smilewanted.com',
+    OustreamTemplateUrl: 'https://prebid.smilewanted.com/scripts_outstream/infeed.js',
+    formatTypeSw: 'video_outstream'
+  }
+};
+
 // Default params with optional ones
 describe('smilewantedBidAdapterTests', function () {
-  var DEFAULT_PARAMS = [{
-    adUnitCode: 'sw_300x250',
-    bidId: '12345',
-    sizes: [
-      [300, 250],
-      [300, 200]
-    ],
-    bidder: 'smilewanted',
-    params: {
-      zoneId: '1234',
-      bidfloor: 2.50
-    },
-    requestId: 'request_abcd1234',
-    transactionId: 'trans_abcd1234'
-  }];
-
-  var BID_RESPONSE = {
-    body: {
-      cpm: 3,
-      width: 300,
-      height: 250,
-      creativeId: 'crea_sw_1',
-      currency: 'EUR',
-      isNetCpm: true,
-      ttl: 300,
-      adUrl: 'https://www.smilewanted.com',
-      ad: '< --- sw script --- >',
-      cSyncUrl: 'https://csync.smilewanted.com'
-    }
-  };
-
   it('SmileWanted - Verify build request', function () {
     config.setConfig({
       'currency': {
         'adServerCurrency': 'EUR'
       }
     });
-    const request = spec.buildRequests(DEFAULT_PARAMS);
-    expect(request[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
-    expect(request[0]).to.have.property('method').and.to.equal('POST');
-    const requestContent = JSON.parse(request[0].data);
-    expect(requestContent).to.have.property('zoneId').and.to.equal('1234');
-    expect(requestContent).to.have.property('currencyCode').and.to.equal('EUR');
-    expect(requestContent).to.have.property('bidfloor').and.to.equal(2.50);
-    expect(requestContent).to.have.property('sizes');
-    expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(300);
-    expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(250);
-    expect(requestContent.sizes[1]).to.have.property('w').and.to.equal(300);
-    expect(requestContent.sizes[1]).to.have.property('h').and.to.equal(200);
-    expect(requestContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestDisplay = spec.buildRequests(DISPLAY_REQUEST);
+    expect(requestDisplay[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestDisplay[0]).to.have.property('method').and.to.equal('POST');
+    const requestDisplayContent = JSON.parse(requestDisplay[0].data);
+    expect(requestDisplayContent).to.have.property('zoneId').and.to.equal(1);
+    expect(requestDisplayContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestDisplayContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestDisplayContent).to.have.property('sizes');
+    expect(requestDisplayContent.sizes[0]).to.have.property('w').and.to.equal(300);
+    expect(requestDisplayContent.sizes[0]).to.have.property('h').and.to.equal(250);
+    expect(requestDisplayContent.sizes[1]).to.have.property('w').and.to.equal(300);
+    expect(requestDisplayContent.sizes[1]).to.have.property('h').and.to.equal(200);
+    expect(requestDisplayContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestVideoInstream = spec.buildRequests(VIDEO_INSTREAM_REQUEST);
+    expect(requestVideoInstream[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestVideoInstream[0]).to.have.property('method').and.to.equal('POST');
+    const requestVideoInstreamContent = JSON.parse(requestVideoInstream[0].data);
+    expect(requestVideoInstreamContent).to.have.property('zoneId').and.to.equal(2);
+    expect(requestVideoInstreamContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestVideoInstreamContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestVideoInstreamContent).to.have.property('sizes');
+    expect(requestVideoInstreamContent.sizes[0]).to.have.property('w').and.to.equal(640);
+    expect(requestVideoInstreamContent.sizes[0]).to.have.property('h').and.to.equal(480);
+    expect(requestVideoInstreamContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
+
+    const requestVideoOutstream = spec.buildRequests(VIDEO_OUTSTREAM_REQUEST);
+    expect(requestVideoOutstream[0]).to.have.property('url').and.to.equal('https://prebid.smilewanted.com');
+    expect(requestVideoOutstream[0]).to.have.property('method').and.to.equal('POST');
+    const requestVideoOutstreamContent = JSON.parse(requestVideoOutstream[0].data);
+    expect(requestVideoOutstreamContent).to.have.property('zoneId').and.to.equal(3);
+    expect(requestVideoOutstreamContent).to.have.property('currencyCode').and.to.equal('EUR');
+    expect(requestVideoOutstreamContent).to.have.property('bidfloor').and.to.equal(2.50);
+    expect(requestVideoOutstreamContent).to.have.property('sizes');
+    expect(requestVideoOutstreamContent.sizes[0]).to.have.property('w').and.to.equal(640);
+    expect(requestVideoOutstreamContent.sizes[0]).to.have.property('h').and.to.equal(480);
+    expect(requestVideoOutstreamContent).to.have.property('transactionId').and.to.not.equal(null).and.to.not.be.undefined;
   });
 
   it('SmileWanted - Verify build request with referrer', function () {
-    const request = spec.buildRequests(DEFAULT_PARAMS, {
+    const request = spec.buildRequests(DISPLAY_REQUEST, {
       refererInfo: {
         referer: 'http://localhost/Prebid.js/integrationExamples/gpt/hello_world.html'
       }
@@ -87,7 +176,7 @@ describe('smilewantedBidAdapterTests', function () {
           allowAuctionWithoutConsent: true
         }
       });
-      const request = spec.buildRequests(DEFAULT_PARAMS, {
+      const request = spec.buildRequests(DISPLAY_REQUEST, {
         gdprConsent: {
           consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA',
           gdprApplies: true
@@ -110,7 +199,7 @@ describe('smilewantedBidAdapterTests', function () {
           allowAuctionWithoutConsent: true
         }
       });
-      const request = spec.buildRequests(DEFAULT_PARAMS, {
+      const request = spec.buildRequests(DISPLAY_REQUEST, {
         gdprConsent: {
           consentString: 'BOO_ch7OO_ch7AKABBENA2-AAAAZ97_______9______9uz_Gv_r_f__33e8_39v_h_7_u___m_-zzV4-_lvQV1yPA1OrfArgFA'
         }
@@ -121,13 +210,12 @@ describe('smilewantedBidAdapterTests', function () {
     });
   });
 
-  it('SmileWanted - Verify parse response', function () {
-    const request = spec.buildRequests(DEFAULT_PARAMS);
-    const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
+  it('SmileWanted - Verify parse response - Display', function () {
+    const request = spec.buildRequests(DISPLAY_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_DISPLAY, request[0]);
     expect(bids).to.have.lengthOf(1);
     const bid = bids[0];
     expect(bid.cpm).to.equal(3);
-    expect(bid.adUrl).to.equal('https://www.smilewanted.com');
     expect(bid.ad).to.equal('< --- sw script --- >');
     expect(bid.width).to.equal(300);
     expect(bid.height).to.equal(250);
@@ -135,10 +223,56 @@ describe('smilewantedBidAdapterTests', function () {
     expect(bid.currency).to.equal('EUR');
     expect(bid.netRevenue).to.equal(true);
     expect(bid.ttl).to.equal(300);
-    expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
+    expect(bid.requestId).to.equal(DISPLAY_REQUEST[0].bidId);
 
     expect(function () {
-      spec.interpretResponse(BID_RESPONSE, {
+      spec.interpretResponse(BID_RESPONSE_DISPLAY, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
+  });
+
+  it('SmileWanted - Verify parse response - Video Instream', function () {
+    const request = spec.buildRequests(VIDEO_INSTREAM_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_VIDEO_INSTREAM, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3);
+    expect(bid.ad).to.equal(null);
+    expect(bid.vastUrl).to.equal('https://vast.smilewanted.com');
+    expect(bid.width).to.equal(640);
+    expect(bid.height).to.equal(480);
+    expect(bid.creativeId).to.equal('crea_sw_2');
+    expect(bid.currency).to.equal('EUR');
+    expect(bid.netRevenue).to.equal(true);
+    expect(bid.ttl).to.equal(300);
+    expect(bid.requestId).to.equal(VIDEO_INSTREAM_REQUEST[0].bidId);
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE_VIDEO_INSTREAM, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
+  });
+
+  it('SmileWanted - Verify parse response - Video Oustream', function () {
+    const request = spec.buildRequests(VIDEO_OUTSTREAM_REQUEST);
+    const bids = spec.interpretResponse(BID_RESPONSE_VIDEO_OUTSTREAM, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3);
+    expect(bid.vastUrl).to.equal('https://vast.smilewanted.com');
+    expect(bid.renderer.url).to.equal('https://prebid.smilewanted.com/scripts_outstream/infeed.js');
+    expect(bid.width).to.equal(640);
+    expect(bid.height).to.equal(480);
+    expect(bid.creativeId).to.equal('crea_sw_3');
+    expect(bid.currency).to.equal('EUR');
+    expect(bid.netRevenue).to.equal(true);
+    expect(bid.ttl).to.equal(300);
+    expect(bid.requestId).to.equal(VIDEO_OUTSTREAM_REQUEST[0].bidId);
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE_VIDEO_OUTSTREAM, {
         data: 'invalid Json'
       })
     }).to.not.throw();
@@ -155,7 +289,7 @@ describe('smilewantedBidAdapterTests', function () {
   });
 
   it('SmileWanted - Verify if bid request valid', function () {
-    expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
+    expect(spec.isBidRequestValid(DISPLAY_REQUEST[0])).to.equal(true);
     expect(spec.isBidRequestValid({
       params: {
         zoneId: 1234
@@ -173,14 +307,14 @@ describe('smilewantedBidAdapterTests', function () {
   it('SmileWanted - Verify user sync', function () {
     var syncs = spec.getUserSyncs({
       iframeEnabled: true
-    }, [BID_RESPONSE]);
+    }, [BID_RESPONSE_DISPLAY]);
     expect(syncs).to.have.lengthOf(1);
     expect(syncs[0].type).to.equal('iframe');
     expect(syncs[0].url).to.equal('https://csync.smilewanted.com');
 
     syncs = spec.getUserSyncs({
       iframeEnabled: false
-    }, [BID_RESPONSE]);
+    }, [BID_RESPONSE_DISPLAY]);
     expect(syncs).to.have.lengthOf(0);
 
     syncs = spec.getUserSyncs({


### PR DESCRIPTION
This PR allows video support (Instream and Outstream) for the SmileWanted adapter.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

## Testing
### Video Instream
```
    var videoAdUnit = {
        code: 'video1',
        mediaTypes: {
            video: {
                playerSize: [640, 480],
                context: 'instream'
            }
        },
        bids: [{
            bidder: 'smilewanted',
            params: {
                zoneId: 2,
            }
        }]
    };
```

### Video Outstream
```
    var videoAdUnit = {
        code: 'video1',
        mediaTypes: {
            video: {
                playerSize: [640, 480],
                context: 'outstream'
            }
        },
        bids: [{
            bidder: 'smilewanted',
            params: {
                zoneId: 3,
            }
        }]
    };
```
