### PR TITLE
Adding UsPrivacy/CCPA support in smartadserver adapter.

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -83,6 +83,10 @@ export const spec = {
         payload.gdpr = bidderRequest.gdprConsent.gdprApplies; // we're handling the undefined case server side
       }
 
+      if (bidderRequest && bidderRequest.uspConsent) {
+        payload.us_privacy = bidderRequest.uspConsent;
+      }
+
       var payloadString = JSON.stringify(payload);
       return {
         method: 'POST',

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -271,6 +271,35 @@ describe('Smart bid adapter tests', function () {
     });
   });
 
+  describe('ccpa/us privacy tests', function () {
+    afterEach(function () {
+      config.resetConfig();
+      $$PREBID_GLOBAL$$.requestBids.removeAll();
+    });
+
+    it('Verify build request with us privacy', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        },
+        consentManagement: {
+          cmp: 'iab',
+          consentRequired: true,
+          timeout: 1000,
+          allowAuctionWithoutConsent: true
+        }
+      });
+
+      const uspConsentValue = '1YNN'
+      const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+        uspConsent: uspConsentValue
+      });
+      const requestContent = JSON.parse(request[0].data);
+
+      expect(requestContent).to.have.property('us_privacy').and.to.equal(uspConsentValue);
+    });
+  });
+
   describe('Instream video tests', function () {
     afterEach(function () {
       config.resetConfig();


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
We added the usprivacy support in the SmartAdServer adapter.

Here's the pull request that updates the documentation accordingly : https://github.com/prebid/prebid.github.io/pull/1885

Thanks :)