### PR TITLE
improveStartDelay change default value

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -72,7 +72,7 @@ export const spec = {
           videoProtocol: bid.params.video.protocol,
           playerWidth: playerSize[0],
           playerHeight: playerSize[1],
-          adBreak: bid.params.video.startDelay || 0
+          adBreak: bid.params.video.startDelay || 1
         };
       } else {
         return {};

--- a/modules/smartadserverBidAdapter.md
+++ b/modules/smartadserverBidAdapter.md
@@ -89,7 +89,7 @@ Please reach out to your Technical account manager for more information.
                 bidfloor: 5,
                 video: {
                     protocol: 6,
-                    startDelay: 0
+                    startDelay: 1
                 }
             }
         }]


### PR DESCRIPTION
After documentation update default value is now 1 and 0 does not exist.

## Type of change
- [ ] Other minor fix

## Description of change
Following a discovery that startDelay 0 doesn't exist we have a pending change to documentation to remove 0 and set the default value to 1.

https://github.com/prebid/prebid.github.io/pull/2047

## Other information
lowen@smartadserver.com
