### PR TITLE
Add host field into limelight bidder adapter

### DIFF
--- a/modules/projectLimeLightBidAdapter.js
+++ b/modules/projectLimeLightBidAdapter.js
@@ -52,8 +52,9 @@ export const spec = {
       utils.logMessage(e);
       winTop = window;
     }
-    return Object.entries(utils.groupBy(validBidRequests.map(bidRequest => buildPlacement(bidRequest)), 'host'))
-      .map(placement => buildRequest(winTop, placement[0], placement[1].map(placement => placement.adUnit)));
+    const placements = utils.groupBy(validBidRequests.map(bidRequest => buildPlacement(bidRequest)), 'host')
+    return Object.keys(placements)
+      .map(host => buildRequest(winTop, host, placements[host].map(placement => placement.adUnit)));
   },
 
   onBidWon: (bid) => {

--- a/modules/projectLimeLightBidAdapter.js
+++ b/modules/projectLimeLightBidAdapter.js
@@ -4,7 +4,6 @@ import {ajax} from '../src/ajax.js';
 import * as utils from '../src/utils.js';
 
 const BIDDER_CODE = 'project-limelight';
-const URL = 'https://ads.project-limelight.com/hb';
 
 /**
  * Determines whether or not the given bid response is valid.
@@ -23,19 +22,6 @@ function isBidResponseValid(bid) {
       return Boolean(bid.vastXml || bid.vastUrl);
   }
   return false;
-}
-
-function extractBidSizes(bid) {
-  const bidSizes = [];
-
-  bid.sizes.forEach(size => {
-    bidSizes.push({
-      width: size[0],
-      height: size[1]
-    });
-  });
-
-  return bidSizes;
 }
 
 export const spec = {
@@ -65,30 +51,9 @@ export const spec = {
     } catch (e) {
       utils.logMessage(e);
       winTop = window;
-    };
-    const placements = [];
-    const request = {
-      'secure': (location.protocol === 'https:'),
-      'deviceWidth': winTop.screen.width,
-      'deviceHeight': winTop.screen.height,
-      'adUnits': placements
-    };
-    for (let i = 0; i < validBidRequests.length; i++) {
-      const bid = validBidRequests[i];
-      const params = bid.params;
-      placements.push({
-        id: params.adUnitId,
-        bidId: bid.bidId,
-        transactionId: bid.transactionId,
-        sizes: extractBidSizes(bid),
-        type: params.adUnitType.toUpperCase()
-      });
     }
-    return {
-      method: 'POST',
-      url: URL,
-      data: request
-    };
+    return Object.entries(utils.groupBy(validBidRequests.map(bidRequest => buildPlacement(bidRequest)), 'host'))
+      .map(placement => buildRequest(winTop, placement[0], placement[1].map(placement => placement.adUnit)));
   },
 
   onBidWon: (bid) => {
@@ -123,3 +88,34 @@ export const spec = {
 };
 
 registerBidder(spec);
+
+function buildRequest(winTop, host, adUnits) {
+  return {
+    method: 'POST',
+    url: `https://${host}/hb`,
+    data: {
+      secure: (location.protocol === 'https:'),
+      deviceWidth: winTop.screen.width,
+      deviceHeight: winTop.screen.height,
+      adUnits: adUnits
+    }
+  }
+}
+
+function buildPlacement(bidRequest) {
+  return {
+    host: bidRequest.params.host,
+    adUnit: {
+      id: bidRequest.params.adUnitId,
+      bidId: bidRequest.bidId,
+      transactionId: bidRequest.transactionId,
+      sizes: bidRequest.sizes.map(size => {
+        return {
+          width: size[0],
+          height: size[1]
+        }
+      }),
+      type: bidRequest.params.adUnitType.toUpperCase()
+    }
+  }
+}

--- a/modules/projectLimeLightBidAdapter.md
+++ b/modules/projectLimeLightBidAdapter.md
@@ -18,6 +18,7 @@ Module that connects to Project Limelight SSP demand sources
                 bids: [{
                         bidder: 'project-limelight',
                         params: {
+                            host: 'ads.project-limelight.com',
                             adUnitId: 0,
                             adUnitType: 'banner'
                         }
@@ -34,6 +35,7 @@ var videoAdUnit = [{
                 bids: [{
                         bidder: 'project-limelight',
                         params: {
+                            host: 'ads.project-limelight.com',
                             adUnitId: 0,
                             adUnitType: 'video'
                         }

--- a/test/spec/modules/projectLimeLightBidAdapter_spec.js
+++ b/test/spec/modules/projectLimeLightBidAdapter_spec.js
@@ -2,11 +2,12 @@ import {expect} from 'chai';
 import {spec} from '../../../modules/projectLimeLightBidAdapter.js';
 
 describe('ProjectLimeLightAdapter', function () {
-  let bid = {
+  const bid1 = {
     bidId: '2dd581a2b6281d',
     bidder: 'project-limelight',
     bidderRequestId: '145e1d6a7837c9',
     params: {
+      host: 'ads.project-limelight.com',
       adUnitId: 123,
       adUnitType: 'banner'
     },
@@ -14,46 +15,83 @@ describe('ProjectLimeLightAdapter', function () {
     auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
     sizes: [[300, 250]],
     transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62'
-  };
+  }
+  const bid2 = {
+    bidId: '58ee9870c3164a',
+    bidder: 'project-limelight',
+    bidderRequestId: '209fdaf1c81649',
+    params: {
+      host: 'cpm.project-limelight.com',
+      adUnitId: 456,
+      adUnitType: 'banner'
+    },
+    placementCode: 'placement_1',
+    auctionId: '482f88de-29ab-45c8-981a-d25e39454a34',
+    sizes: [[350, 200]],
+    transactionId: '068867d1-46ec-40bb-9fa0-e24611786fb4'
+  }
+  const bid3 = {
+    bidId: '019645c7d69460',
+    bidder: 'project-limelight',
+    bidderRequestId: 'f2b15f89e77ba6',
+    params: {
+      host: 'ads.project-limelight.com',
+      adUnitId: 789,
+      adUnitType: 'video'
+    },
+    placementCode: 'placement_2',
+    auctionId: 'e4771143-6aa7-41ec-8824-ced4342c96c8',
+    sizes: [[800, 600]],
+    transactionId: '738d5915-6651-43b9-9b6b-d50517350917'
+  }
 
   describe('buildRequests', function () {
-    let serverRequest = spec.buildRequests([bid]);
-    it('Creates a ServerRequest object with method, URL and data', function () {
-      expect(serverRequest).to.exist;
-      expect(serverRequest.method).to.exist;
-      expect(serverRequest.url).to.exist;
-      expect(serverRequest.data).to.exist;
-    });
-    it('Returns POST method', function () {
-      expect(serverRequest.method).to.equal('POST');
-    });
+    const serverRequests = spec.buildRequests([bid1, bid2, bid3])
+    it('Creates two ServerRequests', function() {
+      expect(serverRequests).to.exist
+      expect(serverRequests).to.have.lengthOf(2)
+    })
+    serverRequests.forEach(serverRequest => {
+      it('Creates a ServerRequest object with method, URL and data', function () {
+        expect(serverRequest).to.exist
+        expect(serverRequest.method).to.exist
+        expect(serverRequest.url).to.exist
+        expect(serverRequest.data).to.exist
+      })
+      it('Returns POST method', function () {
+        expect(serverRequest.method).to.equal('POST')
+      })
+      it('Returns valid data if array of bids is valid', function () {
+        let data = serverRequest.data
+        expect(data).to.be.an('object')
+        expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'secure', 'adUnits')
+        expect(data.deviceWidth).to.be.a('number')
+        expect(data.deviceHeight).to.be.a('number')
+        expect(data.secure).to.be.a('boolean')
+        data.adUnits.forEach(adUnit => {
+          expect(adUnit).to.have.all.keys('id', 'bidId', 'type', 'sizes', 'transactionId')
+          expect(adUnit.id).to.be.a('number')
+          expect(adUnit.bidId).to.be.a('string')
+          expect(adUnit.type).to.be.a('string')
+          expect(adUnit.transactionId).to.be.a('string')
+          expect(adUnit.sizes).to.be.an('array')
+        })
+      })
+    })
     it('Returns valid URL', function () {
-      expect(serverRequest.url).to.equal('https://ads.project-limelight.com/hb');
-    });
-    it('Returns valid data if array of bids is valid', function () {
-      let data = serverRequest.data;
-      expect(data).to.be.an('object');
-      expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'secure', 'adUnits');
-      expect(data.deviceWidth).to.be.a('number');
-      expect(data.deviceHeight).to.be.a('number');
-      expect(data.secure).to.be.a('boolean');
-      let adUnits = data['adUnits'];
-      for (let i = 0; i < adUnits.length; i++) {
-        let adUnit = adUnits[i];
-        expect(adUnit).to.have.all.keys('id', 'bidId', 'type', 'sizes', 'transactionId');
-        expect(adUnit.id).to.be.a('number');
-        expect(adUnit.bidId).to.be.a('string');
-        expect(adUnit.type).to.be.a('string');
-        expect(adUnit.transactionId).to.be.a('string');
-        expect(adUnit.sizes).to.be.an('array');
-      }
-    });
+      expect(serverRequests[0].url).to.equal('https://ads.project-limelight.com/hb')
+      expect(serverRequests[1].url).to.equal('https://cpm.project-limelight.com/hb')
+    })
+    it('Returns valid adUnits', function () {
+      validateAdUnit(serverRequests[0].data.adUnits[0], bid1)
+      validateAdUnit(serverRequests[1].data.adUnits[0], bid2)
+      validateAdUnit(serverRequests[0].data.adUnits[1], bid3)
+    })
     it('Returns empty data if no valid requests are passed', function () {
-      serverRequest = spec.buildRequests([]);
-      let data = serverRequest.data;
-      expect(data.adUnits).to.be.an('array').that.is.empty;
-    });
-  });
+      const serverRequests = spec.buildRequests([])
+      expect(serverRequests).to.be.an('array').that.is.empty
+    })
+  })
   describe('interpretBannerResponse', function () {
     let resObject = {
       body: [ {
@@ -168,3 +206,16 @@ describe('ProjectLimeLightAdapter', function () {
     });
   });
 });
+
+function validateAdUnit(adUnit, bid) {
+  expect(adUnit.id).to.equal(bid.params.adUnitId)
+  expect(adUnit.bidId).to.equal(bid.bidId)
+  expect(adUnit.type).to.equal(bid.params.adUnitType.toUpperCase())
+  expect(adUnit.transactionId).to.equal(bid.transactionId)
+  expect(adUnit.sizes).to.deep.equal(bid.sizes.map(size => {
+    return {
+      width: size[0],
+      height: size[1]
+    }
+  }))
+}

--- a/test/spec/modules/projectLimeLightBidAdapter_spec.js
+++ b/test/spec/modules/projectLimeLightBidAdapter_spec.js
@@ -205,6 +205,44 @@ describe('ProjectLimeLightAdapter', function () {
       expect(spec.isBidRequestValid(bidFailed)).to.equal(false);
     });
   });
+  describe('interpretResponse', function() {
+    let resObject = {
+      requestId: '123',
+      mediaType: 'banner',
+      cpm: 0.3,
+      width: 320,
+      height: 50,
+      ad: '<h1>Hello ad</h1>',
+      ttl: 1000,
+      creativeId: '123asd',
+      netRevenue: true,
+      currency: 'USD'
+    };
+    it('should skip responses which do not contain required params', function() {
+      let bidResponses = {
+        body: [ {
+          mediaType: 'banner',
+          cpm: 0.3,
+          ttl: 1000,
+          currency: 'USD'
+        }, resObject ]
+      }
+      expect(spec.interpretResponse(bidResponses)).to.deep.equal([ resObject ]);
+    });
+    it('should skip responses which do not contain expected mediaType', function() {
+      let bidResponses = {
+        body: [ {
+          requestId: '123',
+          mediaType: 'native',
+          cpm: 0.3,
+          creativeId: '123asd',
+          ttl: 1000,
+          currency: 'USD'
+        }, resObject ]
+      }
+      expect(spec.interpretResponse(bidResponses)).to.deep.equal([ resObject ]);
+    });
+  });
 });
 
 function validateAdUnit(adUnit, bid) {


### PR DESCRIPTION
## Type of change
Bidder adapter related changes

## Description of change
This PR adds `host` field into limelight bidder adapter

- test parameters for validating bids
```
var adUnits = [{
                code: 'placementCode',
                sizes: [[300, 250]],
                bids: [{
                        bidder: 'project-limelight',
                        params: {
                            host: 'ads.project-limelight.com',
                            adUnitId: 0,
                            adUnitType: 'banner'
                        }
                    }]
                }
            ];
```
```
var videoAdUnit = [{
                code: 'video1',
                sizes: [[300, 250]],
                bids: [{
                        bidder: 'project-limelight',
                        params: {
                            host: 'ads.project-limelight.com',
                            adUnitId: 0,
                            adUnitType: 'video'
                        }
                }]
            }];
```

- contact email of the adapter’s maintainer engineering@project-limelight.com
- [x] official adapter submission
- Bidder params documentation here https://github.com/prebid/prebid.github.io/pull/2048
