### PR TITLE
Bugfix: Stop Duplicate Alias User Syncs

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -10,7 +10,6 @@ config.setDefaults({
     syncsPerBidder: 5,
     syncDelay: 3000,
     auctionDelay: 0,
-    allowDuplicates: true
   }
 });
 
@@ -131,11 +130,11 @@ export function newUserSync(userSyncDependencies) {
    * @params {string} bidder The name of the bidder adding a sync
    * @returns {object} The updated version of numAdapterBids
    */
-  function incrementAdapterBids(numAdapterBids, bidderOrUrl) {
-    if (!numAdapterBids[bidderOrUrl]) {
-      numAdapterBids[bidderOrUrl] = 1;
+  function incrementAdapterBids(numAdapterBids, url) {
+    if (!numAdapterBids[url]) {
+      numAdapterBids[url] = 1;
     } else {
-      numAdapterBids[bidderOrUrl] += 1;
+      numAdapterBids[url] += 1;
     }
     return numAdapterBids;
   }
@@ -153,7 +152,6 @@ export function newUserSync(userSyncDependencies) {
    * userSync.registerSync('image', 'rubicon', 'http://example.com/pixel')
    */
   publicApi.registerSync = (type, bidder, url) => {
-    const bidderOrUrl = usConfig.allowDuplicates === true ? bidder : url;
     if (hasFiredBidder.has(bidder)) {
       return utils.logMessage(`already fired syncs for "${bidder}", ignoring registerSync call`);
     }
@@ -163,8 +161,8 @@ export function newUserSync(userSyncDependencies) {
     if (!bidder) {
       return utils.logWarn(`Bidder is required for registering sync`);
     }
-    if (usConfig.syncsPerBidder !== 0 && Number(numAdapterBids[bidderOrUrl]) >= usConfig.syncsPerBidder) {
-      return utils.logWarn(`Number of user syncs exceeded for "${bidderOrUrl}"`);
+    if (usConfig.syncsPerBidder !== 0 && Number(numAdapterBids[url]) >= usConfig.syncsPerBidder) {
+      return utils.logWarn(`Number of user syncs exceeded for "${url}"`);
     }
 
     const canBidderRegisterSync = publicApi.canBidderRegisterSync(type, bidder);
@@ -174,7 +172,7 @@ export function newUserSync(userSyncDependencies) {
 
     // the bidder's pixel has passed all checks and is allowed to register
     queue[type].push([bidder, url]);
-    numAdapterBids = incrementAdapterBids(numAdapterBids, bidderOrUrl);
+    numAdapterBids = incrementAdapterBids(numAdapterBids, url);
   };
 
   /**

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -165,6 +165,26 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
   });
 
+  it('should limit the number of syncs per bidder by the sync url and not bidder name', function () {
+    const userSync = newTestUserSync({
+      syncsPerBidder: 1,
+      allowDuplicates: false
+    });
+    userSync.registerSync('image', 'testBidder', 'http://example.com/1');
+    userSync.registerSync('image', 'aliasedTestBidder', 'http://example.com/1');
+    userSync.registerSync('image', 'testBidder', 'http://example.com/3');
+    userSync.syncUsers();
+    console.log('what is this');
+    console.log(triggerPixelStub.getCall(0).args[0]);
+    console.log(triggerPixelStub.getCall(1).args[0]);
+
+    expect(triggerPixelStub.getCall(0)).to.not.be.null;
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|3]/);
+    expect(triggerPixelStub.getCall(1)).to.not.be.null;
+    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|3]/);
+    expect(triggerPixelStub.getCall(2)).to.be.null;
+  });
+
   it('should balance out bidder requests', function () {
     const userSync = newTestUserSync();
     userSync.registerSync('image', 'atestBidder', 'http://example.com/1');

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -139,21 +139,9 @@ describe('user sync', function () {
   });
 
   it('should limit the number of syncs per bidder', function () {
-    const userSync = newTestUserSync({syncsPerBidder: 2});
+    const userSync = newTestUserSync({syncsPerBidder: 1});
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
-    userSync.registerSync('image', 'testBidder', 'http://example.com/2');
-    userSync.registerSync('image', 'testBidder', 'http://example.com/3');
-    userSync.syncUsers();
-    expect(triggerPixelStub.getCall(0)).to.not.be.null;
-    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2]/);
-    expect(triggerPixelStub.getCall(1)).to.not.be.null;
-    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2]/);
-    expect(triggerPixelStub.getCall(2)).to.be.null;
-  });
-
-  it('should not limit the number of syncs per bidder when set to 0', function() {
-    const userSync = newTestUserSync({syncsPerBidder: 0});
-    userSync.registerSync('image', 'testBidder', 'http://example.com/1');
+    userSync.registerSync('image', 'testAliasBidder', 'http://example.com/1');
     userSync.registerSync('image', 'testBidder', 'http://example.com/2');
     userSync.registerSync('image', 'testBidder', 'http://example.com/3');
     userSync.syncUsers();
@@ -163,26 +151,21 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
     expect(triggerPixelStub.getCall(2)).to.not.be.null;
     expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(3)).to.be.null;
   });
 
-  it('should limit the number of syncs per bidder by the sync url and not bidder name', function () {
-    const userSync = newTestUserSync({
-      syncsPerBidder: 1,
-      allowDuplicates: false
-    });
+  it('should not limit the number of syncs per bidder when set to 0', function() {
+    const userSync = newTestUserSync({syncsPerBidder: 0});
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
-    userSync.registerSync('image', 'aliasedTestBidder', 'http://example.com/1');
-    userSync.registerSync('image', 'testBidder', 'http://example.com/3');
+    userSync.registerSync('image', 'testAliasBidder', 'http://example.com/1');
+    userSync.registerSync('image', 'testBidder', 'http://example.com/2');
     userSync.syncUsers();
-    console.log('what is this');
-    console.log(triggerPixelStub.getCall(0).args[0]);
-    console.log(triggerPixelStub.getCall(1).args[0]);
-
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
-    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|3]/);
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
     expect(triggerPixelStub.getCall(1)).to.not.be.null;
-    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|3]/);
-    expect(triggerPixelStub.getCall(2)).to.be.null;
+    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(2)).to.not.be.null;
+    expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
   });
 
   it('should balance out bidder requests', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Prebid currently registers and limits userSync calls based on the bidder name. When Aliases are used, this causes duplicate sync requests as the sync URL is the same as in the original adapter. This fix will instead look at how many times the URL is used instead of how many times a bidder name was used in determining how to limit syncs.

## Other information
#4408 

