### PR TITLE
Adding workflow to run end to end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "5 * * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,58 +2,81 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
+
+aliases: 
+  - &environment
+      docker:
+        # specify the version you desire here
+        - image: circleci/node:8.9.0
+        
+        # Specify service dependencies here if necessary
+        # CircleCI maintains a library of pre-built images
+        # documented at https://circleci.com/docs/2.0/circleci-images/
+        # - image: circleci/mongo:3.4.4
+      working_directory: ~/Prebid.js
+
+  - &restore_dep_cache
+      keys:
+        - v1-dependencies-{{ checksum "package.json" }}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+  - &save_dep_cache
+      paths:
+        - node_modules
+      key: v1-dependencies-{{ checksum "package.json" }}
+
+  - &install
+      name: Install gulp cli
+      command: sudo npm install -g gulp-cli
+
+  - &run_unit_test
+      name: BrowserStack testing
+      command: gulp test --browserstack --nolintfix
+
+  - &run_endtoend_test
+      name: BrowserStack End to end testing
+      command: echo "Running end to end test using workflows"
+
+  # Download and run BrowserStack local
+  - &setup_browserstack
+      name : Download BrowserStack Local binary and start it.
+      command : |
+        # Download the browserstack binary file
+        wget "https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip"
+        # Unzip it
+        unzip BrowserStackLocal-linux-x64.zip
+        # Run the file with user's access key
+        ./BrowserStackLocal ${BROWSERSTACK_ACCESS_KEY} &
+
+  - &unit_test_steps
+    - checkout
+    - restore_cache: *restore_dep_cache
+    - run: npm install
+    - save_cache: *save_dep_cache
+    - run: *install
+    - run: *setup_browserstack
+    - run: *run_unit_test
+
+  - &endtoend_test_steps
+    - checkout
+    - restore_cache: *restore_dep_cache
+    - run: npm install
+    - save_cache: *save_dep_cache
+    - run: *install
+    - run: *setup_browserstack
+    - run: *run_endtoend_test
+
 version: 2
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8.9.0
+    <<: *environment
+    steps: *unit_test_steps
       
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/Prebid.js
-
-    steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
-      - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
-      - run: sudo npm install -g gulp-cli
-      # Download and run BrowserStack local
-      - run:
-          name : Download BrowserStack Local binary and start it.
-          command : |
-            # Download the browserstack binary file
-            wget "https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip"
-            # Unzip it
-            unzip BrowserStackLocal-linux-x64.zip
-            # Run the file with user's access key
-            ./BrowserStackLocal ${BROWSERSTACK_ACCESS_KEY} &
-      # run tests!
-      - run: 
-          name: BrowserStack testing
-          command: gulp test --browserstack --nolintfix
   e2etest:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8.9.0
-    steps:
-      - run: echo "Running end to end test using workflows"
+    <<: *environment
+    steps: *endtoend_test_steps
+
 workflows:
   version: 2
   commit:
@@ -62,16 +85,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 * * * *"
           filters:
             branches:
               only:
                 - master
                 - circleci-workflow
     jobs:
-      - build
-      - e2etest:
-          requires:
-            - build
-
-  
+      - e2etest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,30 @@ jobs:
       - run: 
           name: BrowserStack testing
           command: gulp test --browserstack --nolintfix
+  e2etest:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8.9.0
+    steps:
+      - run: echo "Running end to end test using workflows"
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+  nightly:
+    triggers:
+      - schedule:
+          cron: "5 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - ${CIRCLE_BRANCH}
+    jobs:
+      - build
+      - e2etest:
+          requires:
+            - build
+
+  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
             branches:
               only:
                 - master
-                - ${CIRCLE_BRANCH}
+                - circleci-workflow
     jobs:
       - build
       - e2etest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 
   - &run_endtoend_test
       name: BrowserStack End to end testing
-      command: echo "Running end to end test using workflows"
+      command: echo "127.0.0.1 test.localhost" | sudo tee -a /etc/hosts && gulp e2e-test --host=test.localhost
 
   # Download and run BrowserStack local
   - &setup_browserstack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,10 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
                 - master
-                - circleci-workflow
     jobs:
       - e2etest


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds a new circleci job to run end to end tests every night on master branch. Job to run unit tests remains same. I have updated the config to use [circleci workflow](https://circleci.com/docs/2.0/workflows/) and [aliases](https://circleci.com/docs/2.0/writing-yaml/#anchors-and-aliases) 

#### Why run once every night ?
- Our end to end tests are not very stable due to various reasons, problems with browserstack booting up browsers, connection failures in browserstack and no bid response in browserstack vm's. 
- Functional tests takes around 15 mins to run and hence it is not feasible as of now to run on every commit.

Please see https://circleci.com/gh/prebid/workflows/Prebid.js for past successful runs of both jobs. 
