### PR TITLE
Conversant Bid Adapter update for 3.0

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -3,7 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory';
 import { BANNER, VIDEO } from '../src/mediaTypes';
 
 const BIDDER_CODE = 'conversant';
-const URL = '//web.hb.ad.cpe.dotomi.com/s2s/header/24';
+const URL = 'https://web.hb.ad.cpe.dotomi.com/s2s/header/24';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -44,26 +44,24 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {BidRequest[]} validBidRequests - an array of bids
+   * @param bidderRequest
    * @return {ServerRequest} Info describing the request to the server.
    */
   buildRequests: function(validBidRequests, bidderRequest) {
-    const loc = utils.getTopWindowLocation();
-    const page = loc.href;
-    const isPageSecure = (loc.protocol === 'https:') ? 1 : 0;
+    const page = (bidderRequest && bidderRequest.refererInfo) ? bidderRequest.refererInfo.referer : '';
     let siteId = '';
     let requestId = '';
     let pubcid = null;
 
     const conversantImps = validBidRequests.map(function(bid) {
       const bidfloor = utils.getBidIdParameter('bidfloor', bid.params);
-      const secure = isPageSecure || (utils.getBidIdParameter('secure', bid.params) ? 1 : 0);
 
       siteId = utils.getBidIdParameter('site_id', bid.params);
       requestId = bid.auctionId;
 
       const imp = {
         id: bid.bidId,
-        secure: secure,
+        secure: 1,
         bidfloor: bidfloor || 0,
         displaymanager: 'Prebid.js',
         displaymanagerver: '$prebid.version$'
@@ -154,6 +152,7 @@ export const spec = {
    * Unpack the response from the server into a list of bids.
    *
    * @param {*} serverResponse A successful response from the server.
+   * @param bidRequest
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function(serverResponse, bidRequest) {
@@ -249,7 +248,7 @@ function getDevice() {
  *
  * [[300, 250], [300, 600]] => [{w: 300, h: 250}, {w: 300, h: 600}]
  *
- * @param {number[2][]|number[2]} bidSizes - arrays of widths and heights
+ * @param {Array.<Array.<number>>} bidSizes - arrays of widths and heights
  * @returns {object[]} Array of objects with w and h
  */
 function convertSizes(bidSizes) {

--- a/modules/conversantBidAdapter.md
+++ b/modules/conversantBidAdapter.md
@@ -13,7 +13,11 @@ Module that connects to Conversant's demand sources.  Supports banners and video
 var adUnits = [
     {
         code: 'banner-test-div',
-        sizes: [[300, 250]],
+        mediaTypes: {
+            banner: {        
+                sizes: [[300, 250],[300,600]]
+            }
+        },
         bids: [{
             bidder: "conversant",
             params: {

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -2,8 +2,6 @@ import {expect} from 'chai';
 import {spec} from 'modules/conversantBidAdapter';
 import * as utils from 'src/utils';
 
-var Adapter = require('modules/conversantBidAdapter');
-
 describe('Conversant adapter tests', function() {
   const siteId = '108060';
   const versionPattern = /^\d+\.\d+\.\d+(.)*$/;
@@ -16,7 +14,6 @@ describe('Conversant adapter tests', function() {
         site_id: siteId,
         position: 1,
         tag_id: 'tagid-1',
-        secure: false,
         bidfloor: 0.5
       },
       placementCode: 'pcode000',
@@ -30,8 +27,7 @@ describe('Conversant adapter tests', function() {
     {
       bidder: 'conversant',
       params: {
-        site_id: siteId,
-        secure: false
+        site_id: siteId
       },
       mediaTypes: {
         banner: {
@@ -50,8 +46,7 @@ describe('Conversant adapter tests', function() {
       params: {
         site_id: siteId,
         position: 2,
-        tag_id: '',
-        secure: false
+        tag_id: ''
       },
       placementCode: 'pcode002',
       transactionId: 'tx002',
@@ -198,9 +193,15 @@ describe('Conversant adapter tests', function() {
   });
 
   it('Verify buildRequest', function() {
-    const request = spec.buildRequests(bidRequests);
+    const page = 'http://test.com?a=b&c=123';
+    const bidderRequest = {
+      refererInfo: {
+        referer: page
+      }
+    };
+    const request = spec.buildRequests(bidRequests, bidderRequest);
     expect(request.method).to.equal('POST');
-    expect(request.url).to.equal('//web.hb.ad.cpe.dotomi.com/s2s/header/24');
+    expect(request.url).to.equal('https://web.hb.ad.cpe.dotomi.com/s2s/header/24');
     const payload = request.data;
 
     expect(payload).to.have.property('id', 'req000');
@@ -209,7 +210,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp).to.be.an('array').with.lengthOf(6);
 
     expect(payload.imp[0]).to.have.property('id', 'bid000');
-    expect(payload.imp[0]).to.have.property('secure', 0);
+    expect(payload.imp[0]).to.have.property('secure', 1);
     expect(payload.imp[0]).to.have.property('bidfloor', 0.5);
     expect(payload.imp[0]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[0]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -221,7 +222,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[0]).to.not.have.property('video');
 
     expect(payload.imp[1]).to.have.property('id', 'bid001');
-    expect(payload.imp[1]).to.have.property('secure', 0);
+    expect(payload.imp[1]).to.have.property('secure', 1);
     expect(payload.imp[1]).to.have.property('bidfloor', 0);
     expect(payload.imp[1]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[1]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -232,7 +233,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[1].banner.format).to.deep.equal([{w: 728, h: 90}, {w: 468, h: 60}]);
 
     expect(payload.imp[2]).to.have.property('id', 'bid002');
-    expect(payload.imp[2]).to.have.property('secure', 0);
+    expect(payload.imp[2]).to.have.property('secure', 1);
     expect(payload.imp[2]).to.have.property('bidfloor', 0);
     expect(payload.imp[2]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[2]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -242,7 +243,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 600}, {w: 160, h: 600}]);
 
     expect(payload.imp[3]).to.have.property('id', 'bid003');
-    expect(payload.imp[3]).to.have.property('secure', 0);
+    expect(payload.imp[3]).to.have.property('secure', 1);
     expect(payload.imp[3]).to.have.property('bidfloor', 0);
     expect(payload.imp[3]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[3]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -261,7 +262,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[3]).to.not.have.property('banner');
 
     expect(payload.imp[4]).to.have.property('id', 'bid004');
-    expect(payload.imp[4]).to.have.property('secure', 0);
+    expect(payload.imp[4]).to.have.property('secure', 1);
     expect(payload.imp[4]).to.have.property('bidfloor', 0);
     expect(payload.imp[4]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[4]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -280,7 +281,7 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[4]).to.not.have.property('banner');
 
     expect(payload.imp[5]).to.have.property('id', 'bid005');
-    expect(payload.imp[5]).to.have.property('secure', 0);
+    expect(payload.imp[5]).to.have.property('secure', 1);
     expect(payload.imp[5]).to.have.property('bidfloor', 0);
     expect(payload.imp[5]).to.have.property('displaymanager', 'Prebid.js');
     expect(payload.imp[5]).to.have.property('displaymanagerver').that.matches(versionPattern);
@@ -299,8 +300,7 @@ describe('Conversant adapter tests', function() {
     expect(payload).to.have.property('site');
     expect(payload.site).to.have.property('id', siteId);
     expect(payload.site).to.have.property('mobile').that.is.oneOf([0, 1]);
-    const loc = utils.getTopWindowLocation();
-    const page = loc.href;
+
     expect(payload.site).to.have.property('page', page);
 
     expect(payload).to.have.property('device');
@@ -365,7 +365,7 @@ describe('Conversant adapter tests', function() {
 
   it('Verify publisher commond id support', function() {
     // clone bidRequests
-    let requests = utils.deepClone(bidRequests)
+    let requests = utils.deepClone(bidRequests);
 
     // add pubcid to every entry
     requests.forEach((unit) => {
@@ -378,7 +378,7 @@ describe('Conversant adapter tests', function() {
 
   it('Verify User ID publisher commond id support', function() {
     // clone bidRequests
-    let requests = utils.deepClone(bidRequests)
+    let requests = utils.deepClone(bidRequests);
 
     // add pubcid to every entry
     requests.forEach((unit) => {
@@ -415,4 +415,4 @@ describe('Conversant adapter tests', function() {
     expect(payload).to.have.deep.nested.property('user.ext.consent', '');
     expect(payload).to.not.have.deep.nested.property('regs.ext.gdpr');
   });
-})
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Prebid 3.0 requested updates

1. Replace deprecated getTopWindowLocation() function with bidderRequest.refererInfo.referer
2. Change to use HTTPS all the time
3. Update example to use mediaTypes.banner.sizes

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer

pyang@conversantmedia.com

- [ ] official adapter submission

