### PR TITLE
move uspDataHandler out of gdprDataHandler

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -271,8 +271,13 @@ adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTi
   if (gdprDataHandler.getConsentData()) {
     bidRequests.forEach(bidRequest => {
       bidRequest['gdprConsent'] = gdprDataHandler.getConsentData();
-      bidRequest['uspConsent'] = uspDataHandler.getConsentData();
     });
+  }
+
+  if (uspDataHandler.getConsentData()) {
+    bidRequests.forEach(bidRequest => {
+      bidRequest['uspConsent'] = uspDataHandler.getConsentData();
+    })
   }
   return bidRequests;
 };

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -277,7 +277,7 @@ adapterManager.makeBidRequests = function(adUnits, auctionStart, auctionId, cbTi
   if (uspDataHandler.getConsentData()) {
     bidRequests.forEach(bidRequest => {
       bidRequest['uspConsent'] = uspDataHandler.getConsentData();
-    })
+    });
   }
   return bidRequests;
 };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Minor fix that moves the `uspDataHandler` code out of the `gdpr` code.  This will ensure the USP object gets assigned to the `bidRequest` if the publisher wasn't using GDPR in their setup/build file.
