### PR TITLE
Gumgum add in video

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -4,7 +4,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 import { config } from '../src/config.js'
 import { getStorageManager } from '../src/storageManager.js';
-import includes from 'core-js/library/fn/array/includes.js';
+import includes from 'core-js-pure/features/array/includes';
 import { registerBidder } from '../src/adapters/bidderFactory.js'
 
 const storage = getStorageManager();

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -1,10 +1,11 @@
 import * as utils from '../src/utils.js'
 
-import { config } from '../src/config.js'
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import includes from 'core-js-pure/features/array/includes.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js'
+
+import { config } from '../src/config.js'
 import { getStorageManager } from '../src/storageManager.js';
+import includes from 'core-js/library/fn/array/includes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js'
 
 const storage = getStorageManager();
 
@@ -142,6 +143,8 @@ function isBidRequestValid (bid) {
     case !!(params.inSlot): break;
     case !!(params.ICV): break;
     case !!(params.video): break;
+    case !!(params.inVideo): break;
+
     default:
       utils.logWarn(`[GumGum] No product selected for the placement ${adUnitCode}, please check your implementation.`);
       return false;
@@ -241,7 +244,11 @@ function buildRequests (validBidRequests, bidderRequest) {
       data.t = params.video;
       data.pi = 7;
     }
-
+    if (params.inVideo) {
+      data = Object.assign(data, _getVidParams(mediaTypes.video));
+      data.t = params.inVideo;
+      data.pi = 6;
+    }
     if (gdprConsent) {
       data.gdprApplies = gdprConsent.gdprApplies ? 1 : 0;
     }
@@ -322,6 +329,7 @@ function interpretResponse (serverResponse, bidRequest) {
       // referrer: REFERER,
       ...(product === 7 && { vastXml: markup }),
       ad: wrapper ? getWrapperCode(wrapper, Object.assign({}, serverResponseBody, { bidRequest })) : markup,
+      ...(product === 6 && {ad: markup}),
       cpm: isTestUnit ? 0.1 : cpm,
       creativeId,
       currency: cur || 'USD',

--- a/modules/gumgumBidAdapter.md
+++ b/modules/gumgumBidAdapter.md
@@ -37,6 +37,18 @@ var adUnits = [
         }
       }
     ]
+  },{
+    code: 'test-div',
+    sizes: [[300, 50]],
+    bids: [
+      {
+        bidder: 'gumgum',
+        params: {
+          inVideo: 'ggumtest', // GumGum Zone ID given to the client
+          bidfloor: 0.03 // CPM bid floor
+        }
+      }
+    ]
   }
 ];
 ```

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -159,6 +159,7 @@ describe('gumgumAdapter', function () {
         'video': '10433395'
       };
       const bidRequest = spec.buildRequests([request])[0];
+      // 7 is video product line
       expect(bidRequest.data.pi).to.eq(7);
       expect(bidRequest.data.mind).to.eq(videoVals.minduration);
       expect(bidRequest.data.maxd).to.eq(videoVals.maxduration);
@@ -168,6 +169,37 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.pr).to.eq(videoVals.protocols.join(','));
       expect(bidRequest.data.viw).to.eq(videoVals.playerSize[0].toString());
       expect(bidRequest.data.vih).to.eq(videoVals.playerSize[1].toString());
+    });
+    it('should add parameters associated with invideo if invideo request param is found', function () {
+      const inVideoVals = {
+        playerSize: [640, 480],
+        context: 'instream',
+        minduration: 1,
+        maxduration: 2,
+        linearity: 1,
+        startdelay: 1,
+        placement: 123456,
+        protocols: [1, 2]
+      };
+      const request = Object.assign({}, bidRequests[0]);
+      delete request.params;
+      request.mediaTypes = {
+        video: inVideoVals
+      };
+      request.params = {
+        'inVideo': '10433395'
+      };
+      const bidRequest = spec.buildRequests([request])[0];
+      // 6 is invideo product line
+      expect(bidRequest.data.pi).to.eq(6);
+      expect(bidRequest.data.mind).to.eq(inVideoVals.minduration);
+      expect(bidRequest.data.maxd).to.eq(inVideoVals.maxduration);
+      expect(bidRequest.data.li).to.eq(inVideoVals.linearity);
+      expect(bidRequest.data.sd).to.eq(inVideoVals.startdelay);
+      expect(bidRequest.data.pt).to.eq(inVideoVals.placement);
+      expect(bidRequest.data.pr).to.eq(inVideoVals.protocols.join(','));
+      expect(bidRequest.data.viw).to.eq(inVideoVals.playerSize[0].toString());
+      expect(bidRequest.data.vih).to.eq(inVideoVals.playerSize[1].toString());
     });
     it('should not add additional parameters depending on params field', function () {
       const request = spec.buildRequests(bidRequests)[0];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Added support for invideo (non-linear ads) into gumgum's adapter. 
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'gumgum',
    params: {
	inVideo: 'ggumtest'
    }
 }

```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/1926

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
