### PR TITLE
Adding Edge Query X Adapter with test unit

### DIFF
--- a/modules/edgequeryxBidAdapter.js
+++ b/modules/edgequeryxBidAdapter.js
@@ -1,7 +1,7 @@
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER,  VIDEO } from '../src/mediaTypes.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'edgequeryx';
 
@@ -37,7 +37,7 @@ export const spec = {
       let payload = {
         accountId: bid.params.accountId,
         widgetId: bid.params.widgetId,
-        currencyCode: "EUR",
+        currencyCode: 'EUR',
         appName: bid.params.appName && bid.params.appName !== '' ? bid.params.appName : undefined,
         tagId: bid.adUnitCode,
         pageDomain: bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer ? bidderRequest.refererInfo.referer : undefined,
@@ -47,20 +47,20 @@ export const spec = {
         prebidVersion: '$prebid.version$'
       };
 
-    const bannerMediaType = utils.deepAccess(bid, 'mediaTypes.banner');
-    payload.sizes = bannerMediaType.sizes.map(size => ({
+      const bannerMediaType = utils.deepAccess(bid, 'mediaTypes.banner');
+      payload.sizes = bannerMediaType.sizes.map(size => ({
         w: size[0],
         h: size[1]
-    }));
+      }));
 
-    if (bidderRequest && bidderRequest.gdprConsent) {
+      if (bidderRequest && bidderRequest.gdprConsent) {
         payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
         payload.gdpr = bidderRequest.gdprConsent.gdprApplies;
       }
 
       if (bidderRequest && bidderRequest.uspConsent) {
         payload.us_privacy = bidderRequest.uspConsent;
-      }    
+      }
 
       var payloadString = JSON.stringify(payload);
 
@@ -103,7 +103,6 @@ export const spec = {
     }
     return bidResponses;
   },
-
 
   getUserSyncs: function (syncOptions, serverResponses) {
     const syncs = [];

--- a/modules/edgequeryxBidAdapter.js
+++ b/modules/edgequeryxBidAdapter.js
@@ -1,8 +1,7 @@
-import { Renderer } from '../src/Renderer.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
-import { registerBidder, getIabSubCategory } from '../src/adapters/bidderFactory.js';
-import { BANNER, NATIVE, VIDEO, ADPOD } from '../src/mediaTypes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER,  VIDEO } from '../src/mediaTypes.js';
 
 
 
@@ -87,8 +86,6 @@ export const spec = {
     let response = serverResponse.body;
     try {
       if (response) {
-        const bidRequest = JSON.parse(bidRequestString.data);
-
         let bidResponse = {
           requestId: response.requestId,
           cpm: response.cpm,

--- a/modules/edgequeryxBidAdapter.js
+++ b/modules/edgequeryxBidAdapter.js
@@ -1,0 +1,125 @@
+import { Renderer } from '../src/Renderer.js';
+import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
+import { registerBidder, getIabSubCategory } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO, ADPOD } from '../src/mediaTypes.js';
+
+
+
+const BIDDER_CODE = 'edgequeryx';
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['eqx'], // short code
+  supportedMediaTypes: [BANNER, VIDEO],
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    return !!(bid.params && bid.params.accountId && bid.params.widgetId);
+  },
+
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests an array of bids
+   * @param {BidderRequest} bidderRequest bidder request object
+   * @return {ServerRequest[]} Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    // use bidderRequest.bids[] to get bidder-dependent request info
+    // if your bidder supports multiple currencies, use config.getConfig(currency)
+    // to find which one the ad server needs
+
+    // pull requested transaction ID from bidderRequest.bids[].transactionId
+    return validBidRequests.map(bid => {
+      // Common bid request attributes for banner, outstream and instream.
+      let payload = {
+        accountId: bid.params.accountId,
+        widgetId: bid.params.widgetId,
+        currencyCode: "EUR",
+        appName: bid.params.appName && bid.params.appName !== '' ? bid.params.appName : undefined,
+        tagId: bid.adUnitCode,
+        pageDomain: bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer ? bidderRequest.refererInfo.referer : undefined,
+        transactionId: bid.transactionId,
+        timeout: config.getConfig('bidderTimeout'),
+        bidId: bid.bidId,
+        prebidVersion: '$prebid.version$'
+      };
+
+    const bannerMediaType = utils.deepAccess(bid, 'mediaTypes.banner');
+    payload.sizes = bannerMediaType.sizes.map(size => ({
+        w: size[0],
+        h: size[1]
+    }));
+
+    if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
+        payload.gdpr = bidderRequest.gdprConsent.gdprApplies;
+      }
+
+      if (bidderRequest && bidderRequest.uspConsent) {
+        payload.us_privacy = bidderRequest.uspConsent;
+      }    
+
+      var payloadString = JSON.stringify(payload);
+
+      return {
+        method: 'POST',
+        url: (bid.params.domain !== undefined ? bid.params.domain : 'https://deep.edgequery.io') + '/prebid/x',
+        data: payloadString,
+      };
+    });
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @param {*} bidRequestString
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequestString) {
+    const bidResponses = [];
+    let response = serverResponse.body;
+    try {
+      if (response) {
+        const bidRequest = JSON.parse(bidRequestString.data);
+
+        let bidResponse = {
+          requestId: response.requestId,
+          cpm: response.cpm,
+          currency: response.currency,
+          width: response.width,
+          height: response.height,
+          ad: response.ad,
+          ttl: response.ttl,
+          creativeId: response.creativeId,
+          netRevenue: response.netRevenue
+        };
+
+        bidResponses.push(bidResponse);
+      }
+    } catch (error) {
+      utils.logError('Error while parsing Edge Query X response', error);
+    }
+    return bidResponses;
+  },
+
+
+  getUserSyncs: function (syncOptions, serverResponses) {
+    const syncs = [];
+    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+      syncs.push({
+        type: 'iframe',
+        url: serverResponses[0].body.cSyncUrl
+      });
+    }
+    return syncs;
+  }
+};
+
+registerBidder(spec);

--- a/modules/edgequeryxBidAdapter.js
+++ b/modules/edgequeryxBidAdapter.js
@@ -3,9 +3,8 @@ import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER,  VIDEO } from '../src/mediaTypes.js';
 
-
-
 const BIDDER_CODE = 'edgequeryx';
+
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['eqx'], // short code
@@ -19,7 +18,6 @@ export const spec = {
   isBidRequestValid: function (bid) {
     return !!(bid.params && bid.params.accountId && bid.params.widgetId);
   },
-
 
   /**
    * Make a server request from the list of BidRequests.

--- a/modules/edgequeryxBidAdapter.mb
+++ b/modules/edgequeryxBidAdapter.mb
@@ -1,0 +1,39 @@
+# Overview
+
+```
+Module Name: Edge, Query X Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: contact@edgequery.com
+```
+
+# Description
+
+Connect to Edge Query X for bids.
+
+The Edge Query X adapter requires setup and approval from the Edge Query team.
+Please reach out to your Technical account manager for more information.
+
+# Test Parameters
+
+## Web
+```
+    var adUnits = [
+        {
+            code: 'test-div',
+            mediaTypes: {
+                banner: {
+                    sizes: [[1, 1]]
+                }
+            },
+            bids: [
+                {
+                    bidder: "edgequeryx",
+                    params: {
+                        accountId: "test",
+                        widgetId: "test"
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/edgequeryxBidAdapter_spec.js
+++ b/test/spec/modules/edgequeryxBidAdapter_spec.js
@@ -1,0 +1,117 @@
+import {
+    expect
+  } from 'chai';
+  import {
+    spec
+  } from 'modules/edgequeryxBidAdapter.js';
+  import {
+    newBidder
+  } from 'src/adapters/bidderFactory.js';
+  import {
+    config
+  } from 'src/config.js';
+  import * as utils from 'src/utils.js';
+  import { requestBidsHook } from 'modules/consentManagement.js';
+  
+  // Default params with optional ones
+  describe('Edge Query X bid adapter tests', function () {
+    var DEFAULT_PARAMS = [{
+      bidId: 'abcd1234',
+      mediaTypes: {
+        banner: {
+          sizes: [
+            [1, 1]
+          ]
+        }
+      },
+      bidder: 'edgequeryx',
+      params: {
+        accountId: "test",
+        widgetId: "test"
+      },
+      requestId: 'efgh5678',
+      transactionId: 'zsfgzzg'
+    }];
+  
+    var BID_RESPONSE = {
+      body: {
+        cpm: 22,
+        width: 1,
+        height: 1,
+        creativeId: 'EQXTest',
+        currency: 'EUR',
+        netRevenue: true,
+        ttl: 360,
+        ad: '< --- awesome script --- >'
+      }
+    };
+  
+    it('Verify build request', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests(DEFAULT_PARAMS);
+      expect(request[0]).to.have.property('url').and.to.equal('https://deep.edgequery.io/prebix/x');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+
+      expect(requestContent).to.have.property('accountId').and.to.equal('test');
+      expect(requestContent).to.have.property('widgetId').and.to.equal('test');
+      expect(requestContent).to.have.property('sizes');
+      expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(1);
+      expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(1);
+    });
+  
+    it('Verify parse response', function () {
+      const request = spec.buildRequests(DEFAULT_PARAMS);
+      const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
+      expect(bids).to.have.lengthOf(1);
+      const bid = bids[0];
+      expect(bid.cpm).to.equal(22);
+      expect(bid.ad).to.equal('< --- awesome script --- >');
+      expect(bid.width).to.equal(1);
+      expect(bid.height).to.equal(1);
+      expect(bid.creativeId).to.equal('EQXTest');
+      expect(bid.currency).to.equal('EUR');
+      expect(bid.netRevenue).to.equal(true);
+      expect(bid.ttl).to.equal(300);
+      expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
+  
+      expect(function () {
+        spec.interpretResponse(BID_RESPONSE, {
+          data: 'invalid Json'
+        })
+      }).to.not.throw();
+    });
+  
+    it('Verifies bidder code', function () {
+      expect(spec.code).to.equal('edgequeryx');
+    });
+  
+    it('Verifies bidder aliases', function () {
+      expect(spec.aliases).to.have.lengthOf(1);
+      expect(spec.aliases[0]).to.equal('eqx');
+    });
+  
+    it('Verifies if bid request valid', function () {
+      expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
+      expect(spec.isBidRequestValid({})).to.equal(false);
+      expect(spec.isBidRequestValid({
+        params: {}
+      })).to.equal(false);
+      expect(spec.isBidRequestValid({
+        params: {
+          widgetyId: 'abcdef'
+        }
+      })).to.equal(false);
+      expect(spec.isBidRequestValid({
+        params: {
+          widgetId: 'test',
+          accountId: 'test'
+        }
+      })).to.equal(true);
+    });
+  });
+  

--- a/test/spec/modules/edgequeryxBidAdapter_spec.js
+++ b/test/spec/modules/edgequeryxBidAdapter_spec.js
@@ -1,117 +1,115 @@
 import {
     expect
-  } from 'chai';
-  import {
+} from 'chai';
+import {
     spec
-  } from 'modules/edgequeryxBidAdapter.js';
-  import {
+} from 'modules/edgequeryxBidAdapter.js';
+import {
     newBidder
-  } from 'src/adapters/bidderFactory.js';
-  import {
+} from 'src/adapters/bidderFactory.js';
+import {
     config
-  } from 'src/config.js';
-  import * as utils from 'src/utils.js';
-  import { requestBidsHook } from 'modules/consentManagement.js';
-  
-  // Default params with optional ones
-  describe('Edge Query X bid adapter tests', function () {
-    var DEFAULT_PARAMS = [{
-      bidId: 'abcd1234',
-      mediaTypes: {
-        banner: {
-          sizes: [
-            [1, 1]
-          ]
-        }
-      },
-      bidder: 'edgequeryx',
-      params: {
-        accountId: "test",
-        widgetId: "test"
-      },
-      requestId: 'efgh5678',
-      transactionId: 'zsfgzzg'
-    }];
-  
-    var BID_RESPONSE = {
-      body: {
-        cpm: 22,
-        width: 1,
-        height: 1,
-        creativeId: 'EQXTest',
-        currency: 'EUR',
-        netRevenue: true,
-        ttl: 360,
-        ad: '< --- awesome script --- >'
-      }
-    };
-  
-    it('Verify build request', function () {
-      config.setConfig({
-        'currency': {
-          'adServerCurrency': 'EUR'
-        }
-      });
-      const request = spec.buildRequests(DEFAULT_PARAMS);
-      expect(request[0]).to.have.property('url').and.to.equal('https://deep.edgequery.io/prebix/x');
-      expect(request[0]).to.have.property('method').and.to.equal('POST');
-      const requestContent = JSON.parse(request[0].data);
+} from 'src/config.js';
+import * as utils from 'src/utils.js';
+import { requestBidsHook } from 'modules/consentManagement.js';
 
-      expect(requestContent).to.have.property('accountId').and.to.equal('test');
-      expect(requestContent).to.have.property('widgetId').and.to.equal('test');
-      expect(requestContent).to.have.property('sizes');
-      expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(1);
-      expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(1);
+// Default params with optional ones
+describe('Edge Query X bid adapter tests', function () {
+    var DEFAULT_PARAMS = [{
+        bidId: 'abcd1234',
+        mediaTypes: {
+            banner: {
+                sizes: [
+                    [1, 1]
+                ]
+            }
+        },
+        bidder: 'edgequeryx',
+        params: {
+            accountId: "test",
+            widgetId: "test"
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+    }];
+    var BID_RESPONSE = {
+        body: {
+            cpm: 22,
+            width: 1,
+            height: 1,
+            creativeId: 'EQXTest',
+            currency: 'EUR',
+            netRevenue: true,
+            ttl: 360,
+            ad: '< --- awesome script --- >'
+        }
+    };
+
+    it('Verify build request', function () {
+        config.setConfig({
+            'currency': {
+                'adServerCurrency': 'EUR'
+            }
+        });
+        const request = spec.buildRequests(DEFAULT_PARAMS);
+        expect(request[0]).to.have.property('url').and.to.equal('https://deep.edgequery.io/prebix/x');
+        expect(request[0]).to.have.property('method').and.to.equal('POST');
+        const requestContent = JSON.parse(request[0].data);
+
+        expect(requestContent).to.have.property('accountId').and.to.equal('test');
+        expect(requestContent).to.have.property('widgetId').and.to.equal('test');
+        expect(requestContent).to.have.property('sizes');
+        expect(requestContent.sizes[0]).to.have.property('w').and.to.equal(1);
+        expect(requestContent.sizes[0]).to.have.property('h').and.to.equal(1);
     });
-  
+
     it('Verify parse response', function () {
-      const request = spec.buildRequests(DEFAULT_PARAMS);
-      const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
-      expect(bids).to.have.lengthOf(1);
-      const bid = bids[0];
-      expect(bid.cpm).to.equal(22);
-      expect(bid.ad).to.equal('< --- awesome script --- >');
-      expect(bid.width).to.equal(1);
-      expect(bid.height).to.equal(1);
-      expect(bid.creativeId).to.equal('EQXTest');
-      expect(bid.currency).to.equal('EUR');
-      expect(bid.netRevenue).to.equal(true);
-      expect(bid.ttl).to.equal(300);
-      expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
-  
-      expect(function () {
-        spec.interpretResponse(BID_RESPONSE, {
-          data: 'invalid Json'
-        })
-      }).to.not.throw();
+        const request = spec.buildRequests(DEFAULT_PARAMS);
+        const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
+        expect(bids).to.have.lengthOf(1);
+        const bid = bids[0];
+        expect(bid.cpm).to.equal(22);
+        expect(bid.ad).to.equal('< --- awesome script --- >');
+        expect(bid.width).to.equal(1);
+        expect(bid.height).to.equal(1);
+        expect(bid.creativeId).to.equal('EQXTest');
+        expect(bid.currency).to.equal('EUR');
+        expect(bid.netRevenue).to.equal(true);
+        expect(bid.ttl).to.equal(300);
+        expect(bid.requestId).to.equal(DEFAULT_PARAMS[0].bidId);
+
+        expect(function () {
+            spec.interpretResponse(BID_RESPONSE, {
+                data: 'invalid Json'
+            })
+        }).to.not.throw();
     });
-  
+
     it('Verifies bidder code', function () {
-      expect(spec.code).to.equal('edgequeryx');
+        expect(spec.code).to.equal('edgequeryx');
     });
-  
+
     it('Verifies bidder aliases', function () {
-      expect(spec.aliases).to.have.lengthOf(1);
-      expect(spec.aliases[0]).to.equal('eqx');
+        expect(spec.aliases).to.have.lengthOf(1);
+        expect(spec.aliases[0]).to.equal('eqx');
     });
-  
+
     it('Verifies if bid request valid', function () {
-      expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
-      expect(spec.isBidRequestValid({})).to.equal(false);
-      expect(spec.isBidRequestValid({
-        params: {}
-      })).to.equal(false);
-      expect(spec.isBidRequestValid({
-        params: {
-          widgetyId: 'abcdef'
-        }
-      })).to.equal(false);
-      expect(spec.isBidRequestValid({
-        params: {
-          widgetId: 'test',
-          accountId: 'test'
-        }
-      })).to.equal(true);
+        expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);
+        expect(spec.isBidRequestValid({})).to.equal(false);
+        expect(spec.isBidRequestValid({
+            params: {}
+        })).to.equal(false);
+        expect(spec.isBidRequestValid({
+            params: {
+                widgetyId: 'abcdef'
+            }
+        })).to.equal(false);
+        expect(spec.isBidRequestValid({
+            params: {
+                widgetId: 'test',
+                accountId: 'test'
+            }
+        })).to.equal(true);
     });
-  });
-  
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ X ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Creating a new Adapter for Edge Query X format.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
                {
                    bidder: "edgequeryx",
                    params: {
                        accountId: "test",
                        widgetId: "test"
                    }
                }
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer : olivier@edgequery.com
- [ X ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1962

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
