### PR TITLE
Freewheel Adapter: change mediatype to video when applicable

### DIFF
--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -319,7 +319,11 @@ export const spec = {
     var playerSize = [];
     if (bidrequest.mediaTypes.video && bidrequest.mediaTypes.video.playerSize) {
       // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3
-      playerSize = bidrequest.mediaTypes.video.playerSize;
+      if (utils.isArray(bidrequest.mediaTypes.video.playerSize[0])) {
+        playerSize = bidrequest.mediaTypes.video.playerSize[0];
+      } else {
+        playerSize = bidrequest.mediaTypes.video.playerSize;
+      }
     } else if (bidrequest.mediaTypes.banner.sizes) {
       // If mediaTypes is banner, get size from mediaTypes.banner.sizes per http://prebid.org/blog/pbjs-3
       playerSize = getBiggerSizeWithLimit(bidrequest.mediaTypes.banner.sizes, bidrequest.mediaTypes.banner.minSizeLimit, bidrequest.mediaTypes.banner.maxSizeLimit);
@@ -366,6 +370,7 @@ export const spec = {
 
       if (bidrequest.mediaTypes.video) {
         bidResponse.vastXml = serverResponse;
+        bidResponse.mediaType = 'video';
       }
 
       bidResponse.ad = formatAdHTML(bidrequest, playerSize);

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -455,6 +455,7 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           vastXml: response,
+          mediaType: 'video',
           ad: ad
         }
       ];
@@ -477,6 +478,7 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           vastXml: response,
+          mediaType: 'video',
           ad: formattedAd
         }
       ];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
This bugfix leverages the prebid cache for video bid response. It changes the bidResponse from banner to video when applicable. It also fixes a bug on the player size detection, causing invalid size sent to the adserver.

cc @xwang202 who made the last edition on this adapter
