### PR TITLE
add adomain to bid.meta in telaria adapter

### DIFF
--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -286,7 +286,7 @@ function createBid(status, reqBid, response, width, height, bidderCode) {
 
   bid.meta = bid.meta || {};
   if (response && response.adomain && response.adomain.length > 0) {
-    bid.meta.advertiserDomains = response.adomain.split();
+    bid.meta.advertiserDomains = response.adomain;
   }
 
   return bid;

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -283,6 +283,11 @@ function createBid(status, reqBid, response, width, height, bidderCode) {
       ad: response.adm
     });
   }
+  
+  bid.meta = bid.meta || {};
+  if (response && response.adomain && response.adomain.length > 0) {
+    bid.meta.advertiserDomains = response.adomain;
+  }
 
   return bid;
 }

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -286,7 +286,7 @@ function createBid(status, reqBid, response, width, height, bidderCode) {
   
   bid.meta = bid.meta || {};
   if (response && response.adomain && response.adomain.length > 0) {
-    bid.meta.advertiserDomains = str.split(response.adomain);
+    bid.meta.advertiserDomains = response.adomain.split();
   }
 
   return bid;

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -283,7 +283,7 @@ function createBid(status, reqBid, response, width, height, bidderCode) {
       ad: response.adm
     });
   }
-  
+
   bid.meta = bid.meta || {};
   if (response && response.adomain && response.adomain.length > 0) {
     bid.meta.advertiserDomains = response.adomain.split();

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -286,7 +286,7 @@ function createBid(status, reqBid, response, width, height, bidderCode) {
   
   bid.meta = bid.meta || {};
   if (response && response.adomain && response.adomain.length > 0) {
-    bid.meta.advertiserDomains = response.adomain;
+    bid.meta.advertiserDomains = str.split(response.adomain);
   }
 
   return bid;

--- a/test/spec/modules/telariaBidAdapter_spec.js
+++ b/test/spec/modules/telariaBidAdapter_spec.js
@@ -236,7 +236,7 @@ describe('TelariaAdapter', () => {
     it('should get correct bid response', () => {
       let expectedResponseKeys = ['bidderCode', 'width', 'height', 'statusMessage', 'adId', 'mediaType', 'source',
         'getStatusCode', 'getSize', 'requestId', 'cpm', 'creativeId', 'vastXml',
-        'vastUrl', 'currency', 'netRevenue', 'ttl', 'ad'];
+        'vastUrl', 'currency', 'netRevenue', 'ttl', 'ad', 'meta'];
 
       let bidRequest = spec.buildRequests(stub, BIDDER_REQUEST)[0];
       bidRequest.bidId = '1234';


### PR DESCRIPTION

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
this puts the adomain key in the right spot, related to https://github.com/prebid/Prebid.js/pull/5358 and partially solves https://github.com/prebid/Prebid.js/issues/3115 for Telaria

