### PR TITLE
Quantcast: Fix for empty video parameters

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -34,7 +34,21 @@ function extractBidSizes(bid) {
 }
 
 function makeVideoImp(bid) {
-  const video = bid.params.video;
+  const video = {};
+  if (bid.params.video) {
+    video['mimes'] = bid.params.video.mimes;
+    video['minduration'] = bid.params.video.minduration;
+    video['maxduration'] = bid.params.video.maxduration;
+    video['protocols'] = bid.params.video.protocols;
+    video['startdelay'] = bid.params.video.startdelay;
+    video['linearity'] = bid.params.video.linearity;
+    video['battr'] = bid.params.video.battr;
+    video['maxbitrate'] = bid.params.video.maxbitrate;
+    video['playbackmethod'] = bid.params.video.playbackmethod;
+    video['delivery'] = bid.params.video.delivery;
+    video['placement'] = bid.params.video.placement;
+    video['api'] = bid.params.video.api;
+  }
   if (utils.isArray(bid.mediaTypes.video.playerSize[0])) {
     video['w'] = bid.mediaTypes.video.playerSize[0][0];
     video['h'] = bid.mediaTypes.video.playerSize[0][1];

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -49,6 +49,9 @@ function makeVideoImp(bid) {
     video['placement'] = bid.params.video.placement;
     video['api'] = bid.params.video.api;
   }
+  if (bid.mediaTypes.video.mimes) {
+    video['mimes'] = bid.mediaTypes.video.mimes;
+  }
   if (utils.isArray(bid.mediaTypes.video.playerSize[0])) {
     video['w'] = bid.mediaTypes.video.playerSize[0][0];
     video['h'] = bid.mediaTypes.video.playerSize[0][1];

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -203,6 +203,40 @@ describe('Quantcast adapter', function () {
       expect(requests[0].data).to.equal(JSON.stringify(expectedVideoBidRequest));
     });
 
+    it('overrides video parameters with parameters from adunit', function() {
+      setupVideoBidRequest({
+        mimes: ['video/mp4']
+      });
+      bidRequest.mediaTypes.video.mimes = ['video/webm'];
+
+      const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+      const expectedVideoBidRequest = {
+        publisherId: QUANTCAST_TEST_PUBLISHER,
+        requestId: '2f7b179d443f14',
+        imp: [
+          {
+            video: {
+              mimes: ['video/webm'],
+              w: 600,
+              h: 300
+            },
+            placementCode: 'div-gpt-ad-1438287399331-0',
+            bidFloor: 1e-10
+          }
+        ],
+        site: {
+          page: 'http://example.com/hello.html',
+          referrer: 'http://example.com/hello.html',
+          domain: 'example.com'
+        },
+        bidId: '2f7b179d443f14',
+        gdprSignal: 0,
+        prebidJsVersion: '$prebid.version$'
+      };
+
+      expect(requests[0].data).to.equal(JSON.stringify(expectedVideoBidRequest));
+    });
+
     it('sends video bid request when no video parameters are given', function () {
       setupVideoBidRequest(null);
 

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -39,24 +39,11 @@ describe('Quantcast adapter', function () {
     };
   });
 
-  function setupVideoBidRequest() {
+  function setupVideoBidRequest(videoParams) {
     bidRequest.params = {
       publisherId: 'test-publisher', // REQUIRED - Publisher ID provided by Quantcast
       // Video object as specified in OpenRTB 2.5
-      video: {
-        mimes: ['video/mp4'], // required
-        minduration: 3, // optional
-        maxduration: 5, // optional
-        protocols: [3], // optional
-        startdelay: 1, // optional
-        linearity: 1, // optinal
-        battr: [1, 2], // optional
-        maxbitrate: 10, // optional
-        playbackmethod: [1], // optional
-        delivery: [1], // optional
-        placement: 1, // optional
-        api: [2, 3] // optional
-      }
+      video: videoParams
     };
     bidRequest['mediaTypes'] = {
       video: {
@@ -162,7 +149,20 @@ describe('Quantcast adapter', function () {
     });
 
     it('sends video bid requests containing all the required parameters', function () {
-      setupVideoBidRequest();
+      setupVideoBidRequest({
+        mimes: ['video/mp4'], // required
+        minduration: 3, // optional
+        maxduration: 5, // optional
+        protocols: [3], // optional
+        startdelay: 1, // optional
+        linearity: 1, // optinal
+        battr: [1, 2], // optional
+        maxbitrate: 10, // optional
+        playbackmethod: [1], // optional
+        delivery: [1], // optional
+        placement: 1, // optional
+        api: [2, 3] // optional
+      });
 
       const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
       const expectedVideoBidRequest = {
@@ -183,6 +183,36 @@ describe('Quantcast adapter', function () {
               delivery: [1],
               placement: 1,
               api: [2, 3],
+              w: 600,
+              h: 300
+            },
+            placementCode: 'div-gpt-ad-1438287399331-0',
+            bidFloor: 1e-10
+          }
+        ],
+        site: {
+          page: 'http://example.com/hello.html',
+          referrer: 'http://example.com/hello.html',
+          domain: 'example.com'
+        },
+        bidId: '2f7b179d443f14',
+        gdprSignal: 0,
+        prebidJsVersion: '$prebid.version$'
+      };
+
+      expect(requests[0].data).to.equal(JSON.stringify(expectedVideoBidRequest));
+    });
+
+    it('sends video bid request when no video parameters are given', function () {
+      setupVideoBidRequest(null);
+
+      const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+      const expectedVideoBidRequest = {
+        publisherId: QUANTCAST_TEST_PUBLISHER,
+        requestId: '2f7b179d443f14',
+        imp: [
+          {
+            video: {
               w: 600,
               h: 300
             },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Copy values from video parameters object, rather than using object directly. Also check if the object is missing.
