### PR TITLE
ConsentManagement: fallback to defaultGdprScope if gdprApplies undefined

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -301,7 +301,8 @@ function processCmpData(consentObject, hookConfig) {
   }
 
   function checkV2Data() {
-    let gdprApplies = consentObject && consentObject.gdprApplies;
+    // if CMP does not respond with a gdprApplies boolean, use defaultGdprScope (gdprScope)
+    let gdprApplies = consentObject && typeof consentObject.gdprApplies === 'boolean' ? consentObject.gdprApplies : gdprScope;
     let tcString = consentObject && consentObject.tcString;
     return !!(
       (typeof gdprApplies !== 'boolean') ||
@@ -372,7 +373,7 @@ function storeConsentData(cmpConsentObject) {
     consentData = {
       consentString: (cmpConsentObject) ? cmpConsentObject.tcString : undefined,
       vendorData: (cmpConsentObject) || undefined,
-      gdprApplies: (cmpConsentObject) ? cmpConsentObject.gdprApplies : gdprScope
+      gdprApplies: cmpConsentObject && typeof cmpConsentObject.gdprApplies === 'boolean' ? cmpConsentObject.gdprApplies : gdprScope
     };
   }
   consentData.apiVersion = cmpVersion;

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -655,6 +655,35 @@ describe('consentManagement', function () {
           expect(consent).to.be.null;
         });
 
+        it('It still considers it a valid cmp response if gdprApplies is not a boolean', function () {
+          // gdprApplies is undefined, should just still store consent response but use whatever defaultGdprScope was
+          let testConsentData = {
+            tcString: 'abc12345234',
+            purposeOneTreatment: false,
+            eventStatus: 'tcloaded'
+          };
+          cmpStub = sinon.stub(window, '__tcfapi').callsFake((...args) => {
+            args[2](testConsentData, true);
+          });
+
+          setConsentConfig({
+            cmpApi: 'iab',
+            timeout: 7500,
+            defaultGdprScope: true
+          });
+
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, {});
+          let consent = gdprDataHandler.getConsentData();
+          sinon.assert.notCalled(utils.logWarn);
+          sinon.assert.notCalled(utils.logError);
+          expect(didHookReturn).to.be.true;
+          expect(consent.consentString).to.equal(testConsentData.tcString);
+          expect(consent.gdprApplies).to.be.true;
+          expect(consent.apiVersion).to.equal(2);
+        });
+
         it('throws a warning + stores consentData + calls callback when processCmpData check failed while config had allowAuction set to true', function () {
           let testConsentData = {};
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Other

## Description of change
If a cmp responds with a valid tcf string but for some reason not with gdprApplies as a boolean, we should still use the tcfString.

Currently, the response is considered "invalid" and thrown out.

This change will set gdprApplies to whatever the defaultGdprScope is in the case where the CMP responds with a non - boolean gdprApplies.