### PR TITLE
Replace call to old url module with call to utils

### DIFF
--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -2,7 +2,6 @@ import { ajax } from '../src/ajax.js';
 import adapter from '../src/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import CONSTANTS from '../src/constants.json';
-import * as url from '../src/url.js';
 import * as utils from '../src/utils.js';
 
 const emptyUrl = '';
@@ -117,7 +116,7 @@ function send(data, status) {
   }
   data.initOptions = initOptions;
 
-  let terceptAnalyticsRequestUrl = url.format({
+  let terceptAnalyticsRequestUrl = utils.buildUrl({
     protocol: 'https',
     hostname: (initOptions && initOptions.hostName) || defaultHostName,
     pathname: (initOptions && initOptions.pathName) || defaultPathName,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Replace call to old url module with call to utils in terceptAnalyticsAdapter to resolve build error.