### PR TITLE
fix bug related to default usersync config for image-based pixels

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -2,20 +2,22 @@ import * as utils from './utils.js';
 import { config } from './config.js';
 import includes from 'core-js/library/fn/array/includes.js';
 
+export const USERSYNC_DEFAULT_CONFIG = {
+  syncEnabled: true,
+  filterSettings: {
+    image: {
+      bidders: '*',
+      filter: 'include'
+    }
+  },
+  syncsPerBidder: 5,
+  syncDelay: 3000,
+  auctionDelay: 0
+};
+
 // Set userSync default values
 config.setDefaults({
-  'userSync': {
-    syncEnabled: true,
-    filterSettings: {
-      image: {
-        bidders: '*',
-        filter: 'include'
-      }
-    },
-    syncsPerBidder: 5,
-    syncDelay: 3000,
-    auctionDelay: 0
-  }
+  'userSync': utils.deepClone(USERSYNC_DEFAULT_CONFIG)
 });
 
 /**
@@ -45,6 +47,20 @@ export function newUserSync(userSyncDependencies) {
   let usConfig = userSyncDependencies.config;
   // Update if it's (re)set
   config.getConfig('userSync', (conf) => {
+    // if userSync.filterSettings only contains iframe, merge in default image config to ensure image pixels are fired
+    if (conf.userSync) {
+      let fs = conf.userSync.filterSettings;
+      if (utils.isPlainObject(fs)) {
+        let fsKeys = Object.keys(fs);
+        if (fsKeys.length === 1 && fsKeys[0] === 'iframe') {
+          conf.userSync.filterSettings.image = {
+            bidders: '*',
+            filter: 'include'
+          };
+        }
+      }
+    }
+
     usConfig = Object.assign(usConfig, conf.userSync);
   });
 

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -424,8 +424,8 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
     expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
     expect(triggerPixelStub.getCall(1)).to.be.null;
-
   });
+
   it('should override default image syncs if setConfig used all filter', function() {
     const userSync = newUserSync({
       config: config.getConfig('userSync'),

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { config } from 'src/config.js';
 // Use require since we need to be able to write to these vars
 const utils = require('../../src/utils');
-let { newUserSync } = require('../../src/userSync');
+let { newUserSync, USERSYNC_DEFAULT_CONFIG } = require('../../src/userSync');
 
 describe('user sync', function () {
   let triggerPixelStub;
@@ -34,6 +34,7 @@ describe('user sync', function () {
   });
 
   beforeEach(function () {
+    config.setConfig({ userSync: USERSYNC_DEFAULT_CONFIG });
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
     logWarnStub = sinon.stub(utils, 'logWarn');
     shuffleStub = sinon.stub(utils, 'shuffle').callsFake((array) => array.reverse());
@@ -47,6 +48,7 @@ describe('user sync', function () {
     shuffleStub.restore();
     getUniqueIdentifierStrStub.restore();
     insertUserSyncIframeStub.restore();
+    config.resetConfig();
   });
 
   it('should register and fire a pixel URL', function () {
@@ -372,6 +374,85 @@ describe('user sync', function () {
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
     expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com/1');
     expect(insertUserSyncIframeStub.getCall(0)).to.be.null;
+  });
+
+  it('should still allow default image syncs if setConfig only defined iframe', function () {
+    const userSync = newUserSync({
+      config: config.getConfig('userSync'),
+      browserSupportsCookies: true
+    });
+
+    config.setConfig({
+      userSync: {
+        filterSettings: {
+          iframe: {
+            bidders: ['bidderXYZ'],
+            filter: 'include'
+          }
+        }
+      }
+    });
+
+    userSync.registerSync('image', 'testBidder', 'http://example.com');
+    userSync.registerSync('iframe', 'bidderXYZ', 'http://example.com/iframe');
+    userSync.syncUsers();
+    expect(triggerPixelStub.getCall(0)).to.not.be.null;
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
+    expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
+  });
+
+  it('should override default image syncs if setConfig used image filter', function () {
+    const userSync = newUserSync({
+      config: config.getConfig('userSync'),
+      browserSupportsCookies: true
+    });
+
+    config.setConfig({
+      userSync: {
+        filterSettings: {
+          image: {
+            bidders: ['bidderXYZ'],
+            filter: 'exclude'
+          }
+        }
+      }
+    });
+
+    userSync.registerSync('image', 'testBidder', 'http://example.com');
+    userSync.registerSync('image', 'bidderXYZ', 'http://example.com/image-blocked');
+    userSync.syncUsers();
+    expect(triggerPixelStub.getCall(0)).to.not.be.null;
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
+    expect(triggerPixelStub.getCall(1)).to.be.null;
+
+  });
+  it('should override default image syncs if setConfig used all filter', function() {
+    const userSync = newUserSync({
+      config: config.getConfig('userSync'),
+      browserSupportsCookies: true
+    });
+
+    config.setConfig({
+      userSync: {
+        filterSettings: {
+          all: {
+            bidders: ['bidderXYZ'],
+            filter: 'exclude'
+          }
+        }
+      }
+    });
+
+    userSync.registerSync('image', 'testBidder', 'http://example.com');
+    userSync.registerSync('image', 'bidderXYZ', 'http://example.com/image-blocked');
+    userSync.registerSync('iframe', 'testBidder', 'http://example.com/iframe');
+    userSync.registerSync('iframe', 'bidderXYZ', 'http://example.com/iframe-blocked');
+    userSync.syncUsers();
+    expect(triggerPixelStub.getCall(0)).to.not.be.null;
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.equal('http://example.com');
+    expect(triggerPixelStub.getCall(1)).to.be.null;
+    expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
+    expect(insertUserSyncIframeStub.getCall(1)).to.be.null;
   });
 
   describe('publicAPI', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes #4864 

This fix ensures the default userSync config (which allowed image pixels for all bidders) is properly used when a publisher only defines iframe `filterSettings`.  If the publisher defines their own `image` or `all` config in the `filterSettings` field, then the default image setting is overwritten.