### PR TITLE
appnexus adapter : include hb_source in request to server

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -174,12 +174,15 @@ export const spec = {
 
     const hasAdPodBid = find(bidRequests, hasAdPod);
     if (hasAdPodBid) {
+      payload.hb_source = 7;
       bidRequests.filter(hasAdPod).forEach(adPodBid => {
         const adPodTags = createAdPodRequest(tags, adPodBid);
         // don't need the original adpod placement because it's in adPodTags
         const nonPodTags = payload.tags.filter(tag => tag.uuid !== adPodBid.bidId);
         payload.tags = [...nonPodTags, ...adPodTags];
       });
+    } else {
+      payload.hb_source = 1;
     }
 
     const criteoId = utils.deepAccess(bidRequests[0], `userId.criteoId`);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -659,7 +659,7 @@ function bidToTag(bid) {
   const videoMediaType = utils.deepAccess(bid, `mediaTypes.${VIDEO}`);
   const context = utils.deepAccess(bid, 'mediaTypes.video.context');
 
-  if (bid.mediaType === VIDEO || (videoMediaType && context === 'adpod')) {
+  if (videoMediaType && context === 'adpod') {
     tag.hb_source = 7;
   } else {
     tag.hb_source = 1;

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -659,6 +659,11 @@ function bidToTag(bid) {
   const videoMediaType = utils.deepAccess(bid, `mediaTypes.${VIDEO}`);
   const context = utils.deepAccess(bid, 'mediaTypes.video.context');
 
+  if (bid.mediaType === VIDEO || (videoMediaType && context === 'adpod')) {
+    tag.hb_source = 7;
+  } else {
+    tag.hb_source = 1;
+  }
   if (bid.mediaType === VIDEO || videoMediaType) {
     tag.ad_types.push(VIDEO);
   }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -174,15 +174,12 @@ export const spec = {
 
     const hasAdPodBid = find(bidRequests, hasAdPod);
     if (hasAdPodBid) {
-      payload.hb_source = 7;
       bidRequests.filter(hasAdPod).forEach(adPodBid => {
         const adPodTags = createAdPodRequest(tags, adPodBid);
         // don't need the original adpod placement because it's in adPodTags
         const nonPodTags = payload.tags.filter(tag => tag.uuid !== adPodBid.bidId);
         payload.tags = [...nonPodTags, ...adPodTags];
       });
-    } else {
-      payload.hb_source = 1;
     }
 
     const criteoId = utils.deepAccess(bidRequests[0], `userId.criteoId`);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -164,6 +164,7 @@ describe('AppNexusAdapter', function () {
       const payload = JSON.parse(request.data);
 
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
+      expect(payload.tags[0].hb_source).to.deep.equal(1);
     });
 
     it('sends bid request to ENDPOINT via POST', function () {
@@ -193,6 +194,7 @@ describe('AppNexusAdapter', function () {
         id: 123,
         minduration: 100
       });
+      expect(payload.tags[0].hb_source).to.deep.equal(1);
     });
 
     it('should add video property when adUnit includes a renderer', function () {
@@ -417,6 +419,44 @@ describe('AppNexusAdapter', function () {
       expect(payload3.tags.length).to.equal(15);
     });
 
+    it('should contain hb_source value for adpod', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDurationSec: 300,
+              durationRangeSec: [15, 30],
+            }
+          }
+        }
+      );
+      const request = spec.buildRequests([bidRequest])[0];
+      const payload = JSON.parse(request.data);
+      expect(payload.tags[0].hb_source).to.deep.equal(7);
+    });
+
+    it('should contain hb_source value for other media', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          mediaType: 'banner',
+          params: {
+            sizes: [[300, 250], [300, 600]],
+            placementId: 13144370
+          }
+        }
+      );
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.tags[0].hb_source).to.deep.equal(1);
+    });
+
     it('adds brand_category_exclusion to request when set', function() {
       let bidRequest = Object.assign({}, bidRequests[0]);
       sinon
@@ -480,6 +520,7 @@ describe('AppNexusAdapter', function () {
         saleprice: {required: true},
         privacy_supported: true
       });
+      expect(payload.tags[0].hb_source).to.equal(1);
     });
 
     it('should always populated tags[].sizes with 1,1 for native if otherwise not defined', function () {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -164,6 +164,7 @@ describe('AppNexusAdapter', function () {
       const payload = JSON.parse(request.data);
 
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
+      expect(payload.hb_source).to.equal(1);
     });
 
     it('sends bid request to ENDPOINT via POST', function () {
@@ -417,6 +418,44 @@ describe('AppNexusAdapter', function () {
       expect(payload3.tags.length).to.equal(15);
     });
 
+    it('should contain hb_source value for adpod', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: { placementId: '14542875' }
+        },
+        {
+          mediaTypes: {
+            video: {
+              context: 'adpod',
+              playerSize: [640, 480],
+              adPodDurationSec: 300,
+              durationRangeSec: [15, 30],
+            }
+          }
+        }
+      );
+      const request = spec.buildRequests([bidRequest])[0];
+      const payload = JSON.parse(request.data);
+      expect(payload.hb_source).to.equal(7);
+    });
+
+    it('should contain hb_source value for other media', function() {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          mediaType: 'banner',
+          params: {
+            sizes: [[300, 250], [300, 600]],
+            placementId: 13144370
+          }
+        }
+      );
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+      expect(payload.hb_source).to.equal(1);
+    });
+
     it('adds brand_category_exclusion to request when set', function() {
       let bidRequest = Object.assign({}, bidRequests[0]);
       sinon
@@ -480,6 +519,7 @@ describe('AppNexusAdapter', function () {
         saleprice: {required: true},
         privacy_supported: true
       });
+      expect(payload.hb_source).to.equal(1);
     });
 
     it('should always populated tags[].sizes with 1,1 for native if otherwise not defined', function () {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -164,7 +164,6 @@ describe('AppNexusAdapter', function () {
       const payload = JSON.parse(request.data);
 
       expect(payload.tags[0].ad_types).to.deep.equal(['video']);
-      expect(payload.hb_source).to.equal(1);
     });
 
     it('sends bid request to ENDPOINT via POST', function () {
@@ -418,44 +417,6 @@ describe('AppNexusAdapter', function () {
       expect(payload3.tags.length).to.equal(15);
     });
 
-    it('should contain hb_source value for adpod', function() {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
-          params: { placementId: '14542875' }
-        },
-        {
-          mediaTypes: {
-            video: {
-              context: 'adpod',
-              playerSize: [640, 480],
-              adPodDurationSec: 300,
-              durationRangeSec: [15, 30],
-            }
-          }
-        }
-      );
-      const request = spec.buildRequests([bidRequest])[0];
-      const payload = JSON.parse(request.data);
-      expect(payload.hb_source).to.equal(7);
-    });
-
-    it('should contain hb_source value for other media', function() {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
-          mediaType: 'banner',
-          params: {
-            sizes: [[300, 250], [300, 600]],
-            placementId: 13144370
-          }
-        }
-      );
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-      expect(payload.hb_source).to.equal(1);
-    });
-
     it('adds brand_category_exclusion to request when set', function() {
       let bidRequest = Object.assign({}, bidRequests[0]);
       sinon
@@ -519,7 +480,6 @@ describe('AppNexusAdapter', function () {
         saleprice: {required: true},
         privacy_supported: true
       });
-      expect(payload.hb_source).to.equal(1);
     });
 
     it('should always populated tags[].sizes with 1,1 for native if otherwise not defined', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change







<!-- For new bidder adapters, please provide the following -->

Add a param to inform appnexus adapter endpoint whether the request is an adpod request or any other media type. 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
