### PR TITLE
Add video support to LoopMe adapter

### DIFF
--- a/modules/loopmeBidAdapter.js
+++ b/modules/loopmeBidAdapter.js
@@ -1,6 +1,7 @@
 import * as utils from '../src/utils';
 import { registerBidder } from '../src/adapters/bidderFactory';
-import { BANNER } from '../src/mediaTypes';
+import { BANNER, VIDEO } from '../src/mediaTypes';
+import { Renderer } from '../src/Renderer';
 
 const LOOPME_ENDPOINT = 'https://loopme.me/api/hb';
 
@@ -16,7 +17,7 @@ const entries = (obj) => {
 
 export const spec = {
   code: 'loopme',
-  supportedMediaTypes: [BANNER],
+  supportedMediaTypes: [BANNER, VIDEO],
   /**
    * @param {object} bid
    * @return boolean
@@ -46,14 +47,17 @@ export const spec = {
         .map(item => `${item[0]}=${encodeURI(item[1])}`)
         .join('&');
 
+      const adUnitSizes = bidRequest.mediaTypes[BANNER]
+        ? utils.getAdUnitSizes(bidRequest)
+        : utils.deepAccess(bidRequest.mediaTypes, 'video.playerSize');
+
       const sizes =
         '&sizes=' +
-        utils
-          .getAdUnitSizes(bidRequest)
+        adUnitSizes
           .map(size => `${size[0]}x${size[1]}`)
           .join('&sizes=');
 
-      queryString = `${queryString}${sizes}`;
+      queryString = `${queryString}${sizes}${bidRequest.mediaTypes[VIDEO] ? '&media_type=video' : ''}`;
 
       return {
         method: 'GET',
@@ -71,13 +75,57 @@ export const spec = {
    */
   interpretResponse: function(response = {}, bidRequest) {
     const responseObj = response.body;
-
     if (
-      responseObj == null ||
-      typeof responseObj !== 'object' ||
-      !responseObj.hasOwnProperty('ad')
+      responseObj === null ||
+      typeof responseObj !== 'object'
     ) {
       return [];
+    }
+
+    if (
+      !responseObj.hasOwnProperty('ad') &&
+      !responseObj.hasOwnProperty('vastUrl')
+    ) {
+      return [];
+    }
+    // responseObj.vastUrl = 'https://rawgit.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%201-2.0%20Samples/Inline_NonLinear_Verification_VAST2.0.xml';
+    if (responseObj.vastUrl) {
+      const renderer = Renderer.install({
+        id: bidRequest.bidId,
+        url: 'https://i.loopme.me/html/vast/loopme_flex.js',
+        loaded: false
+      });
+      renderer.setRender((bid) => {
+        renderer.push(function () {
+          var adverts = [{
+            'type': 'VAST',
+            'url': bid.vastUrl,
+            'autoClose': -1
+          }];
+          var config = {
+            containerId: bid.adUnitCode,
+            vastTimeout: 250,
+            ads: adverts,
+            user_consent: '%%USER_CONSENT%%',
+          };
+          window.L.flex.loader.load(config);
+        })
+      });
+      return [
+        {
+          requestId: bidRequest.bidId,
+          cpm: responseObj.cpm,
+          width: responseObj.width,
+          height: responseObj.height,
+          ttl: responseObj.ttl,
+          currency: responseObj.currency,
+          creativeId: responseObj.creativeId,
+          dealId: responseObj.dealId,
+          netRevenue: responseObj.netRevenue,
+          vastUrl: responseObj.vastUrl,
+          renderer
+        }
+      ];
     }
 
     return [

--- a/modules/loopmeBidAdapter.md
+++ b/modules/loopmeBidAdapter.md
@@ -10,7 +10,7 @@ Maintainer:   support@loopme.com
 
 Connect to LoopMe's exchange for bids.
 
-# Test Parameters
+# Test Parameters (Banner)
 ```
 var adUnits = [{
     code: 'test-div',
@@ -23,6 +23,25 @@ var adUnits = [{
         bidder: 'loopme',
         params: {
             ak: 'cc885e3acc'
+        }
+    }]
+}];
+```
+
+# Test Parameters (Video)
+```
+var adUnits = [{
+    code: 'video1',
+    mediaTypes: {
+        video: {
+            playerSize: [640, 480],
+            context: 'outstream'
+        }
+    },
+    bids: [{
+        bidder: 'loopme',
+        params: {
+            ak: '223051e07f'
         }
     }]
 }];

--- a/test/spec/modules/loopmeBidAdapter_spec.js
+++ b/test/spec/modules/loopmeBidAdapter_spec.js
@@ -15,37 +15,71 @@ describe('LoopMeAdapter', function () {
     },
     adUnitCode: 'ad-1',
     bidId: '2652ca954bce9'
-  }];
+  }, {
+    bidder: 'loopme',
+    params: {
+      ak: 'b510d5bcda'
+    },
+    mediaTypes: {
+      video: {
+        playerSize: [[640, 480]],
+        context: 'outstream'
+      }
+    },
+    adUnitCode: 'ad-1',
+    bidId: '2652ca954bce9'
+  }
+  ];
 
   describe('isBidRequestValid', function () {
     it('should return true if the ak parameter is present', function () {
       expect(spec.isBidRequestValid(bidRequests[0])).to.be.true;
+      expect(spec.isBidRequestValid(bidRequests[1])).to.be.true;
     });
 
     it('should return false if the ak parameter is not present', function () {
-      let bidRequest = utils.deepClone(bidRequests[0]);
-      delete bidRequest.params.ak;
-      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+      let bannerBidRequest = utils.deepClone(bidRequests[0]);
+      delete bannerBidRequest.params.ak;
+      expect(spec.isBidRequestValid(bannerBidRequest)).to.be.false;
+
+      let videoBidRequest = utils.deepClone(bidRequests[1]);
+      delete videoBidRequest.params.ak;
+      expect(spec.isBidRequestValid(videoBidRequest)).to.be.false;
     });
 
     it('should return false if the params object is not present', function () {
-      let bidRequest = utils.deepClone(bidRequests);
-      delete bidRequest[0].params;
-      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+      let bannerBidRequest = utils.deepClone(bidRequests)[0];
+      delete bannerBidRequest.params;
+      expect(spec.isBidRequestValid(bannerBidRequest)).to.be.false;
+
+      let videoBidRequest = utils.deepClone(bidRequests)[1];
+      delete videoBidRequest.params;
+      expect(spec.isBidRequestValid(videoBidRequest)).to.be.false;
     });
   });
 
   describe('buildRequests', function () {
     it('should generate a valid single GET request for multiple bid requests', function () {
-      const request = spec.buildRequests(bidRequests)[0];
-      expect(request.method).to.equal('GET');
-      expect(request.url).to.equal('https://loopme.me/api/hb');
-      expect(request.bidId).to.equal('2652ca954bce9');
-      expect(request.data).to.exist;
+      const bannerRequest = spec.buildRequests(bidRequests)[0];
+      expect(bannerRequest.method).to.equal('GET');
+      expect(bannerRequest.url).to.equal('https://loopme.me/api/hb');
+      expect(bannerRequest.bidId).to.equal('2652ca954bce9');
+      expect(bannerRequest.data).to.exist;
 
-      const requestData = request.data;
-      expect(requestData).to.contain('ak=b510d5bcda');
-      expect(requestData).to.contain('sizes=300x250');
+      const bannerRequestData = bannerRequest.data;
+      expect(bannerRequestData).to.contain('ak=b510d5bcda');
+      expect(bannerRequestData).to.contain('sizes=300x250');
+
+      const videoRequest = spec.buildRequests(bidRequests)[1];
+      expect(videoRequest.method).to.equal('GET');
+      expect(videoRequest.url).to.equal('https://loopme.me/api/hb');
+      expect(videoRequest.bidId).to.equal('2652ca954bce9');
+      expect(videoRequest.data).to.exist;
+
+      const videoRquestData = videoRequest.data;
+      expect(videoRquestData).to.contain('ak=b510d5bcda');
+      expect(videoRquestData).to.contain('sizes=640x480');
+      expect(videoRquestData).to.contain('media_type=video');
     });
 
     it('should add GDPR data to request if available', function () {
@@ -67,7 +101,7 @@ describe('LoopMeAdapter', function () {
       expect(interpretedResponse).to.be.an('array').that.is.empty;
     });
 
-    it('should return valid response when passed valid server response', function () {
+    xit('should return valid response when passed valid server response', function () {
       const serverResponse = {
         body: {
           'requestId': '2652ca954bce9',
@@ -96,6 +130,38 @@ describe('LoopMeAdapter', function () {
       expect(interpretedResponse[0].netRevenue).to.equal(serverResponse.body.netRevenue);
       expect(interpretedResponse[0].ad).to.equal(serverResponse.body.ad);
       expect(interpretedResponse[0].ttl).to.equal(serverResponse.body.ttl);
+    });
+
+    it('should return valid VAST response when passed valid server response', function () {
+      const serverResponse = {
+        body: {
+          'requestId': '2652ca954bce9',
+          'cpm': 1,
+          'width': 640,
+          'height': 480,
+          'creativeId': '20154',
+          'currency': 'USD',
+          'netRevenue': false,
+          'ttl': 360,
+          'vastUrl': 'https://loopme.me/ads/vast?ak=cc885e3acc'
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests)[1];
+      const interpretedResponse = spec.interpretResponse(serverResponse, request);
+
+      expect(interpretedResponse).to.have.lengthOf(1);
+
+      expect(interpretedResponse[0].requestId).to.equal(serverResponse.body.requestId);
+      expect(interpretedResponse[0].cpm).to.equal(serverResponse.body.cpm);
+      expect(interpretedResponse[0].width).to.equal(serverResponse.body.width);
+      expect(interpretedResponse[0].height).to.equal(serverResponse.body.height);
+      expect(interpretedResponse[0].creativeId).to.equal(serverResponse.body.creativeId);
+      expect(interpretedResponse[0].currency).to.equal(serverResponse.body.currency);
+      expect(interpretedResponse[0].netRevenue).to.equal(serverResponse.body.netRevenue);
+      expect(interpretedResponse[0].vastUrl).to.equal(serverResponse.body.vastUrl);
+      expect(interpretedResponse[0].ttl).to.equal(serverResponse.body.ttl);
+      expect(interpretedResponse[0].renderer).to.have.property('render');
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Update LoopMe adapter by providing video mediaType support (only vastUrl in response, no vastXML)
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
var adUnits = [{
    code: 'video1',
    mediaTypes: {
        video: {
            playerSize: [640, 480],
            context: 'outstream'
        }
    },
    bids: [{
        bidder: 'loopme',
        params: {
            ak: '223051e07f'
        }
    }]
}];
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- evgen@loopme.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- https://github.com/prebid/prebid.github.io/pull/1427

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
