### PR TITLE
Update NasmediaAdmixerBidAdapter

### DIFF
--- a/modules/nasmediaAdmixerBidAdapter.js
+++ b/modules/nasmediaAdmixerBidAdapter.js
@@ -1,0 +1,85 @@
+
+import {registerBidder} from '../src/adapters/bidderFactory';
+import {BANNER} from '../src/mediaTypes';
+
+const ADMIXER_ENDPOINT = 'https://adn.admixer.co.kr:10443/prebid/ad_req';
+const BIDDER_CODE = 'nasmediaAdmixer';
+
+const DEFAULT_BID_TTL = 360;
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_REVENUE = false;
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid: function (bid) {
+    return !!(bid && bid.params && bid.params.media_key && bid.params.adunit_id);
+  },
+
+  buildRequests: function (validBidRequests, bidderRequest) {
+    return validBidRequests.map(bid => {
+      const payload = {
+        media_key: bid.params.media_key,
+        adunit_id: bid.params.adunit_id,
+        req_id: bid.bidId,
+        referrer: bidderRequest.refererInfo.referer,
+        os: getOs(),
+        platform: getPlatform(),
+      };
+
+      return {
+        method: 'GET',
+        url: ADMIXER_ENDPOINT,
+        data: payload,
+      }
+    })
+  },
+
+  interpretResponse: function (serverResponse, bidRequest) {
+    const serverBody = serverResponse.body;
+    const bidResponses = [];
+
+    if (serverBody && serverBody.error_code === 0 && serverBody.body && serverBody.body.length > 0) {
+      let bidData = serverBody.body[0];
+
+      const bidResponse = {
+        ad: bidData.ad,
+        requestId: serverBody.req_id,
+        creativeId: bidData.ad_id,
+        cpm: bidData.cpm,
+        width: bidData.width,
+        height: bidData.height,
+        currency: bidData.currency ? bidData.currency : DEFAULT_CURRENCY,
+        netRevenue: DEFAULT_REVENUE,
+        ttl: DEFAULT_BID_TTL
+      };
+
+      bidResponses.push(bidResponse);
+    }
+    return bidResponses;
+  }
+}
+
+function getOs() {
+  let ua = navigator.userAgent;
+  if (ua.match(/(iPhone|iPod|iPad)/)) {
+    return 'ios';
+  } else if (ua.match(/Android/)) {
+    return 'android';
+  } else if (ua.match(/Window/)) {
+    return 'windows';
+  } else {
+    return 'etc';
+  }
+}
+
+function getPlatform() {
+  return (isMobile()) ? 'm_web' : 'pc_web';
+}
+
+function isMobile() {
+  return (/(ios|ipod|ipad|iphone|android)/i).test(navigator.userAgent.toLowerCase());
+}
+
+registerBidder(spec);

--- a/modules/nasmediaAdmixerBidAdapter.md
+++ b/modules/nasmediaAdmixerBidAdapter.md
@@ -5,25 +5,29 @@ Module Name: NasmediaAdmixer Bidder Adapter
 Module Type: Bidder Adapter
 Maintainer: prebid@nasmedia.co.kr
 ```
-
+``
 # Description
 
 Module that connects to NasmediaAdmixer demand sources. 
 Banner formats are supported.
 The NasmediaAdmixer adapter doesn't support multiple sizes per ad-unit and will use the first one if multiple sizes are defined.
 
-
 # Test Parameters
 ```
     var adUnits = [
       {
         code: 'banner-ad-div',
-        sizes: [[320, 480]],  // banner size
+        mediaTypes: { 
+          banner: { // banner size
+            sizes: [[300, 250]]
+          }
+        },
         bids: [
           {
             bidder: 'nasmediaAdmixer',
             params: {
-              ax_key: 'ajj7jba3',  //required parameter
+              media_key: '19038695',  //required
+              adunit_id: '24190632',  //required
             }
           }
         ]

--- a/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
+++ b/test/spec/modules/nasmediaAdmixerBidAdapter_spec.js
@@ -1,0 +1,143 @@
+import {expect} from 'chai';
+import {spec} from 'modules/nasmediaAdmixerBidAdapter';
+import {newBidder} from 'src/adapters/bidderFactory';
+
+describe('nasmediaAdmixerBidAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      'bidder': 'nasmediaAdmixer',
+      'params': {
+        'media_key': 'media_key',
+        'adunit_id': 'adunit_id',
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250]],
+      'bidId': '3361d01e67dbd6',
+      'bidderRequestId': '2b60dcd392628a',
+      'auctionId': '124cb070528662',
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      const bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'media_key': '',
+        'adunit_id': '',
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidRequests = [
+      {
+        'bidder': 'nasmediaAdmixer',
+        'params': {
+          'media_key': '19038695',
+          'adunit_id': '24190632',
+        },
+        'adUnitCode': 'adunit-code',
+        'sizes': [[300, 250]],
+        'bidId': '3361d01e67dbd6',
+        'bidderRequestId': '2b60dcd392628a',
+        'auctionId': '124cb070528662',
+      }
+    ];
+    const bidderRequest = {refererInfo: {referer: 'https://example.com'}};
+
+    it('sends bid request to url via GET', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.method).to.equal('GET');
+      expect(request.url).to.match(new RegExp(`https://adn.admixer.co.kr`));
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const response = {
+      'body': {
+        'bidder': 'nasmediaAdmixer',
+        'req_id': '861a8e7952c82c',
+        'error_code': 0,
+        'error_msg': 'OK',
+        'body': [{
+          'ad_id': '20049',
+          'width': 300,
+          'height': 250,
+          'currency': 'USD',
+          'cpm': 1.769221,
+          'ad': '<!-- Creative -->'
+        }]
+      },
+      'headers': {
+        'get': function () {
+        }
+      }
+    };
+
+    const bidRequest = {
+      'bidder': 'nasmediaAdmixer',
+      'params': {
+        'media_key': '19038695',
+        'adunit_id': '24190632',
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [320, 480]],
+      'bidId': '31300c8b9697cd',
+      'bidderRequestId': '2bf570adcf83fa',
+      'auctionId': '169827a33f03cc',
+    };
+
+    it('should get correct bid response', function () {
+      const expectedResponse = [
+        {
+          'requestId': '861a8e7952c82c',
+          'cpm': 1.769221,
+          'currency': 'USD',
+          'width': 300,
+          'height': 250,
+          'ad': '<!-- Creative -->',
+          'creativeId': '20049',
+          'ttl': 360,
+          'netRevenue': false
+        }
+      ];
+
+      const result = spec.interpretResponse(response, bidRequest);
+      expect(result).to.have.lengthOf(1);
+      let resultKeys = Object.keys(result[0]);
+      expect(resultKeys.sort()).to.deep.equal(Object.keys(expectedResponse[0]).sort());
+      resultKeys.forEach(function (k) {
+        if (k === 'ad') {
+          expect(result[0][k]).to.match(/<!-- Creative -->$/);
+        } else {
+          expect(result[0][k]).to.equal(expectedResponse[0][k]);
+        }
+      });
+    });
+
+    it('handles nobid responses', function () {
+      response.body = {
+        'bidder': 'nasmediaAdmixer',
+        'req_id': '861a8e7952c82c',
+        'error_code': 0,
+        'error_msg': 'OK',
+        'body': []
+      };
+
+      const result = spec.interpretResponse(response, bidRequest);
+      expect(result).to.have.lengthOf(0);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [X] Feature
- [X] New bidder adapter 
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
* Adding NasmediaAdmixer bid adapter with 3.0 compliance.
* Modified an existing bid param ('media_key') and added a new bid param ('adunit_id')

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
  {
      bidder: 'nasmediaAdmixer',
         params: {
            media_key: '19038695',  //required
            adunit_id: '24190632',  //required
        }
  }
```

## Description of change
- prebid@nasmedia.co.kr
- [x] official adapter submission
