### PR TITLE
myTargetBidAdapter: support currency config

### DIFF
--- a/modules/mytargetBidAdapter.js
+++ b/modules/mytargetBidAdapter.js
@@ -35,6 +35,12 @@ function getSiteName(referrer) {
   return sitename;
 }
 
+function getCurrency() {
+  let currency = config.getConfig('currency.adServerCurrency');
+
+  return (currency === 'USD') ? currency : DEFAULT_CURRENCY;
+}
+
 function generateRandomId() {
   return Math.random().toString(16).substring(2);
 }
@@ -60,7 +66,7 @@ export const spec = {
         page: referrer
       },
       settings: {
-        currency: DEFAULT_CURRENCY,
+        currency: getCurrency(),
         windowSize: {
           width: window.screen.width,
           height: window.screen.height

--- a/test/spec/modules/mytargetBidAdapter_spec.js
+++ b/test/spec/modules/mytargetBidAdapter_spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { config } from 'src/config';
 import { spec } from 'modules/mytargetBidAdapter';
 
 describe('MyTarget Adapter', function() {
@@ -113,6 +114,35 @@ describe('MyTarget Adapter', function() {
       expect(settings.windowSize).to.be.an('object');
       expect(settings.windowSize.width).to.equal(window.screen.width);
       expect(settings.windowSize.height).to.equal(window.screen.height);
+    });
+
+    it('should pass currency from currency.adServerCurrency', function() {
+      const configStub = sinon.stub(config, 'getConfig').callsFake(
+        key => key === 'currency.adServerCurrency' ? 'USD' : '');
+
+      let bidRequest = spec.buildRequests(bidRequests, bidderRequest);
+      let settings = bidRequest.data.settings;
+
+      expect(settings).to.be.an('object');
+      expect(settings.currency).to.equal('USD');
+      expect(settings.windowSize).to.be.an('object');
+      expect(settings.windowSize.width).to.equal(window.screen.width);
+      expect(settings.windowSize.height).to.equal(window.screen.height);
+
+      configStub.restore();
+    });
+
+    it('should ignore currency other than "RUB" or "USD"', function() {
+      const configStub = sinon.stub(config, 'getConfig').callsFake(
+        key => key === 'currency.adServerCurrency' ? 'EUR' : '');
+
+      let bidRequest = spec.buildRequests(bidRequests, bidderRequest);
+      let settings = bidRequest.data.settings;
+
+      expect(settings).to.be.an('object');
+      expect(settings.currency).to.equal('RUB');
+
+      configStub.restore();
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Pass currency value from the global config. Supports only 'USD' or 'RUB' (default).

- contact email of the adapter’s maintainer
support_target@corp.my.com
- [x] official adapter submission