### PR TITLE
consolidate logic around common chunk inclusions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,5 @@
 
-const sharedWhiteList = [
-  "core-js/library/fn/array/find", // no ie11
-  "core-js/library/fn/array/includes", // no ie11
-  "core-js/library/fn/set", // ie11 supports Set but not Set#values
-  "core-js/library/fn/string/includes", // no ie11
-  "core-js/library/fn/number/is-integer", // no ie11,
-  "core-js/library/fn/array/from" // no ie11
-];
+const allowedModules = require("./allowedModules");
 
 module.exports = {
   "env": {
@@ -45,25 +38,10 @@ module.exports = {
     "no-undef": "off",
     "no-useless-escape": "off",
   },
-  "overrides": [{
-    "files": "modules/**/*.js",
+  "overrides": Object.keys(allowedModules).map((key) => ({
+    "files": key + "/**/*.js",
     "rules": {
-      "prebid/validate-imports": ["error", [
-        ...sharedWhiteList,
-        "jsencrypt",
-        "crypto-js"
-      ]]
+      "prebid/validate-imports": ["error", allowedModules[key]]
     }
-  }, {
-    "files": "src/**/*.js",
-    "rules": {
-      "prebid/validate-imports": ["error", [
-        ...sharedWhiteList,
-        "fun-hooks/no-eval",
-        "just-clone",
-        "dlv",
-        "dset"
-      ]]
-    }
-  }]
+  }))
 };

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -1,0 +1,24 @@
+
+const sharedWhiteList = [
+  "core-js/library/fn/array/find", // no ie11
+  "core-js/library/fn/array/includes", // no ie11
+  "core-js/library/fn/set", // ie11 supports Set but not Set#values
+  "core-js/library/fn/string/includes", // no ie11
+  "core-js/library/fn/number/is-integer", // no ie11,
+  "core-js/library/fn/array/from" // no ie11
+];
+
+module.exports = {
+  'modules': [
+    ...sharedWhiteList,
+    'jsencrypt',
+    'crypto-js'
+  ],
+  'src': [
+    ...sharedWhiteList,
+    'fun-hooks/no-eval',
+    'just-clone',
+    'dlv',
+    'dset'
+  ]
+};

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -5,6 +5,7 @@ var helpers = require('./gulpHelpers');
 var RequireEnsureWithoutJsonp = require('./plugins/RequireEnsureWithoutJsonp.js');
 var { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 var argv = require('yargs').argv;
+var allowedModules = require('./allowedModules');
 
 // list of module names to never include in the common bundle chunk
 var neverBundle = [
@@ -26,12 +27,14 @@ plugins.push(  // this plugin must be last so it can be easily removed for karma
     name: 'prebid',
     filename: 'prebid-core.js',
     minChunks: function(module) {
-      return (
+       return (
         (
-          module.context && module.context === path.resolve('./src') &&
+          module.context && module.context.startsWith(path.resolve('./src')) &&
           !(module.resource && neverBundle.some(name => module.resource.includes(name)))
         ) ||
-        module.resource && module.resource.includes(path.resolve('./node_modules/core-js'))
+        module.resource && (allowedModules.src.concat(['core-js'])).some(
+          name => module.resource.includes(path.resolve('./node_modules/' + name))
+        )
       );
     }
   })


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fix the logic around common chunk inclusion code. It seems it was mostly working correctly (according to `--analyze`) but the logic was a bit incorrect, this update makes it more explicit and shares the logic with the linter.