### PR TITLE
AdagioBidAdapter: cast organizationId param as a string

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -394,6 +394,9 @@ export const spec = {
 
     // Regroug ad units by siteId
     const groupedAdUnits = adUnits.reduce((groupedAdUnits, adUnit) => {
+      if (adUnit.params && adUnit.params.organizationId) {
+        adUnit.params.organizationId = adUnit.params.organizationId.toString();
+      }
       (groupedAdUnits[adUnit.params.organizationId] = groupedAdUnits[adUnit.params.organizationId] || []).push(adUnit);
       return groupedAdUnits;
     }, {});

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -414,7 +414,16 @@ describe('adagioAdapter', () => {
       const requests = spec.buildRequests([bidRequests[0]], bidderRequest);
       const request = requests[0];
       expect(request.data.adUnits[0].features.print_number).to.equal('2');
-    })
+    });
+
+    it('organizationId param key must be a string', () => {
+      const requests = spec.buildRequests([Object.assign({}, bidRequests[0], {params: {organizationId: 1010}})], bidderRequest);
+      const request = requests[0];
+      expect(request.data.adUnits[0].params).to.exist;
+      expect(request.data.adUnits[0].params.organizationId).to.deep.equal('1010');
+      expect(request.data.adUnits[0].organizationId).to.exist;
+      expect(request.data.adUnits[0].organizationId).to.deep.equal('1010');
+    });
 
     it('GDPR consent is applied', () => {
       const requests = spec.buildRequests(bidRequests, bidderRequest);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -421,8 +421,8 @@ describe('adagioAdapter', () => {
       const request = requests[0];
       expect(request.data.adUnits[0].params).to.exist;
       expect(request.data.adUnits[0].params.organizationId).to.deep.equal('1010');
-      expect(request.data.adUnits[0].organizationId).to.exist;
-      expect(request.data.adUnits[0].organizationId).to.deep.equal('1010');
+      expect(request.data.organizationId).to.exist;
+      expect(request.data.organizationId).to.deep.equal('1010');
     });
 
     it('GDPR consent is applied', () => {


### PR DESCRIPTION
## Type of change
- [ x] Bugfix

## Description of change
Force the adagio `organizationId` param to be a string and avoid customers to get a bad response from Adagio SSP.

- contact email of the adapter’s maintainer
dev@adagio.io