### PR TITLE
Update ajax call and log errors for CriteoId modules

### DIFF
--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -6,7 +6,7 @@
  */
 
 import * as utils from '../src/utils.js'
-import * as ajax from '../src/ajax.js'
+import { ajax } from '../src/ajax.js'
 import { getRefererInfo } from '../src/refererDetection.js'
 import { submodule } from '../src/hook.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -85,9 +85,8 @@ function callCriteoUserSync(parsedCriteoData, gdprString) {
     gdprString
   );
 
-  ajax.ajaxBuilder()(
-    url,
-    response => {
+  ajax(url, {
+    success: response => {
       const jsonResponse = JSON.parse(response);
       if (jsonResponse.bidId) {
         saveOnAllStorages(bididStorageKey, jsonResponse.bidId);
@@ -101,8 +100,12 @@ function callCriteoUserSync(parsedCriteoData, gdprString) {
       } else if (jsonResponse.bundle) {
         saveOnAllStorages(bundleStorageKey, jsonResponse.bundle);
       }
+    },
+    error: error => {
+      if (error !== '')
+        utils.logError(error);
     }
-  );
+  });
 }
 
 /** @type {Submodule} */

--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -102,8 +102,9 @@ function callCriteoUserSync(parsedCriteoData, gdprString) {
       }
     },
     error: error => {
-      if (error !== '')
+      if (error !== '') {
         utils.logError(error);
+      }
     }
   });
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Update ajax function call and log errors.
CriteoId module does not call a the _continue action callback_ when identifying because it is done asynchronously on our side. We always return the identifiers previously stored locally.

- Contact emails: ja.pologarcia@criteo.com and h.duthil@criteo.com
