### PR TITLE
Trion 2.44 legacy adapter update

### DIFF
--- a/modules/trionBidAdapter.js
+++ b/modules/trionBidAdapter.js
@@ -11,13 +11,13 @@ export const spec = {
   isBidRequestValid: function (bid) {
     return !!(bid && bid.params && bid.params.pubId && bid.params.sectionId);
   },
-  buildRequests: function (validBidRequests) {
+  buildRequests: function (validBidRequests, bidderRequest) {
     var bidRequests = [];
 
     for (var i = 0; i < validBidRequests.length; i++) {
       var bid = validBidRequests[i];
 
-      var trionUrlParams = buildTrionUrlParams(bid);
+      var trionUrlParams = buildTrionUrlParams(bid, bidderRequest);
 
       bidRequests.push({
         method: 'GET',
@@ -56,12 +56,12 @@ export const spec = {
 
     return bidResponses;
   },
-  getUserSyncs: function getUserSyncs(syncOptions) {
+  getUserSyncs: function getUserSyncs(syncOptions, serverResponses, gdprConsent, usPrivacy) {
     if (syncOptions.iframeEnabled) {
       handlePostMessage();
       return [{
         type: 'iframe',
-        url: getSyncUrl()
+        url: getSyncUrl(gdprConsent, usPrivacy)
       }];
     }
   }
@@ -69,23 +69,50 @@ export const spec = {
 };
 registerBidder(spec);
 
-function getSyncUrl() {
+function getSyncUrl(gdprConsent, usPrivacy) {
   var unParsedPubAndSection = getStorageData(BASE_KEY + 'lps') || ':';
   var pubSectionArray = unParsedPubAndSection.split(':') || [];
   var pubId = pubSectionArray[0] || -1;
   var sectionId = pubSectionArray[1] || -1;
-  var url = utils.getTopWindowUrl();
-  return USER_SYNC_URL + `?p=${pubId}&s=${sectionId}&u=${url}`;
+  var url = getPublisherUrl();
+  var consentParams = '';
+  if (gdprConsent) {
+    if (gdprConsent.consentString) {
+      consentParams += '&gc=' + encodeURIComponent(gdprConsent.consentString);
+    }
+    consentParams += '&g=' + (gdprConsent.gdprApplies ? 1 : 0);
+  }
+  if (usPrivacy) {
+    consentParams = '&up=' + encodeURIComponent(usPrivacy);
+  }
+  return USER_SYNC_URL + `?p=${pubId}&s=${sectionId}${consentParams}&u=${url}`;
 }
 
-function buildTrionUrlParams(bid) {
+function getPublisherUrl() {
+  var url = '';
+  try {
+    if (window.top == window) {
+      url = window.location.href;
+    } else {
+      try {
+        url = window.top.location.href;
+      } catch (e) {
+        url = document.referrer;
+      }
+    }
+  } catch (e) {
+  }
+  return url
+}
+
+function buildTrionUrlParams(bid, bidderRequest) {
   var pubId = utils.getBidIdParameter('pubId', bid.params);
   var sectionId = utils.getBidIdParameter('sectionId', bid.params);
-  var re = utils.getBidIdParameter('re', bid.params);
-  var url = utils.getTopWindowUrl();
-  var sizes = utils.parseSizesInput(bid.sizes).join(',');
-  var isAutomated = (navigator && navigator.webdriver) ? 1 : 0;
-  var isHidden = (document.hidden) ? 1 : 0;
+  var url = getPublisherUrl();
+  var bidSizes = getBidSizesFromBidRequest(bid);
+  var sizes = utils.parseSizesInput(bidSizes).join(',');
+  var isAutomated = (navigator && navigator.webdriver) ? '1' : '0';
+  var isHidden = (document.hidden) ? '1' : '0';
   var visibilityState = encodeURIComponent(document.visibilityState);
 
   var intT = window.TR_INT_T && window.TR_INT_T != -1 ? window.TR_INT_T : null;
@@ -101,7 +128,7 @@ function buildTrionUrlParams(bid) {
   trionUrl = utils.tryAppendQueryString(trionUrl, 'bidId', bid.bidId);
   trionUrl = utils.tryAppendQueryString(trionUrl, 'pubId', pubId);
   trionUrl = utils.tryAppendQueryString(trionUrl, 'sectionId', sectionId);
-  trionUrl = utils.tryAppendQueryString(trionUrl, 're', re);
+  trionUrl = utils.tryAppendQueryString(trionUrl, 'vers', '$prebid.version$');
   if (url) {
     trionUrl += 'url=' + url + '&';
   }
@@ -114,12 +141,27 @@ function buildTrionUrlParams(bid) {
   trionUrl = utils.tryAppendQueryString(trionUrl, 'tr_wd', isAutomated);
   trionUrl = utils.tryAppendQueryString(trionUrl, 'tr_hd', isHidden);
   trionUrl = utils.tryAppendQueryString(trionUrl, 'tr_vs', visibilityState);
-
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    var gdpr = bidderRequest.gdprConsent;
+    if (gdpr) {
+      if (gdpr.consentString) {
+        trionUrl = utils.tryAppendQueryString(trionUrl, 'gdprc', encodeURIComponent(gdpr.consentString));
+      }
+      trionUrl = utils.tryAppendQueryString(trionUrl, 'gdpr', (gdpr.gdprApplies ? 1 : 0));
+    }
+  }
+  if (bidderRequest && bidderRequest.uspConsent) {
+    trionUrl = utils.tryAppendQueryString(trionUrl, 'usp', encodeURIComponent(bidderRequest.uspConsent));
+  }
   // remove the trailing "&"
   if (trionUrl.lastIndexOf('&') === trionUrl.length - 1) {
     trionUrl = trionUrl.substring(0, trionUrl.length - 1);
   }
   return trionUrl;
+}
+
+function getBidSizesFromBidRequest(bid) {
+  return (bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) ? bid.mediaTypes.banner.sizes : bid.sizes;
 }
 
 function handlePostMessage() {

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -13,6 +13,11 @@ const TRION_BID = {
     pubId: '1',
     sectionId: '2'
   },
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 250], [300, 600]]
+    }
+  },
   adUnitCode: 'adunit-code',
   sizes: [[300, 250], [300, 600]],
   bidId: 'test-bid-id',
@@ -20,6 +25,13 @@ const TRION_BID = {
 };
 
 const TRION_BID_REQUEST = [TRION_BID];
+
+const TRION_BIDDER_REQUEST = {
+  'bidderCode': 'trion',
+  'auctionId': '12345',
+  'bidderRequestId': 'abc1234',
+  'bids': TRION_BID_REQUEST
+};
 
 const TRION_BID_RESPONSE = {
   bidId: 'test-bid-id',
@@ -33,6 +45,23 @@ const TRION_BID_RESPONSE = {
     msg: 'response messaging'
   }
 
+};
+
+const getPublisherUrl = function () {
+  var url = null;
+  try {
+    if (window.top == window) {
+      url = window.location.href;
+    } else {
+      try {
+        url = window.top.location.href;
+      } catch (e) {
+        url = document.referrer;
+      }
+    }
+  } catch (e) {
+  }
+  return url
 };
 
 describe('Trion adapter tests', function () {
@@ -107,17 +136,13 @@ describe('Trion adapter tests', function () {
       expect(bidUrlParams).to.include('pubId=1');
       expect(bidUrlParams).to.include('sectionId=2');
       expect(bidUrlParams).to.include('sizes=300x250,300x600');
+      expect(bidUrlParams).to.include('vers=$prebid.version$');
     });
 
     it('should call buildRequests with the correct optional params', function () {
-      let params = TRION_BID_REQUEST[0].params;
-      params.re = 1;
       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
-
       let bidUrlParams = bidRequests[0].data;
-      expect(bidUrlParams).to.include('re=1');
-      expect(bidUrlParams).to.include(utils.getTopWindowUrl());
-      delete params.re;
+      expect(bidUrlParams).to.include(getPublisherUrl());
     });
 
     describe('webdriver', function () {
@@ -125,9 +150,6 @@ describe('Trion adapter tests', function () {
 
       beforeEach(function () {
         originalWD = window.navigator.webdriver;
-        window.navigator['__defineGetter__']('webdriver', function () {
-          return 1;
-        });
       });
 
       afterEach(function () {
@@ -136,26 +158,42 @@ describe('Trion adapter tests', function () {
         });
       });
 
-      it('should send the correct state when there is non human traffic', function () {
-        let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
-        let bidUrlParams = bidRequests[0].data;
-        expect(bidUrlParams).to.include('tr_wd=1');
+      describe('is present', function () {
+        beforeEach(function () {
+          window.navigator['__defineGetter__']('webdriver', function () {
+            return 1;
+          });
+        });
+
+        it('when there is non human traffic', function () {
+          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+          let bidUrlParams = bidRequests[0].data;
+          expect(bidUrlParams).to.include('tr_wd=1');
+        });
+      });
+
+      describe('is not present', function () {
+        beforeEach(function () {
+          window.navigator['__defineGetter__']('webdriver', function () {
+            return 0;
+          });
+        });
+
+        it('when there is not non human traffic', function () {
+          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+          let bidUrlParams = bidRequests[0].data;
+          expect(bidUrlParams).to.include('tr_wd=0');
+        });
       });
     });
 
-    describe('visibility', function () {
+    describe('document', function () {
       let originalHD;
       let originalVS;
 
       beforeEach(function () {
         originalHD = document.hidden;
         originalVS = document.visibilityState;
-        document['__defineGetter__']('hidden', function () {
-          return 1;
-        });
-        document['__defineGetter__']('visibilityState', function () {
-          return 'hidden';
-        });
       });
 
       afterEach(function () {
@@ -167,11 +205,64 @@ describe('Trion adapter tests', function () {
         });
       });
 
-      it('should send the correct states when the document is not visible', function () {
-        let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+      describe('is visible', function () {
+        beforeEach(function () {
+          document['__defineGetter__']('hidden', function () {
+            return 1;
+          });
+          document['__defineGetter__']('visibilityState', function () {
+            return 'visible';
+          });
+        });
+
+        it('should detect and send the document is visible', function () {
+          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+          let bidUrlParams = bidRequests[0].data;
+          expect(bidUrlParams).to.include('tr_hd=1');
+          expect(bidUrlParams).to.include('tr_vs=visible');
+        });
+      });
+
+      describe('is hidden', function () {
+        beforeEach(function () {
+          document['__defineGetter__']('hidden', function () {
+            return 1;
+          });
+          document['__defineGetter__']('visibilityState', function () {
+            return 'hidden';
+          });
+        });
+
+        it('should detect and send the document is hidden', function () {
+          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+          let bidUrlParams = bidRequests[0].data;
+          expect(bidUrlParams).to.include('tr_hd=1');
+          expect(bidUrlParams).to.include('tr_vs=hidden');
+        });
+      });
+    });
+
+    describe('should call buildRequests with correct consent params', function () {
+      it('when gdpr is present', function () {
+        TRION_BIDDER_REQUEST.gdprConsent = {
+          consentString: 'test_gdpr_str',
+          gdprApplies: true
+        };
+        let bidRequests = spec.buildRequests(TRION_BID_REQUEST, TRION_BIDDER_REQUEST);
         let bidUrlParams = bidRequests[0].data;
-        expect(bidUrlParams).to.include('tr_hd=1');
-        expect(bidUrlParams).to.include('tr_vs=hidden');
+        let gcEncoded = encodeURIComponent(TRION_BIDDER_REQUEST.gdprConsent.consentString);
+        expect(bidUrlParams).to.include('gdprc=' + gcEncoded);
+        expect(bidUrlParams).to.include('gdpr=1');
+        delete TRION_BIDDER_REQUEST.gdprConsent;
+      });
+
+      it('when us privacy is present', function () {
+        TRION_BIDDER_REQUEST.uspConsent = '1YYY';
+        let bidRequests = spec.buildRequests(TRION_BID_REQUEST, TRION_BIDDER_REQUEST);
+        let bidUrlParams = bidRequests[0].data;
+        let uspEncoded = encodeURIComponent(TRION_BIDDER_REQUEST.uspConsent);
+        expect(bidUrlParams).to.include('usp=' + uspEncoded);
+        delete TRION_BIDDER_REQUEST.uspConsent;
       });
     });
   });
@@ -245,10 +336,35 @@ describe('Trion adapter tests', function () {
 
     it('should register trion user script', function () {
       let syncs = spec.getUserSyncs({iframeEnabled: true});
-      let url = utils.getTopWindowUrl();
+      let pageUrl = getPublisherUrl();
       let pubId = 1;
       let sectionId = 2;
-      let syncString = `?p=${pubId}&s=${sectionId}&u=${url}`;
+      let syncString = `?p=${pubId}&s=${sectionId}&u=${pageUrl}`;
+      expect(syncs[0]).to.deep.equal({type: 'iframe', url: USER_SYNC_URL + syncString});
+    });
+
+    it('should register trion user script with gdpr params', function () {
+      let gdprConsent = {
+        consentString: 'test_gdpr_str',
+        gdprApplies: true
+      };
+      let syncs = spec.getUserSyncs({iframeEnabled: true}, null, gdprConsent);
+      let pageUrl = getPublisherUrl();
+      let pubId = 1;
+      let sectionId = 2;
+      let gcEncoded = encodeURIComponent(gdprConsent.consentString);
+      let syncString = `?p=${pubId}&s=${sectionId}&gc=${gcEncoded}&g=1&u=${pageUrl}`;
+      expect(syncs[0]).to.deep.equal({type: 'iframe', url: USER_SYNC_URL + syncString});
+    });
+
+    it('should register trion user script with us privacy params', function () {
+      let uspConsent = '1YYY';
+      let syncs = spec.getUserSyncs({iframeEnabled: true}, null, null, uspConsent);
+      let pageUrl = getPublisherUrl();
+      let pubId = 1;
+      let sectionId = 2;
+      let uspEncoded = encodeURIComponent(uspConsent);
+      let syncString = `?p=${pubId}&s=${sectionId}&up=${uspEncoded}&u=${pageUrl}`;
       expect(syncs[0]).to.deep.equal({type: 'iframe', url: USER_SYNC_URL + syncString});
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Updating Trion adapter in v2.44 so pubs still on version 2 can still use our newer updates.  This include consent params and various trion internal request param changes.
