### PR TITLE
[BUGFIX] AdagioBidAdapter getDataFromLocalStorage

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -14,7 +14,7 @@ const SUPPORTED_MEDIA_TYPES = ['banner'];
 const ADAGIO_TAG_URL = 'https://script.4dex.io/localstore.js';
 const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
 const GVLID = 617;
-const storage = getStorageManager(GVLID);
+const storage = getStorageManager(GVLID, 'adagio');
 
 export const ADAGIO_PUBKEY = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC9el0+OEn6fvEh1RdVHQu4cnT0
@@ -23,10 +23,8 @@ t0b0lsHN+W4n9kitS/DZ/xnxWK/9vxhv0ZtL1LL/rwR5Mup7rmJbNtDoNBw4TIGj
 pV6EP3MTLosuUEpLaQIDAQAB
 -----END PUBLIC KEY-----`;
 
-export function getAdagioScript() {
+export function adagioScriptFromLocalStorageCb(ls) {
   try {
-    const ls = storage.getDataFromLocalStorage(ADAGIO_LOCALSTORAGE_KEY);
-
     if (!ls) {
       utils.logWarn('Adagio Script not found');
       return;
@@ -56,6 +54,12 @@ export function getAdagioScript() {
   } catch (err) {
     //
   }
+}
+
+export function getAdagioScript() {
+  storage.getDataFromLocalStorage(ADAGIO_LOCALSTORAGE_KEY, (ls) => {
+    adagioScriptFromLocalStorageCb(ls)
+  });
 }
 
 function canAccessTopWindow() {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -7,7 +7,7 @@ import sha256 from 'crypto-js/sha256.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'adagio';
-const VERSION = '2.2.0';
+const VERSION = '2.2.1';
 const FEATURES_VERSION = '1';
 const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = ['banner'];

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getAdagioScript, spec } from 'modules/adagioBidAdapter.js';
+import { adagioScriptFromLocalStorageCb, spec } from 'modules/adagioBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import * as utils from 'src/utils.js';
 
@@ -738,7 +738,7 @@ describe('adagioAdapter', () => {
     });
   });
 
-  describe('getAdagioScript', () => {
+  describe('adagioScriptFromLocalStorageCb', () => {
     const VALID_HASH = 'Lddcw3AADdQDrPtbRJkKxvA+o1CtScGDIMNRpHB3NnlC/FYmy/9RKXelKrYj/sjuWusl5YcOpo+lbGSkk655i8EKuDiOvK6ae/imxSrmdziIp+S/TA6hTFJXcB8k1Q9OIp4CMCT52jjXgHwX6G0rp+uYoCR25B1jHaHnpH26A6I=';
     const INVALID_HASH = 'invalid';
     const VALID_SCRIPT_CONTENT = 'var _ADAGIO=function(){};(_ADAGIO)();\n';
@@ -752,7 +752,7 @@ describe('adagioAdapter', () => {
       utilsMock.expects('logWarn').withExactArgs('No hash found in Adagio script').never();
       utilsMock.expects('logWarn').withExactArgs('Invalid Adagio script found').never();
 
-      getAdagioScript();
+      adagioScriptFromLocalStorageCb(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY));
 
       expect(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY)).to.equals('// hash: ' + VALID_HASH + '\n' + VALID_SCRIPT_CONTENT);
       utilsMock.verify();
@@ -765,7 +765,7 @@ describe('adagioAdapter', () => {
       utilsMock.expects('logWarn').withExactArgs('No hash found in Adagio script').never();
       utilsMock.expects('logWarn').withExactArgs('Invalid Adagio script found').once();
 
-      getAdagioScript();
+      adagioScriptFromLocalStorageCb(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY));
 
       expect(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY)).to.be.null;
       utilsMock.verify();
@@ -778,7 +778,7 @@ describe('adagioAdapter', () => {
       utilsMock.expects('logWarn').withExactArgs('No hash found in Adagio script').never();
       utilsMock.expects('logWarn').withExactArgs('Invalid Adagio script found').once();
 
-      getAdagioScript();
+      adagioScriptFromLocalStorageCb(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY));
 
       expect(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY)).to.be.null;
       utilsMock.verify();
@@ -791,7 +791,7 @@ describe('adagioAdapter', () => {
       utilsMock.expects('logWarn').withExactArgs('No hash found in Adagio script').once();
       utilsMock.expects('logWarn').withExactArgs('Invalid Adagio script found').never();
 
-      getAdagioScript();
+      adagioScriptFromLocalStorageCb(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY));
 
       expect(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY)).to.be.null;
       utilsMock.verify();

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -7,7 +7,7 @@ describe('adagioAdapter', () => {
   let utilsMock;
   const adapter = newBidder(spec);
   const ENDPOINT = 'https://mp.4dex.io/prebid';
-  const VERSION = '2.2.0';
+  const VERSION = '2.2.1';
 
   beforeEach(function() {
     localStorage.removeItem('adagioScript');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Handle properly the new `getDataFromLocalStorage()` function introduced in 3.14.0.


Contact email of the adapter’s maintainer: dev@adagio.io
