### PR TITLE
 add adomain to bid.meta in spotx adapter

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -333,7 +333,7 @@ export const spec = {
 
           bid.meta = bid.meta || {};
           if (spotxBid && spotxBid.adomain && spotxBid.adomain.length > 0) {
-            bid.meta.advertiserDomains = spotxBid.adomain.split();
+            bid.meta.advertiserDomains = spotxBid.adomain;
           }
 
           const context1 = utils.deepAccess(currentBidRequest, 'mediaTypes.video.context');

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -330,6 +330,11 @@ export const spec = {
             width: spotxBid.w,
             height: spotxBid.h
           };
+          
+          bid.meta = bid.meta || {};
+          if (response && response.adomain && response.adomain.length > 0) {
+            bid.meta.advertiserDomains = str.split(response.adomain);
+          }
 
           const context1 = utils.deepAccess(currentBidRequest, 'mediaTypes.video.context');
           const context2 = utils.deepAccess(currentBidRequest, 'params.ad_unit');

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -330,10 +330,10 @@ export const spec = {
             width: spotxBid.w,
             height: spotxBid.h
           };
-          
+
           bid.meta = bid.meta || {};
-          if (response && response.adomain && response.adomain.length > 0) {
-            bid.meta.advertiserDomains = str.split(response.adomain);
+          if (spotxBid && spotxBid.adomain && spotxBid.adomain.length > 0) {
+            bid.meta.advertiserDomains = spotxBid.adomain.split();
           }
 
           const context1 = utils.deepAccess(currentBidRequest, 'mediaTypes.video.context');

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -381,6 +381,7 @@ describe('the spotx adapter', function () {
               impid: 123,
               cur: 'USD',
               price: 12,
+              adomain: ['abc.com'],
               crid: 321,
               w: 400,
               h: 300,
@@ -392,6 +393,7 @@ describe('the spotx adapter', function () {
               impid: 124,
               cur: 'USD',
               price: 13,
+              adomain: ['def.com'],
               w: 200,
               h: 100,
               ext: {
@@ -409,6 +411,7 @@ describe('the spotx adapter', function () {
       expect(responses).to.be.an('array').with.length(2);
       expect(responses[0].cache_key).to.equal('cache123');
       expect(responses[0].channel_id).to.equal(12345);
+      expect(responses[0].adomain).to.equal(['abc.com']);
       expect(responses[0].cpm).to.equal(12);
       expect(responses[0].creativeId).to.equal(321);
       expect(responses[0].currency).to.equal('USD');
@@ -423,6 +426,7 @@ describe('the spotx adapter', function () {
       expect(responses[1].cache_key).to.equal('cache124');
       expect(responses[1].channel_id).to.equal(12345);
       expect(responses[1].cpm).to.equal(13);
+      expect(responses[1].adomain).to.equal(['def.com']);
       expect(responses[1].creativeId).to.equal('');
       expect(responses[1].currency).to.equal('USD');
       expect(responses[1].height).to.equal(100);

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -411,7 +411,7 @@ describe('the spotx adapter', function () {
       expect(responses).to.be.an('array').with.length(2);
       expect(responses[0].cache_key).to.equal('cache123');
       expect(responses[0].channel_id).to.equal(12345);
-      expect(responses[0].adomain[0]).to.equal('abc.com');
+      expect(responses[0].meta.advertiserDomains[0]).to.equal('abc.com');
       expect(responses[0].cpm).to.equal(12);
       expect(responses[0].creativeId).to.equal(321);
       expect(responses[0].currency).to.equal('USD');
@@ -426,7 +426,7 @@ describe('the spotx adapter', function () {
       expect(responses[1].cache_key).to.equal('cache124');
       expect(responses[1].channel_id).to.equal(12345);
       expect(responses[1].cpm).to.equal(13);
-      expect(responses[1].adomain[0]).to.equal('def.com');
+      expect(responses[1].meta.advertiserDomains[0]).to.equal('def.com');
       expect(responses[1].creativeId).to.equal('');
       expect(responses[1].currency).to.equal('USD');
       expect(responses[1].height).to.equal(100);

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -411,7 +411,7 @@ describe('the spotx adapter', function () {
       expect(responses).to.be.an('array').with.length(2);
       expect(responses[0].cache_key).to.equal('cache123');
       expect(responses[0].channel_id).to.equal(12345);
-      expect(responses[0].adomain).to.equal(['abc.com']);
+      expect(responses[0].adomain[0]).to.equal('abc.com');
       expect(responses[0].cpm).to.equal(12);
       expect(responses[0].creativeId).to.equal(321);
       expect(responses[0].currency).to.equal('USD');
@@ -426,7 +426,7 @@ describe('the spotx adapter', function () {
       expect(responses[1].cache_key).to.equal('cache124');
       expect(responses[1].channel_id).to.equal(12345);
       expect(responses[1].cpm).to.equal(13);
-      expect(responses[1].adomain).to.equal(['def.com']);
+      expect(responses[1].adomain[0]).to.equal('def.com');
       expect(responses[1].creativeId).to.equal('');
       expect(responses[1].currency).to.equal('USD');
       expect(responses[1].height).to.equal(100);


### PR DESCRIPTION


<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

this puts the adomain key in the right spot, related to https://github.com/prebid/Prebid.js/pull/5358 and partially solves https://github.com/prebid/Prebid.js/issues/3115 for SpotX
