### PR TITLE
Adpod deal support

### DIFF
--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -116,7 +116,8 @@ function getPricePartForAdpodKey(bid) {
   let pricePart
   let prioritizeDeals = config.getConfig('adpod.prioritizeDeals');
   if (prioritizeDeals && utils.deepAccess(bid, 'video.dealTier')) {
-    pricePart = utils.deepAccess(bid, 'video.dealTier');
+    const adpodDealPrefix = config.getConfig(`adpod.dealTier.${bid.bidderCode}.prefix`);
+    pricePart = (adpodDealPrefix) ? adpodDealPrefix + utils.deepAccess(bid, 'video.dealTier') : utils.deepAccess(bid, 'video.dealTier');
   } else {
     const granularity = getPriceGranularity(bid.mediaType);
     pricePart = getPriceByGranularity(granularity)(bid);
@@ -474,7 +475,11 @@ export function getTargeting({codes, callback} = {}) {
       let bidDealTier = utils.deepAccess(bid, 'video.dealTier');
       let minDealTier = config.getConfig(`adpod.dealTier.${bid.bidderCode}.minDealTier`);
       if (minDealTier && bidDealTier) {
-        partitions[Number(bidDealTier > minDealTier)].push(bid);
+        if (bidDealTier >= minDealTier) {
+          partitions[1].push(bid)
+        } else {
+          partitions[0].push(bid)
+        }
       } else if (bidDealTier) {
         partitions[1].push(bid)
       } else {

--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -453,7 +453,7 @@ export function sortByPricePerSecond(a, b) {
  * @param {function} callback
  * @returns targeting kvs for adUnitCodes
  */
-export function getTargeting({codes, callback, filterBids} = {}) {
+export function getTargeting({codes, callback} = {}) {
   if (!callback) {
     utils.logError('No callback function was defined in the getTargeting call.  Aborting getTargeting().');
     return;
@@ -471,11 +471,12 @@ export function getTargeting({codes, callback, filterBids} = {}) {
   let prioritizeDeals = config.getConfig('adpod.prioritizeDeals');
   if (prioritizeDeals) {
     let [otherBids, highPriorityDealBids] = bids.reduce((partitions, bid) => {
-      let bidderCode = bid.bidderCode
-      if (filterBids && filterBids[bidderCode]) {
-        partitions[Number(filterBids[bidderCode].call(null, bid))].push(bid);
-      } else if (bid.video.dealTier) {
-        partitions[1].push(bid);
+      let bidDealTier = utils.deepAccess(bid, 'video.dealTier');
+      let minDealTier = config.getConfig(`adpod.dealTier.${bid.bidderCode}.minDealTier`);
+      if (minDealTier && bidDealTier) {
+        partitions[Number(bidDealTier > minDealTier)].push(bid);
+      } else if (bidDealTier) {
+        partitions[1].push(bid)
       } else {
         partitions[0].push(bid);
       }

--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -112,6 +112,18 @@ function createDispatcher(timeoutDuration) {
   };
 }
 
+function getPricePartForAdpodKey(bid) {
+  let pricePart
+  let prioritizeDeals = config.getConfig('adpod.prioritizeDeals');
+  if (prioritizeDeals && utils.deepAccess(bid, 'video.dealTier')) {
+    pricePart = utils.deepAccess(bid, 'video.dealTier');
+  } else {
+    const granularity = getPriceGranularity(bid.mediaType);
+    pricePart = getPriceByGranularity(granularity)(bid);
+  }
+  return pricePart
+}
+
 /**
  * This function reads certain fields from the bid to generate a specific key used for caching the bid in Prebid Cache
  * @param {Object} bid bid object to update
@@ -120,16 +132,14 @@ function createDispatcher(timeoutDuration) {
 function attachPriceIndustryDurationKeyToBid(bid, brandCategoryExclusion) {
   let initialCacheKey = bidCacheRegistry.getInitialCacheKey(bid);
   let duration = utils.deepAccess(bid, 'video.durationBucket');
-  const granularity = getPriceGranularity(bid.mediaType);
-  let cpmFixed = getPriceByGranularity(granularity)(bid);
-
+  const pricePart = getPricePartForAdpodKey(bid);
   let pcd;
 
   if (brandCategoryExclusion) {
     let category = utils.deepAccess(bid, 'meta.adServerCatId');
-    pcd = `${cpmFixed}_${category}_${duration}s`;
+    pcd = `${pricePart}_${category}_${duration}s`;
   } else {
-    pcd = `${cpmFixed}_${duration}s`;
+    pcd = `${pricePart}_${duration}s`;
   }
 
   if (!bid.adserverTargeting) {
@@ -443,7 +453,7 @@ export function sortByPricePerSecond(a, b) {
  * @param {function} callback
  * @returns targeting kvs for adUnitCodes
  */
-export function getTargeting({codes, callback} = {}) {
+export function getTargeting({codes, callback, filterBids} = {}) {
   if (!callback) {
     utils.logError('No callback function was defined in the getTargeting call.  Aborting getTargeting().');
     return;
@@ -457,7 +467,26 @@ export function getTargeting({codes, callback} = {}) {
 
   let bids = getBidsForAdpod(bidsReceived, adPodAdUnits);
   bids = (competiveExclusionEnabled || deferCachingEnabled) ? getExclusiveBids(bids) : bids;
-  bids.sort(sortByPricePerSecond);
+
+  let prioritizeDeals = config.getConfig('adpod.prioritizeDeals');
+  if (prioritizeDeals) {
+    let [otherBids, highPriorityDealBids] = bids.reduce((partitions, bid) => {
+      let bidderCode = bid.bidderCode
+      if (filterBids && filterBids[bidderCode]) {
+        partitions[Number(filterBids[bidderCode].call(null, bid))].push(bid);
+      } else if (bid.video.dealTier) {
+        partitions[1].push(bid);
+      } else {
+        partitions[0].push(bid);
+      }
+      return partitions;
+    }, [[], []]);
+    highPriorityDealBids.sort(sortByPricePerSecond);
+    otherBids.sort(sortByPricePerSecond);
+    bids = highPriorityDealBids.concat(otherBids);
+  } else {
+    bids.sort(sortByPricePerSecond);
+  }
 
   let targeting = {};
   if (deferCachingEnabled === false) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,7 +498,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       case ADPOD:
         const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
         bid.meta = Object.assign({}, bid.meta, { iabSubCatId });
-        const adpodDealPrefix = config.getConfig(`adpod.dealPrefix.${bidRequest.bidder}`);
+        const adpodDealPrefix = config.getConfig(`adpod.dealTier.${bidRequest.bidder}.prefix`);
         const dealTier = (adpodDealPrefix) ? adpodDealPrefix + rtbBid.rtb.dealPriority : rtbBid.rtb.dealPriority;
         bid.video = {
           context: ADPOD,

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,9 +498,12 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       case ADPOD:
         const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
         bid.meta = Object.assign({}, bid.meta, { iabSubCatId });
+        const adpodDealPrefix = config.getConfig(`adpod.dealPrefix.${bidRequest.bidder}`);
+        const dealTier = (adpodDealPrefix) ? adpodDealPrefix + rtbBid.rtb.dealPriority : rtbBid.rtb.dealPriority;
         bid.video = {
           context: ADPOD,
           durationSeconds: Math.floor(rtbBid.rtb.video.duration_ms / 1000),
+          dealTier
         };
         bid.vastUrl = rtbBid.rtb.video.asset_url;
         break;

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,8 +498,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       case ADPOD:
         const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
         bid.meta = Object.assign({}, bid.meta, { iabSubCatId });
-        const adpodDealPrefix = config.getConfig(`adpod.dealTier.${bidRequest.bidder}.prefix`);
-        const dealTier = (adpodDealPrefix) ? adpodDealPrefix + rtbBid.rtb.dealPriority : rtbBid.rtb.dealPriority;
+        const dealTier = rtbBid.rtb.dealPriority;
         bid.video = {
           context: ADPOD,
           durationSeconds: Math.floor(rtbBid.rtb.video.duration_ms / 1000),

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -766,6 +766,75 @@ describe('adpod.js', function () {
       expect(storeStub.called).to.equal(false);
       expect(auctionBids.length).to.equal(1);
     });
+
+    it('should set deal tier in place of cpm when prioritzeDeals is true', function() {
+      config.setConfig({
+        adpod: {
+          deferCaching: true,
+          brandCategoryExclusion: true,
+          prioritizeDeals: true
+        }
+      });
+
+      let bidResponse1 = {
+        adId: 'adId01277',
+        auctionId: 'no_defer_123',
+        mediaType: 'video',
+        cpm: 5,
+        pbMg: '5.00',
+        adserverTargeting: {
+          hb_pb: '5.00'
+        },
+        meta: {
+          adServerCatId: 'test'
+        },
+        video: {
+          context: ADPOD,
+          durationSeconds: 15,
+          durationBucket: 15,
+          dealTier: 'tier7'
+        }
+      };
+
+      let bidResponse2 = {
+        adId: 'adId46547',
+        auctionId: 'no_defer_123',
+        mediaType: 'video',
+        cpm: 12,
+        pbMg: '12.00',
+        adserverTargeting: {
+          hb_pb: '12.00'
+        },
+        meta: {
+          adServerCatId: 'value'
+        },
+        video: {
+          context: ADPOD,
+          durationSeconds: 15,
+          durationBucket: 15
+        }
+      };
+
+      let bidderRequest = {
+        adUnitCode: 'adpod_1',
+        auctionId: 'no_defer_123',
+        mediaTypes: {
+          video: {
+            context: ADPOD,
+            playerSize: [300, 300],
+            adPodDurationSec: 300,
+            durationRangeSec: [15, 30, 45],
+            requireExactDuration: false
+          }
+        },
+      };
+
+      callPrebidCacheHook(callbackFn, auctionInstance, bidResponse1, afterBidAddedSpy, bidderRequest);
+      callPrebidCacheHook(callbackFn, auctionInstance, bidResponse2, afterBidAddedSpy, bidderRequest);
+
+      expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('tier7_test_15s');
+      expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('12.00_value_15s');
+    })
   });
 
   describe('checkAdUnitSetupHook', function () {

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -772,7 +772,13 @@ describe('adpod.js', function () {
         adpod: {
           deferCaching: true,
           brandCategoryExclusion: true,
-          prioritizeDeals: true
+          prioritizeDeals: true,
+          dealTier: {
+            'appnexus': {
+              'prefix': 'tier',
+              'minDealTier': 5
+            }
+          }
         }
       });
 
@@ -780,6 +786,7 @@ describe('adpod.js', function () {
         adId: 'adId01277',
         auctionId: 'no_defer_123',
         mediaType: 'video',
+        bidderCode: 'appnexus',
         cpm: 5,
         pbMg: '5.00',
         adserverTargeting: {
@@ -792,7 +799,7 @@ describe('adpod.js', function () {
           context: ADPOD,
           durationSeconds: 15,
           durationBucket: 15,
-          dealTier: 'tier7'
+          dealTier: 7
         }
       };
 
@@ -800,6 +807,7 @@ describe('adpod.js', function () {
         adId: 'adId46547',
         auctionId: 'no_defer_123',
         mediaType: 'video',
+        bidderCode: 'appnexus',
         cpm: 12,
         pbMg: '12.00',
         adserverTargeting: {

--- a/test/spec/modules/freeWheelAdserverVideo_spec.js
+++ b/test/spec/modules/freeWheelAdserverVideo_spec.js
@@ -197,6 +197,95 @@ describe('freeWheel adserver module', function() {
     expect(targeting['preroll_1'].length).to.equal(3);
     expect(targeting['midroll_1'].length).to.equal(3);
   });
+
+  it('should prioritize bids with deal', function() {
+    config.setConfig({
+      adpod: {
+        deferCaching: true,
+        prioritizeDeals: true
+      }
+    });
+
+    let tier6Bid = createBid(10, 'preroll_1', 15, 'tier6_395_15s', '123', '395');
+    tier6Bid['video']['dealTier'] = 'tier6'
+
+    let tier7Bid = createBid(11, 'preroll_1', 45, 'tier7_395_15s', '123', '395');
+    tier7Bid['video']['dealTier'] = 'tier7'
+
+    let bidsReceived = [
+      tier6Bid,
+      tier7Bid,
+      createBid(15, 'preroll_1', 90, '15.00_395_90s', '123', '395'),
+    ]
+    amStub.returns(bidsReceived);
+    let targeting;
+    adpodUtils.getTargeting({
+      callback: function(errorMsg, targetingResult) {
+        targeting = targetingResult;
+      }
+    });
+
+    requests[0].respond(
+      200,
+      { 'Content-Type': 'text/plain' },
+      JSON.stringify({'responses': bidsReceived.slice(1)})
+    );
+
+    expect(targeting['preroll_1'].length).to.equal(3);
+    expect(targeting['preroll_1']).to.deep.include({'hb_pb_cat_dur': 'tier6_395_15s'});
+    expect(targeting['preroll_1']).to.deep.include({'hb_pb_cat_dur': 'tier7_395_15s'});
+    expect(targeting['preroll_1']).to.deep.include({'hb_cache_id': '123'});
+  });
+
+  it('should apply filteredBids function to bids if configured', function() {
+    config.setConfig({
+      adpod: {
+        deferCaching: true,
+        prioritizeDeals: true
+      }
+    });
+
+    let tier2Bid = createBid(10, 'preroll_1', 15, 'tier2_395_15s', '123', '395');
+    tier2Bid['video']['dealTier'] = 'tier2'
+    tier2Bid['adserverTargeting']['hb_pb'] = '10.00'
+
+    let tier7Bid = createBid(11, 'preroll_1', 45, 'tier7_395_15s', '123', '395');
+    tier7Bid['video']['dealTier'] = 'tier7'
+    tier7Bid['adserverTargeting']['hb_pb'] = '11.00'
+
+    let bid = createBid(15, 'preroll_1', 15, '15.00_395_90s', '123', '395');
+    bid['adserverTargeting']['hb_pb'] = '15.00'
+
+    let bidsReceived = [
+      tier2Bid,
+      tier7Bid,
+      bid
+    ]
+    amStub.returns(bidsReceived);
+    let targeting;
+    adpodUtils.getTargeting({
+      callback: function(errorMsg, targetingResult) {
+        targeting = targetingResult;
+      },
+      filterBids: {
+        'appnexus': function(bid) {
+          return bid.video.dealTier == 'tier7'
+        }
+      }
+    });
+
+    requests[0].respond(
+      200,
+      { 'Content-Type': 'text/plain' },
+      JSON.stringify({'responses': [tier7Bid, bid]})
+    );
+
+    expect(targeting['preroll_1'].length).to.equal(3);
+    expect(targeting['preroll_1']).to.deep.include({'hb_pb_cat_dur': 'tier7_395_15s'});
+    expect(targeting['preroll_1']).to.deep.include({'hb_pb_cat_dur': '15.00_395_90s'});
+    expect(targeting['preroll_1']).to.not.include({'hb_pb_cat_dur': 'tier2_395_15s'});
+    expect(targeting['preroll_1']).to.deep.include({'hb_cache_id': '123'});
+  })
 });
 
 function getBidsReceived() {

--- a/test/spec/modules/freeWheelAdserverVideo_spec.js
+++ b/test/spec/modules/freeWheelAdserverVideo_spec.js
@@ -237,20 +237,26 @@ describe('freeWheel adserver module', function() {
     expect(targeting['preroll_1']).to.deep.include({'hb_cache_id': '123'});
   });
 
-  it('should apply filteredBids function to bids if configured', function() {
+  it('should apply minDealTier to bids if configured', function() {
     config.setConfig({
       adpod: {
         deferCaching: true,
-        prioritizeDeals: true
+        prioritizeDeals: true,
+        dealTier: {
+          'appnexus': {
+            prefix: 'tier',
+            minDealTier: 5
+          }
+        }
       }
     });
 
     let tier2Bid = createBid(10, 'preroll_1', 15, 'tier2_395_15s', '123', '395');
-    tier2Bid['video']['dealTier'] = 'tier2'
+    tier2Bid['video']['dealTier'] = 2
     tier2Bid['adserverTargeting']['hb_pb'] = '10.00'
 
     let tier7Bid = createBid(11, 'preroll_1', 45, 'tier7_395_15s', '123', '395');
-    tier7Bid['video']['dealTier'] = 'tier7'
+    tier7Bid['video']['dealTier'] = 7
     tier7Bid['adserverTargeting']['hb_pb'] = '11.00'
 
     let bid = createBid(15, 'preroll_1', 15, '15.00_395_90s', '123', '395');
@@ -266,11 +272,6 @@ describe('freeWheel adserver module', function() {
     adpodUtils.getTargeting({
       callback: function(errorMsg, targetingResult) {
         targeting = targetingResult;
-      },
-      filterBids: {
-        'appnexus': function(bid) {
-          return bid.video.dealTier == 'tier7'
-        }
       }
     });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds deal support to adpod. 

#### Background
Publisher requires a method to prioritize certain video deals higher in the Freewheel stack to ensure delivery and performance. They want to use the deal tier passed by bidder to help to inflate the CPM that gets passed into Freewheel to get higher priority there.

Introducing two new adpod configs 
- `prioritizeDeals` flag to give higher preference to deals and will replace cpm with `bid.video.tier` in `hb_pb_cat_dur` value.  e.g `hb_pb_cat_dur=dealId_395_15s`
- `dealTier` to set prefix and minimum deal tier for each bidder. Each Publisher can have different line item setup in adserver with different priorities. Publisher and bidders know what deal keyword to use to target line items. 

// minDealTier is an int which will give high preference to deal bids with tier >= 5
// Note: bids with tier less than 5 will not be ignored but their cache key will contain dealId in place of cpm. These bids will be auctioned just like non-deal bids.

```
// This will replace the cpm with dealId in cache key as well as targeting kv pair when prioritizeDeals flag is set to true.
pbjs.setConfig({
  adpod: {
    prioritizeDeals: true,
    dealTier: {
      'appnexus': {
        prefix: 'tier',
        minDealTier: 5
      },
      'some-other-bidder': {
        prefix: 'deals',
        minDealTier: 20
      }
    }
  }
})
```

In case of adpod, bidder returns multiple bids. Each bid can have different priority/deal tier set. Publisher may want to have control over deal tier. We are adding `filterBids` option to `
pbjs.adServers.freewheel.getTargeting` to select certain deal bids. 

``` 

pbjs.adServers.freewheel.getTargeting({
    codes: [adUnitCode1],
    callback: function(err, targeting) {
        //pass targeting to player api
    }
});
```

Following show the sample return value.
``` 
// Sample return targeting key value pairs
{
  'adUnitCode-1': [
    {
      'hb_pb_cat_dur': 'tier9_400_15s', // Bid with deal id
    },
    {
      'hb_pb_cat_dur': 'tier7_401_15s', // Bid with deal id
    },
    {
      'hb_pb_cat_dur': '15.00_402_15s',
    },
    {
      'hb_cache_id': '123'
    }
  ]
}
```
