### PR TITLE
deprecate support for adUnit.sizes for pubs

### DIFF
--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -36,7 +36,11 @@
     pbjs.que.push(function() {
         var adUnits = [{
             code: 'div-gpt-ad-1460505748561-0',
-            sizes: [[300, 250]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]]
+              } 
+            },
             bids: [
               {
                 bidder: 'appnexus',

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -418,12 +418,6 @@ const OPEN_RTB_PROTOCOL = {
       });
 
       let mediaTypes = {};
-      // default to banner if mediaTypes isn't defined
-      if (!(nativeParams || videoParams || bannerParams)) {
-        const sizeObjects = adUnit.sizes.map(size => ({ w: size[0], h: size[1] }));
-        mediaTypes['banner'] = {format: sizeObjects};
-      }
-
       if (bannerParams && bannerParams.sizes) {
         const sizes = utils.parseSizesInput(bannerParams.sizes);
 
@@ -780,8 +774,7 @@ export function PrebidServer() {
 
     // at this point ad units should have a size array either directly or mapped so filter for that
     const validAdUnits = adUnits.filter(unit =>
-      (unit.sizes && unit.sizes.length) ||
-      (unit.mediaTypes && unit.mediaTypes.native)
+      unit.mediaTypes && (unit.mediaTypes.native || (unit.mediaTypes.banner && unit.mediaTypes.banner.sizes) || (unit.mediaTypes.video && unit.mediaTypes.video.playerSize))
     );
 
     // in case config.bidders contains invalid bidders, we only process those we sent requests for

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -69,35 +69,46 @@ function setRenderSize(doc, width, height) {
 }
 
 export const checkAdUnitSetup = hook('sync', function (adUnits) {
-  adUnits.forEach((adUnit) => {
-    const mediaTypes = adUnit.mediaTypes;
-    const normalizedSize = utils.getAdUnitSizes(adUnit);
-
-    if (mediaTypes && mediaTypes.banner) {
-      const banner = mediaTypes.banner;
-      if (banner.sizes) {
-        // make sure we always send [[h,w]] format
-        banner.sizes = normalizedSize;
-        adUnit.sizes = normalizedSize;
-      } else {
-        utils.logError('Detected a mediaTypes.banner object did not include sizes.  This is a required field for the mediaTypes.banner object.  Removing invalid mediaTypes.banner object from request.');
-        delete adUnit.mediaTypes.banner;
+  function validateSizes(sizes, targLength) {
+    let cleanSizes = [];
+    if (utils.isArray(sizes) && ((targLength) ? sizes.length === targLength : sizes.length > 0)) {
+      // check if an array of arrays or array of numbers
+      if (sizes.every(sz => isArrayOfNums(sz, 2))) {
+        cleanSizes = sizes;
+      } else if (isArrayOfNums(sizes, 2)) {
+        cleanSizes.push(sizes);
       }
-    } else if (adUnit.sizes) {
-      utils.logWarn('Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).');
-      adUnit.sizes = normalizedSize;
+    }
+    return cleanSizes;
+  }
+
+  // adUnits.forEach((adUnit) => {
+  return adUnits.filter(adUnit => {
+    const mediaTypes = adUnit.mediaTypes;
+    if (!mediaTypes || Object.keys(mediaTypes).length === 0) {
+      utils.logError(`Detected adUnit.code '${adUnit.code}' did not have a 'mediaTypes' object defined.  This is a required field for the auction, so this adUnit has been removed.`);
+      return false;
     }
 
-    if (mediaTypes && mediaTypes.video) {
+    if (mediaTypes.banner) {
+      const bannerSizes = validateSizes(mediaTypes.banner.sizes);
+      if (bannerSizes.length > 0) {
+        mediaTypes.banner.sizes = bannerSizes;
+        // TODO eventually remove this internal copy once we're ready to deprecate bidders from reading this adUnit.sizes property
+        adUnit.sizes = bannerSizes;
+      } else {
+        utils.logError('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.');
+        delete adUnit.mediaTypes.banner;
+      }
+    }
+
+    if (mediaTypes.video) {
       const video = mediaTypes.video;
       if (video.playerSize) {
-        if (Array.isArray(video.playerSize) && video.playerSize.length === 1 && video.playerSize.every(plySize => isArrayOfNums(plySize, 2))) {
-          adUnit.sizes = video.playerSize;
-        } else if (isArrayOfNums(video.playerSize, 2)) {
-          let newPlayerSize = [];
-          newPlayerSize.push(video.playerSize);
-          utils.logInfo(`Transforming video.playerSize from [${video.playerSize}] to [[${newPlayerSize}]] so it's in the proper format.`);
-          adUnit.sizes = video.playerSize = newPlayerSize;
+        let tarPlayerSizeLen = (typeof video.playerSize[0] === 'number') ? 2 : 1;
+        const videoSizes = validateSizes(video.playerSize, tarPlayerSizeLen);
+        if (videoSizes.length > 0) {
+          adUnit.sizes = video.playerSize = videoSizes;
         } else {
           utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.');
           delete adUnit.mediaTypes.video.playerSize;
@@ -105,7 +116,7 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
       }
     }
 
-    if (mediaTypes && mediaTypes.native) {
+    if (mediaTypes.native) {
       const nativeObj = mediaTypes.native;
       if (nativeObj.image && nativeObj.image.sizes && !Array.isArray(nativeObj.image.sizes)) {
         utils.logError('Please use an array of sizes for native.image.sizes field.  Removing invalid mediaTypes.native.image.sizes property from request.');
@@ -120,8 +131,8 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
         delete adUnit.mediaTypes.native.icon.sizes;
       }
     }
+    return true;
   });
-  return adUnits;
 }, 'checkAdUnitSetup');
 
 /// ///////////////////////////////

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -82,7 +82,6 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
     return cleanSizes;
   }
 
-  // adUnits.forEach((adUnit) => {
   return adUnits.filter(adUnit => {
     const mediaTypes = adUnit.mediaTypes;
     if (!mediaTypes || Object.keys(mediaTypes).length === 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -169,6 +169,7 @@ export function getAdUnitSizes(adUnit) {
     } else {
       sizes.push(bannerSizes);
     }
+  // TODO - remove this else block when we're ready to deprecate adUnit.sizes for bidders
   } else if (Array.isArray(adUnit.sizes)) {
     if (Array.isArray(adUnit.sizes[0])) {
       sizes = adUnit.sizes;

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1274,7 +1274,6 @@ describe('S2S Adapter', function () {
       server.respondWith(JSON.stringify(cacheResponse));
 
       config.setConfig({ s2sConfig: CONFIG });
-      debugger; // eslint-disable-line
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       server.respond();
       sinon.assert.calledOnce(addBidResponse);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1190,6 +1190,11 @@ describe('Unit: Prebid Module', function () {
 
       adUnits = [{
         code: 'adUnit-code',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]]
+          }
+        },
         bids: [
           {bidder: BIDDER_CODE, params: {placementId: 'id'}},
         ]
@@ -1314,9 +1319,11 @@ describe('Unit: Prebid Module', function () {
           adUnits: [
             {
               code: 'test1',
+              mediaTypes: { banner: { sizes: [] } },
               bids: [],
             }, {
               code: 'test2',
+              mediaTypes: { banner: { sizes: [] } },
               bids: [],
             }
           ],
@@ -1396,9 +1403,11 @@ describe('Unit: Prebid Module', function () {
             {
               code: 'test1',
               transactionId: 'd0676a3c-ff32-45a5-af65-8175a8e7ddca',
+              mediaTypes: { banner: { sizes: [] } },
               bids: []
             }, {
               code: 'test2',
+              mediaTypes: { banner: { sizes: [] } },
               bids: []
             }
           ]
@@ -1419,9 +1428,11 @@ describe('Unit: Prebid Module', function () {
           adUnits: [
             {
               code: 'test1',
+              mediaTypes: { banner: { sizes: [] } },
               bids: []
             }, {
               code: 'test2',
+              mediaTypes: { banner: { sizes: [] } },
               bids: []
             }
           ]
@@ -1562,7 +1573,6 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
-            assert.ok(logInfoSpy.calledWith('Transforming video.playerSize from [640,480] to [[640,480]] so it\'s in the proper format.'), 'expected message was logged');
           });
 
           it('should normalize adUnit.sizes and adUnit.mediaTypes.banner.sizes', function () {
@@ -1601,7 +1611,7 @@ describe('Unit: Prebid Module', function () {
             });
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250], [300, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner).to.be.undefined;
-            assert.ok(logErrorSpy.calledWith('Detected a mediaTypes.banner object did not include sizes.  This is a required field for the mediaTypes.banner object.  Removing invalid mediaTypes.banner object from request.'));
+            assert.ok(logErrorSpy.calledWith('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.'));
 
             let badVideo1 = [{
               code: 'testb2',
@@ -1763,7 +1773,7 @@ describe('Unit: Prebid Module', function () {
       before(function () {
         adUnits = [{
           code: 'adUnit-code',
-          sizes: [[300, 250], [300, 600]],
+          mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } },
           bids: [
             {bidder: 'appnexus', params: {placementId: '10433394'}}
           ]
@@ -1771,13 +1781,13 @@ describe('Unit: Prebid Module', function () {
         let adUnitCodes = ['adUnit-code'];
         let auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: timeout});
 
-        adUnits[0]['mediaType'] = 'native';
+        adUnits[0]['mediaTypes'] = { native: {} };
         adUnitCodes = ['adUnit-code'];
         let auction1 = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: timeout});
 
         adUnits = [{
           code: 'adUnit-code',
-          nativeParams: {type: 'image'},
+          mediaTypes: { native: { type: 'image' } },
           sizes: [[300, 250], [300, 600]],
           bids: [
             {bidder: 'appnexus', params: {placementId: 'id'}}
@@ -1811,7 +1821,7 @@ describe('Unit: Prebid Module', function () {
       it('should call callBids function on adapterManager', function () {
         let adUnits = [{
           code: 'adUnit-code',
-          sizes: [[300, 250], [300, 600]],
+          mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } },
           bids: [
             {bidder: 'appnexus', params: {placementId: '10433394'}}
           ]
@@ -1823,8 +1833,7 @@ describe('Unit: Prebid Module', function () {
       it('splits native type to individual native assets', function () {
         let adUnits = [{
           code: 'adUnit-code',
-          nativeParams: {type: 'image'},
-          sizes: [[300, 250], [300, 600]],
+          mediaTypes: { native: { type: 'image' } },
           bids: [
             {bidder: 'appnexus', params: {placementId: 'id'}}
           ]


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR implements some changes to no longer let publishers use the `adUnit.sizes` property directly in their `adUnits`.  They'll have to use the corresponding `mediaTypes` object to properly define what type of request they're going to make and set the appropriate `size` field for that `mediaType`.

A note on the internal logic - Prebid will continue to make an internal copy of the corresponding `mediaType`'s sizes to the `adUnit.sizes` property only to allow any potential bidders access that information.  This 'bidder' support for the `adUnit.sizes` will eventually be deprecated during a future major release.

As part of this PR, I implemented some other changes to support this publisher deprecation to clean up the code.

## Other information
The adUnit.sizes has been marked as deprecated for quite a while now.  All our documentation examples should already be updated to using the `mediaTypes` approach, so there shouldn't be any other docs changes needed.