### PR TITLE
Gdpr vendor exceptions

### DIFF
--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -36,48 +36,15 @@ function getGvlid() {
  * @returns {boolean}
  */
 function validateRules(rule, consentData, currentModule, gvlid) {
-  let isAllowed = false;
-  if (!rule.vendorExceptions) rule.vendorExceptions = [];
-  if (rule.enforcePurpose && rule.enforceVendor) {
-    if (
-      includes(rule.vendorExceptions, currentModule) ||
-      (
-        utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true &&
-        utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true
-      )
-    ) {
-      isAllowed = true;
-    }
-  } else if (rule.enforcePurpose === false && rule.enforceVendor === true) {
-    if (
-      includes(rule.vendorExceptions, currentModule) ||
-      (
-        utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true
-      )
-    ) {
-      isAllowed = true;
-    }
-  } else if (rule.enforcePurpose === false && rule.enforceVendor === false) {
-    if (
-      !includes(rule.vendorExceptions, currentModule) ||
-      (
-        (utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true) &&
-        (utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true)
-      )
-    ) {
-      isAllowed = true;
-    }
-  } else if (rule.enforcePurpose === true && rule.enforceVendor === false) {
-    if (
-      (utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true) &&
-      (
-        !includes(rule.vendorExceptions, currentModule) ||
-        (utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true)
-      )
-    ) {
-      isAllowed = true;
-    }
+  // if vendor has exception => always true
+  if (includes(rule.vendorExceptions || [], currentModule)) {
+    return true;
   }
+  let isAllowed = false;
+  // if enforcePurpose is false or purpose was granted isAllowed is true, otherwise false
+  isAllowed = rule.enforcePurpose === false || utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true;
+  // if enforceVendor is false or vendor was granted isAllowed is true, otherwise false
+  isAllowed = rule.enforceVendor === false || utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true;
   return isAllowed;
 }
 

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -40,12 +40,11 @@ function validateRules(rule, consentData, currentModule, gvlid) {
   if (includes(rule.vendorExceptions || [], currentModule)) {
     return true;
   }
-  let isAllowed = false;
   // if enforcePurpose is false or purpose was granted isAllowed is true, otherwise false
-  isAllowed = rule.enforcePurpose === false || utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true;
+  const purposeAllowed = rule.enforcePurpose === false || utils.deepAccess(consentData, 'vendorData.purpose.consents.1') === true;
   // if enforceVendor is false or vendor was granted isAllowed is true, otherwise false
-  isAllowed = rule.enforceVendor === false || utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true;
-  return isAllowed;
+  const vendorAllowed = rule.enforceVendor === false || utils.deepAccess(consentData, `vendorData.vendor.consents.${gvlid}`) === true;
+  return purposeAllowed && vendorAllowed;
 }
 
 /**


### PR DESCRIPTION
## Type of change
- [X] Miscommunication

## Description of change
According to the PRD https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E/edit# the  `gdpr.rules[].vendorExceptions` field is supposed to be a simple global setting for a vendor always being allowed regardless,

I believe in one of the first iterations of the spec it was supposed to do what it currently does with the "if enforceVendor is false then vendorExceptions means we should enforce these vendors"

But the latest revision of the spec indicated if a bidder / module is in vendorException, then they are allowed no matter what.