### PR TITLE
Price Floors skipRate debug by query string

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -288,6 +288,7 @@ export function updateAdUnitsForAuction(adUnits, floorData, skipped, auctionId) 
         skipped,
         modelVersion: utils.deepAccess(floorData, 'data.modelVersion') || '',
         location: floorData.data.location,
+        skipRate: floorData.skipRate
       }
     });
   });
@@ -311,7 +312,8 @@ export function createFloorsDataForAuction(adUnits, auctionId) {
     return;
   }
   // determine the skip rate now
-  const isSkipped = Math.random() * 100 < parseFloat(utils.deepAccess(resolvedFloorsData, 'data.skipRate') || 0);
+  const auctionSkipRate = utils.getParameterByName('pbjs_skipRate') || resolvedFloorsData.skipRate;
+  const isSkipped = Math.random() * 100 < parseFloat(auctionSkipRate);
   resolvedFloorsData.skipped = isSkipped;
   updateAdUnitsForAuction(adUnits, resolvedFloorsData, isSkipped, auctionId);
   return resolvedFloorsData;
@@ -389,6 +391,7 @@ export function isFloorsDataValid(floorsData) {
  */
 export function parseFloorData(floorsData, location) {
   if (floorsData && typeof floorsData === 'object' && isFloorsDataValid(floorsData)) {
+    utils.logInfo(`${MODULE_NAME}: A ${location} set the auction floor data set to `, floorsData);
     return {
       ...floorsData,
       location
@@ -505,6 +508,7 @@ export function handleSetFloorsConfig(config) {
     'enabled', enabled => enabled !== false, // defaults to true
     'auctionDelay', auctionDelay => auctionDelay || 0,
     'endpoint', endpoint => endpoint || {},
+    'skipRate', () => !isNaN(utils.deepAccess(config, 'data.skipRate')) ? config.data.skipRate : config.skipRate || 0,
     'enforcement', enforcement => utils.pick(enforcement || {}, [
       'enforceJS', enforceJS => enforceJS !== false, // defaults to true
       'enforcePBS', enforcePBS => enforcePBS === true, // defaults to false

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -200,7 +200,8 @@ function sendMessage(auctionId, bidWonId) {
         'modelName', () => auctionCache.floorData.modelVersion || '',
         'skipped',
         'enforcement', () => utils.deepAccess(auctionCache.floorData, 'enforcements.enforceJS'),
-        'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals')
+        'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals'),
+        'skipRate', skipRate => !isNaN(skipRate) ? skipRate : 0
       ]);
     }
 

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -344,6 +344,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'adUnit Model Version',
         location: 'adUnit',
+        skipRate: 0
       });
     });
     it('bidRequests should have getFloor function and flooring meta data when setConfig occurs', function () {
@@ -353,6 +354,49 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
+      });
+    });
+    it('should take the right skipRate depending on input', function () {
+      // first priority is data object
+      sandbox.stub(Math, 'random').callsFake(() => 0.99);
+      let inputFloors = {
+        ...basicFloorConfig,
+        skipRate: 10,
+        data: {
+          ...basicFloorData,
+          skipRate: 50
+        }
+      };
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 50
+      });
+
+      // if that does not exist uses topLevel skipRate setting
+      delete inputFloors.data.skipRate;
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 10
+      });
+
+      // if that is not there defaults to zero
+      delete inputFloors.skipRate;
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should not overwrite previous data object if the new one is bad', function () {
@@ -378,6 +422,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should dynamically add new schema fileds and functions if added via setConfig', function () {
@@ -453,6 +498,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
       fakeFloorProvider.respond();
     });
@@ -486,6 +532,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'fetch model name',
         location: 'fetch',
+        skipRate: 0
       });
     });
     it('Should not break if floor provider returns non json', function () {
@@ -503,6 +550,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should handle not using fetch correctly', function () {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -664,7 +664,8 @@ describe('rubicon analytics adapter', function () {
       auctionInit.bidderRequests[0].bids[0].floorData = {
         skipped: false,
         modelVersion: 'someModelName',
-        location: 'setConfig'
+        location: 'setConfig',
+        skipRate: 15
       };
       let flooredResponse = {
         ...BID,
@@ -733,7 +734,8 @@ describe('rubicon analytics adapter', function () {
         modelName: 'someModelName',
         skipped: false,
         enforcement: true,
-        dealsEnforced: false
+        dealsEnforced: false,
+        skipRate: 15
       });
       // first adUnit's adSlot
       expect(message.auctions[0].adUnits[0].adSlot).to.equal('12345/sports');


### PR DESCRIPTION
+ Rubicon Analytics log floors skipRate

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change

#### Price Floors Module
Adding debug ability for overriding the floors module's skipRate via query string.

By setting `pbjs_skipRate=<number>` as a query param in the page url will have each auction use the passed skipRate <number>.

#### Rubicon Analytics Adapter
Log the skipRate set for the auction
