### PR TITLE
Add usersync to Adpone adapter

### DIFF
--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -51,13 +51,15 @@ export const spec = {
           }))
       };
 
+      const options = {
+        withCredentials: true
+      };
+
       return {
         method: ADPONE_REQUEST_METHOD,
         url,
-        options: {
-          withCredentials: true,
-        },
-        data
+        data,
+        options,
       };
     });
   },

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -51,7 +51,11 @@ export const spec = {
           }))
       };
 
-      return { method: ADPONE_REQUEST_METHOD, url, data, withCredentials: true };
+      return {
+        method: ADPONE_REQUEST_METHOD,
+        url,
+        data
+      };
     });
   },
 

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -9,10 +9,10 @@ const ADPONE_REQUEST_METHOD = 'POST';
 const ADPONE_CURRENCY = 'EUR';
 const adapterState = {};
 
-function _createSync(placementId) {
+function _createSync() {
   return {
     type: 'iframe',
-    url: ADPONE_SYNC_ENDPOINT + '?id=' + placementId
+    url: ADPONE_SYNC_ENDPOINT
   }
 }
 
@@ -20,7 +20,7 @@ function getUserSyncs(syncOptions, responses, gdprConsent) {
   if (gdprConsent && gdprConsent.gdprApplies === true) {
     return []
   } else {
-    return (syncOptions.iframeEnabled) ? adapterState.uniquePlacementIds.map(_createSync) : ([]);
+    return (syncOptions.iframeEnabled) ? _createSync() : ([]);
   }
 }
 

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -4,6 +4,7 @@ import * as utils from '../src/utils';
 
 const ADPONE_CODE = 'adpone';
 const ADPONE_ENDPOINT = 'https://rtb.adpone.com/bid-request';
+const ADPONE_SYNC_ENDPOINT = 'https://eu-ads.adpone.com';
 const ADPONE_REQUEST_METHOD = 'POST';
 const ADPONE_CURRENCY = 'EUR';
 const adapterState = {};
@@ -11,7 +12,7 @@ const adapterState = {};
 function _createSync(placementId) {
   return {
     type: 'iframe',
-    url: `https://eu-ads.adpone.com?id=${placementId}`
+    url: ADPONE_SYNC_ENDPOINT + '?id=' + placementId
   }
 }
 

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -15,7 +15,7 @@ function _createSync() {
 }
 
 function getUserSyncs(syncOptions) {
-  return (syncOptions.iframeEnabled) ? _createSync() : ([]);
+  return (syncOptions && syncOptions.iframeEnabled) ? _createSync() : ([]);
 }
 
 export const spec = {

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -54,6 +54,9 @@ export const spec = {
       return {
         method: ADPONE_REQUEST_METHOD,
         url,
+        options: {
+          withCredentials: true,
+        },
         data
       };
     });

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -1,13 +1,11 @@
 import {BANNER} from '../src/mediaTypes';
 import {registerBidder} from '../src/adapters/bidderFactory';
-import * as utils from '../src/utils';
 
 const ADPONE_CODE = 'adpone';
 const ADPONE_ENDPOINT = 'https://rtb.adpone.com/bid-request';
 const ADPONE_SYNC_ENDPOINT = 'https://eu-ads.adpone.com';
 const ADPONE_REQUEST_METHOD = 'POST';
 const ADPONE_CURRENCY = 'EUR';
-const adapterState = {};
 
 function _createSync() {
   return {
@@ -16,12 +14,8 @@ function _createSync() {
   }
 }
 
-function getUserSyncs(syncOptions, responses, gdprConsent) {
-  if (gdprConsent && gdprConsent.gdprApplies === true) {
-    return []
-  } else {
-    return (syncOptions.iframeEnabled) ? _createSync() : ([]);
-  }
+function getUserSyncs(syncOptions) {
+  return (syncOptions.iframeEnabled) ? _createSync() : ([]);
 }
 
 export const spec = {
@@ -35,7 +29,6 @@ export const spec = {
   },
 
   buildRequests: bidRequests => {
-    adapterState.uniquePlacementIds = bidRequests.map(req => req.params.placementId).filter(utils.uniques);
     return bidRequests.map(bid => {
       const url = ADPONE_ENDPOINT + '?pid=' + bid.params.placementId;
       const data = {

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -51,7 +51,11 @@ export const spec = {
           }))
       };
 
-      return { method: ADPONE_REQUEST_METHOD, url, data }
+      const options = {
+        withCredentials: true
+      };
+
+      return { method: ADPONE_REQUEST_METHOD, url, data, options }
     });
   },
 

--- a/modules/adponeBidAdapter.js
+++ b/modules/adponeBidAdapter.js
@@ -51,11 +51,7 @@ export const spec = {
           }))
       };
 
-      const options = {
-        withCredentials: true
-      };
-
-      return { method: ADPONE_REQUEST_METHOD, url, data, options }
+      return { method: ADPONE_REQUEST_METHOD, url, data, withCredentials: true };
     });
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "2.33.0-pre",
+  "version": "2.34.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6434,12 +6434,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6454,17 +6456,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6581,7 +6586,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6593,6 +6599,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6607,6 +6614,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6614,12 +6622,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6638,6 +6648,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6718,7 +6729,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6730,6 +6742,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6851,6 +6864,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/spec/modules/adponeBidAdapter_spec.js
+++ b/test/spec/modules/adponeBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { spec } from 'modules/adponeBidAdapter';
-
+const EMPTY_ARRAY = [];
 describe('adponeBidAdapter', function () {
   let bid = {
     bidder: 'adpone',
@@ -102,8 +102,10 @@ describe('interpretResponse', function () {
 });
 
 describe('getUserSyncs', function () {
-  it('Verifies sync iframe option', function () {
-    expect(spec.getUserSyncs({iframeEnabled: false})).to.deep.equal([]);
+  it('Verifies getUserSyncs returns expected result', function () {
+    expect((typeof (spec.getUserSyncs)).should.equals('function'));
+    expect(spec.getUserSyncs({iframeEnabled: false})).to.deep.equal(EMPTY_ARRAY);
+    expect(spec.getUserSyncs(null)).to.deep.equal(EMPTY_ARRAY);
     expect(spec.getUserSyncs({iframeEnabled: true})).to.deep.equal({
       type: 'iframe',
       url: 'https://eu-ads.adpone.com'

--- a/test/spec/modules/adponeBidAdapter_spec.js
+++ b/test/spec/modules/adponeBidAdapter_spec.js
@@ -103,9 +103,8 @@ describe('interpretResponse', function () {
 
 describe('getUserSyncs', function () {
   it('Verifies sync iframe option', function () {
-    expect(spec.getUserSyncs({}, [], {gdprApplies: true})).to.deep.equal([]);
-    expect(spec.getUserSyncs({iframeEnabled: false}, [], {gdprApplies: false})).to.deep.equal([]);
-    expect(spec.getUserSyncs({iframeEnabled: true}, [], {gdprApplies: false})).to.deep.equal({
+    expect(spec.getUserSyncs({iframeEnabled: false})).to.deep.equal([]);
+    expect(spec.getUserSyncs({iframeEnabled: true})).to.deep.equal({
       type: 'iframe',
       url: 'https://eu-ads.adpone.com'
     });

--- a/test/spec/modules/adponeBidAdapter_spec.js
+++ b/test/spec/modules/adponeBidAdapter_spec.js
@@ -100,3 +100,14 @@ describe('interpretResponse', function () {
     expect(response).to.deep.equal([])
   });
 });
+
+describe('getUserSyncs', function () {
+  it('Verifies sync iframe option', function () {
+    expect(spec.getUserSyncs({}, [], {gdprApplies: true})).to.deep.equal([]);
+    expect(spec.getUserSyncs({iframeEnabled: false}, [], {gdprApplies: false})).to.deep.equal([]);
+    expect(spec.getUserSyncs({iframeEnabled: true}, [], {gdprApplies: false})).to.deep.equal({
+      type: 'iframe',
+      url: 'https://eu-ads.adpone.com'
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x ] Other

## Description of change
Add user sync to adpone adapter

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
