### PR TITLE
Update comment in config.js file, since we're out of the Deprecation phase.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,5 @@
 /*
  * Module for getting and setting Prebid configuration.
- *
- * Prebid previously defined these properties directly on the global object:
- * pbjs.logging = true;
- *
- * Defining and access properties in this way is now deprecated, but these will
- * continue to work during a deprecation window.
  */
 import { isValidPriceConfig } from './cpmBucketManager';
 import find from 'core-js/library/fn/array/find';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
Have updated a comment which says we're still supporting a workflow where you can directly define and access properties on the `pbjs` global object. Since the Deprecation period is over, this comment seems no longer necessary. 