### PR TITLE
Viewdeos add outstream params extension

### DIFF
--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -231,12 +231,15 @@ function newRenderer(requestId) {
  */
 function outstreamRender(bid) {
   bid.renderer.push(() => {
-    window.VOutstreamAPI.initOutstreams([{
+    const params = utils.isArray(bid.params) ? bid.params[0] : bid.params;
+    const outstreamConfig = params.outstream ? params.outstream : {};
+    const opts = Object.assign({}, outstreamConfig, {
       width: bid.width,
       height: bid.height,
       vastUrl: bid.vastUrl,
       elId: bid.adUnitCode
-    }]);
+    });
+    window.VOutstreamAPI.initOutstreams([opts]);
   });
 }
 

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -5,7 +5,7 @@ import {Renderer} from '../src/Renderer';
 import findIndex from 'core-js/library/fn/array/find-index';
 
 const URL = '//hb.sync.viewdeos.com/auction/';
-const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.01/outstream.min.js';
+const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.11/outstream-unit.min.js';
 const BIDDER_CODE = 'viewdeosDX';
 const OUTSTREAM = 'outstream';
 const DISPLAY = 'display';


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Allow configuring outstream player from params of bidder

```
{
...
  params: {
    aid:331133,
    outstream: {
      //param: value
    }
  }
}
```


**P.S: not sure, is it expected that bid  in renderer handler is an array ?** 
