### PR TITLE
Sonobi - added CCPA support to sonobi bidder adapter

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -142,6 +142,10 @@ export const spec = {
       payload.kw = keywords;
     }
 
+    if (bidderRequest && bidderRequest.uspConsent) {
+      payload.us_privacy = bidderRequest.uspConsent;
+    }
+
     // If there is no key_maker data, then don't make the request.
     if (isEmpty(data)) {
       return null;
@@ -236,7 +240,7 @@ export const spec = {
   /**
    * Register User Sync.
    */
-  getUserSyncs: (syncOptions, serverResponses) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
     const syncs = [];
     try {
       if (syncOptions.pixelEnabled) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -300,7 +300,8 @@ describe('SonobiBidAdapter', function () {
         'reachedTop': true,
         'referer': 'https://example.com',
         'stack': ['https://example.com']
-      }
+      },
+      uspConsent: 'someCCPAString'
     };
     it('should include the digitrust id and keyv', () => {
       window.DigiTrust = {
@@ -545,7 +546,12 @@ describe('SonobiBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.kw).to.equal('sports,news,some_other_keyword');
     });
-  })
+
+    it('should return a properly formatted request with us_privacy included', function() {
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.data.us_privacy).to.equal('someCCPAString');
+    });
+  });
 
   describe('.interpretResponse', function () {
     const bidRequests = {


### PR DESCRIPTION


## Type of change
- [x] Feature


## Description of change
Updated the sonobi bidder adapter to send the uspConsent string to the bid endpoint as query param us_privacy.


- apex.prebid@sonobi.com
- [x] official adapter submission

