### PR TITLE
LiveIntentId submodule updates

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -189,6 +189,16 @@
                         name: "sharedid",
                         expires: 28
                       }
+                    }, {
+                      name: "liveIntentId",
+                      params: {
+                        publisherId: "9896876"
+                      },
+                      storage: {
+                        type: "cookie",
+                        name: "_li_pbid",
+                        expires: 28
+                      }
                     }],
                     syncDelay: 5000,
                     auctionDelay: 1000

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -48,11 +48,12 @@ function parseLiveIntentCollectorConfig(collectConfig) {
 }
 
 function initializeLiveConnect(configParams) {
+  configParams = configParams || {};
   if (liveConnect) {
     return liveConnect;
   }
 
-  const publisherId = (configParams && configParams.publisherId) || 'any';
+  const publisherId = configParams.publisherId || 'any';
   const identityResolutionConfig = {
     source: 'prebid',
     publisherId: publisherId
@@ -109,10 +110,10 @@ export const liveIntentIdSubmodule = {
       return { 'lipb': { ...base, ...value } };
     }
 
-    if (configParams) {
-      initializeLiveConnect(configParams || {});
-      tryFireEvent();
+    if (!liveConnect) {
+      initializeLiveConnect(configParams);
     }
+    tryFireEvent();
 
     return (value && typeof value['unifiedId'] === 'string') ? composeIdObject(value) : undefined;
   },

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -54,7 +54,7 @@ function initializeLiveConnect(configParams) {
 
   const publisherId = configParams && configParams.publisherId;
   if (!publisherId && typeof publisherId !== 'string') {
-    utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}' - ${JSON.stringify(configParams)}`);
+    utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}'`);
     return;
   }
 

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -21,6 +21,9 @@ let liveConnect = null;
  * This function is used in tests
  */
 export function reset() {
+  if (window && window.liQ) {
+    window.liQ = [];
+  }
   eventFired = false;
   liveConnect = null;
 }
@@ -51,7 +54,7 @@ function initializeLiveConnect(configParams) {
 
   const publisherId = configParams && configParams.publisherId;
   if (!publisherId && typeof publisherId !== 'string') {
-    utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}'`);
+    utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}' - ${JSON.stringify(configParams)}`);
     return;
   }
 
@@ -76,9 +79,6 @@ function initializeLiveConnect(configParams) {
   liveConnectConfig.wrapperName = 'prebid';
   liveConnectConfig.identityResolutionConfig = identityResolutionConfig;
   liveConnectConfig.identifiersToResolve = configParams.identifiersToResolve || [];
-  if (configParams.providedIdentifierName) {
-    liveConnectConfig.providedIdentifierName = configParams.providedIdentifierName;
-  }
   const usPrivacyString = uspDataHandler.getConsentData();
   if (usPrivacyString) {
     liveConnectConfig.usPrivacyString = usPrivacyString;

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -68,12 +68,6 @@ function initializeLiveConnect(configParams) {
   if (configParams.partner) {
     identityResolutionConfig.source = configParams.partner
   }
-  if (configParams.storage && configParams.storage.expires) {
-    identityResolutionConfig.expirationDays = configParams.storage.expires;
-  }
-  if (configParams.ajaxTimeout) {
-    identityResolutionConfig.ajaxTimeout = configParams.ajaxTimeout;
-  }
 
   const liveConnectConfig = parseLiveIntentCollectorConfig(configParams.liCollectConfig);
   liveConnectConfig.wrapperName = 'prebid';

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -52,12 +52,7 @@ function initializeLiveConnect(configParams) {
     return liveConnect;
   }
 
-  const publisherId = configParams && configParams.publisherId;
-  if (!publisherId && typeof publisherId !== 'string') {
-    utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}'`);
-    return;
-  }
-
+  const publisherId = (configParams && configParams.publisherId) || 'any';
   const identityResolutionConfig = {
     source: 'prebid',
     publisherId: publisherId
@@ -115,7 +110,7 @@ export const liveIntentIdSubmodule = {
     }
 
     if (configParams) {
-      initializeLiveConnect(configParams);
+      initializeLiveConnect(configParams || {});
       tryFireEvent();
     }
 

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -449,7 +449,7 @@ function initSubmodules(submodules, consentData) {
 
       if (storedId) {
         // cache decoded value (this is copied to every adUnit bid)
-        submodule.idObj = submodule.submodule.decode(storedId, submodule.config);
+        submodule.idObj = submodule.submodule.decode(storedId, submodule.config.params);
       }
     } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
@@ -458,7 +458,7 @@ function initSubmodules(submodules, consentData) {
       const response = submodule.submodule.getId(submodule.config.params, consentData, undefined);
       if (utils.isPlainObject(response)) {
         if (typeof response.callback === 'function') { submodule.callback = response.callback; }
-        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config); }
+        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config.params); }
       }
     }
     carry.push(submodule);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.23.0-pre",
+  "version": "3.24.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15211,15 +15211,14 @@
       "dev": true
     },
     "live-connect-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-1.1.1.tgz",
-      "integrity": "sha512-PsYiZ6R6ecBQgcg3BWvzGf2TNOqpNFK1lUyfYAUEZ+DPwPciKNRM3CQIDtytVvR9vsH7nhotMaU3bBgb7iuPfQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-1.1.10.tgz",
+      "integrity": "sha512-G/LJKN3b21DZILCQRyataC/znLvJRyogtu7mAkKlkhP9B9UJ8bcOL7ihW/clD2PsT4hVUkeabHhUGsPCmhsjFw==",
       "requires": {
         "@kiosked/ulid": "^3.0.0",
-        "abab": "^2.0.2",
+        "abab": "^2.0.3",
         "browser-cookies": "^1.2.0",
-        "tiny-hashes": "1.0.1",
-        "tiny-uuid4": "^1.0.1"
+        "tiny-hashes": "1.0.1"
       }
     },
     "livereload-js": {
@@ -20778,11 +20777,6 @@
           "dev": true
         }
       }
-    },
-    "tiny-uuid4": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-uuid4/-/tiny-uuid4-1.0.1.tgz",
-      "integrity": "sha1-vUTp3V9fvRdo1tH78wIMiGobd2Y="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "fun-hooks": "^0.9.9",
     "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2",
-    "live-connect-js": "1.1.1"
+    "live-connect-js": "1.1.10"
   }
 }

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -33,21 +33,6 @@ describe('LiveIntentId', function () {
     resetLiveIntentIdSubmodule();
   });
 
-  it('should log an error if no configParams were passed when getId', function () {
-    liveIntentIdSubmodule.getId();
-    expect(logErrorStub.calledOnce).to.be.true;
-  });
-
-  it('should log an error if publisherId configParam was not passed when getId', function () {
-    liveIntentIdSubmodule.getId({});
-    expect(logErrorStub.calledOnce).to.be.true;
-  });
-
-  it('should log an error if publisherId configParam was not passed when decode', function () {
-    liveIntentIdSubmodule.decode({}, {});
-    expect(logErrorStub.calledOnce).to.be.true;
-  });
-
   it('should initialize LiveConnect with a us privacy string when getId, and include it in all requests', function () {
     consentDataStub.returns('1YNY');
     let callBackSpy = sinon.spy();


### PR DESCRIPTION
## Type of change

- [X] Bugfix
- [X] Feature
- [X] Refactoring (no functional changes, no api changes)
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?


## Description of change
Bumped the live-connect-js version with changes:
- fixed the problem where userId/index.js was sending the full config on `decode`, while the docs claim it should only send `.params`
- removed the uuid lib(smaller code)
- removed the support for legacy LI first party cookies(less storage interactions)
- removed the redundant config parameter `providedIdentifierName`(reduced the config params list)
- support for running live-connect inside of multiple wrappers

- A link to a PR on the docs repo:https://github.com/prebid/prebid.github.io/pull/2079

