### PR TITLE
Sonobi - send entire userid payload

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -104,9 +104,7 @@ export const spec = {
     if (validBidRequests[0].schain) {
       payload.schain = JSON.stringify(validBidRequests[0].schain)
     }
-
-    console.log(validBidRequests)
-
+    
     if (deepAccess(validBidRequests[0], 'userId') && Object.keys(validBidRequests[0].userId).length > 0) {
       payload.userid = JSON.stringify(validBidRequests[0].userId);
     }

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -105,6 +105,12 @@ export const spec = {
       payload.schain = JSON.stringify(validBidRequests[0].schain)
     }
 
+    console.log(validBidRequests)
+
+    if (deepAccess(validBidRequests[0], 'userId') && Object.keys(validBidRequests[0].userId).length > 0) {
+      payload.userid = JSON.stringify(validBidRequests[0].userId);
+    }
+
     // If there is no key_maker data, then don't make the request.
     if (isEmpty(data)) {
       return null;

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -104,7 +104,6 @@ export const spec = {
     if (validBidRequests[0].schain) {
       payload.schain = JSON.stringify(validBidRequests[0].schain)
     }
-    
     if (deepAccess(validBidRequests[0], 'userId') && Object.keys(validBidRequests[0].userId).length > 0) {
       payload.userid = JSON.stringify(validBidRequests[0].userId);
     }

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -370,7 +370,40 @@ describe('SonobiBidAdapter', function () {
     it('should return a properly formatted request with schain defined', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(JSON.parse(bidRequests.data.schain)).to.deep.equal(bidRequest[0].schain)
-    })
+    });
+
+    it('should return a properly formatted request with userid as a JSON-encoded set of User ID results', function () {
+      bidRequest[0].userId = {'pubcid': 'abcd-efg-0101', 'tdid': 'td-abcd-efg-0101'};
+      bidRequest[1].userId = {'pubcid': 'abcd-efg-0101', 'tdid': 'td-abcd-efg-0101'};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
+      expect(JSON.parse(bidRequests.data.userid)).to.eql({'pubcid': 'abcd-efg-0101', 'tdid': 'td-abcd-efg-0101'});
+    });
+
+    it('should return a properly formatted request with userid omitted if there are no userIds', function () {
+      bidRequest[0].userId = {};
+      bidRequest[1].userId = {};
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
+      expect(bidRequests.data.userid).to.equal(undefined);
+    });
+
+    it('should return a properly formatted request with userid omitted', function () {
+      bidRequest[0].userId = undefined;
+      bidRequest[1].userId = undefined;
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
+      expect(bidRequests.method).to.equal('GET');
+      expect(bidRequests.data.ref).not.to.be.empty;
+      expect(bidRequests.data.s).not.to.be.empty;
+      expect(bidRequests.data.userid).to.equal(undefined);
+    });
   })
 
   describe('.interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Added the userid param to Sonobi's bid request endpoint to accept the entire userId payload

- contact email of the adapter’s maintainer - apex.prebid@sonobi.com
- [x] official adapter submission
