### PR TITLE
Allow bundling without core.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -180,7 +180,8 @@ function bundle(dev, moduleArr) {
     }
   }
 
-  var entries = [helpers.getBuiltPrebidCoreFile(dev)].concat(helpers.getBuiltModules(dev, modules));
+  var core = !argv.core ? [ ] : [helpers.getBuiltPrebidCoreFile(dev)];
+  var entries = core.concat(helpers.getBuiltModules(dev, modules));
 
   var outputFileName = argv.bundleName ? argv.bundleName : 'prebid.js';
 
@@ -198,6 +199,12 @@ function bundle(dev, moduleArr) {
   )
     .pipe(gulpif(dev, sourcemaps.init({loadMaps: true})))
     .pipe(concat(outputFileName))
+    .pipe(gulpif(!argv.core, header(
+      'window.<%= global %>=window.<%= global %>||{};' +
+      'window.<%= global %>.que=window.<%= global %>.que||[];' +
+      'window.<%= global %>.que.push(function(){', { global: prebid.globalVarName }
+    )))
+    .pipe(gulpif(!argv.core, footer('});')))
     .pipe(gulpif(!argv.manualEnable, footer('\n<%= global %>.processQueue();', {
       global: prebid.globalVarName
     }


### PR DESCRIPTION
## Type of change
- [X] Build related changes

## Description of change
This PR adds a `--[no-]core` build flag to build Prebid.js without core:
* `gulp build --no-core` bundles all modules (but not the core) in _prebid.js_.
* `gulp build --no-core --modules=audienceNetworkBidAdapter,consentManagement --bundle-name prebid-modules` bundles _audienceNetworkBidAdapter.js_ and _consentManagement.js_ in _prebid-modules.js_.

The use case here is for third-party libraries loaded onto a page where Prebid is already available. In this scenario, only modules need to be loaded. Rather than making one request per module, this PR would enable making a single request to load all applicable modules. Workflow:
1. Third-party library is loaded.
2. Is Prebid.js already available on the page?
-- YES: Single request to _prebid-modules.js_ (build with modules but without core)
-- NO (1): Single request to _prebid.js_ (build with modules and core), or:
-- NO (2): Two requests to _prebid.js_ and _prebid-modules.js_ (potentially in parallel).
3. Prebid core and modules are now available for use.