### PR TITLE
pbjs.registerBidAdapter options

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -565,10 +565,10 @@ $$PREBID_GLOBAL$$.offEvent = function (event, handler, id) {
  * @param  {string} bidderCode [description]
  * @alias module:pbjs.registerBidAdapter
  */
-$$PREBID_GLOBAL$$.registerBidAdapter = function (bidderAdaptor, bidderCode) {
+$$PREBID_GLOBAL$$.registerBidAdapter = function (bidderAdaptor, bidderCode, options) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.registerBidAdapter', arguments);
   try {
-    adapterManager.registerBidAdapter(bidderAdaptor(), bidderCode);
+    adapterManager.registerBidAdapter(bidderAdaptor(), bidderCode, options);
   } catch (e) {
     utils.logError('Error registering bidder adapter : ' + e.message);
   }


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

`adapterManager.registerBidAdapter` takes a third optional argument, currently only used to specify `supportedMediaTypes`. This change adds a generic options parameter to  `$$PREBID_GLOBAL$$.registerBidAdapter` which is passed to `adapterManager.registerBidAdapter`. This allows bid adapters that are registered via the global API to specify supportedMediaTypes (and therefore act as native/video adapters.) 