### PR TITLE
Media.net : BidAdapter & Analytics improvements

### DIFF
--- a/modules/medianetAnalyticsAdapter.js
+++ b/modules/medianetAnalyticsAdapter.js
@@ -119,7 +119,7 @@ class Configure {
 
   init() {
     // Forces Logging % to 100%
-    let urlObj = utils.parseUrl(pageDetails.page);
+    let urlObj = URL.parseUrl(pageDetails.page);
     if (utils.deepAccess(urlObj, 'search.medianet_test') || urlObj.hostname === 'localhost') {
       this.loggingPercent = 100;
       this.ajaxState = CONFIG_PASS;
@@ -143,7 +143,7 @@ class PageDetail {
     const twitterUrl = this._getUrlFromSelector('meta[name="twitter:url"]', 'content');
     const refererInfo = getRefererInfo();
 
-    this.domain = utils.parseUrl(refererInfo.referer).host;
+    this.domain = URL.parseUrl(refererInfo.referer).host;
     this.page = refererInfo.referer;
     this.is_top = refererInfo.reachedTop;
     this.referrer = this._getTopWindowReferrer();
@@ -208,6 +208,7 @@ class AdSlot {
     this.adext = adext;
     this.logged = false;
     this.targeting = undefined;
+    this.medianetPresent = 0;
   }
 
   getLoggingData() {
@@ -216,7 +217,8 @@ class AdSlot {
       mediaTypes: this.mediaTypes && this.mediaTypes.join('|'),
       szs: this.bannerSizes.join('|'),
       tmax: this.tmax,
-      targ: JSON.stringify(this.targeting)
+      targ: JSON.stringify(this.targeting),
+      ismn: this.medianetPresent
     },
     this.adext && {'adext': JSON.stringify(this.adext)},
     );
@@ -259,6 +261,7 @@ class Bid {
 
   getLoggingData() {
     return {
+      adid: this.adId,
       pvnm: this.bidder,
       src: this.src,
       ogbdp: this.originalCpm,
@@ -304,7 +307,8 @@ class Auction {
       ets: this.auctionEndTime - this.auctionInitTime,
       tts: this.setTargetingTime - this.auctionInitTime,
       wts: this.bidWonTime - this.auctionInitTime,
-      aucstatus: this.status
+      aucstatus: this.status,
+      acid: this.acid
     }
   }
 
@@ -375,6 +379,7 @@ function bidRequestedHandler({ auctionId, auctionStart, bids, start, timeout, us
     if (bidder === MEDIANET_BIDDER_CODE) {
       bidObj.crid = utils.deepAccess(bid, 'params.crid');
       bidObj.pubcrid = utils.deepAccess(bid, 'params.crid');
+      auctions[auctionId].adSlots[adUnitCode].medianetPresent = 1;
     }
   });
 }
@@ -393,8 +398,9 @@ function bidResponseHandler(bid) {
   Object.assign(
     bidObj,
     { cpm, width, height, mediaType, timeToRespond, dealId, creativeId },
-    { adId, currency, originalCpm }
+    { adId, currency }
   );
+  bidObj.originalCpm = originalCpm || cpm;
   let dfpbd = utils.deepAccess(bid, 'adserverTargeting.hb_pb');
   if (!dfpbd) {
     let priceGranularity = getPriceGranularity(mediaType, bid);
@@ -559,6 +565,34 @@ function formatQS(data) {
 function firePixel(qs) {
   logsQueue.push(ENDPOINT + '&' + qs);
   utils.triggerPixel(ENDPOINT + '&' + qs);
+}
+
+class URL {
+  static parseUrl(url) {
+    let parsed = document.createElement('a');
+    parsed.href = decodeURIComponent(url);
+    return {
+      hostname: parsed.hostname,
+      search: URL.parseQS(parsed.search || ''),
+      host: parsed.host || window.location.host
+    };
+  }
+  static parseQS(query) {
+    return !query ? {} : query
+      .replace(/^\?/, '')
+      .split('&')
+      .reduce((acc, criteria) => {
+        let [k, v] = criteria.split('=');
+        if (/\[\]$/.test(k)) {
+          k = k.replace('[]', '');
+          acc[k] = acc[k] || [];
+          acc[k].push(v);
+        } else {
+          acc[k] = v || '';
+        }
+        return acc;
+      }, {});
+  }
 }
 
 let medianetAnalytics = Object.assign(adapter({URL, analyticsType}), {

--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -135,6 +135,7 @@ function extParams(params, gdpr, uspConsent, userId) {
   let windowSize = spec.getWindowSize();
   let gdprApplies = !!(gdpr && gdpr.gdprApplies);
   let uspApplies = !!(uspConsent);
+  let coppaApplies = !!(config.getConfig('coppa'));
   return Object.assign({},
     { customer_id: params.cid },
     { prebid_version: $$PREBID_GLOBAL$$.version },
@@ -142,6 +143,7 @@ function extParams(params, gdpr, uspConsent, userId) {
     (gdprApplies) && { gdpr_consent_string: gdpr.consentString || '' },
     { usp_applies: uspApplies },
     uspApplies && { usp_consent_string: uspConsent || '' },
+    {coppa_applies: coppaApplies},
     windowSize.w !== -1 && windowSize.h !== -1 && { screen: windowSize },
     userId && { user_id: userId }
   );

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -309,6 +309,7 @@ let VALID_BID_REQUEST = [{
       'prebid_version': $$PREBID_GLOBAL$$.version,
       'gdpr_applies': false,
       'usp_applies': false,
+      'coppa_applies': false,
       'screen': {
         'w': 1000,
         'h': 1000
@@ -393,6 +394,7 @@ let VALID_BID_REQUEST = [{
       'prebid_version': $$PREBID_GLOBAL$$.version,
       'gdpr_applies': false,
       'usp_applies': false,
+      'coppa_applies': false,
       'screen': {
         'w': 1000,
         'h': 1000
@@ -478,6 +480,7 @@ let VALID_BID_REQUEST = [{
       'prebid_version': $$PREBID_GLOBAL$$.version,
       'gdpr_applies': false,
       'usp_applies': false,
+      'coppa_applies': false,
       'screen': {
         'w': 1000,
         'h': 1000
@@ -564,6 +567,7 @@ let VALID_BID_REQUEST = [{
         britepoolid: '82efd5e1-816b-4f87-97f8-044f407e2911'
       },
       'usp_applies': false,
+      'coppa_applies': false,
       'screen': {
         'w': 1000,
         'h': 1000
@@ -651,6 +655,7 @@ let VALID_BID_REQUEST = [{
       'prebid_version': $$PREBID_GLOBAL$$.version,
       'gdpr_applies': false,
       'usp_applies': false,
+      'coppa_applies': true,
       'screen': {
         'w': 1000,
         'h': 1000
@@ -992,6 +997,7 @@ let VALID_BID_REQUEST = [{
       'gdpr_consent_string': 'consentString',
       'gdpr_applies': true,
       'usp_applies': true,
+      'coppa_applies': false,
       'usp_consent_string': '1NYN',
       'screen': {
         'w': 1000,
@@ -1149,6 +1155,12 @@ describe('Media.net bid adapter', function () {
     });
 
     it('should have valid crid present in bid request', function() {
+      sandbox.stub(config, 'getConfig').callsFake((key) => {
+        const config = {
+          'coppa': true
+        };
+        return config[key];
+      });
       let bidreq = spec.buildRequests(VALID_BID_REQUEST_WITH_CRID, VALID_AUCTIONDATA);
       expect(JSON.parse(bidreq.data)).to.deep.equal(VALID_PAYLOAD_WITH_CRID);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We have added `coppa` support in Bid Adapter. Additionally in Analytics adapter, we are logging extra keys like auction id, ad id, is media.net present etc 

