### PR TITLE
removed the encoding for sizes

### DIFF
--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -27,7 +27,7 @@ export const spec = {
 
     validBidRequests.forEach(i => {
       let params = {
-        sizes: parseSizesInput(getAdUnitSizes(i)).join('%2C'),
+        sizes: parseSizesInput(getAdUnitSizes(i)).join(','),
         jst: 'hb',
         ord: Math.random() * 10000000000000000,
         tz: getTz(),

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -219,6 +219,6 @@ describe('betweenBidAdapterTests', function () {
     let request = spec.buildRequests(bidRequestData);
     let req_data = request[0].data;
 
-    expect(req_data.sizes).to.deep.equal('970x250%2C240x400%2C728x90');
+    expect(req_data.sizes).to.deep.equal('970x250,240x400,728x90');
   });
 });


### PR DESCRIPTION
## Type of change

- [x] Other

## Description of change

Removed the encoding for the parameter «sizes»

---
Contact email of the adapter’s maintainer: khaylov@betweenx.com
- [x] official adapter submission
