### PR TITLE
Conversant Bid Adapter adds support for extended ids

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -137,6 +137,12 @@ export const spec = {
       userExt.fpc = pubcid;
     }
 
+    // Add Eids if available
+    const eids = collectEids(validBidRequests);
+    if (eids.length > 0) {
+      userExt.eids = eids;
+    }
+
     // Only add the user object if it's not empty
     if (!utils.isEmpty(userExt)) {
       payload.user = {ext: userExt};
@@ -284,6 +290,45 @@ function isVideoRequest(bid) {
 function copyOptProperty(src, dst, dstName) {
   if (src) {
     dst[dstName] = src;
+  }
+}
+
+/**
+ * Collect IDs from validBidRequests and store them as an extended id array
+ * @param bidRequests valid bid requests
+ */
+function collectEids(bidRequests) {
+  const request = bidRequests[0]; // bidRequests have the same userId object
+  const eids = [];
+
+  addEid(eids, request, 'userId.tdid', 'adserver.org');
+  addEid(eids, request, 'userId.idl_env', 'liveramp.com');
+  addEid(eids, request, 'userId.criteoId', 'criteo.com');
+  addEid(eids, request, 'userId.id5id', 'id5-sync.com');
+  addEid(eids, request, 'userId.parrableid', 'parrable.com');
+  addEid(eids, request, 'userId.digitrustid.data.id', 'digitru.st');
+  addEid(eids, request, 'userId.lipb.lipbid', 'liveintent.com');
+
+  return eids;
+}
+
+/**
+ * Extract and push a single extended id into eids array
+ * @param eids Array of extended IDs
+ * @param idObj Object containing IDs
+ * @param keyPath Nested properties expressed as a path
+ * @param source Source for the ID
+ */
+function addEid(eids, idObj, keyPath, source) {
+  const id = utils.deepAccess(idObj, keyPath);
+  if (id) {
+    eids.push({
+      source: source,
+      uids: [{
+        id: id,
+        atype: 1
+      }]
+    });
   }
 }
 

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -374,6 +374,7 @@ describe('Conversant adapter tests', function() {
     //  construct http post payload
     const payload = spec.buildRequests(requests).data;
     expect(payload).to.have.deep.nested.property('user.ext.fpc', 12345);
+    expect(payload).to.not.have.nested.property('user.ext.eids');
   });
 
   it('Verify User ID publisher commond id support', function() {
@@ -387,6 +388,7 @@ describe('Conversant adapter tests', function() {
     //  construct http post payload
     const payload = spec.buildRequests(requests).data;
     expect(payload).to.have.deep.nested.property('user.ext.fpc', 67890);
+    expect(payload).to.not.have.nested.property('user.ext.eids');
   });
 
   it('Verify GDPR bid request', function() {
@@ -414,5 +416,23 @@ describe('Conversant adapter tests', function() {
     const payload = spec.buildRequests(bidRequests, bidRequest).data;
     expect(payload).to.have.deep.nested.property('user.ext.consent', '');
     expect(payload).to.not.have.deep.nested.property('regs.ext.gdpr');
+  });
+
+  describe('Extended ID', function() {
+    it('Verify unifiedid and liveramp', function() {
+      // clone bidRequests
+      let requests = utils.deepClone(bidRequests);
+
+      // add pubcid to every entry
+      requests.forEach((unit) => {
+        Object.assign(unit, {userId: {pubcid: 112233, tdid: 223344, idl_env: 334455}});
+      });
+      //  construct http post payload
+      const payload = spec.buildRequests(requests).data;
+      expect(payload).to.have.deep.nested.property('user.ext.eids', [
+        {source: 'adserver.org', uids: [{id: 223344, atype: 1}]},
+        {source: 'liveramp.com', uids: [{id: 334455, atype: 1}]}
+      ]);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add support to Conversant adapter for extended IDs including unified id etc.

- contact email of the adapter’s maintainer  pyang@conversantmedia.com

- [ ] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
