### PR TITLE
Update LockerDome adUnitId bid param

### DIFF
--- a/modules/lockerdomeBidAdapter.md
+++ b/modules/lockerdomeBidAdapter.md
@@ -22,7 +22,7 @@ var adUnits = [{
     bids: [{
         bidder: 'lockerdome',
         params: {
-            adUnitId: 10809467961050726
+            adUnitId: 'LD10809467961050726'
         }
     }]
 }];

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -6,7 +6,7 @@ describe('LockerDomeAdapter', function () {
   const bidRequests = [{
     bidder: 'lockerdome',
     params: {
-      adUnitId: 10809467961050726
+      adUnitId: 'LD10809467961050726'
     },
     mediaTypes: {
       banner: {
@@ -22,7 +22,7 @@ describe('LockerDomeAdapter', function () {
   }, {
     bidder: 'lockerdome',
     params: {
-      adUnitId: 9434769725128806
+      adUnitId: 'LD9434769725128806'
     },
     mediaTypes: {
       banner: {
@@ -66,14 +66,14 @@ describe('LockerDomeAdapter', function () {
 
       expect(bids[0].requestId).to.equal('2652ca954bce9');
       expect(bids[0].adUnitCode).to.equal('ad-1');
-      expect(bids[0].adUnitId).to.equal(10809467961050726);
+      expect(bids[0].adUnitId).to.equal('LD10809467961050726');
       expect(bids[0].sizes).to.have.lengthOf(1);
       expect(bids[0].sizes[0][0]).to.equal(300);
       expect(bids[0].sizes[0][1]).to.equal(250);
 
       expect(bids[1].requestId).to.equal('4510f2834773ce');
       expect(bids[1].adUnitCode).to.equal('ad-2');
-      expect(bids[1].adUnitId).to.equal(9434769725128806);
+      expect(bids[1].adUnitId).to.equal('LD9434769725128806');
       expect(bids[1].sizes).to.have.lengthOf(1);
       expect(bids[1].sizes[0][0]).to.equal(300);
       expect(bids[1].sizes[0][1]).to.equal(600);


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Other

## Description of change
Updated LockerDome adUnitId bid param information to reflect our latest adUnitId format. This is not a breaking change.

## Other information
Accompanying change in prebid.github.io: https://github.com/prebid/prebid.github.io/pull/1475
