### PR TITLE
Fix bug in rubicon bid adapter for fpd keywords

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -575,7 +575,7 @@ export const spec = {
     const keywords = (params.keywords || []).concat(
       utils.deepAccess(config.getConfig('fpd.user'), 'keywords') || [],
       utils.deepAccess(config.getConfig('fpd.context'), 'keywords') || []);
-    data.kw = keywords.length ? keywords.join(',') : '';
+    data.kw = Array.isArray(keywords) && keywords.length ? keywords.join(',') : '';
 
     /**
      * Prebid AdSlot

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1924,6 +1924,12 @@ describe('the rubicon adapter', function () {
             }
           });
         });
+
+        it('should not fail if keywords param is not an array', function () {
+          bidderRequest.bids[0].params.keywords = 'a,b,c';
+          const slotParams = spec.createSlotParams(bidderRequest.bids[0], bidderRequest);
+          expect(slotParams.kw).to.equal('');
+        });
       });
 
       describe('hasVideoMediaType', function () {


### PR DESCRIPTION

## Type of change
- [X] Bugfix

## Description of change
If the user input non array into keywords it would break and not send bids.

Here is the new test without the isArray check:

![image](https://user-images.githubusercontent.com/13972794/78516022-f8a5a500-776c-11ea-8d54-a08b63cfecb7.png)
