### PR TITLE
Conversant Bid Adapter handles vast xml

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -196,7 +196,12 @@ export const spec = {
             };
 
             if (request.video) {
-              bid.vastUrl = responseAd;
+              if (responseAd.charAt(0) === '<') {
+                bid.vastXml = responseAd;
+              } else {
+                bid.vastUrl = responseAd;
+              }
+
               bid.mediaType = 'video';
               bid.width = request.video.w;
               bid.height = request.video.h;

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -156,6 +156,14 @@ describe('Conversant adapter tests', function() {
           price: 3.99,
           adomain: ['https://example.com'],
           id: 'bid003'
+        }, {
+          nurl: 'notify004',
+          adm: '<?xml><VAST></VAST>',
+          crid: '1004',
+          impid: 'bid004',
+          price: 4.99,
+          adomain: ['https://example.com'],
+          id: 'bid004'
         }]
       }]
     },
@@ -315,7 +323,7 @@ describe('Conversant adapter tests', function() {
   it('Verify interpretResponse', function() {
     const request = spec.buildRequests(bidRequests);
     const response = spec.interpretResponse(bidResponses, request);
-    expect(response).to.be.an('array').with.lengthOf(3);
+    expect(response).to.be.an('array').with.lengthOf(4);
 
     let bid = response[0];
     expect(bid).to.have.property('requestId', 'bid000');
@@ -352,6 +360,9 @@ describe('Conversant adapter tests', function() {
     expect(bid).to.have.property('mediaType', 'video');
     expect(bid).to.have.property('ttl', 300);
     expect(bid).to.have.property('netRevenue', true);
+
+    bid = response[3];
+    expect(bid).to.have.property('vastXml', '<?xml><VAST></VAST>');
   });
 
   it('Verify handling of bad responses', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Conversant adapter to accept VAST XML for video responses

- contact email of the adapter’s maintainer: pyang@conversantmedia.com
- [ ] official adapter submission
