### PR TITLE
change iabSubCatId name to primaryCatId

### DIFF
--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -352,7 +352,7 @@ export function checkVideoBidSetupHook(fn, bid, bidRequest, videoMediaType, cont
   if (context === ADPOD) {
     let result = true;
     let brandCategoryExclusion = config.getConfig('adpod.brandCategoryExclusion');
-    if (brandCategoryExclusion && !utils.deepAccess(bid, 'meta.iabSubCatId')) {
+    if (brandCategoryExclusion && !utils.deepAccess(bid, 'meta.primaryCatId')) {
       result = false;
     }
 

--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -231,7 +231,7 @@ function createBid(bidResponse, bidRequest) {
   if (context === ADPOD) {
     Object.assign(bid, {
       meta: {
-        iabSubCatId: bidResponse.iabSubCatId,
+        primaryCatId: bidResponse.primaryCatId,
       },
       video: {
         context: ADPOD,

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -264,7 +264,7 @@ export const spec = {
   getMappingFileInfo: function() {
     return {
       url: mappingFileUrl,
-      refreshInDays: 7
+      refreshInDays: 2
     }
   },
 
@@ -525,8 +525,8 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     const videoContext = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
     switch (videoContext) {
       case ADPOD:
-        const iabSubCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
-        bid.meta = Object.assign({}, bid.meta, { iabSubCatId });
+        const primaryCatId = getIabSubCategory(bidRequest.bidder, rtbBid.brand_category_id);
+        bid.meta = Object.assign({}, bid.meta, { primaryCatId });
         const dealTier = rtbBid.deal_priority;
         bid.video = {
           context: ADPOD,

--- a/modules/categoryTranslation.js
+++ b/modules/categoryTranslation.js
@@ -52,8 +52,8 @@ export function getAdserverCategoryHook(fn, adUnitCode, bid) {
       } catch (error) {
         logError('Failed to parse translation mapping file');
       }
-      if (bid.meta.iabSubCatId && mapping['mapping'] && mapping['mapping'][bid.meta.iabSubCatId]) {
-        bid.meta.adServerCatId = mapping['mapping'][bid.meta.iabSubCatId]['id'];
+      if (bid.meta.primaryCatId && mapping['mapping'] && mapping['mapping'][bid.meta.primaryCatId]) {
+        bid.meta.adServerCatId = mapping['mapping'][bid.meta.primaryCatId]['id'];
       } else {
         // This bid will be automatically ignored by adpod module as adServerCatId was not found
         bid.meta.adServerCatId = undefined;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -106,7 +106,7 @@ export const storage = getCoreStorageManager('bidderFactory');
  * @property {object} [native] Object for storing native creative assets
  * @property {object} [video] Object for storing video response data
  * @property {object} [meta] Object for storing bid meta data
- * @property {string} [meta.iabSubCatId] The IAB subcategory ID
+ * @property {string} [meta.primaryCatId] The IAB primary category ID
  * @property [Renderer] renderer A Renderer which can be used as a default for this bid,
  *   if the publisher doesn't override it. This is only relevant for Outstream Video bids.
  */

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -981,7 +981,7 @@ describe('adpod.js', function () {
         durationBucket: 15
       },
       meta: {
-        iabSubCatId: 'testCategory_123'
+        primaryCatId: 'testCategory_123'
       },
       vastXml: '<VAST>test XML here</VAST>'
     };
@@ -1050,7 +1050,7 @@ describe('adpod.js', function () {
       });
 
       let goodBid = utils.deepClone(adpodTestBid);
-      goodBid.meta.iabSubCatId = undefined;
+      goodBid.meta.primaryCatId = undefined;
       checkVideoBidSetupHook(callbackFn, goodBid, bidderRequestNoExact, {}, ADPOD);
       expect(callbackResult).to.be.null;
       expect(bailResult).to.equal(true);
@@ -1074,7 +1074,7 @@ describe('adpod.js', function () {
       }
 
       let noCatBid = utils.deepClone(adpodTestBid);
-      noCatBid.meta.iabSubCatId = undefined;
+      noCatBid.meta.primaryCatId = undefined;
       testInvalidAdpodBid(noCatBid, false);
 
       let noContextBid = utils.deepClone(adpodTestBid);
@@ -1101,7 +1101,7 @@ describe('adpod.js', function () {
           durationSeconds: 30
         },
         meta: {
-          iabSubCatId: 'testCategory_123'
+          primaryCatId: 'testCategory_123'
         },
         vastXml: '<VAST/>'
       };

--- a/test/spec/modules/categoryTranslation_spec.js
+++ b/test/spec/modules/categoryTranslation_spec.js
@@ -34,7 +34,7 @@ describe('category translation', function () {
     }));
     let bid = {
       meta: {
-        iabSubCatId: 'iab-1'
+        primaryCatId: 'iab-1'
       }
     }
     getAdserverCategoryHook(sinon.spy(), 'code', bid);
@@ -57,7 +57,7 @@ describe('category translation', function () {
     }));
     let bid = {
       meta: {
-        iabSubCatId: 'iab-2'
+        primaryCatId: 'iab-2'
       }
     }
     getAdserverCategoryHook(sinon.spy(), 'code', bid);

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -528,7 +528,7 @@ function createBid(cpm, adUnitCode, durationBucket, priceIndustryDuration, uuid,
     },
     'customCacheKey': `${priceIndustryDuration}_${uuid}`,
     'meta': {
-      'iabSubCatId': 'iab-1',
+      'primaryCatId': 'iab-1',
       'adServerCatId': label
     },
     'videoCacheKey': '4cf395af-8fee-4960-af0e-88d44e399f14'

--- a/test/spec/modules/freeWheelAdserverVideo_spec.js
+++ b/test/spec/modules/freeWheelAdserverVideo_spec.js
@@ -342,7 +342,7 @@ function createBid(cpm, adUnitCode, durationBucket, priceIndustryDuration, uuid,
     },
     'customCacheKey': `${priceIndustryDuration}_${uuid}`,
     'meta': {
-      'iabSubCatId': 'iab-1',
+      'primaryCatId': 'iab-1',
       'adServerCatId': industry
     },
     'videoCacheKey': '4cf395af-8fee-4960-af0e-88d44e399f14'

--- a/test/spec/modules/konduitWrapper_spec.js
+++ b/test/spec/modules/konduitWrapper_spec.js
@@ -170,7 +170,7 @@ function createBid(cpm, adUnitCode, durationBucket, priceIndustryDuration, uuid,
     },
     'customCacheKey': `${priceIndustryDuration}_${uuid}`,
     'meta': {
-      'iabSubCatId': 'iab-1',
+      'primaryCatId': 'iab-1',
       'adServerCatId': label
     },
     'videoCacheKey': '4cf395af-8fee-4960-af0e-88d44e399f14'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)


## Description of change
<!-- Describe the change proposed in this pull request -->
1) Somewhat recently we (PBJS PMC) defined a whole set of meta attributes at http://prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response . One of them is bidResponse.meta.primaryCatId and another is a secondaryCatIds array
2) I just found that the Long Form Video feature http://prebid.org/dev-docs/bidder-adaptor.html#long-form-video-content defines bidResponse.meta.iabSubCatId
I suspect that no one is actually using primaryCatId or secondaryCatIds right now, so we could change them, but the names seem more clear than 'iabSubCatId'
<!-- For new bidder adapters, please provide the following -->


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/2012

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
