### PR TITLE
Updating criteo-direct-rsa-validate to 1.1.0 to fix issue #4851

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "babel-plugin-transform-object-assign": "^6.22.0",
     "core-js": "^2.4.1",
-    "criteo-direct-rsa-validate": "^1.0.0",
+    "criteo-direct-rsa-validate": "^1.1.0",
     "crypto-js": "^3.1.9-1",
     "deep-equal": "^1.0.1",
     "dlv": "1.1.3",


### PR DESCRIPTION
##Type of change
- [X] Bugfix

## Description of change
Fixing issue #4851 
We've release a new version of our library. Dependencies were wrongly typed as 'dependencies' instead of 'devDependencies'. Moreover, the 'build' dependency was not used and could be removed.