### PR TITLE
Implementation of setBidderConfig and bidder-specific data

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -476,7 +476,7 @@ function tryCallBidderMethod(bidder, method, param) {
     const spec = adapter.getSpec();
     if (spec && spec[method] && typeof spec[method] === 'function') {
       utils.logInfo(`Invoking ${bidder}.${method}`);
-      spec[method](param);
+      config.runWithBidder(bidder, bind.call(spec[method], spec, param));
     }
   } catch (e) {
     utils.logWarn(`Error calling ${method} of ${bidder}`);

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -1,6 +1,6 @@
 /** @module adaptermanger */
 
-import { flatten, getBidderCodes, getDefinedParams, shuffle, timestamp, getBidderRequest } from './utils';
+import { flatten, getBidderCodes, getDefinedParams, shuffle, timestamp, getBidderRequest, bind } from './utils';
 import { getLabels, resolveStatus } from './sizeMapping';
 import { processNativeAdUnitParams, nativeAdapters } from './native';
 import { newBidder } from './adapters/bidderFactory';
@@ -337,9 +337,21 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done
     } : undefined);
-    adapter.callBids(bidRequest, addBidResponse.bind(bidRequest), doneCb.bind(bidRequest), ajax, onTimelyResponse);
+    config.runWithBidder(
+      bidRequest.bidderCode,
+      bind.call(
+        adapter.callBids,
+        adapter,
+        bidRequest,
+        addBidResponse.bind(bidRequest),
+        doneCb.bind(bidRequest),
+        ajax,
+        onTimelyResponse,
+        config.callbackWithBidder(bidRequest.bidderCode)
+      )
+    );
   });
-}
+};
 
 function doingS2STesting() {
   return _s2sConfig && _s2sConfig.enabled && _s2sConfig.testing && s2sTestingModule;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -167,6 +167,7 @@ export function newBidder(spec) {
     getSpec: function() {
       return Object.freeze(spec);
     },
+    registerSyncs,
     callBids: function(bidderRequest, addBidResponse, done, ajax, onTimelyResponse, configEnabledCallback) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -167,8 +167,7 @@ export function newBidder(spec) {
     getSpec: function() {
       return Object.freeze(spec);
     },
-    registerSyncs,
-    callBids: function(bidderRequest, addBidResponse, done, ajax, onTimelyResponse) {
+    callBids: function(bidderRequest, addBidResponse, done, ajax, onTimelyResponse, configEnabledCallback) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
       }
@@ -216,7 +215,7 @@ export function newBidder(spec) {
       // Callbacks don't compose as nicely as Promises. We should call done() once _all_ the
       // Server requests have returned and been processed. Since `ajax` accepts a single callback,
       // we need to rig up a function which only executes after all the requests have been responded.
-      const onResponse = delayExecution(afterAllResponses, requests.length)
+      const onResponse = delayExecution(configEnabledCallback(afterAllResponses), requests.length)
       requests.forEach(processRequest);
 
       function formatGetParameters(data) {
@@ -233,7 +232,7 @@ export function newBidder(spec) {
             ajax(
               `${request.url}${formatGetParameters(request.data)}`,
               {
-                success: onSuccess,
+                success: configEnabledCallback(onSuccess),
                 error: onFailure
               },
               undefined,
@@ -247,7 +246,7 @@ export function newBidder(spec) {
             ajax(
               request.url,
               {
-                success: onSuccess,
+                success: configEnabledCallback(onSuccess),
                 error: onFailure
               },
               typeof request.data === 'string' ? request.data : JSON.stringify(request.data),

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@
 import { isValidPriceConfig } from './cpmBucketManager';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
+import Set from 'core-js/library/fn/set';
 import { parseQS } from './url';
 
 const utils = require('./utils');
@@ -216,15 +217,9 @@ export function newConfig() {
   function _getConfig() {
     if (currBidder && bidderConfig && utils.isPlainObject(bidderConfig[currBidder])) {
       let currBidderConfig = bidderConfig[currBidder];
+      const configTopicSet = new Set(Object.keys(config).concat(Object.keys(currBidderConfig)));
 
-      const configTopicSet = Object.keys(config).concat(Object.keys(currBidderConfig)).reduce((set, key) => {
-        set.add(key);
-        return set;
-      }, new Set());
-      const uniqTopics = [];
-      configTopicSet.forEach(key => uniqTopics.push(key));
-
-      return uniqTopics.reduce((memo, topic) => {
+      return [ ...configTopicSet ].reduce((memo, topic) => {
         if (!currBidderConfig[topic]) {
           memo[topic] = config[topic];
         } else if (!config[topic]) {

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ import includes from 'core-js/library/fn/array/includes';
 import Set from 'core-js/library/fn/set';
 import { parseQS } from './url';
 
+const from = require('core-js/library/fn/array/from');
 const utils = require('./utils');
 const CONSTANTS = require('./constants');
 
@@ -219,7 +220,7 @@ export function newConfig() {
       let currBidderConfig = bidderConfig[currBidder];
       const configTopicSet = new Set(Object.keys(config).concat(Object.keys(currBidderConfig)));
 
-      return [ ...configTopicSet ].reduce((memo, topic) => {
+      return from(configTopicSet).reduce((memo, topic) => {
         if (!currBidderConfig[topic]) {
           memo[topic] = config[topic];
         } else if (!config[topic]) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -780,6 +780,7 @@ $$PREBID_GLOBAL$$.getConfig = config.getConfig;
  * ```
  */
 $$PREBID_GLOBAL$$.setConfig = config.setConfig;
+$$PREBID_GLOBAL$$.setBidderConfig = config.setBidderConfig;
 
 $$PREBID_GLOBAL$$.que.push(() => listenMessagesFromCreative());
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -954,7 +954,7 @@ export function delayExecution(func, numRequiredCalls) {
   return function () {
     numCalls++;
     if (numCalls === numRequiredCalls) {
-      func.apply(null, arguments);
+      func.apply(this, arguments);
     }
   }
 }

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -152,9 +152,12 @@ describe('adapterManager tests', function () {
           callBids: function(bidRequest, addBidResponse, done, ajax, timeout, configCallback) {
             let myResults = results[bidRequest.bidderCode] = [];
             myResults.push(config.getConfig('buildRequests'));
+            myResults.push(config.getConfig('test1'));
+            myResults.push(config.getConfig('test2'));
             // emulate ajax callback that would register bids
             setTimeout(configCallback(() => {
               myResults.push(config.getConfig('interpretResponse'));
+              myResults.push(config.getConfig('afterInterpretResponse'));
               if (++cbCount === Object.keys(bidders).length) {
                 assertions();
               }
@@ -172,19 +175,32 @@ describe('adapterManager tests', function () {
         buildRequests: {
           data: 1
         },
-        interpretResponse: 'baseInterpret'
+        test1: { speedy: true },
+        interpretResponse: 'baseInterpret',
+        afterInterpretResponse: 'anotherBaseInterpret'
       });
       config.setBidderConfig({
-        appnexus: {
+        bidders: [ 'appnexus' ],
+        config: {
           buildRequests: {
             test: 2
           },
+          test1: { fun: { safe: true, cheap: false } },
           interpretResponse: 'appnexusInterpret'
-        },
-        rubicon: {
+        }
+      });
+      config.setBidderConfig({
+        bidders: [ 'rubicon' ],
+        config: {
           buildRequests: 'rubiconBuild',
           interpretResponse: 'rubiconInterpret'
-        },
+        }
+      });
+      config.setBidderConfig({
+        bidders: [ 'appnexus', 'rubicon' ],
+        config: {
+          test2: { amazing: true }
+        }
       });
 
       adapterManager.callBids(adUnits, bidderRequest, () => {}, () => {});
@@ -196,17 +212,26 @@ describe('adapterManager tests', function () {
               data: 1,
               test: 2
             },
-            'appnexusInterpret'
+            { fun: { safe: true, cheap: false }, speedy: true },
+            { amazing: true },
+            'appnexusInterpret',
+            'anotherBaseInterpret'
           ],
           'pubmatic': [
             {
               data: 1
             },
-            'baseInterpret'
+            { speedy: true },
+            undefined,
+            'baseInterpret',
+            'anotherBaseInterpret'
           ],
           'rubicon': [
             'rubiconBuild',
-            'rubiconInterpret'
+            { speedy: true },
+            { amazing: true },
+            'rubiconInterpret',
+            'anotherBaseInterpret'
           ]
         });
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -139,7 +139,7 @@ describe('adapterManager tests', function () {
 
     it('should give bidders access to bidder-specific config', function(done) {
       let mockBidders = ['rubicon', 'appnexus', 'pubmatic'];
-      let bidderRequest = getBidRequests().filter(bidRequest => mockBidders.includes(bidRequest.bidderCode));
+      let bidderRequest = getBidRequests().filter(bidRequest => includes(mockBidders, bidRequest.bidderCode));
       let adUnits = getAdUnits();
 
       let bidders = {};

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -33,6 +33,8 @@ function onTimelyResponseStub() {
 
 }
 
+let wrappedCallback = config.callbackWithBidder(CODE);
+
 describe('bidders created by newBidder', function () {
   let spec;
   let bidder;
@@ -71,7 +73,7 @@ describe('bidders created by newBidder', function () {
       spec.getUserSyncs.returns([]);
 
       bidder.callBids({});
-      bidder.callBids({ bids: 'nothing useful' }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids({ bids: 'nothing useful' }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.called).to.equal(false);
@@ -85,7 +87,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -99,7 +101,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(false);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -113,7 +115,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.onSecondCall().returns(false);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.called).to.equal(false);
       expect(spec.isBidRequestValid.calledTwice).to.equal(true);
@@ -127,7 +129,7 @@ describe('bidders created by newBidder', function () {
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.called).to.equal(false);
     });
@@ -143,7 +145,7 @@ describe('bidders created by newBidder', function () {
         data: data
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(url);
@@ -168,7 +170,7 @@ describe('bidders created by newBidder', function () {
         options: options
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(url);
@@ -191,7 +193,7 @@ describe('bidders created by newBidder', function () {
         data: data
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(`${url}?arg=2&`);
@@ -215,7 +217,7 @@ describe('bidders created by newBidder', function () {
         options: opt
       });
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.calledOnce).to.equal(true);
       expect(ajaxStub.firstCall.args[0]).to.equal(`${url}?arg=2&`);
@@ -244,7 +246,7 @@ describe('bidders created by newBidder', function () {
         }
       ]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(ajaxStub.calledTwice).to.equal(true);
     });
@@ -257,7 +259,7 @@ describe('bidders created by newBidder', function () {
       spec.interpretResponse.returns([]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.callCount).to.equal(0);
     });
@@ -297,7 +299,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(spec.interpretResponse.calledOnce).to.equal(true);
       const response = spec.interpretResponse.firstCall.args[0]
@@ -329,7 +331,7 @@ describe('bidders created by newBidder', function () {
       ]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(spec.interpretResponse.calledTwice).to.equal(true);
       expect(doneStub.calledOnce).to.equal(true);
@@ -360,7 +362,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.calledOnce).to.equal(true);
       expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -379,7 +381,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(spec.getUserSyncs.calledOnce).to.equal(true);
       expect(spec.getUserSyncs.firstCall.args[1].length).to.equal(1);
@@ -398,7 +400,7 @@ describe('bidders created by newBidder', function () {
         url: 'usersync.com'
       }]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(userSyncStub.called).to.equal(true);
       expect(userSyncStub.firstCall.args[0]).to.equal('iframe');
@@ -427,7 +429,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
@@ -457,7 +459,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
     });
@@ -489,7 +491,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(spec.interpretResponse.called).to.equal(false);
       expect(doneStub.calledOnce).to.equal(true);
@@ -507,7 +509,7 @@ describe('bidders created by newBidder', function () {
       spec.interpretResponse.returns([]);
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.callCount).to.equal(0);
       expect(doneStub.calledOnce).to.equal(true);
@@ -524,7 +526,7 @@ describe('bidders created by newBidder', function () {
       });
       spec.getUserSyncs.returns([]);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(spec.getUserSyncs.calledOnce).to.equal(true);
       expect(spec.getUserSyncs.firstCall.args[1]).to.deep.equal([]);
@@ -670,7 +672,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -707,7 +709,7 @@ describe('validate bid response: ', function () {
 
     const bidder = newBidder(spec);
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
     expect(addBidResponseStub.calledOnce).to.equal(false);
     expect(logErrorSpy.callCount).to.equal(1);
@@ -740,7 +742,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -772,7 +774,7 @@ describe('validate bid response: ', function () {
     const bidder = newBidder(spec);
 
     spec.interpretResponse.returns(bids1);
-    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub);
+    bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
     expect(addBidResponseStub.calledOnce).to.equal(true);
     expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
New `pbjs.setBidderConfig` API which allows you to set specific bidder config per bidder and allows bidders access to that protected data.

`pbjs.getConfig` sync API now allows access to bidder overrides when called synchronously from the spec, e.g. in `spec.isBidRequestValid`, `spec.buildRequests`, `spec.interpretResponse`, or `spec.getUserSyncs`. Bidder-specific data is automatically merged with global config and returned to bidder.

Example:
```javascript
pbjs.setConfig({
   user: {
      keywords: ["a","b"]
   }
});
var privateUserData =  {
  gender: "M",
  yob: "1984",
  geo: { country: "ca" }
}
pbjs.setBidderConfig({
  rubicon: {
    user: privateUserData
  },
  appnexus: {
    user: privateUserData
  }
});

// in pubmatic
buildRequests() {
  console.log(config.getConfig('user'));
 // { keywords: ["a","b"]}
}

// in appnexus
buildRequests() {
  console.log(config.getConfig('user'));
  // {
  //   "keywords": [
  //     "a",
  //     "b"
  //   ],
  //   "gender": "M",
  //   "yob": "1984",
  //   "geo": {
  //     "country": "ca"
  //   }
  // }
}
```

## Extra info
There is also an internal config API `config.getBidderConfig` which allows core modules access to all bidder config. I have a feeling this could be useful for prebid-server and such?

Regarding SChain, currently prebid-server pulls off and sends a single SChain object to the server request. If accepted, this code should be refactor to get it from config and we'd have to decide what it does about bidder specific config (and SChain objects).
