### PR TITLE
#4280 Addition of initialize method to DigiTrust facade

### DIFF
--- a/integrationExamples/gpt/digitrust_min_DTinit.html
+++ b/integrationExamples/gpt/digitrust_min_DTinit.html
@@ -1,0 +1,281 @@
+<html>
+<head>
+    <title>DigiTrust Init - No Framework</title>
+
+    <script>
+        (function (window, document) {
+            if (!window.__cmp) {
+                window.__cmp = (function () {
+                    var listen = window.attachEvent || window.addEventListener;
+                    listen('message', function (event) {
+                        window.__cmp.receiveMessage(event);
+                    }, false);
+
+                    function addLocatorFrame() {
+                        if (!window.frames['__cmpLocator']) {
+                            if (document.body) {
+                                var frame = document.createElement('iframe');
+                                frame.style.display = 'none';
+                                frame.name = '__cmpLocator';
+                                document.body.appendChild(frame);
+                            } else {
+                                setTimeout(addLocatorFrame, 5);
+                            }
+                        }
+                    }
+                    addLocatorFrame();
+
+                    var commandQueue = [];
+                    var cmp = function (command, parameter, callback) {
+                        if (command === 'ping') {
+                            if (callback) {
+                                callback({
+                                    gdprAppliesGlobally: !!(window.__cmp && window.__cmp.config && window.__cmp.config.storeConsentGlobally),
+                                    cmpLoaded: false
+                                });
+                            }
+                        } else {
+                            commandQueue.push({
+                                command: command,
+                                parameter: parameter,
+                                callback: callback
+                            });
+                        }
+                    };
+                    cmp.commandQueue = commandQueue;
+                    cmp.receiveMessage = function (event) {
+                        var data = event && event.data && event.data.__cmpCall;
+                        if (data) {
+                            commandQueue.push({
+                                callId: data.callId,
+                                command: data.command,
+                                parameter: data.parameter,
+                                event: event
+                            });
+                        }
+                    };
+                    cmp.config = {
+                        //
+                        // Modify config values here
+                        //
+                        // globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
+                        // customPurposeListLocation: './purposes.json',
+                        // globalConsentLocation: './portal.html',
+                        // storeConsentGlobally: false,
+                        // storePublisherData: false,
+                        logging: 'debug'//,
+                        // localization: {},
+                        // forceLocale: 'en-us'
+                    };
+                    return cmp;
+                }());
+                var t = document.createElement('script');
+                t.async = false;
+                t.src = 'http://acdn.adnxs.com/cmp/cmp.bundle.js';
+                var tag = document.getElementsByTagName('head')[0];
+                tag.appendChild(t);
+            }
+        })(window, document);
+        // window.__cmp('showConsentTool');
+    </script>
+
+    <script>
+        var FAILSAFE_TIMEOUT = 2000;
+
+        var adUnits = [
+            {
+                code: 'test-div',
+                sizes: [[300, 250], [300, 600], [728, 90]],
+                bids: [
+                    {
+                        bidder: 'rubicon',
+                        params: {
+                            accountId: '1001',
+                            siteId: '113932',
+                            zoneId: '535510'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+    </script>
+    <script src="../../build/dev/prebid.js" async></script>
+
+    <script>
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function () {
+            googletag.pubads().disableInitialLoad();
+        });
+
+        pbjs.que.push(function () {
+            pbjs.setConfig({
+                debug: true,
+                consentManagement: {
+                    cmpApi: 'iab',
+                    timeout: 1000,
+                    allowAuctionWithoutConsent: true
+                },
+                usersync: {
+                    userIds: [{
+                        name: "digitrust",
+                        params: {
+                            init: {
+                                member: 'example_member_id',
+                                site: 'example_site_id'
+                            },
+                            callback: function (digiTrustResult) {
+                                // This callback can be used by publisher page to react to error conditions
+                                // Or pass the DigiTrust ID on.
+                                // If the Prebid userId system already has a managed copy of the DigiTrust ID
+                                // this callback will not be invoked.
+                                var elem = document.getElementById('idDiv');
+                                var msg;
+                                if (digiTrustResult.success) {
+                                    console.log('Success in Digitrust init');
+                                    if (digiTrustResult.identity && digiTrustResult.identity.id != null) {
+                                        msg = 'DigiTrust Id (encrypted): ' + digiTrustResult.identity.id;
+                                        elem.innerHTML = msg;
+                                        console.log(msg);
+                                    }
+                                    else {
+                                        console.error('Digitrust gave success, but no identity returned');
+                                    }
+                                }
+                                else {
+                                    console.error('Digitrust init failed');
+                                }
+                            }
+                        },
+                        storage: {
+                            type: "html5",
+                            name: "pbjsdigitrust",
+                            expires: 60
+                        }
+                    }]
+                }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest
+            });
+        });
+
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent) return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function () {
+                pbjs.que.push(function () {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+
+        setTimeout(function () {
+            sendAdserverRequest();
+        }, FAILSAFE_TIMEOUT);
+    </script>
+
+    <script>
+        (function () {
+            var gads = document.createElement('script');
+            gads.async = true;
+            gads.type = 'text/javascript';
+            var useSSL = 'https:' == document.location.protocol;
+            gads.src = (useSSL ? 'https:' : 'http:') +
+                '//www.googletagservices.com/tag/js/gpt.js';
+            var node = document.getElementsByTagName('script')[0];
+            node.parentNode.insertBefore(gads, node);
+        })();
+    </script>
+
+    <script>
+        googletag.cmd.push(function () {
+            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250], [300, 600]], 'test-div').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+
+</head>
+
+<body>
+    <h2>DigiTrust Init - No Framework</h2>
+
+    <p>
+        Testing for case where DigiTrust.init is called with minimal Prebid against stub object.
+    </p>
+    <div id="idDiv"></div>
+
+    <div id='test-div'>
+        <script>
+            googletag.cmd.push(function () { googletag.display('test-div'); });
+        </script>
+    </div>
+
+    <script>
+        // "digitrustIframe": "http://local.digitru.st/dist/dt.html"
+        // "digitrustIframe": "http://cdn-staging.digitru.st/dist/dt.html"
+        function simulateDigitrustInit() {
+            setTimeout(function () {
+                if (window.DigiTrust == null) {
+                    setTimeout(simulateDigitrustInit, 1500);
+                    return;
+                }
+        DigiTrust.initialize({
+            member: 'example_member_id',
+            site: 'example_site_id',
+            //logging: { level: "DEBUG", enable: true },
+            environment: {
+                redirectInterval: {
+                    exp: 2,
+                    experiod: 's'
+                },
+                urls: {
+                    "digitrustIframe": "//local.digitru.st/dist/dt_debug.html",
+                    "digitrustIdService": "//local.digitru.st/misc/faked_id_service_v1.json"
+                },
+                iframe: {
+                    postMessageOrigin: "http://local.digitru.st",
+                    timeoutDuration: (1000 * 60)
+                },
+                crypto: {
+                    serverCryptoRate: 1.0
+                },
+                logging: { enable: true, level: 'DEBUG' }
+            }
+        },
+            function (digiTrustResult) {
+                //console.log("Digi sample callback", digiTrustResult);
+                //console.log('Digi value: ' + digiTrustResult.success);
+
+                if (digiTrustResult.success) {
+                    console.log('Success in Digitrust init');
+                    /*
+                    if(digiTrustResult.identity.id != null) {
+                        DigiTrustCrypto.decrypt(digiTrustResult.identity.id, function(decryptedId) {
+                            console.log(decryptedId);
+                        });
+                    }
+                    else{
+                        console.error('Digitrust gave success, but no identity returned');
+                    }
+                    */
+                }
+                else {
+                    console.error('Digitrust init failed');
+                }
+
+            });
+
+    }, 3000);
+        }
+
+        simulateDigitrustInit();
+    </script>
+</body>
+</html>

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -102,6 +102,13 @@ function initDigitrustFacade(config) {
       callCount: 0,
       initCallback: null
     },
+    initialize: function (config) {
+      /* This method is present to catch an edge case where DigiTrust publishers transition
+       * to Prebid with minimal integration, but have not removed old DigiTrust.initialize call.
+       * It should not be used */
+      utils.logInfo('Warning - call to Digitrust.initialize within a Prebid integration. Please initialize through pbjs.configure with the userSync option');
+      initializeDigiTrust(config);
+    },
     getUser: function (obj, callback) {
       var isAsync = !!isFunc(callback);
       var cb = isAsync ? callback : noop;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix

## Description of change
Bug fix for issue #4280   
Handles legacy DigiTrust.initialize call when migrating to Prebid.

- contact email of the adapter’s maintainer 
ccole@emination.com
- [ X] official adapter submission

## Other information
Issue #4280 