### PR TITLE
add support for TCF2

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -329,7 +329,7 @@ function processCmpData(consentObject, hookConfig) {
       exitModule(null, hookConfig);
     }
   } else {
-    cmpFailed('Unable to derive CMP version to process data.  Consent object does not conform to TCF v1 or 2 specs.', hookConfig, consentObject);
+    cmpFailed('Unable to derive CMP version to process data.  Consent object does not conform to TCF v1 or v2 specs.', hookConfig, consentObject);
   }
 }
 

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -19,6 +19,7 @@ export let consentTimeout;
 export let allowAuction;
 export let staticConsentData;
 
+let cmpVersion = 0;
 let consentData;
 let addedConsentHook = false;
 
@@ -47,11 +48,70 @@ function lookupStaticConsentData(cmpSuccess, cmpError, hookConfig) {
  * @param {object} hookConfig contains module related variables (see comment in requestBidsHook function)
  */
 function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
-  function handleCmpResponseCallbacks() {
+  function findCMP() {
+    let f = window;
+    let cmpFrame;
+    let cmpFunction;
+    while (!cmpFrame) {
+      try {
+        if (typeof f.__tcfapi === 'function' || typeof f.__cmp === 'function') {
+          if (typeof f.__tcfapi === 'function') {
+            cmpVersion = 2;
+            cmpFunction = f.__tcfapi;
+          } else {
+            cmpVersion = 1;
+            cmpFunction = f.__cmp;
+          }
+          cmpFrame = f;
+          break;
+        }
+      } catch (e) { }
+
+      // need separate try/catch blocks due to the exception errors thrown when trying to check for a frame that doesn't exist in 3rd party env
+      try {
+        if (f.frames['__tcfapiLocator']) {
+          cmpVersion = 2;
+          cmpFrame = f;
+          break;
+        }
+      } catch (e) { }
+
+      try {
+        if (f.frames['__cmpLocator']) {
+          cmpVersion = 1;
+          cmpFrame = f;
+          break;
+        }
+      } catch (e) { }
+
+      if (f === window.top) break;
+      f = f.parent;
+    }
+    return {
+      cmpFrame,
+      cmpFunction
+    };
+  }
+
+  function v2CmpResponseCallback(tcfData, success) {
+    utils.logInfo('Received a response from CMP', tcfData);
+    if (success) {
+      if (tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
+        cmpSuccess(tcfData, hookConfig);
+      } else if (tcfData.eventStatus === 'cmpuishown' && tcfData.tcString.length > 0 && tcfData.purposeOneTreatment === true) {
+        cmpSuccess(tcfData, hookConfig);
+      }
+    } else {
+      cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);
+    }
+  }
+
+  function handleV1CmpResponseCallbacks() {
     const cmpResponse = {};
 
     function afterEach() {
       if (cmpResponse.getConsentData && cmpResponse.getVendorConsents) {
+        utils.logInfo('Received all requested responses from CMP', cmpResponse);
         cmpSuccess(cmpResponse, hookConfig);
       }
     }
@@ -68,10 +128,13 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     }
   }
 
-  let callbackHandler = handleCmpResponseCallbacks();
+  let v1CallbackHandler = handleV1CmpResponseCallbacks();
   let cmpCallbacks = {};
-  let cmpFunction;
+  let { cmpFrame, cmpFunction } = findCMP();
 
+  if (!cmpFrame) {
+    return cmpError('CMP not found.', hookConfig);
+  }
   // to collect the consent information from the user, we perform two calls to the CMP in parallel:
   // first to collect the user's consent choices represented in an encoded string (via getConsentData)
   // second to collect the user's full unparsed consent information (via getVendorConsents)
@@ -81,34 +144,28 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   // check to see if prebid is in a safeframe (with CMP support)
   // else assume prebid may be inside an iframe and use the IAB CMP locator code to see if CMP's located in a higher parent window. this works in cross domain iframes
   // if the CMP is not found, the iframe function will call the cmpError exit callback to abort the rest of the CMP workflow
-  try {
-    cmpFunction = window.__cmp || utils.getWindowTop().__cmp;
-  } catch (e) { }
 
   if (utils.isFn(cmpFunction)) {
-    cmpFunction('getConsentData', null, callbackHandler.consentDataCallback);
-    cmpFunction('getVendorConsents', null, callbackHandler.vendorConsentsCallback);
+    utils.logInfo('Detected CMP API is directly accessible, calling it now...');
+    if (cmpVersion === 1) {
+      cmpFunction('getConsentData', null, v1CallbackHandler.consentDataCallback);
+      cmpFunction('getVendorConsents', null, v1CallbackHandler.vendorConsentsCallback);
+    } else if (cmpVersion === 2) {
+      cmpFunction('addEventListener', cmpVersion, v2CmpResponseCallback);
+    }
   } else if (inASafeFrame() && typeof window.$sf.ext.cmp === 'function') {
-    callCmpWhileInSafeFrame('getConsentData', callbackHandler.consentDataCallback);
-    callCmpWhileInSafeFrame('getVendorConsents', callbackHandler.vendorConsentsCallback);
+    utils.logInfo('Detected Prebid.js is encased in a SafeFrame and CMP is registered, calling it now...');
+    cmpVersion = 1;
+    callCmpWhileInSafeFrame('getConsentData', v1CallbackHandler.consentDataCallback);
+    callCmpWhileInSafeFrame('getVendorConsents', v1CallbackHandler.vendorConsentsCallback);
   } else {
-    // find the CMP frame
-    let f = window;
-    let cmpFrame;
-    while (!cmpFrame) {
-      try {
-        if (f.frames['__cmpLocator']) cmpFrame = f;
-      } catch (e) { }
-      if (f === window.top) break;
-      f = f.parent;
+    utils.logInfo('Detected CMP is outside the current iframe when Prebid.js is located, calling it now...');
+    if (cmpVersion === 1) {
+      callCmpWhileInIframe('getConsentData', cmpFrame, v1CallbackHandler.consentDataCallback);
+      callCmpWhileInIframe('getVendorConsents', cmpFrame, v1CallbackHandler.vendorConsentsCallback);
+    } else if (cmpVersion === 2) {
+      callCmpWhileInIframe('addEventListener', cmpFrame, v2CmpResponseCallback);
     }
-
-    if (!cmpFrame) {
-      return cmpError('CMP not found.', hookConfig);
-    }
-
-    callCmpWhileInIframe('getConsentData', cmpFrame, callbackHandler.consentDataCallback);
-    callCmpWhileInIframe('getVendorConsents', cmpFrame, callbackHandler.vendorConsentsCallback);
   }
 
   function inASafeFrame() {
@@ -138,17 +195,22 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   }
 
   function callCmpWhileInIframe(commandName, cmpFrame, moduleCallback) {
+    let apiName = (cmpVersion === 2) ? '__tcfapi' : '__cmp';
+
     /* Setup up a __cmp function to do the postMessage and stash the callback.
       This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
-    window.__cmp = function (cmd, arg, callback) {
+    window[apiName] = function (cmd, arg, callback) {
       let callId = Math.random() + '';
+      let callName = `${apiName}Call`;
       let msg = {
-        __cmpCall: {
+        [callName]: {
           command: cmd,
           parameter: arg,
           callId: callId
         }
       };
+      if (cmpVersion !== 1) msg[callName].version = cmpVersion;
+
       cmpCallbacks[callId] = callback;
       cmpFrame.postMessage(msg, '*');
     }
@@ -157,27 +219,18 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     window.addEventListener('message', readPostMessageResponse, false);
 
     // call CMP
-    window.__cmp(commandName, null, cmpIframeCallback);
+    window[apiName](commandName, null, moduleCallback);
 
     function readPostMessageResponse(event) {
-      let json = (typeof event.data === 'string' && strIncludes(event.data, 'cmpReturn')) ? JSON.parse(event.data) : event.data;
-      if (json.__cmpReturn && json.__cmpReturn.callId) {
-        let i = json.__cmpReturn;
+      let cmpDataPkgName = `${apiName}Return`;
+      let json = (typeof event.data === 'string' && strIncludes(event.data, cmpDataPkgName)) ? JSON.parse(event.data) : event.data;
+      if (json[cmpDataPkgName] && json[cmpDataPkgName].callId) {
+        let payload = json[cmpDataPkgName];
         // TODO - clean up this logic (move listeners?); we have duplicate messages responses because 2 eventlisteners are active from the 2 cmp requests running in parallel
-        if (typeof cmpCallbacks[i.callId] !== 'undefined') {
-          cmpCallbacks[i.callId](i.returnValue, i.success);
-          delete cmpCallbacks[i.callId];
+        if (typeof cmpCallbacks[payload.callId] !== 'undefined') {
+          cmpCallbacks[payload.callId](payload.returnValue, payload.success);
         }
       }
-    }
-
-    function removePostMessageListener() {
-      window.removeEventListener('message', readPostMessageResponse, false);
-    }
-
-    function cmpIframeCallback(consentObject) {
-      removePostMessageListener();
-      moduleCallback(consentObject);
     }
   }
 }
@@ -204,6 +257,7 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
 
   // in case we already have consent (eg during bid refresh)
   if (consentData) {
+    utils.logInfo('User consent information already known.  Pulling internally stored information...');
     return exitModule(null, hookConfig);
   }
 
@@ -232,22 +286,50 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
  * @param {object} hookConfig contains module related variables (see comment in requestBidsHook function)
  */
 function processCmpData(consentObject, hookConfig) {
-  let gdprApplies = consentObject && consentObject.getConsentData && consentObject.getConsentData.gdprApplies;
-  if (
-    (typeof gdprApplies !== 'boolean') ||
-    (gdprApplies === true &&
-      !(utils.isStr(consentObject.getConsentData.consentData) &&
-        utils.isPlainObject(consentObject.getVendorConsents) &&
-        Object.keys(consentObject.getVendorConsents).length > 1
+  function checkV1Data(consentObject) {
+    let gdprApplies = consentObject && consentObject.getConsentData && consentObject.getConsentData.gdprApplies;
+    return !!(
+      (typeof gdprApplies !== 'boolean') ||
+      (gdprApplies === true &&
+        !(utils.isStr(consentObject.getConsentData.consentData) &&
+          utils.isPlainObject(consentObject.getVendorConsents) &&
+          Object.keys(consentObject.getVendorConsents).length > 1
+        )
       )
-    )
-  ) {
-    cmpFailed(`CMP returned unexpected value during lookup process.`, hookConfig, consentObject);
-  } else {
-    clearTimeout(hookConfig.timer);
-    storeConsentData(consentObject);
+    );
+  }
 
-    exitModule(null, hookConfig);
+  function checkV2Data() {
+    let gdprApplies = consentObject && consentObject.gdprApplies;
+    let tcString = consentObject && consentObject.tcString;
+    return !!(
+      (typeof gdprApplies !== 'boolean') ||
+      (gdprApplies === true && !utils.isStr(tcString))
+    );
+  }
+
+  // do extra things for static config
+  if (userCMP === 'static') {
+    cmpVersion = (consentObject.getConsentData) ? 1 : (consentObject.getTCData) ? 2 : 0;
+    // remove extra layer in static v2 data object so it matches normal v2 CMP object for processing step
+    if (cmpVersion === 2) {
+      consentObject = consentObject.getTCData;
+    }
+  }
+
+  // determine which set of checks to run based on cmpVersion
+  let checkFn = (cmpVersion === 1) ? checkV1Data : (cmpVersion === 2) ? checkV2Data : null;
+
+  if (utils.isFn(checkFn)) {
+    if (checkFn(consentObject)) {
+      cmpFailed(`CMP returned unexpected value during lookup process.`, hookConfig, consentObject);
+    } else {
+      clearTimeout(hookConfig.timer);
+      storeConsentData(consentObject);
+      exitModule(null, hookConfig);
+    }
+  } else {
+    cmpFailed('Unable to derive CMP version to process data.  Consent object does not conform to TCF v1 or 2 specs.', hookConfig, consentObject);
   }
 }
 
@@ -279,17 +361,27 @@ function cmpFailed(errMsg, hookConfig, extraArgs) {
  * @param {object} cmpConsentObject required; an object representing user's consent choices (can be undefined in certain use-cases for this function only)
  */
 function storeConsentData(cmpConsentObject) {
-  consentData = {
-    consentString: (cmpConsentObject) ? cmpConsentObject.getConsentData.consentData : undefined,
-    vendorData: (cmpConsentObject) ? cmpConsentObject.getVendorConsents : undefined,
-    gdprApplies: (cmpConsentObject) ? cmpConsentObject.getConsentData.gdprApplies : undefined
-  };
+  if (cmpVersion === 1) {
+    consentData = {
+      consentString: (cmpConsentObject) ? cmpConsentObject.getConsentData.consentData : undefined,
+      vendorData: (cmpConsentObject) ? cmpConsentObject.getVendorConsents : undefined,
+      gdprApplies: (cmpConsentObject) ? cmpConsentObject.getConsentData.gdprApplies : undefined
+    };
+  } else {
+    consentData = {
+      consentString: (cmpConsentObject) ? cmpConsentObject.tcString : undefined,
+      vendorData: (cmpConsentObject) || undefined,
+      gdprApplies: (cmpConsentObject) ? cmpConsentObject.gdprApplies : undefined
+    };
+  }
+  consentData.apiVersion = cmpVersion;
+
   gdprDataHandler.setConsentData(consentData);
 }
 
 /**
  * This function handles the exit logic for the module.
- * There are several paths in the module's logic to call this function and we only allow 1 of the 3 potential exits to happen before suppressing others.
+ * While there are several paths in the module's logic to call this function, we only allow 1 of the 3 potential exits to happen before suppressing others.
  *
  * We prevent multiple exits to avoid conflicting messages in the console depending on certain scenarios.
  * One scenario could be auction was canceled due to timeout with CMP being reached.
@@ -336,6 +428,7 @@ function exitModule(errMsg, hookConfig, extraArgs) {
 export function resetConsentData() {
   consentData = undefined;
   userCMP = undefined;
+  cmpVersion = 0;
   gdprDataHandler.setConsentData(null);
 }
 

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -159,7 +159,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     callCmpWhileInSafeFrame('getConsentData', v1CallbackHandler.consentDataCallback);
     callCmpWhileInSafeFrame('getVendorConsents', v1CallbackHandler.vendorConsentsCallback);
   } else {
-    utils.logInfo('Detected CMP is outside the current iframe when Prebid.js is located, calling it now...');
+    utils.logInfo('Detected CMP is outside the current iframe where Prebid.js is located, calling it now...');
     if (cmpVersion === 1) {
       callCmpWhileInIframe('getConsentData', cmpFrame, v1CallbackHandler.consentDataCallback);
       callCmpWhileInIframe('getVendorConsents', cmpFrame, v1CallbackHandler.vendorConsentsCallback);

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -153,9 +153,9 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     } else if (cmpVersion === 2) {
       cmpFunction('addEventListener', cmpVersion, v2CmpResponseCallback);
     }
-  } else if (inASafeFrame() && typeof window.$sf.ext.cmp === 'function') {
+  } else if (cmpVersion === 1 && inASafeFrame() && typeof window.$sf.ext.cmp === 'function') {
+    // this safeframe workflow is only supported with TCF v1 spec; the v2 recommends to use the iframe postMessage route instead (even if you are in a safeframe).
     utils.logInfo('Detected Prebid.js is encased in a SafeFrame and CMP is registered, calling it now...');
-    cmpVersion = 1;
     callCmpWhileInSafeFrame('getConsentData', v1CallbackHandler.consentDataCallback);
     callCmpWhileInSafeFrame('getVendorConsents', v1CallbackHandler.vendorConsentsCallback);
   } else {

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -207,7 +207,10 @@ function hasGDPRConsent(consentData) {
     if (!consentData.consentString) {
       return false;
     }
-    if (consentData.vendorData && consentData.vendorData.purposeConsents && consentData.vendorData.purposeConsents['1'] === false) {
+    if (consentData.apiVersion === 1 && utils.deepAccess(consentData, 'vendorData.purposeConsents.1') === false) {
+      return false;
+    }
+    if (consentData.apiVersion === 2 && utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === false) {
       return false;
     }
   }

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -1,9 +1,8 @@
-import {setConsentConfig, requestBidsHook, resetConsentData, userCMP, consentTimeout, allowAuction, staticConsentData} from 'modules/consentManagement.js';
-import {gdprDataHandler} from 'src/adapterManager.js';
+import { setConsentConfig, requestBidsHook, resetConsentData, userCMP, consentTimeout, allowAuction, staticConsentData } from 'modules/consentManagement.js';
+import { gdprDataHandler } from 'src/adapterManager.js';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 
-let assert = require('chai').assert;
 let expect = require('chai').expect;
 
 describe('consentManagement', function () {
@@ -29,13 +28,13 @@ describe('consentManagement', function () {
         sinon.assert.callCount(utils.logInfo, 4);
       });
 
-      it('should exit consent manager if config is not an object', function() {
+      it('should exit consent manager if config is not an object', function () {
         setConsentConfig('');
         expect(userCMP).to.be.undefined;
         sinon.assert.calledOnce(utils.logWarn);
       });
 
-      it('should exit consent manager if gdpr not set with new config structure', function() {
+      it('should exit consent manager if gdpr not set with new config structure', function () {
         setConsentConfig({ usp: { cmpApi: 'iab', timeout: 50 } });
         expect(userCMP).to.be.undefined;
         sinon.assert.calledOnce(utils.logWarn);
@@ -45,7 +44,6 @@ describe('consentManagement', function () {
     describe('valid setConsentConfig value', function () {
       afterEach(function () {
         config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
       });
 
       it('results in all user settings overriding system defaults', function () {
@@ -61,7 +59,7 @@ describe('consentManagement', function () {
         expect(allowAuction).to.be.false;
       });
 
-      it('should use new consent manager config structure for gdpr', function() {
+      it('should use new consent manager config structure for gdpr', function () {
         setConsentConfig({
           gdpr: { cmpApi: 'daa', timeout: 8700 }
         });
@@ -70,7 +68,7 @@ describe('consentManagement', function () {
         expect(consentTimeout).to.be.equal(8700);
       });
 
-      it('should ignore config.usp and use config.gdpr, with default cmpApi', function() {
+      it('should ignore config.usp and use config.gdpr, with default cmpApi', function () {
         setConsentConfig({
           gdpr: { timeout: 5000 },
           usp: { cmpApi: 'daa', timeout: 50 }
@@ -80,7 +78,7 @@ describe('consentManagement', function () {
         expect(consentTimeout).to.be.equal(5000);
       });
 
-      it('should ignore config.usp and use config.gdpr, with default cmpAip and timeout', function() {
+      it('should ignore config.usp and use config.gdpr, with default cmpAip and timeout', function () {
         setConsentConfig({
           gdpr: {},
           usp: { cmpApi: 'daa', timeout: 50 }
@@ -90,7 +88,7 @@ describe('consentManagement', function () {
         expect(consentTimeout).to.be.equal(10000);
       });
 
-      it('should recognize config.gdpr, with default cmpAip and timeout', function() {
+      it('should recognize config.gdpr, with default cmpAip and timeout', function () {
         setConsentConfig({
           gdpr: {}
         });
@@ -99,7 +97,7 @@ describe('consentManagement', function () {
         expect(consentTimeout).to.be.equal(10000);
       });
 
-      it('should fallback to old consent manager config object if no config.gdpr', function() {
+      it('should fallback to old consent manager config object if no config.gdpr', function () {
         setConsentConfig({
           cmpApi: 'iab',
           timeout: 3333,
@@ -116,9 +114,8 @@ describe('consentManagement', function () {
     describe('static consent string setConsentConfig value', () => {
       afterEach(() => {
         config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
       });
-      it('results in user settings overriding system defaults', () => {
+      it('results in user settings overriding system defaults for v1 spec', () => {
         let staticConfig = {
           cmpApi: 'static',
           timeout: 7500,
@@ -154,361 +151,87 @@ describe('consentManagement', function () {
                 '2': true,
                 '3': true,
                 '4': true,
-                '5': false,
-                '6': true,
-                '7': true,
-                '8': true,
-                '9': true,
-                '10': true,
-                '11': true,
-                '12': true,
-                '13': true,
-                '14': true,
-                '15': true,
-                '16': true,
-                '17': true,
-                '18': true,
-                '19': true,
-                '20': true,
-                '21': true,
-                '22': true,
-                '23': true,
-                '24': true,
-                '25': true,
-                '26': true,
-                '27': true,
-                '28': true,
-                '29': true,
-                '30': true,
-                '31': true,
-                '32': true,
-                '33': true,
-                '34': true,
-                '35': true,
-                '36': true,
-                '37': true,
-                '38': true,
-                '39': true,
-                '40': true,
-                '41': true,
-                '42': true,
-                '43': true,
-                '44': true,
-                '45': true,
-                '46': true,
-                '47': true,
-                '48': true,
-                '49': true,
-                '50': true,
-                '51': true,
-                '52': true,
-                '53': true,
-                '54': false,
-                '55': true,
-                '56': true,
-                '57': true,
-                '58': true,
-                '59': true,
-                '60': true,
-                '61': true,
-                '62': true,
-                '63': true,
-                '64': true,
-                '65': true,
-                '66': true,
-                '67': true,
-                '68': true,
-                '69': true,
-                '70': true,
-                '71': true,
-                '72': true,
-                '73': true,
-                '74': true,
-                '75': true,
-                '76': true,
-                '77': true,
-                '78': true,
-                '79': true,
-                '80': true,
-                '81': true,
-                '82': true,
-                '83': false,
-                '84': true,
-                '85': true,
-                '86': true,
-                '87': true,
-                '88': true,
-                '89': true,
-                '90': true,
-                '91': true,
-                '92': true,
-                '93': true,
-                '94': true,
-                '95': true,
-                '96': false,
-                '97': true,
-                '98': true,
-                '99': false,
-                '100': true,
-                '101': true,
-                '102': true,
-                '103': false,
-                '104': true,
-                '105': true,
-                '106': false,
-                '107': false,
-                '108': true,
-                '109': true,
-                '110': true,
-                '111': true,
-                '112': true,
-                '113': true,
-                '114': true,
-                '115': true,
-                '116': false,
-                '117': false,
-                '118': false,
-                '119': true,
-                '120': true,
-                '121': false,
-                '122': true,
-                '123': false,
-                '124': true,
-                '125': true,
-                '126': true,
-                '127': true,
-                '128': true,
-                '129': true,
-                '130': true,
-                '131': true,
-                '132': true,
-                '133': true,
-                '134': true,
-                '135': false,
-                '136': true,
-                '137': false,
-                '138': true,
-                '139': true,
-                '140': true,
-                '141': true,
-                '142': true,
-                '143': true,
-                '144': true,
-                '145': true,
-                '146': false,
-                '147': true,
-                '148': true,
-                '149': true,
-                '150': true,
-                '151': true,
-                '152': false,
-                '153': true,
-                '154': true,
-                '155': true,
-                '156': true,
-                '157': true,
-                '158': true,
-                '159': true,
-                '160': true,
-                '161': true,
-                '162': true,
-                '163': true,
-                '164': true,
-                '165': true,
-                '166': false,
-                '167': true,
-                '168': true,
-                '169': true,
-                '170': true,
-                '171': false,
-                '172': false,
-                '173': true,
-                '174': true,
-                '175': true,
-                '176': false,
-                '177': true,
-                '178': false,
-                '179': true,
-                '180': true,
-                '181': false,
-                '182': true,
-                '183': true,
-                '184': false,
-                '185': true,
-                '186': false,
-                '187': false,
-                '188': true,
-                '189': true,
-                '190': true,
-                '191': false,
-                '192': true,
-                '193': true,
-                '194': true,
-                '195': true,
-                '196': false,
-                '197': true,
-                '198': true,
-                '199': true,
-                '200': true,
-                '201': true,
-                '202': true,
-                '203': true,
-                '204': false,
-                '205': true,
-                '206': false,
-                '207': false,
-                '208': true,
-                '209': true,
-                '210': true,
-                '211': true,
-                '212': true,
-                '213': true,
-                '214': false,
-                '215': true,
-                '216': false,
-                '217': true,
-                '218': false,
-                '219': false,
-                '220': false,
-                '221': false,
-                '222': false,
-                '223': false,
-                '224': true,
-                '225': true,
-                '226': true,
-                '227': true,
-                '228': true,
-                '229': true,
-                '230': true,
-                '231': false,
-                '232': true,
-                '233': false,
-                '234': true,
-                '235': true,
-                '236': true,
-                '237': true,
-                '238': true,
-                '239': true,
-                '240': true,
-                '241': true,
-                '242': false,
-                '243': false,
-                '244': true,
-                '245': true,
-                '246': true,
-                '247': false,
-                '248': true,
-                '249': true,
-                '250': false,
-                '251': false,
-                '252': true,
-                '253': true,
-                '254': true,
-                '255': true,
-                '256': true,
-                '257': true,
-                '258': true,
-                '259': true,
-                '260': true,
-                '261': false,
-                '262': true,
-                '263': false,
-                '264': true,
-                '265': true,
-                '266': true,
-                '267': false,
-                '268': false,
-                '269': true,
-                '270': true,
-                '271': false,
-                '272': true,
-                '273': true,
-                '274': true,
-                '275': true,
-                '276': true,
-                '277': true,
-                '278': true,
-                '279': true,
-                '280': true,
-                '281': true,
-                '282': true,
-                '283': false,
-                '284': true,
-                '285': true,
-                '286': false,
-                '287': false,
-                '288': true,
-                '289': true,
-                '290': true,
-                '291': true,
-                '292': false,
-                '293': false,
-                '294': true,
-                '295': true,
-                '296': false,
-                '297': true,
-                '298': false,
-                '299': true,
-                '300': false,
-                '301': true,
-                '302': true,
-                '303': true,
-                '304': true,
-                '305': false,
-                '306': false,
-                '307': false,
-                '308': true,
-                '309': true,
-                '310': true,
-                '311': false,
-                '312': false,
-                '313': false,
-                '314': true,
-                '315': true,
-                '316': true,
-                '317': true,
-                '318': true,
-                '319': true,
-                '320': true,
-                '321': false,
-                '322': false,
-                '323': true,
-                '324': false,
-                '325': true,
-                '326': true,
-                '327': false,
-                '328': true,
-                '329': false,
-                '330': false,
-                '331': true,
-                '332': false,
-                '333': true,
-                '334': false,
-                '335': false,
-                '336': false,
-                '337': false,
-                '338': false,
-                '339': true,
-                '340': false,
-                '341': false,
-                '342': false,
-                '343': false,
-                '344': false,
-                '345': true,
-                '346': false,
-                '347': false,
-                '348': false,
-                '349': true,
-                '350': false,
-                '351': false,
-                '352': false,
-                '353': false,
-                '354': true,
-                '355': false,
-                '356': false,
-                '357': false,
-                '358': false,
-                '359': true
+                '5': false
+              }
+            }
+          }
+        };
+
+        setConsentConfig(staticConfig);
+        expect(userCMP).to.be.equal('static');
+        expect(consentTimeout).to.be.equal(0); // should always return without a timeout when config is used
+        expect(allowAuction).to.be.false;
+        expect(staticConsentData).to.be.equal(staticConfig.consentData);
+      });
+
+      it('results in user settings overriding system defaults for v2 spec', () => {
+        let staticConfig = {
+          cmpApi: 'static',
+          timeout: 7500,
+          allowAuctionWithoutConsent: false,
+          consentData: {
+            getTCData: {
+              'tcString': 'COuqj-POu90rDBcBkBENAZCgAPzAAAPAACiQFwwBAABAA1ADEAbQC4YAYAAgAxAG0A',
+              'cmpId': 92,
+              'cmpVersion': 100,
+              'tcfPolicyVersion': 2,
+              'gdprApplies': true,
+              'isServiceSpecific': true,
+              'useNonStandardStacks': false,
+              'purposeOneTreatment': false,
+              'publisherCC': 'US',
+              'cmpStatus': 'loaded',
+              'eventStatus': 'tcloaded',
+              'outOfBand': {
+                'allowedVendors': {},
+                'discloseVendors': {}
+              },
+              'purpose': {
+                'consents': {
+                  '1': true,
+                  '2': true,
+                  '3': true
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                }
+              },
+              'vendor': {
+                'consents': {
+                  '1': false,
+                  '2': true,
+                  '3': false
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': true,
+                  '3': false,
+                  '4': false,
+                  '5': false
+                }
+              },
+              'specialFeatureOptins': {
+                '1': false,
+                '2': false
+              },
+              'restrictions': {},
+              'publisher': {
+                'consents': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                },
+                'customPurpose': {
+                  'consents': {},
+                  'legitimateInterests': {}
+                }
               }
             }
           }
@@ -554,7 +277,6 @@ describe('consentManagement', function () {
         utils.logWarn.restore();
         utils.logError.restore();
         config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
         resetConsentData();
       });
 
@@ -593,12 +315,11 @@ describe('consentManagement', function () {
 
       beforeEach(function () {
         didHookReturn = false;
-        window.__cmp = function() {};
+        window.__cmp = function () { };
       });
 
       afterEach(function () {
         config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
         cmpStub.restore();
         delete window.__cmp;
         resetConsentData();
@@ -614,7 +335,7 @@ describe('consentManagement', function () {
           args[2](testConsentData);
         });
         setConsentConfig(goodConfigWithAllowAuction);
-        requestBidsHook(() => {}, {});
+        requestBidsHook(() => { }, {});
         cmpStub.restore();
 
         // reset the stub to ensure it wasn't called during the second round of calls
@@ -634,121 +355,39 @@ describe('consentManagement', function () {
       });
     });
 
-    describe('CMP workflow for safeframe page', function () {
-      let registerStub = sinon.stub();
+    describe('iframe tests', function () {
+      let cmpPostMessageCb = () => { };
+      let stringifyResponse;
 
-      beforeEach(function () {
-        didHookReturn = false;
-        window.$sf = {
-          ext: {
-            register: function() {},
-            cmp: function() {}
-          }
-        };
-        sinon.stub(utils, 'logError');
-        sinon.stub(utils, 'logWarn');
-      });
-
-      afterEach(function () {
-        delete window.$sf;
-        config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
-        registerStub.restore();
-        utils.logError.restore();
-        utils.logWarn.restore();
-        resetConsentData();
-      });
-
-      it('should return the consent data from a safeframe callback', function () {
-        var testConsentData = {
-          data: {
-            msgName: 'cmpReturn',
-            vendorConsents: {
-              metadata: 'abc123def',
-              gdprApplies: true
-            },
-            vendorConsentData: {
-              consentData: 'abc123def',
-              gdprApplies: true
-            }
-          }
-        };
-        registerStub = sinon.stub(window.$sf.ext, 'register').callsFake((...args) => {
-          args[2](testConsentData.data.msgName, testConsentData.data);
-        });
-
-        setConsentConfig(goodConfigWithAllowAuction);
-        requestBidsHook(() => {
-          didHookReturn = true;
-        }, {adUnits: [{ sizes: [[300, 250]] }]});
-        let consent = gdprDataHandler.getConsentData();
-
-        sinon.assert.notCalled(utils.logWarn);
-        sinon.assert.notCalled(utils.logError);
-        expect(didHookReturn).to.be.true;
-        expect(consent.consentString).to.equal('abc123def');
-        expect(consent.gdprApplies).to.be.true;
-      });
-    });
-
-    describe('CMP workflow for iframed page', function () {
-      let ifr = null;
-      let stringifyResponse = false;
-
-      beforeEach(function () {
-        sinon.stub(utils, 'logError');
-        sinon.stub(utils, 'logWarn');
-        ifr = createIFrameMarker();
-        window.addEventListener('message', cmpMessageHandler, false);
-      });
-
-      afterEach(function () {
-        config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
-        delete window.__cmp;
-        utils.logError.restore();
-        utils.logWarn.restore();
-        resetConsentData();
-        document.body.removeChild(ifr);
-        window.removeEventListener('message', cmpMessageHandler);
-      });
-
-      function createIFrameMarker() {
-        var ifr = document.createElement('iframe');
+      function createIFrameMarker(frameName) {
+        let ifr = document.createElement('iframe');
         ifr.width = 0;
         ifr.height = 0;
-        ifr.name = '__cmpLocator';
+        ifr.name = frameName;
         document.body.appendChild(ifr);
         return ifr;
       }
 
-      function cmpMessageHandler(event) {
-        if (event && event.data) {
-          var data = event.data;
-          if (data.__cmpCall) {
-            var callId = data.__cmpCall.callId;
-            var returnValue = null;
-            var response = {
-              __cmpReturn: {
-                callId,
-                returnValue: {
-                  consentData: 'encoded_consent_data_via_post_message',
-                  gdprApplies: true,
-                },
-                success: true
-              }
-            };
-            event.source.postMessage(stringifyResponse ? JSON.stringify(response) : response, '*');
+      function creatCmpMessageHandler(prefix, returnValue) {
+        return function (event) {
+          if (event && event.data) {
+            let data = event.data;
+            if (data[`${prefix}Call`]) {
+              let callId = data[`${prefix}Call`].callId;
+              let response = {
+                [`${prefix}Return`]: {
+                  callId,
+                  returnValue,
+                  success: true
+                }
+              };
+              event.source.postMessage(stringifyResponse ? JSON.stringify(response) : response, '*');
+            }
           }
         }
       }
 
-      // Run tests with JSON response and String response
-      // from CMP window postMessage listener.
-      testIFramedPage('with/JSON response', false);
-      testIFramedPage('with/String response', true);
-
-      function testIFramedPage(testName, messageFormatString) {
+      function testIFramedPage(testName, messageFormatString, tarConsentString, ver) {
         it(`should return the consent string from a postmessage + addEventListener response - ${testName}`, (done) => {
           stringifyResponse = messageFormatString;
           setConsentConfig(goodConfigWithAllowAuction);
@@ -756,96 +395,256 @@ describe('consentManagement', function () {
             let consent = gdprDataHandler.getConsentData();
             sinon.assert.notCalled(utils.logWarn);
             sinon.assert.notCalled(utils.logError);
-            expect(consent.consentString).to.equal('encoded_consent_data_via_post_message');
+            expect(consent.consentString).to.equal(tarConsentString);
             expect(consent.gdprApplies).to.be.true;
+            expect(consent.apiVersion).to.equal(ver);
             done();
           }, {});
         });
       }
+
+      beforeEach(function () {
+        sinon.stub(utils, 'logError');
+        sinon.stub(utils, 'logWarn');
+      });
+
+      afterEach(function () {
+        utils.logError.restore();
+        utils.logWarn.restore();
+        config.resetConfig();
+        resetConsentData();
+      });
+
+      describe('v1 CMP workflow for safeframe page', function () {
+        let registerStub = sinon.stub();
+        let ifrSf = null;
+        beforeEach(function () {
+          didHookReturn = false;
+          window.$sf = {
+            ext: {
+              register: function () { },
+              cmp: function () { }
+            }
+          };
+          ifrSf = createIFrameMarker('__cmpLocator');
+        });
+
+        afterEach(function () {
+          delete window.$sf;
+          registerStub.restore();
+          document.body.removeChild(ifrSf);
+        });
+
+        it('should return the consent data from a safeframe callback', function () {
+          let testConsentData = {
+            data: {
+              msgName: 'cmpReturn',
+              vendorConsents: {
+                metadata: 'abc123def',
+                gdprApplies: true
+              },
+              vendorConsentData: {
+                consentData: 'abc123def',
+                gdprApplies: true
+              }
+            }
+          };
+          registerStub = sinon.stub(window.$sf.ext, 'register').callsFake((...args) => {
+            args[2](testConsentData.data.msgName, testConsentData.data);
+          });
+
+          setConsentConfig(goodConfigWithAllowAuction);
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, { adUnits: [{ sizes: [[300, 250]] }] });
+          let consent = gdprDataHandler.getConsentData();
+
+          sinon.assert.notCalled(utils.logWarn);
+          sinon.assert.notCalled(utils.logError);
+          expect(didHookReturn).to.be.true;
+          expect(consent.consentString).to.equal('abc123def');
+          expect(consent.gdprApplies).to.be.true;
+          expect(consent.apiVersion).to.equal(1);
+        });
+      });
+
+      describe('v1 CMP workflow for iframe pages', function () {
+        stringifyResponse = false;
+        let ifr1 = null;
+
+        beforeEach(function () {
+          ifr1 = createIFrameMarker('__cmpLocator');
+          cmpPostMessageCb = creatCmpMessageHandler('__cmp', {
+            consentData: 'encoded_consent_data_via_post_message',
+            gdprApplies: true,
+          });
+          window.addEventListener('message', cmpPostMessageCb, false);
+        });
+
+        afterEach(function () {
+          delete window.__cmp; // deletes the local copy made by the postMessage CMP call function
+          document.body.removeChild(ifr1);
+          window.removeEventListener('message', cmpPostMessageCb);
+        });
+
+        // Run tests with JSON response and String response
+        // from CMP window postMessage listener.
+        testIFramedPage('with/JSON response', false, 'encoded_consent_data_via_post_message', 1);
+        testIFramedPage('with/String response', true, 'encoded_consent_data_via_post_message', 1);
+      });
+
+      describe('v2 CMP workflow for iframe pages:', function () {
+        stringifyResponse = false;
+        let ifr2 = null;
+
+        beforeEach(function () {
+          ifr2 = createIFrameMarker('__tcfapiLocator');
+          cmpPostMessageCb = creatCmpMessageHandler('__tcfapi', {
+            tcString: 'abc12345234',
+            gdprApplies: true,
+            purposeOneTreatment: false,
+            eventStatus: 'tcloaded'
+          });
+          window.addEventListener('message', cmpPostMessageCb, false);
+        });
+
+        afterEach(function () {
+          delete window.__tcfapi; // deletes the local copy made by the postMessage CMP call function
+          document.body.removeChild(ifr2);
+          window.removeEventListener('message', cmpPostMessageCb);
+        });
+
+        testIFramedPage('with/JSON response', false, 'abc12345234', 2);
+        testIFramedPage('with/String response', true, 'abc12345234', 2);
+      });
     });
 
-    describe('CMP workflow for normal pages:', function () {
+    describe('direct calls to CMP API tests', function () {
       let cmpStub = sinon.stub();
 
       beforeEach(function () {
         didHookReturn = false;
         sinon.stub(utils, 'logError');
         sinon.stub(utils, 'logWarn');
-        window.__cmp = function() {};
       });
 
       afterEach(function () {
         config.resetConfig();
-        $$PREBID_GLOBAL$$.requestBids.removeAll();
         cmpStub.restore();
         utils.logError.restore();
         utils.logWarn.restore();
-        delete window.__cmp;
         resetConsentData();
       });
 
-      it('performs lookup check and stores consentData for a valid existing user', function () {
-        let testConsentData = {
-          gdprApplies: true,
-          consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
-        };
-        cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
-          args[2](testConsentData);
+      describe('v1 CMP workflow for normal pages:', function () {
+        beforeEach(function () {
+          window.__cmp = function () { };
         });
 
-        setConsentConfig(goodConfigWithAllowAuction);
+        afterEach(function () {
+          delete window.__cmp;
+        });
 
-        requestBidsHook(() => {
-          didHookReturn = true;
-        }, {});
-        let consent = gdprDataHandler.getConsentData();
+        it('performs lookup check and stores consentData for a valid existing user', function () {
+          let testConsentData = {
+            gdprApplies: true,
+            consentData: 'BOJy+UqOJy+UqABAB+AAAAAZ+A=='
+          };
+          cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
+            args[2](testConsentData);
+          });
 
-        sinon.assert.notCalled(utils.logWarn);
-        sinon.assert.notCalled(utils.logError);
-        expect(didHookReturn).to.be.true;
-        expect(consent.consentString).to.equal(testConsentData.consentData);
-        expect(consent.gdprApplies).to.be.true;
+          setConsentConfig(goodConfigWithAllowAuction);
+
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, {});
+          let consent = gdprDataHandler.getConsentData();
+
+          sinon.assert.notCalled(utils.logWarn);
+          sinon.assert.notCalled(utils.logError);
+          expect(didHookReturn).to.be.true;
+          expect(consent.consentString).to.equal(testConsentData.consentData);
+          expect(consent.gdprApplies).to.be.true;
+          expect(consent.apiVersion).to.equal(1);
+        });
       });
 
-      it('throws an error when processCmpData check failed while config had allowAuction set to false', function () {
-        let testConsentData = {};
-        let bidsBackHandlerReturn = false;
-
-        cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
-          args[2](testConsentData);
+      describe('v2 CMP workflow for normal pages:', function () {
+        beforeEach(function() {
+          window.__tcfapi = function () { };
         });
 
-        setConsentConfig(goodConfigWithCancelAuction);
-
-        requestBidsHook(() => {
-          didHookReturn = true;
-        }, { bidsBackHandler: () => bidsBackHandlerReturn = true });
-        let consent = gdprDataHandler.getConsentData();
-
-        sinon.assert.calledOnce(utils.logError);
-        expect(didHookReturn).to.be.false;
-        expect(bidsBackHandlerReturn).to.be.true;
-        expect(consent).to.be.null;
-      });
-
-      it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', function () {
-        let testConsentData = {};
-
-        cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
-          args[2](testConsentData);
+        afterEach(function () {
+          delete window.__tcfapi;
         });
 
-        setConsentConfig(goodConfigWithAllowAuction);
+        it('performs lookup check and stores consentData for a valid existing user', function () {
+          let testConsentData = {
+            tcString: 'abc12345234',
+            gdprApplies: true,
+            purposeOneTreatment: false,
+            eventStatus: 'tcloaded'
+          };
+          cmpStub = sinon.stub(window, '__tcfapi').callsFake((...args) => {
+            args[2](testConsentData, true);
+          });
 
-        requestBidsHook(() => {
-          didHookReturn = true;
-        }, {});
-        let consent = gdprDataHandler.getConsentData();
+          setConsentConfig(goodConfigWithAllowAuction);
 
-        sinon.assert.calledOnce(utils.logWarn);
-        expect(didHookReturn).to.be.true;
-        expect(consent.consentString).to.be.undefined;
-        expect(consent.gdprApplies).to.be.undefined;
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, {});
+          let consent = gdprDataHandler.getConsentData();
+          sinon.assert.notCalled(utils.logWarn);
+          sinon.assert.notCalled(utils.logError);
+          expect(didHookReturn).to.be.true;
+          expect(consent.consentString).to.equal(testConsentData.tcString);
+          expect(consent.gdprApplies).to.be.true;
+          expect(consent.apiVersion).to.equal(2);
+        });
+
+        it('throws an error when processCmpData check failed while config had allowAuction set to false', function () {
+          let testConsentData = {};
+          let bidsBackHandlerReturn = false;
+
+          cmpStub = sinon.stub(window, '__tcfapi').callsFake((...args) => {
+            args[2](testConsentData);
+          });
+
+          setConsentConfig(goodConfigWithCancelAuction);
+
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, { bidsBackHandler: () => bidsBackHandlerReturn = true });
+          let consent = gdprDataHandler.getConsentData();
+
+          sinon.assert.calledOnce(utils.logError);
+          expect(didHookReturn).to.be.false;
+          expect(bidsBackHandlerReturn).to.be.true;
+          expect(consent).to.be.null;
+        });
+
+        it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', function () {
+          let testConsentData = {};
+
+          cmpStub = sinon.stub(window, '__tcfapi').callsFake((...args) => {
+            args[2](testConsentData);
+          });
+
+          setConsentConfig(goodConfigWithAllowAuction);
+
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, {});
+          let consent = gdprDataHandler.getConsentData();
+
+          sinon.assert.calledOnce(utils.logWarn);
+          expect(didHookReturn).to.be.true;
+          expect(consent.consentString).to.be.undefined;
+          expect(consent.gdprApplies).to.be.undefined;
+          expect(consent.apiVersion).to.equal(2);
+        });
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Implements the feature described in #4801

Key things to note:
- Added support to call and process consent data from TCF2 CMPs, while also maintaining logic for v1 CMPs.
- Added a new function to detect the CMPs was implemented; this will attempt to climb each parent window from where Prebid is located to find the CMP objects (whether its the CMP's API function or their locator frame).  Preference is given to the TCF2 spec in this logic.  
**NOTE** This does slightly change the logic used for the v1 checks, which only checked the current window then the top window when finding the CMP API.  I think this should be fine.
- To support dynamic updates to the consent data after the page has initially loaded, I removed all our `removeEventListeners` references in order to keep the listeners open and ready to respond.  This also includes removing the `delete cmpCallbacks[i.callId];` code we had for the iframe route (so we can act properly when a follow-up event is triggered from the original `callId`).
- I updated the `userId/index.js` to handle looking at the updated version of the `vendorData` object for the TCF2 spec.

As a follow-up to the last note, the are 8 bid adapters (currently) who read the `gdprConsent.vendorData` field to either do some logic or pass along some of the values in their request.  These bidders are as followed:
- criteo  @leonardlabat
- emoteev @piotr-yuxuan 
- fidelity @onaydenov 
- invibes @rcheptanariu 
- proxistore @vincentproxistore 
- teads @valsouche 
- underdogmedia @mash-a & @Jacobkmiller 
- widespace @ahsun-ahmed 

Ideally, these adapters should be updated to read the new `gdprConsent.apiVersion` field so they can look at the updated locations/field names for the `vendorData` they need to know.  I (hopefully) tagged all the main contributors so they are aware.