### PR TITLE
Delaying removal of floor data for 3 seconds

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -532,8 +532,10 @@ export function handleSetFloorsConfig(config) {
 
     if (!addedFloorsHook) {
       // register hooks / listening events
-      // when auction finishes remove it's associated floor data
-      events.on(CONSTANTS.EVENTS.AUCTION_END, (args) => delete _floorDataForAuction[args.auctionId]);
+      // when auction finishes remove it's associated floor data after 3 seconds so we stil have it for latent responses
+      events.on(CONSTANTS.EVENTS.AUCTION_END, (args) => {
+        setTimeout(() => delete _floorDataForAuction[args.auctionId], 3000);
+      });
 
       // we want our hooks to run after the currency hooks
       getGlobal().requestBids.before(requestBidsHook, 50);


### PR DESCRIPTION

## Type of change
- [X] Other

## Description of change
Currently, the floors module removes it's auction floor data at the AUCTION END event.

The problem with this is that bidResponses may still trickle in shortly after this occurs.

And then we do not have the floor data for these responses, so they are not floored or do not contain the necessary data needed.

So we simply add a 3 seconds setTimeout to delete the floor data so we can still do floors stuff for the bid responses.