### PR TITLE
Update underdogmedia adapter for pbjs 3.0

### DIFF
--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -4,15 +4,16 @@ import { registerBidder } from '../src/adapters/bidderFactory';
 const BIDDER_CODE = 'underdogmedia';
 const UDM_ADAPTER_VERSION = '3.0V';
 const UDM_VENDOR_ID = '159';
+const prebidVersion = '$prebid.version$' 
 
-utils.logMessage(`Initializing UDM Adapter. PBJS Version: ${$$PREBID_GLOBAL$$.version} with adapter version: ${UDM_ADAPTER_VERSION}  Updated 20191028`);
+utils.logMessage(`Initializing UDM Adapter. PBJS Version: ${prebidVersion} with adapter version: ${UDM_ADAPTER_VERSION}  Updated 20191028`);
 
 export const spec = {
   code: BIDDER_CODE,
   bidParams: [],
 
   isBidRequestValid: function (bid) {
-    const bidSizes = bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes ? bid.mediaTypes.banner.sizes : bid.sizes
+    const bidSizes = bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes ? bid.mediaTypes.banner.sizes : bid.sizes;
     return !!((bid.params && bid.params.siteId) && (bidSizes && bidSizes.length > 0));
   },
 
@@ -21,7 +22,7 @@ export const spec = {
     var siteId = 0;
 
     validBidRequests.forEach(bidParam => {
-      let bidParamSizes = bidParam.mediaTypes && bidParam.mediaTypes.banner && bidParam.mediaTypes.banner.sizes ? bidParam.mediaTypes.banner.sizes : bidParam.sizes
+      let bidParamSizes = bidParam.mediaTypes && bidParam.mediaTypes.banner && bidParam.mediaTypes.banner.sizes ? bidParam.mediaTypes.banner.sizes : bidParam.sizes;
       sizes = utils.flatten(sizes, utils.parseSizesInput(bidParamSizes));
       siteId = bidParam.params.siteId;
     });

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -4,7 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory';
 const BIDDER_CODE = 'underdogmedia';
 const UDM_ADAPTER_VERSION = '3.0V';
 const UDM_VENDOR_ID = '159';
-const prebidVersion = '$prebid.version$' 
+const prebidVersion = '$prebid.version$';
 
 utils.logMessage(`Initializing UDM Adapter. PBJS Version: ${prebidVersion} with adapter version: ${UDM_ADAPTER_VERSION}  Updated 20191028`);
 

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -2,17 +2,18 @@ import * as utils from '../src/utils';
 import { config } from '../src/config';
 import { registerBidder } from '../src/adapters/bidderFactory';
 const BIDDER_CODE = 'underdogmedia';
-const UDM_ADAPTER_VERSION = '1.13V';
+const UDM_ADAPTER_VERSION = '3.0V';
 const UDM_VENDOR_ID = '159';
 
-utils.logMessage(`Initializing UDM Adapter. PBJS Version: ${$$PREBID_GLOBAL$$.version} with adapter version: ${UDM_ADAPTER_VERSION}  Updated 20180604`);
+utils.logMessage(`Initializing UDM Adapter. PBJS Version: ${$$PREBID_GLOBAL$$.version} with adapter version: ${UDM_ADAPTER_VERSION}  Updated 20191028`);
 
 export const spec = {
   code: BIDDER_CODE,
   bidParams: [],
 
   isBidRequestValid: function (bid) {
-    return !!((bid.params && bid.params.siteId) && (bid.sizes && bid.sizes.length > 0));
+    const bidSizes = bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes ? bid.mediaTypes.banner.sizes : bid.sizes
+    return !!((bid.params && bid.params.siteId) && (bidSizes && bidSizes.length > 0));
   },
 
   buildRequests: function (validBidRequests, bidderRequest) {
@@ -20,7 +21,8 @@ export const spec = {
     var siteId = 0;
 
     validBidRequests.forEach(bidParam => {
-      sizes = utils.flatten(sizes, utils.parseSizesInput(bidParam.sizes));
+      let bidParamSizes = bidParam.mediaTypes && bidParam.mediaTypes.banner && bidParam.mediaTypes.banner.sizes ? bidParam.mediaTypes.banner.sizes : bidParam.sizes
+      sizes = utils.flatten(sizes, utils.parseSizesInput(bidParamSizes));
       siteId = bidParam.params.siteId;
     });
 
@@ -67,7 +69,8 @@ export const spec = {
         }
 
         var sizeNotFound = true;
-        utils.parseSizesInput(bidParam.sizes).forEach(size => {
+        const bidParamSizes = bidParam.mediaTypes && bidParam.mediaTypes.banner && bidParam.mediaTypes.banner.sizes ? bidParam.mediaTypes.banner.sizes : bidParam.sizes
+        utils.parseSizesInput(bidParamSizes).forEach(size => {
           if (size === mid.width + 'x' + mid.height) {
             sizeNotFound = false;
           }

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -49,7 +49,7 @@ export const spec = {
     if (!data.gdprApplies || data.consentGiven) {
       return {
         method: 'GET',
-        url: `${window.location.protocol}//udmserve.net/udm/img.fetch`,
+        url: 'https://udmserve.net/udm/img.fetch',
         data: data,
         bidParams: validBidRequests
       };

--- a/modules/underdogmediaBidAdapter.md
+++ b/modules/underdogmediaBidAdapter.md
@@ -13,7 +13,11 @@ Module that connects to Underdog Media's servers to fetch bids.
     var adUnits = [
         {
             code: 'test-div',
-            sizes: [[300, 250]],  // a display size
+            mediaTypes: {
+            banner: {
+                sizes: [[300, 250]],  // a display size
+            }
+          },
             bids: [
                 {
                     bidder: "underdogmedia",

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -13,7 +13,11 @@ describe('UnderdogMedia adapter', function () {
           siteId: 12143
         },
         adUnitCode: '/19968336/header-bid-tag-1',
-        sizes: [[300, 250], [300, 600], [728, 90], [160, 600], [320, 50]],
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 600], [728, 90], [160, 600], [320, 50]],
+          }
+        },
         bidId: '23acc48ad47af5',
         auctionId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
         bidderRequestId: '1c56ad30b9b8ca8',
@@ -43,7 +47,11 @@ describe('UnderdogMedia adapter', function () {
           params: {
             siteId: '12143'
           },
-          sizes: [[300, 250], [300, 600]]
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]]
+            }
+          }
         };
         const isValid = spec.isBidRequestValid(validBid);
 
@@ -66,7 +74,11 @@ describe('UnderdogMedia adapter', function () {
         let invalidBid = {
           bidder: 'underdogmedia',
           params: {},
-          sizes: [[300, 250], [300, 600]]
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]]
+            }
+          }
         };
         const isValid = spec.isBidRequestValid(invalidBid);
 
@@ -77,8 +89,12 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250]],
             bidder: 'underdogmedia',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]]
+              }
+            },
             params: {
               siteId: '12143'
             },
@@ -95,7 +111,11 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250], [728, 90]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              }
+            },
             bidder: 'underdogmedia',
             params: {
               siteId: '12143'
@@ -113,7 +133,11 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250], [728, 90]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              }
+            },
             bidder: 'underdogmedia',
             params: {
               siteId: '12143'
@@ -133,7 +157,11 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250], [728, 90]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              }
+            },
             bidder: 'underdogmedia',
             params: {
               siteId: '12143'
@@ -164,7 +192,11 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250], [728, 90]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              }
+            },
             bidder: 'underdogmedia',
             params: {
               siteId: '12143'
@@ -199,7 +231,11 @@ describe('UnderdogMedia adapter', function () {
         let bidRequests = [
           {
             bidId: '3c9408cdbf2f68',
-            sizes: [[300, 250], [728, 90]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              }
+            },
             bidder: 'underdogmedia',
             params: {
               siteId: '12143'


### PR DESCRIPTION
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Ad sizes are now in mediaTypes.banner.sizes


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

-  jake@underdogmedia.com
- [x] official adapter submission