### PR TITLE
One Video: Added banner support for Dynamic Ad Placement (DAP)

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -3,7 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'oneVideo';
 export const spec = {
   code: 'oneVideo',
-  VERSION: '3.0.1',
+  VERSION: '3.0.2',
   ENDPOINT: 'https://ads.adaptv.advertising.com/rtb/openrtb?ext_id=',
   SYNC_ENDPOINT1: 'https://cm.g.doubleclick.net/pixel?google_nid=adaptv_dbm&google_cm&google_sc',
   SYNC_ENDPOINT2: 'https://pr-bh.ybp.yahoo.com/sync/adaptv_ortb/{combo_uid}',
@@ -93,7 +93,6 @@ export const spec = {
     } else {
       bidResponse.mediaType = 'video'
     }
-
 
     if (bid.nurl) {
       bidResponse.vastUrl = bid.nurl;

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -21,12 +21,18 @@ export const spec = {
     }
 
     // Video validations
-    if (typeof bid.params.video === 'undefined' || typeof bid.params.video.playerWidth === 'undefined' || typeof bid.params.video.playerHeight == 'undefined' || typeof bid.params.video.mimes == 'undefined' || (bid.mediaTypes.video.context === 'outstream' && bid.params.video.display === 1)) {
+    if (typeof bid.params.video === 'undefined' || typeof bid.params.video.playerWidth === 'undefined' || typeof bid.params.video.playerHeight == 'undefined' || typeof bid.params.video.mimes == 'undefined') {
       return false;
     }
 
+    // Prevend DAP Outstream validation
+    if (bid.mediaTypes.video) {
+      if (bid.mediaTypes.video.context === 'outstream' && bid.params.video.display === 1) {
+        return false;
+      }
+    }
     // Banner DAP validation
-    if (bid.mediaTypes.banner && typeof bid.params.video.display === 'undefined') {
+    if (bid.mediaTypes.banner && (typeof bid.params.video.display === 'undefined' || !bid.params.video.display)) {
       return false;
     }
 

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -32,7 +32,7 @@ export const spec = {
       }
     }
     // Banner DAP validation
-    if (bid.mediaTypes.banner && (typeof bid.params.video.display === 'undefined' || !bid.params.video.display)) {
+    if (bid.mediaTypes.banner && (!bid.params.video.display)) {
       return false;
     }
 

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -8,7 +8,7 @@ export const spec = {
   SYNC_ENDPOINT1: 'https://cm.g.doubleclick.net/pixel?google_nid=adaptv_dbm&google_cm&google_sc',
   SYNC_ENDPOINT2: 'https://pr-bh.ybp.yahoo.com/sync/adaptv_ortb/{combo_uid}',
   SYNC_ENDPOINT3: 'https://match.adsrvr.org/track/cmf/generic?ttd_pid=adaptv&ttd_tpi=1',
-  supportedMediaTypes: ['video'],
+  supportedMediaTypes: ['video', 'banner'],
   /**
    * Determines whether or not the given bid request is valid.
    *
@@ -82,18 +82,31 @@ export const spec = {
       creativeId: bid.crid,
       width: size.width,
       height: size.height,
-      mediaType: 'video',
       currency: response.cur,
       ttl: 100,
       netRevenue: true,
       adUnitCode: bidRequest.adUnitCode
     };
+
+    if (bidRequest.mediaTypes.banner) {
+      bidResponse.mediaType = 'banner'
+    } else {
+      bidResponse.mediaType = 'video'
+    }
+
+
     if (bid.nurl) {
       bidResponse.vastUrl = bid.nurl;
+    } else if (bid.adm && bidRequest.params.video.display === 1) {
+      bidResponse.ad = bid.adm
     } else if (bid.adm) {
       bidResponse.vastXml = bid.adm;
     }
-    bidResponse.renderer = (bidRequest.mediaTypes.video.context === 'outstream') ? newRenderer(bidRequest, bidResponse) : undefined;
+
+    if (bidRequest.mediaTypes.video) {
+      bidResponse.renderer = (bidRequest.mediaTypes.video.context === 'outstream') ? newRenderer(bidRequest, bidResponse) : undefined;
+    }
+
     return bidResponse;
   },
   /**

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -21,7 +21,12 @@ export const spec = {
     }
 
     // Video validations
-    if (typeof bid.params.video === 'undefined' || typeof bid.params.video.playerWidth === 'undefined' || typeof bid.params.video.playerHeight == 'undefined' || typeof bid.params.video.mimes == 'undefined') {
+    if (typeof bid.params.video === 'undefined' || typeof bid.params.video.playerWidth === 'undefined' || typeof bid.params.video.playerHeight == 'undefined' || typeof bid.params.video.mimes == 'undefined' || (bid.mediaTypes.video.context === 'outstream' && bid.params.video.display === 1)) {
+      return false;
+    }
+
+    // Banner DAP validation
+    if (bid.mediaTypes.banner && typeof bid.params.video.display === 'undefined') {
       return false;
     }
 

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -99,11 +99,7 @@ export const spec = {
       adUnitCode: bidRequest.adUnitCode
     };
 
-    if (bidRequest.mediaTypes.banner) {
-      bidResponse.mediaType = 'banner'
-    } else {
-      bidResponse.mediaType = 'video'
-    }
+    bidResponse.mediaType = (bidRequest.mediaTypes.banner) ? 'banner' : 'video'
 
     if (bid.nurl) {
       bidResponse.vastUrl = bid.nurl;

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -1,89 +1,168 @@
 # Overview
 
 **Module Name**: One Video Bidder Adapter
-**Module Type**: Bidder Adapter  
+**Module Type**: Bidder Adapter
 **Maintainer**: deepthi.neeladri.sravana@verizonmedia.com
 
 # Description
 
-Connects to One Video demand source to fetch bids.
+Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to fetch bids.
 
 
-# Test Parameters for Video
+# Instream Video adUnit example & parameters
+*Note:* The Video SSP ad server will respond with an VAST XML to load into your defined player.
 ```
-    var adUnits = [
-
-	{
-      code: 'video1',
-        sizes: [640,480],
-        mediaTypes: {
-          video: {
-            context: "instream"
-          }
-        },
-        bids: [
-          {
-            bidder: 'oneVideo',
-            params: {
-              video: {
-                playerWidth: 480,
-                playerHeight: 640,
-                mimes: ['video/mp4', 'application/javascript'],
-                protocols: [2,5],
-                api: [2],
-                position: 1,
-                delivery: [2],
-                playbackmethod: [1,5],
-                sid: <scpid>,
-                rewarded: 1,
-                placement: 1,
-                inventoryid: 123,
-                minduration: 10,
-                maxduration: 30,
-               },
-               site: {
-                  id: 1,
-                  page: 'http://abhi12345.com',
-                  referrer: 'http://abhi12345.com'
+  var adUnits = [
+    {
+        code: 'video1',
+          mediaTypes: {
+            video: {
+                  context: 'instream',
+                  playerSize: [480, 640]
+            }
+          },
+          bids: [
+            {
+              bidder: 'oneVideo',
+              params: {
+                video: {
+                  playerWidth: 480,
+                  playerHeight: 640,
+                  mimes: ['video/mp4', 'application/javascript'],
+                  protocols: [2,5],
+                  api: [2],
+                  position: 1,
+                  delivery: [2],
+                  playbackmethod: [1,5],
+                  sid: <scpid>,
+                  rewarded: 1,
+                  placement: 1,
+                  inventoryid: 123,
+                  minduration: 10,
+                  maxduration: 30,
                 },
-               pubId: 'brxd'
-              }
-           }
-        ]
+                site: {
+                    id: 1,
+                    page: 'https://verizonmedia.com',
+                    referrer: 'https://verizonmedia.com'
+                  },
+                pubId: 'HBExchange'
+                }
+            }
+          ]
+      }
+  ]
+```
+# Outstream Video adUnit example & parameters
+*Note:* The Video SSP ad server will load it's own Outstream Renderer (player) as a fallback if no player is defined on the publisher page. The Outstream player will inject into the div id that has an identical adUnit code.
+```
+  var adUnits = [
+    {
+        code: 'video1',
+          mediaTypes: {
+            video: {
+                  context: 'outstream',
+                  playerSize: [480, 640]
+            }
+          },
+          bids: [
+            {
+              bidder: 'oneVideo',
+              params: {
+                video: {
+                  playerWidth: 480,
+                  playerHeight: 640,
+                  mimes: ['video/mp4', 'application/javascript'],
+                  protocols: [2,5],
+                  api: [2],
+                  position: 1,
+                  delivery: [2],
+                  playbackmethod: [1,5],
+                  sid: <scpid>,
+                  rewarded: 1,
+                  placement: 1,
+                  inventoryid: 123,
+                  minduration: 10,
+                  maxduration: 30,
+                },
+                site: {
+                    id: 1,
+                    page: 'https://verizonmedia.com',
+                    referrer: 'https://verizonmedia.com'
+                  },
+                pubId: 'HBExchange'
+                }
+            }
+          ]
+      }
+  ]
+```
+
+# S2S / Video: Dynamic Ad Placement (DAP) adUnit example & parameters
+*Note:* The Video SSP ad server will respond with HTML embed tag to be injected into an iFrame you create.
+```
+  var adUnits = [
+    {
+      code: 'video1',
+      mediaTypes: {
+        video: {
+          context: "instream",
+          playerSize: [480, 640]
+        }
+      },
+      bids: [
+        {
+          bidder: 'oneVideo',
+          params: {
+            video: {
+              playerWidth: 480,
+              playerHeight: 640,
+              mimes: ['video/mp4', 'application/javascript'],
+              position: 1,
+              display: 1
+            },
+            site: {
+              id: 1,
+              page: 'https://verizonmedia.com',
+              referrer: 'https://verizonmedia.com'
+            },
+            pubId: 'HBExchangeDAP'
+          }
+        }
+      ]
     }
 ]
 ```
-# Test Parameters for banner request
+# Prebid.js / Banner: Dynamic Ad Placement (DAP) adUnit example & parameters
+*Note:* The Video SSP ad server will respond with HTML embed tag to be injected into an iFrame created by Google Ad Manager (GAM).
 ```
-    var adUnits = [
+  var adUnits = [
+    {
+      code: 'banner-1',
+      mediaTypes: {
+        banner: {
+          sizes: [300, 250]
+        }
+      },
+      bids: [
         {
-            code: 'video1',
-              sizes: [640,480],
-              mediaTypes: {
-                video: {
-                  context: "instream"
-                }
-              },
-              bids: [
-                {
-                  bidder: 'oneVideo',
-                  params: {
-                    video: {
-                      playerWidth: 480,
-                      playerHeight: 640,
-                      mimes: ['video/mp4', 'application/javascript'],
-                      position: 1,
-                      display: 1
-                    },
-                    site: {
-                      id: 1,
-                      page: 'http://abhi12345.com',
-                      referrer: 'http://abhi12345.com'
-                    },
-                    pubId: 'OneMDisplay'
-                  }
-                }
-            ]
-       }
+          bidder: 'oneVideo',
+          params: {
+            video: {
+              playerWidth: 300,
+              playerHeight: 250,
+              mimes: ['video/mp4', 'application/javascript'],
+              display: 1
+            },
+            site: {
+              id: 1,
+              page: 'https://verizonmedia.com',
+              referrer: 'https://verizonmedia.com'
+            },
+            pubId: 'HBExchangeDAP'
+          }
+        }
+      ]
+    }
 ]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.19.0-pre",
+  "version": "3.18.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.18.0-pre",
+  "version": "3.19.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -136,7 +136,7 @@ describe('OneVideoBidAdapter', function () {
       const placement = bidRequest.params.video.placement;
       const rewarded = bidRequest.params.video.rewarded;
       const inventoryid = bidRequest.params.video.inventoryid;
-      const VERSION = '3.0.1';
+      const VERSION = '3.0.2';
       expect(data.imp[0].video.w).to.equal(width);
       expect(data.imp[0].video.h).to.equal(height);
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -134,12 +134,34 @@ describe('OneVideoBidAdapter', function () {
             sizes: [640, 480]
           }
         },
+        bidder: 'oneVideo',
+        sizes: [640, 480],
+        bidId: '30b3efwfwe1e',
+        adUnitCode: 'video1',
         params: {
           video: {
+            playerWidth: 640,
+            playerHeight: 480,
+            mimes: ['video/mp4', 'application/javascript'],
+            protocols: [2, 5],
+            api: [2],
+            position: 1,
+            delivery: [2],
+            playbackmethod: [1, 5],
+            sid: 134,
+            rewarded: 1,
+            placement: 1,
+            inventoryid: 123,
             display: 1
-          }
+          },
+          site: {
+            id: 1,
+            page: 'https://news.yahoo.com/portfolios',
+            referrer: 'http://www.yahoo.com'
+          },
+          pubId: 'brxd'
         }
-      }
+      };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     })
 
@@ -259,7 +281,7 @@ describe('OneVideoBidAdapter', function () {
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       expect(bidResponse.ad).to.equal('<div>DAP UNIT HERE</div>');
       expect(bidResponse.mediaType).to.equal('banner');
-      expect(bidResponse.renderer).to.equal('undefined');
+      expect(bidResponse.renderer).to.be.undefined;
     });
   });
 

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -90,7 +90,7 @@ describe('OneVideoBidAdapter', function () {
       };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
-    it('should return true when the "pubId" param is missing', function () {
+    it('should return true when the "pubId" param exists', function () {
       bidRequest.params = {
         video: {
           playerWidth: 480,
@@ -115,6 +115,50 @@ describe('OneVideoBidAdapter', function () {
       bidRequest.params = {};
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
     });
+
+    it('should return false when the mediaType is "banner" and display="undefined" (DAP 3P)', function () {
+      bidRequest = {
+        mediaTypes: {
+          banner: {
+            sizes: [640, 480]
+          }
+        }
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    })
+
+    it('should return true when the mediaType is "banner" and display=1 (DAP 3P)', function () {
+      bidRequest = {
+        mediaTypes: {
+          banner: {
+            sizes: [640, 480]
+          }
+        },
+        params: {
+          video: {
+            display: 1
+          }
+        }
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    })
+
+    it('should return false when the mediaType is "video" and context="outstream" and display=1 (DAP 3P)', function () {
+      bidRequest = {
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            playerSize: [640, 480]
+          }
+        },
+        params: {
+          video: {
+            display: 1
+          }
+        }
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    })
   });
 
   describe('spec.buildRequests', function () {
@@ -176,7 +220,7 @@ describe('OneVideoBidAdapter', function () {
       expect(bidResponse.length).to.equal(0);
     });
 
-    it('should return a valid bid response with just "adm"', function () {
+    it('should return a valid video bid response with just "adm"', function () {
       const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
       const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
       let o = {
@@ -196,6 +240,26 @@ describe('OneVideoBidAdapter', function () {
         renderer: (bidRequest.mediaTypes.video.context === 'outstream') ? newRenderer(bidRequest, bidResponse) : undefined,
       };
       expect(bidResponse).to.deep.equal(o);
+    });
+    // @abrowning14 check that banner DAP response is appended to o.ad + mediaType: 'banner'
+    it('should return a valid DAP banner bid-response', function () {
+      bidRequest = {
+        mediaTypes: {
+          banner: {
+            sizes: [640, 480]
+          }
+        },
+        params: {
+          video: {
+            display: 1
+          }
+        }
+      }
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<div>DAP UNIT HERE</div>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse.ad).to.equal('<div>DAP UNIT HERE</div>');
+      expect(bidResponse.mediaType).to.equal('banner');
+      expect(bidResponse.renderer).to.equal('undefined');
     });
   });
 
@@ -267,7 +331,7 @@ describe('OneVideoBidAdapter', function () {
     });
   });
   describe('should send banner object', function () {
-    it('should send banner object when display is 1', function () {
+    it('should send banner object when display is 1 and context="instream" (DAP O&O)', function () {
       bidRequest = {
         mediaTypes: {
           video: {
@@ -320,7 +384,7 @@ describe('OneVideoBidAdapter', function () {
       expect(data.imp[0].banner.ext.maxduration).to.equal(bidRequest.params.video.maxduration);
       expect(data.site.id).to.equal(bidRequest.params.site.id);
     });
-    it('should send video object when display is other than 1', function () {
+    it('should send video object when display is other than 1 (VAST for All)', function () {
       bidRequest = {
         mediaTypes: {
           video: {
@@ -365,7 +429,7 @@ describe('OneVideoBidAdapter', function () {
       expect(data.imp[0].video.pos).to.equal(position);
       expect(data.imp[0].video.mimes).to.equal(bidRequest.params.video.mimes);
     });
-    it('should send video object when display is not passed', function () {
+    it('should send video object when display is not passed (VAST for All)', function () {
       bidRequest = {
         mediaTypes: {
           video: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X ] Feature

## Description of change
Added 'banner' support for Dynamic Ad Placement (DAP) feature in the oneVideo adapter.
Now when mediaTypes: {banner: { sizes: [300, 250]}} is passed the oneVideo adapter will send a bid-request as well for the DAP response.


<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
1. adUnit mediaTypes must be set to banner.
2. bidder params must remain video and you must pass display: 1
3. DAP will only respond if the Video SSP Exchange has DAP enabled.
4. You can use this test Exchange by entering pubId: 'HBExchangeDAP'
5. The DAP unit can only render within an iframe - use GAM to do so as provided in http://prebid.org/dev-docs/examples/basic-example.html
```
{
  bidder: 'oneVideo',
  params: {
                    video: {
                        playerWidth: 300,
                        playerHeight: 250,
                        mimes: ['video/mp4', 'application/javascript'],
                        api: [1, 2],
                        display: 1,
                    },
                    pubId: 'YOUR_PUBLISHER_ID'
                }
}
```

Be sure to test the integration with your ad server using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Hi @DeepthiNeeladri,
Could you please review my pull request.
I have tested this locally and it is working now as expected:
You can review this live demo using a hosted version of the fixed adaptor with prebid.js v3.19.0
https://cdn.vidible.tv/prod/2020-05/06/5eb2714cb7eac40001500f52_v1.html

### Here is a summary of the changes I have made to https://github.com/prebid/Prebid.js/blob/master/modules/oneVideoBidAdapter.js

1. 11: supportedMediaTypes: ['video', 'banner'], Added "banner" type to support DAP flow
2. 85: Deleted bidResponse.mediaType = 'video', Moved logic below to row 90
3. new line 90: Added If this is DAP request set response mediaType as "banner"
4. 91-95: If this is DAP response, append the adm into bidResponse.ad not only bidResponse.vastXml
5. 96: Wrapped the outstream renderer setter only if this is Not a DAP response.

