### PR TITLE
Correctly reference bidrequest and determine mediatype of bidresponse

### DIFF
--- a/modules/emx_digitalBidAdapter.js
+++ b/modules/emx_digitalBidAdapter.js
@@ -7,7 +7,7 @@ import includes from 'core-js/library/fn/array/includes';
 const BIDDER_CODE = 'emx_digital';
 const ENDPOINT = 'hb.emxdgt.com';
 const RENDERER_URL = '//js.brealtime.com/outstream/1.30.0/bundle.js';
-const ADAPTER_VERSION = '1.40.3';
+const ADAPTER_VERSION = '1.41.0';
 const DEFAULT_CUR = 'USD';
 
 export const emxAdapter = {
@@ -39,11 +39,11 @@ export const emxAdapter = {
       h: sizes[0][1]
     };
   },
-  formatVideoResponse: (bidResponse, emxBid) => {
+  formatVideoResponse: (bidResponse, emxBid, bidRequest) => {
     bidResponse.vastXml = emxBid.adm;
-    if (!emxBid.renderer && (!emxBid.mediaTypes || !emxBid.mediaTypes.video || !emxBid.mediaTypes.video.context || emxBid.mediaTypes.video.context === 'outstream')) {
+    if (bidRequest.bidRequest && bidRequest.bidRequest.mediaTypes && bidRequest.bidRequest.mediaTypes.video && bidRequest.bidRequest.mediaTypes.video.context === 'outstream') {
       bidResponse.renderer = emxAdapter.createRenderer(bidResponse, {
-        id: emxBid.bidId,
+        id: emxBid.id,
         url: RENDERER_URL
       });
     }
@@ -188,14 +188,14 @@ export const spec = {
 
     return true;
   },
-  buildRequests: function (validBidRequests, bidderRequest) {
+  buildRequests: function (validBidRequests, bidRequest) {
     const emxImps = [];
-    const timeout = bidderRequest.timeout || '';
+    const timeout = bidRequest.timeout || '';
     const timestamp = Date.now();
     const url = location.protocol + '//' + ENDPOINT + ('?t=' + timeout + '&ts=' + timestamp + '&src=pbjs');
     const secure = location.protocol.indexOf('https') > -1 ? 1 : 0;
     const domain = utils.getTopWindowLocation().hostname;
-    const page = bidderRequest.refererInfo.referer;
+    const page = bidRequest.refererInfo.referer;
     const device = emxAdapter.getDevice();
     const ref = emxAdapter.getReferrer();
 
@@ -217,7 +217,7 @@ export const spec = {
     });
 
     let emxData = {
-      id: bidderRequest.auctionId,
+      id: bidRequest.auctionId,
       imp: emxImps,
       device,
       site: {
@@ -229,17 +229,18 @@ export const spec = {
       version: ADAPTER_VERSION
     };
 
-    emxData = emxAdapter.getGdpr(bidderRequest, Object.assign({}, emxData));
+    emxData = emxAdapter.getGdpr(bidRequest, Object.assign({}, emxData));
     return {
       method: 'POST',
       url: url,
       data: JSON.stringify(emxData),
       options: {
         withCredentials: true
-      }
+      },
+      bidRequest
     };
   },
-  interpretResponse: function (serverResponse) {
+  interpretResponse: function (serverResponse, bidRequest) {
     let emxBidResponses = [];
     let response = serverResponse.body || {};
     if (response.seatbid && response.seatbid.length > 0 && response.seatbid[0].bid) {
@@ -261,7 +262,7 @@ export const spec = {
         };
         if (emxBid.adm && emxBid.adm.indexOf('<?xml version=') > -1) {
           isVideo = true;
-          bidResponse = emxAdapter.formatVideoResponse(bidResponse, Object.assign({}, emxBid));
+          bidResponse = emxAdapter.formatVideoResponse(bidResponse, Object.assign({}, emxBid), bidRequest);
         }
         bidResponse.mediaType = (isVideo ? VIDEO : BANNER);
         emxBidResponses.push(bidResponse);

--- a/test/spec/modules/emx_digitalBidAdapter_spec.js
+++ b/test/spec/modules/emx_digitalBidAdapter_spec.js
@@ -358,6 +358,28 @@ describe('emx_digital Adapter', function () {
   });
 
   describe('interpretResponse', function () {
+    let bid = {
+      'bidder': 'emx_digital',
+      'params': {
+        'tagid': '25251',
+        'video': {}
+      },
+      'mediaTypes': {
+        'video': {
+          'context': 'instream',
+          'playerSize': [640, 480]
+        }
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [
+        [300, 250],
+        [300, 600]
+      ],
+      'bidId': '30b31c2501de1e',
+      'bidderRequestId': '22edbae3120bf6',
+      'auctionId': '1d1a01234a475'
+    };
+
     const serverResponse = {
       'id': '12819a18-56e1-4256-b836-b69a10202668',
       'seatbid': [{
@@ -458,7 +480,8 @@ describe('emx_digital Adapter', function () {
     it('returns a banner bid for non-xml creatives', function () {
       let result = spec.interpretResponse({
         body: serverResponse
-      });
+      }, { bidRequest: bid }
+      );
       const ad0 = result[0];
       const ad1 = result[1];
       expect(ad0.mediaType).to.equal('banner');
@@ -480,7 +503,8 @@ describe('emx_digital Adapter', function () {
 
       let result = spec.interpretResponse({
         body: serverResponse
-      });
+      }, { bidRequest: bid }
+      );
       const ad0 = result[0];
       const ad1 = result[1];
       expect(ad0.mediaType).to.equal('video');


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Currently our adapter was referencing the bid for information about mediatype, which would always fail resulting in our renderer to be applied in 'instream' mediatype contexts. These changes will fix that by passing along the correct bidRequest information to interpretResponse.