### PR TITLE
Specify second parameter for parseInt for pubmaticBidAdapter

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -174,8 +174,8 @@ function _parseAdSlot(bid) {
       utils.logWarn(LOG_WARN_PREFIX + 'AdSlot Error: adSlot not in required format');
       return;
     }
-    bid.params.width = parseInt(splits[0]);
-    bid.params.height = parseInt(splits[1]);
+    bid.params.width = parseInt(splits[0], 10);
+    bid.params.height = parseInt(splits[1], 10);
   } else if (bid.hasOwnProperty('mediaTypes') &&
          bid.mediaTypes.hasOwnProperty(BANNER) &&
           bid.mediaTypes.banner.hasOwnProperty('sizes')) {
@@ -441,8 +441,8 @@ function _createBannerRequest(bid) {
         utils.logWarn(LOG_WARN_PREFIX + 'Error: mediaTypes.banner.size missing for adunit: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
         return bannerObj;
       } else {
-        bannerObj.w = parseInt(sizes[0][0]);
-        bannerObj.h = parseInt(sizes[0][1]);
+        bannerObj.w = parseInt(sizes[0][0], 10);
+        bannerObj.h = parseInt(sizes[0][1], 10);
         sizes = sizes.splice(1, sizes.length - 1);
       }
     } else {
@@ -482,11 +482,11 @@ function _createVideoRequest(bid) {
     }
     // read playersize and assign to h and w.
     if (utils.isArray(bid.mediaTypes.video.playerSize[0])) {
-      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0][0]);
-      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[0][1]);
+      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0][0], 10);
+      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[0][1], 10);
     } else if (utils.isNumber(bid.mediaTypes.video.playerSize[0])) {
-      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0]);
-      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[1]);
+      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0], 10);
+      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[1], 10);
     }
     if (bid.params.video.hasOwnProperty('skippable')) {
       videoObj.ext = {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Using 2nd parameter of `parseInt` to avoid auto base detection by the browser (when input are string it can mismatch).