### PR TITLE
ozone 2.2.0 adapter updates

### DIFF
--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import { spec, getWidthAndHeightFromVideoObject, playerSizeIsNestedArray, defaultSize } from 'modules/ozoneBidAdapter';
 import { config } from 'src/config';
 import {Renderer} from '../../../src/Renderer';
+import {getGranularityKeyName, getGranularityObject} from '../../../modules/ozoneBidAdapter';
+import * as utils from '../../../src/utils';
 const OZONEURI = 'https://elb.the-ozone-project.com/openrtb2/auction';
 const BIDDER_CODE = 'ozone';
 /*
@@ -18,9 +20,24 @@ var validBidRequests = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  }
+];
+var validBidRequestsWithUserIdData = [
+  {
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff8',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    sizes: [[300, 250], [300, 600]],
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87',
+    userId: {'pubcid': '12345678', 'id5id': 'ID5-someId', 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableid': 'parrableid123'}
   }
 ];
 var validBidRequestsMinimal = [
@@ -45,7 +62,7 @@ var validBidRequestsNoSizes = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
 ];
@@ -59,7 +76,7 @@ var validBidRequestsWithBannerMediaType = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     mediaTypes: {banner: {sizes: [[300, 250], [300, 600]]}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -73,7 +90,7 @@ var validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, video: {skippable: true, playback_method: ['auto_play_sound_off'], targetDiv: 'some-different-div-id-to-my-adunitcode'} } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, video: {skippable: true, playback_method: ['auto_play_sound_off'], targetDiv: 'some-different-div-id-to-my-adunitcode'} } ] },
     mediaTypes: {video: {mimes: ['video/mp4'], 'context': 'outstream', 'sizes': [640, 480]}, native: {info: 'dummy data'}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -92,7 +109,7 @@ var validBidderRequest = {
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }],
@@ -118,7 +135,7 @@ var bidderRequestWithFullGdpr = {
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: {'gender': 'bart', 'age': 'low'}, lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }],
@@ -159,6 +176,70 @@ var bidderRequestWithFullGdpr = {
   },
 };
 
+var gdpr1 = {
+  'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+  'vendorData': {
+    'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+    'gdprApplies': true,
+    'hasGlobalScope': false,
+    'cookieVersion': '1',
+    'created': '2019-05-31T12:46:48.825',
+    'lastUpdated': '2019-05-31T12:46:48.825',
+    'cmpId': '28',
+    'cmpVersion': '1',
+    'consentLanguage': 'en',
+    'consentScreen': '1',
+    'vendorListVersion': 148,
+    'maxVendorId': 631,
+    'purposeConsents': {
+      '1': true,
+      '2': true,
+      '3': true,
+      '4': true,
+      '5': true
+    },
+    'vendorConsents': {
+      '468': true,
+      '522': true,
+      '524': true, /* 524 is ozone */
+      '565': true,
+      '591': true
+    }
+  },
+  'gdprApplies': true
+};
+
+// simulating the Mirror
+var bidderRequestWithPartialGdpr = {
+  auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+  auctionStart: 1536838908986,
+  bidderCode: 'ozone',
+  bidderRequestId: '1c1586b27a1b5c8',
+  bids: [{
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff8',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+    sizes: [[300, 250], [300, 600]],
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  }],
+  doneCbCallCount: 1,
+  start: 1536838908987,
+  timeout: 3000,
+  gdprConsent: {
+    'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+    'gdprApplies': true,
+    'vendorData': {
+      'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+      'gdprApplies': true
+    }
+  },
+};
+
 // make sure the impid matches the request bidId
 var validResponse = {
   'body': {
@@ -170,10 +251,10 @@ var validResponse = {
             'id': '677903815252395017',
             'impid': '2899ec066a91ff8',
             'price': 0.5,
-            'adm': '<script src="https://fra1-ib.adnxs.com/ab?e=wqT_3QLXB6DXAwAAAwDWAAUBCNDh6dwFENjt4vTs9Y6bWhjxtI3siuOTmREqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUI3J-y5YnPFbYABotc95eMuOBYABAYoBA1VTRJIBAQbwUpgBrAKgAdgEqAEBsAEAuAECwAEDyAEC0AEA2AEA4AEA8AEAigI7dWYoJ2EnLCAyNTI5ODg1LCAxNTM2ODQ4MDgwKTt1ZigncicsIDk4NDkzNTgxNh4A8JySAv0BIWJ6YWpPQWl1c0s0S0VJM0oteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlQX19fXzhQYUFCd0FYZ0JnQUVCaUFFQmtBRUJtQUVCb0FFQnFBRURzQUVBdVFFcGk0aURBQURnUDhFQktZdUlnd0FBNERfSkFUMDR0TTFxYXZFXzJRRUFBQUFBQUFEd1AtQUJBUFVCBQ8oSmdDQUtBQ0FMVUMFEARMMAkI8FBNQUNBY2dDQWRBQ0FkZ0NBZUFDQU9nQ0FQZ0NBSUFEQVpBREFKZ0RBYWdEcnJDdUNyb0RDVVpTUVRFNk16WTROT0FER2cuLpoCPSFLQXVvRkE2AAFwblBGYklBUW9BRG9KUmxKQk1Ub3pOamcwUUJwSkENAfBAOEQ4LsICL2h0dHA6Ly9wcmViaWQub3JnL2Rldi1kb2NzL2dldHRpbmctc3RhcnRlZC5odG1s2AIA4AKtmEjqAiINOthkZW1vLnRoZS1vem9uZS1wcm9qZWN0LmNvbS_yAhMKD0NVU1RPTV9NT0RFTF9JRBIA8gIaChZDLhYAIExFQUZfTkFNRQEdCB4KGjIzAPCHTEFTVF9NT0RJRklFRBIAgAMAiAMBkAMAmAMUoAMBqgMAwAOsAsgDANgDAOADAOgDAPgDA4AEAJIECS9vcGVucnRiMpgEAKIECTEyNy4wLjAuMagEALIEDAgAEAAYACAAMAA4ALgEAMAEAMgEANIEDjkzMjUjRlJBMTozNjg02gQCCAHgBADwBEHvIIgFAZgFAKAF_xEBsAGqBSRkNjE5ODgwNy03YTUzLTQxNDEtYjJkYi1kMmNiNzU0ZDY4YmHABQDJBWlQFPA_0gUJCQkMpAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYAmAYAuAYAwQYAAAAAAAAAAMgGAA..&s=ab84b182eef7d9b4e58c74fe8987705c25ed803c&referrer=https%3A%2F%2Fdemo.the-ozone-project.com%2F&pp=${AUCTION_PRICE}"></script>',
+            'adm': '<script src="https://fra1-ib.adnxs.com/ab?e=wqT_3QLXB6DXAwAAAwDWAAUBCNDh6dwFENjt4vTs9Y6bWhjxtI3siuOTmREqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUI3J-y5YnPFbYABotc95eMuOBYABAYoBA1VTRJIBAQbwUpgBrAKgAdgEqAEBsAEAuAECwAEDyAEC0AEA2AEA4AEA8AEAigI7dWYoJ2EnLCAyNTI5ODg1LCAxNTM2ODQ4MDgwKTt1ZigncicsIDk4NDkzNTgxNh4A8JySAv0BIWJ6YWpPQWl1c0s0S0VJM0oteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlQX19fXzhQYUFCd0FYZ0JnQUVCaUFFQmtBRUJtQUVCb0FFQnFBRURzQUVBdVFFcGk0aURBQURnUDhFQktZdUlnd0FBNERfSkFUMDR0TTFxYXZFXzJRRUFBQUFBQUFEd1AtQUJBUFVCBQ8oSmdDQUtBQ0FMVUMFEARMMAkI8FBNQUNBY2dDQWRBQ0FkZ0NBZUFDQU9nQ0FQZ0NBSUFEQVpBREFKZ0RBYWdEcnJDdUNyb0RDVVpTUVRFNk16WTROT0FER2cuLpoCPSFLQXVvRkE2AAFwblBGYklBUW9BRG9KUmxKQk1Ub3pOamcwUUJwSkENAfBAOEQ4LsICL2h0dHA6Ly9wcmViaWQub3JnL2Rldi1kb2NzL2dldHRpbmctc3RhcnRlZC5odG1s2AIA4AKtmEjqAiINOthkZW1vLnRoZS1vem9uZS1wcm9qZWN0LmNvbS_yAhMKD0NVU1RPTV9NT0RFTF9JRBIA8gIaChZDLhYAIExFQUZfTkFNRQEdCB4KGjIzAPCHTEFTVF9NT0RJRklFRBIAgAMAiAMBkAMAmAMUoAMBqgMAwAOsAsgDANgDAOADAOgDAPgDA4AEAJIECS9vcGVucnRiMpgEAKIECTEyNy4wLjAuMagEALIEDAgAEAAYACAAMAA4ALgEAMAEAMgEANIEDjkzMjUjRlJBMTozNjg02gQCCAHgBADwBEHvIIgFAZgFAKAF_xEBsAGqBSRkNjE5ODgwNy03YTUzLTQxNDEtYjJkYi1kMmNiNzU0ZDY4YmHABQDJBWlQFPA_0gUJCQkMpAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYAmAYAuAYAwQYAAAAAAAAAAMgGAA..&s=ab84b182eef7d9b4e58c74fe8987705c25ed803c&referrer=http%3A%2F%2Fdemo.the-ozone-project.com%2F&pp=${AUCTION_PRICE}"></script>',
             'adid': '98493581',
             'adomain': [
-              'https://prebid.org'
+              'http://prebid.org'
             ],
             'iurl': 'https://fra1-ib.adnxs.com/cr?id=98493581',
             'cid': '9325',
@@ -201,6 +282,7 @@ var validResponse = {
         'seat': 'appnexus'
       }
     ],
+    'cur': 'GBP', /* NOTE - this is where cur is, not in the seatbids. */
     'ext': {
       'responsetimemillis': {
         'appnexus': 47,
@@ -225,10 +307,10 @@ var validOutstreamResponse = {
             'id': '677903815252395017',
             'impid': '2899ec066a91ff8',
             'price': 0.5,
-            'adm': '<script src="https://fra1-ib.adnxs.com/ab?e=wqT_3QLXB6DXAwAAAwDWAAUBCNDh6dwFENjt4vTs9Y6bWhjxtI3siuOTmREqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUI3J-y5YnPFbYABotc95eMuOBYABAYoBA1VTRJIBAQbwUpgBrAKgAdgEqAEBsAEAuAECwAEDyAEC0AEA2AEA4AEA8AEAigI7dWYoJ2EnLCAyNTI5ODg1LCAxNTM2ODQ4MDgwKTt1ZigncicsIDk4NDkzNTgxNh4A8JySAv0BIWJ6YWpPQWl1c0s0S0VJM0oteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlQX19fXzhQYUFCd0FYZ0JnQUVCaUFFQmtBRUJtQUVCb0FFQnFBRURzQUVBdVFFcGk0aURBQURnUDhFQktZdUlnd0FBNERfSkFUMDR0TTFxYXZFXzJRRUFBQUFBQUFEd1AtQUJBUFVCBQ8oSmdDQUtBQ0FMVUMFEARMMAkI8FBNQUNBY2dDQWRBQ0FkZ0NBZUFDQU9nQ0FQZ0NBSUFEQVpBREFKZ0RBYWdEcnJDdUNyb0RDVVpTUVRFNk16WTROT0FER2cuLpoCPSFLQXVvRkE2AAFwblBGYklBUW9BRG9KUmxKQk1Ub3pOamcwUUJwSkENAfBAOEQ4LsICL2h0dHA6Ly9wcmViaWQub3JnL2Rldi1kb2NzL2dldHRpbmctc3RhcnRlZC5odG1s2AIA4AKtmEjqAiINOthkZW1vLnRoZS1vem9uZS1wcm9qZWN0LmNvbS_yAhMKD0NVU1RPTV9NT0RFTF9JRBIA8gIaChZDLhYAIExFQUZfTkFNRQEdCB4KGjIzAPCHTEFTVF9NT0RJRklFRBIAgAMAiAMBkAMAmAMUoAMBqgMAwAOsAsgDANgDAOADAOgDAPgDA4AEAJIECS9vcGVucnRiMpgEAKIECTEyNy4wLjAuMagEALIEDAgAEAAYACAAMAA4ALgEAMAEAMgEANIEDjkzMjUjRlJBMTozNjg02gQCCAHgBADwBEHvIIgFAZgFAKAF_xEBsAGqBSRkNjE5ODgwNy03YTUzLTQxNDEtYjJkYi1kMmNiNzU0ZDY4YmHABQDJBWlQFPA_0gUJCQkMpAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYAmAYAuAYAwQYAAAAAAAAAAMgGAA..&s=ab84b182eef7d9b4e58c74fe8987705c25ed803c&referrer=https%3A%2F%2Fdemo.the-ozone-project.com%2F&pp=${AUCTION_PRICE}"></script>',
+            'adm': '<script src="https://fra1-ib.adnxs.com/ab?e=wqT_3QLXB6DXAwAAAwDWAAUBCNDh6dwFENjt4vTs9Y6bWhjxtI3siuOTmREqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUI3J-y5YnPFbYABotc95eMuOBYABAYoBA1VTRJIBAQbwUpgBrAKgAdgEqAEBsAEAuAECwAEDyAEC0AEA2AEA4AEA8AEAigI7dWYoJ2EnLCAyNTI5ODg1LCAxNTM2ODQ4MDgwKTt1ZigncicsIDk4NDkzNTgxNh4A8JySAv0BIWJ6YWpPQWl1c0s0S0VJM0oteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlQX19fXzhQYUFCd0FYZ0JnQUVCaUFFQmtBRUJtQUVCb0FFQnFBRURzQUVBdVFFcGk0aURBQURnUDhFQktZdUlnd0FBNERfSkFUMDR0TTFxYXZFXzJRRUFBQUFBQUFEd1AtQUJBUFVCBQ8oSmdDQUtBQ0FMVUMFEARMMAkI8FBNQUNBY2dDQWRBQ0FkZ0NBZUFDQU9nQ0FQZ0NBSUFEQVpBREFKZ0RBYWdEcnJDdUNyb0RDVVpTUVRFNk16WTROT0FER2cuLpoCPSFLQXVvRkE2AAFwblBGYklBUW9BRG9KUmxKQk1Ub3pOamcwUUJwSkENAfBAOEQ4LsICL2h0dHA6Ly9wcmViaWQub3JnL2Rldi1kb2NzL2dldHRpbmctc3RhcnRlZC5odG1s2AIA4AKtmEjqAiINOthkZW1vLnRoZS1vem9uZS1wcm9qZWN0LmNvbS_yAhMKD0NVU1RPTV9NT0RFTF9JRBIA8gIaChZDLhYAIExFQUZfTkFNRQEdCB4KGjIzAPCHTEFTVF9NT0RJRklFRBIAgAMAiAMBkAMAmAMUoAMBqgMAwAOsAsgDANgDAOADAOgDAPgDA4AEAJIECS9vcGVucnRiMpgEAKIECTEyNy4wLjAuMagEALIEDAgAEAAYACAAMAA4ALgEAMAEAMgEANIEDjkzMjUjRlJBMTozNjg02gQCCAHgBADwBEHvIIgFAZgFAKAF_xEBsAGqBSRkNjE5ODgwNy03YTUzLTQxNDEtYjJkYi1kMmNiNzU0ZDY4YmHABQDJBWlQFPA_0gUJCQkMpAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYAmAYAuAYAwQYAAAAAAAAAAMgGAA..&s=ab84b182eef7d9b4e58c74fe8987705c25ed803c&referrer=http%3A%2F%2Fdemo.the-ozone-project.com%2F&pp=${AUCTION_PRICE}"></script>',
             'adid': '98493581',
             'adomain': [
-              'https://prebid.org'
+              'http://prebid.org'
             ],
             'iurl': 'https://fra1-ib.adnxs.com/cr?id=98493581',
             'cid': '9325',
@@ -390,7 +472,7 @@ describe('ozone Adapter', function () {
         placementId: '1310000099',
         publisherId: '9876abcd12-3',
         siteId: '1234567890',
-        customData: {'gender': 'bart', 'age': 'low'},
+        customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}],
         lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}},
       },
       siteId: 1234567890
@@ -615,35 +697,75 @@ describe('ozone Adapter', function () {
       }
     };
 
-    it('should not validate customData not being an object', function () {
+    it('should not validate customData not being an array', function () {
       expect(spec.isBidRequestValid(xBadCustomData)).to.equal(false);
     });
 
-    var xCustomParams = {
+    var xBadCustomData_OLD_CUSTOMDATA_VALUE = {
       bidder: BIDDER_CODE,
       params: {
         'placementId': '1234567890',
         'publisherId': '9876abcd12-3',
-        'customParams': {'info': 'this is not allowed'},
-        siteId: '1234567890'
+        'siteId': '1234567890',
+        'customData': {'gender': 'bart', 'age': 'low'}
       }
     };
 
-    it('should not validate customParams being sent', function () {
-      expect(spec.isBidRequestValid(xCustomParams)).to.equal(false);
+    it('should not validate customData being an object, not an array', function () {
+      expect(spec.isBidRequestValid(xBadCustomData_OLD_CUSTOMDATA_VALUE)).to.equal(false);
     });
 
-    var xBadCustomData = {
+    var xBadCustomData_zerocd = {
+      bidder: BIDDER_CODE,
+      params: {
+        'placementId': '1111111110',
+        'publisherId': '9876abcd12-3',
+        'siteId': '1234567890',
+        'customData': []
+      }
+    };
+
+    it('should not validate customData array having no elements', function () {
+      expect(spec.isBidRequestValid(xBadCustomData_zerocd)).to.equal(false);
+    });
+
+    var xBadCustomData_notargeting = {
       bidder: BIDDER_CODE,
       params: {
         'placementId': '1234567890',
         'publisherId': '9876abcd12-3',
-        'customData': 'this should be an object',
+        'customData': [{'settings': {}, 'xx': {'gender': 'bart', 'age': 'low'}}],
         siteId: '1234567890'
       }
     };
-    it('should not validate ozoneData being sent', function () {
-      expect(spec.isBidRequestValid(xBadCustomData)).to.equal(false);
+    it('should not validate customData[] having no "targeting"', function () {
+      expect(spec.isBidRequestValid(xBadCustomData_notargeting)).to.equal(false);
+    });
+
+    var xBadCustomData_tgt_not_obj = {
+      bidder: BIDDER_CODE,
+      params: {
+        'placementId': '1234567890',
+        'publisherId': '9876abcd12-3',
+        'customData': [{'settings': {}, 'targeting': 'this should be an object'}],
+        siteId: '1234567890'
+      }
+    };
+    it('should not validate customData[0].targeting not being an object', function () {
+      expect(spec.isBidRequestValid(xBadCustomData_tgt_not_obj)).to.equal(false);
+    });
+
+    var xBadCustomParams = {
+      bidder: BIDDER_CODE,
+      params: {
+        'placementId': '1234567890',
+        'publisherId': '9876abcd12-3',
+        'siteId': '1234567890',
+        'customParams': 'this key is no longer valid'
+      }
+    };
+    it('should not validate customParams - this is a renamed key', function () {
+      expect(spec.isBidRequestValid(xBadCustomParams)).to.equal(false);
     });
 
     var xBadLotame = {
@@ -737,7 +859,7 @@ describe('ozone Adapter', function () {
       expect(request.data).to.be.a('string');
       var data = JSON.parse(request.data);
       expect(data.imp[0].ext.ozone.lotameData).to.be.an('object');
-      expect(data.imp[0].ext.ozone.customData).to.be.an('object');
+      expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(request).not.to.have.key('lotameData');
       expect(request).not.to.have.key('customData');
     });
@@ -749,7 +871,7 @@ describe('ozone Adapter', function () {
       expect(request.data).to.be.a('string');
       var data = JSON.parse(request.data);
       expect(data.imp[0].ext.ozone.lotameData).to.be.an('object');
-      expect(data.imp[0].ext.ozone.customData).to.be.an('object');
+      expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(data.imp[0].ext.ozone.ozoneData).to.be.undefined;
       expect(request).not.to.have.key('lotameData');
       expect(request).not.to.have.key('customData');
@@ -796,6 +918,8 @@ describe('ozone Adapter', function () {
         consentString: consentString,
         gdprApplies: true,
         vendorData: {
+          metadata: consentString,
+          gdprApplies: true,
           vendorConsents: {524: true},
           purposeConsents: {1: true, 2: true, 3: true, 4: true, 5: true}
         }
@@ -804,46 +928,25 @@ describe('ozone Adapter', function () {
       const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.regs.ext.gdpr).to.equal(1);
-      expect(payload.regs.ext.oz_con).to.exist.and.to.equal(1);
-      expect(payload.regs.ext.gap).to.exist.and.to.be.an('array').and.to.eql([1, 2, 3, 4, 5]);
+      expect(payload.user.ext.consent).to.equal(consentString);
     });
 
-    it('should add correct gdpr consent information to the request when user has accepted only some purpose consents', function () {
+    it('should add gdpr consent information to the request when ozone is true and vendorData is missing vendorConsents (Mirror)', function () {
       let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
       let bidderRequest = validBidderRequest;
       bidderRequest.gdprConsent = {
         consentString: consentString,
         gdprApplies: true,
         vendorData: {
-          vendorConsents: {524: true},
-          purposeConsents: {1: true, 4: true, 5: true}
+          metadata: consentString,
+          gdprApplies: true
         }
       }
 
       const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.regs.ext.gdpr).to.equal(1);
-      expect(payload.regs.ext.oz_con).to.exist.and.to.equal(1);
-      expect(payload.regs.ext.gap).to.exist.and.to.be.an('array').and.to.eql([1, 4, 5]);
-    });
-
-    it('should add gdpr consent information to the request when ozone is false', function () {
-      let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
-      bidderRequest.gdprConsent = {
-        consentString: consentString,
-        gdprApplies: true,
-        vendorData: {
-          vendorConsents: {}, /* 524 is not present */
-          purposeConsents: {1: true, 2: true, 3: true, 4: true, 5: true}
-        }
-      };
-
-      const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
-      const payload = JSON.parse(request.data);
-      expect(payload.regs.ext.gdpr).to.equal(1);
-      expect(payload.regs.ext.oz_con).to.exist.and.to.equal(0);
-      expect(payload.regs.ext.gap).to.exist.and.to.be.an('array').and.to.eql([1, 2, 3, 4, 5]);
+      expect(payload.user.ext.consent).to.equal(consentString);
     });
 
     it('should set regs.ext.gdpr flag to 0 when gdprApplies is false', function () {
@@ -853,6 +956,8 @@ describe('ozone Adapter', function () {
         consentString: consentString,
         gdprApplies: false,
         vendorData: {
+          metadata: consentString,
+          gdprApplies: true,
           vendorConsents: {}, /* 524 is not present */
           purposeConsents: {1: true, 2: true, 3: true, 4: true, 5: true}
         }
@@ -861,8 +966,123 @@ describe('ozone Adapter', function () {
       const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.regs.ext.gdpr).to.equal(0);
-      expect(payload.regs.ext.oz_con).to.be.undefined;
-      expect(payload.regs.ext.gap).to.be.undefined;
+    });
+
+    it('should not have imp[N].ext.ozone.userId', function () {
+      let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
+      let bidderRequest = validBidderRequest;
+      bidderRequest.gdprConsent = {
+        consentString: consentString,
+        gdprApplies: false,
+        vendorData: {
+          metadata: consentString,
+          gdprApplies: true,
+          vendorConsents: {524: true},
+          purposeConsents: {1: true, 2: true, 3: true, 4: true, 5: true}
+        }
+      };
+
+      let bidRequests = validBidRequests;
+      // values from http://prebid.org/dev-docs/modules/userId.html#pubcommon-id
+      bidRequests[0]['userId'] = {
+        'criteortus': '1111',
+        'digitrustid': {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
+        'id5id': '2222',
+        'idl_env': '3333',
+        'lipb': {'lipbid': '4444'},
+        'parrableid': 'eidVersion.encryptionKeyReference.encryptedValue',
+        'pubcid': '5555',
+        'tdid': '6666'
+      };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      let firstBid = payload.imp[0].ext.ozone;
+      expect(firstBid).to.not.have.property('userId');
+      delete validBidRequests[0].userId; // tidy up now, else it will screw with other tests
+    });
+
+    it('should pick up the value of pubcid when built using the pubCommonId module (not userId)', function () {
+      console.log(validBidRequests[0].crumbs);
+      let bidRequests = validBidRequests;
+      // values from http://prebid.org/dev-docs/modules/userId.html#pubcommon-id
+      bidRequests[0]['userId'] = {
+        'criteortus': '1111',
+        'digitrustid': {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
+        'id5id': '2222',
+        'idl_env': '3333',
+        'lipb': {'lipbid': '4444'},
+        'parrableid': 'eidVersion.encryptionKeyReference.encryptedValue',
+        // 'pubcid': '5555', // remove pubcid from here to emulate the OLD module & cause the failover code to kick in
+        'tdid': '6666'
+      };
+      const request = spec.buildRequests(bidRequests, validBidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.ext.ozone.pubcid).to.equal(bidRequests[0]['crumbs']['pubcid']);
+      delete validBidRequests[0].userId; // tidy up now, else it will screw with other tests
+    });
+
+    it('should add a user.ext.eids object to contain user ID data in the new location (Nov 2019)', function() {
+      const request = spec.buildRequests(validBidRequestsWithUserIdData, validBidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.user).to.exist;
+      expect(payload.user.ext).to.exist;
+      expect(payload.user.ext.eids).to.exist;
+      expect(payload.user.ext.eids[0]['source']).to.equal('pubcid');
+      expect(payload.user.ext.eids[0]['uids'][0]['id']).to.equal('12345678');
+      expect(payload.user.ext.eids[1]['source']).to.equal('pubcommon');
+      expect(payload.user.ext.eids[1]['uids'][0]['id']).to.equal('12345678');
+      expect(payload.user.ext.eids[2]['source']).to.equal('id5-sync.com');
+      expect(payload.user.ext.eids[2]['uids'][0]['id']).to.equal('ID5-someId');
+      expect(payload.user.ext.eids[3]['source']).to.equal('criteortus');
+      expect(payload.user.ext.eids[3]['uids'][0]['id']).to.equal('critId123');
+      expect(payload.user.ext.eids[4]['source']).to.equal('liveramp.com');
+      expect(payload.user.ext.eids[4]['uids'][0]['id']).to.equal('liverampId');
+      expect(payload.user.ext.eids[5]['source']).to.equal('liveintent.com');
+      expect(payload.user.ext.eids[5]['uids'][0]['id']).to.equal('lipbidId123');
+      expect(payload.user.ext.eids[6]['source']).to.equal('parrable.com');
+      expect(payload.user.ext.eids[6]['uids'][0]['id']).to.equal('parrableid123');
+    });
+
+    it('should use oztestmode GET value if set', function() {
+      // mock the getGetParametersAsObject function to simulate GET parameters for oztestmode:
+      spec.getGetParametersAsObject = function() {
+        return {'oztestmode': 'mytestvalue_123'};
+      };
+      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.imp[0].ext.ozone.customData).to.be.an('array');
+      expect(data.imp[0].ext.ozone.customData[0].targeting.oztestmode).to.equal('mytestvalue_123');
+    });
+    it('should use oztestmode GET value if set, even if there is no customdata in config', function() {
+      // mock the getGetParametersAsObject function to simulate GET parameters for oztestmode:
+      spec.getGetParametersAsObject = function() {
+        return {'oztestmode': 'mytestvalue_123'};
+      };
+      const request = spec.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.imp[0].ext.ozone.customData).to.be.an('array');
+      expect(data.imp[0].ext.ozone.customData[0].targeting.oztestmode).to.equal('mytestvalue_123');
+    });
+    var specMock = utils.deepClone(spec);
+    it('should use a valid ozstoredrequest GET value if set to override the placementId values, and set oz_rw if we find it', function() {
+      // mock the getGetParametersAsObject function to simulate GET parameters for ozstoredrequest:
+      specMock.getGetParametersAsObject = function() {
+        return {'ozstoredrequest': '1122334455'}; // 10 digits are valid
+      };
+      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.ext.ozone.oz_rw).to.equal(1);
+      expect(data.imp[0].ext.prebid.storedrequest.id).to.equal('1122334455');
+    });
+    it('should NOT use an invalid ozstoredrequest GET value if set to override the placementId values, and set oz_rw to 0', function() {
+      // mock the getGetParametersAsObject function to simulate GET parameters for ozstoredrequest:
+      specMock.getGetParametersAsObject = function() {
+        return {'ozstoredrequest': 'BADVAL'}; // 10 digits are valid
+      };
+      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.ext.ozone.oz_rw).to.equal(0);
+      expect(data.imp[0].ext.prebid.storedrequest.id).to.equal('1310000099');
     });
   });
 
@@ -883,11 +1103,17 @@ describe('ozone Adapter', function () {
     });
 
     it('should build bid array with gdpr', function () {
-      var validBidderRequestWithGdpr = validBidderRequest;
+      var validBidderRequestWithGdpr = bidderRequestWithFullGdpr;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
       const result = spec.interpretResponse(validResponse, request);
       expect(result.length).to.equal(1);
+    });
+
+    it('should build bid array with only partial gdpr', function () {
+      var validBidderRequestWithGdpr = bidderRequestWithPartialGdpr;
+      validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
+      const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
     });
 
     it('should fail ok if no seatbid in server response', function () {
@@ -914,16 +1140,32 @@ describe('ozone Adapter', function () {
       const result = spec.interpretResponse(validBidResponse1adWith2Bidders, request);
       expect(result.length).to.equal(2);
     });
+
+    it('should have a ttl of 600', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(result[0].ttl).to.equal(300);
+    });
   });
 
   describe('userSyncs', function () {
     it('should fail gracefully if no server response', function () {
-      const result = spec.getUserSyncs('bad', false);
+      const result = spec.getUserSyncs('bad', false, gdpr1);
       expect(result).to.be.empty;
     });
     it('should fail gracefully if server response is empty', function () {
-      const result = spec.getUserSyncs('bad', []);
+      const result = spec.getUserSyncs('bad', [], gdpr1);
       expect(result).to.be.empty;
+    });
+    it('should append the various values if they exist', function() {
+      // get the cookie bag populated
+      spec.buildRequests(validBidRequests, validBidderRequest);
+      const result = spec.getUserSyncs({iframeEnabled: true}, 'good server response', gdpr1);
+      expect(result).to.be.an('array');
+      expect(result[0].url).to.include('publisherId=9876abcd12-3');
+      expect(result[0].url).to.include('siteId=1234567890');
+      expect(result[0].url).to.include('gdpr=1');
+      expect(result[0].url).to.include('gdpr_consent=BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA');
     });
   });
 
@@ -981,12 +1223,39 @@ describe('ozone Adapter', function () {
       expect(result).to.be.null;
     });
   });
+
   describe('default size', function () {
     it('should should return default sizes if no obj is sent', function () {
       let obj = '';
       const result = defaultSize(obj);
       expect(result.defaultHeight).to.equal(250);
       expect(result.defaultWidth).to.equal(300);
+    });
+  });
+
+  describe('getGranularityKeyName', function() {
+    it('should return a string granularity as-is', function() {
+      const result = getGranularityKeyName('', 'this is it', '');
+      expect(result).to.equal('this is it');
+    });
+    it('should return "custom" for a mediaTypeGranularity object', function() {
+      const result = getGranularityKeyName('', {}, '');
+      expect(result).to.equal('custom');
+    });
+    it('should return "custom" for a mediaTypeGranularity object', function() {
+      const result = getGranularityKeyName('', false, 'string buckets');
+      expect(result).to.equal('string buckets');
+    });
+  });
+
+  describe('getGranularityObject', function() {
+    it('should return an object as-is', function() {
+      const result = getGranularityObject('', {'name': 'mark'}, '', '');
+      expect(result.name).to.equal('mark');
+    });
+    it('should return an object as-is', function() {
+      const result = getGranularityObject('', false, 'custom', {'name': 'rupert'});
+      expect(result.name).to.equal('rupert');
     });
   });
 });


### PR DESCRIPTION
Type of change

 [X] Bugfix
 [X] Feature

 

Description of changes

• Removal of GDPR parameters that were being read outside of the daisy-bit (which breaks requests when used on-page with certain CMP implementations that don't expose those values.)

• An onpage 'ozone' config to turn off/disable the custom key-value pairs the adapter sets should the publishers find their ad-request URL lengths are close to exceeding Google/DFP limits

• TTL update to 300 ms for bids in the adapter, up from 60 ms

• Cookie sync - append querystring values (if present) in call to cookie sync endpoint - gdpr, gdpr_consent, pubcid, publisherId, and siteId

• Updated checks / validation for customData to ensure clients cannot send invalid customData (currently customData not passing these checks silently breaks on the server-side, now we'll throw a client-side error to avoid confusion)

• Cleaned Up Developer comments as requested from previous PR

• added support for prebid user ID module

• Added support of ozone-specific querystrings for debugging/QA.