### PR TITLE
YIELDONE adapter - change urls to adapt https

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -5,9 +5,9 @@ import { Renderer } from '../src/Renderer';
 import { BANNER, VIDEO } from '../src/mediaTypes';
 
 const BIDDER_CODE = 'yieldone';
-const ENDPOINT_URL = '//y.one.impact-ad.jp/h_bid';
-const USER_SYNC_URL = '//y.one.impact-ad.jp/push_sync';
-const VIDEO_PLAYER_URL = '//img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
+const ENDPOINT_URL = 'https://y.one.impact-ad.jp/h_bid';
+const USER_SYNC_URL = 'https://y.one.impact-ad.jp/push_sync';
+const VIDEO_PLAYER_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { spec } from 'modules/yieldoneBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-const ENDPOINT = '//y.one.impact-ad.jp/h_bid';
-const USER_SYNC_URL = '//y.one.impact-ad.jp/push_sync';
-const VIDEO_PLAYER_URL = '//img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
+const ENDPOINT = 'https://y.one.impact-ad.jp/h_bid';
+const USER_SYNC_URL = 'https://y.one.impact-ad.jp/push_sync';
+const VIDEO_PLAYER_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 
 describe('yieldoneBidAdapter', function() {
   const adapter = newBidder(spec);
@@ -100,7 +100,7 @@ describe('yieldoneBidAdapter', function() {
     let bidRequestBanner = [
       {
         'method': 'GET',
-        'url': '//y.one.impact-ad.jp/h_bid',
+        'url': 'https://y.one.impact-ad.jp/h_bid',
         'data': {
           'v': 'hb1',
           'p': '36891',
@@ -164,7 +164,7 @@ describe('yieldoneBidAdapter', function() {
     let bidRequestVideo = [
       {
         'method': 'GET',
-        'url': '//y.one.impact-ad.jp/h_bid',
+        'url': 'https://y.one.impact-ad.jp/h_bid',
         'data': {
           'v': 'hb1',
           'p': '41993',


### PR DESCRIPTION

## Type of change

- [x] Other

## Description of change
- Modified to use only secure requests

contact email of the adapter’s maintainer y1dev@platform-one.co.jp


- [x] official adapter submission
