### PR TITLE
OpenX Adapter: Added support for schain non-rtb payload

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -101,6 +101,10 @@ export const spec = {
       payload.digkeyv = digitrust.keyv;
     }
 
+    if (validBidRequests[0].schain) {
+      payload.schain = JSON.stringify(validBidRequests[0].schain)
+    }
+
     // If there is no key_maker data, then don't make the request.
     if (isEmpty(data)) {
       return null;

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -109,6 +109,22 @@ describe('SonobiBidAdapter', function () {
       userSync.canBidderRegisterSync.restore();
     });
     let bidRequest = [{
+      'schain': {
+        'ver': '1.0',
+        'complete': 1,
+        'nodes': [
+          {
+            'asi': 'indirectseller.com',
+            'sid': '00001',
+            'hp': 1
+          },
+          {
+            'asi': 'indirectseller-2.com',
+            'sid': '00002',
+            'hp': 0
+          },
+        ]
+      },
       'bidder': 'sonobi',
       'params': {
         'placement_id': '1a2b3c4d5e6f1a2b3c4d',
@@ -350,6 +366,11 @@ describe('SonobiBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.ius).to.equal(1);
     });
+
+    it('should return a properly formatted request with schain defined', function () {
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(JSON.parse(bidRequests.data.schain)).to.deep.equal(bidRequest[0].schain)
+    })
   })
 
   describe('.interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Added support for supply chain based on https://github.com/prebid/Prebid.js/pull/4084 using a serialized [non-rtb payload](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md#supplychain-for-non-openrtb-requests)

Please let me know if this should be moved into a utility function instead.