### PR TITLE
Rubicon add alias

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -155,7 +155,7 @@ export const spec = {
           id: bidRequest.adUnitCode,
           secure: 1,
           ext: {
-            rubicon: bidRequest.params
+            [bidRequest.bidder]: bidRequest.params
           },
           video: utils.deepAccess(bidRequest, 'mediaTypes.video') || {}
         }],
@@ -175,12 +175,20 @@ export const spec = {
           }
         }
       }
+
+      // Add alias if it is there
+      if (bidRequest.bidder !== 'rubicon') {
+        data.ext.prebid.aliases = {
+          [bidRequest.bidder]: 'rubicon'
+        }
+      }
+
       const bidFloor = parseFloat(utils.deepAccess(bidRequest, 'params.floor'));
       if (!isNaN(bidFloor)) {
         data.imp[0].bidfloor = bidFloor;
       }
       // if value is set, will overwrite with same value
-      data.imp[0].ext.rubicon.video.size_id = determineRubiconVideoSizeId(bidRequest)
+      data.imp[0].ext[bidRequest.bidder].video.size_id = determineRubiconVideoSizeId(bidRequest)
 
       appendSiteAppDevice(data, bidRequest, bidderRequest);
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1282,6 +1282,22 @@ describe('the rubicon adapter', function () {
           expect(post.ext.prebid.cache.vastxml.returnCreative).to.equal(false)
         });
 
+        it('should add alias name to PBS Request', function() {
+          createVideoBidderRequest();
+
+          bidderRequest.bidderCode = 'superRubicon';
+          bidderRequest.bids[0].bidder = 'superRubicon';
+          let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+
+          // should have the aliases object sent to PBS
+          expect(request.data.ext.prebid).to.haveOwnProperty('aliases');
+          expect(request.data.ext.prebid.aliases).to.deep.equal({superRubicon: 'rubicon'});
+
+          // should have the imp ext bidder params be under the alias name not rubicon superRubicon
+          expect(request.data.imp[0].ext).to.have.property('superRubicon').that.is.an('object');
+          expect(request.data.imp[0].ext).to.not.haveOwnProperty('rubicon');
+        });
+
         it('should send correct bidfloor to PBS', function() {
           createVideoBidderRequest();
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Fixes #4453 

Adding aliases to the PBS request

Changing the `rubicon` to use `bidRequest.bidder` instead.