### PR TITLE
Update LockerDome adapter to support Prebid 3.0

### DIFF
--- a/modules/lockerdomeBidAdapter.js
+++ b/modules/lockerdomeBidAdapter.js
@@ -14,13 +14,16 @@ export const spec = {
         requestId: bid.bidId,
         adUnitCode: bid.adUnitCode,
         adUnitId: utils.getBidIdParameter('adUnitId', bid.params),
-        sizes: bid.sizes
+        sizes: bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes
       }
     });
+
+    const bidderRequestCanonicalUrl = (bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.canonicalUrl) || '';
+    const bidderRequestReferer = (bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer) || '';
     const payload = {
       bidRequests: adUnitBidRequests,
-      url: utils.getTopWindowLocation().href,
-      referrer: utils.getTopWindowReferrer()
+      url: encodeURIComponent(bidderRequestCanonicalUrl),
+      referrer: encodeURIComponent(bidderRequestReferer)
     };
 
     if (bidderRequest && bidderRequest.gdprConsent) {

--- a/modules/lockerdomeBidAdapter.md
+++ b/modules/lockerdomeBidAdapter.md
@@ -13,7 +13,6 @@ Connects to LockerDome Ad Server for bids.
 ```
 var adUnits = [{
     code: 'ad-div',
-    sizes: [[300, 250]],
     mediaTypes: {
         banner: {
             sizes: [[300, 250]]

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -15,7 +15,6 @@ describe('LockerDomeAdapter', function () {
     },
     adUnitCode: 'ad-1',
     transactionId: 'b55e97d7-792c-46be-95a5-3df40b115734',
-    sizes: [[300, 250]],
     bidId: '2652ca954bce9',
     bidderRequestId: '14a54fade69854',
     auctionId: 'd4c83108-615d-4c2c-9384-dac9ffd4fd72'
@@ -31,7 +30,6 @@ describe('LockerDomeAdapter', function () {
     },
     adUnitCode: 'ad-2',
     transactionId: '73459f05-c482-4706-b2b7-72e6f6264ce6',
-    sizes: [[300, 600]],
     bidId: '4510f2834773ce',
     bidderRequestId: '14a54fade69854',
     auctionId: 'd4c83108-615d-4c2c-9384-dac9ffd4fd72'
@@ -51,18 +49,24 @@ describe('LockerDomeAdapter', function () {
 
   describe('buildRequests', function () {
     it('should generate a valid single POST request for multiple bid requests', function () {
-      const request = spec.buildRequests(bidRequests);
+      const bidderRequest = {
+        refererInfo: {
+          canonicalUrl: 'https://example.com/canonical',
+          referer: 'https://example.com'
+        }
+      };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.method).to.equal('POST');
       expect(request.url).to.equal('https://lockerdome.com/ladbid/prebid');
       expect(request.data).to.exist;
 
       const requestData = JSON.parse(request.data);
 
-      expect(requestData.url).to.equal(utils.getTopWindowLocation().href);
-      expect(requestData.referrer).to.equal(utils.getTopWindowReferrer());
-
       const bids = requestData.bidRequests;
       expect(bids).to.have.lengthOf(2);
+
+      expect(requestData.url).to.equal(encodeURIComponent(bidderRequest.refererInfo.canonicalUrl));
+      expect(requestData.referrer).to.equal(encodeURIComponent(bidderRequest.refererInfo.referer));
 
       expect(bids[0].requestId).to.equal('2652ca954bce9');
       expect(bids[0].adUnitCode).to.equal('ad-1');
@@ -84,6 +88,10 @@ describe('LockerDomeAdapter', function () {
         gdprConsent: {
           consentString: 'AAABBB',
           gdprApplies: true
+        },
+        refererInfo: {
+          canonicalUrl: 'https://example.com/canonical',
+          referer: 'https://example.com'
         }
       };
       const request = spec.buildRequests(bidRequests, bidderRequest);
@@ -129,7 +137,14 @@ describe('LockerDomeAdapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests);
+      const bidderRequest = {
+        refererInfo: {
+          canonicalUrl: 'https://example.com/canonical',
+          referer: 'https://example.com'
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
       const interpretedResponse = spec.interpretResponse(serverResponse, request);
 
       expect(interpretedResponse).to.have.lengthOf(2);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
We are updating the LockerDome adapter for Prebid 3.0
http://prebid.org/blog/pbjs-3
This is a resubmission on the master branch, since our previous pull request (https://github.com/prebid/Prebid.js/pull/4282) was on the 3.0 branch.