### PR TITLE
update criteo userid in appnexus bid adapter

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -182,12 +182,12 @@ export const spec = {
       });
     }
 
-    const rtusId = utils.deepAccess(bidRequests[0], `userId.criteortus.${BIDDER_CODE}.userid`);
-    if (rtusId) {
+    const criteoId = utils.deepAccess(bidRequests[0], `userId.criteoId`);
+    if (criteoId) {
       let tpuids = [];
       tpuids.push({
         'provider': 'criteo',
-        'user_id': rtusId
+        'user_id': criteoId
       });
       payload.tpuids = tpuids;
     }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -681,11 +681,7 @@ describe('AppNexusAdapter', function () {
     it('should populate tpids array when userId is available', function () {
       const bidRequest = Object.assign({}, bidRequests[0], {
         userId: {
-          criteortus: {
-            appnexus: {
-              userid: 'sample-userid'
-            }
-          }
+          criteoId: 'sample-userid'
         }
       });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fix for #4860 

Updating the criteo userId reference in the appnexus bid adapter to the supported version from the `criteoIdSystem` file.