### PR TITLE
GumGum: uses encodeURIComponent inline

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -60,7 +60,7 @@ function _getBrowserParams(topWindowUrl) {
     pu: topUrl,
     ce: storage.cookiesAreEnabled(),
     dpr: topWindow.devicePixelRatio || 1,
-    jcsi: JSON.stringify({ t: 0, rq: 8 }),
+    jcsi: encodeURIComponent(JSON.stringify({ t: 0, rq: 8 })),
     ogu: getOgURL()
   }
 

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -228,6 +228,13 @@ describe('gumgumAdapter', function () {
         expect(bidRequest.data).to.not.include.any.keys('ns');
       }
     });
+    it('has jcsi param correctly encoded', function () {
+      const jcsi = JSON.stringify({ t: 0, rq: 8 });
+      const encodedJCSI = encodeURIComponent(jcsi);
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data.jcsi).to.not.contain(/\{.*\}/);
+      expect(bidRequest.data.jcsi).to.eq(encodedJCSI);
+    });
   })
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Encodes a param object instead of relying on parseQueryStringParameters


