### PR TITLE
Rubicon Video COPPA fix

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -237,7 +237,7 @@ export const spec = {
       }
 
       if (config.getConfig('coppa') === true) {
-        utils.deepSetValue(request, 'regs.coppa', 1);
+        utils.deepSetValue(data, 'regs.coppa', 1);
       }
 
       return {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1356,6 +1356,24 @@ describe('the rubicon adapter', function () {
           expect(requests.length).to.equal(1);
           expect(requests[0].url).to.equal(FASTLANE_ENDPOINT);
         });
+
+        it('should include coppa flag in video bid request', () => {
+          createVideoBidderRequest();
+
+          sandbox.stub(Date, 'now').callsFake(() =>
+            bidderRequest.auctionStart + 100
+          );
+
+          sandbox.stub(config, 'getConfig').callsFake(key => {
+            const config = {
+              'coppa': true
+            };
+            return config[key];
+          });
+
+          const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+          expect(request.data.regs.coppa).to.equal(1);
+        });
       });
 
       describe('combineSlotUrlParams', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
It looks like there is a bug in a Rubicon adapter - when setting coppa flag, the current implementation tries to do that on a non-defined `request` object, instead of `data`, which seems to be the right place for it.
Feels like the problem line was just copy-pasted from https://github.com/rubicon-project/Prebid.js/blob/4f16865157caca46b7e024d81202419517835451/modules/prebidServerBidAdapter/index.js#L575