### PR TITLE
added additional ad unit counters

### DIFF
--- a/src/adUnits.js
+++ b/src/adUnits.js
@@ -2,15 +2,47 @@ import { deepAccess } from './utils';
 
 let adUnits = {};
 
+function ensureAdUnit(adunit, bidderCode) {
+  let adUnit = adUnits[adunit] = adUnits[adunit] || { bidders: {} };
+  if (bidderCode) {
+    return adUnit.bidders[bidderCode] = adUnit.bidders[bidderCode] || {}
+  }
+  return adUnit;
+}
+
+function incrementAdUnitCount(adunit, counter, bidderCode) {
+  let adUnit = ensureAdUnit(adunit, bidderCode);
+  adUnit[counter] = (adUnit[counter] || 0) + 1;
+  return adUnit[counter];
+}
+
 /**
  * Increments and returns current Adunit counter
  * @param {string} adunit id
  * @returns {number} current adunit count
  */
-function incrementCounter(adunit) {
-  adUnits[adunit] = adUnits[adunit] || {};
-  adUnits[adunit].counter = (deepAccess(adUnits, `${adunit}.counter`) + 1) || 1;
-  return adUnits[adunit].counter;
+function incrementRequestsCounter(adunit) {
+  return incrementAdUnitCount(adunit, 'requestsCounter');
+}
+
+/**
+ * Increments and returns current Adunit requests counter for a bidder
+ * @param {string} adunit id
+ * @param {string} bidderCode code
+ * @returns {number} current adunit bidder requests count
+ */
+function incrementBidderRequestsCounter(adunit, bidderCode) {
+  return incrementAdUnitCount(adunit, 'requestsCounter', bidderCode);
+}
+
+/**
+ * Increments and returns current Adunit wins counter for a bidder
+ * @param {string} adunit id
+ * @param {string} bidderCode code
+ * @returns {number} current adunit bidder requests count
+ */
+function incrementBidderWinsCounter(adunit, bidderCode) {
+  return incrementAdUnitCount(adunit, 'winsCounter', bidderCode);
 }
 
 /**
@@ -18,8 +50,28 @@ function incrementCounter(adunit) {
  * @param {string} adunit id
  * @returns {number} current adunit count
  */
-function getCounter(adunit) {
-  return deepAccess(adUnits, `${adunit}.counter`) || 0;
+function getRequestsCounter(adunit) {
+  return deepAccess(adUnits, `${adunit}.requestsCounter`) || 0;
+}
+
+/**
+ * Returns current Adunit requests counter for a specific bidder code
+ * @param {string} adunit id
+ * @param {string} bidder code
+ * @returns {number} current adunit bidder requests count
+ */
+function getBidderRequestsCounter(adunit, bidder) {
+  return deepAccess(adUnits, `${adunit}.bidders.${bidder}.requestsCounter`) || 0;
+}
+
+/**
+ * Returns current Adunit requests counter for a specific bidder code
+ * @param {string} adunit id
+ * @param {string} bidder code
+ * @returns {number} current adunit bidder requests count
+ */
+function getBidderWinsCounter(adunit, bidder) {
+  return deepAccess(adUnits, `${adunit}.bidders.${bidder}.winsCounter`) || 0;
 }
 
 /**
@@ -27,8 +79,12 @@ function getCounter(adunit) {
  * @module adunitCounter
  */
 let adunitCounter = {
-  incrementCounter,
-  getCounter
+  incrementRequestsCounter,
+  incrementBidderRequestsCounter,
+  incrementBidderWinsCounter,
+  getRequestsCounter,
+  getBidderRequestsCounter,
+  getBidderWinsCounter
 }
 
 export { adunitCounter };

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -100,7 +100,9 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels, src})
               bidderRequestId,
               auctionId,
               src,
-              bidRequestsCount: adunitCounter.getCounter(adUnit.code),
+              bidRequestsCount: adunitCounter.getRequestsCounter(adUnit.code),
+              bidderRequestsCount: adunitCounter.getBidderRequestsCounter(adUnit.code, bid.bidder),
+              bidderWinsCount: adunitCounter.getBidderWinsCounter(adUnit.code, bid.bidder),
             }));
           }
           return bids;
@@ -488,6 +490,7 @@ adapterManager.callTimedOutBidders = function(adUnits, timedOutBidders, cbTimeou
 adapterManager.callBidWonBidder = function(bidder, bid, adUnits) {
   // Adding user configured params to bidWon event data
   bid.params = utils.getUserConfiguredParams(adUnits, bid.adUnitCode, bid.bidder);
+  adunitCounter.incrementBidderWinsCounter(bid.adUnitCode, bid.bidder);
   tryCallBidderMethod(bidder, 'onBidWon', bid);
 };
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -456,9 +456,11 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
         // drop the bidder from the ad unit if it's not compatible
         utils.logWarn(utils.unsupportedBidderMessage(adUnit, bidder));
         adUnit.bids = adUnit.bids.filter(bid => bid.bidder !== bidder);
+      } else {
+        adunitCounter.incrementBidderRequestsCounter(adUnit.code, bidder);
       }
     });
-    adunitCounter.incrementCounter(adUnit.code);
+    adunitCounter.incrementRequestsCounter(adUnit.code);
   });
 
   if (!adUnits || adUnits.length === 0) {

--- a/test/spec/unit/adUnits_spec.js
+++ b/test/spec/unit/adUnits_spec.js
@@ -4,20 +4,46 @@ import { adunitCounter } from 'src/adUnits';
 describe('Adunit Counter', function () {
   const ADUNIT_ID_1 = 'test1';
   const ADUNIT_ID_2 = 'test2';
+  const BIDDER_ID_1 = 'bidder1';
+  const BIDDER_ID_2 = 'bidder2';
 
-  it('increments and checks counter of adunit 1', function () {
-    adunitCounter.incrementCounter(ADUNIT_ID_1);
-    expect(adunitCounter.getCounter(ADUNIT_ID_1)).to.be.equal(1);
+  it('increments and checks requests counter of adunit 1', function () {
+    adunitCounter.incrementRequestsCounter(ADUNIT_ID_1);
+    expect(adunitCounter.getRequestsCounter(ADUNIT_ID_1)).to.be.equal(1);
   });
-  it('checks counter of adunit 2', function () {
-    expect(adunitCounter.getCounter(ADUNIT_ID_2)).to.be.equal(0);
+  it('checks requests counter of adunit 2', function () {
+    expect(adunitCounter.getRequestsCounter(ADUNIT_ID_2)).to.be.equal(0);
   });
-  it('increments and checks counter of adunit 1', function () {
-    adunitCounter.incrementCounter(ADUNIT_ID_1);
-    expect(adunitCounter.getCounter(ADUNIT_ID_1)).to.be.equal(2);
+  it('increments and checks requests counter of adunit 1', function () {
+    adunitCounter.incrementRequestsCounter(ADUNIT_ID_1);
+    expect(adunitCounter.getRequestsCounter(ADUNIT_ID_1)).to.be.equal(2);
   });
-  it('increments and checks counter of adunit 2', function () {
-    adunitCounter.incrementCounter(ADUNIT_ID_2);
-    expect(adunitCounter.getCounter(ADUNIT_ID_2)).to.be.equal(1);
+  it('increments and checks requests counter of adunit 2', function () {
+    adunitCounter.incrementRequestsCounter(ADUNIT_ID_2);
+    expect(adunitCounter.getRequestsCounter(ADUNIT_ID_2)).to.be.equal(1);
+  });
+  it('increments and checks requests counter of adunit 1 for bidder 1', function () {
+    adunitCounter.incrementBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1);
+    expect(adunitCounter.getBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(1);
+  });
+  it('increments and checks requests counter of adunit 1 for bidder 2', function () {
+    adunitCounter.incrementBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_2);
+    expect(adunitCounter.getBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_2)).to.be.equal(1);
+  });
+  it('increments and checks requests counter of adunit 1 for bidder 1', function () {
+    adunitCounter.incrementBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1);
+    expect(adunitCounter.getBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(2);
+  });
+  it('increments and checks wins counter of adunit 1 for bidder 1', function () {
+    adunitCounter.incrementBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_1);
+    expect(adunitCounter.getBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(1);
+  });
+  it('increments and checks wins counter of adunit 2 for bidder 1', function () {
+    adunitCounter.incrementBidderWinsCounter(ADUNIT_ID_2, BIDDER_ID_1);
+    expect(adunitCounter.getBidderWinsCounter(ADUNIT_ID_2, BIDDER_ID_1)).to.be.equal(1);
+  });
+  it('increments and checks wins counter of adunit 1 for bidder 2', function () {
+    adunitCounter.incrementBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_2);
+    expect(adunitCounter.getBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_2)).to.be.equal(1);
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

Added bidder specific counters on the bidderRequest object:

`bidderRequestsCount` 
`bidderWinsCount`

Relatively, counts number requests and wins for the specific bidder in context.

https://github.com/prebid/Prebid.js/issues/4384
