### PR TITLE
Support schain module and send bidfloor param in Sharethrough adapter

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -45,6 +45,10 @@ export const sharethroughAdapterSpec = {
         query.schain = JSON.stringify(bidRequest.schain);
       }
 
+      if (bidRequest.bidfloor) {
+        query.bidfloor = parseFloat(bidRequest.bidfloor);
+      }
+
       // Data that does not need to go to the server,
       // but we need as part of interpretResponse()
       const strData = {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -41,6 +41,10 @@ export const sharethroughAdapterSpec = {
         query.ttduid = bidRequest.userId.tdid;
       }
 
+      if (bidRequest.schain) {
+        query.schain = JSON.stringify(bidRequest.schain);
+      }
+
       // Data that does not need to go to the server,
       // but we need as part of interpretResponse()
       const strData = {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -280,6 +280,31 @@ describe('sharethrough adapter spec', function () {
         }
       });
     });
+
+    it('should add a supply chain parameter if schain is present', function() {
+      // shallow copy of the first bidRequest obj, so we don't mutate
+      const bidRequest = Object.assign({}, bidRequests[0]);
+      bidRequest['schain'] = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'directseller.com',
+            sid: '00001',
+            rid: 'BidRequest1',
+            hp: 1
+          }
+        ]
+      };
+
+      const builtBidRequest = spec.buildRequests([bidRequest])[0];
+      expect(builtBidRequest.data.schain).to.eq(JSON.stringify(bidRequest.schain));
+    });
+
+    it('should not add a supply chain parameter if schain is missing', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data).to.not.include.any.keys('schain');
+    });
   });
 
   describe('.interpretResponse', function () {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -305,6 +305,19 @@ describe('sharethrough adapter spec', function () {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       expect(bidRequest.data).to.not.include.any.keys('schain');
     });
+
+    it('should include the bidfloor parameter if it is present in the bid request', function() {
+      const bidRequest = Object.assign({}, bidRequests[0]);
+      bidRequest['bidfloor'] = 0.50;
+      const builtBidRequest = spec.buildRequests([bidRequest])[0];
+      expect(builtBidRequest.data.bidfloor).to.eq(0.5);
+    });
+
+    it('should not include the bidfloor parameter if it is missing in the bid request', function() {
+      const bidRequest = Object.assign({}, bidRequests[0]);
+      const builtBidRequest = spec.buildRequests([bidRequest])[0];
+      expect(builtBidRequest.data).to.not.include.any.keys('bidfloor');
+    });
   });
 
   describe('.interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on https://prebid.org?

## Description of change
- Sharethrough's bid adapter has been updated to add support for the schain module and to check for and send the `bidfloor` parameter when building bid requests.
- pubgrowth.engineering@sharethrough.com
- See related PR for documentation update: https://github.com/prebid/prebid.github.io/pull/1533