### PR TITLE
Adform adapter: add renderer for outstream bids

### DIFF
--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -258,6 +258,13 @@ describe('Adform adapter', function () {
       };
     });
 
+    it('should set a renderer for an outstream context', function () {
+      serverResponse.body = [serverResponse.body[3]];
+      bidRequest.bids = [bidRequest.bids[6]];
+      let result = spec.interpretResponse(serverResponse, bidRequest);
+      assert.ok(result[0].renderer);
+    });
+
     describe('verifySizes', function () {
       it('should respond with empty response when sizes doesn\'t match', function () {
         serverResponse.body[0].response = 'banner';
@@ -309,6 +316,7 @@ describe('Adform adapter', function () {
 
     let sizes = [[250, 300], [300, 250], [300, 600]];
     let placementCode = ['div-01', 'div-02', 'div-03', 'div-04', 'div-05'];
+    let mediaTypes = [{video: {context: 'outstream'}}];
     let params = [{ mid: 1, url: 'some// there' }, {adxDomain: null, mid: 2, someVar: 'someValue', pt: 'gross'}, { adxDomain: null, mid: 3, pdom: 'home' }, {mid: 5, pt: 'net'}, {mid: 6, pt: 'gross'}];
     bids = [
       {
@@ -388,6 +396,7 @@ describe('Adform adapter', function () {
         params: params[4],
         placementCode: placementCode[2],
         sizes: [],
+        mediaTypes: mediaTypes[0],
         transactionId: '5f33781f-9552-7ev3'
       }
     ];


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Introduced support of inhouse outstream renderer, which is applied by default.