### PR TITLE
fix regression in sourcemaps

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import includes from 'core-js/library/fn/array/includes.js';
 
 const CONSTANTS = require('./constants.json');
 
-export { default as deepAccess } from 'dlv';
+export { default as deepAccess } from 'dlv/index.js';
 export { default as deepSetValue } from 'dset';
 
 var tArr = 'Array';


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Fixes regression from #4876 that broke sourcemaps

## Other information
Was previously fixed in #4071