### PR TITLE
Add coppa support for Quantcast adapter

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -141,6 +141,7 @@ export const spec = {
         gdprConsent: gdprConsent.consentString,
         uspSignal: uspConsent ? 1 : 0,
         uspConsent,
+        coppa: config.getConfig('coppa') === true ? 1 : 0,
         prebidJsVersion: '$prebid.version$'
       };
 

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -357,6 +357,27 @@ describe('Quantcast adapter', function () {
     expect(parsed.uspConsent).to.equal('consentString');
   });
 
+  it('propagates COPPA as 1 if coppa param is true in the bid request', function () {
+    bidRequest.params = {
+      publisherId: 'test_publisher_id',
+      coppa: true
+    };
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+    expect(JSON.parse(requests[0].data).coppa).to.equal(1);
+  });
+
+  it('propagates COPPA as 0 if there is no coppa param or false in the bid request', function () {
+    const requestsWithoutCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
+    expect(JSON.parse(requestsWithoutCoppa[0].data).coppa).to.equal(0);
+
+    bidRequest.params = {
+      publisherId: 'test_publisher_id',
+      coppa: false
+    };
+    const requestsWithFalseCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
+    expect(JSON.parse(requestsWithFalseCoppa[0].data).coppa).to.equal(0);
+  });
+
   describe('`interpretResponse`', function () {
     // The sample response is from https://wiki.corp.qc/display/adinf/QCX
     const body = {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -11,6 +11,7 @@ import {
 } from '../../../modules/quantcastBidAdapter.js';
 import { newBidder } from '../../../src/adapters/bidderFactory.js';
 import { parse } from 'src/url.js';
+import { config } from 'src/config.js';
 
 describe('Quantcast adapter', function () {
   const quantcastAdapter = newBidder(qcSpec);
@@ -138,6 +139,7 @@ describe('Quantcast adapter', function () {
       bidId: '2f7b179d443f14',
       gdprSignal: 0,
       uspSignal: 0,
+      coppa: 0,
       prebidJsVersion: '$prebid.version$'
     };
 
@@ -205,6 +207,7 @@ describe('Quantcast adapter', function () {
         bidId: '2f7b179d443f14',
         gdprSignal: 0,
         uspSignal: 0,
+        coppa: 0,
         prebidJsVersion: '$prebid.version$'
       };
 
@@ -240,6 +243,7 @@ describe('Quantcast adapter', function () {
         bidId: '2f7b179d443f14',
         gdprSignal: 0,
         uspSignal: 0,
+        coppa: 0,
         prebidJsVersion: '$prebid.version$'
       };
 
@@ -271,6 +275,7 @@ describe('Quantcast adapter', function () {
         bidId: '2f7b179d443f14',
         gdprSignal: 0,
         uspSignal: 0,
+        coppa: 0,
         prebidJsVersion: '$prebid.version$'
       };
 
@@ -334,6 +339,7 @@ describe('Quantcast adapter', function () {
         bidId: '2f7b179d443f14',
         gdprSignal: 0,
         uspSignal: 0,
+        coppa: 0,
         prebidJsVersion: '$prebid.version$'
       };
 
@@ -357,25 +363,48 @@ describe('Quantcast adapter', function () {
     expect(parsed.uspConsent).to.equal('consentString');
   });
 
-  it('propagates COPPA as 1 if coppa param is true in the bid request', function () {
-    bidRequest.params = {
-      publisherId: 'test_publisher_id',
-      coppa: true
-    };
-    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
-    expect(JSON.parse(requests[0].data).coppa).to.equal(1);
-  });
+  describe('propagates coppa', function() {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+    });
 
-  it('propagates COPPA as 0 if there is no coppa param or false in the bid request', function () {
-    const requestsWithoutCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
-    expect(JSON.parse(requestsWithoutCoppa[0].data).coppa).to.equal(0);
+    afterEach(() => {
+      sandbox.restore();
+    });
 
-    bidRequest.params = {
-      publisherId: 'test_publisher_id',
-      coppa: false
-    };
-    const requestsWithFalseCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
-    expect(JSON.parse(requestsWithFalseCoppa[0].data).coppa).to.equal(0);
+    it('propagates coppa as 1 if coppa param is set to true in the bid request', function () {
+      bidRequest.params = {
+        publisherId: 'test_publisher_id',
+        coppa: true
+      };
+      sandbox.stub(config, 'getConfig').callsFake((key) => {
+        const config = {
+          'coppa': true
+        };
+        return config[key];
+      });
+      const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(requests[0].data).coppa).to.equal(1);
+    });
+
+    it('propagates coppa as 0 if there is no coppa param or coppa is set to false in the bid request', function () {
+      const requestsWithoutCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(requestsWithoutCoppa[0].data).coppa).to.equal(0);
+
+      bidRequest.params = {
+        publisherId: 'test_publisher_id',
+        coppa: false
+      };
+      sandbox.stub(config, 'getConfig').callsFake((key) => {
+        const config = {
+          'coppa': false
+        };
+        return config[key];
+      });
+      const requestsWithFalseCoppa = qcSpec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(requestsWithFalseCoppa[0].data).coppa).to.equal(0);
+    });
   });
 
   describe('`interpretResponse`', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add coppa support for Quantcast adapter

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
