### PR TITLE
feature: make adjustment for an bid (not only cpm)

### DIFF
--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -614,6 +614,43 @@ describe('auctionmanager.js', function () {
       // reset bidderSettings so we don't mess up further tests
       $$PREBID_GLOBAL$$.bidderSettings = {};
     });
+
+    it('should adjust bids and set custom renderer', function () {
+      const bid = Object.assign({},
+        createBid(2),
+        fixtures.getBidResponses()[1]
+      );
+
+      assert.equal(bid.bidderCode, 'appnexus');
+      assert.equal(bid.cpm, 10);
+
+      $$PREBID_GLOBAL$$.bidderSettings =
+      {
+        appnexus: {
+          bidAdjustment: function (bidObj) {
+            if (bidObj.dealId === 'specialDeal') {
+              bidObj.renderer = 'specialDealRenderer';
+            }
+            return bidObj;
+          },
+        }
+      };
+
+      // match
+      const bidTest1 = Object.assign({}, bid, {
+        dealId: 'specialDeal',
+      });
+      adjustBids(bidTest1);
+      assert.equal(bidTest1.renderer, 'specialDealRenderer');
+
+      // no-match
+      const bidTest2 = Object.assign({}, bid);
+      adjustBids(bidTest2);
+      assert.equal(bidTest2.renderer, undefined);
+
+      // reset bidderSettings so we don't mess up further tests
+      $$PREBID_GLOBAL$$.bidderSettings = {};
+    });
   });
 
   describe('addBidResponse', function () {


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Allow to adjust the bid, but allow more than just the cpm adjustment.

Fixes #4312

This Draft PR is intended as a first discussion point about adjusting the bid, more than just the cpm.
