### PR TITLE
Add support for userid modules in Yieldlab adapter

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -172,8 +172,8 @@ function parseSize (size) {
  */
 function createUserIdString (eids) {
   let str = []
-  for (var eid of eids) {
-    str.push(eid.source + ':' + eid.uids[0].id)
+  for (let i = 0; i < eids.length; i++) {
+    str.push(eids[i].source + ':' + eids[i].uids[0].id)
   }
   return str.join(',')
 }

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -39,6 +39,9 @@ export const spec = {
       if (bid.params.targeting) {
         query.t = createQueryString(bid.params.targeting)
       }
+      if (bid.userIdAsEids) {
+        query.ids = createUserIdString(bid.userIdAsEids)
+      }
     })
 
     if (bidderRequest && bidderRequest.gdprConsent) {
@@ -160,6 +163,19 @@ function getPlayerSize (format) {
  */
 function parseSize (size) {
   return size.split('x').map(Number)
+}
+
+/**
+ * Creates a string out of an array of eids with source and uid
+ * @param {Array} eids
+ * @returns {String}
+ */
+function createUserIdString (eids) {
+  let str = []
+  for (var eid of eids) {
+    str.push(eid.source + ':' + eid.uids[0].id)
+  }
+  return str.join(',')
 }
 
 /**

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -39,7 +39,7 @@ export const spec = {
       if (bid.params.targeting) {
         query.t = createQueryString(bid.params.targeting)
       }
-      if (bid.userIdAsEids) {
+      if (bid.userIdAsEids && Array.isArray(bid.userIdAsEids)) {
         query.ids = createUserIdString(bid.userIdAsEids)
       }
     })

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -18,7 +18,14 @@ const REQUEST = {
   'auctionId': '2e41f65424c87c',
   'adUnitCode': 'adunit-code',
   'bidId': '2d925f27f5079f',
-  'sizes': [728, 90]
+  'sizes': [728, 90],
+  'userIdAsEids': [{
+    'source': 'netid.de',
+    'uids': [{
+      'id': 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
+      'atype': 1
+    }]
+  }]
 }
 
 const RESPONSE = {
@@ -75,6 +82,10 @@ describe('yieldlabBidAdapter', function () {
 
     it('passes targeting to bid request', function () {
       expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2')
+    })
+
+    it('passes userids to bid request', function () {
+      expect(request.url).to.include('ids=netid.de%3AfH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg')
     })
 
     const gdprRequest = spec.buildRequests(bidRequests, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding support for user modules by getting all eids that are present, passing them to our header bidding endpoint, so we can forward them along to DSPs in our ORTB request.