### PR TITLE
Make default s2s ttl configurable

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -832,8 +832,8 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.currency = (response.cur) ? response.cur : DEFAULT_S2S_CURRENCY;
 
           // TODO: Remove when prebid-server returns ttl and netRevenue
-          const config_ttl = _s2sConfig.defaultS2sTtl || DEFAULT_S2S_TTL;
-          bidObject.ttl = (bid.ttl) ? bid.ttl : config_ttl;
+          const configTtl = _s2sConfig.defaultS2sTtl || DEFAULT_S2S_TTL;
+          bidObject.ttl = (bid.ttl) ? bid.ttl : configTtl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 
           bids.push({ adUnit: bid.impid, bid: bidObject });

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -832,7 +832,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.currency = (response.cur) ? response.cur : DEFAULT_S2S_CURRENCY;
 
           // TODO: Remove when prebid-server returns ttl and netRevenue
-          const config_ttl = _s2sConfig.default_s2s_ttl || DEFAULT_S2S_TTL;
+          const config_ttl = _s2sConfig.defaultS2sTtl || DEFAULT_S2S_TTL;
           bidObject.ttl = (bid.ttl) ? bid.ttl : config_ttl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -18,6 +18,7 @@ const getConfig = config.getConfig;
 const TYPE = S2S.SRC;
 let _synced = false;
 const DEFAULT_S2S_CURRENCY = 'USD';
+const DEFAULT_S2S_TTL = 60;
 const DEFAULT_S2S_NETREVENUE = true;
 
 let _s2sConfig;
@@ -109,8 +110,6 @@ function setS2sConfig(options) {
   _s2sConfig = options;
 }
 getConfig('s2sConfig', ({s2sConfig}) => setS2sConfig(s2sConfig));
-
-let DEFAULT_S2S_TTL = _s2sConfig.default_s2s_ttl || 60;
 
 /**
  * resets the _synced variable back to false, primiarily used for testing purposes
@@ -833,7 +832,8 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.currency = (response.cur) ? response.cur : DEFAULT_S2S_CURRENCY;
 
           // TODO: Remove when prebid-server returns ttl and netRevenue
-          bidObject.ttl = (bid.ttl) ? bid.ttl : DEFAULT_S2S_TTL;
+          let config_ttl = _s2sConfig.default_s2s_ttl || DEFAULT_S2S_TTL;
+          bidObject.ttl = (bid.ttl) ? bid.ttl : config_ttl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 
           bids.push({ adUnit: bid.impid, bid: bidObject });

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -832,7 +832,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.currency = (response.cur) ? response.cur : DEFAULT_S2S_CURRENCY;
 
           // TODO: Remove when prebid-server returns ttl and netRevenue
-          const configTtl = _s2sConfig.defaultS2sTtl || DEFAULT_S2S_TTL;
+          const configTtl = _s2sConfig.defaultTtl || DEFAULT_S2S_TTL;
           bidObject.ttl = (bid.ttl) ? bid.ttl : configTtl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -17,7 +17,6 @@ const getConfig = config.getConfig;
 
 const TYPE = S2S.SRC;
 let _synced = false;
-const DEFAULT_S2S_TTL = pbjs_config.getConfig('defaultS2STTL') || 60;
 const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_NETREVENUE = true;
 
@@ -110,6 +109,8 @@ function setS2sConfig(options) {
   _s2sConfig = options;
 }
 getConfig('s2sConfig', ({s2sConfig}) => setS2sConfig(s2sConfig));
+
+let DEFAULT_S2S_TTL = _s2sConfig.default_s2s_ttl || 60;
 
 /**
  * resets the _synced variable back to false, primiarily used for testing purposes

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -17,7 +17,7 @@ const getConfig = config.getConfig;
 
 const TYPE = S2S.SRC;
 let _synced = false;
-const DEFAULT_S2S_TTL = 60;
+const DEFAULT_S2S_TTL = pbjs_config.getConfig('defaultS2STTL') || 60;
 const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_NETREVENUE = true;
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -17,8 +17,8 @@ const getConfig = config.getConfig;
 
 const TYPE = S2S.SRC;
 let _synced = false;
-const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_TTL = 60;
+const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_NETREVENUE = true;
 
 let _s2sConfig;
@@ -832,7 +832,7 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.currency = (response.cur) ? response.cur : DEFAULT_S2S_CURRENCY;
 
           // TODO: Remove when prebid-server returns ttl and netRevenue
-          let config_ttl = _s2sConfig.default_s2s_ttl || DEFAULT_S2S_TTL;
+          const config_ttl = _s2sConfig.default_s2s_ttl || DEFAULT_S2S_TTL;
           bidObject.ttl = (bid.ttl) ? bid.ttl : config_ttl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -71,6 +71,7 @@ config.setDefaults({
  * @property {string} endpoint endpoint to contact
  *  === optional params below ===
  * @property {number} [timeout] timeout for S2S bidders - should be lower than `pbjs.requestBids({timeout})`
+ * @property {number} [defaultTtl] ttl for S2S bidders when pbs does not return a ttl on the response - defaults to 60`
  * @property {boolean} [cacheMarkup] whether to cache the adm result
  * @property {string} [adapter] adapter code to use for S2S
  * @property {string} [syncEndpoint] endpoint URL for syncing cookies

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1704,8 +1704,7 @@ describe('S2S Adapter', function () {
       expect(response).to.not.have.property('videoCacheKey');
       expect(response).to.have.property('ttl', 60);
     });
-    
-    
+
     it('respects defaultS2sTtl', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2158,10 +2158,10 @@ describe('S2S Adapter', function () {
     it('should set default s2s ttl', function () {
       config.setConfig({
         s2sConfig: {
-          default_s2s_ttl: 30
+          defaultS2sTtl: 30
         }
       });
-      expect(config.getConfig('s2sConfig').default_s2s_ttl).to.deep.equal(30)
+      expect(config.getConfig('s2sConfig').defaultS2sTtl).to.deep.equal(30)
     });
 
     it('should set syncUrlModifier', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2179,7 +2179,7 @@ describe('S2S Adapter', function () {
           defaultTtl: 30
         }
       });
-      expect(config.getConfig('s2sConfig').defaultS2sTtl).to.deep.equal(30);
+      expect(config.getConfig('s2sConfig').defaultTtl).to.deep.equal(30);
     });
 
     it('should set syncUrlModifier', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2160,7 +2160,6 @@ describe('S2S Adapter', function () {
         s2sConfig: {
           default_s2s_ttl: 30
           }
-        }
       });
       expect(config.getConfig('s2sConfig').default_s2s_ttl).to.deep.equal(30)
     });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1702,7 +1702,7 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('cpm', 0.5);
       expect(response).to.not.have.property('vastUrl');
       expect(response).to.not.have.property('videoCacheKey');
-      expect(response).to.have.property('ttl', '60');
+      expect(response).to.have.property('ttl', 60);
     });
     
     
@@ -1718,12 +1718,9 @@ describe('S2S Adapter', function () {
 
       sinon.assert.calledOnce(events.emit);
       const event = events.emit.firstCall.args;
-      expect(event[0]).to.equal(CONSTANTS.EVENTS.BIDDER_DONE);
-      expect(event[1].bids[0]).to.have.property('serverResponseTimeMs', 8);
-
       sinon.assert.calledOnce(addBidResponse);
       const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('ttl', '30');
+      expect(response).to.have.property('ttl', 30);
     });
 
     it('handles OpenRTB video responses', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2155,6 +2155,16 @@ describe('S2S Adapter', function () {
       })
     });
 
+    it('should set default s2s ttl', function () {
+      config.setConfig({
+        s2sConfig: {
+          default_s2s_ttl: 30
+          }
+        }
+      });
+      expect(config.getConfig('s2sConfig').default_s2s_ttl).to.deep.equal(30)
+    });
+
     it('should set syncUrlModifier', function () {
       config.setConfig({
         s2sConfig: {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1702,6 +1702,28 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('cpm', 0.5);
       expect(response).to.not.have.property('vastUrl');
       expect(response).to.not.have.property('videoCacheKey');
+      expect(response).to.have.property('ttl', '60');
+    });
+    
+    
+    it('respects defaultS2sTtl', function () {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+        defaultS2sTtl: 30
+      });
+      config.setConfig({ s2sConfig });
+
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      server.requests[0].respond(200, {}, JSON.stringify(RESPONSE_OPENRTB));
+
+      sinon.assert.calledOnce(events.emit);
+      const event = events.emit.firstCall.args;
+      expect(event[0]).to.equal(CONSTANTS.EVENTS.BIDDER_DONE);
+      expect(event[1].bids[0]).to.have.property('serverResponseTimeMs', 8);
+
+      sinon.assert.calledOnce(addBidResponse);
+      const response = addBidResponse.firstCall.args[1];
+      expect(response).to.have.property('ttl', '30');
     });
 
     it('handles OpenRTB video responses', function () {
@@ -2161,7 +2183,7 @@ describe('S2S Adapter', function () {
           defaultS2sTtl: 30
         }
       });
-      expect(config.getConfig('s2sConfig').defaultS2sTtl).to.deep.equal(30)
+      expect(config.getConfig('s2sConfig').defaultS2sTtl).to.deep.equal(30);
     });
 
     it('should set syncUrlModifier', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2159,7 +2159,7 @@ describe('S2S Adapter', function () {
       config.setConfig({
         s2sConfig: {
           default_s2s_ttl: 30
-          }
+        }
       });
       expect(config.getConfig('s2sConfig').default_s2s_ttl).to.deep.equal(30)
     });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1705,10 +1705,10 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('ttl', 60);
     });
 
-    it('respects defaultS2sTtl', function () {
+    it('respects defaultTtl', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
-        defaultS2sTtl: 30
+        defaultTtl: 30
       });
       config.setConfig({ s2sConfig });
 
@@ -2176,7 +2176,7 @@ describe('S2S Adapter', function () {
     it('should set default s2s ttl', function () {
       config.setConfig({
         s2sConfig: {
-          defaultS2sTtl: 30
+          defaultTtl: 30
         }
       });
       expect(config.getConfig('s2sConfig').defaultS2sTtl).to.deep.equal(30);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Makes the default s2s timeout configurable

## Other information
related to  https://github.com/prebid/prebid-server/issues/237