### PR TITLE
add validation to callbackWithBidder to ensure called with function

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -432,7 +432,7 @@ export function newConfig() {
         if (typeof cb === 'function') {
           return runWithBidder(bidder, utils.bind.call(cb, this, ...args))
         } else {
-          utils.logWarn('config.callbackWithBidder callback called with non-function');
+          utils.logWarn('config.callbackWithBidder callback is not a function');
         }
       }
     }

--- a/src/config.js
+++ b/src/config.js
@@ -429,7 +429,11 @@ export function newConfig() {
   function callbackWithBidder(bidder) {
     return function(cb) {
       return function(...args) {
-        return runWithBidder(bidder, utils.bind.call(cb, this, ...args))
+        if (typeof cb === 'function') {
+          return runWithBidder(bidder, utils.bind.call(cb, this, ...args))
+        } else {
+          utils.logWarn('config.callbackWithBidder callback called with non-function');
+        }
       }
     }
   }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Add check in `config.callbackWithBidder` to make sure callback is a `function` to prevent errors from `Function.prototype.bind` if it is not.