### PR TITLE
Disallowing remote requests from Safari and Firefox due to browsers n…

### DIFF
--- a/integrationExamples/gpt/digitrust_Simple.html
+++ b/integrationExamples/gpt/digitrust_Simple.html
@@ -148,6 +148,9 @@
                                 }
                                 else {
                                     console.error('Digitrust init failed');
+                                    if(digiTrustResult.err){
+                                        console.error(digiTrustResult.err);
+                                    }
                                 }
                             }
                         },
@@ -157,6 +160,12 @@
                             expires: 60
                         }
                     }]
+                },
+                userIdTargeting: {
+                    "GAM": true,
+                    "GAM_KEYS": {
+                        "tdid": "TTD_ID" // send tdid as TTD_ID
+                    }
                 }
             });
             pbjs.addAdUnits(adUnits);

--- a/modules/digiTrustIdSystem.js
+++ b/modules/digiTrustIdSystem.js
@@ -95,6 +95,31 @@ function writeDigiId(id) {
 }
 
 /**
+ * Tests to see if the current browser is FireFox
+ */
+function isFirefoxBrowser(ua) {
+  ua = ua || navigator.userAgent;
+  ua = ua.toLowerCase();
+  if (ua.indexOf('firefox') !== -1) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Test to see if the user has a browser that is disallowed for making AJAX
+ * requests due to the behavior not supported DigiTrust ID Cookie.
+ */
+function isDisallowedBrowserForApiCall() {
+  if (utils.isSafariBrowser()) {
+    return true;
+  } else if (isFirefoxBrowser()) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Set up a DigiTrust facade object to mimic the API
  *
  */
@@ -169,6 +194,14 @@ function initDigitrustFacade(config) {
       // check gdpr vendor here. Full DigiTrust library has vendor check built in
       gdprConsent.hasConsent(null, function (hasConsent) {
         if (hasConsent) {
+          if (isDisallowedBrowserForApiCall()) {
+            let resultObj = {
+              success: false,
+              err: 'Your browser does not support DigiTrust Identity'
+            }
+            checkAndCallInitializeCb(resultObj);
+            return;
+          }
           callApi(opts);
         }
       })


### PR DESCRIPTION
…o longer supporting DigiTrust ID.



## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X ] Bugfix
- [X ] Refactoring (no functional changes, no api changes)

## Description of change

Recent changes to the behavior of Safari and Firefox around third party cookie handling mean these browsers can no longer support usage of DigiTrust ID. This change filters out remote requests by these browsers since any response will be invalid.

## Other information
