### PR TITLE
Add warning messages for publishers while native ads send assets containing url without sendId 

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -8,13 +8,14 @@ import { verify } from 'criteo-direct-rsa-validate/build/verify.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const GVLID = 91;
-export const ADAPTER_VERSION = 27;
+export const ADAPTER_VERSION = 28;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = 'https://bidder.criteo.com/cdb';
 const CRITEO_VENDOR_ID = 91;
 const PROFILE_ID_INLINE = 207;
 export const PROFILE_ID_PUBLISHERTAG = 185;
 const storage = getStorageManager(GVLID);
+const LOG_PREFIX = 'Criteo: ';
 
 // Unminified source code can be found in: https://github.com/Prebid-org/prebid-js-external-js-criteo/blob/master/dist/prod.js
 const PUBLISHER_TAG_URL = 'https://static.criteo.net/js/ld/publishertag.prebid.js';
@@ -252,6 +253,7 @@ function buildCdbUrl(context) {
  */
 function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
+  let hasNativeSendId = true;
   const request = {
     publisher: {
       url: context.url,
@@ -279,6 +281,16 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       }
       if (bidRequest.params.nativeCallback || utils.deepAccess(bidRequest, `mediaTypes.${NATIVE}`)) {
         slot.native = true;
+        if (bidRequest.nativeParams &&
+          ((bidRequest.nativeParams.image && bidRequest.nativeParams.image.sendId !== true) ||
+            (bidRequest.nativeParams.icon && bidRequest.nativeParams.icon.sendId !== true) ||
+            (bidRequest.nativeParams.clickUrl && bidRequest.nativeParams.clickUrl.sendId !== true) ||
+            (bidRequest.nativeParams.displayUrl && bidRequest.nativeParams.displayUrl.sendId !== true) ||
+            (bidRequest.nativeParams.privacyLink && bidRequest.nativeParams.privacyLink.sendId !== true) ||
+            (bidRequest.nativeParams.privacyIcon && bidRequest.nativeParams.privacyIcon.sendId !== true))
+        ) {
+          hasNativeSendId = false;
+        }
       }
       if (hasVideoMediaType(bidRequest)) {
         const video = {
@@ -287,7 +299,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
           protocols: bidRequest.mediaTypes.video.protocols,
           maxduration: bidRequest.mediaTypes.video.maxduration,
           api: bidRequest.mediaTypes.video.api
-        }
+        };
 
         video.skip = bidRequest.params.video.skip;
         video.placement = bidRequest.params.video.placement;
@@ -300,6 +312,9 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       return slot;
     }),
   };
+  if (!hasNativeSendId) {
+    utils.logWarn(LOG_PREFIX + 'all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, privacyLink, privacyIcon)');
+  }
   if (networkId) {
     request.publisher.networkid = networkId;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Following the [updated documentation](http://prebid.org/dev-docs/bidders/criteo.html), we want to drop a warning to tell that sendid is mandatory for all fields receiving URLs, notably: product images, clickUrl, logoimage
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
pbjs.addAdUnits([{
    ...
    mediaTypes: {
        native: {
            image: {
                required: true,
                sendId: false //false to see the warning
            },
            icon: {
                required: true,
                sendId: false
            },
            clickUrl: {
                required: true,
                sendId: false
            },
            displayUrl: {
                required: true,
                sendId: false
            },
            privacyLink: {
                required: true,
                sendId: false
            },
            privacyIcon: {
                required: true,
                sendId: false
            }
            //other assets will not trigger the warning
        }
    },     
...
```
