### PR TITLE
Updating Rubicon adapter to include site config for video

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -924,18 +924,26 @@ function appendSiteAppDevice(data, bidRequest, bidderRequest) {
   if (typeof config.getConfig('app') === 'object') {
     data.app = config.getConfig('app');
   } else {
-    data.site = {
-      page: _getPageUrl(bidRequest, bidderRequest)
+    data.site = {};
+    if (typeof config.getConfig('site') === 'object') {
+      data.site = config.getConfig('site');
     }
+    data.site.page = _getPageUrl(bidRequest, bidderRequest);
   }
+
   if (typeof config.getConfig('device') === 'object') {
     data.device = config.getConfig('device');
   }
+
   // Add language to site and device objects if there
   if (bidRequest.params.video.language) {
     ['site', 'device'].forEach(function(param) {
       if (data[param]) {
-        data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
+        if (param == 'site' && !utils.deepAccess(data[param], 'content.language')) {
+          utils.deepSetValue(data[param], 'content.language', bidRequest.params.video.language)
+        } else {
+          data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
+        }
       }
     });
   }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1435,6 +1435,20 @@ describe('the rubicon adapter', function () {
         it('should make a well-formed video request', function () {
           createVideoBidderRequest();
 
+          const _config = {
+            site: {
+              publisher: {
+                id: '1234',
+                domain: 'test.com'
+              },
+              content: {
+                language: 'fr'
+              }
+            }
+          };
+
+          config.setConfig(_config);
+
           sandbox.stub(Date, 'now').callsFake(() =>
             bidderRequest.auctionStart + 100
           );
@@ -1461,7 +1475,16 @@ describe('the rubicon adapter', function () {
           expect(imp.ext.rubicon.video.size_id).to.equal(201);
           expect(imp.ext.rubicon.video.language).to.equal('en');
           // Also want it to be in post.site.content.language
-          expect(post.site.content.language).to.equal('en');
+          expect(post.site).to.deep.equal({
+            publisher: {
+              id: '1234',
+              domain: 'test.com'
+            },
+            content: {
+              language: 'fr'
+            },
+            page: 'localhost'
+          });
           expect(imp.ext.rubicon.video.skip).to.equal(1);
           expect(imp.ext.rubicon.video.skipafter).to.equal(15);
           expect(post.user.ext.consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');


### PR DESCRIPTION
Updated Rubicon bid adapter to check for site object in config for video requests to Prebid server, and pass that data. site.page is defined by the adapter so that will take priority over publisher defined value. site.content.language will only be set by the adapter if it does not exist in the site config and the value exists in rubicon params.video

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
