### PR TITLE
Timeout coefficients

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -40,7 +40,7 @@ let _s2sConfig;
 /**
  * @typedef {Object} S2SDefaultConfig
  * @property {boolean} enabled
- * @property {number} timeout
+ * @property {number} timeout @deprecated This property will be removed in 3.0. Please refer <TBD github pr> for more info
  * @property {number} maxBids
  * @property {string} adapter
  * @property {AdapterOptions} adapterOptions

--- a/src/auction.js
+++ b/src/auction.js
@@ -385,7 +385,15 @@ export function auctionCallbacks(auctionDone, auctionInstance) {
 }
 
 export function doCallbacksIfTimedout(auctionInstance, bidResponse) {
-  if (bidResponse.timeToRespond > auctionInstance.getTimeout() + config.getConfig('timeoutBuffer')) {
+  // TODO: In 3.0 use default values defined in config module. <TBD github issue>
+  let buffer = config.getConfig('timeoutBuffer');
+  if (config.getConfig('timeoutBufferCoefficient')) {
+    let newBuffer = utils.evaluateTimeout(auctionInstance.getTimeout(), config.getConfig('timeoutBufferCoefficient'));
+    if (buffer) {
+      buffer = newBuffer
+    }
+  }
+  if (bidResponse.timeToRespond > auctionInstance.getTimeout() + buffer) {
     auctionInstance.executeCallback(true);
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,7 @@ const DEFAULT_ENABLE_SEND_ALL_BIDS = true;
 const DEFAULT_DISABLE_AJAX_TIMEOUT = false;
 const DEFAULT_BID_CACHE = false;
 
+// @deprecated This property will be removed in 3.0. Please refer <TBD github pr> for more info
 const DEFAULT_TIMEOUTBUFFER = 400;
 
 export const RANDOM = 'random';

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -411,6 +411,16 @@ $$PREBID_GLOBAL$$.removeAdUnit = function (adUnitCode) {
 $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeout, adUnits, adUnitCodes, labels, auctionId } = {}) {
   events.emit(REQUEST_BIDS);
   const cbTimeout = timeout || config.getConfig('bidderTimeout');
+  const s2sConfig = config.getConfig('s2sConfig');
+
+  if (s2sConfig && s2sConfig.timeoutCoefficient) {
+    let newTimeout = utils.evaluateTimeout(cbTimeout, s2sConfig.timeoutCoefficient);
+    if (newTimeout) {
+      s2sConfig.timeout = newTimeout;
+      config.setConfig({s2sConfig: s2sConfig});
+    }
+  }
+
   adUnits = adUnits || $$PREBID_GLOBAL$$.adUnits;
 
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1334,3 +1334,19 @@ export function compareOn(property) {
     return 0;
   }
 }
+
+/**
+ * This function calculates new timeout value
+ * @param {number} auctionTimeout auction timeout
+ * @param {float} coefficient floating point coefficient
+ * @returns {(number|undefined)} new timeout value
+ */
+export function evaluateTimeout(auctionTimeout, coefficient) {
+  let newTimeout = Math.floor(auctionTimeout * parseFloat(coefficient));
+  // Both timeoutBuffer and s2s timeout cannot be greater than auction timeout
+  if (newTimeout > auctionTimeout) {
+    internal.logInfo(`Ignoring evaluated timeout ${newTimeout} as it is greater than ${auctionTimeout}. Prebid will use default settings`);
+    newTimeout = undefined;
+  }
+  return newTimeout;
+}

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1009,4 +1009,28 @@ describe('Utils', function () {
       });
     });
   });
+
+  describe('evaluateTimeout', function() {
+    let logInfoStub;
+    before(function() {
+      logInfoStub = sinon.stub(utils.internal, 'logInfo');
+    });
+
+    after(function() {
+      logInfoStub.restore();
+    })
+
+    it('returns original timeout when auction timeout is higher', function() {
+      let auctionTimeout = 1000;
+      let coefficient = 2.00;
+      expect(utils.evaluateTimeout(auctionTimeout, coefficient)).to.equal(undefined);
+      expect(logInfoStub.calledOnce).to.be.true;
+    });
+
+    it('returns modified timeout when auction timeout is lower', function() {
+      let auctionTimeout = 1000;
+      let coefficient = 0.20;
+      expect(utils.evaluateTimeout(auctionTimeout, coefficient)).to.equal(200);
+    });
+  });
 });


### PR DESCRIPTION
**Do not merge**

## Type of change
- [x] Feature

## Description of change
Another attempt to solve https://github.com/prebid/Prebid.js/issues/3368

Publishers will only need to worry about 2 timeout values. 
1. The `user-specified timeout` value given to PBJS (bidderTimeout).
2. `failsafe timeout` a timer the page puts around PBJS as a whole. http://prebid.org/dev-docs/faq.html#when-starting-out-what-should-my-timeouts-be

We will calculate other 2 timeout values `timeoutBuffer` and `s2sConfig.timeout` using our default coefficient. Defaults will be only available in 3.0
3. timeoutBufferCoefficient - 0.20 
4. s2sConfig.timeoutCoefficient - 0.70

Logic is simple, evaluate timeoutBuffer and s2sConfig timeout on call to requestBids or on demand and make sure that new timeout does not exceed auction timeout. If it is higher use default value.

How can publisher set their coefficient ? 
```
pbjs.setConfig({
  timeoutBufferCoefficient: 0.20,
  s2sConfig: {
    timeoutCoefficient: 0.70
  } 
})
```

I have added some placeholders for github issues and pr. If this is approved I will create an issue and update
