### PR TITLE
fix a bug when the iframe locator is not present on page

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -63,27 +63,26 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
   // - use the USPAPI locator code to see if USP's located in the current window or an ancestor window. This works in friendly or cross domain iframes
   // - if USPAPI is not found, the iframe function will call the uspError exit callback to abort the rest of the USPAPI workflow
   // - try to call the __uspapi() function directly, otherwise use the postMessage() api
-
   // find the CMP frame/window
-  let f = window;
-  let uspapiFrame;
-  while (!uspapiFrame) {
-    try {
-      if (f.frames['__uspapiLocator']) uspapiFrame = f;
-    } catch (e) { }
-    if (f === window.top) break;
-    f = f.parent;
-  }
-
-  if (!uspapiFrame) {
-    return uspError('USP CMP not found.', hookConfig);
-  }
 
   try {
     // try to call __uspapi directly
-    uspapiFrame.__uspapi('getUSPData', USPAPI_VERSION, callbackHandler.consentDataCallback);
+    window.__uspapi('getUSPData', USPAPI_VERSION, callbackHandler.consentDataCallback);
   } catch (e) {
     // must not have been accessible, try using postMessage() api
+    let f = window;
+    let uspapiFrame;
+    while (!uspapiFrame) {
+      try {
+        if (f.frames['__uspapiLocator']) uspapiFrame = f;
+      } catch (e) { }
+      if (f === window.top) break;
+      f = f.parent;
+    }
+
+    if (!uspapiFrame) {
+      return uspError('USP CMP not found.', hookConfig);
+    }
     callUspApiWhileInIframe('getUSPData', uspapiFrame, callbackHandler.consentDataCallback);
   }
 

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -17,7 +17,6 @@ function createIFrameMarker() {
   ifr.width = 0;
   ifr.height = 0;
   ifr.name = '__uspapiLocator';
-  ifr.id = '__uspapiLocator';
   document.body.appendChild(ifr);
   return ifr;
 }
@@ -267,12 +266,6 @@ describe('consentManagement', function () {
       });
 
       it('Workflow for normal page withoout iframe locater', function() {
-        // remove locator iframe
-        let ifr = document.getElementById('__uspapiLocator');
-        console.log('IFRAME:', ifr);
-        // ifr.remove();
-        // ifr.parentNode.removeChild(ifr);
-
         let testConsentData = {
           uspString: '1NY'
         };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This allows consent to be gathered even if a iframe locator is not on the page. Basically it checks for the global first if it exists in the current page and then only proceeds to look for it in other window/scopes