### PR TITLE
Safeframe resize fix does not select correct element

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -81,8 +81,9 @@ export function _sendAdToCreative(adObject, remoteDomain, source) {
 
 function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
-  ['div:last-child', 'div:last-child iframe'].forEach(elmType => {
-    let element = getElementByAdUnit(elmType);
+  ['div', 'iframe'].forEach(elmType => {
+    // not select element that gets removed after dfp render
+    let element = getElementByAdUnit(elmType + ':not([style*="display: none"])');
     if (element) {
       let elementStyle = element.style;
       elementStyle.width = width + 'px';


### PR DESCRIPTION
## Type of change
- [ ] Bugfix

## Description of change
Div and iframe not getting resized when element is not the last element of the parent, for example, when there is close button element after). We need different solution that does not use last-child css.

## Other information
https://github.com/prebid/Prebid.js/issues/4418
