### PR TITLE
Brightcom Bid Adapter update for 3.0

### DIFF
--- a/modules/brightcomBidAdapter.js
+++ b/modules/brightcomBidAdapter.js
@@ -25,9 +25,10 @@ function buildRequests(bidReqs, bidderRequest) {
     const brightcomImps = [];
     const publisherId = utils.getBidIdParameter('publisherId', bidReqs[0].params);
     utils._each(bidReqs, function (bid) {
-      bid.sizes = ((utils.isArray(bid.sizes) && utils.isArray(bid.sizes[0])) ? bid.sizes : [bid.sizes]);
-      bid.sizes = bid.sizes.filter(size => utils.isArray(size));
-      const processedSizes = bid.sizes.map(size => ({w: parseInt(size[0], 10), h: parseInt(size[1], 10)}));
+      let bidSizes = (bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) || bid.sizes;
+      bidSizes = ((utils.isArray(bidSizes) && utils.isArray(bidSizes[0])) ? bidSizes : [bidSizes]);
+      bidSizes = bidSizes.filter(size => utils.isArray(size));
+      const processedSizes = bidSizes.map(size => ({w: parseInt(size[0], 10), h: parseInt(size[1], 10)}));
 
       const element = document.getElementById(bid.adUnitCode);
       const minSize = _getMinSize(processedSizes);

--- a/modules/brightcomBidAdapter.md
+++ b/modules/brightcomBidAdapter.md
@@ -16,17 +16,25 @@ Brightcom's adapter integration to the Prebid library.
 var adUnits = [
   {
     code: 'test-leaderboard',
-    sizes: [[728, 90]],
+    mediaTypes: {
+      banner: {
+        sizes: [[728, 90]]
+      }
+    },
     bids: [{
       bidder: 'brightcom',
       params: {
-          publisherId: 2141020,
-          bidFloor: 0.01
+        publisherId: 2141020,
+        bidFloor: 0.01
       }
     }]
   }, {
     code: 'test-banner',
-    sizes: [[300, 250]],
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
     bids: [{
       bidder: 'brightcom',
       params: {

--- a/test/spec/modules/brightcomBidAdapter_spec.js
+++ b/test/spec/modules/brightcomBidAdapter_spec.js
@@ -45,10 +45,11 @@ describe('brightcomBidAdapter', function() {
         'publisherId': 1234567
       },
       'adUnitCode': 'adunit-code',
-      'sizes': [
-        [300, 250],
-        [300, 600]
-      ],
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[300, 250], [300, 600]]
+        }
+      },
       'bidId': '5fb26ac22bde4',
       'bidderRequestId': '4bf93aeb730cb9',
       'auctionId': 'ffe9a1f7-7b67-4bda-a8e0-9ee5dc9f442e'
@@ -71,10 +72,11 @@ describe('brightcomBidAdapter', function() {
         'publisherId': 1234567
       },
       'adUnitCode': 'adunit-code',
-      'sizes': [
-        [300, 250],
-        [300, 600]
-      ],
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[300, 250], [300, 600]]
+        }
+      },
       'bidId': '5fb26ac22bde4',
       'bidderRequestId': '4bf93aeb730cb9',
       'auctionId': 'ffe9a1f7-7b67-4bda-a8e0-9ee5dc9f442e',
@@ -84,7 +86,7 @@ describe('brightcomBidAdapter', function() {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when tagid not passed correctly', function () {
+    it('should return false when publisherId not passed correctly', function () {
       bid.params.publisherId = undefined;
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
@@ -114,7 +116,7 @@ describe('brightcomBidAdapter', function() {
     });
 
     it('accepts a single array as a size', function() {
-      bidRequests[0].sizes = [300, 250];
+      bidRequests[0].mediaTypes.banner.sizes = [300, 250];
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data);
       expect(payload.imp[0].banner.format).to.deep.equal([{w: 300, h: 250}]);
@@ -169,7 +171,7 @@ describe('brightcomBidAdapter', function() {
     context('when width or height of the element is zero', function() {
       it('try to use alternative values', function() {
         Object.assign(element, { width: 0, height: 0 });
-        bidRequests[0].sizes = [[800, 2400]];
+        bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];
         const request = spec.buildRequests(bidRequests);
         const payload = JSON.parse(request.data);
         expect(payload.imp[0].banner.ext.viewability).to.equal(25);


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Prebid 3.0 requested updates:

- Start reading sizes from bid.mediaTypes.banner.sizes
- Update example to use mediaTypes.banner.sizes

- contact email of the adapter’s maintainer: vladislavy@brightcom.com
- [x] official adapter submission
