### PR TITLE
Wait for DOMContentLoaded event before observe changes on document body on eplanning adapter

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -231,8 +231,14 @@ function waitForElementsPresent(elements) {
       });
     }
   });
-  const config = {childList: true, subtree: true, characterData: true, attributes: true, attributeOldValue: true};
-  observer.observe(document.body, config);
+  document.addEventListener('DOMContentLoaded', function (event) {
+    var config = {
+      childList: true,
+      subtree: true,
+      characterData: true
+    };
+    observer.observe(document.body, config);
+  });
 }
 
 function registerViewability(div) {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -532,6 +532,7 @@ describe('E-Planning Adapter', function () {
 
     context('when element is fully in view', function() {
       let respuesta;
+      const NO_VIEWABLE = 'F';
       beforeEach(function () {
         createElementVisible();
       });
@@ -539,7 +540,7 @@ describe('E-Planning Adapter', function () {
         respuesta = spec.buildRequests(bidRequests);
         clock.tick(1005);
 
-        expect(respuesta.data.vs).to.equal('F');
+        expect(respuesta.data.vs).to.equal(NO_VIEWABLE);
 
         expect(utils.getDataFromLocalStorage(storageIdRender)).to.equal('1');
         expect(utils.getDataFromLocalStorage(storageIdView)).to.equal('1');
@@ -569,6 +570,7 @@ describe('E-Planning Adapter', function () {
 
     context('when element is out of view', function() {
       let respuesta;
+      const NO_VIEWABLE = 'F';
       beforeEach(function () {
         createElementOutOfView();
       });
@@ -576,7 +578,7 @@ describe('E-Planning Adapter', function () {
       it('when you have a render', function() {
         respuesta = spec.buildRequests(bidRequests);
         clock.tick(1005);
-        expect(respuesta.data.vs).to.equal('F');
+        expect(respuesta.data.vs).to.equal(NO_VIEWABLE);
 
         expect(utils.getDataFromLocalStorage(storageIdRender)).to.equal('1');
         expect(utils.getDataFromLocalStorage(storageIdView)).to.equal(null);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Wait for DOMContentLoaded event before observe changes on document body on eplanning adapter for 2.44.x (this is already fixed on 3.x versions)

- contact email of the adapter’s maintainer: sperez@e-planning.net
- [X] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
