### PR TITLE
Reset GPT targeting for custom div ids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -278,7 +278,7 @@ $$PREBID_GLOBAL$$.setTargetingForGPTAsync = function (adUnit, customSlotMatching
   let targetingSet = targeting.getAllTargeting(adUnit);
 
   // first reset any old targeting
-  targeting.resetPresetTargeting(adUnit);
+  targeting.resetPresetTargeting(adUnit, customSlotMatching);
 
   // now set new targeting keys
   targeting.setTargetingForGPT(targetingSet, customSlotMatching);

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -110,16 +110,18 @@ export function newTargeting(auctionManager) {
     latestAuctionForAdUnit[adUnitCode] = auctionId;
   };
 
-  targeting.resetPresetTargeting = function(adUnitCode) {
+  targeting.resetPresetTargeting = function(adUnitCode, customSlotMatching) {
     if (isGptPubadsDefined()) {
       const adUnitCodes = getAdUnitCodes(adUnitCode);
       const adUnits = auctionManager.getAdUnits().filter(adUnit => includes(adUnitCodes, adUnit.code));
       window.googletag.pubads().getSlots().forEach(slot => {
+        let customSlotMatchingFunc = utils.isFn(customSlotMatching) && customSlotMatching(slot);
         pbTargetingKeys.forEach(function(key) {
           // reset only registered adunits
           adUnits.forEach(function(unit) {
             if (unit.code === slot.getAdUnitPath() ||
-                unit.code === slot.getSlotElementId()) {
+                unit.code === slot.getSlotElementId() ||
+                (utils.isFn(customSlotMatchingFunc) && customSlotMatchingFunc(unit.code))) {
               slot.setTargeting(key, null);
             }
           });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->
When resetting targeting provide `customSlotMatching` function (that is also used for setting gpt targeting).  
Right now, code is checking whether it should reset targeting: **if adUnit code is the same as gpt slot adUnit path** *or* **if adUnit code is the same as div id**. If all these checks fail, use `customSlotMatching` function as fallback to determine if targeting should be reset.

## Other information
This PR is addressing #5131 issue.
