### PR TITLE
Add static API option to the consentManagementUsp module for legacy 2.x. (#4685)

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -14,14 +14,26 @@ const USPAPI_VERSION = 1;
 
 export let consentAPI;
 export let consentTimeout;
+export let staticConsentData;
 
 let consentData;
 let addedConsentHook = false;
 
 // consent APIs
 const uspCallMap = {
-  'iab': lookupUspConsent
+  'iab': lookupUspConsent,
+  'static': lookupStaticConsentData
 };
+
+/**
+ * This function reads the consent string from the config to obtain the consent information of the user.
+ * @param {function(string)} cmpSuccess acts as a success callback when the value is read from config; pass along consentObject (string) from CMP
+ * @param {function(string)} cmpError acts as an error callback while interacting with the config string; pass along an error message (string)
+ * @param {object} hookConfig contains module related variables (see comment in requestBidsHook function)
+ */
+function lookupStaticConsentData(cmpSuccess, cmpError, hookConfig) {
+  cmpSuccess(staticConsentData, hookConfig);
+}
 
 /**
  * This function handles interacting with an USP compliant consent manager to obtain the consent information of the user.
@@ -283,6 +295,14 @@ export function setConsentConfig(config) {
 
   utils.logInfo('USPAPI consentManagement module has been activated...');
 
+  if (consentAPI === 'static') {
+    if (utils.isPlainObject(config.consentData) && utils.isPlainObject(config.consentData.getUSPData)) {
+      if (config.consentData.getUSPData.uspString) staticConsentData = { usPrivacy: config.consentData.getUSPData.uspString };
+      consentTimeout = 0;
+    } else {
+      utils.logError(`consentManagement config with cmpApi: 'static' did not specify consentData. No consents will be available to adapters.`);
+    }
+  }
   if (!addedConsentHook) {
     $$PREBID_GLOBAL$$.requestBids.before(requestBidsHook, 50);
   }

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -3,7 +3,8 @@ import {
   requestBidsHook,
   resetConsentData,
   consentAPI,
-  consentTimeout
+  consentTimeout,
+  staticConsentData
 } from 'modules/consentManagementUsp';
 import * as utils from 'src/utils';
 import { config } from 'src/config';
@@ -82,6 +83,31 @@ describe('consentManagement', function () {
         setConsentConfig(allConfig);
         expect(consentAPI).to.be.equal('daa');
         expect(consentTimeout).to.be.equal(7500);
+      });
+    });
+
+    describe('static consent string setConsentConfig value', () => {
+      afterEach(() => {
+        config.resetConfig();
+        $$PREBID_GLOBAL$$.requestBids.removeAll();
+      });
+      it('results in user settings overriding system defaults', () => {
+        let staticConfig = {
+          usp: {
+            cmpApi: 'static',
+            timeout: 7500,
+            consentData: {
+              getUSPData: {
+                uspString: '1YYY'
+              }
+            }
+          }
+        };
+
+        setConsentConfig(staticConfig);
+        expect(consentAPI).to.be.equal('static');
+        expect(consentTimeout).to.be.equal(0); // should always return without a timeout when config is used
+        expect(staticConsentData.usPrivacy).to.be.equal(staticConfig.usp.consentData.getUSPData.uspString);
       });
     });
   });


### PR DESCRIPTION
The GDPR consent management module has a static configuration option. This change adds "static" as an API option to the consentManagementUsp module.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This change allows a static configuration such as the following to be used rather than the 'iab' API.

```
consentManagement: {
    usp: {
        cmpApi: 'static',
        consentData: {
            getUSPData: {
                uspString: '1YYY'
            }
        }
    }
}
```