### PR TITLE
AdagiobidAdapter 2.2.0: schain, tcf 2.0

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -338,6 +338,9 @@ function _getGdprConsent(bidderRequest) {
     if (bidderRequest.gdprConsent.allowAuctionWithoutConsent !== undefined) {
       consent.allowAuctionWithoutConsent = bidderRequest.gdprConsent.allowAuctionWithoutConsent ? 1 : 0;
     }
+    if (bidderRequest.gdprConsent.apiVersion !== undefined) {
+      consent.apiVersion = bidderRequest.gdprConsent.apiVersion;
+    }
   }
   return consent;
 }

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -7,7 +7,7 @@ import sha256 from 'crypto-js/sha256.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '2.1.0';
+const VERSION = '2.2.0';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -342,6 +342,12 @@ function _getGdprConsent(bidderRequest) {
   return consent;
 }
 
+function _getSchain(bidRequest) {
+  if (utils.deepAccess(bidRequest, 'schain')) {
+    return bidRequest.schain;
+  }
+}
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
@@ -394,6 +400,7 @@ export const spec = {
     const site = _getSite();
     const pageviewId = _getPageviewId();
     const gdprConsent = _getGdprConsent(bidderRequest);
+    const schain = _getSchain(validBidRequests[0]);
     const adUnits = utils._map(validBidRequests, (bidRequest) => {
       bidRequest.features = _getFeatures(bidRequest);
       return bidRequest;
@@ -422,6 +429,7 @@ export const spec = {
           pageviewId: pageviewId,
           adUnits: groupedAdUnits[organizationId],
           gdpr: gdprConsent,
+          schain: schain,
           prebidVersion: '$prebid.version$',
           adapterVersion: VERSION,
           featuresVersion: FEATURES_VERSION

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -7,7 +7,7 @@ describe('adagioAdapter', () => {
   let utilsMock;
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '2.1.0';
+  const VERSION = '2.2.0';
 
   beforeEach(function() {
     localStorage.removeItem('adagioScript');

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -480,6 +480,40 @@ describe('adagioAdapter', () => {
       });
       expect(requests).to.be.empty;
     });
+
+    it('Should add the schain if available at bidder level', () => {
+      const bidRequest = Object.assign({}, bidRequests[0], {
+        schain: {
+          ver: '1.0',
+          complete: 1,
+          nodes: [{
+            asi: 'ssp.test',
+            sid: '00001',
+            hp: 1
+          }]
+        }
+      });
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const request = requests[0];
+
+      expect(request.data.schain).to.exist;
+      expect(request.data.schain).to.deep.equal({
+        ver: '1.0',
+        complete: 1,
+        nodes: [{
+          asi: 'ssp.test',
+          sid: '00001',
+          hp: 1
+        }]
+      });
+    });
+
+    it('Schain should not be added to the request', () => {
+      const requests = spec.buildRequests([bidRequests[0]], bidderRequest);
+      const request = requests[0];
+      expect(request.data.schain).to.not.exist;
+    });
   });
 
   describe('interpretResponse', () => {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -301,7 +301,29 @@ describe('adagioAdapter', () => {
       'gdprConsent': {
         consentString: consentString,
         gdprApplies: true,
-        allowAuctionWithoutConsent: true
+        allowAuctionWithoutConsent: true,
+        apiVersion: 1,
+      },
+      'refererInfo': {
+        'numIframes': 0,
+        'reachedTop': true,
+        'referer': 'http://test.io/index.html?pbjs_debug=true'
+      }
+    };
+
+    let bidderRequestTCF2 = {
+      'bidderCode': 'adagio',
+      'auctionId': '12jejebn',
+      'bidderRequestId': 'hehehehbeheh',
+      'timeout': 3000,
+      'gdprConsent': {
+        consentString: consentString,
+        vendorData: {
+          tcString: consentString,
+          gdprApplies: true
+        },
+        gdprApplies: true,
+        apiVersion: 2
       },
       'refererInfo': {
         'numIframes': 0,
@@ -433,6 +455,17 @@ describe('adagioAdapter', () => {
       expect(request.data.gdpr).to.exist;
       expect(request.data.gdpr.consentString).to.exist.and.to.equal(consentString);
       expect(request.data.gdpr.consentRequired).to.exist.and.to.equal(1);
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(1);
+    });
+
+    it('GDPR consent is applied w/ TCF2', () => {
+      const requests = spec.buildRequests(bidRequests, bidderRequestTCF2);
+      expect(requests).to.have.lengthOf(2);
+      const request = requests[0];
+      expect(request.data.gdpr).to.exist;
+      expect(request.data.gdpr.consentString).to.exist.and.to.equal(consentString);
+      expect(request.data.gdpr.consentRequired).to.exist.and.to.equal(1);
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(2);
     });
 
     it('GDPR consent is not applied', () => {
@@ -443,6 +476,18 @@ describe('adagioAdapter', () => {
       expect(request.data.gdpr).to.exist;
       expect(request.data.gdpr.consentString).to.exist.and.to.equal(consentString);
       expect(request.data.gdpr.consentRequired).to.exist.and.to.equal(0);
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(1);
+    });
+
+    it('GDPR consent is not applied w/ TCF2', () => {
+      bidderRequestTCF2.gdprConsent.gdprApplies = false;
+      const requests = spec.buildRequests(bidRequests, bidderRequestTCF2);
+      expect(requests).to.have.lengthOf(2);
+      const request = requests[0];
+      expect(request.data.gdpr).to.exist;
+      expect(request.data.gdpr.consentString).to.exist.and.to.equal(consentString);
+      expect(request.data.gdpr.consentRequired).to.exist.and.to.equal(0);
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(2);
     });
 
     it('GDPR consent is undefined', () => {
@@ -456,6 +501,20 @@ describe('adagioAdapter', () => {
       expect(request.data.gdpr).to.not.have.property('consentString');
       expect(request.data.gdpr).to.not.have.property('gdprApplies');
       expect(request.data.gdpr).to.not.have.property('allowAuctionWithoutConsent');
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(1);
+    });
+
+    it('GDPR consent is undefined w/ TCF2', () => {
+      delete bidderRequestTCF2.gdprConsent.consentString;
+      delete bidderRequestTCF2.gdprConsent.gdprApplies;
+      delete bidderRequestTCF2.gdprConsent.vendorData;
+      const requests = spec.buildRequests(bidRequests, bidderRequestTCF2);
+      expect(requests).to.have.lengthOf(2);
+      const request = requests[0];
+      expect(request.data.gdpr).to.exist;
+      expect(request.data.gdpr).to.not.have.property('consentString');
+      expect(request.data.gdpr).to.not.have.property('gdprApplies');
+      expect(request.data.gdpr.apiVersion).to.exist.and.to.equal(2);
     });
 
     it('GDPR consent bidderRequest does not have gdprConsent', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
- Add the support to SChain module
- send TCF api version number in bidrequest

contact email of the adapter’s maintainer: dev@adagio.io

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- prebid/prebid.github.io#1844

