### PR TITLE
Add "adtype" from Yieldlab response for media type differentiation

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -80,6 +80,8 @@ export const spec = {
         const primarysize = bidRequest.sizes.length === 2 && !utils.isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0]
         const customsize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : primarysize
         const extId = bidRequest.params.extId !== undefined ? '&id=' + bidRequest.params.extId : ''
+        const adType = matchedBid.adtype !== undefined ? matchedBid.adtype : ''
+
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
@@ -94,7 +96,7 @@ export const spec = {
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}"></script>`
         }
 
-        if (isVideo(bidRequest)) {
+        if (isVideo(bidRequest, adType)) {
           const playersize = getPlayerSize(bidRequest)
           if (playersize) {
             bidResponse.width = playersize[0]
@@ -124,10 +126,11 @@ export const spec = {
 /**
  * Is this a video format?
  * @param {Object} format
+ * @param {String} adtype
  * @returns {Boolean}
  */
-function isVideo (format) {
-  return utils.deepAccess(format, 'mediaTypes.video')
+function isVideo (format, adtype) {
+  return utils.deepAccess(format, 'mediaTypes.video') && adtype.toLowerCase() === 'video'
 }
 
 /**

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -27,8 +27,13 @@ const RESPONSE = {
   format: 0,
   id: 1111,
   price: 1,
-  pid: 2222
+  pid: 2222,
+  adtype: 'BANNER'
 }
+
+const VIDEO_RESPONSE = Object.assign({}, RESPONSE, {
+  'adtype': 'VIDEO'
+})
 
 describe('yieldlabBidAdapter', function () {
   const adapter = newBidder(spec)
@@ -140,7 +145,7 @@ describe('yieldlabBidAdapter', function () {
           }
         }
       })
-      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [VIDEO_REQUEST]})
+      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST]})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
@@ -158,7 +163,7 @@ describe('yieldlabBidAdapter', function () {
           }
         }
       })
-      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [OUTSTREAM_REQUEST]})
+      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [OUTSTREAM_REQUEST]})
 
       expect(result[0].renderer.id).to.equal('2d925f27f5079f')
       expect(result[0].renderer.url).to.equal('https://ad2.movad.net/dynamic.ad?a=o193092&ma_loadEvent=ma-start-event')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
We added 'adtype' as a key to our response (values: 'BANNER', 'VIDEO' or 'NATIVE'), so we can better differentate media types. This fixes bids for adUnits that are from multiple mediatypes (e.g. banner, video.outstream) as our current methods assume unique mediatypes per adUnit. 