### PR TITLE
Fix for key-values and multiple bids having the same adUnitCode

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -538,7 +538,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
 function setupBidTargeting(bidObject, bidderRequest) {
   let keyValues;
   if (bidObject.bidderCode && (bidObject.cpm > 0 || bidObject.dealId)) {
-    let bidReq = find(bidderRequest.bids, bid => bid.adUnitCode === bidObject.adUnitCode);
+    let bidReq = find(bidderRequest.bids, bid => bid.adUnitCode === bidObject.adUnitCode && bid.bidId === bidObject.requestId);
     keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject, bidReq);
   }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When sending multiple bids with the same adUnitCode, the key-value targeting sent to the adserver is often wrong as the matching is based solely on the adUnitCode. This is an improvement, using the requestId.
