### PR TITLE
Secure creative update

### DIFF
--- a/integrationExamples/gpt/x-domain/creative.html
+++ b/integrationExamples/gpt/x-domain/creative.html
@@ -6,7 +6,6 @@ let windowLocation = window.location;
 var urlParser = document.createElement('a');
 urlParser.href = '%%PATTERN:url%%';
 var publisherDomain = urlParser.protocol + '//' + urlParser.hostname;
-var adServerDomain = windowLocation.protocol + '//tpc.googlesyndication.com';
 
 function renderAd(ev) {
     var key = ev.message ? 'message' : 'data';
@@ -58,8 +57,7 @@ function renderAd(ev) {
 function requestAdFromPrebid() {
   var message = JSON.stringify({
     message: 'Prebid Request',
-    adId: '%%PATTERN:hb_adid%%',
-    adServerDomain: adServerDomain
+    adId: '%%PATTERN:hb_adid%%'
   });
   window.parent.postMessage(message, publisherDomain);
 }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -33,7 +33,7 @@ function receiveMessage(ev) {
     });
 
     if (adObject && data.message === 'Prebid Request') {
-      _sendAdToCreative(adObject, data.adServerDomain, ev.source);
+      _sendAdToCreative(adObject, ev.source);
 
       // save winning bids
       auctionManager.addWinningBid(adObject);
@@ -62,7 +62,7 @@ function receiveMessage(ev) {
   }
 }
 
-export function _sendAdToCreative(adObject, remoteDomain, source) {
+export function _sendAdToCreative(adObject, source) {
   const { adId, ad, adUrl, width, height, renderer, cpm } = adObject;
   // rendering for outstream safeframe
   if (isRendererRequired(renderer)) {
@@ -76,7 +76,7 @@ export function _sendAdToCreative(adObject, remoteDomain, source) {
       adId,
       width,
       height
-    }), remoteDomain);
+    }), source.origin);
   }
 }
 

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -33,7 +33,7 @@ function receiveMessage(ev) {
     });
 
     if (adObject && data.message === 'Prebid Request') {
-      _sendAdToCreative(adObject, ev.source);
+      _sendAdToCreative(adObject, ev);
 
       // save winning bids
       auctionManager.addWinningBid(adObject);
@@ -62,21 +62,21 @@ function receiveMessage(ev) {
   }
 }
 
-export function _sendAdToCreative(adObject, source) {
+export function _sendAdToCreative(adObject, ev) {
   const { adId, ad, adUrl, width, height, renderer, cpm } = adObject;
   // rendering for outstream safeframe
   if (isRendererRequired(renderer)) {
     executeRenderer(renderer, adObject);
   } else if (adId) {
     resizeRemoteCreative(adObject);
-    source.postMessage(JSON.stringify({
+    ev.source.postMessage(JSON.stringify({
       message: 'Prebid Response',
       ad: replaceAuctionPrice(ad, cpm),
       adUrl: replaceAuctionPrice(adUrl, cpm),
       adId,
       width,
       height
-    }), source.origin);
+    }), ev.origin);
   }
 }
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -959,11 +959,12 @@ describe('Unit: Prebid Module', function () {
         adUnitCode: config.adUnitCodes[0],
       };
 
-      const source = {
-        postMessage: sinon.stub()
+      const event = {
+        source: { postMessage: sinon.stub() },
+        origin: 'origin.sf.com'
       };
 
-      _sendAdToCreative(mockAdObject, source);
+      _sendAdToCreative(mockAdObject, event);
 
       expect(slots[0].spyGetSlotElementId.called).to.equal(false);
       expect(slots[1].spyGetSlotElementId.called).to.equal(true);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -959,12 +959,11 @@ describe('Unit: Prebid Module', function () {
         adUnitCode: config.adUnitCodes[0],
       };
 
-      const remoteDomain = '*';
       const source = {
         postMessage: sinon.stub()
       };
 
-      _sendAdToCreative(mockAdObject, remoteDomain, source);
+      _sendAdToCreative(mockAdObject, source);
 
       expect(slots[0].spyGetSlotElementId.called).to.equal(false);
       expect(slots[1].spyGetSlotElementId.called).to.equal(true);

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -30,12 +30,11 @@ describe('secureCreatives', () => {
         cpm: '1.00',
         adUnitCode: 'some_dom_id'
       };
-      const remoteDomain = '*';
       const source = {
         postMessage: sinon.stub()
       };
 
-      _sendAdToCreative(mockAdObject, remoteDomain, source);
+      _sendAdToCreative(mockAdObject, source);
       expect(JSON.parse(source.postMessage.args[0][0]).ad).to.equal('<script src="http://prebid.org/creative/1.00"></script>');
       expect(JSON.parse(source.postMessage.args[0][0]).adUrl).to.equal('http://creative.prebid.org/1.00');
       window.googletag = oldVal;

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -30,13 +30,14 @@ describe('secureCreatives', () => {
         cpm: '1.00',
         adUnitCode: 'some_dom_id'
       };
-      const source = {
-        postMessage: sinon.stub()
+      const event = {
+        source: { postMessage: sinon.stub() },
+        origin: 'origin.sf.com'
       };
 
-      _sendAdToCreative(mockAdObject, source);
-      expect(JSON.parse(source.postMessage.args[0][0]).ad).to.equal('<script src="http://prebid.org/creative/1.00"></script>');
-      expect(JSON.parse(source.postMessage.args[0][0]).adUrl).to.equal('http://creative.prebid.org/1.00');
+      _sendAdToCreative(mockAdObject, event);
+      expect(JSON.parse(event.source.postMessage.args[0][0]).ad).to.equal('<script src="http://prebid.org/creative/1.00"></script>');
+      expect(JSON.parse(event.source.postMessage.args[0][0]).adUrl).to.equal('http://creative.prebid.org/1.00');
       window.googletag = oldVal;
       window.apntag = oldapntag;
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
when returning the creative in response to a postMessage() request from an iframe (i.e. safeframe), restrict to the postMessage `event.origin` rather than a hard coded `adServerDomain`.   This changes functionality, but really should be a non-breaking change.
