### PR TITLE
Quantcast: Block bids without purpose 1 consent

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -77,21 +77,10 @@ function getDomain(url) {
 }
 
 function checkTCFv1(vendorData) {
-  // Defer consent check to server if no consent fields in vendor data
-  let purposeConsent = true;
-  let vendorConsent = true;
+  let vendorConsent = vendorData.vendorConsents && vendorData.vendorConsents[QUANTCAST_VENDOR_ID];
+  let purposeConsent = vendorData.purposeConsents && vendorData.purposeConsents[PURPOSE_DATA_COLLECT];
 
-  if (typeof vendorData.purposeConsents !== 'undefined' &&
-    typeof vendorData.purposeConsents[PURPOSE_DATA_COLLECT] !== 'undefined') {
-    vendorConsent = !!(vendorData.purposeConsents[PURPOSE_DATA_COLLECT]);
-  }
-
-  if (typeof vendorData.vendorConsents !== 'undefined' &&
-    typeof vendorData.vendorConsents[QUANTCAST_VENDOR_ID] !== 'undefined') {
-    purposeConsent = !!(vendorData.vendorConsents[QUANTCAST_VENDOR_ID])
-  }
-
-  return vendorConsent && purposeConsent;
+  return !!(vendorConsent && purposeConsent);
 }
 
 function checkTCFv2(tcData) {
@@ -104,6 +93,11 @@ function checkTCFv2(tcData) {
   let qcRestriction = restrictions && restrictions[PURPOSE_DATA_COLLECT]
     ? restrictions[PURPOSE_DATA_COLLECT][QUANTCAST_VENDOR_ID]
     : null;
+
+  if (qcRestriction === 0) {
+    // Not allowed by publisher
+    return false;
+  }
 
   let vendorConsent = tcData.vendor && tcData.vendor.consents && tcData.vendor.consents[QUANTCAST_VENDOR_ID];
   let purposeConsent = tcData.purpose && tcData.purpose.consents && tcData.purpose.consents[PURPOSE_DATA_COLLECT];

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -139,6 +139,7 @@ export const spec = {
         bidId: bid.bidId,
         gdprSignal: gdprConsent.gdprApplies ? 1 : 0,
         gdprConsent: gdprConsent.consentString,
+        gdprVersion: gdprConsent.apiVersion,
         uspSignal: uspConsent ? 1 : 0,
         uspConsent,
         coppa: config.getConfig('coppa') === true ? 1 : 0,

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -94,8 +94,26 @@ function checkTCFv1(vendorData) {
   return vendorConsent && purposeConsent;
 }
 
-function checkTCFv2(vendorData) {
-  return true;
+function checkTCFv2(tcData) {
+  if (tcData.purposeOneTreatment && tcData.publisherCC === 'DE') {
+    // special purpose 1 treatment for Germany
+    return true;
+  }
+
+  let restrictions = tcData.publisher ? tcData.publisher.restrictions : {};
+  let qcRestriction = restrictions && restrictions[PURPOSE_DATA_COLLECT]
+    ? restrictions[PURPOSE_DATA_COLLECT][QUANTCAST_VENDOR_ID]
+    : null;
+
+  let vendorConsent = tcData.vendor && tcData.vendor.consents && tcData.vendor.consents[QUANTCAST_VENDOR_ID];
+  let purposeConsent = tcData.purpose && tcData.purpose.consents && tcData.purpose.consents[PURPOSE_DATA_COLLECT];
+  if (vendorConsent && purposeConsent && qcRestriction !== 2) {
+    // Consent established
+    return true;
+  }
+
+  // No consent established
+  return false;
 }
 
 /**

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -4,6 +4,7 @@ import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'quantcast';
+const QUANTCAST_VENDOR_ID = 11;
 const DEFAULT_BID_FLOOR = 0.0000000001;
 
 export const QUANTCAST_DOMAIN = 'qcx.quantserve.com';
@@ -106,6 +107,16 @@ export const spec = {
     const referrer = utils.deepAccess(bidderRequest, 'refererInfo.referer');
     const page = utils.deepAccess(bidderRequest, 'refererInfo.canonicalUrl') || config.getConfig('pageUrl') || utils.deepAccess(window, 'location.href');
     const domain = getDomain(page);
+
+    // Check for GDPR consent, and drop request if consent has not been given
+    if (gdprConsent.gdprApplies) {
+      if (gdprConsent.vendorData && gdprConsent.vendorData.vendorConsents &&
+        typeof gdprConsent.vendorData.vendorConsents[QUANTCAST_VENDOR_ID.toString(10)] !== 'undefined') {
+        if (!(bidderRequest.gdprConsent.vendorData.vendorConsents[QUANTCAST_VENDOR_ID.toString(10)])) {
+          return;
+        }
+      }
+    }
 
     let bidRequestsList = [];
 

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -150,7 +150,6 @@ export const spec = {
         bidId: bid.bidId,
         gdprSignal: gdprConsent.gdprApplies ? 1 : 0,
         gdprConsent: gdprConsent.consentString,
-        gdprVersion: gdprConsent.apiVersion,
         uspSignal: uspConsent ? 1 : 0,
         uspConsent,
         coppa: config.getConfig('coppa') === true ? 1 : 0,

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -352,6 +352,47 @@ describe('Quantcast adapter', function () {
       gdprConsent: {
         gdprApplies: true,
         consentString: 'consentString',
+        apiVersion: 2
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+    const parsed = JSON.parse(requests[0].data);
+
+    expect(parsed.gdprSignal).to.equal(1);
+    expect(parsed.gdprConsent).to.equal('consentString');
+    expect(parsed.gdprVersion).to.equal(2);
+  });
+
+  it('blocks request without GDPR consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendorConsents: {
+            '11': 0
+          }
+        },
+        apiVersion: 1
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
+  });
+
+  it('allows request with GDPR consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendorConsents: {
+            '11': 1
+          }
+        },
         apiVersion: 1
       }
     };

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -362,26 +362,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('blocks request without TCF v1 vendor consent', function () {
-    const bidderRequest = {
-      gdprConsent: {
-        gdprApplies: true,
-        consentString: 'consentString',
-        vendorData: {
-          vendorConsents: {
-            '11': false
-          }
-        },
-        apiVersion: 1
-      }
-    };
-
-    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
-
-    expect(requests).to.equal(undefined);
-  });
-
-  it('allows request with TCF v1 vendor consent', function () {
+  it('allows request with TCF v1 consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -389,44 +370,7 @@ describe('Quantcast adapter', function () {
         vendorData: {
           vendorConsents: {
             '11': true
-          }
-        },
-        apiVersion: 1
-      }
-    };
-
-    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
-    const parsed = JSON.parse(requests[0].data);
-
-    expect(parsed.gdprSignal).to.equal(1);
-    expect(parsed.gdprConsent).to.equal('consentString');
-  });
-
-  it('blocks request without TCF v1 purpose consent', function () {
-    const bidderRequest = {
-      gdprConsent: {
-        gdprApplies: true,
-        consentString: 'consentString',
-        vendorData: {
-          purposeConsents: {
-            '1': false
-          }
-        },
-        apiVersion: 1
-      }
-    };
-
-    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
-
-    expect(requests).to.equal(undefined);
-  });
-
-  it('allows request with TCF v1 purpose consent', function () {
-    const bidderRequest = {
-      gdprConsent: {
-        gdprApplies: true,
-        consentString: 'consentString',
-        vendorData: {
+          },
           purposeConsents: {
             '1': true
           }
@@ -440,6 +384,50 @@ describe('Quantcast adapter', function () {
 
     expect(parsed.gdprSignal).to.equal(1);
     expect(parsed.gdprConsent).to.equal('consentString');
+  });
+
+  it('blocks request without TCF v1 vendor consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendorConsents: {
+            '11': false
+          },
+          purposeConsents: {
+            '1': true
+          }
+        },
+        apiVersion: 1
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
+  });
+
+  it('blocks request without TCF v1 purpose consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendorConsents: {
+            '11': true
+          },
+          purposeConsents: {
+            '1': false
+          }
+        },
+        apiVersion: 1
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
   });
 
   it('allows TCF v2 request from Germany', function () {
@@ -496,6 +484,16 @@ describe('Quantcast adapter', function () {
         gdprApplies: true,
         consentString: 'consentString',
         vendorData: {
+          vendor: {
+            consents: {
+              '11': true
+            }
+          },
+          purpose: {
+            consents: {
+              '1': true
+            }
+          },
           publisher: {
             restrictions: {
               '1': {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -362,14 +362,14 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('blocks request without GDPR consent', function () {
+  it('blocks request without GDPR vendor consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
         consentString: 'consentString',
         vendorData: {
           vendorConsents: {
-            '11': 0
+            '11': false
           }
         }
       }
@@ -380,14 +380,52 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('allows request with GDPR consent', function () {
+  it('allows request with GDPR vendor consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
         consentString: 'consentString',
         vendorData: {
           vendorConsents: {
-            '11': 1
+            '11': true
+          }
+        }
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+    const parsed = JSON.parse(requests[0].data);
+
+    expect(parsed.gdprSignal).to.equal(1);
+    expect(parsed.gdprConsent).to.equal('consentString');
+  });
+
+  it('blocks request without GDPR purpose consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          purposeConsents: {
+            '1': false
+          }
+        }
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
+  });
+
+  it('allows request with GDPR purpose consent', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          purposeConsents: {
+            '1': true
           }
         }
       }

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -362,7 +362,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('allows request with TCF v1 consent', function () {
+  it('allows TCF v1 request with consent for purpose 1', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -386,7 +386,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('blocks request without TCF v1 vendor consent', function () {
+  it('blocks TCF v1 request without vendor consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -408,7 +408,7 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('blocks request without TCF v1 purpose consent', function () {
+  it('blocks TCF v1 request without consent for purpose 1', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -430,7 +430,7 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('allows TCF v2 request from Germany', function () {
+  it('allows TCF v2 request from Germany for purpose 1', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -450,7 +450,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('allows TCF v2 request when Quantcast has consent', function() {
+  it('allows TCF v2 request when Quantcast has consent for purpose 1', function() {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -476,6 +476,58 @@ describe('Quantcast adapter', function () {
 
     expect(parsed.gdprSignal).to.equal(1);
     expect(parsed.gdprConsent).to.equal('consentString');
+  });
+
+  it('blocks TCF v2 request when no consent for Quantcast', function() {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendor: {
+            consents: {
+              '11': false
+            }
+          },
+          purpose: {
+            consents: {
+              '1': true
+            }
+          }
+        },
+        apiVersion: 2
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
+  });
+
+  it('blocks TCF v2 request when no consent for purpose 1', function() {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        vendorData: {
+          vendor: {
+            consents: {
+              '11': true
+            }
+          },
+          purpose: {
+            consents: {
+              '1': false
+            }
+          }
+        },
+        apiVersion: 2
+      }
+    };
+
+    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
+
+    expect(requests).to.equal(undefined);
   });
 
   it('blocks TCF v2 request when Quantcast not allowed by publisher', function () {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -347,12 +347,11 @@ describe('Quantcast adapter', function () {
     });
   });
 
-  it('propagates GDPR consent string, signal and version', function () {
+  it('propagates GDPR consent string and signal', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
-        consentString: 'consentString',
-        apiVersion: 2
+        consentString: 'consentString'
       }
     };
 
@@ -361,7 +360,6 @@ describe('Quantcast adapter', function () {
 
     expect(parsed.gdprSignal).to.equal(1);
     expect(parsed.gdprConsent).to.equal('consentString');
-    expect(parsed.gdprVersion).to.equal(2);
   });
 
   it('blocks request without GDPR consent', function () {
@@ -373,8 +371,7 @@ describe('Quantcast adapter', function () {
           vendorConsents: {
             '11': 0
           }
-        },
-        apiVersion: 1
+        }
       }
     };
 
@@ -392,8 +389,7 @@ describe('Quantcast adapter', function () {
           vendorConsents: {
             '11': 1
           }
-        },
-        apiVersion: 1
+        }
       }
     };
 
@@ -402,7 +398,6 @@ describe('Quantcast adapter', function () {
 
     expect(parsed.gdprSignal).to.equal(1);
     expect(parsed.gdprConsent).to.equal('consentString');
-    expect(parsed.gdprVersion).to.equal(1);
   });
 
   it('propagates US Privacy/CCPA consent information', function () {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -347,12 +347,21 @@ describe('Quantcast adapter', function () {
     });
   });
 
-  it('propagates GDPR consent string and signal', function () {
-    const bidderRequest = { gdprConsent: { gdprApplies: true, consentString: 'consentString' } }
+  it('propagates GDPR consent string, signal and version', function () {
+    const bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentString',
+        apiVersion: 1
+      }
+    };
+
     const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
     const parsed = JSON.parse(requests[0].data);
+
     expect(parsed.gdprSignal).to.equal(1);
     expect(parsed.gdprConsent).to.equal('consentString');
+    expect(parsed.gdprVersion).to.equal(1);
   });
 
   it('propagates US Privacy/CCPA consent information', function () {

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -362,7 +362,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('blocks request without GDPR vendor consent', function () {
+  it('blocks request without TCF v1 vendor consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -371,7 +371,8 @@ describe('Quantcast adapter', function () {
           vendorConsents: {
             '11': false
           }
-        }
+        },
+        apiVersion: 1
       }
     };
 
@@ -380,7 +381,7 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('allows request with GDPR vendor consent', function () {
+  it('allows request with TCF v1 vendor consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -389,7 +390,8 @@ describe('Quantcast adapter', function () {
           vendorConsents: {
             '11': true
           }
-        }
+        },
+        apiVersion: 1
       }
     };
 
@@ -400,7 +402,7 @@ describe('Quantcast adapter', function () {
     expect(parsed.gdprConsent).to.equal('consentString');
   });
 
-  it('blocks request without GDPR purpose consent', function () {
+  it('blocks request without TCF v1 purpose consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -409,7 +411,8 @@ describe('Quantcast adapter', function () {
           purposeConsents: {
             '1': false
           }
-        }
+        },
+        apiVersion: 1
       }
     };
 
@@ -418,7 +421,7 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('allows request with GDPR purpose consent', function () {
+  it('allows request with TCF v1 purpose consent', function () {
     const bidderRequest = {
       gdprConsent: {
         gdprApplies: true,
@@ -427,7 +430,8 @@ describe('Quantcast adapter', function () {
           purposeConsents: {
             '1': true
           }
-        }
+        },
+        apiVersion: 1
       }
     };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Check TCF v1 and v2 vendor data to verify that Quantcast has purpose 1 consent, dropping bid requests if no consent has been given. Other TCF consent checks are performed server side.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Documentation change: prebid/prebid.github.io#1890
