### PR TITLE
restore version property to the latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.17.0-pre",
+  "version": "3.18.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.12.0",
+  "version": "3.18.0-pre",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change

Version in `package.json` and `package-lock.json` was accidentally change by the merge of https://github.com/prebid/Prebid.js/pull/5158

This PR reverts "version" to the latest released version of Prebid. 

