### PR TITLE
#4904 Modify vendor gdpr check to deny consent on timeout

### DIFF
--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -207,9 +207,9 @@ var gdprConsent = {
     var consentAnswer = false;
     if (typeof (window.__cmp) !== 'undefined') {
       stopTimer = setTimeout(function () {
-        consentAnswer = true;
-        consentCb(consentAnswer);
+        consentAnswer = false;
         processed = true;
+        consentCb(consentAnswer);
       }, options.consentTimeout);
 
       window.__cmp('ping', null, function(pingAnswer) {
@@ -227,9 +227,12 @@ var gdprConsent = {
           consentCb(consentAnswer);
         }
       });
+    } else {
+      // __cmp library is not preset.
+      // ignore this check and rely on id system GDPR consent management
+      consentAnswer = true;
+      consentCb(consentAnswer);
     }
-    consentAnswer = true;
-    consentCb(consentAnswer);
   }
 }
 

--- a/test/spec/modules/digitrustIdSystem_spec.js
+++ b/test/spec/modules/digitrustIdSystem_spec.js
@@ -109,13 +109,23 @@ describe('DigiTrust Id System', function () {
 
     testHook.gdpr.hasConsent(null, handler);
   });
-  it('Should allow consent if timeout', function (done) {
+  it('Should deny consent if timeout', function (done) {
     window.__cmp = function () { };
+    var handler = function (result) {
+      expect(result).to.be.false;
+      done();
+    }
+
+    testHook.gdpr.hasConsent({ consentTimeout: 1 }, handler);
+  });
+  it('Should pass consent test if cmp not present', function (done) {
+    delete window.__cmp
+    testHook = surfaceTestHook();
     var handler = function (result) {
       expect(result).to.be.true;
       done();
     }
 
-    testHook.gdpr.hasConsent({ consentTimeout: 1 }, handler);
+    testHook.gdpr.hasConsent(null, handler);
   });
 });


### PR DESCRIPTION
where __cmp exists. Fix fallthrough error and new test for __cmp not present.


## Type of change
- [X ] Bugfix

## Description of change
This modifies behavior of the cmp vendor check to be more GDPR compliant in cases where cmp is discovered but fails to respond to ping request. Previously consent check passed with assumption GDPR did not apply. More conservative assumption that GDPR does apply if cmp library is found, and fails all tests except explicit consent.

## Other information
Solves #4904 and fixes a fallthrough if case error.
Unit tests show new behavior.
