### PR TITLE
pbsBidAdapter: defaulting to HTTPS

### DIFF
--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -3,15 +3,15 @@ export const S2S_VENDORS = {
   'appnexus': {
     adapter: 'prebidServer',
     enabled: true,
-    endpoint: '//prebid.adnxs.com/pbs/v1/openrtb2/auction',
-    syncEndpoint: '//prebid.adnxs.com/pbs/v1/cookie_sync',
+    endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+    syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
     timeout: 1000
   },
   'rubicon': {
     adapter: 'prebidServer',
     enabled: true,
-    endpoint: '//prebid-server.rubiconproject.com/openrtb2/auction',
-    syncEndpoint: '//prebid-server.rubiconproject.com/cookie_sync',
+    endpoint: 'https://prebid-server.rubiconproject.com/openrtb2/auction',
+    syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
     timeout: 500
   }
 }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1889,8 +1889,8 @@ describe('S2S Adapter', function () {
       expect(vendorConfig).to.have.property('adapter', 'prebidServer');
       expect(vendorConfig.bidders).to.deep.equal(['appnexus']);
       expect(vendorConfig.enabled).to.be.true;
-      expect(vendorConfig).to.have.property('endpoint', '//prebid.adnxs.com/pbs/v1/openrtb2/auction');
-      expect(vendorConfig).to.have.property('syncEndpoint', '//prebid.adnxs.com/pbs/v1/cookie_sync');
+      expect(vendorConfig).to.have.property('endpoint', 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction');
+      expect(vendorConfig).to.have.property('syncEndpoint', 'https://prebid.adnxs.com/pbs/v1/cookie_sync');
       expect(vendorConfig).to.have.property('timeout', 750);
     });
 
@@ -1910,8 +1910,8 @@ describe('S2S Adapter', function () {
       expect(vendorConfig).to.have.property('adapter', 'prebidServer');
       expect(vendorConfig.bidders).to.deep.equal(['rubicon']);
       expect(vendorConfig.enabled).to.be.true;
-      expect(vendorConfig).to.have.property('endpoint', '//prebid-server.rubiconproject.com/openrtb2/auction');
-      expect(vendorConfig).to.have.property('syncEndpoint', '//prebid-server.rubiconproject.com/cookie_sync');
+      expect(vendorConfig).to.have.property('endpoint', 'https://prebid-server.rubiconproject.com/openrtb2/auction');
+      expect(vendorConfig).to.have.property('syncEndpoint', 'https://prebid-server.rubiconproject.com/cookie_sync');
       expect(vendorConfig).to.have.property('timeout', 750);
     });
 
@@ -1922,8 +1922,8 @@ describe('S2S Adapter', function () {
         'bidders': ['rubicon'],
         'defaultVendor': 'rubicon',
         'enabled': true,
-        'endpoint': '//prebid-server.rubiconproject.com/openrtb2/auction',
-        'syncEndpoint': '//prebid-server.rubiconproject.com/cookie_sync',
+        'endpoint': 'https://prebid-server.rubiconproject.com/openrtb2/auction',
+        'syncEndpoint': 'https://prebid-server.rubiconproject.com/cookie_sync',
         'timeout': 750
       })
     });
@@ -1944,8 +1944,8 @@ describe('S2S Adapter', function () {
         accountId: 'abc',
         bidders: ['rubicon'],
         defaultVendor: 'rubicon',
-        endpoint: '//prebid-server.rubiconproject.com/openrtb2/auction',
-        syncEndpoint: '//prebid-server.rubiconproject.com/cookie_sync'
+        endpoint: 'https://prebid-server.rubiconproject.com/openrtb2/auction',
+        syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync'
       })
     });
 


### PR DESCRIPTION
## Description of change

The upcoming Chrome 80 release suppresses cookies to secure sites that don't have the 'secure' flag. But turns out it works the other way around too -- chrome suppresses 'secure' cookies on non-secure connections.

What this means from a Prebid perspective is that all connections to a backend service need to be HTTPS, even if the site itself is non-secure.

So this PR changes Rubicon's default Prebid Server endpoint to HTTPS. And I went ahead and made the same change for adnxs.com assuming you guys are likely to have the same problem.
