### PR TITLE
adding local node version >8.9 to <12.0.0 to avoid breaking build by fibers 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "the prebid.js contributors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=8.9.0 <12.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
@@ -79,6 +79,7 @@
     "karma-webpack": "^3.0.5",
     "lodash": "^4.17.4",
     "mocha": "^5.0.0",
+    "node": ">=8.9.0 <12.0.0",
     "opn": "^5.4.0",
     "resolve-from": "^5.0.0",
     "sinon": "^4.1.3",


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
npm i fails with node >=12 because fibers 3.1.1 doesn't support it. This will install a local node version that fits fibers on npm i.