### PR TITLE
initial update for bidder schain support - feedback wanted

### DIFF
--- a/integrationExamples/gpt/hello_world_schain.html
+++ b/integrationExamples/gpt/hello_world_schain.html
@@ -1,0 +1,169 @@
+<!--
+  This page calls a single bidder for a single ad slot. It can be considered a "hello world" example for using
+  Prebid with the Google Publisher Tag.
+  It also makes a good test page for new adapter PR submissions. Simply set your server's Bid Params object in the
+  bids array inside the adUnits, and it will use your adapter to load an ad.
+  NOTE that many ad servers won't send back an ad if the URL is localhost... so you might need to
+  set an alias in your /etc/hosts file so that you can load this page from a different domain.
+-->
+
+<html>
+
+<head>
+  <script async src="../../build/dev/prebid.js"></script>
+  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script>
+    var FAILSAFE_TIMEOUT = 3300;
+    var PREBID_TIMEOUT = 1000;
+
+    var adUnits = [{
+      code: 'div-gpt-ad-1460505748561-0',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]],
+        }
+      },
+      // Replace this object to test a new Adapter!
+      bids: [{
+        bidder: 'appnexus',
+        params: {
+          placementId: 13144370
+        }
+      }, {
+        bidder: 'districtm',
+        params: {
+          placementId: 13144370
+        }
+      }, {
+        bidder: "rubicon",
+        params: {
+          accountId: 14062,
+          siteId: 70608,
+          zoneId: 498816
+        }
+      }]
+
+    }];
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+  </script>
+
+  <script>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () {
+      googletag.pubads().disableInitialLoad();
+    });
+
+    pbjs.que.push(function () {
+      pbjs.addAdUnits(adUnits);
+      pbjs.setConfig({
+        "schain": {
+          "validation": "off",
+          "config": {
+            "ver": "1.0",
+            "complete": 1,
+            "nodes": [
+              {
+                "asi": "indirectseller.com",
+                "sid": "00001",
+                "hp": 1
+              },
+
+              {
+                "asi": "indirectseller-2.com",
+                "sid": "00002",
+                "hp": 1
+              }
+            ]
+          }
+        }
+      });
+
+      pbjs.setBidderConfig({
+        bidders: ['appnexus'],
+        config: {
+          "schain": {
+            "validation": "strict",
+            "config": {
+              "ver": "1.0",
+              "complete": 1,
+              "nodes": [
+                {
+                  "asi": "myoverride.com",
+                  // "sid": "00001",
+                  "sid": 1,
+                  "hp": 1
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      pbjs.setBidderConfig({
+        bidders: ['districtm'],
+        config: {
+          "schain": {
+            "validation": "relaxed",
+            "config": {
+              "ver": "1.0",
+              "complete": 1,
+              "nodes": [
+                {
+                  "asi": "myoverride.com",
+                  // "sid": "00001",
+                  "sid": 1,
+                  "hp": 1
+                }
+              ]
+            }
+          }
+        }
+      });
+      pbjs.requestBids({
+        bidsBackHandler: sendAdserverRequest,
+        timeout: PREBID_TIMEOUT
+      });
+    });
+
+    function sendAdserverRequest() {
+      if (pbjs.adserverRequestSent) return;
+      pbjs.adserverRequestSent = true;
+      googletag.cmd.push(function () {
+        pbjs.que.push(function () {
+          pbjs.setTargetingForGPTAsync();
+          googletag.pubads().refresh();
+        });
+      });
+    }
+
+    // setTimeout(function () {
+    //   sendAdserverRequest();
+    // }, FAILSAFE_TIMEOUT);
+
+  </script>
+
+  <script>
+    googletag.cmd.push(function () {
+      googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+
+      googletag.pubads().enableSingleRequest();
+      googletag.enableServices();
+    });
+  </script>
+</head>
+
+<body>
+  <h2>Prebid.js Test</h2>
+  <h5>Div-1</h5>
+  <div id='div-gpt-ad-1460505748561-0'>
+    <script type='text/javascript'>
+      googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
+    </script>
+  </div>
+</body>
+
+</html>

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -6,6 +6,7 @@ import { processNativeAdUnitParams, nativeAdapters } from './native';
 import { newBidder } from './adapters/bidderFactory';
 import { ajaxBuilder } from './ajax';
 import { config, RANDOM } from './config';
+import { hook } from './hook';
 import includes from 'core-js/library/fn/array/includes';
 import find from 'core-js/library/fn/array/find';
 import { adunitCounter } from './adUnits';
@@ -160,7 +161,8 @@ export let gdprDataHandler = {
   }
 };
 
-adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, labels) {
+adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, auctionId, cbTimeout, labels) {
+// adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTimeout, labels) {
   let bidRequests = [];
 
   let bidderCodes = getBidderCodes(adUnits);
@@ -264,7 +266,8 @@ adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTi
     });
   }
   return bidRequests;
-};
+// };
+}, 'makeBidRequests');
 
 adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, requestCallbacks, requestBidsTimeout, onTimelyResponse) => {
   if (!bidRequests.length) {

--- a/test/spec/modules/schain_spec.js
+++ b/test/spec/modules/schain_spec.js
@@ -1,4 +1,4 @@
-import {isValidSchainConfig, isSchainObjectValid, copySchainObjectInAdunits} from '../../../modules/schain';
+import {isValidSchainConfig, isSchainObjectValid} from '../../../modules/schain';
 import { expect } from 'chai';
 
 describe('#isValidSchainConfig: module config validation', function() {
@@ -243,44 +243,4 @@ describe('#isSchainObjectValid: schain object validation', function() {
     schainConfig = {};
     expect(isSchainObjectValid(schainConfig, false)).to.true;
   })
-});
-
-describe('Passing schain object to adUnits', function() {
-  let schainConfig;
-
-  beforeEach(function() {
-    schainConfig = {
-      'ver': '1.0',
-      'complete': 1,
-      'nodes': [
-        {
-          'asi': 'indirectseller.com',
-          'sid': '00001',
-          'hp': 1
-        },
-
-        {
-          'asi': 'indirectseller-2.com',
-          'sid': '00002',
-          'hp': 2
-        }
-      ]
-    };
-  });
-
-  it('schain object should be applied to all adUnits', function() {
-    let adUnits = [
-      {
-        bids: [{}, {}]
-      },
-      {
-        bids: [{}, {}]
-      }
-    ];
-    copySchainObjectInAdunits(adUnits, schainConfig);
-    expect(adUnits[0].bids[0].schain).to.equal(schainConfig);
-    expect(adUnits[0].bids[1].schain).to.equal(schainConfig);
-    expect(adUnits[1].bids[0].schain).to.equal(schainConfig);
-    expect(adUnits[1].bids[1].schain).to.equal(schainConfig);
-  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

**This is a Work In Progress for bidder specific schain changes.**

I would like to get feedback on this initial approach, which is a bit different that what was proposed in #4465.  

Summary of module (in this draft state):
- after the `adapterManager.makeBidRequests` function has executed, the module will be called to process the `schain` config(s).
- while going through each bidRequest object (one for each bidder), the module will 'look-up' the schain config for that bidder.  It will attempt to find a bidder specific one if it exists, otherwise it'll assign the global config.
- During each schain look-up, the module will evaluate the schain based on it's `validation` setting and either set `schain.config` object on the `bidRequest.bids.schain` field.  This field will not be set If either: the `validation` is `strict` and the schain config is setup incorrectly or the overall `schain` object was not an object.
- After populating each of the `bidRequests`, the auction will resume as normal.  Bidders will read this `bidRequest` `schain` field (as they did before) and set it in their request.

What's different against the proposal:
- using a different hook point.
- the module is still passing the bidder's `schain` in an auction object for them to read later.
- bidders are still looking at a `bidRequest`'s `schain` field instead of calling `config.getConfig('schain');` (so that prebid will dynamically pull the bidder's `schain`).

The main reasons for this shift was: a set of limitations I encountered when attempting to invalidate an `schain` object within the Prebid `config` objects and how making bidders use the `config.getConfig` with some type of a workaround for the limitations would feel.  See details below...



#### Troubles on overwriting the Prebid Configs
I tried to overwrite the schain config by re-executing the `setBidderConfig` (and `setConfig`) in the following manners:
```
setBidderConfig({
  bidder: ['appnexus'],
  config: {
    // schain: null,
    // schain: {},
    schain: 'invalid'
  }
});
```

In the null case - it passed through the `setBidderConfig` function and made it `null`.  But when I called the `config.getConfig` in the bidder - it always pulled the global `schain` config instead of just `null`.  This was due to this logic check [here](https://github.com/prebid/Prebid.js/blob/master/src/config.js#L224); it thought there was no bidderConfig defined for this topic, so it fell back to the global.

In the {} case - the overwrite didn't work in the `setBidderConfig` due to the Object.assign [here](https://github.com/prebid/Prebid.js/blob/master/src/config.js#L380); since the existing bidder config was listed before the new config (and there were no new values to overwrite), the bidder config stayed put.

In the 'invalid` string case - this actually worked in both the `setBidderConfig` and in the `config.getConfig` in the bidder.  But this didn't seem to be ideal way to manage the implementation for the bidders.

#### Using config listeners to evaluate the config as its submitted

I also attempted to look into using the `subscribe()` and `listeners` functionality from the `config.js` file to do the config evaluation right after it was registered by the `pbjs.setConfig()`; this is done by registering a callback function using `config.getConfig('module', function()...); in the module file.  

While this approach loaded the global `schain` config for us to read, this `subscribe`/`listener` functionality is not currently setup for the `setBidderConfig`.  Given the limited functionality, this approach didn't seem like it would pan-out.

#### Inserting schain in auction object again for bidders
Given the results above and that we couldn't cleanly overwrite the prebid configs, I thought to continue using the approach to pass in a value in the bidRequests for the bidder to read.  

I toyed with some flags that would set for each bidder so they'd know to call the `config.getConfig`, but this didn't really make sense and looked like an extra step the bidder had to go through.  The module was already capable of finding the correct `schain` config for that bidder (whether it was the global or an override), so it could easily pass the correct config to that bidder in a controlled, secure manner.  

This final approach is what I implemented (currently) in this draft PR as it seemed to be a more ideal setup.  

If you got this far - thanks for reading through the above. :)  If you have any suggestions or other ideas to try out so that we're more in-line with the original proposal, please feel free to share.

Thanks.