### PR TITLE
Add GMOSSP Adapter

### DIFF
--- a/modules/gmosspBidAdapter.js
+++ b/modules/gmosspBidAdapter.js
@@ -1,0 +1,134 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
+import { BANNER } from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'gmossp';
+const ENDPOINT = 'https://sp.gmossp-sp.jp/hb/prebid/query.ad';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    return !!(bid.params.sid);
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    const bidRequests = [];
+
+    const url = bidderRequest.refererInfo.referer;
+    const cur = getCurrencyType();
+    const dnt = utils.getDNT() ? '1' : '0';
+
+    for (let i = 0; i < validBidRequests.length; i++) {
+      let queryString = '';
+
+      const request = validBidRequests[i];
+      const tid = request.transactionId;
+      const bid = request.bidId;
+      const ver = '$prebid.version$';
+      const sid = utils.getBidIdParameter('sid', request.params);
+
+      queryString = utils.tryAppendQueryString(queryString, 'tid', tid);
+      queryString = utils.tryAppendQueryString(queryString, 'bid', bid);
+      queryString = utils.tryAppendQueryString(queryString, 'ver', ver);
+      queryString = utils.tryAppendQueryString(queryString, 'sid', sid);
+      queryString = utils.tryAppendQueryString(queryString, 'url', url);
+      queryString = utils.tryAppendQueryString(queryString, 'cur', cur);
+      queryString = utils.tryAppendQueryString(queryString, 'dnt', dnt);
+
+      bidRequests.push({
+        method: 'GET',
+        url: ENDPOINT,
+        data: queryString
+      });
+    }
+    return bidRequests;
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (bidderResponse, requests) {
+    const res = bidderResponse.body;
+
+    if (utils.isEmpty(res)) {
+      return [];
+    }
+
+    try {
+      res.imps.forEach(impTracker => {
+        const tracker = utils.createTrackPixelHtml(impTracker);
+        res.ad += tracker;
+      });
+    } catch (error) {
+      utils.logError('Error appending tracking pixel', error);
+    }
+
+    const bid = {
+      requestId: res.bid,
+      cpm: res.price,
+      currency: res.cur,
+      width: res.w,
+      height: res.h,
+      ad: res.ad,
+      creativeId: res.creativeId,
+      netRevenue: true,
+      ttl: res.ttl || 300
+    };
+
+    return [bid];
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: function(syncOptions, serverResponses) {
+    const syncs = [];
+    if (!serverResponses.length) {
+      return syncs;
+    }
+
+    serverResponses.forEach(res => {
+      if (syncOptions.pixelEnabled && res.body && res.body.syncs.length) {
+        res.body.syncs.forEach(sync => {
+          syncs.push({
+            type: 'image',
+            url: sync
+          })
+        })
+      }
+    })
+    return syncs;
+  },
+
+};
+
+function getCurrencyType() {
+  if (config.getConfig('currency.adServerCurrency')) {
+    return config.getConfig('currency.adServerCurrency');
+  }
+  return 'JPY';
+}
+
+registerBidder(spec);

--- a/modules/gmosspBidAdapter.md
+++ b/modules/gmosspBidAdapter.md
@@ -1,0 +1,36 @@
+# Overview
+
+```
+Module Name: GMOSSP Bid Adapter
+Module Type: Bidder Adapter
+Maintainer:  dev@ml.gmo-am.jp
+```
+
+# Description
+Connects to GMOSSP exchange for bids.
+GMOSSP bid adapter supports Banner.
+
+# Test Parameters
+```
+var adUnits = [
+    // Banner adUnit
+    {
+        code: 'test-div',
+        mediaTypes: {
+            banner: {
+                sizes: [
+                    [300, 250],
+                    [320, 50],
+                    [320, 100]
+                ]
+            }
+        },
+        bids: [{
+            bidder: 'gmossp',
+            params: {
+                sid: '61590'
+            }
+        }]
+    }
+];
+```

--- a/test/spec/modules/gmosspBidAdapter_spec.js
+++ b/test/spec/modules/gmosspBidAdapter_spec.js
@@ -1,0 +1,162 @@
+import { expect } from 'chai';
+import { spec } from 'modules/gmosspBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import * as utils from 'src/utils.js';
+
+const ENDPOINT = 'https://sp.gmossp-sp.jp/hb/prebid/query.ad';
+
+describe('GmosspAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    let bid = {
+      bidder: 'gmossp',
+      params: {
+        sid: '123456'
+      }
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidRequests = [
+      {
+        bidder: 'gmossp',
+        params: {
+          sid: '123456'
+        },
+        adUnitCode: 'adunit-code',
+        sizes: [
+          [300, 250],
+          [320, 50],
+          [320, 100],
+        ],
+        bidId: '2b84475b5b636e',
+        bidderRequestId: '1f4001782ac16c',
+        auctionId: 'aba03555-4802-4c45-9f15-05ffa8594cff',
+        transactionId: '791e9d84-af92-4903-94da-24c7426d9d0c'
+      }
+    ];
+
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'https://hoge.com'
+      }
+    };
+
+    it('sends bid request to ENDPOINT via GET', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      expect(requests[0].url).to.equal(ENDPOINT);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].data).to.equal('tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=3.24.0-pre&sid=123456&url=https%3A%2F%2Fhoge.com&cur=JPY&dnt=0&');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const bidderRequests = [
+      {
+        bidder: 'gmossp',
+        params: {
+          sid: '123456'
+        },
+        adUnitCode: 'adunit-code',
+        sizes: [
+          [300, 250],
+          [320, 50],
+          [320, 100],
+        ],
+        bidId: '2b84475b5b636e',
+        bidderRequestId: '1f4001782ac16c',
+        auctionId: 'aba03555-4802-4c45-9f15-05ffa8594cff',
+        transactionId: '791e9d84-af92-4903-94da-24c7426d9d0c'
+      }
+    ];
+
+    it('should get correct banner bid response', function() {
+      const response = {
+        bid: '2b84475b5b636e',
+        price: 20,
+        w: 300,
+        h: 250,
+        ad: '<div class="gmossp"></div>',
+        creativeId: '985ec572b32be309.76973017',
+        cur: 'JPY',
+        dealId: '',
+        imps: [
+          'https://sp.gmossp-sp.jp/hb/prebid/imp.ad'
+        ],
+        syncs: [
+          'https://sync.dsp.reemo-ad.jp'
+        ],
+        ttl: 300
+      };
+
+      const expectedResponse = [
+        {
+          requestId: '2b84475b5b636e',
+          cpm: 20,
+          currency: 'JPY',
+          width: 300,
+          height: 250,
+          ad: '<div class="gmossp"></div>',
+          creativeId: '985ec572b32be309.76973017',
+          netRevenue: true,
+          ttl: 300
+        }
+      ];
+
+      const result = spec.interpretResponse({ body: response }, bidderRequests);
+      expect(result).to.have.lengthOf(1);
+
+      response.imps.forEach(impTracker => {
+        const tracker = utils.createTrackPixelHtml(impTracker);
+        expectedResponse[0].ad += tracker;
+      });
+
+      expect(result).to.deep.have.same.members(expectedResponse);
+    });
+
+    it('handles nobid responses', function () {
+      const response = '';
+
+      const result = spec.interpretResponse({ body: response }, bidderRequests);
+      expect(result.length).to.equal(0);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    const bidResponse = {
+      body: {
+        ad: {},
+        syncs: [
+          'https://hoge.com'
+        ]
+      }
+    };
+    it('should return returns pixel syncs', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, [bidResponse]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://hoge.com'
+        }
+      ])
+    })
+  });
+});

--- a/test/spec/modules/gmosspBidAdapter_spec.js
+++ b/test/spec/modules/gmosspBidAdapter_spec.js
@@ -64,7 +64,7 @@ describe('GmosspAdapter', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests[0].url).to.equal(ENDPOINT);
       expect(requests[0].method).to.equal('GET');
-      expect(requests[0].data).to.equal('tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=3.24.0-pre&sid=123456&url=https%3A%2F%2Fhoge.com&cur=JPY&dnt=0&');
+      expect(requests[0].data).to.equal('tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=$prebid.version$&sid=123456&url=https%3A%2F%2Fhoge.com&cur=JPY&dnt=0&');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
- test parameters for validating bids
```
{
  bidder: 'gmossp',
  params: {
    sid: '61590'
  }
}
```

- contact email of the adapter’s maintainer
dev@ml.gmo-am.jp

- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/2063