### PR TITLE
#4674 Addition of DigiTrust vendor check for gdpr when cmp is present.

### DIFF
--- a/integrationExamples/gpt/cmp_files/purposes.json
+++ b/integrationExamples/gpt/cmp_files/purposes.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "purposes": [
+	{
+	  "id": 25,
+	  "name": "Custom Purpose 1",
+	  "description": "Here's a description of the first purpose"
+	},
+	{
+	  "id": 26,
+	  "name": "Custom Purpose 2",
+	  "description": "Here's a description of the second purpose"
+	},
+	{
+	  "id": 27,
+	  "name": "Custom Purpose 3",
+	  "description": "Here's a description of the third purpose"
+	},
+	{
+	  "id": 28,
+	  "name": "Custom Purpose 4",
+	  "description": "Here's a description of the fourth purpose"
+	}
+  ]
+}

--- a/integrationExamples/gpt/digitrust_cmp_test.html
+++ b/integrationExamples/gpt/digitrust_cmp_test.html
@@ -1,82 +1,52 @@
 <html>
 <head>
-    <title>Simple DigiTrust Prebid - No Framework</title>
-
+    <title>CMP Simple DigiTrust Prebid - No Framework</title>
     <script>
-        (function (window, document) {
-            if (!window.__cmp) {
-                window.__cmp = (function () {
-                    var listen = window.attachEvent || window.addEventListener;
-                    listen('message', function (event) {
-                        window.__cmp.receiveMessage(event);
-                    }, false);
+        (function (window) {
+            window.__cmp = (function () {
+                window.addEventListener('message', function (event) {
+                    window.__cmp.receiveMessage(event);
+                });
 
-                    function addLocatorFrame() {
-                        if (!window.frames['__cmpLocator']) {
-                            if (document.body) {
-                                var frame = document.createElement('iframe');
-                                frame.style.display = 'none';
-                                frame.name = '__cmpLocator';
-                                document.body.appendChild(frame);
-                            } else {
-                                setTimeout(addLocatorFrame, 5);
-                            }
-                        }
+                var commandQueue = [];
+                var cmp = function (command, parameter, callback) {
+                    commandQueue.push({
+                        command: command,
+                        parameter: parameter,
+                        callback: callback
+                    });
+                };
+                cmp.commandQueue = commandQueue;
+                cmp.receiveMessage = function (event) {
+                    var data = event && event.data && event.data.__cmpCall;
+                    if (data) {
+                        commandQueue.push({
+                            callId: data.callId,
+                            command: data.command,
+                            parameter: data.parameter,
+                            event: event
+                        });
                     }
-                    addLocatorFrame();
+                };
+                cmp.config = {
+                    customPurposeListLocation: './cmp_files/purposes.json',
+                    globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
+                    globalConsentLocation: 'http://cmp-origin-release.digitru.st/1/docs/portal.html',
+                    storeConsentGlobally: false,
+                    storePublisherConsentGlobally: false,
+                    storePublisherData: true,
+                    layout: 'footer',
+                    logging: "debug",
+                    blockBrowsing: false,
+                    forceLocale: 'en',
+                    testingMode: 'always show',
+                    showFooterAfterSubmit: true,
+                };
+                return cmp;
+            }());
+        })(window);
 
-                    var commandQueue = [];
-                    var cmp = function (command, parameter, callback) {
-                        if (command === 'ping') {
-                            if (callback) {
-                                callback({
-                                    gdprAppliesGlobally: !!(window.__cmp && window.__cmp.config && window.__cmp.config.storeConsentGlobally),
-                                    cmpLoaded: false
-                                });
-                            }
-                        } else {
-                            commandQueue.push({
-                                command: command,
-                                parameter: parameter,
-                                callback: callback
-                            });
-                        }
-                    };
-                    cmp.commandQueue = commandQueue;
-                    cmp.receiveMessage = function (event) {
-                        var data = event && event.data && event.data.__cmpCall;
-                        if (data) {
-                            commandQueue.push({
-                                callId: data.callId,
-                                command: data.command,
-                                parameter: data.parameter,
-                                event: event
-                            });
-                        }
-                    };
-                    cmp.config = {
-                        //
-                        // Modify config values here
-                        //
-                        // globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
-                        // customPurposeListLocation: './purposes.json',
-                        // globalConsentLocation: './portal.html',
-                        // storeConsentGlobally: false,
-                        // storePublisherData: false,
-                        logging: 'debug'//,
-                        // localization: {},
-                        // forceLocale: 'en-us'
-                    };
-                    return cmp;
-                }());
-                var t = document.createElement('script');
-                t.async = false;
-                t.src = 'http://acdn.adnxs.com/cmp/cmp.bundle.js';
-                var tag = document.getElementsByTagName('head')[0];
-                tag.appendChild(t);
-            }
-        })(window, document);
-        // window.__cmp('showConsentTool');
+        window.__cmp('renderCmpIfNeeded');
     </script>
 
     <script>
@@ -86,7 +56,7 @@
             {
                 code: 'test-div',
                 sizes: [[300, 250], [300, 600], [728, 90]],
-                mediaTypes: { banner: { sizes: [400, 600], name: 'testAdUnit'}},
+                mediaTypes: { banner: { sizes: [400, 600], name: 'testAdUnit' } },
                 bids: [
                     {
                         bidder: 'rubicon',
@@ -207,7 +177,7 @@
     <h2>DigiTrust Prebid Sample - No Framework</h2>
 
     <p>
-        This sample shows the simplest integration path for using DigiTrust ID with Prebid.
+        This sample tests cmp behavior with simple integration path for using DigiTrust ID with Prebid.
         You can use DigiTrust ID without integrating the entire DigiTrust suite.
     </p>
     <div id="idDiv"></div>
@@ -217,5 +187,6 @@
             googletag.cmd.push(function () { googletag.display('test-div'); });
         </script>
     </div>
+    <script src="http://cmp-origin-release.digitru.st/1/cmp.bundle.js"></script>
 </body>
 </html>

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -39,6 +39,7 @@ var noop = function () {
 
 const MAX_RETRIES = 2;
 const DT_ID_SVC = 'https://prebid.digitru.st/id/v1';
+const DT_VENDOR_ID = 65; // cmp gvlVendorId
 
 var isFunc = function (fn) {
   return typeof (fn) === 'function';
@@ -120,7 +121,7 @@ function initDigitrustFacade(config) {
         }
       }
 
-      if (!isMemberIdValid) {
+      if (!isMemberIdValid(obj.member)) {
         if (!isAsync) {
           return errResp
         } else {
@@ -159,7 +160,12 @@ function initDigitrustFacade(config) {
         }
       }
 
-      callApi(opts);
+      // check gdpr vendor here. Full DigiTrust library has vendor check built in
+      gdprConsent.hasConsent(null, function (hasConsent) {
+        if (hasConsent) {
+          callApi(opts);
+        }
+      })
 
       if (!isAsync) {
         return errResp; // even if it will be successful later, without a callback we report a "failure in this moment"
@@ -188,6 +194,43 @@ var isMemberIdValid = function (memberId) {
     return false;
   }
 };
+
+/**
+ * DigiTrust consent handler for GDPR and __cmp.
+ * */
+var gdprConsent = {
+  hasConsent: function (options, consentCb) {
+    options = options || { consentTimeout: 1500 };
+    var stopTimer;
+    var processed = false;
+    var consentAnswer = false;
+    if (typeof (window.__cmp) !== 'undefined') {
+      stopTimer = setTimeout(function () {
+        consentAnswer = true;
+        consentCb(consentAnswer);
+        processed = true;
+      }, options.consentTimeout);
+
+      window.__cmp('ping', null, function(pingAnswer) {
+        if (pingAnswer.gdprAppliesGlobally) {
+          window.__cmp('getVendorConsents', [DT_VENDOR_ID], function (result) {
+            if (processed) { return; } // timeout before cmp answer, cancel
+            clearTimeout(stopTimer);
+            var myconsent = result.vendorConsents[DT_VENDOR_ID];
+            consentCb(myconsent);
+          });
+        } else {
+          if (processed) { return; } // timeout before cmp answer, cancel
+          clearTimeout(stopTimer);
+          consentAnswer = true;
+          consentCb(consentAnswer);
+        }
+      });
+    }
+    consentAnswer = true;
+    consentCb(consentAnswer);
+  }
+}
 
 /**
  * Encapsulation of needed info for the callback return.
@@ -321,6 +364,7 @@ export function surfaceTestHook() {
 }
 
 testHook.initDigitrustFacade = initDigitrustFacade; // expose for unit tests
+testHook.gdpr = gdprConsent;
 
 /** @type {Submodule} */
 export const digiTrustIdSubmodule = {

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -39,7 +39,7 @@ var noop = function () {
 
 const MAX_RETRIES = 2;
 const DT_ID_SVC = 'https://prebid.digitru.st/id/v1';
-const DT_VENDOR_ID = 65; // cmp gvlVendorId
+const DT_VENDOR_ID = 64; // cmp gvlVendorId
 
 var isFunc = function (fn) {
   return typeof (fn) === 'function';

--- a/test/spec/modules/digitrustIdSystem_spec.js
+++ b/test/spec/modules/digitrustIdSystem_spec.js
@@ -5,8 +5,38 @@ import {
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
-
+const DIGI_VENDOR_ID = 65;
 var testHook = null;
+
+/**
+* A mock implementation of IAB Consent Provider
+*/
+function mockCmp(command, version, callback, parameter) {
+  var resultVal;
+  if (command == 'ping') {
+    resultVal = {
+      gdprAppliesGlobally: mockCmp.stubSettings.isGlobal
+    };
+    callback(resultVal);
+  } else if (command == 'getVendorConsents') {
+    let cbResult = {
+      vendorConsents: []
+    }
+    cbResult.vendorConsents[version] = mockCmp.stubSettings.consents;
+    callback(cbResult);
+  }
+}
+
+mockCmp.stubSettings = {
+  isGlobal: false,
+  consents: true
+};
+
+function setupCmpMock(isGlobal, consents) {
+  window.__cmp = mockCmp;
+  mockCmp.stubSettings.isGlobal = isGlobal;
+  mockCmp.stubSettings.consents = consents;
+}
 
 describe('DigiTrust Id System', function () {
   it('Should create the test hook', function (done) {
@@ -46,5 +76,47 @@ describe('DigiTrust Id System', function () {
     expect(window.DigiTrust).to.exist;
     expect(window.DigiTrust.isClient).to.be.true;
     done();
+  });
+
+  it('Should allow consent when given', function (done) {
+    testHook = surfaceTestHook();
+    setupCmpMock(true, true);
+    var handler = function(result) {
+      expect(result).to.be.true;
+      done();
+    }
+
+    testHook.gdpr.hasConsent(null, handler);
+  });
+
+  it('Should consent if does not apply', function (done) {
+    testHook = surfaceTestHook();
+    setupCmpMock(false, true);
+    var handler = function (result) {
+      expect(result).to.be.true;
+      done();
+    }
+
+    testHook.gdpr.hasConsent(null, handler);
+  });
+
+  it('Should not allow consent when not given', function (done) {
+    testHook = surfaceTestHook();
+    setupCmpMock(true, false);
+    var handler = function (result) {
+      expect(result).to.be.false;
+      done();
+    }
+
+    testHook.gdpr.hasConsent(null, handler);
+  });
+  it('Should allow consent if timeout', function (done) {
+    window.__cmp = function () { };
+    var handler = function (result) {
+      expect(result).to.be.true;
+      done();
+    }
+
+    testHook.gdpr.hasConsent({ consentTimeout: 1 }, handler);
   });
 });

--- a/test/spec/modules/digitrustIdSystem_spec.js
+++ b/test/spec/modules/digitrustIdSystem_spec.js
@@ -5,7 +5,6 @@ import {
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
-const DIGI_VENDOR_ID = 65;
 var testHook = null;
 
 /**


### PR DESCRIPTION

## Type of change
- [X ] Bugfix

## Description of change
This adds in the CMP vendor check for DigiTrust to the DigiTrust ID system module. When cmp is present and GDPR applies, this performs a check for consent specifically against the DigiTrust vendor ID to match behavior in the standalone DigiTrust ID system.

## Other information
Issue #4674 
https://github.com/prebid/Prebid.js/issues/4674
