### PR TITLE
Add supply chain support for Teads adapter

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -46,6 +46,10 @@ export const spec = {
       hb_version: '$prebid.version$'
     };
 
+    if (validBidRequests[0].schain) {
+      payload.schain = validBidRequests[0].schain;
+    }
+
     let gdpr = bidderRequest.gdprConsent;
     if (bidderRequest && gdpr) {
       let isCmp = (typeof gdpr.gdprApplies === 'boolean')

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -226,6 +226,34 @@ describe('teadsBidAdapter', () => {
       checkMediaTypesSizes(mediaTypesPlayerSize, '32x34')
     });
 
+    it('should add schain info to payload if available', function () {
+      const bidRequest = Object.assign({}, bidRequests[0], {
+        schain: {
+          ver: '1.0',
+          complete: 1,
+          nodes: [{
+            asi: 'example.com',
+            sid: '00001',
+            hp: 1
+          }]
+        }
+      });
+
+      const request = spec.buildRequests([bidRequest], bidderResquestDefault);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.schain).to.exist;
+      expect(payload.schain).to.deep.equal({
+        ver: '1.0',
+        complete: 1,
+        nodes: [{
+          asi: 'example.com',
+          sid: '00001',
+          hp: 1
+        }]
+      });
+    });
+
     it('should use good mediaTypes video sizes', function() {
       const mediaTypesVideoSizes = {
         'mediaTypes': {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Forward the supply chain object configured by the publisher to the Teads payload.