### PR TITLE
WIP - S2s testing disable client side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ build/coverage/
 .idea/
 # if you remove the above rule, at least ignore the following:
 
+# VS Code
+.vscode/
+
 # User-specific stuff:
 # .idea/workspace.xml
 # .idea/tasks.xml

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -180,6 +180,10 @@ adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTi
     // these are called on the s2s adapter
     let adaptersServerSide = _s2sConfig.bidders;
 
+    if (adaptersServerSide.length > 0 && isTestingServerOnly()) {
+      clientTestAdapters.length = 0;
+    }
+
     // don't call these client side (unless client request is needed for testing)
     clientBidderCodes = bidderCodes.filter((elm) => {
       return !includes(adaptersServerSide, elm) || includes(clientTestAdapters, elm);
@@ -330,6 +334,10 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
 function doingS2STesting() {
   return _s2sConfig && _s2sConfig.enabled && _s2sConfig.testing && s2sTestingModule;
 }
+
+function isTestingServerOnly() {
+  return Boolean(doingS2STesting() && _s2sConfig.testServerOnly);
+};
 
 function getSupportedMediaTypes(bidderCode) {
   let result = [];

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1142,5 +1142,16 @@ describe('adapterManager tests', function () {
         expect(bidRequests[0].gdprConsent).to.be.undefined;
       });
     });
+
+    describe('s2sTesting testServerOnly', () => {
+      let stubGetSourceBidderMap;
+      beforeEach(() => {
+        stubGetSourceBidderMap = sinon.stub(s2sTesting, 'getSourceBidderMap');
+      });
+
+      afterEach(() => {
+        s2sTesting.getSourceBidderMap.restore();
+      });
+    });
   });
 });


### PR DESCRIPTION
# WIP - DO NOT MERGE

## Type of change
- [ ] Feature
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Added a new `s2sConfig` config flag: `testServerOnly`. This will allow publishers to disable clientside bids should an adUnit resolve to using a server to get bids.

## Other information
#3853 
