### PR TITLE
fix circle ci failing tests

### DIFF
--- a/test/spec/modules/relaidoBidAdapter_spec.js
+++ b/test/spec/modules/relaidoBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec } from 'modules/relaidoBidAdapter.js';
-import * as url from 'src/url.js';
 import * as utils from 'src/utils.js';
 
 const UUID_KEY = 'relaido_uuid';
@@ -275,7 +274,7 @@ describe('RelaidoAdapter', function () {
         ref: window.location.href,
       }
       spec.onBidWon(bid);
-      const parser = url.parse(stub.getCall(0).args[0]);
+      const parser = utils.parseUrl(stub.getCall(0).args[0]);
       const query = parser.search;
       expect(parser.hostname).to.equal('api.relaido.jp');
       expect(parser.pathname).to.equal('/tr/v1/prebid/win.gif');
@@ -309,7 +308,7 @@ describe('RelaidoAdapter', function () {
         timeout: bidderRequest.timeout,
       }];
       spec.onTimeout(data);
-      const parser = url.parse(stub.getCall(0).args[0]);
+      const parser = utils.parseUrl(stub.getCall(0).args[0]);
       const query = parser.search;
       expect(parser.hostname).to.equal('api.relaido.jp');
       expect(parser.pathname).to.equal('/tr/v1/prebid/timeout.gif');


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Due to negligence in merging this PR, https://github.com/prebid/Prebid.js/pull/5101, circle-ci is failing because module `url` has been removed recently which was being used in the spec file of this adapter.