### PR TITLE
Event updates

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -403,6 +403,15 @@ function getWurl(auctionId, adId) {
   }
 }
 
+/**
+ * remove all wurl wurl items
+ */
+export function resetWurlMap() {
+  Object.keys(bidIdMap).forEach(function (key) {
+    wurlMap[key] = undefined;
+  })
+}
+
 const OPEN_RTB_PROTOCOL = {
   buildRequest(s2sBidRequest, bidRequests, adUnits) {
     let imps = [];

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -404,12 +404,12 @@ function getWurl(auctionId, adId) {
 }
 
 /**
- * remove all wurl wurl items
+ * remove all cached wurls
  */
 export function resetWurlMap() {
-  Object.keys(bidIdMap).forEach(function (key) {
+  Object.keys(wurlMap).forEach(key => {
     wurlMap[key] = undefined;
-  })
+  });
 }
 
 const OPEN_RTB_PROTOCOL = {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -562,7 +562,7 @@ const OPEN_RTB_PROTOCOL = {
        * @type {(string|undefined)}
        */
       const pbAdSlot = utils.deepAccess(adUnit, 'fpd.context.pbAdSlot');
-      if (!utils.isEmptyStr(pbAdSlot)) {
+      if (typeof pbAdSlot === 'string' && pbAdSlot) {
         utils.deepSetValue(imp, 'ext.context.data.adslot', pbAdSlot);
       }
 
@@ -725,7 +725,7 @@ const OPEN_RTB_PROTOCOL = {
           // once we get through the transition, this block will be removed.
           if (utils.isPlainObject(extPrebidTargeting)) {
             // If wurl exists, remove hb_winurl and hb_bidid targeting attributes
-            if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
+            if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
               extPrebidTargeting = utils.getDefinedParams(extPrebidTargeting, Object.keys(extPrebidTargeting)
                 .filter(i => (i.indexOf('hb_winurl') === -1 && i.indexOf('hb_bidid') === -1)));
             }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -714,8 +714,8 @@ const OPEN_RTB_PROTOCOL = {
           }
 
           // store wurl by auctionId and adId so it can be accessed from the BID_WON event handler
-          if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
-            addWurl(bidRequest.auctionId, bidObject.adId, utils.deepAccess(bid, 'ext.prebid.event.win'));
+          if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.events.win'))) {
+            addWurl(bidRequest.auctionId, bidObject.adId, utils.deepAccess(bid, 'ext.prebid.events.win'));
           }
 
           let extPrebidTargeting = utils.deepAccess(bid, 'ext.prebid.targeting');
@@ -725,7 +725,7 @@ const OPEN_RTB_PROTOCOL = {
           // once we get through the transition, this block will be removed.
           if (utils.isPlainObject(extPrebidTargeting)) {
             // If wurl exists, remove hb_winurl and hb_bidid targeting attributes
-            if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
+            if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.events.win'))) {
               extPrebidTargeting = utils.getDefinedParams(extPrebidTargeting, Object.keys(extPrebidTargeting)
                 .filter(i => (i.indexOf('hb_winurl') === -1 && i.indexOf('hb_bidid') === -1)));
             }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -366,10 +366,48 @@ let nativeEventTrackerMethodMap = {
  */
 let bidIdMap = {};
 let nativeAssetCache = {}; // store processed native params to preserve
+
+/**
+ * map wurl to auction id and adId for use in the BID_WON event
+ */
+`const wurlMap = {};
+
+/**
+ * @param {string} auctionId
+ * @param {string} adId generated value set to bidObject.adId by bidderFactory Bid()
+ * @param {string} wurl events.winurl passed from prebidServer as wurl
+ */
+function addWurl(auctionId, adId, wurl) {
+  if (![auctionId, adId].some(utils.isEmptyStr)) {
+    wurlMap[`${auctionId}${adId}`] = wurl;
+  }
+}
+
+/**
+ * @param {string} auctionId
+ * @param {string} adId generated value set to bidObject.adId by bidderFactory Bid()
+ */
+function removeWurl(auctionId, adId) {
+  if (![auctionId, adId].some(utils.isEmptyStr)) {
+    wurlMap[`${auctionId}${adId}`] = undefined;
+  }
+}
+/**
+ * @param {string} auctionId
+ * @param {string} adId generated value set to bidObject.adId by bidderFactory Bid()
+ * @return {(string|undefined)} events.winurl which was passed as wurl
+ */
+function getWurl(auctionId, adId) {
+  if (![auctionId, adId].some(utils.isEmptyStr)) {
+    return wurlMap[`${auctionId}${adId}`];
+  }
+}
+
 const OPEN_RTB_PROTOCOL = {
   buildRequest(s2sBidRequest, bidRequests, adUnits) {
     let imps = [];
     let aliases = {};
+    const firstBidRequest = bidRequests[0];
 
     // transform ad unit into array of OpenRTB impression objects
     adUnits.forEach(adUnit => {
@@ -515,14 +553,14 @@ const OPEN_RTB_PROTOCOL = {
        * @type {(string|undefined)}
        */
       const pbAdSlot = utils.deepAccess(adUnit, 'fpd.context.pbAdSlot');
-      if (typeof pbAdSlot === 'string' && pbAdSlot) {
+      if (!utils.isEmptyStr(pbAdSlot)) {
         utils.deepSetValue(imp, 'ext.context.data.adslot', pbAdSlot);
       }
 
       Object.assign(imp, mediaTypes);
 
       // if storedAuctionResponse has been set, pass SRID
-      const storedAuctionResponseBid = find(bidRequests[0].bids, bid => (bid.adUnitCode === adUnit.code && bid.storedAuctionResponse));
+      const storedAuctionResponseBid = find(firstBidRequest.bids, bid => (bid.adUnitCode === adUnit.code && bid.storedAuctionResponse));
       if (storedAuctionResponseBid) {
         utils.deepSetValue(imp, 'ext.prebid.storedauctionresponse.id', storedAuctionResponseBid.storedAuctionResponse.toString());
       }
@@ -544,6 +582,8 @@ const OPEN_RTB_PROTOCOL = {
       test: getConfig('debug') ? 1 : 0,
       ext: {
         prebid: {
+          // set ext.prebid.auctiontimestamp with the auction timestamp. Data type is long integer.
+          auctiontimestamp: firstBidRequest.auctionStart,
           targeting: {
             // includewinners is always true for openrtb
             includewinners: true,
@@ -571,9 +611,9 @@ const OPEN_RTB_PROTOCOL = {
       request.cur = [adServerCur[0]];
     }
 
-    _appendSiteAppDevice(request, bidRequests[0].refererInfo.referer);
+    _appendSiteAppDevice(request, firstBidRequest.refererInfo.referer);
 
-    const digiTrust = _getDigiTrustQueryParams(bidRequests && bidRequests[0]);
+    const digiTrust = _getDigiTrustQueryParams(firstBidRequest);
     if (digiTrust) {
       utils.deepSetValue(request, 'user.ext.digitrust', digiTrust);
     }
@@ -596,19 +636,19 @@ const OPEN_RTB_PROTOCOL = {
     }
 
     if (bidRequests) {
-      if (bidRequests[0].gdprConsent) {
+      if (firstBidRequest.gdprConsent) {
         // note - gdprApplies & consentString may be undefined in certain use-cases for consentManagement module
         let gdprApplies;
-        if (typeof bidRequests[0].gdprConsent.gdprApplies === 'boolean') {
-          gdprApplies = bidRequests[0].gdprConsent.gdprApplies ? 1 : 0;
+        if (typeof firstBidRequest.gdprConsent.gdprApplies === 'boolean') {
+          gdprApplies = firstBidRequest.gdprConsent.gdprApplies ? 1 : 0;
         }
         utils.deepSetValue(request, 'regs.ext.gdpr', gdprApplies);
-        utils.deepSetValue(request, 'user.ext.consent', bidRequests[0].gdprConsent.consentString);
+        utils.deepSetValue(request, 'user.ext.consent', firstBidRequest.gdprConsent.consentString);
       }
 
       // US Privacy (CCPA) support
-      if (bidRequests[0].uspConsent) {
-        utils.deepSetValue(request, 'regs.ext.us_privacy', bidRequests[0].uspConsent);
+      if (firstBidRequest.uspConsent) {
+        utils.deepSetValue(request, 'regs.ext.us_privacy', firstBidRequest.uspConsent);
       }
     }
 
@@ -658,10 +698,26 @@ const OPEN_RTB_PROTOCOL = {
             bidRequest.serverResponseTimeMs = serverResponseTimeMs;
           }
 
-          const extPrebidTargeting = utils.deepAccess(bid, 'ext.prebid.targeting');
+          // Look for seatbid[].bid[].ext.prebid.bidid and place it in the bidResponse object for use in analytics adapters as 'pbsBidId'
+          const bidId = utils.deepAccess(bid, 'ext.prebid.bidid');
+          if (!utils.isEmptyStr(bidId)) {
+            bidObject.pbsBidId = bidId;
+          }
+
+          // store wurl by auctionId and adId so it can be access from the BID_WON event handler
+          if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
+            addWurl(bidRequest.auctionId, bidObject.adId, utils.deepAccess(bid, 'ext.prebid.event.win'));
+          }
+
+          let extPrebidTargeting = utils.deepAccess(bid, 'ext.prebid.targeting');
 
           // If ext.prebid.targeting exists, add it as a property value named 'adserverTargeting'
           if (extPrebidTargeting && typeof extPrebidTargeting === 'object') {
+            // If wurl exists, remove hb_winurl and hb_bidid targeting attributes
+            if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
+              extPrebidTargeting = utils.getDefinedParams(extPrebidTargeting, Object.keys(extPrebidTargeting)
+                .filter(i => (i.indexOf('hb_winurl') === -1 && i.indexOf('hb_bidid') === -1)));
+            }
             bidObject.adserverTargeting = extPrebidTargeting;
           }
 
@@ -774,6 +830,21 @@ const OPEN_RTB_PROTOCOL = {
 };
 
 /**
+ * BID_WON event to request the wurl
+ * @param {Bid} bid the winning bid object
+ */
+function bidWonHandler(bid) {
+  const wurl = getWurl(bid.auctionId, bid.adId);
+  if (!utils.isEmptyStr(wurl)) {
+    utils.logMessage(`Invoking image pixel for wurl on BID_WIN: "${wurl}"`);
+    utils.triggerPixel(wurl);
+
+    // remove from wurl cache, since the wurl url was called
+    removeWurl(bid.auctionId, bid.adId);
+  }
+}
+
+/**
  * Bidder adapter for Prebid Server
  */
 export function PrebidServer() {
@@ -855,6 +926,9 @@ export function PrebidServer() {
     done();
     doClientSideSyncs(requestedBidders);
   }
+
+  // Listen for bid won to call wurl
+  events.on(EVENTS.BID_WON, bidWonHandler);
 
   return Object.assign(this, {
     callBids: baseAdapter.callBids,

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -370,7 +370,7 @@ let nativeAssetCache = {}; // store processed native params to preserve
 /**
  * map wurl to auction id and adId for use in the BID_WON event
  */
-`const wurlMap = {};
+const wurlMap = {};
 
 /**
  * @param {string} auctionId

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -378,7 +378,7 @@ const wurlMap = {};
  * @param {string} wurl events.winurl passed from prebidServer as wurl
  */
 function addWurl(auctionId, adId, wurl) {
-  if (![auctionId, adId].some(utils.isEmptyStr)) {
+  if ([auctionId, adId].every(utils.isStr)) {
     wurlMap[`${auctionId}${adId}`] = wurl;
   }
 }
@@ -388,7 +388,7 @@ function addWurl(auctionId, adId, wurl) {
  * @param {string} adId generated value set to bidObject.adId by bidderFactory Bid()
  */
 function removeWurl(auctionId, adId) {
-  if (![auctionId, adId].some(utils.isEmptyStr)) {
+  if ([auctionId, adId].every(utils.isStr)) {
     wurlMap[`${auctionId}${adId}`] = undefined;
   }
 }
@@ -398,7 +398,7 @@ function removeWurl(auctionId, adId) {
  * @return {(string|undefined)} events.winurl which was passed as wurl
  */
 function getWurl(auctionId, adId) {
-  if (![auctionId, adId].some(utils.isEmptyStr)) {
+  if ([auctionId, adId].every(utils.isStr)) {
     return wurlMap[`${auctionId}${adId}`];
   }
 }
@@ -700,12 +700,12 @@ const OPEN_RTB_PROTOCOL = {
 
           // Look for seatbid[].bid[].ext.prebid.bidid and place it in the bidResponse object for use in analytics adapters as 'pbsBidId'
           const bidId = utils.deepAccess(bid, 'ext.prebid.bidid');
-          if (!utils.isEmptyStr(bidId)) {
+          if (utils.isStr(bidId)) {
             bidObject.pbsBidId = bidId;
           }
 
           // store wurl by auctionId and adId so it can be access from the BID_WON event handler
-          if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
+          if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
             addWurl(bidRequest.auctionId, bidObject.adId, utils.deepAccess(bid, 'ext.prebid.event.win'));
           }
 
@@ -714,7 +714,7 @@ const OPEN_RTB_PROTOCOL = {
           // If ext.prebid.targeting exists, add it as a property value named 'adserverTargeting'
           // The removal of hb_winurl and hb_bidid targeting values is temporary
           // once we get through the transition, this block will be removed.
-          if (extPrebidTargeting && typeof extPrebidTargeting === 'object') {
+          if (utils.isPlainObject(extPrebidTargeting)) {
             // If wurl exists, remove hb_winurl and hb_bidid targeting attributes
             if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
               extPrebidTargeting = utils.getDefinedParams(extPrebidTargeting, Object.keys(extPrebidTargeting)
@@ -837,7 +837,7 @@ const OPEN_RTB_PROTOCOL = {
  */
 function bidWonHandler(bid) {
   const wurl = getWurl(bid.auctionId, bid.adId);
-  if (!utils.isEmptyStr(wurl)) {
+  if (utils.isStr(wurl)) {
     utils.logMessage(`Invoking image pixel for wurl on BID_WIN: "${wurl}"`);
     utils.triggerPixel(wurl);
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -713,7 +713,7 @@ const OPEN_RTB_PROTOCOL = {
             bidObject.pbsBidId = bidId;
           }
 
-          // store wurl by auctionId and adId so it can be access from the BID_WON event handler
+          // store wurl by auctionId and adId so it can be accessed from the BID_WON event handler
           if (utils.isStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {
             addWurl(bidRequest.auctionId, bidObject.adId, utils.deepAccess(bid, 'ext.prebid.event.win'));
           }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -712,6 +712,8 @@ const OPEN_RTB_PROTOCOL = {
           let extPrebidTargeting = utils.deepAccess(bid, 'ext.prebid.targeting');
 
           // If ext.prebid.targeting exists, add it as a property value named 'adserverTargeting'
+          // The removal of hb_winurl and hb_bidid targeting values is temporary
+          // once we get through the transition, this block will be removed.
           if (extPrebidTargeting && typeof extPrebidTargeting === 'object') {
             // If wurl exists, remove hb_winurl and hb_bidid targeting attributes
             if (!utils.isEmptyStr(utils.deepAccess(bid, 'ext.prebid.event.win'))) {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -370,7 +370,7 @@ let nativeAssetCache = {}; // store processed native params to preserve
 /**
  * map wurl to auction id and adId for use in the BID_WON event
  */
-const wurlMap = {};
+let wurlMap = {};
 
 /**
  * @param {string} auctionId
@@ -407,9 +407,7 @@ function getWurl(auctionId, adId) {
  * remove all cached wurls
  */
 export function resetWurlMap() {
-  Object.keys(wurlMap).forEach(key => {
-    wurlMap[key] = undefined;
-  });
+  wurlMap = {};
 }
 
 const OPEN_RTB_PROTOCOL = {

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -87,7 +87,7 @@ function sendMessage(auctionId, bidWonId) {
   function formatBid(bid) {
     return utils.pick(bid, [
       'bidder',
-      'bidId', bidId => utils.deepAccess(bid, 'bidResponse.seatBidId') || bidId,
+      'bidId', bidId => utils.deepAccess(bid, 'bidResponse.pbsBidId') || utils.deepAccess(bid, 'bidResponse.seatBidId') || bidId,
       'status',
       'error',
       'source', (source, bid) => {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -339,6 +339,9 @@ export const spec = {
         utils.deepSetValue(data.imp[0], 'ext.prebid.storedauctionresponse.id', bidRequest.storedAuctionResponse.toString());
       }
 
+      // set ext.prebid.auctiontimestamp using auction time
+      utils.deepSetValue(data.imp[0], 'ext.prebid.auctiontimestamp', bidderRequest.auctionStart);
+
       return {
         method: 'POST',
         url: VIDEO_ENDPOINT,

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -69,7 +69,9 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels, src})
             'fpd',
             'mediaType',
             'renderer',
-            'storedAuctionResponse'
+            'storedAuctionResponse',
+            'seatBidId',
+            'pbsBidId'
           ]));
 
           let {

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -69,9 +69,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, labels, src})
             'fpd',
             'mediaType',
             'renderer',
-            'storedAuctionResponse',
-            'seatBidId',
-            'pbsBidId'
+            'storedAuctionResponse'
           ]));
 
           let {

--- a/src/auction.js
+++ b/src/auction.js
@@ -483,7 +483,7 @@ export const callPrebidCache = hook('async', function(auctionInstance, bidRespon
         afterBidAdded();
       }
     }
-  });
+  }, bidderRequest);
 }, 'callPrebidCache');
 
 // Postprocess the bids so that all the universal properties exist, no matter which bidder they came from.

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -10,7 +10,8 @@
  */
 
 import { ajax } from './ajax.js';
-import { config } from '../src/config.js';
+import * as utils from './utils.js';
+import { config } from './config.js';
 
 /**
  * @typedef {object} CacheableUrlBid
@@ -70,6 +71,10 @@ function toStorageRequest(bid) {
   if (config.getConfig('cache.vasttrack')) {
     payload.bidder = bid.bidder;
     payload.bidid = bid.requestId;
+    // function has a thisArg set to bidderRequest for accessing the auctionStart
+    if (utils.isPlainObject(this) && this.hasOwnProperty('auctionStart')) {
+      payload.timestamp = this.auctionStart;
+    }
   }
 
   if (typeof bid.customCacheKey === 'string' && bid.customCacheKey !== '') {
@@ -126,11 +131,12 @@ function shimStorageCallback(done) {
  *
  * @param {CacheableBid[]} bids A list of bid objects which should be cached.
  * @param {videoCacheStoreCallback} [done] An optional callback which should be executed after
+ * @param {BidderRequest} [bidderRequest]
  * the data has been stored in the cache.
  */
-export function store(bids, done) {
+export function store(bids, done, bidderRequest) {
   const requestData = {
-    puts: bids.map(toStorageRequest)
+    puts: bids.map(toStorageRequest, bidderRequest)
   };
 
   ajax(config.getConfig('cache.url'), shimStorageCallback(done), JSON.stringify(requestData), {

--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -10,8 +10,8 @@
  */
 
 import { ajax } from './ajax.js';
-import * as utils from './utils.js';
 import { config } from './config.js';
+import * as utils from './utils.js';
 
 /**
  * @typedef {object} CacheableUrlBid

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1778,7 +1778,7 @@ describe('S2S Adapter', function () {
       config.setConfig({ s2sConfig });
       const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
       cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.event = {
+        item.bid[0].ext.prebid.events = {
           win: 'https://wurl.com?a=1&b=2'
         };
         item.bid[0].ext.prebid.targeting = {
@@ -1885,7 +1885,7 @@ describe('S2S Adapter', function () {
 
     it('should call triggerPixel if wurl is defined', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
-      clonedResponse.seatbid[0].bid[0].ext.prebid.event = {
+      clonedResponse.seatbid[0].bid[0].ext.prebid.events = {
         win: 'https://wurl.org'
       };
 
@@ -1904,7 +1904,7 @@ describe('S2S Adapter', function () {
 
     it('should not call triggerPixel if the wurl cache does not contain the winning bid', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
-      clonedResponse.seatbid[0].bid[0].ext.prebid.event = {
+      clonedResponse.seatbid[0].bid[0].ext.prebid.events = {
         win: 'https://wurl.org'
       };
 
@@ -1922,7 +1922,7 @@ describe('S2S Adapter', function () {
 
     it('should not call triggerPixel if wurl is undefined', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
-      clonedResponse.seatbid[0].bid[0].ext.prebid.event = {};
+      clonedResponse.seatbid[0].bid[0].ext.prebid.events = {};
 
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
       server.requests[0].respond(200, {}, JSON.stringify(clonedResponse));

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1863,6 +1863,12 @@ describe('S2S Adapter', function () {
         return staticUniqueIds[uniqueIdCount - 1];
       });
       triggerPixelStub.resetHistory();
+
+      config.setConfig({
+        s2sConfig: Object.assign({}, CONFIG, {
+          endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+        })
+      });
     });
 
     afterEach(function () {
@@ -1875,15 +1881,9 @@ describe('S2S Adapter', function () {
 
     after(function () {
       triggerPixelStub.restore();
-    })
+    });
 
     it('should call triggerPixel if wurl is defined', function () {
-      config.setConfig({
-        s2sConfig: Object.assign({}, CONFIG, {
-          endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
-        })
-      });
-
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.event = {
         win: 'https://wurl.org'
@@ -1903,12 +1903,6 @@ describe('S2S Adapter', function () {
     });
 
     it('should not call triggerPixel if the wurl cache does not contain the winning bid', function () {
-      config.setConfig({
-        s2sConfig: Object.assign({}, CONFIG, {
-          endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
-        })
-      });
-
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.event = {
         win: 'https://wurl.org'
@@ -1927,12 +1921,6 @@ describe('S2S Adapter', function () {
     });
 
     it('should not call triggerPixel if wurl is undefined', function () {
-      config.setConfig({
-        s2sConfig: Object.assign({}, CONFIG, {
-          endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
-        })
-      });
-
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.event = {};
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1902,7 +1902,7 @@ describe('S2S Adapter', function () {
       expect(utils.triggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
     });
 
-    it('should not call triggerPixel if the wurl cache does not contain the winning', function () {
+    it('should not call triggerPixel if the wurl cache does not contain the winning bid', function () {
       config.setConfig({
         s2sConfig: Object.assign({}, CONFIG, {
           endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1754,7 +1754,7 @@ describe('S2S Adapter', function () {
       config.setConfig({ s2sConfig });
       const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
       cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.event = {
+        item.bid[0].ext.prebid.events = {
           win: 'https://wurl.com?a=1&b=2'
         };
         item.bid[0].ext.prebid.targeting = {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1848,7 +1848,7 @@ describe('S2S Adapter', function () {
   describe('bid won events', function () {
     let uniqueIdCount = 0;
 
-    const staticUniqueIds = ['1000', '1001', '1002', '1003', '1004', '1005'];
+    const staticUniqueIds = ['1000', '1001', '1002', '1003'];
 
     beforeEach(function () {
       sinon.stub(utils, 'triggerPixel');
@@ -1889,7 +1889,6 @@ describe('S2S Adapter', function () {
       });
 
       sinon.assert.calledOnce(addBidResponse);
-
       expect(utils.triggerPixel.called).to.be.true;
       expect(utils.triggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
     });
@@ -1909,9 +1908,7 @@ describe('S2S Adapter', function () {
       });
 
       sinon.assert.calledOnce(addBidResponse)
-
-      expect(utils.triggerPixel.called).to.be.true;
-      expect(utils.triggerPixel.getCall(0).args[0]).to.not.exist;
+      expect(utils.triggerPixel.called).to.be.false;
     });
 
     it('should not call triggerPixel if wurl is undefined', function () {
@@ -1927,9 +1924,7 @@ describe('S2S Adapter', function () {
       });
 
       sinon.assert.calledOnce(addBidResponse)
-
       expect(utils.triggerPixel.called).to.be.true;
-      expect(utils.triggerPixel.getCall(0).args[0]).to.not.exist;
     });
   })
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1461,6 +1461,7 @@ describe('the rubicon adapter', function () {
           expect(post.site.content.language).to.equal('en');
           expect(imp.ext.rubicon.video.skip).to.equal(1);
           expect(imp.ext.rubicon.video.skipafter).to.equal(15);
+          expect(imp.ext.prebid.auctiontimestamp).to.equal(1472239426000);
           expect(post.user.ext.consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
           expect(post.user.ext.eids[0].source).to.equal('liveintent.com');
           expect(post.user.ext.eids[0].uids[0].id).to.equal('0000-1111-2222-3333');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change
Prebid.js support for tracking Prebid Server (PBS) events

#### PBS BidAdapter changes

to the request
* set `ext.prebid.auctiontimestamp` with the auction timestamp.

to the response
* update pbsBidAdapter to listen to BidsWon events. When it receives an event, look up the relevant `imp.ext.prebid.event.win` and hit the url. 
* remove `hb_winurl` and `hb_bidid` targeting attributes. PUC no longer looks for `hb_winurl`. 
* add the value from`seatbid[].bid[].ext.prebid.bidid` to the bidResponse for use by the analytics adapters as 'pbsBidId' (in addition to the existing seatBidId).

#### videoCache changes
* update the 'vasttrack' routine to pass the auction timestamp as 'timestamp'.

## Other information
Issue #5180 