### PR TITLE
Update core-js to make it easy to remove.

### DIFF
--- a/allowedModules.js
+++ b/allowedModules.js
@@ -5,7 +5,6 @@ const sharedWhiteList = [
   "core-js/library/fn/set", // ie11 supports Set but not Set#values
   "core-js/library/fn/string/includes", // no ie11
   "core-js/library/fn/number/is-integer", // no ie11,
-  "core-js/library/fn/array/from" // no ie11
 ];
 
 module.exports = {

--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -25,8 +25,6 @@ import find from 'core-js/library/fn/array/find.js';
 import { auctionManager } from '../src/auctionManager.js';
 import CONSTANTS from '../src/constants.json';
 
-const from = require('core-js/library/fn/array/from.js');
-
 const TARGETING_KEY_PB_CAT_DUR = 'hb_pb_cat_dur';
 const TARGETING_KEY_CACHE_ID = 'hb_cache_id';
 
@@ -163,7 +161,7 @@ function updateBidQueue(auctionInstance, bidResponse, afterBidAdded) {
   let bidListIter = bidCacheRegistry.getBids(bidResponse);
 
   if (bidListIter) {
-    let bidListArr = from(bidListIter);
+    let bidListArr = Array.from(bidListIter);
     let callDispatcher = bidCacheRegistry.getQueueDispatcher(bidResponse);
     let killQueue = !!(auctionInstance.getAuctionStatus() !== AUCTION_IN_PROGRESS);
     callDispatcher(auctionInstance, bidListArr, afterBidAdded, killQueue);

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,6 @@ import includes from 'core-js/library/fn/array/includes.js';
 import Set from 'core-js/library/fn/set.js';
 import { parseQS } from './url.js';
 
-const from = require('core-js/library/fn/array/from.js');
 const utils = require('./utils.js');
 const CONSTANTS = require('./constants.json');
 
@@ -236,7 +235,7 @@ export function newConfig() {
       let currBidderConfig = bidderConfig[currBidder];
       const configTopicSet = new Set(Object.keys(config).concat(Object.keys(currBidderConfig)));
 
-      return from(configTopicSet).reduce((memo, topic) => {
+      return Array.from(configTopicSet).reduce((memo, topic) => {
         if (typeof currBidderConfig[topic] === 'undefined') {
           memo[topic] = config[topic];
         } else if (typeof config[topic] === 'undefined') {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,1 @@
+import 'core-js/fn/array/from'; // no ie11


### PR DESCRIPTION
## Type of change
- Build related changes

## Description of change
This PR is not complete. It is intended for discussion only.

Currently prebid includes the following core-js polyfills. This adds 40kb to the size of prebid.js.
````
  "core-js/library/fn/array/find", // no ie11
  "core-js/library/fn/array/includes", // no ie11
  "core-js/library/fn/set", // ie11 supports Set but not Set#values
  "core-js/library/fn/string/includes", // no ie11
  "core-js/library/fn/number/is-integer", // no ie11,
  "core-js/library/fn/array/from" // no ie11
````

These features are supported in modern browsers. IE 11 is the main outlier that requires the polyfills. IE 11 traffic is low but it exists. I'd like to make it possible to make a build of prebid without these polyfills.

Our site and others already implement polyfills for IE 11 in our application build process.

One option, similar to this PR, is to move the core-js references to a single file that can be easily included/excluded as needed if using as an npm dependency. The default non-npm build could still prepend these polyfills to prebid.js, I was not familiar enough with the webpack/gulp build process to configure this. The only side-effect would be it would pollute the global scope.

Is this something that could be considered? I'm happy to assist if there is consensus on the goal/approach.

