### PR TITLE
update logic of ad_types field in appnexusBidAdapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -3,6 +3,7 @@ import * as utils from '../src/utils';
 import { config } from '../src/config';
 import { registerBidder, getIabSubCategory } from '../src/adapters/bidderFactory';
 import { BANNER, NATIVE, VIDEO, ADPOD } from '../src/mediaTypes';
+import { auctionManager } from '../src/auctionManager';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
@@ -665,11 +666,13 @@ function bidToTag(bid) {
     tag.video = Object.assign({}, tag.video, {custom_renderer_present: true});
   }
 
-  if (
-    (utils.isEmpty(bid.mediaType) && utils.isEmpty(bid.mediaTypes)) ||
-    (bid.mediaType === BANNER || (bid.mediaTypes && bid.mediaTypes[BANNER]))
-  ) {
+  let adUnit = find(auctionManager.getAdUnits(), au => bid.transactionId === au.transactionId);
+  if (adUnit && adUnit.mediaTypes && adUnit.mediaTypes.banner) {
     tag.ad_types.push(BANNER);
+  }
+
+  if (tag.ad_types.length === 0) {
+    delete tag.ad_types;
   }
 
   return tag;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR changes how the `ad_types` field of the appnexus request is populated in relation to banner media type.

Previously the field was populated automatically with `'banner'` if the `mediaType(s)` field of the bid object was empty or if either of those fields were set to `banner`.  The latter case actually always happened since Prebid.js treats any adUnit request without a defined `mediaTypes` object as `banner` and creates a `mediaTypes` field in the bid with a banner object in this scenario.

Now with this change, the `banner` `ad_type` is only populated if the original `adUnit` contained a `mediaTypes.banner` object.  If the `adUnit.mediaTypes` object is missing, then the field is left out of the appnexus request.  In terms of the delivery decision for the bid, this scenario would defer to the types that are setup within the placement and use that to choose the type of bid to find/return.