### PR TITLE
ViewdeosDX outstream support in legacy

### DIFF
--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -231,12 +231,15 @@ function newRenderer(requestId) {
  */
 function outstreamRender(bid) {
   bid.renderer.push(() => {
-    window.VOutstreamAPI.initOutstreams([{
+    const params = utils.isArray(bid.params) ? bid.params[0] : bid.params;
+    const outstreamConfig = params.outstream ? params.outstream : {};
+    const opts = Object.assign({}, outstreamConfig, {
       width: bid.width,
       height: bid.height,
       vastUrl: bid.vastUrl,
       elId: bid.adUnitCode
-    }]);
+    });
+    window.VOutstreamAPI.initOutstreams([opts]);
   });
 }
 

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -5,7 +5,7 @@ import {Renderer} from '../src/Renderer';
 import findIndex from 'core-js/library/fn/array/find-index';
 
 const URL = '//hb.sync.viewdeos.com/auction/';
-const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.01/outstream.min.js';
+const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.11/outstream-unit.min.js';
 const BIDDER_CODE = 'viewdeosDX';
 const OUTSTREAM = 'outstream';
 const DISPLAY = 'display';

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -112,7 +112,8 @@ function parseRTBResponse(serverResponse, bidderRequest) {
     });
 
     if (serverBid.cpm !== 0 && requestId !== -1) {
-      const bid = createBid(serverBid, getMediaType(bidderRequest.bids[requestId]));
+      const bidReq = bidderRequest.bids[requestId];
+      const bid = createBid(serverBid, getMediaType(bidReq), bidReq.params);
 
       bids.push(bid);
     }
@@ -129,6 +130,10 @@ function bidToTag(bidRequests, bidderRequest) {
   if (utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies')) {
     tag.gdpr = 1;
     tag.gdpr_consent = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
+  }
+
+  if (utils.deepAccess(bidderRequest, 'bidderRequest.uspConsent')) {
+    tag.us_privacy = bidderRequest.uspConsent;
   }
 
   for (let i = 0, length = bidRequests.length; i < length; i++) {
@@ -174,7 +179,7 @@ function getMediaType(bidderRequest) {
  * @param mediaType {Object}
  * @returns {object}
  */
-function createBid(bidResponse, mediaType) {
+function createBid(bidResponse, mediaType, bidderParams) {
   const bid = {
     requestId: bidResponse.requestId,
     creativeId: bidResponse.cmpId,
@@ -201,7 +206,7 @@ function createBid(bidResponse, mediaType) {
     Object.assign(bid, {
       mediaType: 'video',
       adResponse: bidResponse,
-      renderer: newRenderer(bidResponse.requestId)
+      renderer: newRenderer(bidResponse.requestId, bidderParams)
     });
   }
 
@@ -213,10 +218,11 @@ function createBid(bidResponse, mediaType) {
  * @param requestId
  * @returns {*}
  */
-function newRenderer(requestId) {
+function newRenderer(requestId, bidderParams) {
   const renderer = Renderer.install({
     id: requestId,
     url: OUTSTREAM_SRC,
+    config: bidderParams.outstream || {},
     loaded: false
   });
 
@@ -231,9 +237,7 @@ function newRenderer(requestId) {
  */
 function outstreamRender(bid) {
   bid.renderer.push(() => {
-    const params = utils.isArray(bid.params) ? bid.params[0] : bid.params;
-    const outstreamConfig = params.outstream ? params.outstream : {};
-    const opts = Object.assign({}, outstreamConfig, {
+    const opts = Object.assign({}, bid.renderer.getConfig(), {
       width: bid.width,
       height: bid.height,
       vastUrl: bid.vastUrl,

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -4,7 +4,7 @@ import {VIDEO, BANNER} from '../src/mediaTypes';
 import {Renderer} from '../src/Renderer';
 import findIndex from 'core-js/library/fn/array/find-index';
 
-const URL = '//hb.sync.viewdeos.com/auction/';
+const URL = '//ghb.sync.viewdeos.com/auction/';
 const OUTSTREAM_SRC = '//player.sync.viewdeos.com/outstream-unit/2.11/outstream-unit.min.js';
 const BIDDER_CODE = 'viewdeosDX';
 const OUTSTREAM = 'outstream';

--- a/test/spec/modules/viewdeosDXBidAdapter_spec.js
+++ b/test/spec/modules/viewdeosDXBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/viewdeosDXBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory';
 
-const ENDPOINT = '//hb.sync.viewdeos.com/auction/';
+const ENDPOINT = '//ghb.sync.viewdeos.com/auction/';
 
 const DISPLAY_REQUEST = {
   'bidder': 'viewdeos',

--- a/test/spec/modules/viewdeosDXBidAdapter_spec.js
+++ b/test/spec/modules/viewdeosDXBidAdapter_spec.js
@@ -44,6 +44,8 @@ const SERVER_VIDEO_RESPONSE = {
   ]
 };
 
+const SERVER_OUSTREAM_VIDEO_RESPONSE = SERVER_VIDEO_RESPONSE;
+
 const SERVER_DISPLAY_RESPONSE = {
   'source': {'aid': 12345, 'pubId': 54321},
   'bids': [{
@@ -72,6 +74,25 @@ const SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS = {
   }],
   'cookieURLs': ['link3', 'link4'],
   'cookieURLSTypes': ['image', 'iframe']
+};
+
+const outstreamVideoBidderRequest = {
+  bidderCode: 'bidderCode',
+  bids: [{
+    'params': {
+      'aid': 12345,
+      'outstream': {
+        'video_controls': 'show'
+      }
+    },
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        playerSize: [640, 480]
+      }
+    },
+    bidId: '2e41f65424c87c'
+  }]
 };
 
 const videoBidderRequest = {
@@ -119,8 +140,16 @@ const displayEqResponse = [{
   cpm: 0.9
 }];
 
-describe('viewdeosDXBidAdapter', function () { // todo remove only
+describe('viewdeosDXBidAdapter', function () {
   const adapter = newBidder(spec);
+
+  describe('when outstream params are passing properly', function() {
+    const videoBids = spec.interpretResponse({body: SERVER_OUSTREAM_VIDEO_RESPONSE}, {bidderRequest: outstreamVideoBidderRequest});
+    it('should return renderer with expected outstream params config', function() {
+      expect(!!videoBids[0].renderer).to.equal(true);
+      expect(videoBids[0].renderer.getConfig().video_controls).to.equal('show');
+    })
+  })
 
   describe('user syncs as image', function () {
     it('should be returned if pixel enabled', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Allow configuring outstream player from params of bidder

```
{
...
  params: {
    aid:331133,
    outstream: {
      show_controls: 'show'
    }
  }
}
```

# Docs 
https://github.com/prebid/prebid.github.io/pull/1732