### PR TITLE
Update UNICORN Bid Adapter: add publisherId & mediaId

### DIFF
--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -65,9 +65,9 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
     imp,
     cur: UNICORN_DEFAULT_CURRENCY,
     site: {
-      id: window.location.hostname,
+      id: utils.deepAccess(validBidRequests[0], 'params.mediaId') || '',
       publisher: {
-        id: utils.deepAccess(validBidRequests[0], 'params.accountId')
+        id: utils.deepAccess(validBidRequests[0], 'params.publisherId') || 0
       },
       domain: window.location.hostname,
       page: window.location.href,
@@ -86,6 +86,9 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
         stype: 'prebid_uncn',
         bidder: BIDDER_CODE
       }
+    },
+    ext: {
+      accountId: utils.deepAccess(validBidRequests[0], 'params.accountId')
     }
   };
   utils.logInfo('[UNICORN] OpenRTB Formatted Request:', request);

--- a/modules/unicornBidAdapter.md
+++ b/modules/unicornBidAdapter.md
@@ -23,6 +23,8 @@ Module that connects to UNICORN.
             params: {
                 placementId: 'rectangle-ad-1', // OPTIONAL: If placementId is empty, adunit code will be used as placementId. 
                 bidfloorCpm: 0.2, // OPTIONAL: Floor CPM (JPY) defaults to 0
+                publisherId: 99999 // OPTIONAL: Account specific publisher id
+                mediaId: "uc" // OPTIONAL: Publisher specific media id
                 accountId: 12345, // REQUIRED: Account ID for charge request
                 bcat: ['IAB-1', 'IAB-2'] // OPTIONAL: blocked IAB categories
             }

--- a/test/spec/modules/unicornBidAdapter_spec.js
+++ b/test/spec/modules/unicornBidAdapter_spec.js
@@ -75,7 +75,9 @@ const validBidRequests = [
     params: {
       placementId: 'rectangle-ad-1',
       bidfloorCpm: 0,
-      accountId: 12345
+      accountId: 12345,
+      publisherId: 99999,
+      mediaId: 'example'
     },
     mediaTypes: {
       banner: {
@@ -261,10 +263,13 @@ const openRTBRequest = {
     }
   ],
   cur: 'JPY',
+  ext: {
+    accountId: 12345
+  },
   site: {
-    id: 'uni-corn.net',
+    id: 'example',
     publisher: {
-      id: 12345
+      id: 99999
     },
     domain: 'uni-corn.net',
     page: 'https://uni-corn.net/',
@@ -427,7 +432,6 @@ describe('unicornBidAdapterTest', () => {
       const removeUntestableAttrs = data => {
         delete data['device'];
         delete data['site']['domain'];
-        delete data['site']['id'];
         delete data['site']['page'];
         delete data['id'];
         data['imp'].forEach(imp => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Description of change
<!-- Describe the change proposed in this pull request -->
added publisherId & mediaId params to UNICORN BidAdapter
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'unicorn',
    params: {
        placementId: 'rectangle-ad-1', // OPTIONAL: If placementId is empty, adunit code will be used as placementId. 
        bidfloorCpm: 0.2, // OPTIONAL: Floor CPM (JPY) defaults to 0
        publisherId: 99999 // OPTIONAL: Account specific publisher id
        mediaId: "uc" // OPTIONAL: Publisher specific media id
        accountId: 12345, // REQUIRED: Account ID for charge request
        bcat: ['IAB-1', 'IAB-2'] // OPTIONAL: blocked IAB categories
    }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- docs update PR: https://github.com/prebid/prebid.github.io/pull/1955

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
