### PR TITLE
Add CCPA / US privacy data support for LockerDome adapter

### DIFF
--- a/modules/lockerdomeBidAdapter.js
+++ b/modules/lockerdomeBidAdapter.js
@@ -38,6 +38,11 @@ export const spec = {
           consent: bidderRequest.gdprConsent.consentString
         };
       }
+      if (bidderRequest.uspConsent) {
+        payload.us_privacy = {
+          consent: bidderRequest.uspConsent
+        }
+      }
     }
 
     const payloadString = JSON.stringify(payload);

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -118,36 +118,48 @@ describe('LockerDomeAdapter', function () {
       };
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const requestData = JSON.parse(request.data);
-
       expect(requestData.gdpr).to.be.an('object');
       expect(requestData.gdpr).to.have.property('applies', true);
       expect(requestData.gdpr).to.have.property('consent', 'AAABBB');
     });
-  });
 
-  it('should add schain to request if available', function () {
-    const bidderRequest = {
-      refererInfo: {
-        canonicalUrl: 'https://example.com/canonical',
-        referer: 'https://example.com'
-      }
-    };
-    const schainExpected = {
-      ver: '1.0',
-      complete: 1,
-      nodes: [
-        {
-          asi: 'indirectseller.com',
-          sid: '00001',
-          hp: 1
+    it('should add US Privacy data to request if available', function () {
+      const bidderRequest = {
+        uspConsent: 'AAABBB',
+        refererInfo: {
+          canonicalUrl: 'https://example.com/canonical',
+          referer: 'https://example.com'
         }
-      ]
-    };
+      };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const requestData = JSON.parse(request.data);
+      expect(requestData.us_privacy).to.be.an('object');
+      expect(requestData.us_privacy).to.have.property('consent', 'AAABBB');
+    });
 
-    const request = spec.buildRequests(bidRequests, bidderRequest);
-    const requestData = JSON.parse(request.data);
-    expect(requestData.schain).to.be.an('object');
-    expect(requestData.schain).to.deep.equal(schainExpected);
+    it('should add schain to request if available', function () {
+      const bidderRequest = {
+        refererInfo: {
+          canonicalUrl: 'https://example.com/canonical',
+          referer: 'https://example.com'
+        }
+      };
+      const schainExpected = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'indirectseller.com',
+            sid: '00001',
+            hp: 1
+          }
+        ]
+      };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const requestData = JSON.parse(request.data);
+      expect(requestData.schain).to.be.an('object');
+      expect(requestData.schain).to.deep.equal(schainExpected);
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other 

## Description of change
These changes add CCPA / US privacy data support for the LockerDome adapter
Related docs PR: https://github.com/prebid/prebid.github.io/pull/1669

`gulp test` results:
```[10:04:45] Using gulpfile ~/Documents/Bidding_Prebid/Prebid.js/gulpfile.js
[10:04:45] Starting 'test'...
[10:04:45] Starting 'clean'...
[10:04:45] Finished 'clean' after 12 ms
[10:04:45] Starting 'lint'...
[10:05:03] Finished 'lint' after 18 s
[10:05:03] Starting 'test'...
START:
ℹ ｢wdm｣: 
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: 
ℹ ｢wdm｣: Compiled successfully.
11 12 2019 10:05:32.268:INFO [karma-server]: Karma v3.1.4 server started at http://0.0.0.0:9876/
11 12 2019 10:05:32.270:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
11 12 2019 10:05:32.278:INFO [launcher]: Starting browser ChromeHeadless
11 12 2019 10:05:32.792:INFO [HeadlessChrome 78.0.3904 (Linux 0.0.0)]: Connected on socket S3C4Dmy5Dbq5q5mtAAAA with id 37132732
11 12 2019 10:05:34.068:WARN [web-server]: 404: /vuble_renderer.js
11 12 2019 10:05:36.017:WARN [web-server]: 404: /nurl&s=0.66
11 12 2019 10:05:36.017:WARN [web-server]: 404: /burl&s=0.66
11 12 2019 10:05:36.537:WARN [web-server]: 404: /scriptUrl.com
LOG: 'entrance', '5:36'
Finished in 5.522 secs / 2.888 secs @ 10:05:39 GMT-0600 (Central Standard Time)
SUMMARY:
✔ 4898 tests completed
ℹ 2 tests skipped
[10:05:39] Finished 'test' after 36 s
[10:05:39] Finished 'test' after 54 s```