### PR TITLE
Run full suite of unit tests

### DIFF
--- a/test/spec/modules/adtargetBidAdapter_spec.js
+++ b/test/spec/modules/adtargetBidAdapter_spec.js
@@ -123,7 +123,7 @@ const displayEqResponse = [{
   cpm: 0.9
 }];
 
-describe.only('adtargetBidAdapter', () => {
+describe('adtargetBidAdapter', () => {
   const adapter = newBidder(spec);
   describe('inherited functions', () => {
     it('exists and is a function', () => {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
With the merge of https://github.com/prebid/Prebid.js/pull/5296, prebid.js unit tests only ran for `adtargetBidAdapter.js` because of the `only` keyword present on the parent `describe` block.

This PR removes that.