### PR TITLE
update gulp-footer package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-connect": "^5.7.0",
     "gulp-eslint": "^4.0.0",
-    "gulp-footer": "github:prebid/gulp-footer#master",
+    "gulp-footer": "^2.0.2",
     "gulp-header": "^1.7.1",
     "gulp-if": "^2.0.2",
     "gulp-js-escape": "^1.0.1",


### PR DESCRIPTION
## Type of change
- [x] Build related changes


## Description of change
Upon recent review, determined that the latest version of `gulp-footer` package is no longer using vulnerable dependency.  So we can now switch back to the main package instead of using a forked version.

## Other information
See PR #3343 and issue #3330 for details on the original change.

