### PR TITLE
add logic to prefer prebid modules over external modules in build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:8.9.0
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports = {
 }
 ```
 
-Or for Babel 6 and/or Node v8.6.0 and less:
+Or for Babel 6:
 ```javascript
             // you must manually install and specify the presets and plugins yourself
             options: {
@@ -112,7 +112,7 @@ prebid.requestBids({
     $ cd Prebid.js
     $ npm install
 
-*Note:* You need to have `NodeJS` 6.x or greater installed.
+*Note:* You need to have `NodeJS` 8.9.x or greater installed.
 
 *Note:* In the 1.24.0 release of Prebid.js we have transitioned to using gulp 4.0 from using gulp 3.9.1.  To compily with gulp's recommended setup for 4.0, you'll need to have `gulp-cli` installed globally prior to running the general `npm install`.  This shouldn't impact any other projects you may work on that use an earlier version of gulp in it's setup.
 

--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -91,11 +91,11 @@ module.exports = {
     }
     return Object.assign(externalModules.reduce((memo, module) => {
       try {
-        var modulePath = require.resolve(module);
-        // only include modules from our project.  This is in case a dependency shares one of our module's name (like express).
-        if (modulePath.indexOf('/modules/') !== -1) {
-          memo[modulePath] = module;
-        }
+        // prefer internal project modules before looking at project dependencies
+        var modulePath = require.resolve(module, {paths: ['./modules']});
+        if (modulePath === '') modulePath = require.resolve(module);
+
+        memo[modulePath] = module;
       } catch (err) {
         // do something
       }

--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -92,7 +92,10 @@ module.exports = {
     return Object.assign(externalModules.reduce((memo, module) => {
       try {
         var modulePath = require.resolve(module);
-        memo[modulePath] = module;
+        // only include modules from our project.  This is in case a dependency shares one of our module's name (like express).
+        if (modulePath.indexOf('/modules/') !== -1) {
+          memo[modulePath] = module;
+        }
       } catch (err) {
         // do something
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "the prebid.js contributors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=8.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes #4120

This PR fixes the build problem with the Prebid.js `express` module reported in the above issue.

The issue only occurred when you specifically included `express` with the `modules` parameter in a build command (eg `gulp build --modules=express`) and because the module shared a name with one of the project's nested dependencies.  

Basically this line [here](https://github.com/prebid/Prebid.js/blob/master/gulpHelpers.js#L94) recognized the `express` module in the `node_modules` folder and included that path when the overall function was compiling the list of module paths to include for the build.  When this path was added to the build process, it had issues trying to find its dependent packages since they were installed in the wrong locations (if we were actually using the package `express` directly in the project).

By adding a check to only include modules that belong to our project, it avoids adding that other file path and allows the build to proceed as normal.