### PR TITLE
update outstream prod url

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -6,7 +6,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes';
 const BIDDER_CODE = 'grid';
 const ENDPOINT_URL = '//grid.bidswitch.net/hb';
 const TIME_TO_LIVE = 360;
-const RENDERER_URL = '//cdn.adnxs.com/renderer/video/ANOutstreamVideo.js';
+const RENDERER_URL = '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
 
 const LOG_ERROR_MESS = {
   noAuid: 'Bid from response has no auid parameter - ',

--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -7,7 +7,7 @@ const BIDDER_CODE = 'trustx';
 const ENDPOINT_URL = '//sofia.trustx.org/hb';
 const TIME_TO_LIVE = 360;
 const ADAPTER_SYNC_URL = '//sofia.trustx.org/push_sync';
-const RENDERER_URL = '//cdn.adnxs.com/renderer/video/ANOutstreamVideo.js';
+const RENDERER_URL = '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
 
 const LOG_ERROR_MESS = {
   noAuid: 'Bid from response has no auid parameter - ',

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -144,7 +144,7 @@ const OUTSTREAM_VIDEO_REQUEST = {
         }
       ],
       renderer: {
-        url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+        url: 'http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
         render: function (bid) {
           ANOutstreamVideo.renderAd({
             targetId: bid.adUnitCode,

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -735,12 +735,12 @@ describe('TrustXAdapter', function () {
     expect(spyRendererInstall.calledTwice).to.equal(true);
     expect(spyRendererInstall.getCall(0).args[0]).to.deep.equal({
       id: 'e6e65553fc8',
-      url: '//cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+      url: '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
       loaded: false
     });
     expect(spyRendererInstall.getCall(1).args[0]).to.deep.equal({
       id: 'c8fdcb3f269f',
-      url: '//cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+      url: '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
       loaded: false
     });
 

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -114,7 +114,7 @@ describe('Renderer', function () {
       $$PREBID_GLOBAL$$.adUnits = [{
         code: 'video1',
         renderer: {
-          url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+          url: 'http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
           render: sinon.spy()
         }
       }]


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)


## Description of change
Update outsteram production url throughout prebid.js

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
   var adUnits = [
           {
               code: 'test-div',
               sizes: [[640, 360]],
               mediaTypes: { video: {playerSize: [640, 480],
                       context: 'outstream',
                       mimes: ['video/mp4']} },
               bids: [
                   {
                       bidder: "trustx",
                       params: {
                           uid: 7697
                       }
                   }
               ]
           }
       ];
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/