### PR TITLE
Change to request DigiTrust ID "withCredentials" and ID failure in UserId system.

### DIFF
--- a/integrationExamples/gpt/digitrust_Full.html
+++ b/integrationExamples/gpt/digitrust_Full.html
@@ -70,7 +70,7 @@
                 }());
                 var t = document.createElement('script');
                 t.async = false;
-                t.src = 'http://acdn.adnxs.com/cmp/cmp.bundle.js';
+                t.src = 'https://acdn.adnxs.com/cmp/cmp.bundle.js';
                 var tag = document.getElementsByTagName('head')[0];
                 tag.appendChild(t);
             }

--- a/integrationExamples/gpt/digitrust_Simple.html
+++ b/integrationExamples/gpt/digitrust_Simple.html
@@ -71,7 +71,7 @@
                 }());
                 var t = document.createElement('script');
                 t.async = false;
-                t.src = 'http://acdn.adnxs.com/cmp/cmp.bundle.js';
+                t.src = 'https://acdn.adnxs.com/cmp/cmp.bundle.js';
                 var tag = document.getElementsByTagName('head')[0];
                 tag.appendChild(t);
             }

--- a/integrationExamples/gpt/digitrust_cmp_test.html
+++ b/integrationExamples/gpt/digitrust_cmp_test.html
@@ -187,6 +187,6 @@
             googletag.cmd.push(function () { googletag.display('test-div'); });
         </script>
     </div>
-    <script src="http://cmp-origin-release.digitru.st/1/cmp.bundle.js"></script>
+    <script src="https://cmp-origin-release.digitru.st/1/cmp.bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fix to other discovered issues of DigiTrust ID failing to write into userId system.
Adjust samples to call https pages in all cases for testing purposes.

Address issue #5002 along with additional found issues

## Type of change
- [x ] Bugfix

## Description of change
This change fixes new regression bugs that have caused DigiTrust ID integration to fail within the Prebid UserId system. This also addresses issue 5002 whereby an existing DigiTrust ID would be discarded and an new one issued due to lack of credentials being passed with the API call.

Additionally, some improvements were made to samples to make them operate over http and https.


- contact email of the adapter’s maintainer
- [ X] official adapter submission

## Other information
Issue #5002 