### PR TITLE
appnexusBidAdapter - fix outstream bid property

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -482,7 +482,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     Object.assign(bid, {
       width: rtbBid.rtb.video.player_width,
       height: rtbBid.rtb.video.player_height,
-      vastUrl: rtbBid.rtb.video.asset_url,
+      vastXml: rtbBid.rtb.video.content,
       vastImpUrl: rtbBid.notify_url,
       ttl: 3600
     });

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -760,7 +760,7 @@ describe('AppNexusAdapter', function () {
       }
 
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
-      expect(result[0]).to.have.property('vastUrl');
+      expect(result[0]).to.have.property('vastXml');
       expect(result[0]).to.have.property('vastImpUrl');
       expect(result[0]).to.have.property('mediaType', 'video');
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes #3364

At some point, the appnexus outstream bid response changed from providing a vastUrl (in the `asset_url` property) to providing the raw vastXml (in the `content`) property.

As highlighted within the above issue, the `appnexusBidAdapter` didn't make the corresponding update to set the ideal value in the prebid bidResponse object - so nothing was being set in the bid's normal vast fields.  

This PR corrects this issue by setting the proper vast field in the bid and reading from the correct source in the raw bid response.


Side Note - it seems the AppNexus Outstream Renderer doesn't explicitly rely on the `bid.vastUrl` or `bid.vastXml` fields to render the outstream bid.  

The AN Renderer seems to read the vast XML from the unique `bid.adResponse` field (which is made in the adapter code); the field is itself a copy of the raw bid response object.  This is why despite this issue, the outstream bids were still rendering.