### PR TITLE
[feature] Add a config list of submodules that require refreshing the stored ID after each bid request

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -386,6 +386,10 @@ function initSubmodules(submodules, consentData) {
         refreshNeeded = storedDate && (Date.now() - storedDate.getTime() > submodule.config.storage.refreshInSeconds * 1000);
       }
 
+      if (CONSTANTS.SUBMODULES_THAT_ALWAYS_REFRESH_ID[submodule.config.name] === true) {
+        refreshNeeded = true;
+      }
+
       if (!storedId || refreshNeeded) {
         // No previously saved id.  Request one from submodule.
         response = submodule.submodule.getId(submodule.config.params, consentData, storedId);

--- a/src/constants.json
+++ b/src/constants.json
@@ -95,5 +95,8 @@
   "BID_STATUS" : {
     "BID_TARGETING_SET": "targetingSet",
     "RENDERED": "rendered"
+  },
+  "SUBMODULES_THAT_ALWAYS_REFRESH_ID": {
+    "parrableId": true
   }
 }

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1093,7 +1093,7 @@ describe('User ID', function() {
         });
       });
 
-      // emit an auction end event to run the mock callback
+      // attach a handler for auction end event to run the second bid request
       events.on(CONSTANTS.EVENTS.AUCTION_END, function handler(submodule) {
         if (submodule === 'parrableIdSubmoduleMock') {
           // make the second bid request, id should have been refreshed
@@ -1109,6 +1109,7 @@ describe('User ID', function() {
         }
       });
 
+      // emit an auction end event to run the submodule callback
       events.emit(CONSTANTS.EVENTS.AUCTION_END, 'parrableIdSubmoduleMock');
     });
   });


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change
Parrable submodule requires that Parrable ID is updated frequently in the browser to enforce consumer privacy requirements and thus we generalized this requirement to a feature of submodules that can always refresh their stored id by adding the submodule name to a config list.

The list exists in constants.json as "SUBMODULES_THAT_ALWAYS_REFRESH_ID" as a key-value object, where the key is a submodule name, and the value if set to true, the submodule will always get its callback executed on each auction end event and the stored id in storage updated with the callback result.

In the unit tests, I created a mock submodule that has the same name of parrableId (because CONSTANTS are directly required inside userId index.js). and I mocked two consecutive bid requests, with an initial stored ID in the cookie. and I am asserting that the second request will get the updated value that is returned from the submodule callback.  

