### PR TITLE
VIS.X adapter: don't use utils.getTopWindowUrl()

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -67,7 +67,6 @@ export const spec = {
     });
 
     const payload = {
-      u: utils.getTopWindowUrl(),
       pt: 'net',
       auids: auids.join(','),
       sizes: utils.getKeys(sizeMap).join(','),
@@ -77,13 +76,18 @@ export const spec = {
       wrapperVersion: '$prebid.version$'
     };
 
-    if (bidderRequest && bidderRequest.gdprConsent) {
-      if (bidderRequest.gdprConsent.consentString) {
-        payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+    if (bidderRequest) {
+      if (bidderRequest.refererInfo && bidderRequest.refererInfo.referer) {
+        payload.u = encodeURIComponent(bidderRequest.refererInfo.referer);
       }
-      payload.gdpr_applies =
-        (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean')
-          ? Number(bidderRequest.gdprConsent.gdprApplies) : 1;
+      if (bidderRequest.gdprConsent) {
+        if (bidderRequest.gdprConsent.consentString) {
+          payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+        }
+        payload.gdpr_applies =
+            (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean')
+              ? Number(bidderRequest.gdprConsent.gdprApplies) : 1;
+      }
     }
 
     return {

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -40,6 +40,12 @@ describe('VisxAdapter', function () {
   });
 
   describe('buildRequests', function () {
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'http://example.com'
+      }
+    };
+    const encodedReferrer = encodeURIComponent(bidderRequest.refererInfo.referer);
     let bidRequests = [
       {
         'bidder': 'visx',
@@ -77,10 +83,10 @@ describe('VisxAdapter', function () {
     ];
 
     it('should attach valid params to the tag', function () {
-      const request = spec.buildRequests([bidRequests[0]]);
+      const request = spec.buildRequests([bidRequests[0]], bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535');
       expect(payload).to.have.property('sizes', '300x250,300x600');
@@ -89,10 +95,10 @@ describe('VisxAdapter', function () {
     });
 
     it('sizes must not be duplicated', function () {
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
@@ -102,10 +108,10 @@ describe('VisxAdapter', function () {
 
     it('pt parameter must be "net" if params.priceType === "gross"', function () {
       bidRequests[1].params.priceType = 'gross';
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
@@ -115,10 +121,10 @@ describe('VisxAdapter', function () {
     });
     it('pt parameter must be "net" if params.priceType === "net"', function () {
       bidRequests[1].params.priceType = 'net';
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
@@ -129,10 +135,10 @@ describe('VisxAdapter', function () {
 
     it('pt parameter must be "net" if params.priceType === "undefined"', function () {
       bidRequests[1].params.priceType = 'undefined';
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
@@ -144,10 +150,10 @@ describe('VisxAdapter', function () {
     it('should add currency from currency.bidderCurrencyDefault', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? 'JPY' : 'USD');
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');
@@ -159,10 +165,10 @@ describe('VisxAdapter', function () {
     it('should add currency from currency.adServerCurrency', function () {
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.visx' ? '' : 'USD');
-      const request = spec.buildRequests(bidRequests);
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = request.data;
       expect(payload).to.be.an('object');
-      expect(payload).to.have.property('u').that.is.a('string');
+      expect(payload).to.have.property('u', encodedReferrer);
       expect(payload).to.have.property('pt', 'net');
       expect(payload).to.have.property('auids', '903535,903535,903536');
       expect(payload).to.have.property('sizes', '300x250,300x600,728x90');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Using url from refererInfo.referer instead of utils.getTopWindowUrl.
