### PR TITLE
Yieldmo Bid Adapter: don't uriencode params

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
       title: localWindow.document.title || '',
       w: localWindow.innerWidth,
       h: localWindow.innerHeight,
-      userConsent: encodeURIComponent(
+      userConsent:
         JSON.stringify({
           // case of undefined, stringify will remove param
           gdprApplies:
@@ -49,11 +49,10 @@ export const spec = {
             bidderRequest && bidderRequest.gdprConsent
               ? bidderRequest.gdprConsent.consentString
               : '',
-        })
-      ),
+        }),
       us_privacy:
         bidderRequest && bidderRequest.uspConsent
-          ? encodeURIComponent(bidderRequest.uspConsent)
+          ? bidderRequest.uspConsent
           : '',
     };
 
@@ -76,12 +75,11 @@ export const spec = {
         serverRequest.cri_prebid = criteoId;
       }
       if (request.schain) {
-        serverRequest.schain = encodeURIComponent(
-          JSON.stringify(request.schain)
-        );
+        serverRequest.schain =
+          JSON.stringify(request.schain);
       }
     });
-    serverRequest.p = encodeURIComponent('[' + serverRequest.p.toString() + ']');
+    serverRequest.p = '[' + serverRequest.p.toString() + ']';
     return {
       method: 'GET',
       url: SERVER_ENDPOINT,

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -90,7 +90,7 @@ describe('YieldmoAdapter', function () {
     it('should place bid information into the p parameter of data', function () {
       let placementInfo = spec.buildRequests(bidArray, bidderRequest).data.p;
       expect(placementInfo).to.equal(
-        encodeURIComponent('[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]],"bidFloor":0.1}]')
+        '[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]],"bidFloor":0.1}]'
       );
       bidArray.push({
         bidder: 'yieldmo',
@@ -117,20 +117,20 @@ describe('YieldmoAdapter', function () {
       // multiple placements
       placementInfo = spec.buildRequests(bidArray, bidderRequest).data.p;
       expect(placementInfo).to.equal(
-        encodeURIComponent('[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]],"bidFloor":0.1},{"placement_id":"adunit-code-1","callback_id":"123456789","sizes":[[300,250],[300,600]],"bidFloor":0.2}]')
+        '[{"placement_id":"adunit-code","callback_id":"30b31c1838de1e","sizes":[[300,250],[300,600]],"bidFloor":0.1},{"placement_id":"adunit-code-1","callback_id":"123456789","sizes":[[300,250],[300,600]],"bidFloor":0.2}]'
       );
     });
 
     it('should add placement id if given', function () {
       bidArray[0].params.placementId = 'ym_1293871298';
       let placementInfo = spec.buildRequests(bidArray, bidderRequest).data.p;
-      expect(placementInfo).to.include(encodeURIComponent('"ym_placement_id":"ym_1293871298"'));
-      expect(placementInfo).not.to.include(encodeURIComponent('"ym_placement_id":"ym_0987654321"'));
+      expect(placementInfo).to.include('"ym_placement_id":"ym_1293871298"');
+      expect(placementInfo).not.to.include('"ym_placement_id":"ym_0987654321"');
 
       bidArray[1].params.placementId = 'ym_0987654321';
       placementInfo = spec.buildRequests(bidArray, bidderRequest).data.p;
-      expect(placementInfo).to.include(encodeURIComponent('"ym_placement_id":"ym_1293871298"'));
-      expect(placementInfo).to.include(encodeURIComponent('"ym_placement_id":"ym_0987654321"'));
+      expect(placementInfo).to.include('"ym_placement_id":"ym_1293871298"');
+      expect(placementInfo).to.include('"ym_placement_id":"ym_0987654321"');
     });
 
     it('should add additional information to data parameter of request', function () {
@@ -230,10 +230,10 @@ describe('YieldmoAdapter', function () {
       };
       const data = spec.buildRequests(bidArray, bidderRequest).data;
       expect(data.userConsent).equal(
-        encodeURIComponent(JSON.stringify({
+        JSON.stringify({
           gdprApplies: true,
           cmp: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
-        }))
+        })
       );
     });
 
@@ -252,7 +252,7 @@ describe('YieldmoAdapter', function () {
       };
       bidArray[0].schain = schain;
       const request = spec.buildRequests([bidArray[0]], bidderRequest);
-      expect(request.data.schain).equal(encodeURIComponent(JSON.stringify(schain)));
+      expect(request.data.schain).equal(JSON.stringify(schain));
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Rollback of the issue here: https://github.com/prebid/Prebid.js/pull/5230 caused our workaround to doubly uri encode some parameters. This is to fix this issue.

- adapter maintainer email: opensource@yieldmo.com