### PR TITLE
feat(displaymanager): added displaymanager and version with user object

### DIFF
--- a/modules/deepintentBidAdapter.js
+++ b/modules/deepintentBidAdapter.js
@@ -37,13 +37,7 @@ export const spec = {
       imp: validBidRequests.map(bid => buildImpression(bid)),
       site: buildSite(bidderRequest),
       device: buildDevice(),
-      user: user && user.length == 1 ? user[0] : {},
-      source: {
-        fd: 0,
-        ext: {
-          type: 2
-        }
-      }
+      user: user && user.length == 1 ? user[0] : {}
     };
 
     return {
@@ -99,10 +93,19 @@ function buildImpression(bid) {
     banner: buildBanner(bid),
     displaymanager: 'di_prebid',
     displaymanagerver: DI_M_V,
-    ext: bid.params.custom ? bid.params.custom : {}
+    ext: buildCustomParams(bid)
   };
 }
+function buildCustomParams(bid) {
+  if (bid.params && bid.params.custom) {
+    return {
+      deepintent: bid.params.custom
 
+    }
+  } else {
+    return {}
+  }
+}
 function buildUser(bid) {
   if (bid && bid.params && bid.params.user) {
     return {

--- a/test/spec/modules/deepintentBidAdapter_spec.js
+++ b/test/spec/modules/deepintentBidAdapter_spec.js
@@ -19,14 +19,14 @@ describe('Deepintent adapter', function () {
           tagId: '100013',
           w: 728,
           h: 90,
-          user:{
-            id: "di_testuid",
-            buyeruid: "di_testbuyeruid",
+          user: {
+            id: 'di_testuid',
+            buyeruid: 'di_testbuyeruid',
             yob: 2002,
-            gender: "F"
+            gender: 'F'
           },
           custom: {
-            "position": "right-box"
+            'position': 'right-box'
           }
         }
       }
@@ -127,21 +127,15 @@ describe('Deepintent adapter', function () {
       let bRequest = spec.buildRequests(request);
       let data = JSON.parse(bRequest.data);
       expect(data.imp[0].ext).to.be.a('object');
-      expect(data.imp[0].ext.position).to.equal('right-box');
+      expect(data.imp[0].ext.deepintent.position).to.equal('right-box');
     });
-    it('bid request check: source params', function () {
-      let bRequest = spec.buildRequests(request);
-      let data = JSON.parse(bRequest.data);
-      expect(data.source.fd).to.equal(0);
-      expect(data.source.ext.type).to.equal(2);
-    });
-    it('bid request check: displaymanager check',function(){
+    it('bid request check: displaymanager check', function() {
       let bRequest = spec.buildRequests(request);
       let data = JSON.parse(bRequest.data);
       expect(data.imp[0].displaymanager).to.equal('di_prebid');
       expect(data.imp[0].displaymanagerver).to.equal('1.0.0');
     });
-    it('bid request check: user object check',function () {
+    it('bid request check: user object check', function () {
       let bRequest = spec.buildRequests(request);
       let data = JSON.parse(bRequest.data);
       expect(data.user).to.be.a('object');

--- a/test/spec/modules/deepintentBidAdapter_spec.js
+++ b/test/spec/modules/deepintentBidAdapter_spec.js
@@ -19,9 +19,14 @@ describe('Deepintent adapter', function () {
           tagId: '100013',
           w: 728,
           h: 90,
+          user:{
+            id: "di_testuid",
+            buyeruid: "di_testbuyeruid",
+            yob: 2002,
+            gender: "F"
+          },
           custom: {
-            user_gender: 'female',
-            user_max_age: 25
+            "position": "right-box"
           }
         }
       }
@@ -122,14 +127,28 @@ describe('Deepintent adapter', function () {
       let bRequest = spec.buildRequests(request);
       let data = JSON.parse(bRequest.data);
       expect(data.imp[0].ext).to.be.a('object');
-      expect(data.imp[0].ext.user_gender).to.equal('female');
-      expect(data.imp[0].ext.user_max_age).to.equal(25);
+      expect(data.imp[0].ext.position).to.equal('right-box');
     });
     it('bid request check: source params', function () {
       let bRequest = spec.buildRequests(request);
       let data = JSON.parse(bRequest.data);
       expect(data.source.fd).to.equal(0);
       expect(data.source.ext.type).to.equal(2);
+    });
+    it('bid request check: displaymanager check',function(){
+      let bRequest = spec.buildRequests(request);
+      let data = JSON.parse(bRequest.data);
+      expect(data.imp[0].displaymanager).to.equal('di_prebid');
+      expect(data.imp[0].displaymanagerver).to.equal('1.0.0');
+    });
+    it('bid request check: user object check',function () {
+      let bRequest = spec.buildRequests(request);
+      let data = JSON.parse(bRequest.data);
+      expect(data.user).to.be.a('object');
+      expect(data.user.id).to.equal('di_testuid');
+      expect(data.user.buyeruid).to.equal('di_testbuyeruid');
+      expect(data.user.yob).to.equal(2002);
+      expect(data.user.gender).to.equal('F');
     })
   });
   describe('user sync check', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
1) Added displaymanager field for internal user
2) User object addition for user overrides.
3) Wrapping of custom parameters in ext object for avoiding conflicts across exchanges.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    tagid: "1399"
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
sourabh@deepintent.com
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1649
## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
