### PR TITLE
PS bid adapter update to copy site object from config

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -268,10 +268,9 @@ function _appendSiteAppDevice(request, pageUrl) {
     request.app = config.getConfig('app');
     request.app.publisher = {id: _s2sConfig.accountId}
   } else {
-    request.site = {
-      publisher: { id: _s2sConfig.accountId },
-      page: pageUrl
-    }
+    request.site = (typeof config.getConfig('site') === 'object') ? config.getConfig('site') : {};
+    request.site.publisher = { id: _s2sConfig.accountId },
+    request.site.page = pageUrl;
   }
   if (typeof config.getConfig('device') === 'object') {
     request.device = config.getConfig('device');

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -268,8 +268,11 @@ function _appendSiteAppDevice(request, pageUrl) {
     request.app = config.getConfig('app');
     request.app.publisher = {id: _s2sConfig.accountId}
   } else {
-    request.site = (typeof config.getConfig('site') === 'object') ? config.getConfig('site') : {};
-    request.site.publisher = { id: _s2sConfig.accountId },
+    request.site = {};
+    if (typeof config.getConfig('site') === 'object') {
+      request.site = config.getConfig('site');
+    }
+    utils.deepSetValue(request.site, 'publisher.id', _s2sConfig.accountId);
     request.site.page = pageUrl;
   }
   if (typeof config.getConfig('device') === 'object') {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -899,6 +899,15 @@ describe('S2S Adapter', function () {
 
       const _config = {
         s2sConfig: s2sConfig,
+        site: {
+          publisher: {
+            id: '1234',
+            domain: 'test.com'
+          },
+          content: {
+            language: 'en'
+          }
+        }
       };
 
       config.setConfig(_config);
@@ -906,7 +915,21 @@ describe('S2S Adapter', function () {
       const requestBid = JSON.parse(server.requests[0].requestBody);
       expect(requestBid.site).to.exist.and.to.be.a('object');
       expect(requestBid.site.publisher).to.exist.and.to.be.a('object');
+      expect(requestBid.site.publisher.id).to.exist.and.to.be.a('string');
+      expect(requestBid.site.publisher.domain).to.exist.and.to.be.a('string');
       expect(requestBid.site.page).to.exist.and.to.be.a('string');
+      expect(requestBid.site.content).to.exist.and.to.be.a('object');
+      expect(requestBid.site.content.language).to.exist.and.to.be.a('string');
+      expect(requestBid.site).to.deep.equal({
+        publisher: {
+          id: '1',
+          domain: 'test.com'
+        },
+        content: {
+          language: 'en'
+        },
+        page: 'http://mytestpage.com'
+      });
     });
 
     it('adds appnexus aliases to request', function () {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Updated Prebid Server bid adapter to check for the site object in the prebid configuration. If exists, this will be copied over into the request and publisher/page will either be created properties or will overwrite existing config defined values. This will allow other OpenRTB fields within the site object to be passed to Prebid Server, i.e. site.content

## Other information
[#3783](https://github.com/prebid/Prebid.js/pull/3783)