### PR TITLE
Remove leftover return value from requestBids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -521,7 +521,6 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
 
   adUnitCodes.forEach(code => targeting.setLatestAuctionForAdUnit(code, auction.getAuctionId()));
   auction.callBids();
-  return auction;
 });
 
 export function executeStorageCallbacks(fn, reqBidsConfigObj) {


### PR DESCRIPTION
## Type of change
- [x ] Refactoring (no functional changes, no api changes)

## Description of change

Someone mentioned that `requestBids` is not propertly returning anything (it's `undefined`). This is because it is an async hook and async hooks cannot return a value on account of them being asynchronous. The return value is a leftover addition that was added to support the old `pre1api` module, but it was never documented and is not part of our public API. This pull-request is to remove it so it doesn't confuse anyone else.
