### PR TITLE
Enable withCredentials on Unified ID ajax call

### DIFF
--- a/modules/userId/unifiedIdSystem.js
+++ b/modules/userId/unifiedIdSystem.js
@@ -49,7 +49,7 @@ export const unifiedIdSubmodule = {
           }
         }
         callback(responseObj);
-      }, undefined, { method: 'GET' });
+      }, undefined, { method: 'GET', withCredentials: true });
     }
   }
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The change in this PR is to enable withCredentials = true in the Ajax request that is made to the Unified ID system in the User ID module. This setting needs to be enabled so that cookies are correctly sent to the endpoint and so that cookies are able to be set when the endpoint responds with Set-Cookie headers.
Reference: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials


<!-- For new bidder adapters, please provide the following -->
- contact email - minh.daole@thetradedesk.com