### PR TITLE
create stubs for localStorage in widespaceBidAdapter test file

### DIFF
--- a/test/spec/modules/widespaceBidAdapter_spec.js
+++ b/test/spec/modules/widespaceBidAdapter_spec.js
@@ -144,6 +144,35 @@ describe('+widespaceAdatperTest', function () {
     const request = spec.buildRequests(bidRequest, bidderRequest);
     const UrlRegExp = /^((ftp|http|https):)?\/\/[^ "]+$/;
 
+    let fakeLocalStorage = {};
+    let lsSetStub;
+    let lsGetStub;
+    let lsRemoveStub;
+
+    beforeEach(function() {
+      lsSetStub = sinon.stub(window.localStorage, 'setItem').callsFake(function (name, value) {
+        fakeLocalStorage[name] = value;
+      });
+
+      lsGetStub = sinon.stub(window.localStorage, 'getItem').callsFake(function (key) {
+        return fakeLocalStorage[key] || null;
+      });
+
+      lsRemoveStub = sinon.stub(window.localStorage, 'removeItem').callsFake(function (key) {
+        if (key && (fakeLocalStorage[key] !== null || fakeLocalStorage[key] !== undefined)) {
+          delete fakeLocalStorage[key];
+        }
+        return true;
+      });
+    });
+
+    afterEach(function() {
+      lsSetStub.restore();
+      lsGetStub.restore();
+      lsRemoveStub.restore();
+      fakeLocalStorage = {};
+    });
+
     it('-bidRequest method is POST', function () {
       expect(request[0].method).to.equal('POST');
     });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)
- [x] Other

## Description of change
This PR is meant to help prevent sporadic browserstack unit test failures related to use of `localStorage` in the `widespaceBidAdapter` file.  

The error causing the test failures is: `Access is denied`.  Based on some research, this error is due to when some permission settings in IE browsers prevents access to `localStorage`.  

The sporadic nature of the error is likely just timing/initialization of the Browserstack IE 11 browser not having the right setting(s) at the time of the test.  Normally rerunning the job causes the tests to pass fine, but the frequency of this error over time has made rerunning the jobs become tedious to do - especially when the related PR isn't about the `widespaceBidAdapter`.

See example here in recent circleCI test job for a failure and subsequent pass:
https://circleci.com/gh/prebid/Prebid.js/3857 (fail)
https://circleci.com/gh/prebid/Prebid.js/3858 (pass)