### PR TITLE
OpenX adapter: support Criteo ID

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -12,7 +12,8 @@ const BIDDER_VERSION = '3.0.1';
 const USER_ID_CODE_TO_QUERY_ARG = {
   idl_env: 'lre', // liveramp
   pubcid: 'pubcid', // publisher common id
-  tdid: 'ttduuid' // the trade desk
+  tdid: 'ttduuid', // the trade desk
+  criteoId: 'criteoid' // criteo id
 };
 
 export const spec = {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1150,7 +1150,7 @@ describe('OpenxAdapter', function () {
         });
 
         it('should send a criteoid query param when userId.criteoId is defined in the bid requests', function () {
-          const bidRequestsWithLiveRampEnvelope = [{
+          const bidRequestsWithCriteo = [{
             bidder: 'openx',
             params: {
               unit: '11',
@@ -1169,7 +1169,7 @@ describe('OpenxAdapter', function () {
             bidderRequestId: 'test-bid-request-1',
             auctionId: 'test-auction-1'
           }];
-          const request = spec.buildRequests(bidRequestsWithLiveRampEnvelope, mockBidderRequest);
+          const request = spec.buildRequests(bidRequestsWithCriteo, mockBidderRequest);
           expect(request[0].data.criteoid).to.equal('00000000-aaaa-1111-bbbb-222222222222');
         });
       });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1142,6 +1142,37 @@ describe('OpenxAdapter', function () {
           expect(request[0].data.lre).to.equal('00000000-aaaa-1111-bbbb-222222222222');
         });
       });
+      
+      describe('with the criteo id for exchanges', function () {
+        it('should not send a criteoid query param when there is no userId.criteoId defined in the bid requests', function () {
+          const request = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);
+          expect(request[0].data).to.not.have.any.keys('criteoid');
+        });
+
+        it('should send a criteoid query param when userId.criteoId is defined in the bid requests', function () {
+          const bidRequestsWithLiveRampEnvelope = [{
+            bidder: 'openx',
+            params: {
+              unit: '11',
+              delDomain: 'test-del-domain'
+            },
+            userId: {
+              criteoId: '00000000-aaaa-1111-bbbb-222222222222'
+            },
+            adUnitCode: 'adunit-code',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [300, 600]]
+              }
+            },
+            bidId: 'test-bid-id-1',
+            bidderRequestId: 'test-bid-request-1',
+            auctionId: 'test-auction-1'
+          }];
+          const request = spec.buildRequests(bidRequestsWithLiveRampEnvelope, mockBidderRequest);
+          expect(request[0].data.criteoid).to.equal('00000000-aaaa-1111-bbbb-222222222222');
+        });
+      });
     });
   });
 

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1142,7 +1142,7 @@ describe('OpenxAdapter', function () {
           expect(request[0].data.lre).to.equal('00000000-aaaa-1111-bbbb-222222222222');
         });
       });
-      
+
       describe('with the criteo id for exchanges', function () {
         it('should not send a criteoid query param when there is no userId.criteoId defined in the bid requests', function () {
           const request = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Criteo support for OpenX adapter

Criteo ID Example
```
pbjs.setConfig({
    userSync: {
        userIds: [{
            name: "criteo",
        }]
    }
});
```