### PR TITLE
Fix for trackerName bug in Google Analytics adapter

### DIFF
--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -31,15 +31,29 @@ let adapter = {};
  * @param  {object} options use to configure adapter;
  * @return {[type]}    [description]
  */
-adapter.enableAnalytics = function ({ provider, options }) {
+adapter.enableAnalytics = function ({ provider, options, trackingId }) {
   _gaGlobal = provider || 'ga';
-  _trackerSend = options && options.trackerName ? options.trackerName + '.send' : 'send';
-  _sampled = typeof options === 'undefined' || typeof options.sampling === 'undefined' ||
-             Math.random() < parseFloat(options.sampling);
 
   if (options && typeof options.global !== 'undefined') {
     _gaGlobal = options.global;
   }
+
+  if (typeof trackingId !== 'string') {
+    utils.logWarn(`GA tracking ID missing in call to 'pbjs.enableAnalytics()'. Events won't be sent to GA.`);
+  } else {
+    if (options && options.trackerName) {
+      _analyticsQueue.push(function () {
+        window[_gaGlobal]('create', trackingId, 'auto', options.trackerName);
+      });
+      _trackerSend = `${options.trackerName}.send`;
+    } else {
+      _trackerSend = `gtag_${trackingId.replace(/-/gi, '_')}.send`;
+    }
+  }
+
+  _sampled = typeof options === 'undefined' || typeof options.sampling === 'undefined' ||
+    Math.random() < parseFloat(options.sampling);
+
   if (options && typeof options.enableDistribution !== 'undefined') {
     _enableDistribution = options.enableDistribution;
   }

--- a/test/spec/modules/googleAnalyticsAdapter_spec.js
+++ b/test/spec/modules/googleAnalyticsAdapter_spec.js
@@ -7,7 +7,7 @@ describe('Ga', function () {
     var cpmDistribution = function(cpm) {
       return cpm <= 1 ? '<= 1$' : '> 1$';
     }
-    var config = { options: { trackerName: 'foo', enableDistribution: true, cpmDistribution: cpmDistribution } };
+    var config = { trackingId: 'U-3434-3434', options: { trackerName: 'foo', enableDistribution: true, cpmDistribution: cpmDistribution } };
 
     // enableAnalytics can only be called once
     ga.enableAnalytics(config);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change

When we try to configure Google Analytics with Prebid.js using the following code snippet,

(Take note that we are configuring our own trackerName and NOT using the default one!)
```(javascript)
  pbjs.enableAnalytics({
    provider: 'ga',
    options: {
      trackerName: 'myTracker'
    }
  });
```

The current implementation DOES NOT CREATE a tracker with the trackerName stated above. It ultimately results in the events that are generated in Prebid.js not being sent to GA server.

Also, if we decide to use the default trackerName name (by not providing any trackerName in the options property), still the current implementation will fail to send events to the GA server.

This PR includes a fix for both the problems discussed above. But it introduces a mandatory property that you need to provide while calling the API pbjs.enableAnalytics(). The mandatory property is trackingId.

You will now configure GA like this:

```(javascript)
  pbjs.enableAnalytics({
    provider: 'ga',
    trackingId: 'UA-323-323',
    options: {
      trackerName: 'myTracker'
    }
  });
```

This property, trackingId, is the same trackingId that you get whilte you configure and create a property in your GA account.

There is a hack for the current implementation though, which can still help us send events to GA. You have to provide this config while configuring GA.

```(javascript)
  pbjs.enableAnalytics({
    provider: 'ga',
    options: {
      trackerName: 'gtag_UA_323_323'
    }
  });
```

If you manually provide a trackerName and prepend the string `gtag_` in front of your tracking id, you'll still be able to send events to GA. But, this doesn't allow you to rename the trackerName to something else, which can be a useful feature if you're tracking multiple things on a webpage.

Please use this Chrome App, [GA Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) to see all the events being sent to GA.