### PR TITLE
if seatBidId is on bidResponse, always use it

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -416,10 +416,6 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         }
         bid.clientLatencyMillis = Date.now() - cache.auctions[args.auctionId].timestamp;
         bid.bidResponse = parseBidResponse(args, bid.bidResponse);
-        // RP server banner overwrites bidId with bid.seatBidId
-        if (utils.deepAccess(bid, 'bidResponse.seatBidId') && bid.bidder === 'rubicon' && bid.source === 'server' && ['video', 'banner'].some(i => utils.deepAccess(bid, 'bidResponse.mediaType') === i)) {
-          bid.seatBidId = bid.bidResponse.seatBidId;
-        }
         break;
       case BIDDER_DONE:
         args.bids.forEach(bid => {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -224,7 +224,6 @@ const MOCK = {
         'transactionId': 'c116413c-9e3f-401a-bee1-d56aec29a1d4',
         'sizes': [[1000, 300], [970, 250], [728, 90]],
         'bidId': '3bd4ebb1c900e2',
-        'seatBidId': 'aaaa-bbbb-cccc-dddd',
         'bidderRequestId': '1be65d7958826a',
         'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
       }
@@ -653,6 +652,40 @@ describe('rubicon analytics adapter', function () {
       validate(message);
 
       expect(message).to.deep.equal(ANALYTICS_MESSAGE);
+    });
+
+    it('should correctly overwrite bidId if seatBidId is on the bidResponse', function () {
+      // Only want one bid request in our mock auction
+      let bidRequested = utils.deepClone(MOCK.BID_REQUESTED);
+      bidRequested.bids.shift();
+      let auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
+      auctionInit.adUnits.shift();
+
+      // clone the mock bidResponse and duplicate
+      let seatBidResponse = utils.deepClone(BID2);
+      seatBidResponse.seatBidId = 'abc-123-do-re-me';
+
+      const setTargeting = {
+        [seatBidResponse.adUnitCode]: seatBidResponse.adserverTargeting
+      };
+
+      const bidWon = Object.assign({}, seatBidResponse, {
+        'status': 'rendered'
+      });
+
+      // spoof the auction with just our duplicates
+      events.emit(AUCTION_INIT, auctionInit);
+      events.emit(BID_REQUESTED, bidRequested);
+      events.emit(BID_RESPONSE, seatBidResponse);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, setTargeting);
+      events.emit(BID_WON, bidWon);
+
+      let message = JSON.parse(server.requests[0].requestBody);
+
+      validate(message);
+      expect(message.auctions[0].adUnits[0].bids[0].bidId).to.equal('abc-123-do-re-me');
+      expect(message.bidsWon[0].bidId).to.equal('abc-123-do-re-me');
     });
 
     it('should pick the highest cpm bid if more than one bid per bidRequestId', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix -> Not really a "bug" just code cleanup

## Description of change
For Rubicon analytics adapter if there is a `seatBidId` on the bidResponse object then we will be sure to use that as the `bidId` we send to the batched endpoint.

This is just removing a couple unnecessary checks and adding a test.