### PR TITLE
Criteo adapter should reactivate limited native support

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -7,7 +7,7 @@ import * as utils from '../src/utils';
 import find from 'core-js/library/fn/array/find';
 import { verify } from 'criteo-direct-rsa-validate/build/verify';
 
-export const ADAPTER_VERSION = 25;
+export const ADAPTER_VERSION = 26;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = 'https://bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,7 +1,7 @@
 import { loadExternalScript } from '../src/adloader';
 import { registerBidder } from '../src/adapters/bidderFactory';
 import { config } from '../src/config';
-import { BANNER, VIDEO } from '../src/mediaTypes';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes';
 import { parse } from '../src/url';
 import * as utils from '../src/utils';
 import find from 'core-js/library/fn/array/find';
@@ -23,7 +23,7 @@ const FAST_BID_PUBKEY_N = 'ztQYwCE5BU7T9CDM5he6rKoabstXRmkzx54zFPZkWbK530dwtLBDe
 /** @type {BidderSpec} */
 export const spec = {
   code: BIDDER_CODE,
-  supportedMediaTypes: [ BANNER, VIDEO ],
+  supportedMediaTypes: [ BANNER, VIDEO, NATIVE ],
 
   /**
    * @param {object} bid
@@ -72,6 +72,7 @@ export const spec = {
     if (publisherTagAvailable()) {
       // eslint-disable-next-line no-undef
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID_PUBLISHERTAG, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
+      adapter.setEnableSendAllBids(config.getConfig('enableSendAllBids'));
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
     } else {
@@ -120,7 +121,12 @@ export const spec = {
           dealId: slot.dealCode,
         };
         if (slot.native) {
-          bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
+          if (bidRequest.params.nativeCallback || config.getConfig('enableSendAllBids')) {
+            bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
+          } else {
+            bid.native = createPrebidNativeAd(slot.native);
+            bid.mediaType = NATIVE;
+          }
         } else if (slot.video) {
           bid.vastUrl = slot.displayurl;
           bid.mediaType = VIDEO;
@@ -179,7 +185,6 @@ function publisherTagAvailable() {
 /**
  * @param {BidRequest[]} bidRequests
  * @param bidderRequest
- * @return {CriteoContext}
  */
 function buildContext(bidRequests, bidderRequest) {
   let referrer = '';
@@ -253,7 +258,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       if (bidRequest.params.publisherSubId) {
         slot.publishersubid = bidRequest.params.publisherSubId;
       }
-      if (bidRequest.params.nativeCallback) {
+      if (bidRequest.params.nativeCallback || utils.deepAccess(bidRequest, `mediaTypes.${NATIVE}`)) {
         slot.native = true;
       }
       if (hasVideoMediaType(bidRequest)) {
@@ -360,6 +365,27 @@ function hasValidVideoMediaType(bidRequest) {
   }
 
   return false;
+}
+
+/**
+ * Create prebid compatible native ad with native payload
+ * @param {*} payload
+ * @returns prebid native ad assets
+ */
+function createPrebidNativeAd(payload) {
+  return {
+    title: payload.products[0].title,
+    body: payload.products[0].description,
+    sponsoredBy: payload.advertiser.description,
+    icon: payload.advertiser.logo,
+    image: payload.products[0].image,
+    clickUrl: payload.products[0].click_url,
+    privacyLink: payload.privacy.optout_click_url,
+    privacyIcon: payload.privacy.optout_image_url,
+    cta: payload.products[0].call_to_action,
+    price: payload.products[0].price,
+    impressionTrackers: payload.impression_pixels.map(pix => pix.url)
+  };
 }
 
 /**

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -72,7 +72,10 @@ export const spec = {
     if (publisherTagAvailable()) {
       // eslint-disable-next-line no-undef
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID_PUBLISHERTAG, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
-      adapter.setEnableSendAllBids(config.getConfig('enableSendAllBids'));
+      const enableSendAllBids = config.getConfig('enableSendAllBids');
+      if (adapter.setEnableSendAllBids && typeof adapter.setEnableSendAllBids === 'function' && typeof enableSendAllBids === 'boolean') {
+        adapter.setEnableSendAllBids(enableSendAllBids);
+      }
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
     } else {
@@ -121,8 +124,10 @@ export const spec = {
           dealId: slot.dealCode,
         };
         if (slot.native) {
-          if (bidRequest.params.nativeCallback || config.getConfig('enableSendAllBids')) {
+          if (bidRequest.params.nativeCallback) {
             bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
+          } else if (config.getConfig('enableSendAllBids') === true) {
+            return;
           } else {
             bid.native = createPrebidNativeAd(slot.native);
             bid.mediaType = NATIVE;

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -898,6 +898,34 @@ describe('The Criteo bidding adapter', function () {
       expect(bids).to.have.lengthOf(0);
     });
 
+    it('should not parse bid response with native when enableSendAllBids is not set', function () {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            bidId: 'abc123',
+            cpm: 1.23,
+            width: 728,
+            height: 90,
+            zoneid: 123,
+            native: {}
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: 123,
+          },
+          native: true,
+        }]
+      };
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(0);
+    });
+
     it('should properly parse a bid response with a zoneId passed as a string', function () {
       const response = {
         body: {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { createBid } from 'src/bidfactory';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils';
 import { config } from '../../../src/config';
-import { VIDEO } from '../../../src/mediaTypes';
+import { NATIVE, VIDEO } from '../../../src/mediaTypes';
 
 describe('The Criteo bidding adapter', function () {
   let utilsMock;
@@ -747,7 +747,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].dealId).to.equal('myDealCode');
     });
 
-    it('should properly parse a bid responsewith with a zoneId', function () {
+    it('should properly parse a bid response with a zoneId', function () {
       const response = {
         body: {
           slots: [{
@@ -780,7 +780,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].height).to.equal(90);
     });
 
-    it('should properly parse a bid responsewith with a video', function () {
+    it('should properly parse a bid response with a video', function () {
       const response = {
         body: {
           slots: [{
@@ -813,7 +813,92 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].mediaType).to.equal(VIDEO);
     });
 
-    it('should properly parse a bid responsewith with a zoneId passed as a string', function () {
+    it('should properly parse a bid response with native', function () {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            bidId: 'abc123',
+            cpm: 1.23,
+            width: 728,
+            height: 90,
+            zoneid: 123,
+            native: {
+              'products': [{
+                'title': 'Product title',
+                'description': 'Product desc',
+                'price': '100',
+                'click_url': 'https://product.click',
+                'image': {
+                  'url': 'https://publisherdirect.criteo.com/publishertag/preprodtest/creative.png',
+                  'height': 300,
+                  'width': 300
+                },
+                'call_to_action': 'Try it now!'
+              }],
+              'advertiser': {
+                'description': 'sponsor',
+                'domain': 'criteo.com',
+                'logo': {'url': 'https://www.criteo.com/images/criteo-logo.svg', 'height': 300, 'width': 300}
+              },
+              'privacy': {
+                'optout_click_url': 'https://info.criteo.com/privacy/informations',
+                'optout_image_url': 'https://static.criteo.net/flash/icon/nai_small.png',
+              },
+              'impression_pixels': [{'url': 'https://my-impression-pixel/test/impression'}, {'url': 'https://cas.com/lg.com'}]
+            }
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: 123,
+          },
+          native: true,
+        }]
+      };
+      config.setConfig({'enableSendAllBids': false});
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('test-bidId');
+      expect(bids[0].adId).to.equal('abc123');
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].mediaType).to.equal(NATIVE);
+    });
+
+    it('should not parse bid response with native when enableSendAllBids is true', function () {
+      const response = {
+        body: {
+          slots: [{
+            impid: 'test-requestId',
+            bidId: 'abc123',
+            cpm: 1.23,
+            width: 728,
+            height: 90,
+            zoneid: 123,
+            native: {}
+          }],
+        },
+      };
+      const request = {
+        bidRequests: [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: 123,
+          },
+          native: true,
+        }]
+      };
+      config.setConfig({'enableSendAllBids': true});
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(0);
+    });
+
+    it('should properly parse a bid response with a zoneId passed as a string', function () {
       const response = {
         body: {
           slots: [{


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Re-enable support for native creative in prebid adapter
