### PR TITLE
Revert "implements the todo comment in the code"

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -93,6 +93,8 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
       const bannerSizes = validateSizes(mediaTypes.banner.sizes);
       if (bannerSizes.length > 0) {
         mediaTypes.banner.sizes = bannerSizes;
+        // TODO eventually remove this internal copy once we're ready to deprecate bidders from reading this adUnit.sizes property
+        adUnit.sizes = bannerSizes;
       } else {
         utils.logError('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.');
         delete adUnit.mediaTypes.banner;
@@ -105,7 +107,7 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
         let tarPlayerSizeLen = (typeof video.playerSize[0] === 'number') ? 2 : 1;
         const videoSizes = validateSizes(video.playerSize, tarPlayerSizeLen);
         if (videoSizes.length > 0) {
-          video.playerSize = videoSizes;
+          adUnit.sizes = video.playerSize = videoSizes;
         } else {
           utils.logError('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.');
           delete adUnit.mediaTypes.video.playerSize;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1513,6 +1513,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: fullAdUnit
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.image.sizes).to.deep.equal([150, 150]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.icon.sizes).to.deep.equal([75, 75]);
@@ -1542,6 +1543,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: noOptnlFieldAdUnit
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
 
             let mixedAdUnit = [{
@@ -1564,6 +1566,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: mixedAdUnit
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[400, 350]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
 
             let altVideoPlayerSize = [{
@@ -1579,6 +1582,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: altVideoPlayerSize
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
           });
@@ -1597,6 +1601,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: normalizeAdUnit
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner.sizes).to.deep.equal([[300, 250]]);
           });
         });
@@ -1616,6 +1621,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badBanner
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250], [300, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner).to.be.undefined;
             assert.ok(logErrorSpy.calledWith('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.'));
 
@@ -1632,6 +1638,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badVideo1
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
             assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
@@ -1649,6 +1656,7 @@ describe('Unit: Prebid Module', function () {
             $$PREBID_GLOBAL$$.requestBids({
               adUnits: badVideo2
             });
+            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
             expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
             expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
             assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));


### PR DESCRIPTION
Reverts prebid/Prebid.js#4821

Some issues have been reported as a result of the original commit; namely in the dfpAdServerVideo module not successfully building the video adUrl.

Need to undo this change for now until more analysis can be done for this type of change.