### PR TITLE
Sonobi - removed unneeded query params

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -106,10 +106,6 @@ export const spec = {
       payload.hfa = `PRE-${validBidRequests[0].crumbs.pubcid}`;
     }
 
-    if (deepAccess(validBidRequests[0], 'userId.tdid')) {
-      payload.tdid = validBidRequests[0].userId.tdid;
-    }
-
     if (validBidRequests[0].params.referrer) {
       payload.ref = validBidRequests[0].params.referrer;
     }

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -100,10 +100,6 @@ export const spec = {
 
     if (deepAccess(validBidRequests[0], 'params.hfa')) {
       payload.hfa = deepAccess(validBidRequests[0], 'params.hfa');
-    } else if (deepAccess(validBidRequests[0], 'userId.pubcid')) {
-      payload.hfa = `PRE-${validBidRequests[0].userId.pubcid}`;
-    } else if (deepAccess(validBidRequests[0], 'crumbs.pubcid')) {
-      payload.hfa = `PRE-${validBidRequests[0].crumbs.pubcid}`;
     }
 
     if (validBidRequests[0].params.referrer) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -436,48 +436,7 @@ describe('SonobiBidAdapter', function () {
     it('should return null if there is nothing to bid on', function () {
       const bidRequests = spec.buildRequests([{params: {}}], bidderRequests)
       expect(bidRequests).to.equal(null);
-    })
-
-    it('should return a properly formatted request with commonid as hfa', function () {
-      delete bidRequest[0].params.hfa;
-      delete bidRequest[1].params.hfa;
-      bidRequest[0].crumbs = {'pubcid': 'abcd-efg-0101'};
-      bidRequest[1].crumbs = {'pubcid': 'abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
-      expect(bidRequests.method).to.equal('GET');
-      expect(bidRequests.data.ref).not.to.be.empty;
-      expect(bidRequests.data.s).not.to.be.empty;
-      expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
     });
-
-    it('should return a properly formatted request with commonid from User ID as hfa', function () {
-      delete bidRequest[0].params.hfa;
-      delete bidRequest[1].params.hfa;
-      bidRequest[0].userId = {'pubcid': 'abcd-efg-0101'};
-      bidRequest[1].userId = {'pubcid': 'abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
-      expect(bidRequests.method).to.equal('GET');
-      expect(bidRequests.data.ref).not.to.be.empty;
-      expect(bidRequests.data.s).not.to.be.empty;
-      expect(bidRequests.data.hfa).to.equal('PRE-abcd-efg-0101');
-      delete bidRequest[0].userId;
-      delete bidRequest[1].userId;
-    })
-
-    it('should return a properly formatted request with hfa preferred over commonid', function () {
-      bidRequest[0].params.hfa = 'hfakey';
-      bidRequest[1].params.hfa = 'hfakey';
-      bidRequest[0].crumbs = {'pubcid': 'abcd-efg-0101'};
-      bidRequest[1].crumbs = {'pubcid': 'abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
-      expect(bidRequests.method).to.equal('GET')
-      expect(bidRequests.data.ref).not.to.be.empty
-      expect(bidRequests.data.s).not.to.be.empty
-      expect(bidRequests.data.hfa).to.equal('hfakey')
-    })
 
     it('should set ius as 0 if Sonobi cannot drop iframe pixels', function () {
       userSync.canBidderRegisterSync.returns(false);

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -466,19 +466,6 @@ describe('SonobiBidAdapter', function () {
       delete bidRequest[1].userId;
     })
 
-    it('should return a properly formatted request with unified id from User ID as tdid', function () {
-      delete bidRequest[0].params.tdid;
-      delete bidRequest[1].params.tdid;
-      bidRequest[0].userId = {'tdid': 'td-abcd-efg-0101'};
-      bidRequest[1].userId = {'tdid': 'td-abcd-efg-0101'};
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json');
-      expect(bidRequests.method).to.equal('GET');
-      expect(bidRequests.data.ref).not.to.be.empty;
-      expect(bidRequests.data.s).not.to.be.empty;
-      expect(bidRequests.data.tdid).to.equal('td-abcd-efg-0101');
-    })
-
     it('should return a properly formatted request with hfa preferred over commonid', function () {
       bidRequest[0].params.hfa = 'hfakey';
       bidRequest[1].params.hfa = 'hfakey';


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)


## Description of change
Removed TDID param from bid request since it is passed into the userid param now.
Removed pub common id as a value for hfa query param

- apex.prebid@sonobi.com
- [x] official adapter submission
