### PR TITLE
Update ixBidAdapter.js

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -287,7 +287,8 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   const payload = {};
 
   // Parse additional runtime configs.
-  const otherIxConfig = config.getConfig('ix');
+  const bidderCode = bidderRequest.bidderCode || 'ix';
+  const otherIxConfig = config.getConfig(bidderCode);
   if (otherIxConfig) {
     // Append firstPartyData to r.site.page if firstPartyData exists.
     if (typeof otherIxConfig.firstPartyData === 'object') {

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -287,7 +287,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   const payload = {};
 
   // Parse additional runtime configs.
-  const bidderCode = bidderRequest.bidderCode || 'ix';
+  const bidderCode = (bidderRequest && bidderRequest.bidderCode) || 'ix';
   const otherIxConfig = config.getConfig(bidderCode);
   if (otherIxConfig) {
     // Append firstPartyData to r.site.page if firstPartyData exists.


### PR DESCRIPTION
If the Index adapter is aliased, this gathers the alias instead of using the hard coded 'ix' value for bidder code.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Support for aliasing the adapter

