### PR TITLE
onetagBidAdapter: added CCPA support

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -53,6 +53,10 @@ function buildRequests(validBidRequests, bidderRequest) {
     };
   }
 
+  if (bidderRequest && bidderRequest.uspConsent) {
+    payload.usPrivacy = bidderRequest.uspConsent;
+  }
+
   const payloadString = JSON.stringify(payload);
 
   return {
@@ -63,7 +67,7 @@ function buildRequests(validBidRequests, bidderRequest) {
 }
 
 function interpretResponse(serverResponse, request) {
-  var body = serverResponse.body;
+  let body = serverResponse.body;
   const bids = [];
 
   if (typeof serverResponse === 'string') {
@@ -104,7 +108,7 @@ function interpretResponse(serverResponse, request) {
  * @returns {{location: *, referrer: (*|string), masked: *, wWidth: (*|Number), wHeight: (*|Number), sWidth, sHeight, date: string, timeOffset: number}}
  */
 function getPageInfo() {
-  var w, d, l, r, m, p, e, t, s;
+  let w, d, l, r, m, p, e, t, s;
   for (w = window, d = w.document, l = d.location.href, r = d.referrer, m = 0, e = encodeURIComponent, t = new Date(), s = screen; w !== w.parent;) {
     try {
       p = w.parent; l = p.location.href; r = p.document.referrer; w = p;
@@ -170,7 +174,7 @@ function requestsToBids(bid) {
   return toRet;
 }
 
-function getUserSyncs(syncOptions, serverResponses, gdprConsent) {
+function getUserSyncs(syncOptions, serverResponses, gdprConsent, usPrivacy) {
   const syncs = [];
   if (syncOptions.iframeEnabled) {
     const rnd = new Date().getTime();
@@ -181,6 +185,10 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent) {
       if (typeof gdprConsent.gdprApplies === 'boolean') {
         params += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
       }
+    }
+
+    if (usPrivacy && typeof usPrivacy === 'string') {
+      params += '&us_privacy=' + usPrivacy;
     }
 
     syncs.push({

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -174,7 +174,7 @@ function requestsToBids(bid) {
   return toRet;
 }
 
-function getUserSyncs(syncOptions, serverResponses, gdprConsent, usPrivacy) {
+function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
   const syncs = [];
   if (syncOptions.iframeEnabled) {
     const rnd = new Date().getTime();
@@ -187,8 +187,8 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, usPrivacy) {
       }
     }
 
-    if (usPrivacy && typeof usPrivacy === 'string') {
-      params += '&us_privacy=' + usPrivacy;
+    if (uspConsent && typeof uspConsent === 'string') {
+      params += '&us_privacy=' + uspConsent;
     }
 
     syncs.push({

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -113,6 +113,21 @@ describe('onetag', function () {
       expect(payload.gdprConsent.consentString).to.exist.and.to.equal(consentString);
       expect(payload.gdprConsent.consentRequired).to.exist.and.to.be.true;
     });
+    it('should send us privacy string', function () {
+      let consentString = 'us_foo';
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        'uspConsent': consentString
+      };
+      let serverRequest = spec.buildRequests([bid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+
+      expect(payload.usPrivacy).to.exist;
+      expect(payload.usPrivacy).to.exist.and.to.equal(consentString);
+    });
   });
   describe('interpretResponse', function () {
     const resObject = {
@@ -203,6 +218,13 @@ describe('onetag', function () {
       expect(syncs[0].type).to.equal('iframe');
       expect(syncs[0].url).to.include(sync_endpoint);
       expect(syncs[0].url).to.not.match(/(?:[?&](?:gdpr_consent=([^&]*)|gdpr=([^&]*)))+$/);
+    });
+    it('Should send us privacy string', function () {
+      let usConsentString = 'us_foo';
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, {}, {}, usConsentString);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.include(sync_endpoint);
+      expect(syncs[0].url).to.match(/(?:[?&](?:us_privacy=us_foo(?:[&][^&]*)*))+$/);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added support for CCPA consent data from the CMP.

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/ : 
https://github.com/prebid/prebid.github.io/pull/1793

Replaces #4823