### PR TITLE
added CCPA support, gvlid to adform and adformOpenRTB adapters

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -9,8 +9,10 @@ import * as utils from '../src/utils.js';
 const OUTSTREAM_RENDERER_URL = 'https://s2.adform.net/banners/scripts/video/outstream/render.js';
 
 const BIDDER_CODE = 'adform';
+const GVLID = 50;
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [ BANNER, VIDEO ],
   isBidRequestValid: function (bid) {
     return !!(bid.params.mid);
@@ -47,13 +49,19 @@ export const spec = {
     request.push('pt=' + netRevenue);
     request.push('stid=' + validBidRequests[0].auctionId);
 
-    if (bidderRequest && bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) {
+    const gdprApplies = utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
+    const consentString = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
+    if (gdprApplies !== undefined) {
       gdprObject = {
-        gdpr: bidderRequest.gdprConsent.gdprApplies,
-        gdpr_consent: bidderRequest.gdprConsent.consentString
+        gdpr: gdprApplies,
+        gdpr_consent: consentString
       };
-      request.push('gdpr=' + gdprObject.gdpr);
-      request.push('gdpr_consent=' + gdprObject.gdpr_consent);
+      request.push('gdpr=' + (gdprApplies & 1));
+      request.push('gdpr_consent=' + consentString);
+    }
+
+    if (bidderRequest && bidderRequest.uspConsent) {
+      request.push('us_privacy=' + bidderRequest.uspConsent);
     }
 
     for (i = 1, l = globalParams.length; i < l; i++) {

--- a/modules/adformOpenRTBBidAdapter.js
+++ b/modules/adformOpenRTBBidAdapter.js
@@ -11,6 +11,7 @@ import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'adformOpenRTB';
+const GVLID = 50;
 const NATIVE_ASSET_IDS = { 0: 'title', 2: 'icon', 3: 'image', 5: 'sponsoredBy', 4: 'body', 1: 'cta' };
 const NATIVE_PARAMS = {
   title: {
@@ -46,6 +47,7 @@ const NATIVE_PARAMS = {
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [ NATIVE ],
   isBidRequestValid: bid => !!bid.params.mid,
   buildRequests: (validBidRequests, bidderRequest) => {
@@ -122,9 +124,13 @@ export const spec = {
       request.is_debug = !!test;
       request.test = 1;
     }
-    if (utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies')) {
+    if (utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies') !== undefined) {
       request.user = { ext: { consent: bidderRequest.gdprConsent.consentString } };
       request.regs = { ext: { gdpr: bidderRequest.gdprConsent.gdprApplies & 1 } };
+    }
+
+    if (bidderRequest.uspConsent) {
+      utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
     }
 
     return {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -129,25 +129,24 @@ describe('Adform adapter', function () {
       assert.equal(parsedUrl.query.pt, 'gross');
     });
 
-    describe('gdpr', function () {
+    describe('user privacy', function () {
       it('should send GDPR Consent data to adform if gdprApplies', function () {
-        let resultBids = JSON.parse(JSON.stringify(bids[0]));
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
 
-        assert.equal(parsedUrl.gdpr, 'true');
+        assert.equal(parsedUrl.gdpr, '1');
         assert.equal(parsedUrl.gdpr_consent, 'concentDataString');
       });
 
-      it('should not send GDPR Consent data to adform if gdprApplies is false or undefined', function () {
-        let resultBids = JSON.parse(JSON.stringify(bids[0]));
+      it('should not send GDPR Consent data to adform if gdprApplies is undefined', function () {
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: false, consentString: 'concentDataString'}});
         let parsedUrl = parseUrl(request.url).query;
 
-        assert.ok(!parsedUrl.gdpr);
-        assert.ok(!parsedUrl.gdpr_consent);
+        assert.equal(parsedUrl.gdpr, '0');
+        assert.equal(parsedUrl.gdpr_consent, 'concentDataString');
 
         request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: undefined, consentString: 'concentDataString'}});
+        parsedUrl = parseUrl(request.url).query;
         assert.ok(!parsedUrl.gdpr);
         assert.ok(!parsedUrl.gdpr_consent);
       });
@@ -162,6 +161,13 @@ describe('Adform adapter', function () {
 
         request = spec.buildRequests([bids[0]]);
         assert.ok(!request.gdpr);
+      });
+
+      it('should send CCPA Consent data to adform', function () {
+        const request = spec.buildRequests([bids[0]], {uspConsent: '1YA-'});
+        const parsedUrl = parseUrl(request.url).query;
+
+        assert.equal(parsedUrl.us_privacy, '1YA-');
       });
     });
   });
@@ -247,14 +253,14 @@ describe('Adform adapter', function () {
       for (let i = 0; i < result.length; i++) {
         assert.equal(result[i].gdpr, true);
         assert.equal(result[i].gdpr_consent, 'ERW342EIOWT34234KMGds');
-      };
+      }
 
       bidRequest.gdpr = undefined;
       result = spec.interpretResponse(serverResponse, bidRequest);
       for (let i = 0; i < result.length; i++) {
         assert.ok(!result[i].gdpr);
         assert.ok(!result[i].gdpr_consent);
-      };
+      }
     });
 
     it('should set a renderer only for an outstream context', function () {
@@ -302,13 +308,13 @@ describe('Adform adapter', function () {
         serverResponse.body = [serverResponse.body[0]];
         bidRequest.bids = [bidRequest.bids[0]];
 
-        bidRequest.bids[0].sizes = [['300', '250'], ['250', '300'], ['300', '600'], ['600', '300']]
+        bidRequest.bids[0].sizes = [['300', '250'], ['250', '300'], ['300', '600'], ['600', '300']];
         let result = spec.interpretResponse(serverResponse, bidRequest);
 
         assert.equal(result[0].width, 300);
         assert.equal(result[0].height, 600);
       });
-    })
+    });
   });
 
   beforeEach(function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
- added gvlid
- added CCPA support
- send `gdprApplies:false` flag to adserver

- Scope.FL.Scripts@adform.com
- [x] official adapter submission


- https://github.com/prebid/prebid.github.io/pull/1968
