### PR TITLE
#5011 Fix to set Secure attribute on cookie when SameSite=none

### DIFF
--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -64,8 +64,8 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
       if (result && result.valid) {
         const domainPortion = (domain && domain !== '') ? ` ;domain=${encodeURIComponent(domain)}` : '';
         const expiresPortion = (expires && expires !== '') ? ` ;expires=${expires}` : '';
-        var isNone = (sameSite != null && sameSite.toLowerCase() == 'none')
-        var secure = (isNone) ? '; Secure' : '';
+        const isNone = (sameSite != null && sameSite.toLowerCase() == 'none')
+        const secure = (isNone) ? '; Secure' : '';
         document.cookie = `${key}=${encodeURIComponent(value)}${expiresPortion}; path=/${domainPortion}${sameSite ? `; SameSite=${sameSite}` : ''}${secure}`;
       }
     }

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -64,7 +64,9 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
       if (result && result.valid) {
         const domainPortion = (domain && domain !== '') ? ` ;domain=${encodeURIComponent(domain)}` : '';
         const expiresPortion = (expires && expires !== '') ? ` ;expires=${expires}` : '';
-        document.cookie = `${key}=${encodeURIComponent(value)}${expiresPortion}; path=/${domainPortion}${sameSite ? `; SameSite=${sameSite}` : ''}`;
+        var isNone = (sameSite != null && sameSite.toLowerCase() == 'none')
+        var secure = (isNone) ? '; Secure' : '';
+        document.cookie = `${key}=${encodeURIComponent(value)}${expiresPortion}; path=/${domainPortion}${sameSite ? `; SameSite=${sameSite}` : ''}${secure}`;
       }
     }
     if (done && typeof done === 'function') {


### PR DESCRIPTION
## Type of change
- [X ] Bugfix

## Description of change
This change modifies the storageManager to detect if SameSite=None is used in the set cookie options. When the value "none" is specified for SameSite the browser also requires that the cookie be marked "Secure". This change automatically applies the "Secure" attribute when samesite=none is detected.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

Tested against DigiTrust ID that sets cookie.
(/integrationExamples/gpt/digitrust_Simple.html) sample page.
Note: this must be run over HTTPS connection to operate correctly.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

## Other Information
Must be run over HTTPS connection to operate correctly. Testing this over HTTP is an invalid scenario.