### PR TITLE
fix double-urlencoded referer in stv adapter

### DIFF
--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -28,7 +28,7 @@ export const spec = {
       const placementId = params.placement;
 
       const rnd = Math.floor(Math.random() * 99999999999);
-      const referrer = encodeURIComponent(bidderRequest.refererInfo.referer);
+      const referrer = bidderRequest.refererInfo.referer;
       const bidId = bidRequest.bidId;
       let endpoint = VADS_ENDPOINT_URL;
 


### PR DESCRIPTION
## Type of change
- [x ] Bugfix

## Description of change
Fix double-urlencoded referer in stv adapter