### PR TITLE
adformBidAdapter. Outstream renderer condition

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -117,7 +117,7 @@ export const spec = {
           mediaType: type
         };
 
-        if (!bid.renderer && utils.deepAccess(bid, 'mediaTypes.video.context') === 'outstream') {
+        if (!bid.renderer && type === VIDEO && utils.deepAccess(bid, 'mediaTypes.video.context') === 'outstream') {
           bidObject.renderer = Renderer.install({id: bid.bidId, url: OUTSTREAM_RENDERER_URL});
           bidObject.renderer.setRender(renderer);
         }

--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -98,7 +98,7 @@ export const spec = {
       response = responses[i];
       type = response.response === 'banner' ? BANNER : VIDEO;
       bid = bids[i];
-      if (VALID_RESPONSES[response.response] && (verifySize(response, bid.sizes) || type === VIDEO)) {
+      if (VALID_RESPONSES[response.response] && (verifySize(response, utils.getAdUnitSizes(bid)) || type === VIDEO)) {
         bidObject = {
           requestId: bid.bidId,
           cpm: response.win_bid,

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -258,11 +258,12 @@ describe('Adform adapter', function () {
       };
     });
 
-    it('should set a renderer for an outstream context', function () {
-      serverResponse.body = [serverResponse.body[3]];
-      bidRequest.bids = [bidRequest.bids[6]];
+    it('should set a renderer only for an outstream context', function () {
+      serverResponse.body = [serverResponse.body[3], serverResponse.body[2]];
+      bidRequest.bids = [bidRequest.bids[6], bidRequest.bids[6]];
       let result = spec.interpretResponse(serverResponse, bidRequest);
       assert.ok(result[0].renderer);
+      assert.equal(result[1].renderer, undefined);
     });
 
     describe('verifySizes', function () {
@@ -314,9 +315,9 @@ describe('Adform adapter', function () {
   beforeEach(function () {
     config.setConfig({ currency: {} });
 
-    let sizes = [[250, 300], [300, 250], [300, 600]];
+    let sizes = [[250, 300], [300, 250], [300, 600], [600, 300]];
     let placementCode = ['div-01', 'div-02', 'div-03', 'div-04', 'div-05'];
-    let mediaTypes = [{video: {context: 'outstream'}}];
+    let mediaTypes = [{video: {context: 'outstream'}, banner: {sizes: sizes[3]}}];
     let params = [{ mid: 1, url: 'some// there' }, {adxDomain: null, mid: 2, someVar: 'someValue', pt: 'gross'}, { adxDomain: null, mid: 3, pdom: 'home' }, {mid: 5, pt: 'net'}, {mid: 6, pt: 'gross'}];
     bids = [
       {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
1. Ensuring renderer is not applied to banners https://github.com/prebid/Prebid.js/pull/4363#discussion_r352583927

2. Using utils.getAdUnitSizes