### PR TITLE
Fix invalid reference to "global"

### DIFF
--- a/modules/playgroundxyzBidAdapter.js
+++ b/modules/playgroundxyzBidAdapter.js
@@ -166,7 +166,7 @@ function isMobile() {
 }
 
 function isConnectedTV() {
-  return (/(smart[-]?tv|hbbtv|appletv|googletv|hdmi|netcast\.tv|viera|nettv|roku|\bdtv\b|sonydtv|inettvbrowser|\btv\b)/i).test(global.navigator.userAgent);
+  return (/(smart[-]?tv|hbbtv|appletv|googletv|hdmi|netcast\.tv|viera|nettv|roku|\bdtv\b|sonydtv|inettvbrowser|\btv\b)/i).test(navigator.userAgent);
 }
 
 registerBidder(spec);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
<!-- Describe the change proposed in this pull request -->

This change removes a reference to `global`, which causes an exception when the adapter code loads on non-mobile devices.

Note that there is no additional tests added as part of this PR - the existing tests DO cover the affected line, however it appears that they DO NOT fail when executed on ChromeHeadless. I can only assume that ChromeHeadless exposes a `global` object in simiar fashion to NodeJS, resulting in the existing tests passing.

https://nodejs.org/api/globals.html#globals_global


