### PR TITLE
Fidelity adapter: TCFv2 support, kubient alias.

### DIFF
--- a/modules/fidelityBidAdapter.js
+++ b/modules/fidelityBidAdapter.js
@@ -6,6 +6,7 @@ const BIDDER_SERVER = 'x.fidelity-media.com';
 const FIDELITY_VENDOR_ID = 408;
 export const spec = {
   code: BIDDER_CODE,
+  aliases: ['kubient'],
   gvlid: 408,
   isBidRequestValid: function isBidRequestValid(bid) {
     return !!(bid && bid.params && bid.params.zoneid);
@@ -110,8 +111,11 @@ function setConsentParams(gdprConsent, uspConsent, payload) {
     if (typeof gdprConsent.consentString !== 'undefined') {
       payload.consent_str = gdprConsent.consentString;
     }
-    if (gdprConsent.vendorData && gdprConsent.vendorData.vendorConsents && typeof gdprConsent.vendorData.vendorConsents[FIDELITY_VENDOR_ID.toString(10)] !== 'undefined') {
+    if (gdprConsent.apiVersion === 1 && gdprConsent.vendorData && gdprConsent.vendorData.vendorConsents && typeof gdprConsent.vendorData.vendorConsents[FIDELITY_VENDOR_ID.toString(10)] !== 'undefined') {
       payload.consent_given = gdprConsent.vendorData.vendorConsents[FIDELITY_VENDOR_ID.toString(10)] ? 1 : 0;
+    }
+    if (gdprConsent.apiVersion === 2 && gdprConsent.vendorData && gdprConsent.vendorData.vendor && gdprConsent.vendorData.vendor.consents && typeof gdprConsent.vendorData.vendor.consents[FIDELITY_VENDOR_ID.toString(10)] !== 'undefined') {
+      payload.consent_given = gdprConsent.vendorData.vendor.consents[FIDELITY_VENDOR_ID.toString(10)] ? 1 : 0;
     }
   }
   if (typeof uspConsent !== 'undefined') {

--- a/test/spec/modules/fidelityBidAdapter_spec.js
+++ b/test/spec/modules/fidelityBidAdapter_spec.js
@@ -109,7 +109,7 @@ describe('FidelityAdapter', function () {
       expect(payload.schain).to.equal(schainString);
     });
 
-    it('should add consent information to the request', function () {
+    it('should add consent information to the request - TCF v1', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let uspConsentString = '1YN-';
       bidderRequest.gdprConsent = {
@@ -118,9 +118,39 @@ describe('FidelityAdapter', function () {
         consentString: consentString,
         vendorData: {
           vendorConsents: {
-            '408': 1
+            '408': true
           },
         },
+        apiVersion: 1
+      };
+      bidderRequest.uspConsent = uspConsentString;
+      const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+      const payload = request.data;
+      expect(payload.gdpr).to.exist.and.to.be.a('number');
+      expect(payload.gdpr).to.equal(1);
+      expect(payload.consent_str).to.exist.and.to.be.a('string');
+      expect(payload.consent_str).to.equal(consentString);
+      expect(payload.consent_given).to.exist.and.to.be.a('number');
+      expect(payload.consent_given).to.equal(1);
+      expect(payload.us_privacy).to.exist.and.to.be.a('string');
+      expect(payload.us_privacy).to.equal(uspConsentString);
+    });
+
+    it('should add consent information to the request - TCF v2', function () {
+      let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
+      let uspConsentString = '1YN-';
+      bidderRequest.gdprConsent = {
+        gdprApplies: true,
+        allowAuctionWithoutConsent: true,
+        consentString: consentString,
+        vendorData: {
+          vendor: {
+            consents: {
+              '408': true
+            }
+          },
+        },
+        apiVersion: 2
       };
       bidderRequest.uspConsent = uspConsentString;
       const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Adapter refactoring. 
Improved TCFv2 support.
Alias "kubient" added. 

- test parameters for validating bids
```
var adUnits = [{
      code: 'banner-ad-div',
      mediaTypes: {
        banner: {
          sizes: [[300, 250]],
        }
      },
      bids: [{
        bidder: 'kubient',
        params: {
          zoneid: '27248',
          floor: 0.005,
          server: 'x.fidelity-media.com'
        }
      }]
    }];
```

- contact email of the adapter’s maintainer prebid@kubient.com
- [x] official adapter submission

## Other information
Docs: https://github.com/prebid/prebid.github.io/pull/2011