### PR TITLE
update to use dlv/index to fix webpack sourcemaps

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import includes from 'core-js/library/fn/array/includes';
 import { parse } from './url';
 const CONSTANTS = require('./constants');
 
-export { default as deepAccess } from 'dlv';
+export { default as deepAccess } from 'dlv/index';
 export { default as deepSetValue } from 'dset';
 
 var tArr = 'Array';


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
For whatever reason the `//# sourceMappingURL=dlv.umd.js.map` at the end of the npm `dlv` module breaks the sourcemaps for the main webpack chunk (in which its included). I'm not sure why that is, although it seems to be the only npm include that has its own sourcemaps, so maybe this is a wider issue that we've avoided.

Either way, I've updated the code to import `dlv/index` which is the unminified code without sourcemaps (and webpack will minify and generate sourcemaps for, which is fine). 

## Other information
Related to #3993 