### PR TITLE
ablida: add onBidWon function, add bidder adapter version to bid requests

### DIFF
--- a/modules/ablidaBidAdapter.js
+++ b/modules/ablidaBidAdapter.js
@@ -1,6 +1,7 @@
 import * as utils from '../src/utils.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {ajax} from '../src/ajax.js';
 
 const BIDDER_CODE = 'ablida';
 const ENDPOINT_URL = 'https://bidder.ablida.net/prebid';
@@ -42,7 +43,8 @@ export const spec = {
         categories: bidRequest.params.categories,
         referer: bidderRequest.refererInfo.referer,
         jaySupported: jaySupported,
-        device: device
+        device: device,
+        adapterVersion: 2
       };
       return {
         method: 'POST',
@@ -69,6 +71,11 @@ export const spec = {
     });
     return bidResponses;
   },
+  onBidWon: function (bid) {
+    if (!bid['nurl']) { return false; }
+    ajax(bid['nurl'], null);
+    return true;
+  }
 };
 
 function getDevice() {

--- a/test/spec/modules/ablidaBidAdapter_spec.js
+++ b/test/spec/modules/ablidaBidAdapter_spec.js
@@ -67,7 +67,8 @@ describe('ablidaBidAdapter', function () {
         bidId: '2b8c4de0116e54',
         jaySupported: true,
         device: 'desktop',
-        referer: 'www.example.com'
+        referer: 'www.example.com',
+        adapterVersion: 2
       }
     };
     let serverResponse = {
@@ -80,7 +81,8 @@ describe('ablidaBidAdapter', function () {
         currency: 'EUR',
         netRevenue: true,
         ttl: 3000,
-        ad: '<script>console.log("ad");</script>'
+        ad: '<script>console.log("ad");</script>',
+        nurl: 'https://example.com/some-tracker'
       }]
     };
     it('should get the correct bid response', function () {
@@ -93,10 +95,25 @@ describe('ablidaBidAdapter', function () {
         currency: 'EUR',
         netRevenue: true,
         ttl: 3000,
-        ad: '<script>console.log("ad");</script>'
+        ad: '<script>console.log("ad");</script>',
+        nurl: 'https://example.com/some-tracker'
       }];
       let result = spec.interpretResponse(serverResponse, bidRequest[0]);
       expect(Object.keys(result)).to.deep.equal(Object.keys(expectedResponse));
     });
   });
+
+  describe('onBidWon', function() {
+    it('Should not ajax call if bid does not contain nurl', function() {
+      const result = spec.onBidWon({});
+      expect(result).to.equal(false)
+    })
+
+    it('Should ajax call if bid nurl', function() {
+      const result = spec.onBidWon({
+        nurl: 'https://example.com/some-tracker'
+      });
+      expect(result).to.equal(true)
+    })
+  })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add onBidWon function and add adapterVersion to request payload.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'ablida',
  params: {
    placementId: 'mediumrectangle-demo'
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
