### PR TITLE
IdentityLink check ats after delaySync

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -42,9 +42,10 @@ export const identityLinkSubmodule = {
     // use protocol relative urls for http or https
     const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? '&ct=1&cv=' + gdprConsentString : ''}`;
     let resp;
-    // if ats library is initialised, use it to retrieve envelope. If not use standard third party endpoint
-    if (window.ats) {
-      resp = function(callback) {
+    resp = function(callback) {
+      // Check ats during callback so it has a chance to initialise.
+      // If ats library is available, use it to retrieve envelope. If not use standard third party endpoint
+      if (window.ats) {
         window.ats.retrieveEnvelope(function (envelope) {
           if (envelope) {
             callback(JSON.parse(envelope).envelope);
@@ -52,15 +53,14 @@ export const identityLinkSubmodule = {
             getEnvelope(url, callback);
           }
         });
-      }
-    } else {
-      resp = function (callback) {
+      } else {
         getEnvelope(url, callback);
       }
-    }
+    };
+
     return {callback: resp};
   }
-}
+};
 // return envelope from third party endpoint
 function getEnvelope(url, callback) {
   ajax(url, response => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
In IdentityLinkIdSystem, the check for window.ats occurs too early.  There is a possibility that ats hasn't been loaded yet, so the id is not generated and stored optimally.  Moving the check to inside the callback so it's applied after delaySync.

- pyang@conversantmedia.com
- [ ] official adapter submission

