### PR TITLE
added new param to sonobi adapter: keywords

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -136,6 +136,12 @@ export const spec = {
       payload.userid = JSON.stringify(validBidRequests[0].userId);
     }
 
+    let keywords = validBidRequests[0].params.keywords; // a CSV of keywords
+
+    if (keywords) {
+      payload.kw = keywords;
+    }
+
     // If there is no key_maker data, then don't make the request.
     if (isEmpty(data)) {
       return null;

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -262,6 +262,7 @@ describe('SonobiBidAdapter', function () {
       },
       'bidder': 'sonobi',
       'params': {
+        'keywords': 'sports,news,some_other_keyword',
         'placement_id': '1a2b3c4d5e6f1a2b3c4d',
         'sizes': [[300, 250], [300, 600]],
         'floor': '1.25',
@@ -341,7 +342,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.digkeyv).to.be.undefined;
       sandbox.restore();
       delete window.DigiTrust;
-    })
+    });
 
     it('should return a properly formatted request', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
@@ -538,6 +539,11 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.ref).not.to.be.empty;
       expect(bidRequests.data.s).not.to.be.empty;
       expect(bidRequests.data.userid).to.equal(undefined);
+    });
+
+    it('should return a properly formatted request with keywrods included as a csv of strings', function() {
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.data.kw).to.equal('sports,news,some_other_keyword');
     });
   })
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Added a new param to the sonobi bidder called "keywords"

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
                            bidder: 'sonobi',
                            params: {
                                keywords:'hello,world',
                                ad_unit: '/7780971/example_ATF_MR'
                            }
                        }
```


- prebid.apex@sonobi.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- https://github.com/prebid/prebid.github.io/pull/1653
