### PR TITLE
parrableIdSystem: Send current page location to back-end

### DIFF
--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -6,8 +6,9 @@
  */
 
 import * as utils from '../src/utils.js'
-import {ajax} from '../src/ajax.js';
-import {submodule} from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
+import { getRefererInfo } from '../src/refererDetection.js';
 
 const PARRABLE_URL = 'https://h.parrable.com/prebid';
 
@@ -26,9 +27,12 @@ function isValidConfig(configParams) {
 function fetchId(configParams, consentData, currentStoredId) {
   if (!isValidConfig(configParams)) return;
 
+  const { referer } = getRefererInfo();
+
   const data = {
     eid: currentStoredId || null,
-    trackers: configParams.partner.split(',')
+    trackers: configParams.partner.split(','),
+    url: referer
   };
 
   const searchParams = {

--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -27,12 +27,12 @@ function isValidConfig(configParams) {
 function fetchId(configParams, consentData, currentStoredId) {
   if (!isValidConfig(configParams)) return;
 
-  const { referer } = getRefererInfo();
+  const refererInfo = getRefererInfo();
 
   const data = {
     eid: currentStoredId || null,
     trackers: configParams.partner.split(','),
-    url: referer
+    url: refererInfo.referer
   };
 
   const searchParams = {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

Send the page location (window.location.href) as determined by the logic in the refererDetection module to Parrable's ID system.

The non-Prebid integration with Parrable sends the value of `window.location.href` when making a request to our system. This change makes Prebid more closely match our non-Prebid integration.