### PR TITLE
Surrounding adapter calls in try

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -366,7 +366,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done
     } : undefined);
-    let adapterDone = doneCb.bind(bidRequest);
+    const adapterDone = doneCb.bind(bidRequest);
     try {
       config.runWithBidder(
         bidRequest.bidderCode,

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -366,19 +366,25 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done
     } : undefined);
-    config.runWithBidder(
-      bidRequest.bidderCode,
-      bind.call(
-        adapter.callBids,
-        adapter,
-        bidRequest,
-        addBidResponse.bind(bidRequest),
-        doneCb.bind(bidRequest),
-        ajax,
-        onTimelyResponse,
-        config.callbackWithBidder(bidRequest.bidderCode)
-      )
-    );
+    let adapterDone = doneCb.bind(bidRequest);
+    try {
+      config.runWithBidder(
+        bidRequest.bidderCode,
+        bind.call(
+          adapter.callBids,
+          adapter,
+          bidRequest,
+          addBidResponse.bind(bidRequest),
+          adapterDone,
+          ajax,
+          onTimelyResponse,
+          config.callbackWithBidder(bidRequest.bidderCode)
+        )
+      );
+    } catch (e) {
+      utils.logError(`${bidRequest.bidderCode} Bid Adapter emitted an uncaught error when parsing their bidRequest`, {e, bidRequest});
+      adapterDone();
+    }
   });
 };
 

--- a/test/spec/modules/adomikAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adomikAnalyticsAdapter_spec.js
@@ -7,6 +7,13 @@ let constants = require('src/constants.json');
 describe('Adomik Prebid Analytic', function () {
   let sendEventStub;
   let sendWonEventStub;
+  let clock;
+  before(function () {
+    clock = sinon.useFakeTimers();
+  });
+  after(function () {
+    clock.restore();
+  });
 
   describe('enableAnalytics', function () {
     beforeEach(function () {
@@ -120,7 +127,6 @@ describe('Adomik Prebid Analytic', function () {
       expect(adomikAnalytics.currentContext.timeouted).to.equal(true);
 
       // Step 7: Send auction end event
-      var clock = sinon.useFakeTimers();
       events.emit(constants.EVENTS.AUCTION_END, {});
 
       setTimeout(function() {
@@ -130,7 +136,6 @@ describe('Adomik Prebid Analytic', function () {
       }, 3000);
 
       clock.tick(5000);
-      clock.restore();
 
       sinon.assert.callCount(adomikAnalytics.track, 6);
     });

--- a/test/spec/modules/tribeosBidAdapter_spec.js
+++ b/test/spec/modules/tribeosBidAdapter_spec.js
@@ -75,8 +75,6 @@ describe('tribeosBidAdapter', function() {
     expect(bids).to.have.lengthOf(1);
     let bid = bids[0];
 
-    console.error(JSON.stringify(bid));
-
     expect(bid.cpm).to.equal(1.1);
     expect(bid.currency).to.equal('USD');
     expect(bid.width).to.equal(300);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -43,16 +43,23 @@ var rubiconAdapterMock = {
   callBids: sinon.stub()
 };
 
+var badAdapterMock = {
+  bidder: 'badBidder',
+  callBids: sinon.stub().throws(Error('some fake error'))
+};
+
 describe('adapterManager tests', function () {
   let orgAppnexusAdapter;
   let orgAdequantAdapter;
   let orgPrebidServerAdapter;
   let orgRubiconAdapter;
+  let orgBadBidderAdapter;
   before(function () {
     orgAppnexusAdapter = adapterManager.bidderRegistry['appnexus'];
     orgAdequantAdapter = adapterManager.bidderRegistry['adequant'];
     orgPrebidServerAdapter = adapterManager.bidderRegistry['prebidServer'];
     orgRubiconAdapter = adapterManager.bidderRegistry['rubicon'];
+    orgBadBidderAdapter = adapterManager.bidderRegistry['badBidder'];
   });
 
   after(function () {
@@ -60,6 +67,7 @@ describe('adapterManager tests', function () {
     adapterManager.bidderRegistry['adequant'] = orgAdequantAdapter;
     adapterManager.bidderRegistry['prebidServer'] = orgPrebidServerAdapter;
     adapterManager.bidderRegistry['rubicon'] = orgRubiconAdapter;
+    adapterManager.bidderRegistry['badBidder'] = orgBadBidderAdapter;
     config.setConfig({s2sConfig: { enabled: false }});
   });
 
@@ -72,11 +80,16 @@ describe('adapterManager tests', function () {
       sinon.stub(utils, 'logError');
       appnexusAdapterMock.callBids.reset();
       adapterManager.bidderRegistry['appnexus'] = appnexusAdapterMock;
+      adapterManager.bidderRegistry['rubicon'] = rubiconAdapterMock;
+      adapterManager.bidderRegistry['badBidder'] = badAdapterMock;
     });
 
     afterEach(function () {
       utils.logError.restore();
       delete adapterManager.bidderRegistry['appnexus'];
+      delete adapterManager.bidderRegistry['rubicon'];
+      delete adapterManager.bidderRegistry['badBidder'];
+      config.resetConfig();
     });
 
     it('should log an error if a bidder is used that does not exist', function () {
@@ -95,6 +108,34 @@ describe('adapterManager tests', function () {
       sinon.assert.called(utils.logError);
     });
 
+    it('should catch a bidder adapter thrown error and continue with other bidders', function () {
+      const adUnits = [{
+        code: 'adUnit-code',
+        sizes: [[728, 90]],
+        bids: [
+          {bidder: 'appnexus', params: {placementId: 'id'}},
+          {bidder: 'badBidder', params: {placementId: 'id'}},
+          {bidder: 'rubicon', params: {account: 1111, site: 2222, zone: 3333}}
+        ]
+      }];
+      let bidRequests = adapterManager.makeBidRequests(adUnits, 1111, 2222, 1000);
+
+      let doneBidders = [];
+      function mockDoneCB() {
+        doneBidders.push(this.bidderCode)
+      }
+      adapterManager.callBids(adUnits, bidRequests, () => {}, mockDoneCB);
+      sinon.assert.calledOnce(appnexusAdapterMock.callBids);
+      sinon.assert.calledOnce(badAdapterMock.callBids);
+      sinon.assert.calledOnce(rubiconAdapterMock.callBids);
+
+      expect(utils.logError.calledOnce).to.be.true;
+      expect(utils.logError.calledWith(
+        'badBidder Bid Adapter emitted an uncaught error when parsing their bidRequest'
+      )).to.be.true;
+      // done should be called for our bidder!
+      expect(doneBidders.indexOf('badBidder') === -1).to.be.false;
+    });
     it('should emit BID_REQUESTED event', function () {
       // function to count BID_REQUESTED events
       let cnt = 0;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1171,6 +1171,12 @@ describe('Unit: Prebid Module', function () {
     let makeRequestsStub;
     let adUnits;
     let clock;
+    before(function () {
+      clock = sinon.useFakeTimers();
+    });
+    after(function () {
+      clock.restore();
+    });
     let bidsBackHandlerStub = sinon.stub();
 
     const BIDDER_CODE = 'sampleBidder';
@@ -1257,7 +1263,6 @@ describe('Unit: Prebid Module', function () {
       spec.isBidRequestValid.returns(true);
       spec.interpretResponse.returns(bids);
 
-      clock = sinon.useFakeTimers();
       let requestObj = {
         bidsBackHandler: null, // does not need to be defined because of newAuction mock in beforeEach
         timeout: 2000,
@@ -1311,7 +1316,6 @@ describe('Unit: Prebid Module', function () {
       auction.getBidsReceived = function() { return [adResponse]; }
       auction.getAuctionId = () => auctionId;
 
-      clock = sinon.useFakeTimers();
       let requestObj = {
         bidsBackHandler: null, // does not need to be defined because of newAuction mock in beforeEach
         timeout: 2000,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Refactoring (no functional changes, no api changes)

## Description of change
Currently, if one of the adapters in the requests throws some uncaught error, the remaining bidders will not be called.

This simply surrounds the adapter calls in a try and if caught calls adapterDone which will log it as a no-bid.

Also updated a few tests to include restoring clock on teardown instead of inside test itself.