### PR TITLE
Update Dspx adapter

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -37,9 +37,25 @@ export const spec = {
         ref: referrer,
         bid_id: bidId,
       };
+
       if (params.pfilter !== undefined) {
         payload.pfilter = params.pfilter;
       }
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        if (payload.pfilter !== undefined) {
+          if (!payload.pfilter.gdpr_consent) {
+            payload.pfilter.gdpr_consent = bidderRequest.gdprConsent.consentString;
+            payload.pfilter.gdpr = bidderRequest.gdprConsent.gdprApplies;
+          }
+        } else {
+          payload.pfilter = {
+            'gdpr_consent': bidderRequest.gdprConsent.consentString,
+            'gdpr': bidderRequest.gdprConsent.gdprApplies
+          };
+        }
+      }
+
       if (params.bcat !== undefined) {
         payload.bcat = params.bcat;
       }

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -25,7 +25,7 @@ export const spec = {
 
       const placementId = params.placement;
       const rnd = Math.floor(Math.random() * 99999999999);
-      const referrer = encodeURIComponent(bidderRequest.refererInfo.referer);
+      const referrer = bidderRequest.refererInfo.referer;
       const bidId = bidRequest.bidId;
       const isDev = params.devMode || false;
 

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -1,42 +1,63 @@
 import * as utils from '../src/utils.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'dspx';
 const ENDPOINT_URL = 'https://buyer.dspx.tv/request/';
 const ENDPOINT_URL_DEV = 'https://dcbuyer.dspx.tv/request/';
+const DEFAULT_VAST_FORMAT = 'vast2';
 
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['dspx'],
+  supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {
     return !!(bid.params.placement);
   },
   buildRequests: function(validBidRequests, bidderRequest) {
     return validBidRequests.map(bidRequest => {
       const params = bidRequest.params;
+
+      const videoData = utils.deepAccess(bidRequest, 'mediaTypes.video') || {};
+      const sizes = utils.parseSizesInput(videoData.playerSize || bidRequest.sizes)[0];
+      const [width, height] = sizes.split('x');
+
       const placementId = params.placement;
       const rnd = Math.floor(Math.random() * 99999999999);
       const referrer = encodeURIComponent(bidderRequest.refererInfo.referer);
       const bidId = bidRequest.bidId;
       const isDev = params.devMode || false;
 
-      let bannerSizes = utils.parseSizesInput(utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes);
-      let [width, height] = bannerSizes[0].split('x');
-
       let endpoint = isDev ? ENDPOINT_URL_DEV : ENDPOINT_URL;
+      let payload = {};
 
-      const payload = {
-        _f: 'html',
-        alternative: 'prebid_js',
-        inventory_item_id: placementId,
-        srw: width,
-        srh: height,
-        idt: 100,
-        rnd: rnd,
-        ref: referrer,
-        bid_id: bidId,
-      };
+      if (isVideoRequest(bidRequest)) {
+        let vastFormat = params.vastFormat || DEFAULT_VAST_FORMAT;
+        payload = {
+          _f: vastFormat,
+          alternative: 'prebid_js',
+          inventory_item_id: placementId,
+          srw: width,
+          srh: height,
+          idt: 100,
+          rnd: rnd,
+          ref: referrer,
+          bid_id: bidId,
+        };
+      } else {
+        payload = {
+          _f: 'html',
+          alternative: 'prebid_js',
+          inventory_item_id: placementId,
+          srw: width,
+          srh: height,
+          idt: 100,
+          rnd: rnd,
+          ref: referrer,
+          bid_id: bidId,
+        };
+      }
 
       if (params.pfilter !== undefined) {
         payload.pfilter = params.pfilter;
@@ -91,9 +112,14 @@ export const spec = {
         currency: currency,
         netRevenue: netRevenue,
         type: response.type,
-        ttl: config.getConfig('_bidderTimeout'),
-        ad: response.adTag
+        ttl: config.getConfig('_bidderTimeout')
       };
+      if (response.vastXml) {
+        bidResponse.vastXml = response.vastXml;
+        bidResponse.mediaType = 'video';
+      } else {
+        bidResponse.ad = response.adTag;
+      }
       bidResponses.push(bidResponse);
     }
     return bidResponses;
@@ -113,6 +139,16 @@ function objectToQueryString(obj, prefix) {
     }
   }
   return str.join('&');
+}
+
+/**
+ * Check if it's a video bid request
+ *
+ * @param {BidRequest} bid - Bid request generated from ad slots
+ * @returns {boolean} True if it's a video bid
+ */
+function isVideoRequest(bid) {
+  return bid.mediaType === 'video' || !!utils.deepAccess(bid, 'mediaTypes.video');
 }
 
 registerBidder(spec);

--- a/modules/dspxBidAdapter.md
+++ b/modules/dspxBidAdapter.md
@@ -1,14 +1,14 @@
 # Overview
 
 ```
-Module Name: Dspx Bidder Adapter
+Module Name: DSPx Bidder Adapter
 Module Type: Bidder Adapter
 Maintainer: prebid@dspx.tv
 ```
 
 # Description
 
-Dspx adapter for Prebid.js 3.0
+DSPx adapter for Prebid v3.
 
 # Test Parameters
 ```
@@ -20,55 +20,46 @@ Dspx adapter for Prebid.js 3.0
                     sizes: [
                       [300, 250],
                       [300, 600],
-                      ],  // a display size
+                    ]
                 }
             },
             bids: [
                 {
                     bidder: "dspx",
                     params: {
-                        placement: '101',
-                        devMode: true,   // if true: library uses dev server for tests
-                        pfilter: {
-                            floorprice: 1000000, // EUR * 1,000,000
-                            private_auction: 1, // Is private auction?  0  - no, 1 - yes
-                            deals: [
-                                 "666-9315-d58a7f9a-bdb9-4450-a3a2-046ba8ab2489;3;25000000;dspx-tv",// DEAL_ID;at;bidfloor;wseat1,wseat2;wadomain1,wadomain2"
-                                 "666-9315-d58a7f9a-bdb9-4450-a6a2-046ba8ab2489;3;25000000;dspx-tv",// DEAL_ID;at;bidfloor;wseat1,wseat2;wadomain1,wadomain2"
-                            ],
-                            geo: {  // set client geo info manually (empty for auto detect)
-                               lat: 52.52437, // Latitude from -90.0 to +90.0, where negative is south.
-                               lon: 13.41053, // Longitude from -180.0 to +180.0, where negative is west
-                               type: 1,  // Source of location data: 1 - GPS/Location Services, 2 - IP Address, 3 - User provided (e.g. registration form)                         
-                               country: 'DE',  // Region of a country using FIPS 10-4 notation
-                               region: 'DE-BE', // Region code using ISO-3166-2; 2-letter state code if USA.
-                               regionfips104: 'GM',  // Region of a country using FIPS 10-4 notation
-                               city:  'BER', // City using United Nations Code for Trade and Transport Locations
-                               zip: '10115' // Zip or postal code.
-                                }
+                        placement: '101',   // [required] info available from your contact with DSPx team
+                        /*
+                            bcat:  "IAB2,IAB4",  // [optional] list of blocked advertiser categories (IAB), comma separated 
+                        */
+                        /*
+                            pfilter: { // [optional]
+                                // [optional] only required if a deal is negotiated
+                                deals: [ // [optional]
+                                    "123-4567-d58a7f9a-..."// DEAL_ID from DSPx contact
+                                ],
+                                private_auction: 1 // [optional]  0  - no, 1 - yes
+                                // usually managed on DSPx side
+                                floorprice: 1000000 // input min_cpm_micros, CPM in EUR * 1000000
                             },
-                        bcat:  "IAB2,IAB4",  // List of  Blocked Categories (IAB) - comma separated 
-                        dvt: "desktop|smartphone|tv|tablet" // DeVice Type (autodetect if not exists)
+                        */
                     }
                 }
             ]
-        },{
-            code: 'test-div',
+        },
+        {
+            code: 'video1',
             mediaTypes: {
-                banner: {
-                    sizes: [[320, 50]],   // a mobile size
+                video: {
+                    playerSize: [640, 480],
+                    context: 'instream'
                 }
             },
-            bids: [
-                {
-                    bidder: "dspx",
-                    params: {
-                        placement: 101
-                    }
+            bids: [{
+                bidder: 'dspx',
+                params: {
+                    placement: '106'
                 }
-            ]
+            }]
         }
     ];
 ```
-
-Required param field is only `placement`. 

--- a/modules/dspxBidAdapter.md
+++ b/modules/dspxBidAdapter.md
@@ -8,7 +8,7 @@ Maintainer: prebid@dspx.tv
 
 # Description
 
-DSPx adapter for Prebid v3.
+DSPx adapter for Prebid.
 
 # Test Parameters
 ```

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -59,8 +59,8 @@ describe('dspxAdapter', function () {
       'sizes': [
         [300, 250]
       ],
-      'bidId': '30b31c1838de1e',
-      'bidderRequestId': '22edbae2733bf6',
+      'bidId': '30b31c1838de1e1',
+      'bidderRequestId': '22edbae2733bf61',
       'auctionId': '1d1a030790a475'
     },
     {
@@ -72,32 +72,94 @@ describe('dspxAdapter', function () {
       'sizes': [
         [300, 250]
       ],
-      'bidId': '30b31c1838de1e',
-      'bidderRequestId': '22edbae2733bf6',
-      'auctionId': '1d1a030790a475'
+      'bidId': '30b31c1838de1e2',
+      'bidderRequestId': '22edbae2733bf62',
+      'auctionId': '1d1a030790a476'
+    }, {
+      'bidder': 'dspx',
+      'params': {
+        'placement': '6682',
+        'pfilter': {
+          'floorprice': 1000000,
+          'private_auction': 0,
+          'geo': {
+            'country': 'DE'
+          }
+        },
+        'bcat': 'IAB2,IAB4',
+        'dvt': 'desktop'
+      },
+      'sizes': [
+        [300, 250]
+      ],
+      'bidId': '30b31c1838de1e3',
+      'bidderRequestId': '22edbae2733bf69',
+      'auctionId': '1d1a030790a477'
+    },
+    {
+      'bidder': 'dspx',
+      'params': {
+        'placement': '101',
+        'devMode': true
+      },
+      'sizes': [
+        [300, 250]
+      ],
+      'bidId': '30b31c1838de1e4',
+      'bidderRequestId': '22edbae2733bf67',
+      'auctionId': '1d1a030790a478'
     }
 
     ];
 
-    let bidderRequest = {
+    // With gdprConsent
+    var bidderRequest = {
+      refererInfo: {
+        referer: 'some_referrer.net'
+      },
+      gdprConsent: {
+        consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+        vendorData: {someData: 'value'},
+        gdprApplies: true
+      }
+    };
+
+    var request1 = spec.buildRequests([bidRequests[0]], bidderRequest)[0];
+    it('sends bid request to our endpoint via GET', function () {
+      expect(request1.method).to.equal('GET');
+      expect(request1.url).to.equal(ENDPOINT_URL);
+      let data = request1.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
+      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bprivate_auction%5D=0&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop');
+    });
+
+    var request2 = spec.buildRequests([bidRequests[1]], bidderRequest)[0];
+    it('sends bid request to our DEV endpoint via GET', function () {
+      expect(request2.method).to.equal('GET');
+      expect(request2.url).to.equal(ENDPOINT_URL_DEV);
+      let data = request2.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
+      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e2&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&prebidDevMode=1');
+    });
+
+    // Without gdprConsent
+    var bidderRequestWithoutGdpr = {
       refererInfo: {
         referer: 'some_referrer.net'
       }
-    }
-
-    const request = spec.buildRequests(bidRequests, bidderRequest);
-    it('sends bid request to our endpoint via GET', function () {
-      expect(request[0].method).to.equal('GET');
-      expect(request[0].url).to.equal(ENDPOINT_URL);
-      let data = request[0].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bprivate_auction%5D=0&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop');
+    };
+    var request3 = spec.buildRequests([bidRequests[2]], bidderRequestWithoutGdpr)[0];
+    it('sends bid request without gdprConsent to our endpoint via GET', function () {
+      expect(request3.method).to.equal('GET');
+      expect(request3.url).to.equal(ENDPOINT_URL);
+      let data = request3.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
+      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e3&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bprivate_auction%5D=0&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop');
     });
 
-    it('sends bid request to our DEV endpoint via GET', function () {
-      expect(request[1].method).to.equal('GET');
-      expect(request[1].url).to.equal(ENDPOINT_URL_DEV);
-      let data = request[1].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e&prebidDevMode=1');
+    var request4 = spec.buildRequests([bidRequests[3]], bidderRequestWithoutGdpr)[0];
+    it('sends bid request without gdprConsent  to our DEV endpoint via GET', function () {
+      expect(request4.method).to.equal('GET');
+      expect(request4.url).to.equal(ENDPOINT_URL_DEV);
+      let data = request4.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
+      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e4&prebidDevMode=1');
     });
   });
 

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -108,6 +108,22 @@ describe('dspxAdapter', function () {
       'bidId': '30b31c1838de1e4',
       'bidderRequestId': '22edbae2733bf67',
       'auctionId': '1d1a030790a478'
+    },
+    {
+      'bidder': 'dspx',
+      'params': {
+        'placement': '101',
+        'devMode': true
+      },
+      'mediaTypes': {
+        'video': {
+          'playerSize': [640, 480],
+          'context': 'instream'
+        }
+      },
+      'bidId': '30b31c1838de1e41',
+      'bidderRequestId': '22edbae2733bf67',
+      'auctionId': '1d1a030790a478'
     }
 
     ];
@@ -161,6 +177,13 @@ describe('dspxAdapter', function () {
       let data = request4.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
       expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e4&prebidDevMode=1');
     });
+
+    var request5 = spec.buildRequests([bidRequests[4]], bidderRequestWithoutGdpr)[0];
+    it('sends bid video request to our rads endpoint via GET', function () {
+      expect(request5.method).to.equal('GET');
+      let data = request5.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
+      expect(data).to.equal('_f=vast2&alternative=prebid_js&inventory_item_id=101&srw=640&srh=480&idt=100&bid_id=30b31c1838de1e41&prebidDevMode=1');
+    });
   });
 
   describe('interpretResponse', function () {
@@ -173,6 +196,21 @@ describe('dspxAdapter', function () {
         'type': 'sspHTML',
         'tag': '<!-- test creative -->',
         'requestId': '220ed41385952a',
+        'currency': 'EUR',
+        'ttl': 60,
+        'netRevenue': true,
+        'zone': '6682'
+      }
+    };
+    let serverVideoResponse = {
+      'body': {
+        'cpm': 5000000,
+        'crid': 100500,
+        'width': '300',
+        'height': '250',
+        'vastXml': '{"reason":7001,"status":"accepted"}',
+        'requestId': '220ed41385952a',
+        'type': 'vast2',
         'currency': 'EUR',
         'ttl': 60,
         'netRevenue': true,
@@ -192,6 +230,19 @@ describe('dspxAdapter', function () {
       ttl: 300,
       type: 'sspHTML',
       ad: '<!-- test creative -->'
+    }, {
+      requestId: '23beaa6af6cdde',
+      cpm: 0.5,
+      width: 0,
+      height: 0,
+      creativeId: 100500,
+      dealId: '',
+      currency: 'EUR',
+      netRevenue: true,
+      ttl: 300,
+      type: 'vast2',
+      vastXml: '{"reason":7001,"status":"accepted"}',
+      mediaType: 'video'
     }];
 
     it('should get the correct bid response by display ad', function () {
@@ -204,6 +255,24 @@ describe('dspxAdapter', function () {
       }];
       let result = spec.interpretResponse(serverResponse, bidRequest[0]);
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+    });
+
+    it('should get the correct dspx video bid response by display ad', function () {
+      let bidRequest = [{
+        'method': 'GET',
+        'url': ENDPOINT_URL,
+        'mediaTypes': {
+          'video': {
+            'playerSize': [640, 480],
+            'context': 'instream'
+          }
+        },
+        'data': {
+          'bid_id': '30b31c1838de1e'
+        }
+      }];
+      let result = spec.interpretResponse(serverVideoResponse, bidRequest[0]);
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[1]));
     });
 
     it('handles empty bid response', function () {


### PR DESCRIPTION
## Type of change
- [x ] Feature

## Description of change
Add video support and gdpr_consent  support

- test parameters for validating bids
```
{
  bidder: 'dspx',
  params: {
      placement: 101, //for bannes and 106 for video
  }
}
```

- contact email of the adapter’s maintainer: prebid@dspx.tv
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/1997/files

