### PR TITLE
feature/alias-sync-config-option

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -331,7 +331,8 @@ export function newBidder(spec) {
   });
 
   function registerSyncs(responses, gdprConsent, uspConsent) {
-    if (spec.getUserSyncs && !adapterManager.aliasRegistry[spec.code]) {
+    const aliasSyncEnabled = config.getConfig('userSync.aliasSyncEnabled');
+    if (spec.getUserSyncs && (aliasSyncEnabled || !adapterManager.aliasRegistry[spec.code])) {
       let filterConfig = config.getConfig('userSync.filterSettings');
       let syncs = spec.getUserSyncs({
         iframeEnabled: !!(filterConfig && (filterConfig.iframe || filterConfig.all)),

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -17,23 +17,7 @@ export const USERSYNC_DEFAULT_CONFIG = {
 
 // Set userSync default values
 config.setDefaults({
-<<<<<<< HEAD
   'userSync': utils.deepClone(USERSYNC_DEFAULT_CONFIG)
-=======
-  'userSync': {
-    syncEnabled: true,
-    filterSettings: {
-      image: {
-        bidders: '*',
-        filter: 'include'
-      }
-    },
-    aliasSyncEnabled: false,
-    syncsPerBidder: 5,
-    syncDelay: 3000,
-    auctionDelay: 0
-  }
->>>>>>> added config option to enabled alias syncs
 });
 
 /**

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -17,7 +17,23 @@ export const USERSYNC_DEFAULT_CONFIG = {
 
 // Set userSync default values
 config.setDefaults({
+<<<<<<< HEAD
   'userSync': utils.deepClone(USERSYNC_DEFAULT_CONFIG)
+=======
+  'userSync': {
+    syncEnabled: true,
+    filterSettings: {
+      image: {
+        bidders: '*',
+        filter: 'include'
+      }
+    },
+    aliasSyncEnabled: false,
+    syncsPerBidder: 5,
+    syncDelay: 3000,
+    auctionDelay: 0
+  }
+>>>>>>> added config option to enabled alias syncs
 });
 
 /**

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -56,15 +56,66 @@ describe('bidders created by newBidder', function () {
 
   describe('when the ajax response is irrelevant', function () {
     let ajaxStub;
+    let getConfigSpy;
 
     beforeEach(function () {
       ajaxStub = sinon.stub(ajax, 'ajax');
       addBidResponseStub.reset();
+      getConfigSpy = sinon.spy(config, 'getConfig');
       doneStub.reset();
     });
 
     afterEach(function () {
       ajaxStub.restore();
+      getConfigSpy.restore();
+    });
+
+    it('should let registerSyncs run with invalid alias and aliasSync enabled', function () {
+      config.setConfig({
+        userSync: {
+          aliasSyncEnabled: true
+        }
+      });
+      spec.code = 'fakeBidder';
+      const bidder = newBidder(spec);
+      bidder.callBids({ bids: [] }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+      expect(getConfigSpy.withArgs('userSync.filterSettings').calledOnce).to.equal(true);
+    });
+
+    it('should let registerSyncs run with valid alias and aliasSync enabled', function () {
+      config.setConfig({
+        userSync: {
+          aliasSyncEnabled: true
+        }
+      });
+      spec.code = 'aliasBidder';
+      const bidder = newBidder(spec);
+      bidder.callBids({ bids: [] }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+      expect(getConfigSpy.withArgs('userSync.filterSettings').calledOnce).to.equal(true);
+    });
+
+    it('should let registerSyncs run with invalid alias and aliasSync disabled', function () {
+      config.setConfig({
+        userSync: {
+          aliasSyncEnabled: false
+        }
+      });
+      spec.code = 'fakeBidder';
+      const bidder = newBidder(spec);
+      bidder.callBids({ bids: [] }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+      expect(getConfigSpy.withArgs('userSync.filterSettings').calledOnce).to.equal(true);
+    });
+
+    it('should not let registerSyncs run with valid alias and aliasSync disabled', function () {
+      config.setConfig({
+        userSync: {
+          aliasSyncEnabled: false
+        }
+      });
+      spec.code = 'aliasBidder';
+      const bidder = newBidder(spec);
+      bidder.callBids({ bids: [] }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+      expect(getConfigSpy.withArgs('userSync.filterSettings').calledOnce).to.equal(false);
     });
 
     it('should handle bad bid requests gracefully', function () {


### PR DESCRIPTION
## Type of change
Feature
Affects user-facing APIs or examples documented on http://prebid.org

## Description of change
This relates to issue #4845.  It was originally decided that Alias syncs would be disabled in PR https://github.com/prebid/Prebid.js/pull/4435/files. Prebid will now provide a userSync config option to reenabled alias sync. This will be defaulted off.

``` 
userSync: {
    aliasSyncEnabled: true,
}
```

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

## Other information
https://github.com/prebid/Prebid.js/pull/4435/files
https://github.com/prebid/prebid.github.io/pull/1810