### PR TITLE
use bidId or bidIds in the payload

### DIFF
--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -9,7 +9,6 @@ function _mapSizes(sizes) {
 
 function _createServerRequest(bidRequests, bidderRequest) {
   const payload = {
-    bidId: bidRequests.map(req => req.bidId),
     auctionId: bidRequests[0].auctionId,
     transactionId: bidRequests[0].transactionId,
     sizes: _mapSizes(bidRequests.map(x => x.sizes)),
@@ -19,6 +18,9 @@ function _createServerRequest(bidRequests, bidderRequest) {
       applies: false
     }
   };
+
+  const bidIds = bidRequests.map(req => req.bidId);
+  bidIds.length === 1 ? payload.bidId = bidIds[0] : payload.bidIds = bidIds;
 
   const options = {
     contentType: 'application/json',

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -50,10 +50,15 @@ describe('ProxistoreBidAdapter', function () {
     });
     it('should have the value consentGiven to true bc we have 418 in the vendor list', function () {
       const data = JSON.parse(request.data);
+
       expect(data.gdpr.consentString).equal(bidderRequest.gdprConsent.consentString);
       expect(data.gdpr.applies).to.be.true;
       expect(data.gdpr.consentGiven).to.be.true;
     });
+    it('should have a property bidId if there is only one bid', function () {
+      const data = JSON.parse(request.data);
+      expect(data.hasOwnProperty('bidId')).to.be.true;
+    })
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Use property name bidId in the request paylaod with simple variable when there is only on bidRequest or use bidIds with an array of string where there is several bid request.

- contact email of the adapter’s maintainer
vincent.descamps@proxistore.com

