### PR TITLE
fix(Renderer): load script only on render

### DIFF
--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -126,10 +126,13 @@ describe('Renderer', function () {
         id: 1,
         adUnitCode: 'video1'
       });
+      testRenderer.setRender(() => {})
+
+      testRenderer.render()
       expect(utilsSpy.callCount).to.equal(1);
     });
 
-    it('should call loadExternalScript() for script not defined on adUnit', function() {
+    it('should call loadExternalScript() for script not defined on adUnit, only when .render() is called', function() {
       $$PREBID_GLOBAL$$.adUnits = [{
         code: 'video1',
         renderer: {
@@ -143,6 +146,9 @@ describe('Renderer', function () {
         id: 1,
         adUnitCode: undefined
       });
+      expect(loadExternalScript.called).to.be.false;
+
+      testRenderer.render()
       expect(loadExternalScript.called).to.be.true;
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

I was playing with Renderer when creating a custom adapter with outstream video support. So I created a Renderer in order to display a player when retrieving some VAST response.
I noticed that the Renderer class loads the external script in it's constructor, not in the render function. Therefore external scripts are loaded, not only when the bid in won but when bid responses are received.
That can cause multiple requests during the auction and bidders that do not win can load any external scripts and access the whole page under the "outstream" module code. That can lead to strategies of sending empty bids to execute random code on the page.

### note

I can't run or test anything because a transitive depenency (fiber) prevents me from installing dependencies... (outdated, not building on osx 10.14 / node 13)

### initial issue
https://github.com/prebid/Prebid.js/issues/5117
