### PR TITLE
implements the todo comment in the code

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -93,8 +93,6 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
       const bannerSizes = validateSizes(mediaTypes.banner.sizes);
       if (bannerSizes.length > 0) {
         mediaTypes.banner.sizes = bannerSizes;
-        // TODO eventually remove this internal copy once we're ready to deprecate bidders from reading this adUnit.sizes property
-        adUnit.sizes = bannerSizes;
       } else {
         utils.logError('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.');
         delete adUnit.mediaTypes.banner;
@@ -107,7 +105,7 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
         let tarPlayerSizeLen = (typeof video.playerSize[0] === 'number') ? 2 : 1;
         const videoSizes = validateSizes(video.playerSize, tarPlayerSizeLen);
         if (videoSizes.length > 0) {
-          adUnit.sizes = video.playerSize = videoSizes;
+          video.playerSize = videoSizes;
         } else {
           utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.');
           delete adUnit.mediaTypes.video.playerSize;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1616,7 +1616,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badBanner
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250], [300, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner).to.be.undefined;
             assert.ok(logErrorSpy.calledWith('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.'));
 
@@ -1633,7 +1632,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badVideo1
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
             assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
@@ -1651,7 +1649,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badVideo2
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
             assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1513,7 +1513,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: fullAdUnit
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.image.sizes).to.deep.equal([150, 150]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.icon.sizes).to.deep.equal([75, 75]);
@@ -1543,7 +1542,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: noOptnlFieldAdUnit
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
 
             let mixedAdUnit = [{
@@ -1566,7 +1564,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: mixedAdUnit
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[400, 350]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
 
             let altVideoPlayerSize = [{
@@ -1582,7 +1579,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: altVideoPlayerSize
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
           });
@@ -1601,7 +1597,6 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: normalizeAdUnit
             });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner.sizes).to.deep.equal([[300, 250]]);
           });
         });


### PR DESCRIPTION
adUnit.sizes was still being referenced here in two places despite being deprecated. This simply deletes the references.

## Type of change-
 [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Removal of an object that is no longer needed

## Other information
http://prebid.org/blog/pbjs-3