### PR TITLE
feature/bidLimit-dealPrioritization

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -44,7 +44,6 @@ export function getHighestCpmBidsFromBidPool(bidsReceived, highestCpmCallback, a
     Object.keys(bidsByBidder).forEach(key => bucketBids.push(bidsByBidder[key].reduce(highestCpmCallback)));
     // if adUnitBidLimit is set, pass top N number bids
     if (adUnitBidLimit > 0) {
-      bucketBids.sort((a, b) => b.cpm - a.cpm);
       bucketBids = dealPrioritization ? bucketBids(sortByDealAndPriceBucketOrCpm(true)) : bucketBids.sort((a, b) => b.cpm - a.cpm);
       bids.push(...bucketBids.slice(0, adUnitBidLimit));
     } else {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { targeting as targetingInstance, filters, sortByDealAndPriceBucket } from 'src/targeting.js';
+import { targeting as targetingInstance, filters, sortByDealAndPriceBucketOrCpm } from 'src/targeting.js';
 import { config } from 'src/config.js';
 import { getAdUnits, createBidReceived } from 'test/fixtures/fixtures.js';
 import CONSTANTS from 'src/constants.json';
@@ -687,7 +687,7 @@ describe('targeting tests', function () {
     });
   });
 
-  describe('sortByDealAndPriceBucket', function() {
+  describe('sortByDealAndPriceBucketOrCpm', function() {
     it('will properly sort bids when some bids have deals and some do not', function () {
       let bids = [{
         adUnitTargeting: {
@@ -723,7 +723,7 @@ describe('targeting tests', function () {
           hb_pb: '100.00',
         }
       }];
-      bids.sort(sortByDealAndPriceBucket);
+      bids.sort(sortByDealAndPriceBucketOrCpm());
       expect(bids[0].adUnitTargeting.hb_adid).to.equal('ghi');
       expect(bids[1].adUnitTargeting.hb_adid).to.equal('jkl');
       expect(bids[2].adUnitTargeting.hb_adid).to.equal('abc');
@@ -758,7 +758,7 @@ describe('targeting tests', function () {
           hb_deal: '9864'
         }
       }];
-      bids.sort(sortByDealAndPriceBucket);
+      bids.sort(sortByDealAndPriceBucketOrCpm());
       expect(bids[0].adUnitTargeting.hb_adid).to.equal('ghi');
       expect(bids[1].adUnitTargeting.hb_adid).to.equal('jkl');
       expect(bids[2].adUnitTargeting.hb_adid).to.equal('abc');
@@ -797,13 +797,64 @@ describe('targeting tests', function () {
           hb_pb: '100.00'
         }
       }];
-      bids.sort(sortByDealAndPriceBucket);
+      bids.sort(sortByDealAndPriceBucketOrCpm());
       expect(bids[0].adUnitTargeting.hb_adid).to.equal('pqr');
       expect(bids[1].adUnitTargeting.hb_adid).to.equal('jkl');
       expect(bids[2].adUnitTargeting.hb_adid).to.equal('ghi');
       expect(bids[3].adUnitTargeting.hb_adid).to.equal('abc');
       expect(bids[4].adUnitTargeting.hb_adid).to.equal('mno');
       expect(bids[5].adUnitTargeting.hb_adid).to.equal('def');
+    });
+
+    it('will properly sort bids when some bids have deals and some do not and by cpm when flag is set to true', function () {
+      let bids = [{
+        cpm: 1.04,
+        adUnitTargeting: {
+          hb_adid: 'abc',
+          hb_pb: '1.00',
+          hb_deal: '1234'
+        }
+      }, {
+        cpm: 0.50,
+        adUnitTargeting: {
+          hb_adid: 'def',
+          hb_pb: '0.50',
+          hb_deal: '4532'
+        }
+      }, {
+        cpm: 0.53,
+        adUnitTargeting: {
+          hb_adid: 'ghi',
+          hb_pb: '0.50',
+          hb_deal: '4532'
+        }
+      }, {
+        cpm: 9.04,
+        adUnitTargeting: {
+          hb_adid: 'jkl',
+          hb_pb: '9.00',
+          hb_deal: '9864'
+        }
+      }, {
+        cpm: 50.00,
+        adUnitTargeting: {
+          hb_adid: 'mno',
+          hb_pb: '50.00',
+        }
+      }, {
+        cpm: 100.00,
+        adUnitTargeting: {
+          hb_adid: 'pqr',
+          hb_pb: '100.00',
+        }
+      }];
+      bids.sort(sortByDealAndPriceBucketOrCpm(true));
+      expect(bids[0].adUnitTargeting.hb_adid).to.equal('jkl');
+      expect(bids[1].adUnitTargeting.hb_adid).to.equal('abc');
+      expect(bids[2].adUnitTargeting.hb_adid).to.equal('ghi');
+      expect(bids[3].adUnitTargeting.hb_adid).to.equal('def');
+      expect(bids[4].adUnitTargeting.hb_adid).to.equal('pqr');
+      expect(bids[5].adUnitTargeting.hb_adid).to.equal('mno');
     });
   });
 


### PR DESCRIPTION
## Type of change
Feature

## Description of change
Prebid will add a new config option to sendBidsControl. When adUnitBidLimit is set above zero and dealPrioritization is set to true, deals will be prioritized first and sorted by highest to lowest cpm.
```
pbjs.setConfig({ 
    adUnitBidLimit: 2,
    dealPrioritization: true
 })

```

## Other information
The  original PR for adUnitBidLimit: https://github.com/prebid/Prebid.js/pull/3906
Documentatin: https://github.com/prebid/prebid.github.io/pull/1829