### PR TITLE
add meta key to interpreted bid response

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -307,6 +307,7 @@ export function newBidder(spec) {
               // creating a copy of original values as cpm and currency are modified later
               bid.originalCpm = bid.cpm;
               bid.originalCurrency = bid.currency;
+              bid.meta = bid.meta || Object.assign({}, bid[bidRequest.bidder]);
               const prebidBid = Object.assign(createBid(CONSTANTS.STATUS.GOOD, bidRequest), bid);
               addBidWithCode(bidRequest.adUnitCode, prebidBid);
             } else {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -423,6 +423,7 @@ describe('bidders created by newBidder', function () {
       expect(bidObject.originalCurrency).to.equal(bid.currency);
       expect(doneStub.calledOnce).to.equal(true);
       expect(logErrorSpy.callCount).to.equal(0);
+      expect(bidObject.meta).to.exist;
     });
 
     it('should call spec.getUserSyncs() with the response', function () {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -401,8 +401,12 @@ describe('bidders created by newBidder', function () {
         adUnitCode: 'mock/placement',
         currency: 'USD',
         netRevenue: true,
-        ttl: 300
+        ttl: 300,
+        bidderCode: 'sampleBidder',
+        sampleBidder: {advertiserId: '12345', networkId: '111222'}
       };
+      const bidderRequest = Object.assign({}, MOCK_BIDS_REQUEST);
+      bidderRequest.bids[0].bidder = 'sampleBidder';
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
@@ -413,7 +417,7 @@ describe('bidders created by newBidder', function () {
 
       spec.interpretResponse.returns(bid);
 
-      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+      bidder.callBids(bidderRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.calledOnce).to.equal(true);
       expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
@@ -424,6 +428,7 @@ describe('bidders created by newBidder', function () {
       expect(doneStub.calledOnce).to.equal(true);
       expect(logErrorSpy.callCount).to.equal(0);
       expect(bidObject.meta).to.exist;
+      expect(bidObject.meta).to.deep.equal({advertiserId: '12345', networkId: '111222'});
     });
 
     it('should call spec.getUserSyncs() with the response', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Add meta key to bid object after interpret response. Most of the bidders send meta data in bidResonse[bidderCode] field, so it copied to meta key now.
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.
