### PR TITLE
Add vast xml support and other minor changes to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -328,6 +328,11 @@ function createVideoRequestData(bid, bidderRequest) {
     }];
   }
 
+  let connection = navigator.connection || navigator.webkitConnection;
+  if (connection && connection.effectiveType) {
+    payload.device.connectiontype = connection.effectiveType;
+  }
+
   return payload;
 }
 

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -72,7 +72,7 @@ export const spec = {
         cpm: response.bidPrice,
         width: firstSize.w,
         height: firstSize.h,
-        creativeId: response.cmpId,
+        creativeId: response.crid || response.cmpId,
         renderer: context === OUTSTREAM ? createRenderer(bidRequest) : null,
         mediaType: VIDEO,
         currency: 'USD',

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -7,7 +7,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes';
 import find from 'core-js/library/fn/array/find';
 import includes from 'core-js/library/fn/array/includes';
 
-const ADAPTER_VERSION = '1.7';
+const ADAPTER_VERSION = '1.8';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 
@@ -68,6 +68,7 @@ export const spec = {
         requestId: bidRequest.bidId,
         bidderCode: spec.code,
         vastUrl: response.url,
+        vastXml: response.vast,
         cpm: response.bidPrice,
         width: firstSize.w,
         height: firstSize.h,
@@ -284,7 +285,9 @@ function createVideoRequestData(bid, bidderRequest) {
         mimes: DEFAULT_MIMES
       }, video),
       bidfloor: bidfloor,
-      secure: topLocation.protocol === 'https:' ? 1 : 0
+      secure: topLocation.protocol === 'https:' ? 1 : 0,
+      displaymanager: ADAPTER_NAME,
+      displaymanagerver: ADAPTER_VERSION
     }],
     site: {
       page: topLocation.href,

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -152,7 +152,8 @@ function createRenderer(bidRequest) {
         height: bid.height,
         expandInView: getPlayerBidParam(bidRequest, 'expandInView', false),
         collapseOnComplete: getPlayerBidParam(bidRequest, 'collapseOnComplete', true),
-        progressColor: getPlayerBidParam(bidRequest, 'progressColor')
+        progressColor: getPlayerBidParam(bidRequest, 'progressColor'),
+        adPosterColor: getPlayerBidParam(bidRequest, 'adPosterColor')
       });
     });
   });

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -13,7 +13,7 @@ const OUTSTREAM = 'outstream';
 
 export const VIDEO_ENDPOINT = 'https://reachms.bfmio.com/bid.json?exchange_id=';
 export const BANNER_ENDPOINT = 'https://display.bfmio.com/prebid_display';
-export const OUTSTREAM_SRC = '//player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
+export const OUTSTREAM_SRC = 'https://player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
 
 export const VIDEO_TARGETING = ['mimes', 'playbackmethod', 'maxduration', 'placement'];
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -109,6 +109,7 @@ Module that connects to Beachfront's demand sources
                         },
                         player: {
                             progressColor: '#50A8FA',
+                            adPosterColor: '#FFF',
                             expandInView: false,
                             collapseOnComplete: true
                         }

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -505,6 +505,7 @@ describe('BeachfrontAdapter', function () {
           cpm: serverResponse.bidPrice,
           creativeId: serverResponse.cmpId,
           vastUrl: serverResponse.url,
+          vastXml: undefined,
           width: width,
           height: height,
           renderer: null,
@@ -512,6 +513,28 @@ describe('BeachfrontAdapter', function () {
           currency: 'USD',
           netRevenue: true,
           ttl: 300
+        });
+      });
+
+      it('should return vast xml if found on the bid response', () => {
+        const width = 640;
+        const height = 480;
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
+        const serverResponse = {
+          bidPrice: 5.00,
+          url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
+          vast: '<VAST version="3.0"></VAST>',
+          cmpId: '123abc'
+        };
+        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+        expect(bidResponse).to.deep.contain({
+          vastUrl: serverResponse.url,
+          vastXml: serverResponse.vast
         });
       });
 

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -496,14 +496,14 @@ describe('BeachfrontAdapter', function () {
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
+          crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         expect(bidResponse).to.deep.equal({
           requestId: bidRequest.bidId,
           bidderCode: spec.code,
           cpm: serverResponse.bidPrice,
-          creativeId: serverResponse.cmpId,
+          creativeId: serverResponse.crid,
           vastUrl: serverResponse.url,
           vastXml: undefined,
           width: width,
@@ -513,6 +513,26 @@ describe('BeachfrontAdapter', function () {
           currency: 'USD',
           netRevenue: true,
           ttl: 300
+        });
+      });
+
+      it('should default to the legacy "cmpId" value for the creative ID', () => {
+        const width = 640;
+        const height = 480;
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
+        const serverResponse = {
+          bidPrice: 5.00,
+          url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
+          cmpId: '123abc'
+        };
+        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+        expect(bidResponse).to.deep.contain({
+          creativeId: serverResponse.cmpId
         });
       });
 
@@ -529,7 +549,7 @@ describe('BeachfrontAdapter', function () {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
           vast: '<VAST version="3.0"></VAST>',
-          cmpId: '123abc'
+          crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         expect(bidResponse).to.deep.contain({
@@ -548,7 +568,7 @@ describe('BeachfrontAdapter', function () {
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
+          crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         expect(bidResponse.renderer).to.deep.contain({
@@ -570,7 +590,7 @@ describe('BeachfrontAdapter', function () {
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
+          crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         window.Beachfront = { Player: sinon.spy() };
@@ -604,7 +624,7 @@ describe('BeachfrontAdapter', function () {
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
+          crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         window.Beachfront = { Player: sinon.spy() };
@@ -685,7 +705,7 @@ describe('BeachfrontAdapter', function () {
         bidResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
+          crid: '123abc'
         };
       });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
- Adds support for vast xml in the bid response when available.
- Adds support for device connection type in the video bid request.
- Adds a secure protocol to outstream player url.
- Adds param for outstream player poster color.
- Adds new value for creative ID in the bid response.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

PR for docs:
prebid/prebid.github.io#1561