### PR TITLE
update endpoint used by id5IdSystem

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -1,13 +1,22 @@
 /**
  * This module adds ID5 to the User ID module
  * The {@link module:modules/userId} module is required
- * @module modules/unifiedIdSystem
+ * @module modules/id5IdSystem
  * @requires module:modules/userId
  */
 
 import * as utils from '../src/utils.js'
-import {ajax} from '../src/ajax.js';
-import {submodule} from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
+import { getRefererInfo } from '../src/refererDetection.js';
+import { getStorageManager } from '../src/storageManager.js';
+
+const MODULE_NAME = 'id5Id';
+const GVLID = 131;
+const BASE_NB_COOKIE_NAME = 'pbjs-id5id';
+const NB_COOKIE_EXP_DAYS = (30 * 24 * 60 * 60 * 1000); // 30 days
+
+const storage = getStorageManager(GVLID, MODULE_NAME);
 
 /** @type {Submodule} */
 export const id5IdSubmodule = {
@@ -16,11 +25,13 @@ export const id5IdSubmodule = {
    * @type {string}
    */
   name: 'id5Id',
+
   /**
    * Vendor id of ID5
    * @type {Number}
    */
-  gvlid: 131,
+  gvlid: GVLID,
+
   /**
    * decode the stored id value for passing to bid requests
    * @function decode
@@ -28,25 +39,46 @@ export const id5IdSubmodule = {
    * @returns {(Object|undefined)}
    */
   decode(value) {
-    return (value && typeof value['ID5ID'] === 'string') ? { 'id5id': value['ID5ID'] } : undefined;
+    if (value && typeof value.ID5ID === 'string') {
+      // don't lose our legacy value from cache
+      return { 'id5id': value.ID5ID };
+    } else if (value && typeof value.universal_uid === 'string') {
+      return { 'id5id': value.universal_uid };
+    } else {
+      return undefined;
+    }
   },
+
   /**
    * performs action to obtain id and return a value in the callback's response argument
-   * @function
+   * @function getId
    * @param {SubmoduleParams} [configParams]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
   getId(configParams, consentData, cacheIdObj) {
-    if (!configParams || typeof configParams.partner !== 'number') {
-      utils.logError(`User ID - ID5 submodule requires partner to be defined as a number`);
+    if (!hasRequiredParams(configParams)) {
       return undefined;
     }
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
-    const storedUserId = this.decode(cacheIdObj);
-    const url = `https://id5-sync.com/g/v1/${configParams.partner}.json?1puid=${storedUserId ? storedUserId.id5id : ''}&gdpr=${hasGdpr}&gdpr_consent=${gdprConsentString}`;
+    const url = `https://id5-sync.com/g/v2/${configParams.partner}.json?gdpr_consent=${gdprConsentString}&gdpr=${hasGdpr}`;
+    const referer = getRefererInfo();
+    const signature = (cacheIdObj && cacheIdObj.signature) ? cacheIdObj.signature : '';
+    const pubId = (cacheIdObj && cacheIdObj.ID5ID) ? cacheIdObj.ID5ID : ''; // TODO: remove when 1puid isn't needed
+    const data = {
+      'partner': configParams.partner,
+      '1puid': pubId, // TODO: remove when 1puid isn't needed
+      'nbPage': incrementNb(configParams),
+      'o': 'pbjs',
+      'pd': configParams.pd || '',
+      'rf': referer.referer,
+      's': signature,
+      'top': referer.reachedTop ? 1 : 0,
+      'u': referer.stack[0] || window.location.href,
+      'v': '$prebid.version$'
+    };
 
     const resp = function (callback) {
       const callbacks = {
@@ -55,6 +87,7 @@ export const id5IdSubmodule = {
           if (response) {
             try {
               responseObj = JSON.parse(response);
+              resetNb(configParams);
             } catch (error) {
               utils.logError(error);
             }
@@ -66,10 +99,54 @@ export const id5IdSubmodule = {
           callback();
         }
       };
-      ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
+      ajax(url, callbacks, JSON.stringify(data), { method: 'POST', withCredentials: true });
     };
     return {callback: resp};
+  },
+
+  /**
+   * Similar to Submodule#getId, this optional method returns response to for id that exists already.
+   *  If IdResponse#id is defined, then it will be written to the current active storage even if it exists already.
+   *  If IdResponse#callback is defined, then it'll called at the end of auction.
+   *  It's permissible to return neither, one, or both fields.
+   * @function extendId
+   * @param {SubmoduleParams} configParams
+   * @param {Object} cacheIdObj - existing id, if any
+   * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
+   */
+  extendId(configParams, cacheIdObj) {
+    incrementNb(configParams);
+    return cacheIdObj;
   }
 };
+
+function hasRequiredParams(configParams) {
+  if (!configParams || typeof configParams.partner !== 'number') {
+    utils.logError(`User ID - ID5 submodule requires partner to be defined as a number`);
+    return false;
+  }
+  return true;
+}
+function nbCookieName(configParams) {
+  return hasRequiredParams(configParams) ? `${BASE_NB_COOKIE_NAME}-${configParams.partner}-nb` : undefined;
+}
+function nbCookieExpStr(expDays) {
+  return (new Date(Date.now() + expDays)).toUTCString();
+}
+function storeNbInCookie(configParams, nb) {
+  storage.setCookie(nbCookieName(configParams), nb, nbCookieExpStr(NB_COOKIE_EXP_DAYS), 'Lax');
+}
+function getNbFromCookie(configParams) {
+  const cacheNb = storage.getCookie(nbCookieName(configParams));
+  return (cacheNb) ? parseInt(cacheNb) : 0;
+}
+function incrementNb(configParams) {
+  const nb = (getNbFromCookie(configParams) + 1);
+  storeNbInCookie(configParams, nb);
+  return nb;
+}
+function resetNb(configParams) {
+  storeNbInCookie(configParams, 0);
+}
 
 submodule('userId', id5IdSubmodule);

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -25,12 +25,13 @@ pbjs.setConfig({
         }, {
             name: "id5Id",
             params: {
-                partner: 173 //Set your real ID5 partner ID here for production, please ask for one at http://id5.io/prebid
+                partner: 173, //Set your real ID5 partner ID here for production, please ask for one at https://id5.io/universal-id
+                pd: "some-pd-string" // See https://console.id5.io/docs/public/prebid for details
             },
             storage: {
                 type: "cookie",
                 name: "id5id",
-                expires: 5, // Expiration of cookies in days
+                expires: 90, // Expiration of cookies in days
                 refreshInSeconds: 8*3600 // User Id cache lifetime in seconds, defaulting to 'expires'
             },
         }, {

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -1,0 +1,383 @@
+import { init, requestBidsHook, setSubmoduleRegistry, coreStorage } from 'modules/userId/index.js';
+import { config } from 'src/config.js';
+import { id5IdSubmodule } from 'modules/id5IdSystem.js';
+import { server } from 'test/mocks/xhr.js';
+import events from 'src/events.js';
+import CONSTANTS from 'src/constants.json';
+
+let expect = require('chai').expect;
+
+describe('ID5 ID System', function() {
+  const ID5_MODULE_NAME = 'id5Id';
+  const ID5_EIDS_NAME = ID5_MODULE_NAME.toLowerCase();
+  const ID5_SOURCE = 'id5-sync.com';
+  const ID5_PARTNER = 173;
+  const ID5_ENDPOINT = `https://id5-sync.com/g/v2/${ID5_PARTNER}.json`;
+  const ID5_COOKIE_NAME = 'id5idcookie';
+  const ID5_NB_COOKIE_NAME = `pbjs-id5id-${ID5_PARTNER}-nb`;
+  const ID5_EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
+  const ID5_STORED_ID = 'storedid5id';
+  const ID5_STORED_SIGNATURE = '123456';
+  const ID5_STORED_OBJ = {
+    'universal_uid': ID5_STORED_ID,
+    'signature': ID5_STORED_SIGNATURE
+  };
+  const ID5_LEGACY_STORED_OBJ = {
+    'ID5ID': ID5_STORED_ID
+  }
+  const ID5_RESPONSE_ID = 'newid5id';
+  const ID5_RESPONSE_SIGNATURE = 'abcdef';
+  const ID5_JSON_RESPONSE = {
+    'universal_uid': ID5_RESPONSE_ID,
+    'signature': ID5_RESPONSE_SIGNATURE,
+    'link_type': 0
+  };
+
+  function getId5FetchConfig(storageName = ID5_COOKIE_NAME, storageType = 'cookie') {
+    return {
+      name: ID5_MODULE_NAME,
+      params: {
+        partner: ID5_PARTNER
+      },
+      storage: {
+        name: storageName,
+        type: storageType,
+        expires: 90
+      }
+    }
+  }
+  function getId5ValueConfig(value) {
+    return {
+      name: ID5_MODULE_NAME,
+      value: {
+        id5id: value
+      }
+    }
+  }
+  function getUserSyncConfig(userIds) {
+    return {
+      userSync: {
+        userIds: userIds,
+        syncDelay: 0
+      }
+    }
+  }
+  function getFetchCookieConfig() {
+    return getUserSyncConfig([getId5FetchConfig()]);
+  }
+  function getFetchLocalStorageConfig() {
+    return getUserSyncConfig([getId5FetchConfig(ID5_COOKIE_NAME, 'html5')]);
+  }
+  function getValueConfig(value) {
+    return getUserSyncConfig([getId5ValueConfig(value)]);
+  }
+  function getAdUnitMock(code = 'adUnit-code') {
+    return {
+      code,
+      mediaTypes: {banner: {}, native: {}},
+      sizes: [[300, 200], [300, 600]],
+      bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}]
+    };
+  }
+
+  describe('Xhr Requests from getId()', function() {
+    const responseHeader = { 'Content-Type': 'application/json' };
+    let callbackSpy = sinon.spy();
+
+    beforeEach(function() {
+      callbackSpy.resetHistory();
+    });
+    afterEach(function () {
+
+    });
+
+    it('should fail if no partner is provided in the config', function() {
+      expect(id5IdSubmodule.getId()).to.be.eq(undefined);
+    });
+
+    it('should call the ID5 server with 1puid field for legacy storedObj format', function () {
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_LEGACY_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.s).to.eq('');
+      expect(requestBody.partner).to.eq(ID5_PARTNER);
+      expect(requestBody['1puid']).to.eq(ID5_STORED_ID);
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+    });
+
+    it('should call the ID5 server with signature field for new storedObj format', function () {
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
+      expect(requestBody.partner).to.eq(ID5_PARTNER);
+      expect(requestBody['1puid']).to.eq('');
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+    });
+
+    it('should call the ID5 server with pd field when pd config is set', function () {
+      const pubData = 'b50ca08271795a8e7e4012813f23d505193d75c0f2e2bb99baa63aa822f66ed3';
+
+      let config = getId5FetchConfig().params;
+      config.pd = pubData;
+
+      let submoduleCallback = id5IdSubmodule.getId(config, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
+      expect(requestBody.pd).to.eq(pubData);
+      expect(requestBody['1puid']).to.eq('');
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+    });
+
+    it('should call the ID5 server with empty pd field when pd config is not set', function () {
+      let config = getId5FetchConfig().params;
+      config.pd = undefined;
+
+      let submoduleCallback = id5IdSubmodule.getId(config, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.pd).to.eq('');
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+    });
+
+    it('should call the ID5 server with nb=1 when no stored value exists', function () {
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.nbPage).to.eq(1);
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('0');
+    });
+
+    it('should call the ID5 server with incremented nb when stored value exists', function () {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '1', expStr);
+
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(request.withCredentials).to.be.true;
+      expect(requestBody.nbPage).to.eq(2);
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('0');
+    });
+  });
+
+  describe('Request Bids Hook', function() {
+    let adUnits;
+
+    beforeEach(function() {
+      sinon.stub(events, 'getEvents').returns([]);
+      coreStorage.setCookie(ID5_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(`${ID5_COOKIE_NAME}_last`, '', ID5_EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+      adUnits = [getAdUnitMock()];
+    });
+    afterEach(function() {
+      events.getEvents.restore();
+      coreStorage.setCookie(ID5_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(`${ID5_COOKIE_NAME}_last`, '', ID5_EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+    });
+
+    it('should add stored ID from cookie to bids', function (done) {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_COOKIE_NAME, JSON.stringify(ID5_STORED_OBJ), expStr);
+
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(getFetchCookieConfig());
+
+      requestBidsHook(function () {
+        adUnits.forEach(unit => {
+          unit.bids.forEach(bid => {
+            expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
+            expect(bid.userId.id5id).to.equal(ID5_STORED_ID);
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: ID5_SOURCE,
+              uids: [{ id: ID5_STORED_ID, atype: 1 }]
+            });
+          });
+        });
+        done();
+      }, { adUnits });
+    });
+
+    it('should add config value ID to bids', function (done) {
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(getValueConfig(ID5_STORED_ID));
+
+      requestBidsHook(function () {
+        adUnits.forEach(unit => {
+          unit.bids.forEach(bid => {
+            expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
+            expect(bid.userId.id5id).to.equal(ID5_STORED_ID);
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: ID5_SOURCE,
+              uids: [{ id: ID5_STORED_ID, atype: 1 }]
+            });
+          });
+        });
+        done();
+      }, { adUnits });
+    });
+
+    it('should set nb=1 in cookie when no stored value exists', function () {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_COOKIE_NAME, JSON.stringify(ID5_STORED_OBJ), expStr);
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
+
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(getFetchCookieConfig());
+
+      let innerAdUnits;
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('1');
+    });
+
+    it('should increment nb in cookie when stored value exists', function () {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_COOKIE_NAME, JSON.stringify(ID5_STORED_OBJ), expStr);
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '1', expStr);
+
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(getFetchCookieConfig());
+
+      let innerAdUnits;
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('2');
+    });
+
+    it('should call ID5 servers with signature and incremented nb post auction if refresh needed', function () {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_COOKIE_NAME, JSON.stringify(ID5_STORED_OBJ), expStr);
+      coreStorage.setCookie(`${ID5_COOKIE_NAME}_last`, (new Date(Date.now() - 50000).toUTCString()), expStr);
+      coreStorage.setCookie(ID5_NB_COOKIE_NAME, '1', expStr);
+
+      let id5Config = getFetchCookieConfig();
+      id5Config.userSync.userIds[0].storage.refreshInSeconds = 2;
+
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(id5Config);
+
+      let innerAdUnits;
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('2');
+
+      expect(server.requests).to.be.empty;
+      events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
+      expect(requestBody.nbPage).to.eq(2);
+
+      const responseHeader = { 'Content-Type': 'application/json' };
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+
+      expect(coreStorage.getCookie(ID5_COOKIE_NAME)).to.be.eq(JSON.stringify(ID5_JSON_RESPONSE));
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('0');
+    });
+
+    it('should call ID5 servers with 1puid and nb=1 post auction if refresh needed for legacy stored object', function () {
+      let expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(ID5_COOKIE_NAME, JSON.stringify(ID5_LEGACY_STORED_OBJ), expStr);
+      coreStorage.setCookie(`${ID5_COOKIE_NAME}_last`, (new Date(Date.now() - 50000).toUTCString()), expStr);
+
+      let id5Config = getFetchCookieConfig();
+      id5Config.userSync.userIds[0].storage.refreshInSeconds = 2;
+
+      setSubmoduleRegistry([id5IdSubmodule]);
+      init(config);
+      config.setConfig(id5Config);
+
+      let innerAdUnits;
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('1');
+
+      expect(server.requests).to.be.empty;
+      events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(request.url).to.contain(ID5_ENDPOINT);
+      expect(requestBody['1puid']).to.eq(ID5_STORED_ID);
+      expect(requestBody.nbPage).to.eq(1);
+
+      const responseHeader = { 'Content-Type': 'application/json' };
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+
+      expect(coreStorage.getCookie(ID5_COOKIE_NAME)).to.be.eq(JSON.stringify(ID5_JSON_RESPONSE));
+      expect(coreStorage.getCookie(ID5_NB_COOKIE_NAME)).to.be.eq('0');
+    });
+  });
+
+  describe('Decode stored object', function() {
+    const decodedObject = { 'id5id': ID5_STORED_ID };
+
+    it('should properly decode from a stored object', function() {
+      expect(id5IdSubmodule.decode(ID5_STORED_OBJ)).to.deep.equal(decodedObject);
+    });
+    it('should properly decode from a legacy stored object', function() {
+      expect(id5IdSubmodule.decode(ID5_LEGACY_STORED_OBJ)).to.deep.equal(decodedObject);
+    });
+    it('should return undefined if passed a string', function() {
+      expect(id5IdSubmodule.decode('somestring')).to.eq(undefined);
+    });
+  });
+});

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -971,54 +971,6 @@ describe('User ID', function() {
         done();
       }, {adUnits});
     });
-    it('test hook from id5id cookies when refresh needed', function(done) {
-      // simulate existing browser local storage values
-      coreStorage.setCookie('id5id', JSON.stringify({'ID5ID': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
-      coreStorage.setCookie('id5id_last', (new Date(Date.now() - 7200 * 1000)).toUTCString(), (new Date(Date.now() + 5000).toUTCString()));
-
-      sinon.stub(utils, 'logError'); // getId should failed with a logError as it has no partnerId
-
-      setSubmoduleRegistry([id5IdSubmodule]);
-      init(config);
-      config.setConfig(getConfigMock(['id5Id', 'id5id', 'cookie', 10, 3600]));
-
-      requestBidsHook(function() {
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.id5id');
-            expect(bid.userId.id5id).to.equal('testid5id');
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'id5-sync.com',
-              uids: [{id: 'testid5id', atype: 1}]
-            });
-          });
-        });
-        sinon.assert.calledOnce(utils.logError);
-        coreStorage.setCookie('id5id', '', EXPIRED_COOKIE_DATE);
-        utils.logError.restore();
-        done();
-      }, {adUnits});
-    });
-
-    it('test hook from id5id value-based config', function(done) {
-      setSubmoduleRegistry([id5IdSubmodule]);
-      init(config);
-      config.setConfig(getConfigValueMock('id5Id', {'id5id': 'testid5id'}));
-
-      requestBidsHook(function() {
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.id5id');
-            expect(bid.userId.id5id).to.equal('testid5id');
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'id5-sync.com',
-              uids: [{id: 'testid5id', atype: 1}]
-            });
-          });
-        });
-        done();
-      }, {adUnits});
-    });
 
     it('test hook from liveIntentId html5', function(done) {
       // simulate existing browser local storage values
@@ -1126,7 +1078,7 @@ describe('User ID', function() {
     it('test hook when pubCommonId, unifiedId, id5Id, identityLink, britepoolId, netId and sharedId have data to pass', function(done) {
       coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('unifiedid', JSON.stringify({'TDID': 'testunifiedid'}), (new Date(Date.now() + 5000).toUTCString()));
-      coreStorage.setCookie('id5id', JSON.stringify({'ID5ID': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
+      coreStorage.setCookie('id5id', JSON.stringify({'universal_uid': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('idl_env', 'AiGNC8Z5ONyZKSpIPf', (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('britepoolid', JSON.stringify({'primaryBPID': 'testbritepoolid'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('netId', JSON.stringify({'netId': 'testnetId'}), (new Date(Date.now() + 5000).toUTCString()));
@@ -1203,7 +1155,7 @@ describe('User ID', function() {
     it('test hook when pubCommonId, unifiedId, id5Id, britepoolId, netId and sharedId have their modules added before and after init', function(done) {
       coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('unifiedid', JSON.stringify({'TDID': 'cookie-value-add-module-variations'}), new Date(Date.now() + 5000).toUTCString());
-      coreStorage.setCookie('id5id', JSON.stringify({'ID5ID': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
+      coreStorage.setCookie('id5id', JSON.stringify({'universal_uid': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('idl_env', 'AiGNC8Z5ONyZKSpIPf', new Date(Date.now() + 5000).toUTCString());
       coreStorage.setCookie('britepoolid', JSON.stringify({'primaryBPID': 'testbritepoolid'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('netId', JSON.stringify({'netId': 'testnetId'}), (new Date(Date.now() + 5000).toUTCString()));
@@ -1296,7 +1248,7 @@ describe('User ID', function() {
     it('should add new id system ', function(done) {
       coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('unifiedid', JSON.stringify({'TDID': 'cookie-value-add-module-variations'}), new Date(Date.now() + 5000).toUTCString());
-      coreStorage.setCookie('id5id', JSON.stringify({'ID5ID': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
+      coreStorage.setCookie('id5id', JSON.stringify({'universal_uid': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('idl_env', 'AiGNC8Z5ONyZKSpIPf', new Date(Date.now() + 5000).toUTCString());
       coreStorage.setCookie('britepoolid', JSON.stringify({'primaryBPID': 'testbritepoolid'}), (new Date(Date.now() + 5000).toUTCString()));
       coreStorage.setCookie('netId', JSON.stringify({'netId': 'testnetId'}), new Date(Date.now() + 5000).toUTCString());


### PR DESCRIPTION
## Type of change
- [X] Feature
- [X] Code style update (formatting, local variables)
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Updated the endpoint used by the ID5 ID system to allow publishers to provide publisher data, such as for authenticated users, to strengthen the Universal ID provided. 

Stored response object changed structure a bit with new variable names, updated relevant code to pull the new values.

Moved the majority of testing out of userId_spec and into a standalone test file, added code coverage as well.

- contact email of the adapter’s maintainer
scott@id5.io

## Docs
- https://github.com/prebid/prebid.github.io/pull/2078
