### PR TITLE
delay request to server by 5 min if we no ads

### DIFF
--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -3,15 +3,15 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 
-var BIDDER_CODE = 'proxistore';
+const BIDDER_CODE = 'proxistore';
 const storage = getStorageManager();
-var PROXISTORE_VENDOR_ID = 418;
+const PROXISTORE_VENDOR_ID = 418;
 
 function _createServerRequest(bidRequests, bidderRequest) {
-  var sizeIds = [];
+  const sizeIds = [];
 
   bidRequests.forEach(function (bid) {
-    var sizeId = {
+    const sizeId = {
       id: bid.bidId,
       sizes: bid.sizes.map(function (size) {
         return {
@@ -22,7 +22,7 @@ function _createServerRequest(bidRequests, bidderRequest) {
     };
     sizeIds.push(sizeId);
   });
-  var payload = {
+  const payload = {
     auctionId: bidRequests[0].auctionId,
     transactionId: bidRequests[0].auctionId,
     bids: sizeIds,
@@ -32,7 +32,7 @@ function _createServerRequest(bidRequests, bidderRequest) {
       applies: false
     }
   };
-  var options = {
+  const options = {
     contentType: 'application/json',
     withCredentials: true
   };
@@ -91,7 +91,7 @@ function isBidRequestValid(bid) {
       const storedDate = new Date(pxNoAds);
       const now = new Date();
       // 5min = 300 0000 seconds
-      var diff = Math.abs(storedDate.getTime() - now.getTime()) / 300000;
+      const diff = Math.abs(storedDate.getTime() - now.getTime()) / 300000;
       if (diff > 5) {
         return false;
       } else {
@@ -111,7 +111,7 @@ function isBidRequestValid(bid) {
  */
 
 function buildRequests(bidRequests, bidderRequest) {
-  var request = _createServerRequest(bidRequests, bidderRequest);
+  const request = _createServerRequest(bidRequests, bidderRequest);
   return request;
 }
 /**
@@ -133,7 +133,7 @@ function interpretResponse(serverResponse, bidRequest) {
   }
 }
 
-var websiteFromBidRequest = function(bidR) {
+const websiteFromBidRequest = function(bidR) {
   if (bidR.data) {
     return JSON.parse(bidR.data).website
   } else if (bidR.params.website) {

--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const { registerBidder } = require('../src/adapters/bidderFactory.js');
 
 var BIDDER_CODE = 'proxistore';
@@ -117,7 +119,7 @@ function buildRequests(bidRequests, bidderRequest) {
  */
 
 function interpretResponse(serverResponse, bidRequest) {
-  const itemName = `PX_NoAds_${websiteFromBidRequest(bidRequest.data)}`;
+  const itemName = `PX_NoAds_${websiteFromBidRequest(bidRequest)}`;
   if (serverResponse.body.length > 0) {
     localStorage.removeItem(itemName, true);
     return serverResponse.body.map(_createBidResponse);
@@ -127,9 +129,12 @@ function interpretResponse(serverResponse, bidRequest) {
   }
 }
 
-var websiteFromBidRequest = function(data) {
-  const parsedData = JSON.parse(data);
-  return parsedData.website;
+var websiteFromBidRequest = function(bidR) {
+  if (bidR.data) {
+    return JSON.parse(bidR.data).website
+  } else if (bidR.params.website) {
+    return bidR.params.website;
+  }
 }
 
 /**

--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -90,13 +89,8 @@ function isBidRequestValid(bid) {
     } else {
       const storedDate = new Date(pxNoAds);
       const now = new Date();
-      // 5min = 300 0000 seconds
-      const diff = Math.abs(storedDate.getTime() - now.getTime()) / 300000;
-      if (diff > 5) {
-        return false;
-      } else {
-        return true;
-      }
+      const diff = Math.abs(storedDate.getTime() - now.getTime()) / 60000;
+      return diff <= 5;
     }
   }
   return !!(bid.params.website && bid.params.language) && !hasNoAd();

--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -1,14 +1,24 @@
 const { registerBidder } = require('../src/adapters/bidderFactory.js');
-const BIDDER_CODE = 'proxistore';
-const PROXISTORE_VENDOR_ID = 418;
+
+var BIDDER_CODE = 'proxistore';
+var PROXISTORE_VENDOR_ID = 418;
 
 function _createServerRequest(bidRequests, bidderRequest) {
-  const sizeIds = [];
-  bidRequests.forEach(bid => {
-    const sizeId = {id: bid.bidId, sizes: bid.sizes.map(size => { return { width: size[0], height: size[1] } })};
+  var sizeIds = [];
+
+  bidRequests.forEach(function (bid) {
+    var sizeId = {
+      id: bid.bidId,
+      sizes: bid.sizes.map(function (size) {
+        return {
+          width: size[0],
+          height: size[1]
+        };
+      })
+    };
     sizeIds.push(sizeId);
   });
-  const payload = {
+  var payload = {
     auctionId: bidRequests[0].auctionId,
     transactionId: bidRequests[0].auctionId,
     bids: sizeIds,
@@ -18,22 +28,22 @@ function _createServerRequest(bidRequests, bidderRequest) {
       applies: false
     }
   };
-
-  const options = {
+  var options = {
     contentType: 'application/json',
     withCredentials: true
   };
 
   if (bidderRequest && bidderRequest.gdprConsent) {
-    if ((typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') && bidderRequest.gdprConsent.gdprApplies) {
+    if (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean' && bidderRequest.gdprConsent.gdprApplies) {
       payload.gdpr.applies = true;
     }
-    if ((typeof bidderRequest.gdprConsent.consentString === 'string') && bidderRequest.gdprConsent.consentString) {
+
+    if (typeof bidderRequest.gdprConsent.consentString === 'string' && bidderRequest.gdprConsent.consentString) {
       payload.gdpr.consentString = bidderRequest.gdprConsent.consentString;
     }
-    if (bidderRequest.gdprConsent.vendorData && bidderRequest.gdprConsent.vendorData.vendorConsents &&
-      typeof bidderRequest.gdprConsent.vendorData.vendorConsents[PROXISTORE_VENDOR_ID.toString(10)] !== 'undefined') {
-      payload.gdpr.consentGiven = !!(bidderRequest.gdprConsent.vendorData.vendorConsents[PROXISTORE_VENDOR_ID.toString(10)]);
+
+    if (bidderRequest.gdprConsent.vendorData && bidderRequest.gdprConsent.vendorData.vendorConsents && typeof bidderRequest.gdprConsent.vendorData.vendorConsents[PROXISTORE_VENDOR_ID.toString(10)] !== 'undefined') {
+      payload.gdpr.consentGiven = !!bidderRequest.gdprConsent.vendorData.vendorConsents[PROXISTORE_VENDOR_ID.toString(10)];
     }
   }
 
@@ -59,17 +69,31 @@ function _createBidResponse(response) {
     vastUrl: response.vastUrl,
     vastXml: response.vastXml,
     dealId: response.dealId
-  }
+  };
 }
-
 /**
  * Determines whether or not the given bid request is valid.
  *
  * @param bid  The bid params to validate.
  * @return boolean True if this is a valid bid, and false otherwise.
  */
+
 function isBidRequestValid(bid) {
-  return !!(bid.params.website && bid.params.language);
+  const hasNoAd = function() {
+    const storedtime = new Date(localStorage.getItem(`PX_NoAds_${bid.params.website}`));
+    if (!storedtime) {
+      return false;
+    } else {
+      const now = new Date();
+      var diff = Math.abs(storedtime.getTime() - now.getTime()) / 30000;
+      if (diff > 5) {
+        return false;
+      } else {
+        return true;
+      }
+    }
+  }
+  return !!(bid.params.website && bid.params.language) && !hasNoAd();
 }
 
 /**
@@ -79,11 +103,11 @@ function isBidRequestValid(bid) {
  * @param bidderRequest
  * @return ServerRequest Info describing the request to the server.
  */
+
 function buildRequests(bidRequests, bidderRequest) {
   var request = _createServerRequest(bidRequests, bidderRequest);
   return request;
 }
-
 /**
  * Unpack the response from the server into a list of bids.
  *
@@ -91,12 +115,21 @@ function buildRequests(bidRequests, bidderRequest) {
  * @param bidRequest Request original server request
  * @return  An array of bids which were nested inside the server.
  */
+
 function interpretResponse(serverResponse, bidRequest) {
+  const itemName = `PX_NoAds_${websiteFromBidRequest(bidRequest.data)}`;
   if (serverResponse.body.length > 0) {
+    localStorage.removeItem(itemName, true);
     return serverResponse.body.map(_createBidResponse);
   } else {
+    localStorage.setItem(itemName, new Date());
     return [];
   }
+}
+
+var websiteFromBidRequest = function(data) {
+  const parsedData = JSON.parse(data);
+  return parsedData.website;
 }
 
 /**
@@ -106,11 +139,12 @@ function interpretResponse(serverResponse, bidRequest) {
  * @param serverResponses List of server's responses.
  * @return The user syncs which should be dropped.
  */
+
 function getUserSyncs(syncOptions, serverResponses) {
   return [];
 }
 
-const spec = {
+var spec = {
   code: BIDDER_CODE,
   isBidRequestValid: isBidRequestValid,
   buildRequests: buildRequests,

--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -1,7 +1,6 @@
 
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
-
 const BIDDER_CODE = 'proxistore';
 const storage = getStorageManager();
 const PROXISTORE_VENDOR_ID = 418;
@@ -83,6 +82,9 @@ function _createBidResponse(response) {
 
 function isBidRequestValid(bid) {
   const hasNoAd = function() {
+    if (!storage.hasLocalStorage()) {
+      return false;
+    }
     const pxNoAds = storage.getDataFromLocalStorage(`PX_NoAds_${bid.params.website}`);
     if (!pxNoAds) {
       return false;

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -28,7 +28,21 @@ describe('ProxistoreBidAdapter', function () {
     transactionId: 511916005
   };
   describe('isBidRequestValid', function () {
-    it('it should be true if required params are presents', function () {
+    it('it should be true if required params are presents and there is no info in the local storage', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('it should be false if the value in the localstorage is less than 5minutes of the actual time', function() {
+      const date = new Date();
+      date.setMinutes(date.getMinutes() - 1)
+      localStorage.setItem(`PX_NoAds_${bid.params.website}`, date)
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('it should be true if the value in the localstorage is more than 5minutes of the actual time', function() {
+      const date = new Date();
+      date.setMinutes(date.getMinutes() - 10)
+      localStorage.setItem(`PX_NoAds_${bid.params.website}`, date)
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
   });
@@ -97,7 +111,11 @@ describe('ProxistoreBidAdapter', function () {
       expect(interpretedResponse.requestId).equal('923756713');
       expect(interpretedResponse.netRevenue).to.be.true;
       expect(interpretedResponse.netRevenue).to.be.true;
-    })
+    });
+    it('should have a value in the local storage if the response is empty', function() {
+      spec.interpretResponse(badResponse, bid);
+      expect(localStorage.getItem(`PX_NoAds_${bid.params.website}`)).to.be.string;
+    });
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-let spec = require('modules/proxistoreBidAdapter');
+let { spec } = require('modules/proxistoreBidAdapter');
 
 const BIDDER_CODE = 'proxistore';
 describe('ProxistoreBidAdapter', function () {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Avoid too many request to our server if we have no ads for the moment.
If we have no ads we write the name of the website as a key and the current date in the local storage. The next time we read it and if we compare to the current time and if the current time is superior to five minutes we call our server if not we reject the bid.

vincent.descamps@proxistore.com
