### PR TITLE
add support for min_height field in pbs native requests

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -510,10 +510,11 @@ const OPEN_RTB_PROTOCOL = {
                   type: imgTypeId,
                   w: utils.deepAccess(params, 'sizes.0'),
                   h: utils.deepAccess(params, 'sizes.1'),
-                  wmin: utils.deepAccess(params, 'aspect_ratios.0.min_width')
+                  wmin: utils.deepAccess(params, 'aspect_ratios.0.min_width'),
+                  hmin: utils.deepAccess(params, 'aspect_ratios.0.min_height')
                 });
-                if (!(asset.w || asset.wmin)) {
-                  throw 'invalid img sizes (must provided sizes or aspect_ratios)';
+                if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
+                  throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
                 }
                 if (Array.isArray(params.aspect_ratios)) {
                   // pass aspect_ratios as ext data I guess?

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -41,6 +41,15 @@ const REQUEST = {
             'required': true,
             'sizes': [989, 742],
           },
+          'icon': {
+            'required': true,
+            'aspect_ratios': [{
+              'min_height': 10,
+              'min_width': 10,
+              'ratio_height': 1,
+              'ratio_width': 1
+            }]
+          },
           'sponsoredBy': {
             'required': true
           }
@@ -419,13 +428,26 @@ const RESPONSE_OPENRTB_NATIVE = {
                 }
               },
               {
+                'id': 2,
+                'img': {
+                  'url': 'https://vcdn.adnxs.com/p/creative-image/1a/3e/e9/5b/1a3ee95b-06cd-4260-98c7-0258627c9197.png',
+                  'w': 127,
+                  'h': 83,
+                  'ext': {
+                    'appnexus': {
+                      'prevent_crop': 0
+                    }
+                  }
+                }
+              },
+              {
                 'id': 0,
                 'title': {
                   'text': 'This is a Prebid Native Creative'
                 }
               },
               {
-                'id': 2,
+                'id': 3,
                 'data': {
                   'value': 'Prebid.org'
                 }
@@ -827,6 +849,17 @@ describe('S2S Adapter', function () {
                 'type': 3,
                 'w': 989,
                 'h': 742
+              }
+            },
+            {
+              'required': 1,
+              'img': {
+                'type': 1,
+                'wmin': 10,
+                'hmin': 10,
+                'ext': {
+                  'aspectratios': ['1:1']
+                }
               }
             },
             {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This PR adds support for a missing field related to native requests using `aspect_ratios` with the PBS adapter.  

In the ORTB Native spec, image related assets (such as image and icons) require either a set of defined sizes or a min_width **and** min_height (which are related to aspect_ratios).

The PBS adapter previously only supported a min_width field, but not a min_height field.  


Additional notes from ORTB Native spec:
https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf (see page 15 in PDF, the Image Request Object sub-section)

## Other information
Docs PR: https://github.com/prebid/prebid.github.io/pull/1596
