### PR TITLE
Telaria Bid Adapter: add adCode & srcPageUrl query string param only once.

### DIFF
--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -227,6 +227,7 @@ function generateUrl(bid, bidderRequest) {
     const params = Object.assign({
       srcPageUrl: getDefaultSrcPageUrl()
     }, bid.params);
+    delete params.adCode;
 
     url += `${getUrlParams(params, bid.schain)}`;
 

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -119,8 +119,8 @@ export const spec = {
   }
 };
 
-function getSrcPageUrl(params) {
-  return (params && params['srcPageUrl']) || encodeURIComponent(document.location.href);
+function getDefaultSrcPageUrl() {
+  return encodeURIComponent(document.location.href);
 }
 
 function getEncodedValIfNotEmpty(val) {
@@ -175,7 +175,10 @@ export const getTimeoutUrl = function(timeoutData) {
   if (!utils.isEmpty(params)) {
     let url = `https://${EVENTS_ENDPOINT}`;
 
-    url += `?srcPageUrl=${getSrcPageUrl(params)}`;
+    params = Object.assign({
+      srcPageUrl: getDefaultSrcPageUrl()
+    }, params);
+
     url += `${getUrlParams(params)}`;
 
     url += '&hb=1&evt=TO';
@@ -221,9 +224,11 @@ function generateUrl(bid, bidderRequest) {
       url += (`&playerHeight=${height}`);
     }
 
-    url += `${getUrlParams(bid.params, bid.schain)}`;
+    const params = Object.assign({
+      srcPageUrl: getDefaultSrcPageUrl()
+    }, bid.params);
 
-    url += `&srcPageUrl=${getSrcPageUrl(bid.params)}`;
+    url += `${getUrlParams(params, bid.schain)}`;
 
     url += (`&transactionId=${bid.transactionId}`);
 

--- a/test/spec/modules/telariaBidAdapter_spec.js
+++ b/test/spec/modules/telariaBidAdapter_spec.js
@@ -118,7 +118,7 @@ describe('TelariaAdapter', () => {
   });
 
   describe('buildRequests', () => {
-    const stub = [{
+    const stub = () => ([{
       mediaTypes: {
         video: {
           playerSize: [[640, 480]],
@@ -131,7 +131,7 @@ describe('TelariaAdapter', () => {
         adCode: 'ssp-!demo!-lufip',
         videoId: 'MyCoolVideo'
       }
-    }];
+    }]);
 
     const schainStub = REQUEST_WITH_SCHAIN;
 
@@ -140,12 +140,12 @@ describe('TelariaAdapter', () => {
     });
 
     it('requires supply code & ad code to make a request', () => {
-      const tempRequest = spec.buildRequests(stub, BIDDER_REQUEST);
+      const tempRequest = spec.buildRequests(stub(), BIDDER_REQUEST);
       expect(tempRequest.length).to.equal(1);
     });
 
     it('generates an array of requests with 4 params, method, url, bidId and vastUrl', () => {
-      const tempRequest = spec.buildRequests(stub, BIDDER_REQUEST);
+      const tempRequest = spec.buildRequests(stub(), BIDDER_REQUEST);
 
       expect(tempRequest.length).to.equal(1);
       expect(tempRequest[0].method).to.equal('GET');
@@ -155,7 +155,7 @@ describe('TelariaAdapter', () => {
     });
 
     it('doesn\'t require player size but is highly recommended', () => {
-      let tempBid = stub;
+      let tempBid = stub();
       tempBid[0].mediaTypes.video.playerSize = null;
       const tempRequest = spec.buildRequests(tempBid, BIDDER_REQUEST);
 
@@ -163,7 +163,7 @@ describe('TelariaAdapter', () => {
     });
 
     it('generates a valid request with sizes as an array of two elements', () => {
-      let tempBid = stub;
+      let tempBid = stub();
       tempBid[0].mediaTypes.video.playerSize = [640, 480];
       tempBid[0].params.adCode = 'ssp-!demo!-lufip';
       tempBid[0].params.supplyCode = 'ssp-demo-rm6rh';
@@ -172,7 +172,7 @@ describe('TelariaAdapter', () => {
     });
 
     it('requires ad code and supply code to make a request', () => {
-      let tempBid = stub;
+      let tempBid = stub();
       tempBid[0].params.adCode = null;
       tempBid[0].params.supplyCode = null;
 
@@ -187,6 +187,24 @@ describe('TelariaAdapter', () => {
       tempBid[0].params.supplyCode = 'ssp-demo-rm6rh';
       let builtRequests = spec.buildRequests(tempBid, BIDDER_REQUEST);
       expect(builtRequests.length).to.equal(1);
+    });
+
+    it('adds srcPageUrl to the request url', () => {
+      const builtRequests = spec.buildRequests(stub(), BIDDER_REQUEST);
+
+      expect(builtRequests.length).to.equal(1);
+      const parts = builtRequests[0].url.split('srcPageUrl=');
+      expect(parts.length).to.equal(2);
+    });
+
+    it('adds srcPageUrl from params to the request only once', () => {
+      const tempBid = stub();
+      tempBid[0].params.srcPageUrl = 'http://www.test.com';
+      const builtRequests = spec.buildRequests(tempBid, BIDDER_REQUEST);
+
+      expect(builtRequests.length).to.equal(1);
+      const parts = builtRequests[0].url.split('srcPageUrl=');
+      expect(parts.length).to.equal(2);
     });
   });
 

--- a/test/spec/modules/telariaBidAdapter_spec.js
+++ b/test/spec/modules/telariaBidAdapter_spec.js
@@ -189,6 +189,14 @@ describe('TelariaAdapter', () => {
       expect(builtRequests.length).to.equal(1);
     });
 
+    it('adds adUnitCode to the request url', () => {
+      const builtRequests = spec.buildRequests(stub(), BIDDER_REQUEST);
+
+      expect(builtRequests.length).to.equal(1);
+      const parts = builtRequests[0].url.split('adCode=');
+      expect(parts.length).to.equal(2);
+    });
+
     it('adds srcPageUrl to the request url', () => {
       const builtRequests = spec.buildRequests(stub(), BIDDER_REQUEST);
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This PR fixes a bug where the Telaria bid adapter includes the `adCode` and `srcPageUrl` query string parameters twice if added to the bidder params.

For example, the configuration below makes a request to (note `&srcPageUrl=...` is included twice):
`https://test-supply-code.ads.tremorhub.com/ad/tag?adCode=test-ad-code&playerWidth=640&playerHeight=360&srcPageUrl=http://www.example.com&supplyCode=test-supply-code&adCode=test-ad-code&srcPageUrl=http://www.example.com&transactionId=5c5234a0-efc9-41a2-810d-defb5323c76e&referrer=http%3A%2F%2Fwww.example.com%2Freferer%2F&hb=1&fmt=json`

```
{
  bidder: 'telaria',
  params: {
    supplyCode: 'test-supply-code',
    adCode: 'test-ad-code',
    srcPageUrl: 'http://www.example.com'
}
```

This PR fixes this issue, and only embeds `srcPageUrl` once: 
`https://test-supply-code.ads.tremorhub.com/ad/tag?adCode=test-ad-code&playerWidth=640&playerHeight=360&srcPageUrl=http://www.example.com&supplyCode=test-supply-code&transactionId=5c5234a0-efc9-41a2-810d-defb5323c76e&referrer=http%3A%2F%2Fwww.example.com%2Freferer%2F&hb=1&fmt=json`

Note that, if `params.srcPageUrl` is not defined, the current default behavior applies (i.e. adding a `srcPageUrl` query string parameter containing `document.location.href`). `params.adCode` is a required field.

## Other information
I had to update the Telaria tests to return a new stub object every time in order to make the tests idempotent.