### PR TITLE
Adagio: update with external js

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -9,29 +9,7 @@ import CONSTANTS from 'src/constants.json';
 const emptyUrl = '';
 const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
-const VERSION = '1.1.0';
-
-const ADSRV_EVENTS = {
-  GPT: {
-    IMPRESSION_VIEWABLE: 'impressionViewable',
-    SLOT_ON_LOAD: 'slotOnLoad',
-    SLOT_RENDER_ENDED: 'slotRenderEnded',
-    SLOT_REQUESTED: 'slotRequested',
-    SLOT_RESPONSE_RECEIVED: 'slotResponseReceived',
-    SLOT_VISIBILITY_CHANGED: 'slotVisibilityChanged',
-  },
-  SAS: {
-    CALL: 'call',
-    CLEAN: 'clean',
-    BEFORE_RENDER: 'beforeRender',
-    CMP_ANSWERED: 'CmpAnswered',
-    CMP_CALLED: 'CmpCalled',
-    LOAD: 'load',
-    NOAD: 'noad',
-    RENDER: 'render',
-    RESET: 'reset'
-  }
-};
+const VERSION = '1.2.0';
 
 window.top.ADAGIO = window.top.ADAGIO || {};
 window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
@@ -41,28 +19,6 @@ window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
 const adagioEnqueue = function adagioEnqueue(action, data) {
   window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });
 }
-
-top.googletag = top.googletag || {};
-top.googletag.cmd = top.googletag.cmd || [];
-top.googletag.cmd.push(function() {
-  const gptEvents = Object.keys(ADSRV_EVENTS.GPT).map(key => ADSRV_EVENTS.GPT[key]);
-  gptEvents.forEach(eventName => {
-    top.googletag.pubads().addEventListener(eventName, args => {
-      adagioEnqueue('gpt-event', { eventName, args });
-    });
-  });
-});
-
-top.sas = top.sas || {};
-top.sas.cmd = top.sas.cmd || [];
-top.sas.cmd.push(function() {
-  const sasEvents = Object.keys(ADSRV_EVENTS.SAS).map(key => ADSRV_EVENTS.SAS[key]);
-  sasEvents.forEach(eventName => {
-    top.sas.events.on(eventName, args => {
-      adagioEnqueue('sas-event', { eventName, args });
-    });
-  });
-});
 
 const adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
   track({ eventType, args }) {

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -9,6 +9,7 @@ import CONSTANTS from 'src/constants.json';
 const emptyUrl = '';
 const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
+const VERSION = '1.1.0';
 
 const ADSRV_EVENTS = {
   GPT: {
@@ -34,6 +35,8 @@ const ADSRV_EVENTS = {
 
 window.top.ADAGIO = window.top.ADAGIO || {};
 window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
+window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
 
 const adagioEnqueue = function adagioEnqueue(action, data) {
   window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -2,10 +2,10 @@
  * Analytics Adapter for Adagio
  */
 
-import adapter from 'src/AnalyticsAdapter';
-import adapterManager from 'src/adapterManager';
-import CONSTANTS from 'src/constants.json';
-import * as utils from 'src/utils';
+import adapter from '../src/AnalyticsAdapter';
+import adapterManager from '../src/adapterManager';
+import CONSTANTS from '../src/constants.json';
+import * as utils from '../src/utils';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -10,7 +10,7 @@ import * as utils from '../src/utils';
 const emptyUrl = '';
 const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
-const VERSION = '1.3.0';
+const VERSION = '2.0.0';
 
 const adagioEnqueue = function adagioEnqueue(action, data) {
   utils.getWindowTop().ADAGIO.queue.push({ action, data, ts: Date.now() });

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -2,17 +2,71 @@
  * Analytics Adapter for Adagio
  */
 
-import adapter from '../src/AnalyticsAdapter';
-import adapterManager from '../src/adapterManager';
+import adapter from 'src/AnalyticsAdapter';
+import adapterManager from 'src/adapterManager';
+import CONSTANTS from 'src/constants.json';
 
-// This config makes Prebid.js call this function on each event:
-//   `window['AdagioPrebidAnalytics']('on', eventType, args)`
-// If it is missing, then Prebid.js will immediately log an error,
-// instead of queueing the events until the function appears.
-var adagioAdapter = adapter({
-  global: 'AdagioPrebidAnalytics',
-  handler: 'on',
-  analyticsType: 'bundle'
+const emptyUrl = '';
+const analyticsType = 'endpoint';
+const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
+
+const ADSRV_EVENTS = {
+  GPT: {
+    IMPRESSION_VIEWABLE: 'impressionViewable',
+    SLOT_ON_LOAD: 'slotOnLoad',
+    SLOT_RENDER_ENDED: 'slotRenderEnded',
+    SLOT_REQUESTED: 'slotRequested',
+    SLOT_RESPONSE_RECEIVED: 'slotResponseReceived',
+    SLOT_VISIBILITY_CHANGED: 'slotVisibilityChanged',
+  },
+  SAS: {
+    CALL: 'call',
+    CLEAN: 'clean',
+    BEFORE_RENDER: 'beforeRender',
+    CMP_ANSWERED: 'CmpAnswered',
+    CMP_CALLED: 'CmpCalled',
+    LOAD: 'load',
+    NOAD: 'noad',
+    RENDER: 'render',
+    RESET: 'reset'
+  }
+};
+
+window.top.ADAGIO = window.top.ADAGIO || {};
+window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+
+const adagioEnqueue = function adagioEnqueue(action, data) {
+  window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });
+}
+
+top.googletag = top.googletag || {};
+top.googletag.cmd = top.googletag.cmd || [];
+top.googletag.cmd.push(function() {
+  const gptEvents = Object.keys(ADSRV_EVENTS.GPT).map(key => ADSRV_EVENTS.GPT[key]);
+  gptEvents.forEach(eventName => {
+    top.googletag.pubads().addEventListener(eventName, args => {
+      adagioEnqueue('gpt-event', { eventName, args });
+    });
+  });
+});
+
+top.sas = top.sas || {};
+top.sas.cmd = top.sas.cmd || [];
+top.sas.cmd.push(function() {
+  const sasEvents = Object.keys(ADSRV_EVENTS.SAS).map(key => ADSRV_EVENTS.SAS[key]);
+  sasEvents.forEach(eventName => {
+    top.sas.events.on(eventName, args => {
+      adagioEnqueue('sas-event', { eventName, args });
+    });
+  });
+});
+
+const adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
+  track({ eventType, args }) {
+    if (typeof args !== 'undefined' && events.indexOf(eventType) !== -1) {
+      adagioEnqueue('pb-analytics-event', { eventName: eventType, args });
+    }
+  }
 });
 
 adapterManager.registerAnalyticsAdapter({

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -41,10 +41,12 @@ adagioAdapter.enableAnalytics = config => {
     return;
   }
 
-  window.top.ADAGIO = window.top.ADAGIO || {};
-  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
-  window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
-  window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
+  const w = utils.getWindowTop();
+
+  w.ADAGIO = w.ADAGIO || {};
+  w.ADAGIO.queue = w.ADAGIO.queue || [];
+  w.ADAGIO.versions = w.ADAGIO.versions || {};
+  w.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
 
   adagioAdapter.originEnableAnalytics(config);
 }

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -9,7 +9,7 @@ import CONSTANTS from 'src/constants.json';
 const emptyUrl = '';
 const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
-const VERSION = '1.2.0';
+const VERSION = '1.3.0';
 
 let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }));
 

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -11,22 +11,36 @@ const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
 const VERSION = '1.2.0';
 
-window.top.ADAGIO = window.top.ADAGIO || {};
-window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
-window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
-window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
+let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }));
 
-const adagioEnqueue = function adagioEnqueue(action, data) {
-  window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });
+function canAccessTopWindow() {
+  try {
+    if (window.top.location.href) {
+      return true;
+    }
+  } catch (error) {
+    return false;
+  }
 }
 
-const adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
-  track({ eventType, args }) {
-    if (typeof args !== 'undefined' && events.indexOf(eventType) !== -1) {
-      adagioEnqueue('pb-analytics-event', { eventName: eventType, args });
-    }
+if (canAccessTopWindow()) {
+  window.top.ADAGIO = window.top.ADAGIO || {};
+  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+  window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
+  window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
+
+  const adagioEnqueue = function adagioEnqueue(action, data) {
+    window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });
   }
-});
+
+  adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
+    track({ eventType, args }) {
+      if (typeof args !== 'undefined' && events.indexOf(eventType) !== -1) {
+        adagioEnqueue('pb-analytics-event', { eventName: eventType, args });
+      }
+    }
+  });
+}
 
 adapterManager.registerAnalyticsAdapter({
   adapter: adagioAdapter,

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -5,17 +5,20 @@
 import adapter from 'src/AnalyticsAdapter';
 import adapterManager from 'src/adapterManager';
 import CONSTANTS from 'src/constants.json';
+import * as utils from 'src/utils';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
 const events = Object.keys(CONSTANTS.EVENTS).map(key => CONSTANTS.EVENTS[key]);
 const VERSION = '1.3.0';
 
-let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }));
+const adagioEnqueue = function adagioEnqueue(action, data) {
+  utils.getWindowTop().ADAGIO.queue.push({ action, data, ts: Date.now() });
+}
 
 function canAccessTopWindow() {
   try {
-    if (window.top.location.href) {
+    if (utils.getWindowTop().location.href) {
       return true;
     }
   } catch (error) {
@@ -23,23 +26,27 @@ function canAccessTopWindow() {
   }
 }
 
-if (canAccessTopWindow()) {
+let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
+  track: function({ eventType, args }) {
+    if (typeof args !== 'undefined' && events.indexOf(eventType) !== -1) {
+      adagioEnqueue('pb-analytics-event', { eventName: eventType, args });
+    }
+  }
+});
+
+adagioAdapter.originEnableAnalytics = adagioAdapter.enableAnalytics;
+
+adagioAdapter.enableAnalytics = config => {
+  if (!canAccessTopWindow()) {
+    return;
+  }
+
   window.top.ADAGIO = window.top.ADAGIO || {};
   window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
   window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
   window.top.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
 
-  const adagioEnqueue = function adagioEnqueue(action, data) {
-    window.top.ADAGIO.queue.push({ action, data, ts: Date.now() });
-  }
-
-  adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
-    track({ eventType, args }) {
-      if (typeof args !== 'undefined' && events.indexOf(eventType) !== -1) {
-        adagioEnqueue('pb-analytics-event', { eventName: eventType, args });
-      }
-    }
-  });
+  adagioAdapter.originEnableAnalytics(config);
 }
 
 adapterManager.registerAnalyticsAdapter({

--- a/modules/adagioAnalyticsAdapter.md
+++ b/modules/adagioAnalyticsAdapter.md
@@ -1,7 +1,7 @@
 # Overview
 
 Module Name: Adagio Analytics Adapter
-Module Type: Adagio Adapter
+Module Type: Analytics Adapter
 Maintainer: dev@adagio.io
 
 # Description

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -195,6 +195,7 @@ const _features = {
   },
 
   getDevice: function() {
+    if (!canAccessTopWindow()) return false;
     const w = window.top;
     const ua = w.navigator.userAgent;
 
@@ -269,6 +270,7 @@ function _getSite() {
 };
 
 function _getPageviewId() {
+  if (!canAccessTopWindow()) return false;
   window.top.ADAGIO.pageviewId = window.top.ADAGIO.pageviewId || utils.generateUUID();
   return window.top.ADAGIO.pageviewId;
 };

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -111,13 +111,15 @@ function _getGdprConsent(bidderRequest) {
 
 // Extra data returned by Adagio SSP Engine
 function _setData(data) {
-  if (window.top.ADAGIO && window.top.ADAGIO.queue) {
-    window.top.ADAGIO.queue.push({
-      action: 'ssp-data',
-      ts: Date.now(),
-      data: data,
-    });
-  }
+  window.top.ADAGIO = window.top.ADAGIO || {};
+  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+  // if (window.top.ADAGIO && window.top.ADAGIO.queue) {
+  window.top.ADAGIO.queue.push({
+    action: 'ssp-data',
+    ts: Date.now(),
+    data: data,
+  });
+  // }
 }
 
 export const spec = {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.1.0';
+const VERSION = '1.1.1';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
@@ -180,7 +180,8 @@ function _getSite() {
 };
 
 function _getPageviewId() {
-  return (!window.top.ADAGIO || !window.top.ADAGIO.pageviewId) ? '_' : window.top.ADAGIO.pageviewId;
+  window.top.ADAGIO.pageviewId = window.top.ADAGIO.pageviewId || utils.generateUUID();
+  return window.top.ADAGIO.pageviewId;
 };
 
 /**

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -344,7 +344,7 @@ export const spec = {
   supportedMediaType: SUPPORTED_MEDIA_TYPES,
 
   isBidRequestValid: function(bid) {
-    const { adUnitCode, auctionId, sizes, bidder, params } = bid;
+    const { adUnitCode, auctionId, sizes, bidder, params, mediaTypes } = bid;
     const { organizationId, site, placement, adUnitElementId } = bid.params;
     let isValid = false;
 
@@ -356,7 +356,7 @@ export const spec = {
       const tempAdUnits = top.ADAGIO.pbjsAdUnits.filter((adUnit) => adUnit.code !== adUnitCode);
       tempAdUnits.push({
         code: adUnitCode,
-        sizes,
+        sizes: (mediaTypes && mediaTypes.banner && Array.isArray(mediaTypes.banner.sizes)) ? mediaTypes.banner.sizes : sizes,
         bids: [{
           bidder,
           params

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -149,6 +149,12 @@ const _features = {
   }
 }
 
+function _pushInAdagioQueue(ob) {
+  window.top.ADAGIO = window.top.ADAGIO || {};
+  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+  window.top.ADAGIO.queue.push(ob);
+};
+
 function _getDevice() {
   const language = navigator.language ? 'language' : 'userLanguage';
   return {
@@ -207,8 +213,10 @@ function _getFeatures(bidRequest) {
     version: FEATURES_VERSION
   };
 
-  _setFeatures({
-    features: adUnitFeature
+  _pushInAdagioQueue({
+    action: 'features',
+    ts: Date.now(),
+    data: adUnitFeature
   });
 
   return features;
@@ -228,27 +236,6 @@ function _getGdprConsent(bidderRequest) {
     }
   }
   return consent;
-}
-
-// Extra data returned by Adagio SSP Engine
-function _setData(data) {
-  window.top.ADAGIO = window.top.ADAGIO || {};
-  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
-  window.top.ADAGIO.queue.push({
-    action: 'ssp-data',
-    ts: Date.now(),
-    data: data,
-  });
-}
-
-function _setFeatures(data) {
-  window.top.ADAGIO = window.top.ADAGIO || {};
-  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
-  window.top.ADAGIO.queue.push({
-    action: 'features',
-    ts: Date.now(),
-    data: data,
-  });
 }
 
 export const spec = {
@@ -309,7 +296,11 @@ export const spec = {
       const response = serverResponse.body;
       if (response) {
         if (response.data) {
-          _setData(response.data)
+          _pushInAdagioQueue({
+            action: 'ssp-data',
+            ts: Date.now(),
+            data: response.data
+          });
         }
         if (response.bids) {
           response.bids.forEach(bidObj => {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -1,16 +1,13 @@
 import find from 'core-js/library/fn/array/find';
 import * as utils from '../src/utils';
 import {registerBidder} from '../src/adapters/bidderFactory';
-
+import { loadExternalScript } from '../src/adloader'
 const BIDDER_CODE = 'adagio';
 const VERSION = '2.0.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
 const ADAGIO_TAG_URL = '//script.4dex.io/localstore.js';
-const ADAGIO_TAG_TO_LOCALSTORE = '//script.4dex.io/adagio.js';
-const ADAGIO_LOCALSTORE_KEY = 'adagioScript';
-const LOCALSTORE_TIMEOUT = 100;
 const ADSRV_EVENTS = {
   GPT: {
     IMPRESSION_VIEWABLE: 'impressionViewable',
@@ -44,7 +41,6 @@ function canAccessTopWindow() {
 }
 
 function initAdagio() {
-  const script = document.createElement('script');
   const w = utils.getWindowTop();
 
   w.ADAGIO = w.ADAGIO || {};
@@ -100,14 +96,7 @@ function initAdagio() {
 
   // Then prepare localstore.js to update localStorage adagio-sj script with
   // the very last version.
-  script.type = 'text/javascript';
-  script.async = true;
-  script.src = ADAGIO_TAG_URL;
-  script.setAttribute('data-key', ADAGIO_LOCALSTORE_KEY);
-  script.setAttribute('data-src', ADAGIO_TAG_TO_LOCALSTORE);
-  setTimeout(function() {
-    utils.insertElement(script);
-  }, LOCALSTORE_TIMEOUT);
+  loadExternalScript(ADAGIO_TAG_URL, BIDDER_CODE)
 }
 
 if (canAccessTopWindow()) {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -112,9 +112,9 @@ const _features = {
 
   getPageDimensions: function() {
     const viewportDims = _features.getViewPortDimensions().split('x');
-    const body = document.body;
-    const html = document.documentElement;
-    const w = window;
+    const w = window.top;
+    const body = w.document.body;
+    const html = w.document.documentElement;
     let pageHeight = 0;
 
     if (w === w.top) {
@@ -129,8 +129,8 @@ const _features = {
   getViewPortDimensions: function() {
     let viewPortWidth;
     let viewPortHeight;
-    const w = window;
-    const d = document;
+    const w = window.top;
+    const d = w.document;
 
     if (w.innerWidth != null) {
       viewPortWidth = w.innerWidth;
@@ -149,7 +149,7 @@ const _features = {
   },
 
   isDomLoading: function() {
-    const w = window;
+    const w = window.top;
     let performance = w.performance || w.msPerformance || w.webkitPerformance || w.mozPerformance;
     let domLoading = -1;
 
@@ -161,8 +161,8 @@ const _features = {
   },
 
   getSlotPosition: function(element) {
-    const w = window;
-    const d = document;
+    const w = window.top;
+    const d = w.document;
     const el = element;
 
     let box = el.getBoundingClientRect();
@@ -196,7 +196,8 @@ const _features = {
   },
 
   getDevice: function() {
-    const ua = navigator.userAgent;
+    const w = window.top;
+    const ua = w.navigator.userAgent;
 
     if ((/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i).test(ua)) {
       return 5; // "tablet"
@@ -208,13 +209,17 @@ const _features = {
   },
 
   getBrowser: function() {
-    const userAgentLoweCase = navigator.userAgent.toLowerCase();
-    return /Edge\/\d./i.test(navigator.userAgent) ? 'edge' : userAgentLoweCase.indexOf('chrome') > 0 ? 'chrome' : userAgentLoweCase.indexOf('firefox') > 0 ? 'firefox' : userAgentLoweCase.indexOf('safari') > 0 ? 'safari' : userAgentLoweCase.indexOf('opera') > 0 ? 'opera' : userAgentLoweCase.indexOf('msie') > 0 || window.top.MSStream ? 'ie' : 'unknow';
+    const w = window.top;
+    const ua = w.navigator.userAgent;
+    const uaLowerCase = ua.toLowerCase();
+    return /Edge\/\d./i.test(ua) ? 'edge' : uaLowerCase.indexOf('chrome') > 0 ? 'chrome' : uaLowerCase.indexOf('firefox') > 0 ? 'firefox' : uaLowerCase.indexOf('safari') > 0 ? 'safari' : uaLowerCase.indexOf('opera') > 0 ? 'opera' : uaLowerCase.indexOf('msie') > 0 || w.MSStream ? 'ie' : 'unknow';
   },
 
   getOS: function() {
-    const userAgentLoweCase = navigator.userAgent.toLowerCase();
-    return userAgentLoweCase.indexOf('linux') > 0 ? 'linux' : userAgentLoweCase.indexOf('mac') > 0 ? 'mac' : userAgentLoweCase.indexOf('win') > 0 ? 'windows' : '';
+    const w = window.top;
+    const ua = w.navigator.userAgent;
+    const uaLowerCase = ua.toLowerCase();
+    return uaLowerCase.indexOf('linux') > 0 ? 'linux' : uaLowerCase.indexOf('mac') > 0 ? 'mac' : uaLowerCase.indexOf('win') > 0 ? 'windows' : '';
   }
 }
 
@@ -258,7 +263,7 @@ function _getPageviewId() {
 function _getFeatures(bidRequest) {
   if (!canAccessTopWindow()) return;
   const adUnitElementId = bidRequest.params.adUnitElementId;
-  const element = document.getElementById(adUnitElementId);
+  const element = window.top.document.getElementById(adUnitElementId);
   let features = {};
 
   if (element) {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -8,27 +8,6 @@ const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
 const ADAGIO_TAG_URL = '//script.4dex.io/localstore.js';
-const ADSRV_EVENTS = {
-  GPT: {
-    IMPRESSION_VIEWABLE: 'impressionViewable',
-    SLOT_ON_LOAD: 'slotOnLoad',
-    SLOT_RENDER_ENDED: 'slotRenderEnded',
-    SLOT_REQUESTED: 'slotRequested',
-    SLOT_RESPONSE_RECEIVED: 'slotResponseReceived',
-    SLOT_VISIBILITY_CHANGED: 'slotVisibilityChanged',
-  },
-  SAS: {
-    CALL: 'call',
-    CLEAN: 'clean',
-    BEFORE_RENDER: 'beforeRender',
-    CMP_ANSWERED: 'CmpAnswered',
-    CMP_CALLED: 'CmpCalled',
-    LOAD: 'load',
-    NOAD: 'noad',
-    RENDER: 'render',
-    RESET: 'reset'
-  }
-};
 
 function canAccessTopWindow() {
   try {
@@ -55,40 +34,6 @@ function initAdagio() {
     } else {
       utils.logWarn('Adagio Script not found');
     }
-  }
-
-  const adagioEnqueue = function adagioEnqueue(action, data) {
-    w.ADAGIO.queue.push({ action, data, ts: Date.now() });
-  }
-
-  // Listen to ad-server events in current window as we can
-  // in a Post-Bid scenario.
-  window.googletag = window.googletag || {};
-  window.googletag.cmd = window.googletag.cmd || [];
-  window.googletag.cmd.push(function() {
-    const gptEvents = Object.keys(ADSRV_EVENTS.GPT).map(key => ADSRV_EVENTS.GPT[key]);
-    gptEvents.forEach(eventName => {
-      window.googletag.pubads().addEventListener(eventName, args => {
-        adagioEnqueue('gpt-event', { eventName, args });
-      });
-    });
-  });
-
-  window.sas = window.sas || {};
-  window.sas.cmd = window.sas.cmd || [];
-  window.sas.cmd.push(function() {
-    const sasEvents = Object.keys(ADSRV_EVENTS.SAS).map(key => ADSRV_EVENTS.SAS[key]);
-    sasEvents.forEach(eventName => {
-      window.sas.events.on(eventName, args => {
-        adagioEnqueue('sas-event', { eventName, args });
-      });
-    });
-  });
-
-  if (window.advstLib && typeof window.advstLib === 'function') {
-    advstLib().eventHandler.addListener('renderEndedEvent', function(e) {
-      adagioEnqueue('adthk-event', { eventName: 'renderEndedEvent', args: e.detail });
-    });
   }
 
   // First, try to load adagio-js from localStorage.

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -58,10 +58,7 @@ top.googletag.cmd.push(function() {
   const gptEvents = Object.keys(ADSRV_EVENTS.GPT).map(key => ADSRV_EVENTS.GPT[key]);
   gptEvents.forEach(eventName => {
     top.googletag.pubads().addEventListener(eventName, args => {
-      const adagioCustomArgs = {
-        adgAuctionId: auctionManager.getLastAuctionId()
-      };
-      adagioEnqueue('gpt-event', { eventName, args: { ...args, ...adagioCustomArgs } });
+      adagioEnqueue('gpt-event', { eventName, args });
     });
   });
 });
@@ -72,10 +69,7 @@ top.sas.cmd.push(function() {
   const sasEvents = Object.keys(ADSRV_EVENTS.SAS).map(key => ADSRV_EVENTS.SAS[key]);
   sasEvents.forEach(eventName => {
     top.sas.events.on(eventName, args => {
-      const adagioCustomArgs = {
-        adgAuctionId: auctionManager.getLastAuctionId()
-      };
-      adagioEnqueue('sas-event', { eventName, args: { ...args, ...adagioCustomArgs } });
+      adagioEnqueue('sas-event', { eventName, args });
     });
   });
 });
@@ -301,7 +295,18 @@ export const spec = {
   supportedMediaType: SUPPORTED_MEDIA_TYPES,
 
   isBidRequestValid: function(bid) {
-    return !!(bid.params.organizationId && bid.params.site && bid.params.placement && bid.params.pagetype && bid.params.adUnitElementId && document.getElementById(bid.params.adUnitElementId) !== null);
+    const { adUnitCode, auctionId } = bid;
+    const { organizationId, site, placement, pagetype, adUnitElementId } = bid.params;
+    const isValid = !!(organizationId && site && placement && pagetype && adUnitElementId && document.getElementById(adUnitElementId) !== null);
+
+    if (isValid === true) {
+      top.ADAGIO.adUnits = top.ADAGIO.adUnits || {};
+      top.ADAGIO.adUnits[adUnitCode] = {
+        auctionId: auctionId,
+        pageviewId: _getPageviewId()
+      };
+    }
+    return isValid;
   },
 
   buildRequests: function(validBidRequests, bidderRequest) {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -35,7 +35,7 @@ const ADSRV_EVENTS = {
 
 function canAccessTopWindow() {
   try {
-    if (window.top.location.href) {
+    if (utils.getWindowTop().location.href) {
       return true;
     }
   } catch (error) {
@@ -123,13 +123,7 @@ const _features = {
     const w = window.top;
     const body = w.document.body;
     const html = w.document.documentElement;
-    let pageHeight = 0;
-
-    if (w === w.top) {
-      pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
-    } else {
-      pageHeight = Math.max(body.offsetHeight, html.scrollHeight, html.offsetHeight);
-    }
+    const pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
 
     return viewportDims[0] + 'x' + pageHeight;
   },
@@ -140,14 +134,9 @@ const _features = {
     const w = window.top;
     const d = w.document;
 
-    if (w.innerWidth != null) {
+    if (w.innerWidth) {
       viewPortWidth = w.innerWidth;
       viewPortHeight = w.innerHeight;
-    } else if (d.documentElement != null &&
-        d.documentElement.clientWidth != null &&
-        d.documentElement.clientWidth !== 0) {
-      viewPortWidth = d.documentElement.clientWidth;
-      viewPortHeight = d.documentElement.clientHeight;
     } else {
       viewPortWidth = d.getElementsByTagName('body')[0].clientWidth;
       viewPortHeight = d.getElementsByTagName('body')[0].clientHeight;
@@ -186,6 +175,7 @@ const _features = {
     const mustDisplayElement = elComputedDisplay === 'none';
 
     if (mustDisplayElement) {
+      el.style = el.style || {};
       el.style.display = 'block';
       box = el.getBoundingClientRect();
       el.style.display = elComputedDisplay;
@@ -301,7 +291,6 @@ function _getFeatures(bidRequest) {
   }
 
   let features = {};
-
   if (element) {
     features = Object.assign({}, {
       print_number: _features.getPrintNumber(element).toString(),

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -36,37 +36,11 @@ setTimeout(function() {
   utils.insertElement(script);
 }, LOCALSTORE_TIMEOUT);
 
-/*
- * Custom Adagio Mapping:
- * ---------------------
- * print_number        | private | defaults to 1
- * page_dimensions     | private | e.g. "5490x954"
- * viewport_dimensions | private | e.g. "1680x954"
- * dom_loading         | private | Navigation Timing "DOM Loading", in milliseconds
- * layout              | private | Responsive layout code. e.g. "AA1"
- * adunit_position     | private | Position of the slot. e.g. "1000x45"
- * user_timestamp      | private | User timestamp. Server-side, this unix timestamp is parsed a UTC timestamp - ex: 1518197208
- * device              | private | IAB device type code: "5" for tablet, "4" for mobile, "2" for others
- * url                 | private | Current URL, (without query string and/or hash)
- * browser             | private | Current Browser name. e.g. "edge", "chrome", etc…
- * os                  | private | Current OS name : "linux", "windows", "mac"
- */
-
 const _features = {
-  /**
-   * Returns the print number of an element
-   * The print number is used only in case of an element is Refreshed
-   * @todo implement this if needed
-   * @returns number - default 1
-   */
   getPrintNumber: function() {
     return 1;
   },
 
-  /**
-   * Returns the page dimensions
-   * @returns {string} width x height. e.g. 1920x2105
-   */
   getPageDimensions: function() {
     const viewportDims = _features.getViewPortDimensions().split('x');
     const body = document.body;
@@ -83,19 +57,12 @@ const _features = {
     return viewportDims[0] + 'x' + pageHeight;
   },
 
-  /**
-   * Returns the viewport dimensions
-   * @returns {string} width x height. e.g. 1920x1024
-   */
   getViewPortDimensions: function() {
     let viewPortWidth;
     let viewPortHeight;
     const w = window;
     const d = document;
 
-    // the more standards compliant browsers (mozilla/netscape/opera/IE7) use w.innerWidth and w.innerHeight
-    // then try IE6 in standards compliant mode (i.e. with a valid doctype as the first line in the document)
-    // finish with older versions of IE
     if (w.innerWidth != null) {
       viewPortWidth = w.innerWidth;
       viewPortHeight = w.innerHeight;
@@ -112,10 +79,6 @@ const _features = {
     return viewPortWidth + 'x' + viewPortHeight;
   },
 
-  /**
-   * Returns the navigation timing "DOM Loading", in milliseconds
-   * @returns {number}
-   */
   isDomLoading: function() {
     const w = window;
     let performance = w.performance || w.msPerformance || w.webkitPerformance || w.mozPerformance;
@@ -128,17 +91,11 @@ const _features = {
     return domLoading;
   },
 
-  /**
-   * Returns the position of an element in the page
-   * @param {HTMLElement} element
-   * @returns {string} x-axis x y-axis. e.g. 1200x324
-   */
   getSlotPosition: function(element) {
     const w = window;
     const d = document;
     const el = element;
 
-    // Source: http://stackoverflow.com/a/26230989 & https://github.com/timoxley/offset/blob/master/index.js
     let box = el.getBoundingClientRect();
     const docEl = d.documentElement;
     const body = d.body;
@@ -147,7 +104,6 @@ const _features = {
     const scrollTop = w.pageYOffset || docEl.scrollTop || body.scrollTop;
     const scrollLeft = w.pageXOffset || docEl.scrollLeft || body.scrollLeft;
 
-    // We need to display an hidden element before we can get his position
     const elComputedStyle = w.getComputedStyle(el, null);
     const elComputedDisplay = elComputedStyle.display || 'block';
     const mustDisplayElement = elComputedDisplay === 'none';
@@ -166,42 +122,27 @@ const _features = {
     return position.x + 'x' + position.y;
   },
 
-  /**
-   * Returns the user timestamp.
-   * Server-side, this unix timestamp is parsed a UTC timestamp, e.g. 1518197208
-   * @returns {number}
-   */
   getTimestamp: function() {
     return Math.floor(new Date().getTime() / 1000) - new Date().getTimezoneOffset() * 60;
   },
 
-  /**
-   * Returns the device type, as an IAB code.
-   * Based on https://github.com/ua-parser/uap-cpp/blob/master/UaParser.cpp#L331, with the following updates:
-   * - replaced `mobile` by `mobi` in the table regexp, so Opera Mobile on phones is not detected as a tablet.
-   * @returns {number}
-   */
   getDevice: function() {
     const ua = navigator.userAgent;
 
-    // Tablets must be checked before phones.
     if ((/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i).test(ua)) {
       return 5; // "tablet"
     }
     if ((/Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/).test(ua)) {
       return 4; // "phone"
     }
-    // Consider that all other devices are personal computers
-    return 2;
+    return 2; // personal computers
   },
 
-  // Browser detection
   getBrowser: function() {
     const userAgentLoweCase = navigator.userAgent.toLowerCase();
     return /Edge\/\d./i.test(navigator.userAgent) ? 'edge' : userAgentLoweCase.indexOf('chrome') > 0 ? 'chrome' : userAgentLoweCase.indexOf('firefox') > 0 ? 'firefox' : userAgentLoweCase.indexOf('safari') > 0 ? 'safari' : userAgentLoweCase.indexOf('opera') > 0 ? 'opera' : userAgentLoweCase.indexOf('msie') > 0 || window.top.MSStream ? 'ie' : 'unknow';
   },
 
-  // OS detection
   getOS: function() {
     const userAgentLoweCase = navigator.userAgent.toLowerCase();
     return userAgentLoweCase.indexOf('linux') > 0 ? 'linux' : userAgentLoweCase.indexOf('mac') > 0 ? 'mac' : userAgentLoweCase.indexOf('win') > 0 ? 'windows' : '';
@@ -266,7 +207,7 @@ function _getFeatures(bidRequest) {
     version: FEATURES_VERSION
   };
 
-  _setData({
+  _setFeatures({
     features: adUnitFeature
   });
 
@@ -295,6 +236,16 @@ function _setData(data) {
   window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
   window.top.ADAGIO.queue.push({
     action: 'ssp-data',
+    ts: Date.now(),
+    data: data,
+  });
+}
+
+function _setFeatures(data) {
+  window.top.ADAGIO = window.top.ADAGIO || {};
+  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+  window.top.ADAGIO.queue.push({
+    action: 'features',
     ts: Date.now(),
     data: data,
   });
@@ -340,7 +291,8 @@ export const spec = {
           pageviewId: pageviewId,
           adUnits: groupedAdUnits[organizationId],
           gdpr: gdprConsent,
-          adapterVersion: VERSION
+          adapterVersion: VERSION,
+          featuresVersion: FEATURES_VERSION
         },
         options: {
           contentType: 'application/json'

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -408,6 +408,9 @@ export const spec = {
   },
 
   buildRequests: function(validBidRequests, bidderRequest) {
+    // AdagioBidAdapter works when window.top can be reached only
+    if (!bidderRequest.refererInfo.reachedTop) return [];
+
     const secure = (location.protocol === 'https:') ? 1 : 0;
     const device = _getDevice();
     const site = _getSite();
@@ -441,9 +444,6 @@ export const spec = {
           prebidVersion: '$prebid.version$',
           adapterVersion: VERSION,
           featuresVersion: FEATURES_VERSION
-          /**
-           * @todo doit on ajouter ici le outerAdUnitElementId si on est en Post-Bid ?
-           */
         },
         options: {
           contentType: 'application/json'

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.0.0';
+const VERSION = '1.1.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
@@ -12,6 +12,11 @@ const ADAGIO_TAG_TO_LOCALSTORE = '//script.4dex.io/adagio.js';
 const ADAGIO_LOCALSTORE_KEY = 'adagioScript';
 const LOCALSTORE_TIMEOUT = 100;
 const script = document.createElement('script');
+
+window.top.ADAGIO = window.top.ADAGIO || {};
+window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
+window.top.ADAGIO.versions = window.top.ADAGIO.versions || {};
+window.top.ADAGIO.versions.adagioBidderAdapter = VERSION;
 
 const getAdagioTag = function getAdagioTag() {
   const ls = window.top.localStorage.getItem('adagioScript');
@@ -150,8 +155,6 @@ const _features = {
 }
 
 function _pushInAdagioQueue(ob) {
-  window.top.ADAGIO = window.top.ADAGIO || {};
-  window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
   window.top.ADAGIO.queue.push(ob);
 };
 
@@ -278,6 +281,7 @@ export const spec = {
           pageviewId: pageviewId,
           adUnits: groupedAdUnits[organizationId],
           gdpr: gdprConsent,
+          prebidVersion: $$PREBID_GLOBAL$$.version,
           adapterVersion: VERSION,
           featuresVersion: FEATURES_VERSION
         },

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.3.0';
+const VERSION = '1.4.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -4,6 +4,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
 const VERSION = '1.0.0';
+const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
 const ADAGIO_TAG_URL = '//script.4dex.io/localstore.js';
@@ -35,30 +36,184 @@ setTimeout(function() {
   utils.insertElement(script);
 }, LOCALSTORE_TIMEOUT);
 
-/**
- * Based on https://github.com/ua-parser/uap-cpp/blob/master/UaParser.cpp#L331, with the following updates:
- * - replaced `mobile` by `mobi` in the table regexp, so Opera Mobile on phones is not detected as a tablet.
+/*
+ * Custom Adagio Mapping:
+ * ---------------------
+ * print_number        | private | defaults to 1
+ * page_dimensions     | private | e.g. "5490x954"
+ * viewport_dimensions | private | e.g. "1680x954"
+ * dom_loading         | private | Navigation Timing "DOM Loading", in milliseconds
+ * layout              | private | Responsive layout code. e.g. "AA1"
+ * adunit_position     | private | Position of the slot. e.g. "1000x45"
+ * user_timestamp      | private | User timestamp. Server-side, this unix timestamp is parsed a UTC timestamp - ex: 1518197208
+ * device              | private | IAB device type code: "5" for tablet, "4" for mobile, "2" for others
+ * url                 | private | Current URL, (without query string and/or hash)
+ * browser             | private | Current Browser name. e.g. "edge", "chrome", etc…
+ * os                  | private | Current OS name : "linux", "windows", "mac"
  */
-function _getDeviceType() {
-  let ua = navigator.userAgent;
 
-  // Tablets must be checked before phones.
-  if ((/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i).test(ua)) {
-    return 5; // "tablet"
+const _features = {
+  /**
+   * Returns the print number of an element
+   * The print number is used only in case of an element is Refreshed
+   * @todo implement this if needed
+   * @returns number - default 1
+   */
+  getPrintNumber: function() {
+    return 1;
+  },
+
+  /**
+   * Returns the page dimensions
+   * @returns {string} width x height. e.g. 1920x2105
+   */
+  getPageDimensions: function() {
+    const viewportDims = _features.getViewPortDimensions().split('x');
+    const body = document.body;
+    const html = document.documentElement;
+    const w = window;
+    let pageHeight = 0;
+
+    if (w === w.top) {
+      pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+    } else {
+      pageHeight = Math.max(body.offsetHeight, html.scrollHeight, html.offsetHeight);
+    }
+
+    return viewportDims[0] + 'x' + pageHeight;
+  },
+
+  /**
+   * Returns the viewport dimensions
+   * @returns {string} width x height. e.g. 1920x1024
+   */
+  getViewPortDimensions: function() {
+    let viewPortWidth;
+    let viewPortHeight;
+    const w = window;
+    const d = document;
+
+    // the more standards compliant browsers (mozilla/netscape/opera/IE7) use w.innerWidth and w.innerHeight
+    // then try IE6 in standards compliant mode (i.e. with a valid doctype as the first line in the document)
+    // finish with older versions of IE
+    if (w.innerWidth != null) {
+      viewPortWidth = w.innerWidth;
+      viewPortHeight = w.innerHeight;
+    } else if (d.documentElement != null &&
+        d.documentElement.clientWidth != null &&
+        d.documentElement.clientWidth !== 0) {
+      viewPortWidth = d.documentElement.clientWidth;
+      viewPortHeight = d.documentElement.clientHeight;
+    } else {
+      viewPortWidth = d.getElementsByTagName('body')[0].clientWidth;
+      viewPortHeight = d.getElementsByTagName('body')[0].clientHeight;
+    }
+
+    return viewPortWidth + 'x' + viewPortHeight;
+  },
+
+  /**
+   * Returns the navigation timing "DOM Loading", in milliseconds
+   * @returns {number}
+   */
+  isDomLoading: function() {
+    const w = window;
+    let performance = w.performance || w.msPerformance || w.webkitPerformance || w.mozPerformance;
+    let domLoading = -1;
+
+    if (performance && performance.timing && performance.timing.navigationStart > 0) {
+      const val = performance.timing.domLoading - performance.timing.navigationStart;
+      if (val > 0) domLoading = val;
+    }
+    return domLoading;
+  },
+
+  /**
+   * Returns the position of an element in the page
+   * @param {HTMLElement} element
+   * @returns {string} x-axis x y-axis. e.g. 1200x324
+   */
+  getSlotPosition: function(element) {
+    const w = window;
+    const d = document;
+    const el = element;
+
+    // Source: http://stackoverflow.com/a/26230989 & https://github.com/timoxley/offset/blob/master/index.js
+    let box = el.getBoundingClientRect();
+    const docEl = d.documentElement;
+    const body = d.body;
+    const clientTop = d.clientTop || body.clientTop || 0;
+    const clientLeft = d.clientLeft || body.clientLeft || 0;
+    const scrollTop = w.pageYOffset || docEl.scrollTop || body.scrollTop;
+    const scrollLeft = w.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+    // We need to display an hidden element before we can get his position
+    const elComputedStyle = w.getComputedStyle(el, null);
+    const elComputedDisplay = elComputedStyle.display || 'block';
+    const mustDisplayElement = elComputedDisplay === 'none';
+
+    if (mustDisplayElement) {
+      el.style.display = 'block';
+      box = el.getBoundingClientRect();
+      el.style.display = elComputedDisplay;
+    }
+
+    const position = {
+      x: Math.round(box.left + scrollLeft - clientLeft),
+      y: Math.round(box.top + scrollTop - clientTop)
+    };
+
+    return position.x + 'x' + position.y;
+  },
+
+  /**
+   * Returns the user timestamp.
+   * Server-side, this unix timestamp is parsed a UTC timestamp, e.g. 1518197208
+   * @returns {number}
+   */
+  getTimestamp: function() {
+    return Math.floor(new Date().getTime() / 1000) - new Date().getTimezoneOffset() * 60;
+  },
+
+  /**
+   * Returns the device type, as an IAB code.
+   * Based on https://github.com/ua-parser/uap-cpp/blob/master/UaParser.cpp#L331, with the following updates:
+   * - replaced `mobile` by `mobi` in the table regexp, so Opera Mobile on phones is not detected as a tablet.
+   * @returns {number}
+   */
+  getDevice: function() {
+    const ua = navigator.userAgent;
+
+    // Tablets must be checked before phones.
+    if ((/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i).test(ua)) {
+      return 5; // "tablet"
+    }
+    if ((/Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/).test(ua)) {
+      return 4; // "phone"
+    }
+    // Consider that all other devices are personal computers
+    return 2;
+  },
+
+  // Browser detection
+  getBrowser: function() {
+    const userAgentLoweCase = navigator.userAgent.toLowerCase();
+    return /Edge\/\d./i.test(navigator.userAgent) ? 'edge' : userAgentLoweCase.indexOf('chrome') > 0 ? 'chrome' : userAgentLoweCase.indexOf('firefox') > 0 ? 'firefox' : userAgentLoweCase.indexOf('safari') > 0 ? 'safari' : userAgentLoweCase.indexOf('opera') > 0 ? 'opera' : userAgentLoweCase.indexOf('msie') > 0 || window.top.MSStream ? 'ie' : 'unknow';
+  },
+
+  // OS detection
+  getOS: function() {
+    const userAgentLoweCase = navigator.userAgent.toLowerCase();
+    return userAgentLoweCase.indexOf('linux') > 0 ? 'linux' : userAgentLoweCase.indexOf('mac') > 0 ? 'mac' : userAgentLoweCase.indexOf('win') > 0 ? 'windows' : '';
   }
-  if ((/Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/).test(ua)) {
-    return 4; // "phone"
-  }
-  // Consider that all other devices are personal computers
-  return 2;
-};
+}
 
 function _getDevice() {
   const language = navigator.language ? 'language' : 'userLanguage';
   return {
     userAgent: navigator.userAgent,
     language: navigator[language],
-    deviceType: _getDeviceType(),
+    deviceType: _features.getDevice(),
     dnt: utils.getDNT() ? 1 : 0,
     geo: {},
     js: 1
@@ -78,20 +233,45 @@ function _getPageviewId() {
   return (!window.top.ADAGIO || !window.top.ADAGIO.pageviewId) ? '_' : window.top.ADAGIO.pageviewId;
 };
 
+/**
+ * Returns all features for a specific adUnit element
+ *
+ * @param {Object} bidRequest
+ * @returns {Object} features for an element (see specs)
+ */
 function _getFeatures(bidRequest) {
-  if (!window.top._ADAGIO || !window.top._ADAGIO.features) {
-    utils.logWarn('adagio.js not found');
-    return {};
+  const adUnitElementId = bidRequest.params.adUnitElementId;
+  const element = document.getElementById(adUnitElementId);
+  let features = {};
+
+  if (element) {
+    features = Object.assign({}, {
+      print_number: _features.getPrintNumber(element).toString(),
+      page_dimensions: _features.getPageDimensions().toString(),
+      viewport_dimensions: _features.getViewPortDimensions().toString(),
+      dom_loading: _features.isDomLoading().toString(),
+      // layout: features.getLayout().toString(),
+      adunit_position: _features.getSlotPosition(element).toString(),
+      user_timestamp: _features.getTimestamp().toString(),
+      device: _features.getDevice().toString(),
+      url: top.location.origin + top.location.pathname,
+      browser: _features.getBrowser(),
+      os: _features.getOS()
+    })
   }
 
-  utils.logInfo('Call to adagio.js');
+  const adUnitFeature = {};
+  adUnitFeature[adUnitElementId] = {
+    features: features,
+    version: FEATURES_VERSION
+  };
 
-  const rawFeatures = window.top._ADAGIO.features.getFeatures(
-    document.getElementById(bidRequest.params.adUnitElementId),
-    {debug: config.getConfig('debug')}
-  );
-  return rawFeatures;
-}
+  _setData({
+    features: adUnitFeature
+  });
+
+  return features;
+};
 
 function _getGdprConsent(bidderRequest) {
   const consent = {};
@@ -113,13 +293,11 @@ function _getGdprConsent(bidderRequest) {
 function _setData(data) {
   window.top.ADAGIO = window.top.ADAGIO || {};
   window.top.ADAGIO.queue = window.top.ADAGIO.queue || [];
-  // if (window.top.ADAGIO && window.top.ADAGIO.queue) {
   window.top.ADAGIO.queue.push({
     action: 'ssp-data',
     ts: Date.now(),
     data: data,
   });
-  // }
 }
 
 export const spec = {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -350,14 +350,14 @@ export const spec = {
 
   isBidRequestValid: function(bid) {
     const { adUnitCode, auctionId, sizes, bidder, params } = bid;
-    const { organizationId, site, placement, pagetype, adUnitElementId } = bid.params;
+    const { organizationId, site, placement, adUnitElementId } = bid.params;
     let isValid = false;
 
     if (canAccessTopWindow()) {
       top.ADAGIO = top.ADAGIO || {};
       top.ADAGIO.adUnits = top.ADAGIO.adUnits || {};
       top.ADAGIO.pbjsAdUnits = top.ADAGIO.pbjsAdUnits || [];
-      isValid = !!(organizationId && site && placement && pagetype && adUnitElementId && document.getElementById(adUnitElementId) !== null);
+      isValid = !!(organizationId && site && placement && adUnitElementId && document.getElementById(adUnitElementId) !== null);
       const tempAdUnits = top.ADAGIO.pbjsAdUnits.filter((adUnit) => adUnit.code !== adUnitCode);
       tempAdUnits.push({
         code: adUnitCode,

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.4.0';
+const VERSION = '1.5.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -109,12 +109,13 @@ function _getGdprConsent(bidderRequest) {
   return consent;
 }
 
-function _setPredictions(predictions) {
+// Extra data returned by Adagio SSP Engine
+function _setData(data) {
   if (window.top.ADAGIO && window.top.ADAGIO.queue) {
     window.top.ADAGIO.queue.push({
-      action: 'set-predictions',
+      action: 'ssp-data',
       ts: Date.now(),
-      predictions: predictions,
+      data: data,
     });
   }
 }
@@ -175,8 +176,8 @@ export const spec = {
     try {
       const response = serverResponse.body;
       if (response) {
-        if (response.predictions) {
-          _setPredictions(response.predictions)
+        if (response.data) {
+          _setData(response.data)
         }
         if (response.bids) {
           response.bids.forEach(bidObj => {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from '../src/utils';
 import {registerBidder} from '../src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.5.0';
+const VERSION = '2.0.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -1,6 +1,6 @@
 import find from 'core-js/library/fn/array/find';
-import * as utils from 'src/utils';
-import { registerBidder } from 'src/adapters/bidderFactory';
+import * as utils from '../src/utils';
+import {registerBidder} from '../src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
 const VERSION = '1.5.0';

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -88,6 +88,12 @@ function initAdagio() {
     });
   });
 
+  if (window.advstLib && typeof window.advstLib === 'function') {
+    advstLib().eventHandler.addListener('renderEndedEvent', function(e) {
+      adagioEnqueue('adthk-event', { eventName: 'renderEndedEvent', args: e.detail });
+    });
+  }
+
   // First, try to load adagio-js from localStorage.
   getAdagioTag();
 

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '1.2.0';
+const VERSION = '1.3.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
@@ -295,12 +295,24 @@ export const spec = {
   supportedMediaType: SUPPORTED_MEDIA_TYPES,
 
   isBidRequestValid: function(bid) {
-    const { adUnitCode, auctionId } = bid;
+    top.ADAGIO = top.ADAGIO || {};
+    top.ADAGIO.adUnits = top.ADAGIO.adUnits || {};
+    top.ADAGIO.pbjsAdUnits = top.ADAGIO.pbjsAdUnits || [];
+    const { adUnitCode, auctionId, sizes, bidder, params } = bid;
     const { organizationId, site, placement, pagetype, adUnitElementId } = bid.params;
     const isValid = !!(organizationId && site && placement && pagetype && adUnitElementId && document.getElementById(adUnitElementId) !== null);
+    const tempAdUnits = top.ADAGIO.pbjsAdUnits.filter((adUnit) => adUnit.code !== adUnitCode);
+    tempAdUnits.push({
+      code: adUnitCode,
+      sizes,
+      bids: [{
+        bidder,
+        params
+      }]
+    });
+    top.ADAGIO.pbjsAdUnits = tempAdUnits;
 
     if (isValid === true) {
-      top.ADAGIO.adUnits = top.ADAGIO.adUnits || {};
       top.ADAGIO.adUnits[adUnitCode] = {
         auctionId: auctionId,
         pageviewId: _getPageviewId()

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -19,10 +19,21 @@ Connects to Adagio demand source to fetch bids.
             {
               bidder: 'adagio', // Required
               params: {
-                siteId: '0', // Required - Site ID from Adagio.
-                placementId: '4', // Required - Placement ID from Adagio. Refers to the placement of an ad unit in a page.
-                pagetypeId: '343', // Required - Page type ID from Adagio.
-                categories: ['IAB12', 'IAB12-2'], // IAB categories of the page.
+                organizationId: '0', // Required - Organization ID from Adagio.
+                site: 'SITE-NAME', // Required - Site Name from Adagio.
+                adUnitElementId: 'dfp_banniere-atf', // Required - AdUnit element id. Refers to the adunit id in a page (ex: document.getElementById(adUnitElementId))
+
+                // The following params are limited to 30 characters,
+                // and can only contain the following characters:
+                // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
+                // - dashes `-`
+                // - underscores `_`
+                // Also, each param can have at most 50 unique active values (case-insensitive).
+                placement: 'ATF', // Required - Placement from Adagio. Refers to the placement of an ad unit in a page.
+                pagetype: 'ARTICLE', // Required - Page type from Adagio.
+                category: 'NEWS', // Recommended - Category from Adagio.
+                subcategory: 'SPORT', // Optional - Sub-Category from Adagio.
+                environment: 'SITE-MOBILE', // Optional - Environment from Adagio.
               }
             }
           ]
@@ -36,21 +47,38 @@ Connects to Adagio demand source to fetch bids.
         alwaysUseBid: true,
         adserverTargeting: [
           {
+            key: "site",
+            val: function (bidResponse) {
+              return bidResponse.site;
+            }
+          },{
             key: "placement",
             val: function (bidResponse) {
-              return bidResponse.placementId;
+              return bidResponse.placement;
             }
           },
           {
             key: "pagetype",
             val: function (bidResponse) {
-              return bidResponse.pagetypeId;
+              return bidResponse.pagetype;
             }
           },
           {
-            key: "categories",
+            key: "category",
             val: function (bidResponse) {
-              return bidResponse.categories.join(",");
+              return bidResponse.category;
+            }
+          },
+          {
+            key: "subcategory",
+            val: function (bidResponse) {
+              return bidResponse.subcategory;
+            }
+          },
+          {
+            key: "environment",
+            val: function (bidResponse) {
+              return bidResponse.environment;
             }
           }
         ]

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -33,7 +33,8 @@ Connects to Adagio demand source to fetch bids.
             placement: 'ban_atf', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
             pagetype: 'article', // Required. The pagetype describes what kind of content will be present in the page.
             category: 'sport', // Recommended. Category of the content displayed in the page.
-            subcategory: 'handball' // Optional. Subcategory of the content displayed in the page.
+            subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
+            postBid: false // Optional. Use it in case of Post-bid integration only.
           }
          }
        ]

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -12,32 +12,32 @@ Connects to Adagio demand source to fetch bids.
 
 ```javascript
     var adUnits = [
+     {
+       code: 'dfp_banniere_atf',
+       sizes: [[300, 250], [300, 600]],
+       bids: [
         {
-          code: 'ad-unit_code',
-          sizes: [[300, 250], [300, 600]],
-          bids: [
-            {
-              bidder: 'adagio', // Required
-              params: {
-                organizationId: '0', // Required - Organization ID from Adagio.
-                site: 'SITE-NAME', // Required - Site Name from Adagio.
-                adUnitElementId: 'dfp_banniere-atf', // Required - AdUnit element id. Refers to the adunit id in a page (ex: document.getElementById(adUnitElementId))
+          bidder: 'adagio', // Required
+          params: {
+            organizationId: '0', // Required - Organization ID provided by Adagio.
+            site: 'news-of-the-day', // Required - Site Name provided by Adagio.
+            adUnitElementId: 'dfp_banniere_atf', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
 
-                // The following params are limited to 30 characters,
-                // and can only contain the following characters:
-                // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
-                // - dashes `-`
-                // - underscores `_`
-                // Also, each param can have at most 50 unique active values (case-insensitive).
-                placement: 'ATF', // Required - Placement from Adagio. Refers to the placement of an ad unit in a page.
-                pagetype: 'ARTICLE', // Required - Page type from Adagio.
-                category: 'NEWS', // Recommended - Category from Adagio.
-                subcategory: 'SPORT', // Optional - Sub-Category from Adagio.
-                environment: 'SITE-MOBILE', // Optional - Environment from Adagio.
-              }
-            }
-          ]
-        }
+            // The following params are limited to 30 characters,
+            // and can only contain the following characters:
+            // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
+            // - dashes `-`
+            // - underscores `_`
+            // Also, each param can have at most 50 unique active values (case-insensitive).
+            environment: 'mobile', // Required. Environment where the page is displayed.
+            placement: 'ban_atf', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
+            pagetype: 'article', // Required. The pagetype describes what kind of content will be present in the page.
+            category: 'sport', // Recommended. Category of the content displayed in the page.
+            subcategory: 'handball' // Optional. Subcategory of the content displayed in the page.
+          }
+         }
+       ]
+     }
     ];
 
     pbjs.addAdUnits(adUnits);
@@ -51,7 +51,14 @@ Connects to Adagio demand source to fetch bids.
             val: function (bidResponse) {
               return bidResponse.site;
             }
-          },{
+          },
+          {
+            key: "environment",
+            val: function (bidResponse) {
+              return bidResponse.environment;
+            }
+          },
+          {
             key: "placement",
             val: function (bidResponse) {
               return bidResponse.placement;
@@ -73,12 +80,6 @@ Connects to Adagio demand source to fetch bids.
             key: "subcategory",
             val: function (bidResponse) {
               return bidResponse.subcategory;
-            }
-          },
-          {
-            key: "environment",
-            val: function (bidResponse) {
-              return bidResponse.environment;
             }
           }
         ]

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -4,6 +4,7 @@ import * as utils from './utils';
 const _requestCache = {};
 const _vendorWhitelist = [
   'criteo',
+  'adagio'
 ]
 
 /**

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -5,6 +5,8 @@ import {
 import {
   parse as parseURL
 } from 'src/url';
+import * as utils from 'src/utils';
+
 let adapterManager = require('src/adapterManager').default;
 let events = require('src/events');
 let constants = require('src/constants.json');
@@ -110,6 +112,79 @@ describe('adagio analytics adapter', () => {
       expect(o.ts).to.not.be.undefined;
       expect(o.data).to.not.be.undefined;
       expect(o.data).to.deep.equal({eventName: constants.EVENTS.AUCTION_END, args: {}});
+    });
+  });
+
+  describe('no track', () => {
+    // delete window.top.ADAGIO;
+    const sandbox = sinon.createSandbox();
+
+    adapterManager.registerAnalyticsAdapter({
+      code: 'adagio',
+      adapter: adagioAnalyticsAdapter
+    });
+
+    beforeEach(() => {
+      sandbox.stub(utils, 'getWindowTop').throws();
+
+      adapterManager.enableAnalytics({
+        provider: 'adagio'
+      });
+    });
+
+    afterEach(() => {
+      adagioAnalyticsAdapter.disableAnalytics();
+      sandbox.restore();
+    });
+
+    it('builds and sends auction data', () => {
+      let bidRequest = {
+        bids: [{
+          adUnitCode: 'div-1',
+          params: {
+            features: {
+              siteId: '2',
+              placement: 'pave_top',
+              pagetype: 'article',
+              category: 'IAB12,IAB12-2',
+              device: '2',
+            }
+          }
+        }, {
+          adUnitCode: 'div-2',
+          params: {
+            features: {
+              siteId: '2',
+              placement: 'ban_top',
+              pagetype: 'article',
+              category: 'IAB12,IAB12-2',
+              device: '2',
+            }
+          },
+        }],
+      };
+      let bidResponse = {
+        bidderCode: 'adagio',
+        width: 300,
+        height: 250,
+        statusMessage: 'Bid available',
+        cpm: 6.2189757658226075,
+        currency: '',
+        netRevenue: false,
+        adUnitCode: 'div-1',
+        timeToRespond: 132,
+      };
+
+      // Step 1: Send bid requested event
+      events.emit(constants.EVENTS.BID_REQUESTED, bidRequest);
+
+      // Step 2: Send bid response event
+      events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
+
+      // Step 3: Send auction end event
+      events.emit(constants.EVENTS.AUCTION_END, {});
+
+      expect(window.top.ADAGIO.queue).length(0);
     });
   });
 });

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -1,0 +1,115 @@
+import adagioAnalyticsAdapter from 'modules/adagioAnalyticsAdapter';
+import {
+  expect
+} from 'chai';
+import {
+  parse as parseURL
+} from 'src/url';
+let adapterManager = require('src/adapterManager').default;
+let events = require('src/events');
+let constants = require('src/constants.json');
+
+describe('adagio analytics adapter', () => {
+  let xhr;
+  let requests;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = request => requests.push(request);
+    sinon.stub(events, 'getEvents').returns([]);
+  });
+
+  afterEach(() => {
+    xhr.restore();
+    events.getEvents.restore();
+  });
+
+  describe('track', () => {
+    adapterManager.registerAnalyticsAdapter({
+      code: 'adagio',
+      adapter: adagioAnalyticsAdapter
+    });
+
+    beforeEach(() => {
+      adapterManager.enableAnalytics({
+        provider: 'adagio'
+      });
+    });
+
+    afterEach(() => {
+      adagioAnalyticsAdapter.disableAnalytics();
+    });
+
+    it('builds and sends auction data', () => {
+      let bidRequest = {
+        bids: [{
+          adUnitCode: 'div-1',
+          params: {
+            features: {
+              siteId: '2',
+              placement: 'pave_top',
+              pagetype: 'article',
+              category: 'IAB12,IAB12-2',
+              device: '2',
+            }
+          }
+        }, {
+          adUnitCode: 'div-2',
+          params: {
+            features: {
+              siteId: '2',
+              placement: 'ban_top',
+              pagetype: 'article',
+              category: 'IAB12,IAB12-2',
+              device: '2',
+            }
+          },
+        }],
+      };
+      let bidResponse = {
+        bidderCode: 'adagio',
+        width: 300,
+        height: 250,
+        statusMessage: 'Bid available',
+        cpm: 6.2189757658226075,
+        currency: '',
+        netRevenue: false,
+        adUnitCode: 'div-1',
+        timeToRespond: 132,
+      };
+
+      // Step 1: Send bid requested event
+      events.emit(constants.EVENTS.BID_REQUESTED, bidRequest);
+
+      // Step 2: Send bid response event
+      events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
+
+      // Step 3: Send auction end event
+      events.emit(constants.EVENTS.AUCTION_END, {});
+
+      expect(window.top.ADAGIO.queue).length(3);
+
+      let o = window.top.ADAGIO.queue.shift();
+      expect(o).to.not.be.undefined;
+      expect(o.action).to.equal('pb-analytics-event');
+      expect(o.ts).to.not.be.undefined;
+      expect(o.data).to.not.be.undefined;
+      expect(o.data).to.deep.equal({eventName: constants.EVENTS.BID_REQUESTED, args: bidRequest});
+
+      o = window.top.ADAGIO.queue.shift();
+      expect(o).to.not.be.undefined;
+      expect(o.action).to.equal('pb-analytics-event');
+      expect(o.ts).to.not.be.undefined;
+      expect(o.data).to.not.be.undefined;
+      expect(o.data).to.deep.equal({eventName: constants.EVENTS.BID_RESPONSE, args: bidResponse});
+
+      o = window.top.ADAGIO.queue.shift();
+      expect(o).to.not.be.undefined;
+      expect(o.action).to.equal('pb-analytics-event');
+      expect(o.ts).to.not.be.undefined;
+      expect(o.data).to.not.be.undefined;
+      expect(o.data).to.deep.equal({eventName: constants.EVENTS.AUCTION_END, args: {}});
+    });
+  });
+});

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -80,6 +80,21 @@ describe('adagioAdapter', () => {
 
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
+      expect(window.top.ADAGIO.adUnits['adunit-code'].printNumber).to.equal(1);
+    })
+
+    it('should compute a printNumber for the new bid request on same adUnitCode and same pageviewId', () => {
+      spec.isBidRequestValid(bid);
+      expect(window.top.ADAGIO.adUnits).ok;
+      expect(window.top.ADAGIO.adUnits['adunit-code']).ok;
+      expect(window.top.ADAGIO.adUnits['adunit-code'].printNumber).to.equal(2);
+
+      spec.isBidRequestValid(bid);
+      expect(window.top.ADAGIO.adUnits['adunit-code'].printNumber).to.equal(3);
+
+      window.top.ADAGIO.pageviewId = 123;
+      spec.isBidRequestValid(bid);
+      expect(window.top.ADAGIO.adUnits['adunit-code'].printNumber).to.equal(1);
     });
 
     it('should return false when organization params is not passed', () => {
@@ -324,7 +339,6 @@ describe('adagioAdapter', () => {
 
     it('AdUnit requested should have the correct sizes array depending on the config', () => {
       const requests = spec.buildRequests(bidRequests);
-      console.log(requests[0].data.adUnits[0]);
       expect(requests[1].data.adUnits[0]).to.have.property('mediaTypes');
     });
 
@@ -394,6 +408,18 @@ describe('adagioAdapter', () => {
       expect(requests[0].data.pageviewId).to.equal('abc');
       expect(requests[1].data.pageviewId).to.equal('abc');
     });
+
+    it('should send the printNumber in features object', () => {
+      window.top.ADAGIO = window.top.ADAGIO || {};
+      window.top.ADAGIO.pageviewId = 'abc';
+      window.top.ADAGIO.adUnits['adunit-code1'] = {
+        pageviewId: 'abc',
+        printNumber: 2
+      };
+      const requests = spec.buildRequests([bidRequests[0]]);
+      const request = requests[0];
+      expect(request.data.adUnits[0].features.print_number).to.equal('2');
+    })
 
     it('GDPR consent is applied', () => {
       const requests = spec.buildRequests(bidRequests, bidderRequest);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -94,6 +94,10 @@ describe('adagioAdapter', () => {
     let sandbox;
     let sdbxStuGetComputedStyle;
 
+    top.ADAGIO = top.ADAGIO || {};
+    top.ADAGIO.adUnits = top.ADAGIO.adUnits || {};
+    top.ADAGIO.pbjsAdUnits = top.ADAGIO.pbjsAdUnits || [];
+
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
 
@@ -197,6 +201,25 @@ describe('adagioAdapter', () => {
       }
     ];
 
+    const bidRequestsWithPostBid = [
+      {
+        'bidder': 'adagio',
+        'params': {
+          organizationId: '456',
+          site: 'ADAGIO-456',
+          placement: 'PAVE_ATF-456',
+          pagetype: 'ARTICLE',
+          adUnitElementId: 'banner-atf-456',
+          postBid: true
+        },
+        'adUnitCode': 'adunit-code3',
+        'sizes': [[300, 250], [300, 600]],
+        'bidId': 'c180kg4267tyqz',
+        'bidderRequestId': '8vfscuixrovn8i',
+        'auctionId': 'lel4fhp239i9km',
+      }
+    ];
+
     let consentString = 'theConsentString';
     let bidderRequest = {
       'bidderCode': 'adagio',
@@ -241,6 +264,24 @@ describe('adagioAdapter', () => {
       let requests = spec.buildRequests(bidRequests);
       let request = requests[0];
       expect(request.data.adUnits[0].features).to.exist;
+    });
+
+    it('outerAdUnitElementId must be added when PostBid param has been set', () => {
+      top.ADAGIO = top.ADAGIO || {};
+      top.ADAGIO.pbjsAdUnits = [];
+
+      top.ADAGIO.pbjsAdUnits.push({
+        code: bidRequestsWithPostBid[0].adUnitCode,
+        sizes: bidRequestsWithPostBid[0].sizes,
+        bids: [{
+          bidder: bidRequestsWithPostBid[0].bidder,
+          params: bidRequestsWithPostBid[0].params
+        }]
+      });
+      let requests = spec.buildRequests(bidRequestsWithPostBid);
+      let request = requests[0];
+      expect(request.data.adUnits[0].features).to.exist;
+      expect(request.data.adUnits[0].params.outerAdUnitElementId).to.exist;
     });
 
     it('generates a pageviewId if missing', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -184,23 +184,23 @@ describe('adagioAdapter', () => {
       expect(request.data.adUnits[0].features).to.deep.equal(expected);
     });
 
-    it('features params must be an object if featurejs is loaded', () => {
-      window.top._ADAGIO = window.top._ADAGIO || {};
-      window.top._ADAGIO.features = window.top._ADAGIO.features || {};
-      window.top._ADAGIO.features.getFeatures = function() {
-        return {
-          prop1: 'one',
-          prop2: 'two'
-        }
-      }
-      const requests = spec.buildRequests(bidRequests);
-      const request = requests[0];
-      const expected = {
-        prop1: 'one',
-        prop2: 'two'
-      };
-      expect(request.data.adUnits[0].features).to.deep.equal(expected);
-    });
+    // it('features params must be an object if featurejs is loaded', () => {
+    //   window.top._ADAGIO = window.top._ADAGIO || {};
+    //   window.top._ADAGIO.features = window.top._ADAGIO.features || {};
+    //   window.top._ADAGIO.features.getFeatures = function() {
+    //     return {
+    //       prop1: 'one',
+    //       prop2: 'two'
+    //     }
+    //   }
+    //   const requests = spec.buildRequests(bidRequests);
+    //   const request = requests[0];
+    //   const expected = {
+    //     prop1: 'one',
+    //     prop2: 'two'
+    //   };
+    //   expect(request.data.adUnits[0].features).to.deep.equal(expected);
+    // });
 
     it('GDPR consent is applied', () => {
       const requests = spec.buildRequests(bidRequests, bidderRequest);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -466,6 +466,14 @@ describe('adagioAdapter', () => {
       expect(window.top.ADAGIO.versions).ok;
       expect(window.top.ADAGIO.versions.adagioBidderAdapter).to.eq(VERSION);
     });
+
+    it('should returns an empty array if the bidder cannot access to window top (based on refererInfo.reachedTop)', () => {
+      const requests = spec.buildRequests(bidRequests, {
+        ...bidderRequest,
+        refererInfo: { reachedTop: false }
+      });
+      expect(requests).to.be.empty;
+    });
   });
 
   describe('interpretResponse', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -6,7 +6,7 @@ import * as utils from 'src/utils';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.4.0';
+  const VERSION = '1.5.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -5,7 +5,7 @@ import { spec } from 'modules/adagioBidAdapter';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.3.0';
+  const VERSION = '1.4.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -5,7 +5,7 @@ import { spec } from 'modules/adagioBidAdapter';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.1.1';
+  const VERSION = '1.2.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -5,7 +5,7 @@ import { spec } from 'modules/adagioBidAdapter';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.2.0';
+  const VERSION = '1.3.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -5,6 +5,7 @@ import { spec } from 'modules/adagioBidAdapter';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
+  const VERSION = '1.1.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {
@@ -282,6 +283,12 @@ describe('adagioAdapter', () => {
       expect(request.data.gdpr).to.exist;
       expect(request.data.gdpr).to.be.empty;
     });
+
+    it('should expose version in window', () => {
+      expect(window.top.ADAGIO).ok;
+      expect(window.top.ADAGIO.versions).ok;
+      expect(window.top.ADAGIO.versions.adagioBidderAdapter).to.eq(VERSION);
+    });
   });
 
   describe('interpretResponse', () => {
@@ -342,7 +349,7 @@ describe('adagioAdapter', () => {
     };
 
     beforeEach(function () {
-      delete (window.top.ADAGIO);
+      // delete (window.top.ADAGIO);
     });
 
     it('Should returns empty response if body is empty', () => {
@@ -380,7 +387,7 @@ describe('adagioAdapter', () => {
       spec.interpretResponse(serverResponse, bidRequest);
       expect(window.top.ADAGIO).ok;
       expect(window.top.ADAGIO.queue).to.be.an('array');
-      expect(window.top.ADAGIO.queue).length(1);
+      expect(window.top.ADAGIO.queue).not.empty;
     });
   });
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -354,20 +354,6 @@ describe('adagioAdapter', () => {
       expect(request.data.adUnits[0].features).to.exist;
     });
 
-    it('device type must be "5" when user agent match tablet test', () => {
-      sandbox.stub(top.navigator, 'userAgent').value('Mozilla/5.0 (iPad; CPU OS 12_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C50');
-      const requests = spec.buildRequests([Object.assign({}, bidRequests[0])], bidderRequest);
-      const request = requests[0];
-      expect(request.data.device.deviceType).to.equal(5);
-    })
-
-    it('device type must be "4" when user agent match phone test', () => {
-      sandbox.stub(top.navigator, 'userAgent').value('Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G950F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 Mobile Safari/537.36');
-      const requests = spec.buildRequests([Object.assign({}, bidRequests[0])], bidderRequest);
-      const request = requests[0];
-      expect(request.data.device.deviceType).to.equal(4);
-    })
-
     it('outerAdUnitElementId must be added when PostBid param has been set', () => {
       top.ADAGIO = top.ADAGIO || {};
       top.ADAGIO.pbjsAdUnits = [];

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -5,7 +5,7 @@ import { spec } from 'modules/adagioBidAdapter';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.1.0';
+  const VERSION = '1.1.1';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {
@@ -243,6 +243,28 @@ describe('adagioAdapter', () => {
       expect(request.data.adUnits[0].features).to.exist;
     });
 
+    it('generates a pageviewId if missing', () => {
+      window.top.ADAGIO = window.top.ADAGIO || {};
+      delete window.top.ADAGIO.pageviewId;
+
+      const requests = spec.buildRequests(bidRequests);
+      expect(requests).to.have.lengthOf(2);
+
+      expect(requests[0].data.pageviewId).to.exist.and.to.not.equal('_').and.to.not.equal('');
+      expect(requests[0].data.pageviewId).to.equal(requests[1].data.pageviewId);
+    });
+
+    it('uses an existing pageviewId if present', () => {
+      window.top.ADAGIO = window.top.ADAGIO || {};
+      window.top.ADAGIO.pageviewId = 'abc';
+
+      const requests = spec.buildRequests(bidRequests);
+      expect(requests).to.have.lengthOf(2);
+
+      expect(requests[0].data.pageviewId).to.equal('abc');
+      expect(requests[1].data.pageviewId).to.equal('abc');
+    });
+
     it('GDPR consent is applied', () => {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests).to.have.lengthOf(2);
@@ -343,6 +365,7 @@ describe('adagioAdapter', () => {
             'bidId': 'c180kg4267tyqz',
             'bidderRequestId': '8vfscuixrovn8i',
             'auctionId': 'lel4fhp239i9km',
+            'pageviewId': 'd8c4fl2k39i0wn',
           }
         ]
       }

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -57,6 +57,27 @@ describe('adagioAdapter', () => {
       'auctionId': 'lel4fhp239i9km',
     };
 
+    let bidWithMediaTypes = {
+      'bidder': 'adagio',
+      'params': {
+        organizationId: '0',
+        placement: 'PAVE_ATF',
+        site: 'SITE-NAME',
+        pagetype: 'ARTICLE',
+        adUnitElementId: 'banner-atf'
+      },
+      'adUnitCode': 'adunit-code-2',
+      'mediaTypes': {
+        banner: {
+          sizes: [[300, 250]],
+        }
+      },
+      sizes: [[300, 600]],
+      'bidId': 'c180kg4267tyqz',
+      'bidderRequestId': '8vfscuixrovn8i',
+      'auctionId': 'lel4fhp239i9km',
+    }
+
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
@@ -88,6 +109,17 @@ describe('adagioAdapter', () => {
     it('should return false if not in the window.top', () => {
       sandbox.stub(utils, 'getWindowTop').throws();
       expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should expose ADAGIO.pbjsAdUnits in window', () => {
+      spec.isBidRequestValid(bidWithMediaTypes);
+      spec.isBidRequestValid(bid);
+      expect(window.top.ADAGIO.pbjsAdUnits).ok;
+      expect(window.top.ADAGIO.pbjsAdUnits).to.have.lengthOf(2);
+      const adUnitWithMediaTypeSizes = window.top.ADAGIO.pbjsAdUnits.filter((aU) => aU.code === 'adunit-code-2')[0];
+      const adUnitWithSizes = window.top.ADAGIO.pbjsAdUnits.filter((aU) => aU.code === 'adunit-code')[0];
+      expect(adUnitWithMediaTypeSizes.sizes).to.eql([[300, 250]]);
+      expect(adUnitWithSizes.sizes).to.eql([[300, 250], [300, 600]]);
     });
   });
 
@@ -204,6 +236,11 @@ describe('adagioAdapter', () => {
           adUnitElementId: 'banner-atf-456'
         },
         'adUnitCode': 'adunit-code3',
+        'mediaTypes': {
+          banner: {
+            sizes: [[300, 250]]
+          }
+        },
         'sizes': [[300, 250], [300, 600]],
         'bidId': 'c180kg4267tyqz',
         'bidderRequestId': '8vfscuixrovn8i',
@@ -283,6 +320,12 @@ describe('adagioAdapter', () => {
       let request = requests[0];
       expect(request.data.adUnits[0].features).to.exist;
       expect(request.data.adUnits[0].features.viewport_dimensions).to.match(/^[\d]+x[\d]+$/);
+    });
+
+    it('AdUnit requested should have the correct sizes array depending on the config', () => {
+      const requests = spec.buildRequests(bidRequests);
+      console.log(requests[0].data.adUnits[0]);
+      expect(requests[1].data.adUnits[0]).to.have.property('mediaTypes');
     });
 
     it('features params must be an object if featurejs is loaded', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -77,12 +77,6 @@ describe('adagioAdapter', () => {
       expect(spec.isBidRequestValid(bidTest)).to.equal(false);
     });
 
-    it('should return false when pagetype params is not passed', () => {
-      let bidTest = Object.assign({}, bid);
-      delete bidTest.params.pagetype;
-      expect(spec.isBidRequestValid(bidTest)).to.equal(false);
-    });
-
     it('should return false when adUnit element id params is not passed', () => {
       let bidTest = Object.assign({}, bid);
       delete bidTest.params.adUnitElementId;

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -6,7 +6,7 @@ import * as utils from 'src/utils';
 describe('adagioAdapter', () => {
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '1.5.0';
+  const VERSION = '2.0.0';
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [x] Other

## Description of change
This PR is about the update of both AdagioBidAdapter and AdagioAnalyticsAdapter and the acceptation by Prebid to grant us our [prebid-js-external-js-adagio-io repository ](https://github.com/Prebid-org/prebid-js-external-js-adagio-io).

### adagioBidAdapter

- add an external loader
- add some custom features detection to be sent with the bid request
- add limitation with safe-frame integration

### adagioAnalyticsAdapter

- move the type from `bundle` to `endpoint`

dev@adagio.io

## Other information

The prebid external js request was followed by @mkendall07.
