### PR TITLE
Consent reset

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -246,6 +246,9 @@ let resetHook = function() {};
  * @param {function} fn required; The next function in the chain, used by hook.js
  */
 export function requestBidsHook(fn, reqBidsConfigObj) {
+  if (!utils.isStr(userCMP)) {
+    userCMP = DEFAULT_CMP;
+  }
   // preserves all module related variables for the current auction instance (used primiarily for concurrent auctions)
   const hookConfig = {
     context: this,

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -236,6 +236,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   }
 }
 
+let resetHook = function() {};
 /**
  * If consentManagement module is enabled (ie included in setConfig), this hook function will attempt to fetch the
  * user's encoded consent string from the supported CMP.  Once obtained, the module will store this
@@ -276,6 +277,9 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
     } else {
       hookConfig.timer = setTimeout(cmpTimedOut.bind(null, hookConfig), consentTimeout);
     }
+  }
+  resetHook = function() {
+    hookConfig.haveExited = false;
   }
 }
 
@@ -430,6 +434,7 @@ export function resetConsentData() {
   userCMP = undefined;
   cmpVersion = 0;
   gdprDataHandler.setConsentData(null);
+  resetHook();
 }
 
 /**


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When resetConsentData is invoked it doesn't reset the hookConfig.hasExisted value, which causes up-pun re-entry of the module, that the consentstring isn't resolved for the secondtime. 
Also the resetConsentData  set's userCMP variable to undefined. Which causes the requestBidHook to report a none support framework is chosen. For now i choose to add a check in the requestHook which sets this value to DEFAULT_CMP, but another option might be to reset it to DEFAULT_CMP instead of undefined in the resetConsentData function