### PR TITLE
Use 'pubcid.org' as the source for pubcid in extended IDs

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -646,7 +646,7 @@ const OPEN_RTB_PROTOCOL = {
     });
 
     if (!imps.length) {
-      utils.logError('Request to Prebid Server rejected due to invalid media type(s) in adUnit.')
+      utils.logError('Request to Prebid Server rejected due to invalid media type(s) in adUnit.');
       return;
     }
     const request = {
@@ -721,7 +721,7 @@ const OPEN_RTB_PROTOCOL = {
 
       if (bidUserId.pubcid) {
         request.user.ext.eids.push({
-          source: 'pubcommon',
+          source: 'pubcid.org',
           uids: [{
             id: bidUserId.pubcid,
           }]
@@ -955,7 +955,7 @@ const isOpenRtb = () => {
 
   const endpoint = (_s2sConfig && _s2sConfig.endpoint) || '';
   return ~endpoint.indexOf(OPEN_RTB_PATH);
-}
+};
 
 /*
  * Returns the required protocol adapter to communicate with the configured

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -580,7 +580,7 @@ describe('S2S Adapter', function () {
 
     it('should not add outstrean without renderer', function () {
       let ortb2Config = utils.deepClone(CONFIG);
-      ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
       config.setConfig({ s2sConfig: ortb2Config });
       adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
@@ -611,7 +611,7 @@ describe('S2S Adapter', function () {
 
       it('adds gdpr consent information to ortb2 request depending on presence of module', function () {
         let ortb2Config = utils.deepClone(CONFIG);
-        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
         let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: ortb2Config };
         config.setConfig(consentConfig);
@@ -710,7 +710,7 @@ describe('S2S Adapter', function () {
 
       it('is added to ortb2 request when in bidRequest', function () {
         let ortb2Config = utils.deepClone(CONFIG);
-        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
         config.setConfig({ s2sConfig: ortb2Config });
 
         let uspBidRequest = utils.deepClone(BID_REQUESTS);
@@ -755,7 +755,7 @@ describe('S2S Adapter', function () {
 
       it('is added to ortb2 request when in bidRequest', function () {
         let ortb2Config = utils.deepClone(CONFIG);
-        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+        ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
         config.setConfig({ s2sConfig: ortb2Config });
 
         let consentBidRequest = utils.deepClone(BID_REQUESTS);
@@ -984,7 +984,7 @@ describe('S2S Adapter', function () {
 
       const _config = {
         s2sConfig: s2sConfig,
-      }
+      };
 
       config.setConfig(_config);
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
@@ -1200,8 +1200,8 @@ describe('S2S Adapter', function () {
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'adserver.org')[0].uids[0].id).is.equal('abc123');
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'criteo.com')).is.not.empty;
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'criteo.com')[0].uids[0].id).is.equal('44VmRDeUE3ZGJ5MzRkRVJHU3BIUlJ6TlFPQUFU');
-      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'pubcommon')).is.not.empty;
-      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'pubcommon')[0].uids[0].id).is.equal('1234');
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'pubcid.org')).is.not.empty;
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'pubcid.org')[0].uids[0].id).is.equal('1234');
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'parrable.com')).is.not.empty;
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'parrable.com')[0].uids[0].id).is.equal('01.1563917337.test-eid');
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveintent.com')).is.not.empty;
@@ -1768,7 +1768,7 @@ describe('S2S Adapter', function () {
 
       const _config = {
         s2sConfig: s2sConfig,
-      }
+      };
 
       config.setConfig(_config);
       config.setConfig({ s2sConfig: CONFIG });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Change the source of pubcid from 'pubcommon' to 'pubcid.org' when extended ID is used

- contact email of the adapter’s maintainer: pyang@conversantmedia.com
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- https://github.com/prebid/prebid.github.io/pull/1656

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
