### PR TITLE
update urls not using https

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -10,7 +10,7 @@ const VERSION = '2.1.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];
-const ADAGIO_TAG_URL = '//script.4dex.io/localstore.js';
+const ADAGIO_TAG_URL = 'https://script.4dex.io/localstore.js';
 const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
 
 export const ADAGIO_PUBKEY = `-----BEGIN PUBLIC KEY-----

--- a/modules/advangelistsBidAdapter.js
+++ b/modules/advangelistsBidAdapter.js
@@ -9,9 +9,9 @@ import includes from 'core-js/library/fn/array/includes';
 const ADAPTER_VERSION = '1.0';
 const BIDDER_CODE = 'advangelists';
 
-export const VIDEO_ENDPOINT = '//nep.advangelists.com/xp/get?pubid=';// 0cf8d6d643e13d86a5b6374148a4afac';
-export const BANNER_ENDPOINT = '//nep.advangelists.com/xp/get?pubid=';// 0cf8d6d643e13d86a5b6374148a4afac';
-export const OUTSTREAM_SRC = '//player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
+export const VIDEO_ENDPOINT = 'https://nep.advangelists.com/xp/get?pubid=';// 0cf8d6d643e13d86a5b6374148a4afac';
+export const BANNER_ENDPOINT = 'https://nep.advangelists.com/xp/get?pubid=';// 0cf8d6d643e13d86a5b6374148a4afac';
+export const OUTSTREAM_SRC = 'https://player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
 export const VIDEO_TARGETING = ['mimes', 'playbackmethod', 'maxduration', 'skip'];
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 

--- a/modules/advertlyBidAdapter.js
+++ b/modules/advertlyBidAdapter.js
@@ -8,7 +8,7 @@ import {Renderer} from '../src/Renderer';
 const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'advertly';
 const DOMAIN = 'https://api.advertly.com/';
-const RENDERER_URL = '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
+const RENDERER_URL = 'https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
 
 function isBidRequestValid(bid) {
   return (typeof bid.params !== 'undefined' && parseInt(utils.getValue(bid.params, 'publisherId')) > 0);

--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -137,7 +137,7 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       return [{
         type: 'iframe',
-        url: '//sync.serverbid.com/ss/' + siteId + '.html'
+        url: 'https://sync.serverbid.com/ss/' + siteId + '.html'
       }];
     }
 

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -15,7 +15,7 @@ const PROFILE_ID_INLINE = 207;
 export const PROFILE_ID_PUBLISHERTAG = 185;
 
 // Unminified source code can be found in: https://github.com/Prebid-org/prebid-js-external-js-criteo/blob/master/dist/prod.js
-const PUBLISHER_TAG_URL = '//static.criteo.net/js/ld/publishertag.prebid.js';
+const PUBLISHER_TAG_URL = 'https://static.criteo.net/js/ld/publishertag.prebid.js';
 
 const FAST_BID_PUBKEY_E = 65537;
 const FAST_BID_PUBKEY_N = 'ztQYwCE5BU7T9CDM5he6rKoabstXRmkzx54zFPZkWbK530dwtLBDeaWBMxHBUT55CYyboR/EZ4efghPi3CoNGfGWezpjko9P6p2EwGArtHEeS4slhu/SpSIFMjG6fdrpRoNuIAMhq1Z+Pr/+HOd1pThFKeGFr2/NhtAg+TXAzaU=';

--- a/modules/emx_digitalBidAdapter.js
+++ b/modules/emx_digitalBidAdapter.js
@@ -7,7 +7,7 @@ import {parse as parseUrl} from '../src/url';
 
 const BIDDER_CODE = 'emx_digital';
 const ENDPOINT = 'hb.emxdgt.com';
-const RENDERER_URL = '//js.brealtime.com/outstream/1.30.0/bundle.js';
+const RENDERER_URL = 'https://js.brealtime.com/outstream/1.30.0/bundle.js';
 const ADAPTER_VERSION = '1.5.0';
 const DEFAULT_CUR = 'USD';
 
@@ -201,7 +201,7 @@ export const spec = {
     const emxImps = [];
     const timeout = bidderRequest.timeout || '';
     const timestamp = Date.now();
-    const url = location.protocol + '//' + ENDPOINT + ('?t=' + timeout + '&ts=' + timestamp + '&src=pbjs');
+    const url = 'https://' + ENDPOINT + ('?t=' + timeout + '&ts=' + timestamp + '&src=pbjs');
     const secure = location.protocol.indexOf('https') > -1 ? 1 : 0;
     const device = emxAdapter.getDevice();
     const site = emxAdapter.getSite(bidderRequest.refererInfo);
@@ -281,7 +281,7 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       syncs.push({
         type: 'iframe',
-        url: '//biddr.brealtime.com/check.html'
+        url: 'https://biddr.brealtime.com/check.html'
       });
     }
     return syncs;

--- a/modules/envivoBidAdapter.js
+++ b/modules/envivoBidAdapter.js
@@ -8,7 +8,7 @@ import {Renderer} from '../src/Renderer';
 const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'envivo';
 const DOMAIN = 'https://ad.nvivo.tv/';
-const RENDERER_URL = '//acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
+const RENDERER_URL = 'https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
 
 function isBidRequestValid(bid) {
   return (typeof bid.params !== 'undefined' && parseInt(utils.getValue(bid.params, 'publisherId')) > 0);

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -11,7 +11,7 @@ import {submodule} from '../src/hook';
 const MODULE_NAME = 'liveIntentId';
 const LIVE_CONNECT_DUID_KEY = '_li_duid';
 const DOMAIN_USER_ID_QUERY_PARAM_KEY = 'duid';
-const DEFAULT_LIVEINTENT_IDENTITY_URL = '//idx.liadm.com';
+const DEFAULT_LIVEINTENT_IDENTITY_URL = 'https://idx.liadm.com';
 const DEFAULT_PREBID_SOURCE = 'prebid';
 
 /** @type {Submodule} */

--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -40,7 +40,7 @@ function _createServerRequest(bidRequests, bidderRequest) {
 
   return {
     method: 'POST',
-    url: bidRequests[0].params.url || '//abs.proxistore.com/' + payload.language + '/v3/rtb/prebid',
+    url: bidRequests[0].params.url || 'https://abs.proxistore.com/' + payload.language + '/v3/rtb/prebid',
     data: JSON.stringify(payload),
     options: options
   };

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -125,12 +125,12 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       return [{
         type: 'iframe',
-        url: '//cdn.aralego.com/ucfad/cookie/sync.html'
+        url: 'https://cdn.aralego.com/ucfad/cookie/sync.html'
       }];
     } else if (syncOptions.pixelEnabled) {
       return [{
         type: 'image',
-        url: '//sync.aralego.com/idSync'
+        url: 'https://sync.aralego.com/idSync'
       }];
     }
   }

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -4,8 +4,8 @@ import {VIDEO, BANNER} from '../src/mediaTypes';
 import {Renderer} from '../src/Renderer';
 import findIndex from 'core-js/library/fn/array/find-index';
 
-const URL = '//hb.sync.viewdeos.com/auction/';
-const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.01/outstream.min.js';
+const URL = 'https://hb.sync.viewdeos.com/auction/';
+const OUTSTREAM_SRC = 'https://player.sync.viewdeos.com/outstream-unit/2.01/outstream.min.js';
 const BIDDER_CODE = 'viewdeosDX';
 const OUTSTREAM = 'outstream';
 const DISPLAY = 'display';

--- a/modules/yieldoneAnalyticsAdapter.js
+++ b/modules/yieldoneAnalyticsAdapter.js
@@ -9,7 +9,7 @@ import * as utils from '../src/utils';
 const ANALYTICS_CODE = 'yieldone';
 const analyticsType = 'endpoint';
 // const VERSION = '1.0.0';
-const defaultUrl = '//pool.tsukiji.iponweb.net/hba';
+const defaultUrl = 'https://pool.tsukiji.iponweb.net/hba';
 const requestedBidders = {};
 const requestedBids = {};
 const referrers = {};

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -68,7 +68,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('//idx.liadm.com/idex/prebid/89899?');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?');
     request.respond(
       200,
       responseHeader,
@@ -83,7 +83,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('//idx.liadm.com/idex/prebid/89899?duid=li-fpc&');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?duid=li-fpc&');
     request.respond(
       200,
       responseHeader,
@@ -106,7 +106,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('//idx.liadm.com/idex/prebid/89899?_thirdPC=third-pc&duid=li-fpc&');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=third-pc&duid=li-fpc&');
     request.respond(
       200,
       responseHeader,
@@ -129,7 +129,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('//idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&');
     request.respond(
       200,
       responseHeader,

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -34,7 +34,7 @@ describe('ProxistoreBidAdapter', function () {
   });
 
   describe('buildRequests', function () {
-    const url = '//abs.proxistore.com/fr/v3/rtb/prebid';
+    const url = 'https://abs.proxistore.com/fr/v3/rtb/prebid';
     const request = spec.buildRequests([bid], bidderRequest);
     it('should return a valid object', function () {
       expect(request).to.be.an('object');

--- a/test/spec/modules/viewdeosDXBidAdapter_spec.js
+++ b/test/spec/modules/viewdeosDXBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/viewdeosDXBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-const ENDPOINT = '//hb.sync.viewdeos.com/auction/';
+const ENDPOINT = 'https://hb.sync.viewdeos.com/auction/';
 
 const DISPLAY_REQUEST = {
   'bidder': 'viewdeos',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes #4736 

When reviewing various files, it was found there were still a number of references using a dynamic/non-secure endpoint URL/script.  As part of the 3.0 requirements, these calls have to be made securely.

This PR updates those outstanding areas.