### PR TITLE
Add cpmDistribution function for Google Analytics adapter

### DIFF
--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -262,6 +262,11 @@ function sendBidWonToGa(bid) {
   checkAnalytics();
 }
 
+/**
+ * Exposed for testing purposes
+ */
+adapter.getCpmDistribution = getCpmDistribution;
+
 adapterManager.registerAnalyticsAdapter({
   adapter,
   code: 'ga'

--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -19,6 +19,7 @@ var _enableCheck = true;
 var _category = 'Prebid.js Bids';
 var _eventCount = 0;
 var _enableDistribution = false;
+var _cpmDistribution = null;
 var _trackerSend = null;
 var _sampled = true;
 
@@ -41,6 +42,9 @@ adapter.enableAnalytics = function ({ provider, options }) {
   }
   if (options && typeof options.enableDistribution !== 'undefined') {
     _enableDistribution = options.enableDistribution;
+  }
+  if (options && typeof options.cpmDistribution === 'function') {
+    _cpmDistribution = options.cpmDistribution;
   }
 
   var bid = null;
@@ -166,6 +170,9 @@ function getLoadTimeDistribution(time) {
 }
 
 function getCpmDistribution(cpm) {
+  if (_cpmDistribution) {
+    return _cpmDistribution(cpm);
+  }
   var distribution;
   if (cpm >= 0 && cpm < 0.5) {
     distribution = '$0-0.5';

--- a/modules/googleAnalyticsAdapter.md
+++ b/modules/googleAnalyticsAdapter.md
@@ -1,0 +1,37 @@
+# Google Analytics Adapter
+
+The google analytics adapter pushes prebid events into google analytics.
+
+## Usage
+
+The simplest way to enable the analytics adapter is this
+
+```javascript
+pbjs.enableAnalytics([{
+  provider: 'ga'
+}]);
+```
+
+Defaults will be used and you should see events being pushed to analytics.
+
+You can customize the adapter with various `options` like this
+
+```javascript
+pbjs.enableAnalytics([{
+  provider: 'ga',
+  options: { ... }
+}]);
+
+Here is a full list of settings available
+
+- `global` (string) - name of the global analytics object. Default is `ga`
+- `trackerName` (string) - use another tracker for prebid events. Default is the default tracker
+- `sampling` (number) - choose a value from `0` to `1`, where `0` means 0% and `1` means 100% tracked
+- `enableDistribution` (boolean) - enables additional events that track load time and cpm distribution
+  by creating buckets for load time and cpm
+- `cpmDistribution` (cpm: number => string) - customize the cpm buckets for the cpm distribution
+
+
+## Additional resources
+
+- [Prebid GA Analytics](http://prebid.org/overview/ga-analytics.html)

--- a/test/spec/modules/googleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/googleAnalyticsAdapter_spec.js
@@ -4,12 +4,24 @@ var assert = require('assert');
 
 describe('Ga', function () {
   describe('enableAnalytics', function () {
-    it('should accept a tracker name option and output prefixed send string', function () {
-      var config = { options: { trackerName: 'foo' } };
-      ga.enableAnalytics(config);
+    var cpmDistribution = function(cpm) {
+      return cpm <= 1 ? '<= 1$' : '> 1$';
+    }
+    var config = { options: { trackerName: 'foo', enableDistribution: true, cpmDistribution: cpmDistribution } };
 
+    // enableAnalytics can only be called once as the 
+    ga.enableAnalytics(config);
+
+    it('should accept a tracker name option and output prefixed send string', function () {
       var output = ga.getTrackerSend();
       assert.equal(output, 'foo.send');
+    });
+
+    it('should use the custom cpm distribution', function() {
+      assert.equal(ga.getCpmDistribution(0.5), '<= 1$');
+      assert.equal(ga.getCpmDistribution(1), '<= 1$');
+      assert.equal(ga.getCpmDistribution(2), '> 1$');
+      assert.equal(ga.getCpmDistribution(5.23), '> 1$');
     });
   });
 });

--- a/test/spec/modules/googleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/googleAnalyticsAdapter_spec.js
@@ -9,7 +9,7 @@ describe('Ga', function () {
     }
     var config = { options: { trackerName: 'foo', enableDistribution: true, cpmDistribution: cpmDistribution } };
 
-    // enableAnalytics can only be called once as the 
+    // enableAnalytics can only be called once
     ga.enableAnalytics(config);
 
     it('should accept a tracker name option and output prefixed send string', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Add an additional option `cpmDistribution` to the google analytics adapter to allow customization of the cpm buckets.

