### PR TITLE
explicitly check undefined to allow falsey values in getConfig

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -221,9 +221,9 @@ export function newConfig() {
       const configTopicSet = new Set(Object.keys(config).concat(Object.keys(currBidderConfig)));
 
       return from(configTopicSet).reduce((memo, topic) => {
-        if (!currBidderConfig[topic]) {
+        if (typeof currBidderConfig[topic] === 'undefined') {
           memo[topic] = config[topic];
-        } else if (!config[topic]) {
+        } else if (typeof config[topic] === 'undefined') {
           memo[topic] = currBidderConfig[topic];
         } else {
           if (utils.isPlainObject(currBidderConfig[topic])) {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -193,7 +193,7 @@ describe('adapterManager tests', function () {
         bidders: [ 'rubicon' ],
         config: {
           buildRequests: 'rubiconBuild',
-          interpretResponse: 'rubiconInterpret'
+          interpretResponse: null
         }
       });
       config.setBidderConfig({
@@ -230,7 +230,7 @@ describe('adapterManager tests', function () {
             'rubiconBuild',
             { speedy: true },
             { amazing: true },
-            'rubiconInterpret',
+            null,
             'anotherBaseInterpret'
           ]
         });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When checking for bidder-specific config the code was treating "falsey" values the same as `undefined`, this means you couldn't override config with falsey values such as `false` or `null`. Explicitly checking for `undefined` fixes the bug.

## Other information
Should fix issues referenced in #4479 