### PR TITLE
Add comment to keep track of sizeMapping mediaQuery bug.

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -125,6 +125,8 @@ function evaluateSizeConfig(configs) {
     ) {
       let ruleMatch = false;
 
+      // TODO: (Prebid - 4.0) Remove empty mediaQuery string check. Disallow empty mediaQuery in sizeConfig.
+      // Refer: https://github.com/prebid/Prebid.js/pull/4691, https://github.com/prebid/Prebid.js/issues/4810 for more details.
       if (config.mediaQuery === '') {
         ruleMatch = true;
       } else {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Adding a **TODO** comment to keep track of fixing the empty mediaQuery declaration issue in sizeConfig in next major Prebid release.

Related - https://github.com/prebid/Prebid.js/pull/4691

https://github.com/prebid/Prebid.js/pull/4691#discussion_r368142586