### PR TITLE
Use TCFv2 consent data in Criteo Id module

### DIFF
--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -56,18 +56,19 @@ function getCriteoDataFromAllStorages() {
   }
 }
 
-function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isPublishertagPresent) {
+function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isPublishertagPresent, gdprString) {
   const url = 'https://gum.criteo.com/sid/json?origin=prebid' +
     `${topUrl ? '&topUrl=' + encodeURIComponent(topUrl) : ''}` +
     `${domain ? '&domain=' + encodeURIComponent(domain) : ''}` +
     `${bundle ? '&bundle=' + encodeURIComponent(bundle) : ''}` +
+    `${gdprString ? '&gdprString=' + encodeURIComponent(gdprString) : ''}` +
     `${areCookiesWriteable ? '&cw=1' : ''}` +
     `${isPublishertagPresent ? '&pbt=1' : ''}`
 
   return url;
 }
 
-function callCriteoUserSync(parsedCriteoData) {
+function callCriteoUserSync(parsedCriteoData, gdprString) {
   const cw = areCookiesWriteable();
   const topUrl = extractProtocolHost(getRefererInfo().referer);
   const domain = extractProtocolHost(document.location.href, true);
@@ -78,7 +79,8 @@ function callCriteoUserSync(parsedCriteoData) {
     domain,
     parsedCriteoData.bundle,
     cw,
-    isPublishertagPresent
+    isPublishertagPresent,
+    gdprString
   );
 
   ajax.ajaxBuilder()(
@@ -119,11 +121,16 @@ export const criteoIdSubmodule = {
   /**
    * get the Criteo Id from local storages and initiate a new user sync
    * @function
+   * @param {SubmoduleParams} [configParams]
+   * @param {ConsentData} [consentData]
    * @returns {{id: {criteoId: string} | undefined}}}
    */
-  getId() {
+  getId(configParams, consentData) {
+    const hasGdprData = consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies;
+    const gdprConsentString = hasGdprData ? consentData.consentString : undefined;
+
     let localData = getCriteoDataFromAllStorages();
-    callCriteoUserSync(localData);
+    callCriteoUserSync(localData, gdprConsentString);
 
     return { id: localData.bidId ? { criteoId: localData.bidId } : undefined }
   }

--- a/test/spec/modules/criteoIdSystem_spec.js
+++ b/test/spec/modules/criteoIdSystem_spec.js
@@ -132,4 +132,26 @@ describe('CriteoId module', function () {
       }
     });
   }));
+
+  const gdprConsentTestCases = [
+    { consentData: { gdprApplies: true, consentString: 'expectedConsentString' }, expected: 'expectedConsentString' },
+    { consentData: { gdprApplies: false, consentString: 'expectedConsentString' }, expected: undefined },
+    { consentData: { gdprApplies: true, consentString: undefined }, expected: undefined },
+    { consentData: { gdprApplies: 'oui', consentString: 'expectedConsentString' }, expected: undefined },
+    { consentData: undefined, expected: undefined }
+  ];
+
+  gdprConsentTestCases.forEach(testCase => it('should call user sync url with the gdprConsent', function () {
+    const emptyObj = '{}';
+    let ajaxStub = sinon.stub().callsFake((url, callback) => callback(emptyObj));
+    ajaxBuilderStub.callsFake(mockResponse(undefined, ajaxStub))
+
+    criteoIdSubmodule.getId(undefined, testCase.consentData);
+
+    if (testCase.expected) {
+      expect(ajaxStub.calledWithMatch(`gdprString=${testCase.expected}`)).to.be.true;
+    } else {
+      expect(ajaxStub.calledWithMatch('gdprString')).not.to.be.true;
+    }
+  }));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Handle TCFv2 consent in Criteo Identification Module. We retrieve the consent already provided by Prebid.js if available and send it to our identification back-end.

- Contact emails: ja.pologarcia@criteo.com and h.duthil@criteo.com
