### PR TITLE
Fix to issue #5141 exception thrown in pbjs.requestBids when DigiTrus…

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -64,8 +64,9 @@ const USER_IDS_CONFIG = {
 
   // DigiTrust
   'digitrustid': {
-    getValue: function(data) {
-      return data.data.id;
+    getValue: function (data) {
+      var id = data && data.data && data.data.id || null;
+      return id;
     },
     source: 'digitru.st',
     atype: 1

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -65,7 +65,10 @@ const USER_IDS_CONFIG = {
   // DigiTrust
   'digitrustid': {
     getValue: function (data) {
-      var id = data && data.data && data.data.id || null;
+      var id = null;
+      if (data && data.data && data.data.id != null) {
+        id = data.data.id;
+      }
       return id;
     },
     source: 'digitru.st',


### PR DESCRIPTION
Fix to issue #5141 exception thrown in pbjs.requestBids when DigiTrust does not init.

Safe extract value of id or null in eids.js.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix

## Description of change
This modifies eids.js where the digitrust ID is extracted. The previous code was pulling a deep property without first checking for null values. The change adds in null checks and returns null instead of throwing an exception.

- contact email of the adapter’s maintainer
- [X ] official adapter submission

## Other information
Issue #5141 
