### PR TITLE
Pass auctionId as a argument to bidsBackHandler

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -175,7 +175,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
             const bids = _bidsReceived
               .filter(utils.bind.call(adUnitsFilter, this, adUnitCodes))
               .reduce(groupByPlacement, {});
-            _callback.apply($$PREBID_GLOBAL$$, [bids, timedOut]);
+            _callback.apply($$PREBID_GLOBAL$$, [bids, timedOut, _auctionId]);
             _callback = null;
           }
         } catch (e) {


### PR DESCRIPTION
Since many people are using a lambda expression its very convenient to have the auctionId being returned into the bidsBackHandler argument

## Type of change
- [x] Feature

## Description of change
Adds auctionId as an argument to the existing bidsBackHandler call.
We use it in order to be able to take decisions in the bidsBackHandler which is the current auction that is going to be rendered.

Since the other place the auctionId is first return is the requestBids (which is outside of the Clojure and the bidsBackHandler that is being passed as a object)