### PR TITLE
Update onBidWon method to only execute 1 url

### DIFF
--- a/integrationExamples/gpt/revcontent_example.html
+++ b/integrationExamples/gpt/revcontent_example.html
@@ -45,7 +45,7 @@
                         apiKey: '8a33fa9cf220ae685dcc3544f847cdda858d3b1c',
                         userId: 673,
                         domain: 'test.com',
-                        endpoint: 'trends-s0.revcontent.com'
+                        endpoint: 'trends.revcontent.com'
                     }
                 }]
             }];

--- a/modules/revcontentBidAdapter.js
+++ b/modules/revcontentBidAdapter.js
@@ -275,14 +275,3 @@ function extractHostname(url) {
 
   return hostname;
 }
-
-function getQueryVariable(variable, url) {
-  var query = url;
-  var vars = query.split('&');
-  for (var i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) == variable) {
-      return decodeURIComponent(pair[1]);
-    }
-  }
-}

--- a/modules/revcontentBidAdapter.js
+++ b/modules/revcontentBidAdapter.js
@@ -3,7 +3,6 @@
 
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
-import {ajax} from '../src/ajax.js';
 
 const BIDDER_CODE = 'revcontent';
 const NATIVE_PARAMS = {
@@ -223,8 +222,7 @@ export const spec = {
     return bidResponses;
   },
   onBidWon: function (bid) {
-    var winUrl = bid.nurl;
-    ajax(winUrl);
+    utils.triggerPixel(bid.nurl);
     return true;
   }
 };

--- a/modules/revcontentBidAdapter.js
+++ b/modules/revcontentBidAdapter.js
@@ -224,12 +224,7 @@ export const spec = {
   },
   onBidWon: function (bid) {
     var winUrl = bid.nurl;
-    winUrl = winUrl.replace(/\$\{AUCTION_PRICE\}/, bid.cpm);
-    var host = extractHostname(winUrl);
-
-    ajax(winUrl + '&viewed=1', null, {withCredentials: true});
-    ajax('https://' + host + '/imp.php', null, 'v=' + encodeURIComponent(encodeURIComponent(getQueryVariable('d', winUrl))) + '&i=' + encodeURIComponent(window.location.href), {method: 'POST', contentType: 'application/x-www-form-urlencoded'});
-
+    ajax(winUrl);
     return true;
   }
 };

--- a/test/spec/modules/revcontentBidAdapter_spec.js
+++ b/test/spec/modules/revcontentBidAdapter_spec.js
@@ -3,6 +3,7 @@ import {assert, expect} from 'chai';
 import {spec} from 'modules/revcontentBidAdapter.js';
 import { NATIVE } from 'src/mediaTypes.js';
 import { config } from 'src/config.js';
+import * as utils from 'src/utils.js';
 
 describe('revcontent adapter', function () {
   let serverResponse, bidRequest, bidResponses;
@@ -325,6 +326,26 @@ describe('revcontent adapter', function () {
       };
       const result = spec.onBidWon(bid);
       assert.ok(result);
+    });
+  });
+
+  describe('onBidWon', function() {
+    const bid = {
+      nurl: 'https://trends-s0.revcontent.com/push/track/?p=${AUCTION_PRICE}&d=nTCdHIfsgKOLFuV7DS1LF%2FnTk5HiFduGU65BgKgB%2BvKyG9YV7ceQWN76HMbBE0C6gwQeXUjravv3Hq5x9TT8CM6r2oUNgkGC9mhgv2yroTH9i3cSoH%2BilxyY19fMXFirtBz%2BF%2FEXKi4bsNh%2BDMPfj0L4elo%2FJEZmx4nslvOneJJjsFjJJtUJc%2F3UPivOisSCa%2B36mAgFQqt%2FSWBriYB%2BVAufz70LaGspF6T6jDzuIyVFJUpLhZVDtLRSJEzh7Lyzzw1FmYarp%2FPg0gZDY48aDdjw5A3Tlj%2Bap0cPHLDprNOyF0dmHDn%2FOVJEDRTWvrQ2JNK1t%2Fg1bGHIih0ec6XBVIBNurqRpLFBuUY6LgXCt0wRZWTByTEZ8AEv8IoYVILJAL%2BXL%2F9IyS4eTcdOUfn5X7gT8QBghCrAFrsCg8ZXKgWddTEXbpN1lU%2FzHdI5eSHkxkJ6WcYxSkY9PyripaIbmKiyb98LQMgTD%2B20RJO5dAmXTQTAcauw6IUPTjgSPEU%2Bd6L5Txd3CM00Hbd%2Bw1bREIQcpKEmlMwrRSwe4bu1BCjlh5A9gvU9Xc2sf7ekS3qPPmtp059r5IfzdNFQJB5aH9HqeDEU%2FxbMHx4ggMgojLBBL1fKrCKLAteEDQxd7PVmFJv7GHU2733vt5TnjKiEhqxHVFyi%2B0MIYMGIziM5HfUqfq3KUf%2F%2FeiCtJKXjg7FS6hOambdimSt7BdGDIZq9QECWdXsXcQqqVLwli27HYDMFVU3TWWRyjkjbhnQID9gQJlcpwIi87jVAODb6qP%2FKGQ%3D%3D',
+      cpm: '0.1'
+    };
+
+    beforeEach(function() {
+      sinon.stub(utils, 'triggerPixel');
+    });
+
+    afterEach(function() {
+      utils.triggerPixel.restore();
+    });
+
+    it('make sure only 1 ajax call is happening', function() {
+      spec.onBidWon(bid);
+      expect(utils.triggerPixel.calledOnce).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Change the onBidWon method to call only 1 url.


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer: aziz@revcontent.com
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
- NA

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
