### PR TITLE
aardvark - schain and ccpa support

### DIFF
--- a/modules/aardvarkBidAdapter.js
+++ b/modules/aardvarkBidAdapter.js
@@ -19,7 +19,7 @@ export const spec = {
 
   isBidRequestValid: function(bid) {
     return ((typeof bid.params.ai === 'string') && !!bid.params.ai.length &&
-        (typeof bid.params.sc === 'string') && !!bid.params.sc.length);
+      (typeof bid.params.sc === 'string') && !!bid.params.sc.length);
   },
 
   buildRequests: function(validBidRequests, bidderRequest) {
@@ -31,6 +31,7 @@ export const spec = {
     var tdId = '';
     var width = window.innerWidth;
     var height = window.innerHeight;
+    var schain = '';
 
     // This reference to window.top can cause issues when loaded in an iframe if not protected with a try/catch.
     try {
@@ -45,6 +46,8 @@ export const spec = {
     if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.tdid'))) {
       tdId = validBidRequests[0].userId.tdid;
     }
+
+    schain = spec.serializeSupplyChain(utils.deepAccess(validBidRequests, '0.schain'));
 
     utils._each(validBidRequests, function(b) {
       var rMap = requestsMap[b.params.ai];
@@ -64,6 +67,9 @@ export const spec = {
         if (tdId) {
           rMap.payload.tdid = tdId;
         }
+        if (schain) {
+          rMap.payload.schain = schain;
+        }
 
         if (pageCategories && pageCategories.length) {
           rMap.payload.categories = pageCategories.slice(0);
@@ -76,7 +82,7 @@ export const spec = {
           });
         }
 
-        if (bidderRequest && bidderRequest.gdprConsent) {
+        if (bidderRequest.gdprConsent) {
           rMap.payload.gdpr = false;
           if (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') {
             rMap.payload.gdpr = bidderRequest.gdprConsent.gdprApplies;
@@ -90,11 +96,15 @@ export const spec = {
         auctionCodes.push(b.params.ai);
       }
 
+      if (bidderRequest.uspConsent) {
+        rMap.payload.us_privacy = bidderRequest.uspConsent
+      }
+
       rMap.shortCodes.push(b.params.sc);
       rMap.payload[b.params.sc] = b.bidId;
 
       if ((typeof b.params.host === 'string') && b.params.host.length &&
-          (b.params.host !== rMap.endpoint)) {
+        (b.params.host !== rMap.endpoint)) {
         rMap.endpoint = b.params.host;
       }
     });
@@ -103,7 +113,7 @@ export const spec = {
       var req = requestsMap[auctionId];
       requests.push({
         method: 'GET',
-        url: `//${req.endpoint}/${auctionId}/${req.shortCodes.join('_')}/aardvark`,
+        url: `https://${req.endpoint}/${auctionId}/${req.shortCodes.join('_')}/aardvark`,
         data: req.payload,
         bidderRequest
       });
@@ -160,30 +170,92 @@ export const spec = {
     return bidResponses;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     const syncs = [];
-    var url = '//' + SYNC_ENDPOINT + '/cs';
+    const params = [];
     var gdprApplies = false;
     if (gdprConsent && (typeof gdprConsent.gdprApplies === 'boolean')) {
       gdprApplies = gdprConsent.gdprApplies;
     }
 
-    if (syncOptions.iframeEnabled) {
-      if (!hasSynced) {
-        hasSynced = true;
-        if (gdprApplies) {
-          url = url + '?g=1&c=' + encodeURIComponent(gdprConsent.consentString);
-        }
-        syncs.push({
-          type: 'iframe',
-          url: url
-        });
-      }
-    } else {
+    if (!syncOptions.iframeEnabled) {
       utils.logWarn('Aardvark: Please enable iframe based user sync.');
+      return syncs;
     }
+
+    if (hasSynced) {
+      return syncs;
+    }
+
+    hasSynced = true;
+    if (gdprApplies) {
+      params.push(['g', '1']);
+      params.push(['c', gdprConsent.consentString]);
+    }
+
+    if (uspConsent) {
+      params.push(['us_privacy', uspConsent]);
+    }
+
+    var queryStr = '';
+    if (params.length) {
+      queryStr = '?' + params.map(p => p[0] + '=' + encodeURIComponent(p[1])).join('&')
+    }
+
+    syncs.push({
+      type: 'iframe',
+      url: `https://${SYNC_ENDPOINT}/cs${queryStr}`
+    });
     return syncs;
-  }
+  },
+
+  /**
+   * Serializes schain params according to OpenRTB requirements
+   * @param {Object} supplyChain
+   * @returns {String}
+   */
+  serializeSupplyChain: function (supplyChain) {
+    if (!hasValidSupplyChainParams(supplyChain)) {
+      return '';
+    }
+
+    return `${supplyChain.ver},${supplyChain.complete}!${spec.serializeSupplyChainNodes(supplyChain.nodes)}`;
+  },
+
+  /**
+   * Properly sorts schain object params
+   * @param {Array} nodes
+   * @returns {String}
+   */
+  serializeSupplyChainNodes: function (nodes) {
+    const nodePropOrder = ['asi', 'sid', 'hp', 'rid', 'name', 'domain'];
+    return nodes.map(node => {
+      return nodePropOrder.map(prop => encodeURIComponent(node[prop] || '')).join(',');
+    }).join('!');
+  },
 };
+
+/**
+ * Make sure the required params are present
+ * @param {Object} schain
+ * @param {Bool}
+ */
+export function hasValidSupplyChainParams(schain) {
+  if (!schain || !schain.nodes) {
+    return false;
+  }
+  const requiredFields = ['asi', 'sid', 'hp'];
+
+  let isValid = schain.nodes.reduce((status, node) => {
+    if (!status) {
+      return status;
+    }
+    return requiredFields.every(field => node[field]);
+  }, true);
+  if (!isValid) {
+    utils.logError('Aardvark: required schain params missing');
+  }
+  return isValid;
+}
 
 registerBidder(spec);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
- When building request, read bidderRequest.uspConsent and pass it as us_privacy query param.
- Add us_privacy query param when creating user sync frame.

There's also PR for 3.x version here: https://github.com/prebid/Prebid.js/pull/4775
Docs update can be found here: https://github.com/prebid/prebid.github.io/pull/1765

-------
- Add support for SupplyChain (schain) in aardvark bid adapter.
- Serialize schain object into string and pass it as a query parameter to aardvark bidder.

Schain  related changes are already merged in 3.x, MR that introduced them in 3.x can be found here: https://github.com/prebid/Prebid.js/pull/4636
Docs update for schain support has already been merged (https://github.com/prebid/prebid.github.io/pull/1740)

- [x] official adapter submission
