### PR TITLE
Refactor refererDetection to allow for URL discovery on AMP pages.

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -8,7 +8,7 @@
  * Canonical URL which refers to an HTML link element, with the attribute of rel="canonical", found in the <head> element of your webpage
  */
 
-import { logWarn } from './utils';
+import { logWarn } from './utils.js';
 
 /**
  * @param {Window} win Window

--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -10,33 +10,24 @@
 
 import { logWarn } from './utils';
 
+/**
+ * @param {Window} win Window
+ * @returns {Function}
+ */
 export function detectReferer(win) {
-  /**
-   * Returns number of frames to reach top from current frame where prebid.js sits
-   * @returns {Array} levels
-   */
-  function getLevels() {
-    let levels = walkUpWindows();
-    let ancestors = getAncestorOrigins();
-
-    if (ancestors) {
-      for (let i = 0, l = ancestors.length; i < l; i++) {
-        levels[i].ancestor = ancestors[i];
-      }
-    }
-    return levels;
-  }
-
   /**
    * This function would return a read-only array of hostnames for all the parent frames.
    * win.location.ancestorOrigins is only supported in webkit browsers. For non-webkit browsers it will return undefined.
+   *
+   * @param {Window} win Window object
    * @returns {(undefined|Array)} Ancestor origins or undefined
    */
-  function getAncestorOrigins() {
+  function getAncestorOrigins(win) {
     try {
       if (!win.location.ancestorOrigins) {
         return;
       }
+
       return win.location.ancestorOrigins;
     } catch (e) {
       // Ignore error
@@ -44,119 +35,23 @@ export function detectReferer(win) {
   }
 
   /**
-   * This function would try to get referer and urls for all parent frames in case of win.location.ancestorOrigins undefined.
-   * @param {Array} levels
-   * @returns {Object} urls for all parent frames and top most detected referer url
-   */
-  function getPubUrlStack(levels) {
-    let stack = [];
-    let defUrl = null;
-    let frameLocation = null;
-    let prevFrame = null;
-    let prevRef = null;
-    let ancestor = null;
-    let detectedRefererUrl = null;
-
-    let i;
-    for (i = levels.length - 1; i >= 0; i--) {
-      try {
-        frameLocation = levels[i].location;
-      } catch (e) {
-        // Ignore error
-      }
-
-      if (frameLocation) {
-        stack.push(frameLocation);
-        if (!detectedRefererUrl) {
-          detectedRefererUrl = frameLocation;
-        }
-      } else if (i !== 0) {
-        prevFrame = levels[i - 1];
-        try {
-          prevRef = prevFrame.referrer;
-          ancestor = prevFrame.ancestor;
-        } catch (e) {
-          // Ignore error
-        }
-
-        if (prevRef) {
-          stack.push(prevRef);
-          if (!detectedRefererUrl) {
-            detectedRefererUrl = prevRef;
-          }
-        } else if (ancestor) {
-          stack.push(ancestor);
-          if (!detectedRefererUrl) {
-            detectedRefererUrl = ancestor;
-          }
-        } else {
-          stack.push(defUrl);
-        }
-      } else {
-        stack.push(defUrl);
-      }
-    }
-    return {
-      stack,
-      detectedRefererUrl
-    };
-  }
-
-  /**
    * This function returns canonical URL which refers to an HTML link element, with the attribute of rel="canonical", found in the <head> element of your webpage
+   *
    * @param {Object} doc document
+   * @returns {string|null}
    */
   function getCanonicalUrl(doc) {
     try {
-      let element = doc.querySelector("link[rel='canonical']");
+      const element = doc.querySelector("link[rel='canonical']");
+
       if (element !== null) {
         return element.href;
       }
     } catch (e) {
+      // Ignore error
     }
-    return null;
-  }
 
-  /**
-   * Walk up to the top of the window to detect origin, number of iframes, ancestor origins and canonical url
-   */
-  function walkUpWindows() {
-    let acc = [];
-    let currentWindow;
-    do {
-      try {
-        currentWindow = currentWindow ? currentWindow.parent : win;
-        try {
-          let isTop = (currentWindow == win.top);
-          let refData = {
-            referrer: currentWindow.document.referrer || null,
-            location: currentWindow.location.href || null,
-            isTop
-          }
-          if (isTop) {
-            refData = Object.assign(refData, {
-              canonicalUrl: getCanonicalUrl(currentWindow.document)
-            })
-          }
-          acc.push(refData);
-        } catch (e) {
-          acc.push({
-            referrer: null,
-            location: null,
-            isTop: (currentWindow == win.top)
-          });
-          logWarn('Trying to access cross domain iframe. Continuing without referrer and location');
-        }
-      } catch (e) {
-        acc.push({
-          referrer: null,
-          location: null,
-          isTop: false
-        });
-        return acc;
-      }
-    } while (currentWindow != win.top);
-    return acc;
+    return null;
   }
 
   /**
@@ -170,31 +65,114 @@ export function detectReferer(win) {
    */
 
   /**
-   * Get referer info
+   * Walk up the windows to get the origin stack and best available referrer, canonical URL, etc.
+   *
    * @returns {refererInfo}
    */
   function refererInfo() {
-    try {
-      let levels = getLevels();
-      let numIframes = levels.length - 1;
-      let reachedTop = (levels[numIframes].location !== null ||
-        (numIframes > 0 && levels[numIframes - 1].referrer !== null));
-      let stackInfo = getPubUrlStack(levels);
-      let canonicalUrl;
-      if (levels[levels.length - 1].canonicalUrl) {
-        canonicalUrl = levels[levels.length - 1].canonicalUrl;
+    const stack = [];
+    const ancestors = getAncestorOrigins(win);
+    let currentWindow;
+    let bestReferrer;
+    let bestCanonicalUrl;
+    let reachedTop = false;
+    let level = 0;
+    let valuesFromAmp = false;
+    let inAmpFrame = false;
+
+    do {
+      const previousWindow = currentWindow;
+      const wasInAmpFrame = inAmpFrame;
+      let currentLocation;
+      let crossOrigin = false;
+      let foundReferrer = null;
+
+      inAmpFrame = false;
+      currentWindow = currentWindow ? currentWindow.parent : win;
+
+      try {
+        currentLocation = currentWindow.location.href || null;
+      } catch (e) {
+        crossOrigin = true;
       }
 
-      return {
-        referer: stackInfo.detectedRefererUrl,
-        reachedTop,
-        numIframes,
-        stack: stackInfo.stack,
-        canonicalUrl
-      };
-    } catch (e) {
-      // Ignore error
-    }
+      if (crossOrigin) {
+        if (wasInAmpFrame) {
+          const context = previousWindow.context;
+
+          try {
+            foundReferrer = context.sourceUrl;
+            bestReferrer = foundReferrer;
+
+            valuesFromAmp = true;
+
+            if (currentWindow === win.top) {
+              reachedTop = true;
+            }
+
+            if (context.canonicalUrl) {
+              bestCanonicalUrl = context.canonicalUrl;
+            }
+          } catch (e) { /* Do nothing */ }
+        } else {
+          logWarn('Trying to access cross domain iframe. Continuing without referrer and location');
+
+          try {
+            const referrer = previousWindow.document.referrer;
+
+            if (referrer) {
+              foundReferrer = referrer;
+
+              if (currentWindow === win.top) {
+                reachedTop = true;
+              }
+            }
+          } catch (e) { /* Do nothing */ }
+
+          if (!foundReferrer && ancestors && ancestors[level - 1]) {
+            foundReferrer = ancestors[level - 1];
+          }
+
+          if (foundReferrer && !valuesFromAmp) {
+            bestReferrer = foundReferrer;
+          }
+        }
+      } else {
+        if (currentLocation) {
+          foundReferrer = currentLocation;
+          bestReferrer = foundReferrer;
+          valuesFromAmp = false;
+
+          if (currentWindow === win.top) {
+            reachedTop = true;
+
+            const canonicalUrl = getCanonicalUrl(currentWindow.document);
+
+            if (canonicalUrl) {
+              bestCanonicalUrl = canonicalUrl;
+            }
+          }
+        }
+
+        if (currentWindow.context && currentWindow.context.sourceUrl) {
+          inAmpFrame = true;
+        }
+      }
+
+      stack.push(foundReferrer);
+      level++;
+    } while (currentWindow !== win.top);
+
+    stack.reverse();
+
+    return {
+      referer: bestReferrer || null,
+      reachedTop,
+      isAmp: valuesFromAmp,
+      numIframes: level - 1,
+      stack,
+      canonicalUrl: bestCanonicalUrl || null
+    };
   }
 
   return refererInfo;

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -1,87 +1,357 @@
 import { detectReferer } from 'src/refererDetection';
 import { expect } from 'chai';
 
-var mocks = {
-  createFakeWindow: function (referrer, href) {
-    return {
-      document: {
-        referrer: referrer
-      },
-      location: {
-        href: href,
-        // TODO: add ancestorOrigins to increase test coverage
-      },
-      parent: null,
-      top: null
-    };
-  }
-}
+/**
+ * Build a walkable linked list of window-like objects for testing.
+ *
+ * @param {Array} urls Array of URL strings starting from the top window.
+ * @param {string} [topReferrer]
+ * @param {string} [canonicalUrl]
+ * @param {boolean} [ancestorOrigins]
+ * @returns {Object}
+ */
+function buildWindowTree(urls, topReferrer = '', canonicalUrl = null, ancestorOrigins = false) {
+  /**
+     * Find the origin from a given fully-qualified URL.
+     *
+     * @param {string} url The fully qualified URL
+     * @returns {string|null}
+     */
+  function getOrigin(url) {
+    const originRegex = new RegExp('^(https?://[^/]+/?)');
 
-describe('referer detection', () => {
-  it('should return referer details in nested friendly iframes', function() {
-    // Fake window object to test friendly iframes
-    // - Main page http://example.com/page.html
-    // - - Iframe1 http://example.com/iframe1.html
-    // - - - Iframe2 http://example.com/iframe2.html
-    let mockIframe2WinObject = mocks.createFakeWindow('http://example.com/iframe1.html', 'http://example.com/iframe2.html');
-    let mockIframe1WinObject = mocks.createFakeWindow('http://example.com/page.html', 'http://example.com/iframe1.html');
-    let mainWinObject = mocks.createFakeWindow('http://example.com/page.html', 'http://example.com/page.html');
-    mainWinObject.document.querySelector = function() {
-      return {
-        href: 'http://prebid.org'
+    const result = originRegex.exec(url);
+
+    if (result && result[0]) {
+      return result[0];
+    }
+
+    return null;
+  }
+
+  let previousWindow;
+  const myOrigin = getOrigin(urls[urls.length - 1]);
+
+  const windowList = urls.map((url, index) => {
+    const theirOrigin = getOrigin(url),
+      sameOrigin = (myOrigin === theirOrigin);
+
+    const win = {};
+
+    if (sameOrigin) {
+      win.location = {
+        href: url
+      };
+
+      if (ancestorOrigins) {
+        win.location.ancestorOrigins = urls.slice(0, index).reverse().map(getOrigin);
+      }
+
+      if (index === 0) {
+        win.document = {
+          referrer: topReferrer
+        };
+
+        if (canonicalUrl) {
+          win.document.querySelector = function(selector) {
+            if (selector === "link[rel='canonical']") {
+              return {
+                href: canonicalUrl
+              };
+            }
+
+            return null;
+          };
+        }
+      } else {
+        win.document = {
+          referrer: urls[index - 1]
+        };
       }
     }
-    mockIframe2WinObject.parent = mockIframe1WinObject;
-    mockIframe2WinObject.top = mainWinObject;
-    mockIframe1WinObject.parent = mainWinObject;
-    mockIframe1WinObject.top = mainWinObject;
-    mainWinObject.top = mainWinObject;
 
-    const getRefererInfo = detectReferer(mockIframe2WinObject);
-    let result = getRefererInfo();
-    let expectedResult = {
-      referer: 'http://example.com/page.html',
-      reachedTop: true,
-      numIframes: 2,
-      stack: [
-        'http://example.com/page.html',
-        'http://example.com/iframe1.html',
-        'http://example.com/iframe2.html'
-      ],
-      canonicalUrl: 'http://prebid.org'
-    };
-    expect(result).to.deep.equal(expectedResult);
+    previousWindow = win;
+
+    return win;
   });
 
-  it('should return referer details in nested cross domain iframes', function() {
-    // Fake window object to test cross domain iframes.
-    // - Main page http://example.com/page.html
-    // - - Iframe1 http://aaa.com/iframe1.html
-    // - - - Iframe2 http://bbb.com/iframe2.html
-    let mockIframe2WinObject = mocks.createFakeWindow('http://aaa.com/iframe1.html', 'http://bbb.com/iframe2.html');
-    // Sinon cannot throw exception when accessing a propery so passing null to create cross domain
-    // environment for refererDetection module
-    let mockIframe1WinObject = mocks.createFakeWindow(null, null);
-    let mainWinObject = mocks.createFakeWindow(null, null);
-    mockIframe2WinObject.parent = mockIframe1WinObject;
-    mockIframe2WinObject.top = mainWinObject;
-    mockIframe1WinObject.parent = mainWinObject;
-    mockIframe1WinObject.top = mainWinObject;
-    mainWinObject.top = mainWinObject;
+  const topWindow = windowList[0];
 
-    const getRefererInfo = detectReferer(mockIframe2WinObject);
-    let result = getRefererInfo();
-    let expectedResult = {
-      referer: 'http://aaa.com/iframe1.html',
-      reachedTop: false,
-      numIframes: 2,
-      stack: [
-        null,
-        'http://aaa.com/iframe1.html',
-        'http://bbb.com/iframe2.html'
-      ],
-      canonicalUrl: undefined
-    };
-    expect(result).to.deep.equal(expectedResult);
+  previousWindow = null;
+
+  windowList.forEach((win) => {
+    win.top = topWindow;
+    win.parent = previousWindow || topWindow;
+    previousWindow = win;
+  });
+
+  return windowList[windowList.length - 1];
+}
+
+describe('Referer detection', () => {
+  describe('Non cross-origin scenarios', () => {
+    describe('No iframes', () => {
+      it('Should return the current window location and no canonical URL', () => {
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/'),
+          result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 0,
+          stack: ['https://example.com/some/page'],
+          canonicalUrl: null
+        });
+      });
+
+      it('Should return the current window location and a canonical URL', () => {
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
+          result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 0,
+          stack: ['https://example.com/some/page'],
+          canonicalUrl: 'https://example.com/canonical/page'
+        });
+      });
+    });
+
+    describe('Friendly iframes', () => {
+      it('Should return the top window location and no canonical URL', () => {
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/'),
+          result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 2,
+          stack: [
+            'https://example.com/some/page',
+            'https://example.com/other/page',
+            'https://example.com/third/page'
+          ],
+          canonicalUrl: null
+        });
+      });
+
+      it('Should return the top window location and a canonical URL', () => {
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
+          result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 2,
+          stack: [
+            'https://example.com/some/page',
+            'https://example.com/other/page',
+            'https://example.com/third/page'
+          ],
+          canonicalUrl: 'https://example.com/canonical/page'
+        });
+      });
+    });
+  });
+
+  describe('Cross-origin scenarios', () => {
+    it('Should return the top URL and no canonical URL with one cross-origin iframe', () => {
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
+        result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://example.com/some/page',
+        reachedTop: true,
+        isAmp: false,
+        numIframes: 1,
+        stack: [
+          'https://example.com/some/page',
+          'https://safe.frame/ad'
+        ],
+        canonicalUrl: null
+      });
+    });
+
+    it('Should return the top URL and no canonical URL with one cross-origin iframe and one friendly iframe', () => {
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
+        result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://example.com/some/page',
+        reachedTop: true,
+        isAmp: false,
+        numIframes: 2,
+        stack: [
+          'https://example.com/some/page',
+          'https://safe.frame/ad',
+          'https://safe.frame/ad'
+        ],
+        canonicalUrl: null
+      });
+    });
+
+    it('Should return the second iframe location with three cross-origin windows and no ancessorOrigins', () => {
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
+        result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://safe.frame/ad',
+        reachedTop: false,
+        isAmp: false,
+        numIframes: 2,
+        stack: [
+          null,
+          'https://safe.frame/ad',
+          'https://otherfr.ame/ad'
+        ],
+        canonicalUrl: null
+      });
+    });
+
+    it('Should return the top window origin with three cross-origin windows with ancessorOrigins', () => {
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/', true),
+        result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://example.com/',
+        reachedTop: false,
+        isAmp: false,
+        numIframes: 2,
+        stack: [
+          'https://example.com/',
+          'https://safe.frame/ad',
+          'https://otherfr.ame/ad'
+        ],
+        canonicalUrl: null
+      });
+    });
+  });
+
+  describe('Cross-origin AMP page scenarios', () => {
+    it('Should return the AMP page source and canonical URLs in an amp-ad iframe for a non-cached AMP page', () => {
+      const testWindow = buildWindowTree(['https://example.com/some/page/amp/', 'https://ad-iframe.ampproject.org/ad']);
+
+      testWindow.context = {
+        sourceUrl: 'https://example.com/some/page/amp/',
+        canonicalUrl: 'https://example.com/some/page/'
+      };
+
+      const result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://example.com/some/page/amp/',
+        reachedTop: true,
+        isAmp: true,
+        numIframes: 1,
+        stack: [
+          'https://example.com/some/page/amp/',
+          'https://ad-iframe.ampproject.org/ad'
+        ],
+        canonicalUrl: 'https://example.com/some/page/'
+      });
+    });
+
+    it('Should return the AMP page source and canonical URLs in an amp-ad iframe for a cached AMP page on top', () => {
+      const testWindow = buildWindowTree(['https://example-com.amp-cache.example.com/some/page/amp/', 'https://ad-iframe.ampproject.org/ad']);
+
+      testWindow.context = {
+        sourceUrl: 'https://example.com/some/page/amp/',
+        canonicalUrl: 'https://example.com/some/page/'
+      };
+
+      const result = detectReferer(testWindow)();
+
+      expect(result).to.deep.equal({
+        referer: 'https://example.com/some/page/amp/',
+        reachedTop: true,
+        isAmp: true,
+        numIframes: 1,
+        stack: [
+          'https://example.com/some/page/amp/',
+          'https://ad-iframe.ampproject.org/ad'
+        ],
+        canonicalUrl: 'https://example.com/some/page/'
+      });
+    });
+
+    describe('Cached AMP page in iframed search result', () => {
+      it('Should return the AMP source and canonical URLs but with a null top-level stack location Without ancesorOrigins', () => {
+        const testWindow = buildWindowTree(['https://google.com/amp/example-com/some/page/amp/', 'https://example-com.amp-cache.example.com/some/page/amp/', 'https://ad-iframe.ampproject.org/ad']);
+
+        testWindow.context = {
+          sourceUrl: 'https://example.com/some/page/amp/',
+          canonicalUrl: 'https://example.com/some/page/'
+        };
+
+        const result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page/amp/',
+          reachedTop: false,
+          isAmp: true,
+          numIframes: 2,
+          stack: [
+            null,
+            'https://example.com/some/page/amp/',
+            'https://ad-iframe.ampproject.org/ad'
+          ],
+          canonicalUrl: 'https://example.com/some/page/'
+        });
+      });
+
+      it('Should return the AMP source and canonical URLs and include the top window origin in the stack with ancesorOrigins', () => {
+        const testWindow = buildWindowTree(['https://google.com/amp/example-com/some/page/amp/', 'https://example-com.amp-cache.example.com/some/page/amp/', 'https://ad-iframe.ampproject.org/ad'], null, null, true);
+
+        testWindow.context = {
+          sourceUrl: 'https://example.com/some/page/amp/',
+          canonicalUrl: 'https://example.com/some/page/'
+        };
+
+        const result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page/amp/',
+          reachedTop: false,
+          isAmp: true,
+          numIframes: 2,
+          stack: [
+            'https://google.com/',
+            'https://example.com/some/page/amp/',
+            'https://ad-iframe.ampproject.org/ad'
+          ],
+          canonicalUrl: 'https://example.com/some/page/'
+        });
+      });
+
+      it('Should return the AMP source and canonical URLs and include the top window origin in the stack with ancesorOrigins and a friendly iframe under the amp-ad iframe', () => {
+        const testWindow = buildWindowTree(['https://google.com/amp/example-com/some/page/amp/', 'https://example-com.amp-cache.example.com/some/page/amp/', 'https://ad-iframe.ampproject.org/ad', 'https://ad-iframe.ampproject.org/ad'], null, null, true);
+
+        testWindow.parent.context = {
+          sourceUrl: 'https://example.com/some/page/amp/',
+          canonicalUrl: 'https://example.com/some/page/'
+        };
+
+        const result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page/amp/',
+          reachedTop: false,
+          isAmp: true,
+          numIframes: 3,
+          stack: [
+            'https://google.com/',
+            'https://example.com/some/page/amp/',
+            'https://ad-iframe.ampproject.org/ad',
+            'https://ad-iframe.ampproject.org/ad'
+          ],
+          canonicalUrl: 'https://example.com/some/page/'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Updates the referrer detection code to allow discovery of and attribution to original URLs on AMP pages served from caches.  Info on the AMP ad iframe context information can be found here: https://github.com/ampproject/amphtml/blob/master/ads/README.md#available-information-to-the-ad

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
I will provide this tomorrow.  There is a single new property on the object returned by `getRefererInfo`: `isAmp` is `true` if the detected referrer was obtained by the AMP context.

## Other information
Related issues:
https://github.com/prebid/Prebid.js/issues/880
https://github.com/prebid/Prebid.js/issues/1284