### PR TITLE
Floors new signals

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -288,6 +288,7 @@ export function updateAdUnitsForAuction(adUnits, floorData, skipped, auctionId) 
         skipped,
         modelVersion: utils.deepAccess(floorData, 'data.modelVersion') || '',
         location: floorData.data.location,
+        skipRate: floorData.skipRate
       }
     });
   });
@@ -311,7 +312,8 @@ export function createFloorsDataForAuction(adUnits, auctionId) {
     return;
   }
   // determine the skip rate now
-  const isSkipped = Math.random() * 100 < parseFloat(utils.deepAccess(resolvedFloorsData, 'data.skipRate') || 0);
+  const auctionSkipRate = utils.getParameterByName('pbjs_skipRate') || resolvedFloorsData.skipRate;
+  const isSkipped = Math.random() * 100 < parseFloat(auctionSkipRate);
   resolvedFloorsData.skipped = isSkipped;
   updateAdUnitsForAuction(adUnits, resolvedFloorsData, isSkipped, auctionId);
   return resolvedFloorsData;
@@ -389,6 +391,7 @@ export function isFloorsDataValid(floorsData) {
  */
 export function parseFloorData(floorsData, location) {
   if (floorsData && typeof floorsData === 'object' && isFloorsDataValid(floorsData)) {
+    utils.logInfo(`${MODULE_NAME}: A ${location} set the auction floor data set to `, floorsData);
     return {
       ...floorsData,
       location
@@ -505,6 +508,7 @@ export function handleSetFloorsConfig(config) {
     'enabled', enabled => enabled !== false, // defaults to true
     'auctionDelay', auctionDelay => auctionDelay || 0,
     'endpoint', endpoint => endpoint || {},
+    'skipRate', () => !isNaN(utils.deepAccess(config, 'data.skipRate')) ? config.data.skipRate : config.skipRate || 0,
     'enforcement', enforcement => utils.pick(enforcement || {}, [
       'enforceJS', enforceJS => enforceJS !== false, // defaults to true
       'enforcePBS', enforcePBS => enforcePBS === true, // defaults to false

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -289,7 +289,7 @@ export function updateAdUnitsForAuction(adUnits, floorData, auctionId) {
         modelVersion: utils.deepAccess(floorData, 'data.modelVersion'),
         location: utils.deepAccess(floorData, 'data.location'),
         skipRate: floorData.skipRate,
-        fetchFailed: _floorsConfig.fetchFailed
+        fetchStatus: _floorsConfig.fetchStatus
       }
     });
   });
@@ -422,6 +422,7 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
   if (_floorsConfig.auctionDelay > 0 && fetching) {
     hookConfig.timer = setTimeout(() => {
       utils.logWarn(`${MODULE_NAME}: Fetch attempt did not return in time for auction`);
+      _floorsConfig.fetchStatus = 'timeout';
       continueAuction(hookConfig);
     }, _floorsConfig.auctionDelay);
     _delayedAuctions.push(hookConfig);
@@ -449,7 +450,7 @@ function resumeDelayedAuctions() {
  */
 export function handleFetchResponse(fetchResponse) {
   fetching = false;
-  _floorsConfig.fetchFailed = false;
+  _floorsConfig.fetchStatus = 'success';
   let floorResponse;
   try {
     floorResponse = JSON.parse(fetchResponse);
@@ -465,7 +466,7 @@ export function handleFetchResponse(fetchResponse) {
 
 function handleFetchError(status) {
   fetching = false;
-  _floorsConfig.fetchFailed = true;
+  _floorsConfig.fetchStatus = 'error';
   utils.logError(`${MODULE_NAME}: Fetch errored with: `, status);
 
   // if any auctions are waiting for fetch to finish, we need to continue them!

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -202,7 +202,7 @@ function sendMessage(auctionId, bidWonId) {
         'enforcement', () => utils.deepAccess(auctionCache.floorData, 'enforcements.enforceJS'),
         'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals'),
         'skipRate', skipRate => !isNaN(skipRate) ? skipRate : 0,
-        'fetchFailed'
+        'fetchStatus'
       ]);
     }
 

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -197,11 +197,12 @@ function sendMessage(auctionId, bidWonId) {
     if (auctionCache.floorData) {
       auction.floors = utils.pick(auctionCache.floorData, [
         'location',
-        'modelName', () => auctionCache.floorData.modelVersion || '',
+        'modelName', () => auctionCache.floorData.modelVersion,
         'skipped',
         'enforcement', () => utils.deepAccess(auctionCache.floorData, 'enforcements.enforceJS'),
         'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals'),
-        'skipRate', skipRate => !isNaN(skipRate) ? skipRate : 0
+        'skipRate', skipRate => !isNaN(skipRate) ? skipRate : 0,
+        'fetchFailed'
       ]);
     }
 

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -200,7 +200,8 @@ function sendMessage(auctionId, bidWonId) {
         'modelName', () => auctionCache.floorData.modelVersion || '',
         'skipped',
         'enforcement', () => utils.deepAccess(auctionCache.floorData, 'enforcements.enforceJS'),
-        'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals')
+        'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals'),
+        'skipRate', skipRate => !isNaN(skipRate) ? skipRate : 0
       ]);
     }
 

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -344,6 +344,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'adUnit Model Version',
         location: 'adUnit',
+        skipRate: 0
       });
     });
     it('bidRequests should have getFloor function and flooring meta data when setConfig occurs', function () {
@@ -353,6 +354,49 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
+      });
+    });
+    it('should take the right skipRate depending on input', function () {
+      // first priority is data object
+      sandbox.stub(Math, 'random').callsFake(() => 0.99);
+      let inputFloors = {
+        ...basicFloorConfig,
+        skipRate: 10,
+        data: {
+          ...basicFloorData,
+          skipRate: 50
+        }
+      };
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 50
+      });
+
+      // if that does not exist uses topLevel skipRate setting
+      delete inputFloors.data.skipRate;
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 10
+      });
+
+      // if that is not there defaults to zero
+      delete inputFloors.skipRate;
+      handleSetFloorsConfig(inputFloors);
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        modelVersion: 'basic model',
+        location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should not overwrite previous data object if the new one is bad', function () {
@@ -378,6 +422,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should dynamically add new schema fileds and functions if added via setConfig', function () {
@@ -453,6 +498,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
       fakeFloorProvider.respond();
     });
@@ -486,6 +532,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'fetch model name',
         location: 'fetch',
+        skipRate: 0
       });
     });
     it('Should not break if floor provider returns non json', function () {
@@ -503,6 +550,7 @@ describe('the price floors module', function () {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
+        skipRate: 0
       });
     });
     it('should handle not using fetch correctly', function () {

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -319,7 +319,7 @@ describe('the price floors module', function () {
         modelVersion: undefined,
         location: undefined,
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
     });
     it('should use adUnit level data if not setConfig or fetch has occured', function () {
@@ -351,7 +351,7 @@ describe('the price floors module', function () {
         modelVersion: 'adUnit Model Version',
         location: 'adUnit',
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
     });
     it('bidRequests should have getFloor function and flooring meta data when setConfig occurs', function () {
@@ -362,7 +362,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
     });
     it('should take the right skipRate depending on input', function () {
@@ -383,7 +383,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 50,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
 
       // if that does not exist uses topLevel skipRate setting
@@ -395,7 +395,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 10,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
 
       // if that is not there defaults to zero
@@ -407,7 +407,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
     });
     it('should not overwrite previous data object if the new one is bad', function () {
@@ -434,7 +434,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: undefined
       });
     });
     it('should dynamically add new schema fileds and functions if added via setConfig', function () {
@@ -511,7 +511,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: undefined
+        fetchStatus: 'timeout'
       });
       fakeFloorProvider.respond();
     });
@@ -541,13 +541,13 @@ describe('the price floors module', function () {
       expect(exposedAdUnits).to.not.be.undefined;
 
       // the exposedAdUnits should be from the fetch not setConfig level data
-      // and fetch failed is false since fetch worked
+      // and fetchStatus is success since fetch worked
       validateBidRequests(true, {
         skipped: false,
         modelVersion: 'fetch model name',
         location: 'fetch',
         skipRate: 0,
-        fetchFailed: false
+        fetchStatus: 'success'
       });
     });
     it('Should not break if floor provider returns 404', function () {
@@ -567,7 +567,7 @@ describe('the price floors module', function () {
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: true
+        fetchStatus: 'error'
       });
     });
     it('Should not break if floor provider returns non json', function () {
@@ -583,13 +583,13 @@ describe('the price floors module', function () {
       // error should have been called for response floor data not being valid
       expect(logErrorSpy.calledOnce).to.equal(true);
       // should have caught the response error and still used setConfig data
-      // and fetch failed is true
+      // and fetchStatus is 'success' but location is setConfig since it had bad data
       validateBidRequests(true, {
         skipped: false,
         modelVersion: 'basic model',
         location: 'setConfig',
         skipRate: 0,
-        fetchFailed: false
+        fetchStatus: 'success'
       });
     });
     it('should handle not using fetch correctly', function () {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -664,7 +664,8 @@ describe('rubicon analytics adapter', function () {
       auctionInit.bidderRequests[0].bids[0].floorData = {
         skipped: false,
         modelVersion: 'someModelName',
-        location: 'setConfig'
+        location: 'setConfig',
+        skipRate: 15
       };
       let flooredResponse = {
         ...BID,
@@ -733,7 +734,8 @@ describe('rubicon analytics adapter', function () {
         modelName: 'someModelName',
         skipped: false,
         enforcement: true,
-        dealsEnforced: false
+        dealsEnforced: false,
+        skipRate: 15
       });
       // first adUnit's adSlot
       expect(message.auctions[0].adUnits[0].adSlot).to.equal('12345/sports');

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -665,7 +665,8 @@ describe('rubicon analytics adapter', function () {
         skipped: false,
         modelVersion: 'someModelName',
         location: 'setConfig',
-        skipRate: 15
+        skipRate: 15,
+        fetchStatus: 'error'
       };
       let flooredResponse = {
         ...BID,
@@ -735,7 +736,8 @@ describe('rubicon analytics adapter', function () {
         skipped: false,
         enforcement: true,
         dealsEnforced: false,
-        skipRate: 15
+        skipRate: 15,
+        fetchStatus: 'error'
       });
       // first adUnit's adSlot
       expect(message.auctions[0].adUnits[0].adSlot).to.equal('12345/sports');


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change

### Price Floors Module

The floors module is updated to pass along a couple additional signals to analytics adapters for better logging and understanding what occurs pre auction.

#### New signals to analytics adapters to consume:
`fetchFailed` - indicates wether or not a fetch attempt was made for floor data and if it received a non 200 http status code.

`skipRate` - the resolved skipRate which was used for the auction. skipRate can come from the floor data or the floor setConfig level. It is now signaled to analytics adapters.

#### New debug feature skipRate override
By setting pbjs_skipRate=<number> as a query param in the page url will have each auction use the passed skipRate .
 

### Rubicon Analytics Adapter

Log these two new fields in the event payload.