### PR TITLE
Add Schain Support. Fidelity Media 2.44.x legacy

### DIFF
--- a/modules/fidelityBidAdapter.js
+++ b/modules/fidelityBidAdapter.js
@@ -1,5 +1,5 @@
-import * as utils from '../src/utils';
-import {registerBidder} from '../src/adapters/bidderFactory';
+import * as utils from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'fidelity';
 const BIDDER_SERVER = 'x.fidelity-media.com';
@@ -26,6 +26,7 @@ export const spec = {
         tmax: bidderRequest.timeout,
         defloc: bidderRequest.refererInfo.referer,
         referrer: getTopWindowReferrer(),
+        schain: getSupplyChain(bidRequest.schain),
       };
       setConsentParams(bidderRequest.gdprConsent, bidderRequest.uspConsent, payload);
 
@@ -117,4 +118,25 @@ function setConsentParams(gdprConsent, uspConsent, payload) {
   }
 }
 
+function getSupplyChain(schain) {
+  var supplyChain = '';
+  if (schain != null && schain.nodes) {
+    supplyChain = schain.ver + ',' + schain.complete;
+    for (let i = 0; i < schain.nodes.length; i++) {
+      supplyChain += '!';
+      supplyChain += (schain.nodes[i].asi) ? encodeURIComponent(schain.nodes[i].asi) : '';
+      supplyChain += ',';
+      supplyChain += (schain.nodes[i].sid) ? encodeURIComponent(schain.nodes[i].sid) : '';
+      supplyChain += ',';
+      supplyChain += (schain.nodes[i].hp) ? encodeURIComponent(schain.nodes[i].hp) : '';
+      supplyChain += ',';
+      supplyChain += (schain.nodes[i].rid) ? encodeURIComponent(schain.nodes[i].rid) : '';
+      supplyChain += ',';
+      supplyChain += (schain.nodes[i].name) ? encodeURIComponent(schain.nodes[i].name) : '';
+      supplyChain += ',';
+      supplyChain += (schain.nodes[i].domain) ? encodeURIComponent(schain.nodes[i].domain) : '';
+    }
+  }
+  return supplyChain;
+}
 registerBidder(spec);

--- a/test/spec/modules/fidelityBidAdapter_spec.js
+++ b/test/spec/modules/fidelityBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { spec } from 'modules/fidelityBidAdapter';
-import { newBidder } from 'src/adapters/bidderFactory';
+import { spec } from 'modules/fidelityBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
 
 describe('FidelityAdapter', function () {
   const adapter = newBidder(spec);
@@ -67,7 +67,19 @@ describe('FidelityAdapter', function () {
           bidId: '2ffb201a808da7',
           bidderRequestId: '178e34bad3658f',
           requestId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
-          transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
+          transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b',
+          schain: {
+            ver: '1.0',
+            complete: 1,
+            nodes: [{
+              asi: 'exchange1.com',
+              sid: '1234',
+              hp: 1,
+              rid: 'bid-request-1',
+              name: 'publisher',
+              domain: 'publisher.com'
+            }]
+          }
         }
       ],
       start: 1472239426002,
@@ -78,7 +90,8 @@ describe('FidelityAdapter', function () {
       }
     };
 
-    it('should add source and verison to the tag', function () {
+    it('should add params to the request', function () {
+      let schainString = '1.0,1!exchange1.com,1234,1,bid-request-1,publisher,publisher.com';
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const payload = request.data;
       expect(payload.from).to.exist;
@@ -92,9 +105,11 @@ describe('FidelityAdapter', function () {
       expect(payload.flashver).to.exist;
       expect(payload.tmax).to.exist;
       expect(payload.defloc).to.exist;
+      expect(payload.schain).to.exist.and.to.be.a('string');
+      expect(payload.schain).to.equal(schainString);
     });
 
-    it('should add gdpr consent information to the request', function () {
+    it('should add consent information to the request', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let uspConsentString = '1YN-';
       bidderRequest.gdprConsent = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter   
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add schain support into Fidelity Media Bid Adapter. 2.44 Legacy

- contact email of the adapter’s maintainer onaydenov@fidelity-media.com
- [X] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/1845

## Other information

MD https://github.com/prebid/prebid.github.io/pull/1845
Master PBJS PR https://github.com/prebid/Prebid.js/pull/4945
