### PR TITLE
FreewheelSSP - enable mediaTypes banner and video with test cases

### DIFF
--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -327,7 +327,7 @@ export const spec = {
       // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
       playerSize = getBiggerSizeWithLimit(bidrequest.mediaTypes.banner.sizes, bidrequest.mediaTypes.banner.minSizeLimit, bidrequest.mediaTypes.banner.maxSizeLimit);
     }
-    
+
     if (typeof serverResponse == 'object' && typeof serverResponse.body == 'string') {
       serverResponse = serverResponse.body;
     }
@@ -363,18 +363,7 @@ export const spec = {
         netRevenue: true,
         ttl: 360
       };
-
-      var mediaTypes = bidrequest.mediaTypes || {};
-      if (mediaTypes.video) {
-        // bidResponse.vastXml = serverResponse;
-        bidResponse.mediaType = 'video';
-
-        var blob = new Blob([serverResponse], {type: 'application/xml'});
-        bidResponse.vastUrl = window.URL.createObjectURL(blob);
-      } else {
-        bidResponse.ad = formatAdHTML(bidrequest, playerSize);
-      }
-
+      bidResponse.ad = formatAdHTML(bidrequest, playerSize);
       bidResponses.push(bidResponse);
     }
 

--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -283,7 +283,17 @@ export const spec = {
       requestParams.loc = location;
     }
 
-    var playerSize = getBiggerSizeWithLimit(currentBidRequest.mediaTypes.banner.sizes, currentBidRequest.mediaTypes.banner.minSizeLimit, currentBidRequest.mediaTypes.banner.maxSizeLimit);
+    var playerSize = [];
+    if (currentBidRequest.sizes) {
+      // Backward compatible code, in case size still pass by sizes in bid request
+      playerSize = getBiggerSize(currentBidRequest.sizes);
+    } else if (currentBidRequest.mediaTypes.video && currentBidRequest.mediaTypes.video.playerSize) {
+      // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3
+      playerSize = currentBidRequest.mediaTypes.video.playerSize;
+    } else if (currentBidRequest.mediaTypes.banner.sizes) {
+      // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
+      playerSize = getBiggerSizeWithLimit(currentBidRequest.mediaTypes.banner.sizes, currentBidRequest.mediaTypes.banner.minSizeLimit, currentBidRequest.mediaTypes.banner.maxSizeLimit);
+    }
 
     if (playerSize[0] > 0 || playerSize[1] > 0) {
       requestParams.playerSize = playerSize[0] + 'x' + playerSize[1];
@@ -306,8 +316,18 @@ export const spec = {
   */
   interpretResponse: function(serverResponse, request) {
     var bidrequest = request.bidRequest;
-    var playerSize = getBiggerSizeWithLimit(bidrequest.mediaTypes.banner.sizes, bidrequest.mediaTypes.banner.minSizeLimit, bidrequest.mediaTypes.banner.maxSizeLimit);
-
+    var playerSize = [];
+    if (bidrequest.sizes) {
+      // Backward compatible code, in case size still pass by sizes in bid request
+      playerSize = getBiggerSize(bidrequest.sizes);
+    } else if (bidrequest.mediaTypes.video && bidrequest.mediaTypes.video.playerSize) {
+      // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3
+      playerSize = bidrequest.mediaTypes.video.playerSize;
+    } else if (bidrequest.mediaTypes.banner.sizes) {
+      // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
+      playerSize = getBiggerSizeWithLimit(bidrequest.mediaTypes.banner.sizes, bidrequest.mediaTypes.banner.minSizeLimit, bidrequest.mediaTypes.banner.maxSizeLimit);
+    }
+    
     if (typeof serverResponse == 'object' && typeof serverResponse.body == 'string') {
       serverResponse = serverResponse.body;
     }

--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -284,15 +284,15 @@ export const spec = {
     }
 
     var playerSize = [];
-    if (currentBidRequest.sizes) {
-      // Backward compatible code, in case size still pass by sizes in bid request
-      playerSize = getBiggerSize(currentBidRequest.sizes);
-    } else if (currentBidRequest.mediaTypes.video && currentBidRequest.mediaTypes.video.playerSize) {
+    if (currentBidRequest.mediaTypes.video && currentBidRequest.mediaTypes.video.playerSize) {
       // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3
       playerSize = currentBidRequest.mediaTypes.video.playerSize;
     } else if (currentBidRequest.mediaTypes.banner.sizes) {
       // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
       playerSize = getBiggerSizeWithLimit(currentBidRequest.mediaTypes.banner.sizes, currentBidRequest.mediaTypes.banner.minSizeLimit, currentBidRequest.mediaTypes.banner.maxSizeLimit);
+    } else {
+      // Backward compatible code, in case size still pass by sizes in bid request
+      playerSize = getBiggerSize(currentBidRequest.sizes);
     }
 
     if (playerSize[0] > 0 || playerSize[1] > 0) {
@@ -317,15 +317,15 @@ export const spec = {
   interpretResponse: function(serverResponse, request) {
     var bidrequest = request.bidRequest;
     var playerSize = [];
-    if (bidrequest.sizes) {
-      // Backward compatible code, in case size still pass by sizes in bid request
-      playerSize = getBiggerSize(bidrequest.sizes);
-    } else if (bidrequest.mediaTypes.video && bidrequest.mediaTypes.video.playerSize) {
+    if (bidrequest.mediaTypes.video && bidrequest.mediaTypes.video.playerSize) {
       // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3
       playerSize = bidrequest.mediaTypes.video.playerSize;
     } else if (bidrequest.mediaTypes.banner.sizes) {
       // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
       playerSize = getBiggerSizeWithLimit(bidrequest.mediaTypes.banner.sizes, bidrequest.mediaTypes.banner.minSizeLimit, bidrequest.mediaTypes.banner.maxSizeLimit);
+    } else {
+      // Backward compatible code, in case size still pass by sizes in bid request
+      playerSize = getBiggerSize(bidrequest.sizes);
     }
 
     if (typeof serverResponse == 'object' && typeof serverResponse.body == 'string') {

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -13,7 +13,7 @@ describe('freewheelSSP BidAdapter Test', () => {
     });
   });
 
-  describe('isBidRequestValid', () => {
+  describe('isBidRequestValidForBanner', () => {
     let bid = {
       'bidder': 'freewheel-ssp',
       'params': {
@@ -47,7 +47,39 @@ describe('freewheelSSP BidAdapter Test', () => {
     });
   });
 
-  describe('buildRequests', () => {
+  describe('isBidRequestValidForVideo', () => {
+    let bid = {
+      'bidder': 'freewheel-ssp',
+      'params': {
+        'zoneId': '277225'
+      },
+      'adUnitCode': 'adunit-code',
+      'mediaTypes': {
+        'video': {
+          'playerSize': [300, 250],
+        }
+      },
+      'sizes': [[300, 250]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    };
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        wrong: 'missing zone id'
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequestsForBanner', () => {
     let bidRequests = [
       {
         'bidder': 'freewheel-ssp',
@@ -120,7 +152,78 @@ describe('freewheelSSP BidAdapter Test', () => {
     });
   })
 
-  describe('interpretResponse', () => {
+  describe('buildRequestsForVideo', () => {
+    let bidRequests = [
+      {
+        'bidder': 'freewheel-ssp',
+        'params': {
+          'zoneId': '277225'
+        },
+        'adUnitCode': 'adunit-code',
+        'mediaTypes': {
+          'video': {
+            'playerSize': [300, 600],
+          }
+        },
+        'sizes': [[300, 250], [300, 600]],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475',
+      }
+    ];
+
+    it('should add parameters to the tag', () => {
+      const request = spec.buildRequests(bidRequests);
+      const payload = request.data;
+      expect(payload.reqType).to.equal('AdsSetup');
+      expect(payload.protocolVersion).to.equal('2.0');
+      expect(payload.zoneId).to.equal('277225');
+      expect(payload.componentId).to.equal('mustang');
+      expect(payload.playerSize).to.equal('300x600');
+    });
+
+    it('sends bid request to ENDPOINT via GET', () => {
+      const request = spec.buildRequests(bidRequests);
+      expect(request.url).to.contain(ENDPOINT);
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should add usp consent to the request', () => {
+      let uspConsentString = '1FW-SSP-uspConsent-';
+      let bidderRequest = {};
+      bidderRequest.uspConsent = uspConsentString;
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = request.data;
+      expect(payload.reqType).to.equal('AdsSetup');
+      expect(payload.protocolVersion).to.equal('2.0');
+      expect(payload.zoneId).to.equal('277225');
+      expect(payload.componentId).to.equal('mustang');
+      expect(payload.playerSize).to.equal('300x600');
+      expect(payload._fw_us_privacy).to.exist.and.to.be.a('string');
+      expect(payload._fw_us_privacy).to.equal(uspConsentString);
+    });
+
+    it('should add gdpr consent to the request', () => {
+      let gdprConsentString = '1FW-SSP-gdprConsent-';
+      let bidderRequest = {
+        'gdprConsent': {
+          'consentString': gdprConsentString
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = request.data;
+      expect(payload.reqType).to.equal('AdsSetup');
+      expect(payload.protocolVersion).to.equal('2.0');
+      expect(payload.zoneId).to.equal('277225');
+      expect(payload.componentId).to.equal('mustang');
+      expect(payload.playerSize).to.equal('300x600');
+      expect(payload._fw_gdpr_consent).to.exist.and.to.be.a('string');
+      expect(payload._fw_gdpr_consent).to.equal(gdprConsentString);
+    });
+  })
+
+  describe('interpretResponseForBanner', () => {
     let bidRequests = [
       {
         'bidder': 'freewheel-ssp',
@@ -177,6 +280,137 @@ describe('freewheelSSP BidAdapter Test', () => {
           }
         },
         'sizes': [[300, 600]],
+        'bidId': '2',
+        'bidderRequestId': '3',
+        'auctionId': '4',
+      }
+    ];
+
+    let response = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><VAST version=\'2.0\'>' +
+    '<Ad id=\'AdswizzAd28517153\'>' +
+    '  <InLine>' +
+    '   <AdSystem>Adswizz</AdSystem>' +
+    '   <Creatives>' +
+    '    <Creative id=\'28517153\' sequence=\'1\'>' +
+    '     <Linear>' +
+    '      <Duration>00:00:09</Duration>' +
+    '      <MediaFiles>' +
+    '       <MediaFile delivery=\'progressive\' bitrate=\'129\' width=\'320\' height=\'240\' type=\'video/mp4\' scalable=\'true\' maintainAspectRatio=\'true\'><![CDATA[http://cdn.stickyadstv.com/www/images/28517153-web-MP4-59e47d565b2d9.mp4]]></MediaFile>' +
+    '      </MediaFiles>' +
+    '     </Linear>' +
+    '    </Creative>' +
+    '   </Creatives>' +
+    '   <Extensions>' +
+    '     <Extension type=\'StickyPricing\'><Price currency="EUR">0.2000</Price></Extension>' +
+    '    </Extensions>' +
+    '  </InLine>' +
+    ' </Ad>' +
+    '</VAST>';
+
+    let ad = '<div id="freewheelssp_prebid_target"></div><script type=\'text/javascript\'>(function() {  var st = document.createElement(\'script\'); st.type = \'text/javascript\'; st.async = true;  st.src = \'http://cdn.stickyadstv.com/mustang/mustang.min.js\';  st.onload = function(){    var vastLoader = new window.com.stickyadstv.vast.VastLoader();    var vast = vastLoader.getVast();    var topWindow = (function(){var res=window; try{while(top != res){if(res.parent.location.href.length)res=res.parent;}}catch(e){}return res;})();    vast.setXmlString(topWindow.freeheelssp_cache["adunit-code"]);    vastLoader.parseAds(vast, {      onSuccess: function() {var config = {      preloadedVast:vast,      autoPlay:true    };    var ad = new window.com.stickyadstv.vpaid.Ad(document.getElementById("freewheelssp_prebid_target"),config);    (new window.com.stickyadstv.tools.ASLoader(277225, \'mustang\')).registerEvents(ad);    ad.initAd(300,600,"",0,"",""); }    });  };  document.head.appendChild(st);})();</script>';
+    let formattedAd = '<div id="freewheelssp_prebid_target"></div><script type=\'text/javascript\'>(function() {  var st = document.createElement(\'script\'); st.type = \'text/javascript\'; st.async = true;  st.src = \'http://cdn.stickyadstv.com/prime-time/floorad.min.js\';  st.onload = function(){    var vastLoader = new window.com.stickyadstv.vast.VastLoader();    var vast = vastLoader.getVast();    var topWindow = (function(){var res=window; try{while(top != res){if(res.parent.location.href.length)res=res.parent;}}catch(e){}return res;})();    vast.setXmlString(topWindow.freeheelssp_cache["adunit-code"]);    vastLoader.parseAds(vast, {      onSuccess: function() {var config = {  preloadedVast:vast,  ASLoader:new window.com.stickyadstv.tools.ASLoader(277225, \'floorad\'),domId:"adunit-code"};window.com.stickyadstv.floorad.start(config); }    });  };  document.head.appendChild(st);})();</script>';
+
+    it('should get correct bid response', () => {
+      var request = spec.buildRequests(bidRequests);
+
+      let expectedResponse = [
+        {
+          requestId: '30b31c1838de1e',
+          cpm: '0.2000',
+          width: 300,
+          height: 600,
+          creativeId: '28517153',
+          currency: 'EUR',
+          netRevenue: true,
+          ttl: 360,
+          ad: ad
+        }
+      ];
+
+      let result = spec.interpretResponse(response, request);
+      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+    });
+
+    it('should get correct bid response with formated ad', () => {
+      var request = spec.buildRequests(formattedBidRequests);
+
+      let expectedResponse = [
+        {
+          requestId: '30b31c1838de1e',
+          cpm: '0.2000',
+          width: 300,
+          height: 600,
+          creativeId: '28517153',
+          currency: 'EUR',
+          netRevenue: true,
+          ttl: 360,
+          ad: formattedAd
+        }
+      ];
+
+      let result = spec.interpretResponse(response, request);
+      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+    });
+
+    it('handles nobid responses', () => {
+      var reqest = spec.buildRequests(formattedBidRequests);
+      let response = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><VAST version=\'2.0\'></VAST>';
+
+      let result = spec.interpretResponse(response, reqest);
+      expect(result.length).to.equal(0);
+    });
+  });
+  describe('interpretResponseForVideo', () => {
+    let bidRequests = [
+      {
+        'bidder': 'freewheel-ssp',
+        'params': {
+          'zoneId': '277225'
+        },
+        'adUnitCode': 'adunit-code',
+        'mediaTypes': {
+          'video': {
+            'playerSize': [300, 600],
+          }
+        },
+        'sizes': [[300, 400]],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475',
+      }
+    ];
+
+    let formattedBidRequests = [
+      {
+        'bidder': 'freewheel-ssp',
+        'params': {
+          'zoneId': '277225',
+          'format': 'floorad'
+        },
+        'adUnitCode': 'adunit-code',
+        'mediaTypes': {
+          'video': {
+            'playerSize': [300, 600],
+          }
+        },
+        'sizes': [[300, 400]],
+        'bidId': '30b3other1c1838de1e',
+        'bidderRequestId': '22edbae273other3bf6',
+        'auctionId': '1d1a03079test0a475',
+      },
+      {
+        'bidder': 'stickyadstv',
+        'params': {
+          'zoneId': '277225',
+          'format': 'test'
+        },
+        'adUnitCode': 'adunit-code',
+        'mediaTypes': {
+          'video': {
+            'playerSize': [300, 600],
+          }
+        },
+        'sizes': [[300, 400]],
         'bidId': '2',
         'bidderRequestId': '3',
         'auctionId': '4',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We add support for mediaTypes banner and video. And test cases related. 
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
zhewang@freewheel.com
- [X] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
