### PR TITLE
Aardvark: schain support

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -197,8 +197,9 @@ export const spec = {
    * @returns {String}
    */
   serializeSupplyChain: function (supplyChain) {
-    if (!hasValidSupplyChainParams(supplyChain)) 
+    if (!hasValidSupplyChainParams(supplyChain)) {
       return '';
+    }
 
     return `${supplyChain.ver},${supplyChain.complete}!${spec.serializeSupplyChainNodes(supplyChain.nodes)}`;
   },
@@ -216,7 +217,7 @@ export const spec = {
   },
 };
 
- /**
+/**
  * Make sure the required params are present
  * @param {Object} schain
  * @param {Bool}
@@ -228,8 +229,9 @@ export function hasValidSupplyChainParams(schain) {
   const requiredFields = ['asi', 'sid', 'hp'];
 
   let isValid = schain.nodes.reduce((status, node) => {
-    if (!status)
+    if (!status) {
       return status;
+    }
     return requiredFields.every(field => node[field]);
   }, true);
   if (!isValid) {

--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -31,6 +31,7 @@ export const spec = {
     var tdId = '';
     var width = window.innerWidth;
     var height = window.innerHeight;
+    var schain = '';
 
     // This reference to window.top can cause issues when loaded in an iframe if not protected with a try/catch.
     try {
@@ -45,6 +46,8 @@ export const spec = {
     if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.tdid'))) {
       tdId = validBidRequests[0].userId.tdid;
     }
+
+    schain = spec.serializeSupplyChain(utils.deepAccess(validBidRequests, '0.schain'));
 
     utils._each(validBidRequests, function(b) {
       var rMap = requestsMap[b.params.ai];
@@ -63,6 +66,9 @@ export const spec = {
 
         if (tdId) {
           rMap.payload.tdid = tdId;
+        }
+        if (schain) {
+          rMap.payload.schain = schain;
         }
 
         if (pageCategories && pageCategories.length) {
@@ -183,7 +189,53 @@ export const spec = {
       utils.logWarn('Aardvark: Please enable iframe based user sync.');
     }
     return syncs;
-  }
+  },
+
+  /**
+   * Serializes schain params according to OpenRTB requirements
+   * @param {Object} supplyChain
+   * @returns {String}
+   */
+  serializeSupplyChain: function (supplyChain) {
+    if (!hasValidSupplyChainParams(supplyChain)) 
+      return '';
+
+    return `${supplyChain.ver},${supplyChain.complete}!${spec.serializeSupplyChainNodes(supplyChain.nodes)}`;
+  },
+
+  /**
+   * Properly sorts schain object params
+   * @param {Array} nodes
+   * @returns {String}
+   */
+  serializeSupplyChainNodes: function (nodes) {
+    const nodePropOrder = ['asi', 'sid', 'hp', 'rid', 'name', 'domain'];
+    return nodes.map(node => {
+      return nodePropOrder.map(prop => encodeURIComponent(node[prop] || '')).join(',');
+    }).join('!');
+  },
 };
+
+ /**
+ * Make sure the required params are present
+ * @param {Object} schain
+ * @param {Bool}
+ */
+export function hasValidSupplyChainParams(schain) {
+  if (!schain || !schain.nodes) {
+    return false;
+  }
+  const requiredFields = ['asi', 'sid', 'hp'];
+
+  let isValid = schain.nodes.reduce((status, node) => {
+    if (!status)
+      return status;
+    return requiredFields.every(field => node[field]);
+  }, true);
+  if (!isValid) {
+    utils.logError('Aardvark: required schain params missing');
+  }
+  return isValid;
+}
 
 registerBidder(spec);

--- a/test/spec/modules/aardvarkBidAdapter_spec.js
+++ b/test/spec/modules/aardvarkBidAdapter_spec.js
@@ -419,4 +419,94 @@ describe('aardvarkAdapterTest', function () {
       });
     });
   });
+
+  describe('schain support', function() {
+    const nodePropsOrder = ['asi', 'sid', 'hp', 'rid', 'name', 'domain'];
+    let schainConfig = {
+      ver: '1.0',
+      complete: 1,
+      nodes: [
+        {
+          asi: 'rtk.io',
+          sid: '1234',
+          hp: 1,
+          rid: 'bid-request-1',
+          name: 'first pub',
+          domain: 'first.com'
+        },
+        {
+          asi: 'rtk.io',
+          sid: '5678',
+          hp: 1,
+          rid: 'bid-request-2',
+          name: 'second pub',
+          domain: 'second.com'
+        }
+      ]
+    };
+
+    const bidRequests = [{
+      bidder: 'aardvark',
+      params: {
+        ai: 'xiby',
+        sc: 'TdAx',
+      },
+      adUnitCode: 'aaa',
+      transactionId: '1b8389fe-615c-482d-9f1a-177fb8f7d5b0',
+      sizes: [300, 250],
+      bidId: '1abgs362e0x48a8',
+      bidderRequestId: '70deaff71c281d',
+      auctionId: '5c66da22-426a-4bac-b153-77360bef5337',
+      schain: schainConfig,
+    }];
+
+    const bidderRequest = {
+      gdprConsent: undefined,
+      refererInfo: {
+        referer: 'https://example.com'
+      }
+    };
+
+    it('should properly serialize schain object with correct delimiters', () => {
+      const results = spec.buildRequests(bidRequests, bidderRequest);
+      const numNodes = schainConfig.nodes.length;
+
+      const schain = results[0].data.schain;
+
+      // each node serialization should start with an !
+      expect(schain.match(/!/g).length).to.equal(numNodes);
+
+      // 5 commas per node plus 1 for version
+      expect(schain.match(/,/g).length).to.equal(numNodes * 5 + 1);
+    });
+
+    it('should send the proper version for the schain', () => {
+      const results = spec.buildRequests(bidRequests, bidderRequest);
+      const schain = decodeURIComponent(results[0].data.schain).split('!');
+      const version = schain.shift().split(',')[0];
+      expect(version).to.equal(bidRequests[0].schain.ver);
+    });
+
+    it('should send the correct value for complete in schain', () => {
+      const results = spec.buildRequests(bidRequests, bidderRequest);
+      const schain = decodeURIComponent(results[0].data.schain).split('!');
+      const complete = schain.shift().split(',')[1];
+      expect(complete).to.equal(String(bidRequests[0].schain.complete));
+    });
+
+    it('should send available params in the right order', () => {
+      const results = spec.buildRequests(bidRequests, bidderRequest);
+      const schain = decodeURIComponent(results[0].data.schain).split('!');
+      schain.shift();
+
+      schain.forEach((serializeNode, nodeIndex) => {
+        const nodeProps = serializeNode.split(',');
+        nodeProps.forEach((nodeProp, propIndex) => {
+          const node = schainConfig.nodes[nodeIndex];
+          const key = nodePropsOrder[propIndex];
+          expect(nodeProp).to.equal(node[key] ? String(node[key]) : '');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add support for SupplyChain (schain) in aardvark bid adapter.  
Serialize schain object into string and pass it as a query parameter to aardvark bidder.

- [x] official adapter submission