### PR TITLE
ozone 2.4.0 adapter updates

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -4,19 +4,21 @@ import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {getPriceBucketString} from '../src/cpmBucketManager.js';
 import { Renderer } from '../src/Renderer.js';
-
 const BIDDER_CODE = 'ozone';
 const ALLOWED_LOTAME_PARAMS = ['oz_lotameid', 'oz_lotamepid', 'oz_lotametpid'];
+
+// *** PROD ***
 const OZONEURI = 'https://elb.the-ozone-project.com/openrtb2/auction';
 const OZONECOOKIESYNC = 'https://elb.the-ozone-project.com/static/load-cookie.html';
 const OZONE_RENDERER_URL = 'https://prebid.the-ozone-project.com/ozone-renderer.js';
 
-const OZONEVERSION = '2.3.0';
-
+const OZONEVERSION = '2.4.0';
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
   cookieSyncBag: {'publisherId': null, 'siteId': null, 'userIdObject': {}}, // variables we want to make available to cookie sync
+  propertyBag: {'lotameWasOverridden': 0, 'pageId': null, 'buildRequestsStart': 0, 'buildRequestsEnd': 0}, /* allow us to store vars in instance scope - needs to be an object to be mutable */
+
   /**
    * Basic check to see whether required parameters are in the request.
    * @param bid
@@ -80,13 +82,11 @@ export const spec = {
     }
     if (bid.hasOwnProperty('mediaTypes') && bid.mediaTypes.hasOwnProperty(VIDEO)) {
       if (!bid.mediaTypes[VIDEO].hasOwnProperty('context')) {
-        utils.logError('OZONE: No context key/value in bid. Rejecting bid: ', bid);
+        utils.logError('OZONE: No video context key/value in bid. Rejecting bid: ', bid);
         return false;
       }
-      if (bid.mediaTypes[VIDEO].context === 'instream') {
-        utils.logWarn('OZONE: video.context instream is not supported. Only outstream video is supported. Video will not be used for Bid: ', bid);
-      } else if (bid.mediaTypes.video.context !== 'outstream') {
-        utils.logError('OZONE: video.context is invalid. Only outstream video is supported. Rejecting bid: ', bid);
+      if (bid.mediaTypes[VIDEO].context !== 'instream' && bid.mediaTypes[VIDEO].context !== 'outstream') {
+        utils.logError('OZONE: video.context is invalid. Only instream/outstream video is supported. Rejecting bid: ', bid);
         return false;
       }
     }
@@ -119,9 +119,10 @@ export const spec = {
   },
 
   buildRequests(validBidRequests, bidderRequest) {
-    utils.logInfo('OZONE: ozone v' + OZONEVERSION + ' validBidRequests', validBidRequests, 'bidderRequest', bidderRequest);
+    this.propertyBag.buildRequestsStart = new Date().getTime();
+    utils.logInfo(`OZONE: buildRequests time: ${this.propertyBag.buildRequestsStart} ozone v ${OZONEVERSION} validBidRequests`, validBidRequests, 'bidderRequest', bidderRequest);
     // First check - is there any config to block this request?
-    if (this.blockTheRequest(bidderRequest)) {
+    if (this.blockTheRequest()) {
       return [];
     }
     let htmlParams = {'publisherId': '', 'siteId': ''};
@@ -140,14 +141,13 @@ export const spec = {
 
     if (bidderRequest && bidderRequest.gdprConsent) {
       utils.logInfo('OZONE: ADDING GDPR info');
-      ozoneRequest.regs = {};
-      ozoneRequest.regs.ext = {}; // setting default values in case there is no additional information, like for the Mirror
-      ozoneRequest.regs.ext.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+      let apiVersion = utils.deepAccess(bidderRequest.gdprConsent, 'apiVersion', '1');
+      ozoneRequest.regs = {ext: {gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0, apiVersion: apiVersion}};
       if (ozoneRequest.regs.ext.gdpr) {
         ozoneRequest.user = ozoneRequest.user || {};
         ozoneRequest.user.ext = {'consent': bidderRequest.gdprConsent.consentString};
       } else {
-        utils.logInfo('OZONE: **** Failed to find required info for GDPR for request object, even though bidderRequest.gdprConsent is TRUE ****');
+        utils.logInfo('OZONE: **** Strange CMP info: bidderRequest.gdprConsent exists BUT bidderRequest.gdprConsent.gdprApplies is false. See bidderRequest logged above. ****');
       }
     } else {
       utils.logInfo('OZONE: WILL NOT ADD GDPR info; no bidderRequest.gdprConsent object was present.');
@@ -156,8 +156,8 @@ export const spec = {
     const ozTestMode = getParams.hasOwnProperty('oztestmode') ? getParams.oztestmode : null; // this can be any string, it's used for testing ads
     ozoneRequest.device = {'w': window.innerWidth, 'h': window.innerHeight};
     let placementIdOverrideFromGetParam = this.getPlacementIdOverrideFromGetParam(); // null or string
-    let arrLotameOverride = this.getLotameOverrideParams();
-    let lotameIdsOverride = 0;
+    let lotameDataSingle = {}; // we will capture lotame data once & send it to the server as ext.ozone.lotameData
+    // build the array of params to attach to `imp`
     let tosendtags = validBidRequests.map(ozoneBidRequest => {
       var obj = {};
       let placementId = placementIdOverrideFromGetParam || this.getPlacementId(ozoneBidRequest); // prefer to use a valid override param, else the bidRequest placement Id
@@ -178,8 +178,14 @@ export const spec = {
           arrBannerSizes = ozoneBidRequest.mediaTypes[BANNER].sizes; /* Note - if there is a sizes element in the config root it will be pushed into here */
           utils.logInfo('OZONE: setting banner size from the mediaTypes.banner element for bidId ' + obj.id + ': ', arrBannerSizes);
         }
-        if (ozoneBidRequest.mediaTypes.hasOwnProperty(VIDEO) && ozoneBidRequest.mediaTypes[VIDEO].context === 'outstream') {
-          obj.video = ozoneBidRequest.mediaTypes[VIDEO];
+        if (ozoneBidRequest.mediaTypes.hasOwnProperty(VIDEO)) {
+          utils.logInfo('OZONE: openrtb 2.5 compliant video');
+          // examine all the video attributes in the config, and either put them into obj.video if allowed by IAB2.5 or else in to obj.video.ext
+          if (typeof ozoneBidRequest.mediaTypes[VIDEO] == 'object') {
+            let childConfig = utils.deepAccess(ozoneBidRequest, 'params.video', {});
+            obj.video = this.unpackVideoConfigIntoIABformat(ozoneBidRequest.mediaTypes[VIDEO], childConfig);
+            obj.video = this.addVideoDefaults(obj.video, ozoneBidRequest.mediaTypes[VIDEO], childConfig);
+          }
           // we need to duplicate some of the video values
           let wh = getWidthAndHeightFromVideoObject(obj.video);
           utils.logInfo('OZONE: setting video object from the mediaTypes.video element: ' + obj.id + ':', obj.video, 'wh=', wh);
@@ -188,13 +194,13 @@ export const spec = {
             obj.video.h = wh['h'];
             if (playerSizeIsNestedArray(obj.video)) { // this should never happen; it was in the original spec for this change though.
               utils.logInfo('OZONE: setting obj.video.format to be an array of objects');
-              obj.video.format = [wh];
+              obj.video.ext.format = [wh];
             } else {
               utils.logInfo('OZONE: setting obj.video.format to be an object');
-              obj.video.format = wh;
+              obj.video.ext.format = wh;
             }
           } else {
-            utils.logInfo('OZONE: cannot set w, h & format values for video; the config is not right');
+            utils.logWarn('OZONE: cannot set w, h & format values for video; the config is not right');
           }
         }
         // Native integration is not complete yet
@@ -223,9 +229,9 @@ export const spec = {
       if (ozoneBidRequest.params.hasOwnProperty('customData')) {
         obj.ext.ozone.customData = ozoneBidRequest.params.customData;
       }
-      utils.logInfo('obj.ext.ozone is ', obj.ext.ozone);
+      utils.logInfo('OZONE: obj.ext.ozone is ', obj.ext.ozone);
       if (ozTestMode != null) {
-        utils.logInfo('setting ozTestMode to ', ozTestMode);
+        utils.logInfo('OZONE: setting ozTestMode to ', ozTestMode);
         if (obj.ext.ozone.hasOwnProperty('customData')) {
           for (let i = 0; i < obj.ext.ozone.customData.length; i++) {
             obj.ext.ozone.customData[i]['targeting']['oztestmode'] = ozTestMode;
@@ -234,38 +240,35 @@ export const spec = {
           obj.ext.ozone.customData = [{'settings': {}, 'targeting': {'oztestmode': ozTestMode}}];
         }
       } else {
-        utils.logInfo('no ozTestMode ');
+        utils.logInfo('OZONE: no ozTestMode ');
       }
       // now deal with lotame, including the optional override parameters
-      if (Object.keys(arrLotameOverride).length === ALLOWED_LOTAME_PARAMS.length) {
-        // all override params are present, override lotame object:
-        if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
-          obj.ext.ozone.lotameData = this.makeLotameObjectFromOverride(arrLotameOverride, ozoneBidRequest.params.lotameData);
-        } else {
-          obj.ext.ozone.lotameData = this.makeLotameObjectFromOverride(arrLotameOverride, {});
-        }
-        lotameIdsOverride = 1;
-      } else if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
-        // no lotame override, use it as-is
-        if (this.isLotameDataValid(ozoneBidRequest.params.lotameData)) {
-          obj.ext.ozone.lotameData = ozoneBidRequest.params.lotameData;
-        } else {
-          utils.logError('INVALID LOTAME DATA FOUND - WILL NOT USE THIS AT ALL ELSE IT MIGHT BREAK THE AUCTION CALL!', ozoneBidRequest.params.lotameData);
-          obj.ext.ozone.lotameData = {};
-        }
+      if (Object.keys(lotameDataSingle).length === 0) { // we've not yet found lotameData, see if we can get it from this bid request object
+        lotameDataSingle = this.tryGetLotameData(ozoneBidRequest);
       }
-      // otherwise don't set obj.ext.ozone.lotameData
       return obj;
     });
 
     // in v 2.0.0 we moved these outside of the individual ad slots
-    let extObj = {'ozone': {'oz_pb_v': OZONEVERSION, 'oz_rw': placementIdOverrideFromGetParam ? 1 : 0, 'oz_lot_rw': lotameIdsOverride}};
+    let extObj = {'ozone': {'oz_pb_v': OZONEVERSION, 'oz_rw': placementIdOverrideFromGetParam ? 1 : 0, 'oz_lot_rw': this.propertyBag.lotameWasOverridden}};
     if (validBidRequests.length > 0) {
       let userIds = this.findAllUserIds(validBidRequests[0]);
       if (userIds.hasOwnProperty('pubcid')) {
         extObj.ozone.pubcid = userIds.pubcid;
       }
     }
+    extObj.ozone.pv = this.getPageId(); // attach the page ID that will be common to all auciton calls for this page if refresh() is called
+    extObj.ozone.lotameData = lotameDataSingle; // 2.4.0 moved lotameData out of bid objects into the single ext.ozone area to remove duplication
+    let ozOmpFloorDollars = config.getConfig('ozone.oz_omp_floor'); // valid only if a dollar value (typeof == 'number')
+    utils.logInfo('OZONE: oz_omp_floor dollar value = ', ozOmpFloorDollars);
+    if (typeof ozOmpFloorDollars === 'number') {
+      extObj.ozone.oz_omp_floor = ozOmpFloorDollars;
+    } else if (typeof ozOmpFloorDollars !== 'undefined') {
+      utils.logError('OZONE: oz_omp_floor is invalid - IF SET then this must be a number, representing dollar value eg. oz_omp_floor: 1.55. You have it set as a ' + (typeof ozOmpFloorDollars));
+    }
+    let ozWhitelistAdserverKeys = config.getConfig('ozone.oz_whitelist_adserver_keys');
+    let useOzWhitelistAdserverKeys = utils.isArray(ozWhitelistAdserverKeys) && ozWhitelistAdserverKeys.length > 0;
+    extObj.ozone.oz_kvp_rw = useOzWhitelistAdserverKeys ? 1 : 0;
 
     var userExtEids = this.generateEids(validBidRequests); // generate the UserIDs in the correct format for UserId module
 
@@ -298,7 +301,8 @@ export const spec = {
         bidderRequest: bidderRequest
       };
       utils.logInfo('OZONE: buildRequests ozoneRequest for single = ', ozoneRequest);
-      utils.logInfo('OZONE: buildRequests going to return for single: ', ret);
+      this.propertyBag.buildRequestsEnd = new Date().getTime();
+      utils.logInfo(`OZONE: buildRequests going to return for single at time ${this.propertyBag.buildRequestsEnd} (took ${this.propertyBag.buildRequestsEnd - this.propertyBag.buildRequestsStart}ms): `, ret);
       return ret;
     }
     // not single request - pull apart the tosendtags array & return an array of objects each containing one element in the imp array.
@@ -320,7 +324,8 @@ export const spec = {
         bidderRequest: bidderRequest
       };
     });
-    utils.logInfo('OZONE: buildRequests going to return for non-single: ', arrRet);
+    this.propertyBag.buildRequestsEnd = new Date().getTime();
+    utils.logInfo(`OZONE: buildRequests going to return for non-single at time ${this.propertyBag.buildRequestsEnd} (took ${this.propertyBag.buildRequestsEnd - this.propertyBag.buildRequestsStart}ms): `, arrRet);
     return arrRet;
   },
   /**
@@ -334,7 +339,9 @@ export const spec = {
    * @returns {*}
    */
   interpretResponse(serverResponse, request) {
-    utils.logInfo('OZONE: interpretResponse: serverResponse, request', serverResponse, request);
+    let startTime = new Date().getTime();
+    utils.logInfo(`OZONE: interpretResponse time: ${startTime} . Time between buildRequests done and interpretResponse start was ${startTime - this.propertyBag.buildRequestsEnd}ms`);
+    utils.logInfo(`OZONE: serverResponse, request`, serverResponse, request);
     serverResponse = serverResponse.body || {};
     // note that serverResponse.id value is the auction_id we might want to use for reporting reasons.
     if (!serverResponse.hasOwnProperty('seatbid')) {
@@ -351,56 +358,120 @@ export const spec = {
     }
     utils.logInfo('OZONE: enhancedAdserverTargeting', enhancedAdserverTargeting);
     serverResponse.seatbid = injectAdIdsIntoAllBidResponses(serverResponse.seatbid); // we now make sure that each bid in the bidresponse has a unique (within page) adId attribute.
+    serverResponse.seatbid = this.removeSingleBidderMultipleBids(serverResponse.seatbid);
+    let ozOmpFloorDollars = config.getConfig('ozone.oz_omp_floor'); // valid only if a dollar value (typeof == 'number')
+    let addOzOmpFloorDollars = typeof ozOmpFloorDollars === 'number';
+    let ozWhitelistAdserverKeys = config.getConfig('ozone.oz_whitelist_adserver_keys');
+    let useOzWhitelistAdserverKeys = utils.isArray(ozWhitelistAdserverKeys) && ozWhitelistAdserverKeys.length > 0;
+
     for (let i = 0; i < serverResponse.seatbid.length; i++) {
       let sb = serverResponse.seatbid[i];
       for (let j = 0; j < sb.bid.length; j++) {
-        const {defaultWidth, defaultHeight} = defaultSize(request.bidderRequest.bids[j]);
+        let thisRequestBid = this.getBidRequestForBidId(sb.bid[j].impid, request.bidderRequest.bids);
+        utils.logInfo(`OZONE seatbid:${i}, bid:${j} Going to set default w h for seatbid/bidRequest`, sb.bid[j], thisRequestBid);
+        const {defaultWidth, defaultHeight} = defaultSize(thisRequestBid);
         let thisBid = ozoneAddStandardProperties(sb.bid[j], defaultWidth, defaultHeight);
-
-        // from https://github.com/prebid/Prebid.js/pull/1082
-        if (utils.deepAccess(thisBid, 'ext.prebid.type') === VIDEO) {
-          utils.logInfo('OZONE: going to attach a renderer to:', j);
-          let renderConf = createObjectForInternalVideoRender(thisBid);
-          thisBid.renderer = Renderer.install(renderConf);
-        } else {
-          utils.logInfo('OZONE: bid is not a video, will not attach a renderer: ', j);
+        let videoContext = null;
+        let isVideo = false;
+        let bidType = utils.deepAccess(thisBid, 'ext.prebid.type');
+        utils.logInfo(`OZONE: this bid type is : ${bidType}`, j);
+        if (bidType === VIDEO) {
+          isVideo = true;
+          videoContext = this.getVideoContextForBidId(thisBid.bidId, request.bidderRequest.bids); // should be instream or outstream (or null if error)
+          if (videoContext === 'outstream') {
+            utils.logInfo('OZONE: going to attach a renderer to OUTSTREAM video : ', j);
+            thisBid.renderer = newRenderer(thisBid.bidId);
+          } else {
+            utils.logInfo('OZONE: bid is not an outstream video, will not attach a renderer: ', j);
+          }
         }
-
-        let ozoneInternalKey = thisBid.bidId;
         let adserverTargeting = {};
         if (enhancedAdserverTargeting) {
-          let allBidsForThisBidid = ozoneGetAllBidsForBidId(ozoneInternalKey, serverResponse.seatbid);
+          let allBidsForThisBidid = ozoneGetAllBidsForBidId(thisBid.bidId, serverResponse.seatbid);
           // add all the winning & non-winning bids for this bidId:
           utils.logInfo('OZONE: Going to iterate allBidsForThisBidId', allBidsForThisBidid);
           Object.keys(allBidsForThisBidid).forEach(function (bidderName, index, ar2) {
+            utils.logInfo(`OZONE: adding adserverTargeting for ${bidderName} for bidId ${thisBid.bidId}`);
+            // let bidderName = bidderNameWH.split('_')[0];
             adserverTargeting['oz_' + bidderName] = bidderName;
-            adserverTargeting['oz_' + bidderName + '_pb'] = String(allBidsForThisBidid[bidderName].price);
             adserverTargeting['oz_' + bidderName + '_crid'] = String(allBidsForThisBidid[bidderName].crid);
             adserverTargeting['oz_' + bidderName + '_adv'] = String(allBidsForThisBidid[bidderName].adomain);
-            adserverTargeting['oz_' + bidderName + '_imp_id'] = String(allBidsForThisBidid[bidderName].impid);
             adserverTargeting['oz_' + bidderName + '_adId'] = String(allBidsForThisBidid[bidderName].adId);
             adserverTargeting['oz_' + bidderName + '_pb_r'] = getRoundedBid(allBidsForThisBidid[bidderName].price, allBidsForThisBidid[bidderName].ext.prebid.type);
             if (allBidsForThisBidid[bidderName].hasOwnProperty('dealid')) {
               adserverTargeting['oz_' + bidderName + '_dealid'] = String(allBidsForThisBidid[bidderName].dealid);
             }
+            if (addOzOmpFloorDollars) {
+              adserverTargeting['oz_' + bidderName + '_omp'] = allBidsForThisBidid[bidderName].price >= ozOmpFloorDollars ? '1' : '0';
+            }
+            if (isVideo) {
+              adserverTargeting['oz_' + bidderName + '_vid'] = videoContext; // outstream or instream
+            }
+            let flr = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.floor');
+            if (flr) {
+              adserverTargeting['oz_' + bidderName + '_flr'] = flr ? 1 : 0;
+            }
+            let rid = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.ruleId');
+            if (rid) {
+              adserverTargeting['oz_' + bidderName + '_rid'] = rid;
+            }
+            if (bidderName.match(/^ozappnexus/)) {
+              adserverTargeting['oz_' + bidderName + '_sid'] = String(allBidsForThisBidid[bidderName].cid);
+            }
           });
+        } else {
+          if (useOzWhitelistAdserverKeys) {
+            utils.logWarn('OZONE: You have set a whitelist of adserver keys but this will be ignored because ozone.enhancedAdserverTargeting is set to false. No per-bid keys will be sent to adserver.');
+          } else {
+            utils.logInfo('OZONE: ozone.enhancedAdserverTargeting is set to false, so no per-bid keys will be sent to adserver.');
+          }
         }
         // also add in the winning bid, to be sent to dfp
-        let {seat: winningSeat, bid: winningBid} = ozoneGetWinnerForRequestBid(ozoneInternalKey, serverResponse.seatbid);
+        let {seat: winningSeat, bid: winningBid} = ozoneGetWinnerForRequestBid(thisBid.bidId, serverResponse.seatbid);
         adserverTargeting['oz_auc_id'] = String(request.bidderRequest.auctionId);
         adserverTargeting['oz_winner'] = String(winningSeat);
-        adserverTargeting['oz_response_id'] = String(serverResponse.id);
         if (enhancedAdserverTargeting) {
-          adserverTargeting['oz_winner_auc_id'] = String(winningBid.id);
-          adserverTargeting['oz_winner_imp_id'] = String(winningBid.impid);
+          adserverTargeting['oz_imp_id'] = String(winningBid.impid);
           adserverTargeting['oz_pb_v'] = OZONEVERSION;
+        }
+        if (useOzWhitelistAdserverKeys) { // delete any un-whitelisted keys
+          utils.logInfo('OZONE: Going to filter out adserver targeting keys not in the whitelist: ', ozWhitelistAdserverKeys);
+          Object.keys(adserverTargeting).forEach(function(key) { if (ozWhitelistAdserverKeys.indexOf(key) === -1) { delete adserverTargeting[key]; } });
         }
         thisBid.adserverTargeting = adserverTargeting;
         arrAllBids.push(thisBid);
       }
     }
-    utils.logInfo('OZONE: interpretResponse going to return', arrAllBids);
+    let endTime = new Date().getTime();
+    utils.logInfo(`OZONE: interpretResponse going to return at time ${endTime} (took ${endTime - startTime}ms) Time from buildRequests Start -> interpretRequests End = ${endTime - this.propertyBag.buildRequestsStart}ms`, arrAllBids);
     return arrAllBids;
+  },
+  /**
+   * If a bidder bids for > 1 size for an adslot, allow only the highest bid
+   * @param seatbid object (serverResponse.seatbid)
+   */
+  removeSingleBidderMultipleBids(seatbid) {
+    var ret = [];
+    for (let i = 0; i < seatbid.length; i++) {
+      let sb = seatbid[i];
+      var retSeatbid = {'seat': sb.seat, 'bid': []};
+      var bidIds = [];
+      for (let j = 0; j < sb.bid.length; j++) {
+        var candidate = sb.bid[j];
+        if (utils.contains(bidIds, candidate.impid)) {
+          continue; // we've already fully assessed this impid, found the highest bid from this seat for it
+        }
+        bidIds.push(candidate.impid);
+        for (let k = j + 1; k < sb.bid.length; k++) {
+          if (sb.bid[k].impid === candidate.impid && sb.bid[k].price > candidate.price) {
+            candidate = sb.bid[k];
+          }
+        }
+        retSeatbid.bid.push(candidate);
+      }
+      ret.push(retSeatbid);
+    }
+    return ret;
   },
   // see http://prebid.org/dev-docs/bidder-adaptor.html#registering-user-syncs
   getUserSyncs(optionsType, serverResponse, gdprConsent) {
@@ -435,7 +506,33 @@ export const spec = {
       }];
     }
   },
-
+  /**
+   * Find the bid matching the bidId in the request object
+   * get instream or outstream if this was a video request else null
+   * @return object|null
+   */
+  getBidRequestForBidId(bidId, arrBids) {
+    for (let i = 0; i < arrBids.length; i++) {
+      if (arrBids[i].bidId === bidId) { // bidId in the request comes back as impid in the seatbid bids
+        return arrBids[i];
+      }
+    }
+    return null;
+  },
+  /**
+   * Locate the bid inside the arrBids for this bidId, then discover the video context, and return it.
+   * IF the bid cannot be found return null, else return a string.
+   * @param bidId
+   * @param arrBids
+   * @return string|null
+   */
+  getVideoContextForBidId(bidId, arrBids) {
+    let requestBid = this.getBidRequestForBidId(bidId, arrBids);
+    if (requestBid != null) {
+      return utils.deepAccess(requestBid, 'mediaTypes.video.context', 'unknown')
+    }
+    return null;
+  },
   /**
    *  Look for pubcid & all the other IDs according to http://prebid.org/dev-docs/modules/userId.html
    *  @return map
@@ -443,15 +540,10 @@ export const spec = {
   findAllUserIds(bidRequest) {
     var ret = {};
     let searchKeysSingle = ['pubcid', 'tdid', 'id5id', 'parrableid', 'idl_env', 'digitrustid', 'criteortus'];
-    utils.logInfo('OZONE: debug iterating keys');
-    utils.logInfo('OZONE: debug bidRequest=', bidRequest);
     if (bidRequest.hasOwnProperty('userId')) {
-      utils.logInfo('OZONE: debug Looking inside userId element');
       for (let arrayId in searchKeysSingle) {
         let key = searchKeysSingle[arrayId];
-        utils.logInfo('OZONE: debug key=', key);
         if (bidRequest.userId.hasOwnProperty(key)) {
-          utils.logInfo('OZONE: debug found value : ', key);
           ret[key] = bidRequest.userId[key];
         }
       }
@@ -466,7 +558,6 @@ export const spec = {
         ret['pubcid'] = pubcid; // if built with old pubCommonId module
       }
     }
-    utils.logInfo('OZONE: debug going to return: ', ret);
     return ret;
   },
   /**
@@ -475,7 +566,7 @@ export const spec = {
    */
   getLotameOverrideParams() {
     const arrGet = this.getGetParametersAsObject();
-    utils.logInfo('getLotameOverrideParams - arrGet', arrGet);
+    utils.logInfo('OZONE: getLotameOverrideParams - arrGet=', arrGet);
     let arrRet = {};
     for (let i in ALLOWED_LOTAME_PARAMS) {
       if (arrGet.hasOwnProperty(ALLOWED_LOTAME_PARAMS[i])) {
@@ -506,13 +597,16 @@ export const spec = {
   },
   /**
    * Use the arrOverride keys/vals to update the arrExisting lotame object.
+   * Ideally we will only be using the oz_lotameid value to update the audiences id, but in the event of bad/missing
+   * pid & tpid we will also have to use substitute values for those too.
+   *
    * @param objOverride object will contain all the ALLOWED_LOTAME_PARAMS parameters
    * @param lotameData object might be {} or contain the lotame data
    */
   makeLotameObjectFromOverride(objOverride, lotameData) {
     if ((lotameData.hasOwnProperty('Profile') && Object.keys(lotameData.Profile).length < 3) ||
       (!lotameData.hasOwnProperty('Profile'))) { // bad or empty lotame object (should contain pid, tpid & Audiences object) - build a total replacement
-      utils.logInfo('makeLotameObjectFromOverride', 'will return a full default lotame object');
+      utils.logInfo('OZONE: makeLotameObjectFromOverride will return a full default lotame object');
       return {
         'Profile': {
           'tpid': objOverride['oz_lotametpid'],
@@ -522,11 +616,11 @@ export const spec = {
       };
     }
     if (utils.deepAccess(lotameData, 'Profile.Audiences.Audience')) {
-      utils.logInfo('makeLotameObjectFromOverride', 'will return the existing lotame object with updated Audience by oz_lotameid');
+      utils.logInfo('OZONE: makeLotameObjectFromOverride will return the existing lotame object with updated Audience by oz_lotameid');
       lotameData.Profile.Audiences.Audience = [{'id': objOverride['oz_lotameid'], 'abbr': objOverride['oz_lotameid']}];
       return lotameData;
     }
-    utils.logInfo('makeLotameObjectFromOverride', 'Weird error - failed to find Profile.Audiences.Audience in lotame object. Will return the object as-is');
+    utils.logInfo('OZONE: makeLotameObjectFromOverride Weird error - failed to find Profile.Audiences.Audience in lotame object. Will return the object as-is');
     return lotameData;
   },
   /**
@@ -622,98 +716,146 @@ export const spec = {
     return ret;
   },
   /**
-   * This will be called IF we want to enforce gdpr on the client
-   * Do we have to block this request? Could be due to config values & gdpr permissions etc
+   * Do we have to block this request? Could be due to config values (no longer checking gdpr)
    * @return {boolean|*[]} true = block the request, else false
    */
-  blockTheRequest(bidderRequest) {
+  blockTheRequest() {
     // if there is an ozone.oz_request = false then quit now.
     let ozRequest = config.getConfig('ozone.oz_request');
     if (typeof ozRequest == 'boolean' && !ozRequest) {
-      utils.logError('OZONE: Will not allow auction : ozone.oz_request is set to false');
-      return true;
-    }
-    // is there ozone.oz_enforceGdpr == true (ANYTHING else means don't enforce GDPR))
-    let ozEnforce = config.getConfig('ozone.oz_enforceGdpr');
-    if (typeof ozEnforce != 'boolean' || !ozEnforce) { // ozEnforce is false by default
-      utils.logError('OZONE: Will not validate GDPR on the client : oz_enforceGdpr is not set to true');
-      return false;
-    }
-    // maybe the module was built without consentManagement module so we won't find any gdpr information
-    if (!bidderRequest.hasOwnProperty('gdprConsent')) {
-      return false;
-    }
-    //
-    // FROM HERE ON : WE ARE DOING GDPR CHECKS
-    //
-    // If there is indeterminate GDPR (gdprConsent.consentString == undefined or not a string), we will DITCH this:
-    if (typeof bidderRequest.gdprConsent.consentString !== 'string') {
-      utils.logError('OZONE: Will block the request - bidderRequest.gdprConsent.consentString is not a string');
-      return true;
-    }
-    // IF the consentManagement module sends through the CMP information and user has refused all permissions:
-    if (this.failsGdprCheck(bidderRequest)) {
+      utils.logWarn('OZONE: Will not allow auction : ozone.oz_request is set to false');
       return true;
     }
     return false;
   },
   /**
-   * Examine the gdpr information inside the bidderRequest and return the boolean answer to the question
-   * @param bidderRequest
-   * @return {boolean}
+   * This returns a random ID for this page. It starts off with the current ms timestamp then appends a random component
+   * @return {string}
    */
-  failsGdprCheck(bidderRequest) {
-    let consentRequired = (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true;
-    if (consentRequired) {
-      let vendorConsentsObject = utils.deepAccess(bidderRequest.gdprConsent, 'vendorData');
-      if (!vendorConsentsObject || typeof vendorConsentsObject !== 'object') {
-        utils.logError('OZONE: gdpr test failed - bidderRequest.gdprConsent.vendorData is not an array');
-        return true;
+  getPageId: function() {
+    if (this.propertyBag.pageId == null) {
+      let randPart = '';
+      let allowable = '0123456789abcdefghijklmnopqrstuvwxyz';
+      for (let i = 20; i > 0; i--) {
+        randPart += allowable[Math.floor(Math.random() * 36)];
       }
-      if (!vendorConsentsObject.hasOwnProperty('purposeConsents')) {
-        return true;
-      }
-      if (typeof vendorConsentsObject.purposeConsents != 'object') {
-        return true;
-      }
-      if (!this.purposeConsentsAreOk((vendorConsentsObject.purposeConsents))) {
-        utils.logError('OZONE: gdpr test failed - missing Purposes consent');
-        return true;
-      }
-      if (!vendorConsentsObject.vendorConsents[524]) {
-        utils.logError('OZONE: gdpr test failed - missing Vendor ID consent');
-        return true;
-      }
+      this.propertyBag.pageId = new Date().getTime() + '_' + randPart;
     }
-    return false;
+    return this.propertyBag.pageId;
   },
   /**
-   * Test that vendor purpose consents 1,2,3,4 and 5 are true
-   * This is because we can't use Object.values(vendorConsentsObject.purposeConsents).slice(0, 5)
-   * @param obj
-   * @return {boolean}
+   * handle the complexity of there possibly being lotameData override (may be valid/invalid) & there may or may not be lotameData present in the bidRequest
+   * NOTE THAT this will also set this.propertyBag.lotameWasOverridden=1 if we use lotame override
+   * @param ozoneBidRequest
+   * @return object representing the absolute lotameData we need to use.
    */
-  purposeConsentsAreOk(obj) {
-    for (let i = 1; i <= 5; i++) {
-      if (!obj.hasOwnProperty(i) || !obj[i]) return false;
+  tryGetLotameData: function(ozoneBidRequest) {
+    const arrLotameOverride = this.getLotameOverrideParams();
+    let ret = {};
+    if (Object.keys(arrLotameOverride).length === ALLOWED_LOTAME_PARAMS.length) {
+      // all override params are present, override lotame object:
+      if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
+        ret = this.makeLotameObjectFromOverride(arrLotameOverride, ozoneBidRequest.params.lotameData);
+      } else {
+        ret = this.makeLotameObjectFromOverride(arrLotameOverride, {});
+      }
+      this.propertyBag.lotameWasOverridden = 1;
+    } else if (ozoneBidRequest.params.hasOwnProperty('lotameData')) {
+      // no lotame override, use it as-is
+      if (this.isLotameDataValid(ozoneBidRequest.params.lotameData)) {
+        ret = ozoneBidRequest.params.lotameData;
+      } else {
+        utils.logError('OZONE: INVALID LOTAME DATA FOUND - WILL NOT USE THIS AT ALL ELSE IT MIGHT BREAK THE AUCTION CALL!', ozoneBidRequest.params.lotameData);
+        ret = {};
+      }
     }
-    return true;
+    return ret;
+  },
+  unpackVideoConfigIntoIABformat(videoConfig, childConfig) {
+    let ret = {'ext': {}};
+    ret = this._unpackVideoConfigIntoIABformat(ret, videoConfig);
+    ret = this._unpackVideoConfigIntoIABformat(ret, childConfig);
+    return ret;
+  },
+  /**
+   *
+   * look in ONE object to get video config (we need to call this multiple times, so child settings override parent)
+   * @param ret
+   * @param objConfig
+   * @return {*}
+   * @private
+   */
+  _unpackVideoConfigIntoIABformat(ret, objConfig) {
+    let arrVideoKeysAllowed = ['mimes', 'minduration', 'maxduration', 'protocols', 'w', 'h', 'startdelay', 'placement', 'linearity', 'skip', 'skipmin', 'skipafter', 'sequence', 'battr', 'maxextended', 'minbitrate', 'maxbitrate', 'boxingallowed', 'playbackmethod', 'playbackend', 'delivery', 'pos', 'companionad', 'api', 'companiontype'];
+    for (const key in objConfig) {
+      var found = false;
+      arrVideoKeysAllowed.forEach(function(arg) {
+        if (arg === key) {
+          ret[key] = objConfig[key];
+          found = true;
+        }
+      });
+      if (!found) {
+        ret.ext[key] = objConfig[key];
+      }
+    }
+    // handle ext separately, if it exists; we have probably built up an ext object already
+    if (objConfig.hasOwnProperty('ext') && typeof objConfig.ext === 'object') {
+      if (objConfig.hasOwnProperty('ext')) {
+        ret.ext = utils.mergeDeep(ret.ext, objConfig.ext);
+      } else {
+        ret.ext = objConfig.ext;
+      }
+    }
+    return ret;
+  },
+  addVideoDefaults(objRet, videoConfig, childConfig) {
+    objRet = this._addVideoDefaults(objRet, videoConfig, false);
+    objRet = this._addVideoDefaults(objRet, childConfig, true); // child config will override parent config
+    return objRet;
+  },
+  /**
+   * modify objRet, adding in default values
+   * @param objRet
+   * @param objConfig
+   * @param addIfMissing
+   * @return {*}
+   * @private
+   */
+  _addVideoDefaults(objRet, objConfig, addIfMissing) {
+    // add inferred values & any default values we want.
+    let context = utils.deepAccess(objConfig, 'context');
+    if (context === 'outstream') {
+      objRet.placement = 3;
+    } else if (context === 'instream') {
+      objRet.placement = 1;
+    }
+    let skippable = utils.deepAccess(objConfig, 'skippable', null);
+    if (skippable == null) {
+      if (addIfMissing && !objRet.hasOwnProperty('skip')) {
+        objRet.skip = skippable ? 1 : 0;
+      }
+    } else {
+      objRet.skip = skippable ? 1 : 0;
+    }
+    return objRet;
   }
-}
+};
 
 /**
  * add a page-level-unique adId element to all server response bids.
- * NOTE that this is distructive - it mutates the serverResponse object sent in as a parameter
+ * NOTE that this is destructive - it mutates the serverResponse object sent in as a parameter
  * @param seatbid  object (serverResponse.seatbid)
  * @returns seatbid object
  */
 export function injectAdIdsIntoAllBidResponses(seatbid) {
-  utils.logInfo('injectAdIdsIntoAllBidResponses', seatbid);
+  utils.logInfo('OZONE: injectAdIdsIntoAllBidResponses', seatbid);
   for (let i = 0; i < seatbid.length; i++) {
     let sb = seatbid[i];
     for (let j = 0; j < sb.bid.length; j++) {
       // modify the bidId per-bid, so each bid has a unique adId within this response, and dfp can select one.
-      sb.bid[j]['adId'] = sb.bid[j]['impid'] + '-' + i;
+      // 2020-06 we now need a second level of ID because there might be multiple identical impid's within a seatbid!
+      sb.bid[j]['adId'] = `${sb.bid[j]['impid']}-${i}-${j}`;
     }
   }
   return seatbid;
@@ -773,10 +915,10 @@ export function ozoneGetWinnerForRequestBid(requestBidId, serverResponseSeatBid)
 }
 
 /**
- * Get a list of all the bids, for this bidId
+ * Get a list of all the bids, for this bidId. The keys in the response object will be {seatname} OR {seatname}{w}x{h} if seatname already exists
  * @param matchBidId
  * @param serverResponseSeatBid
- * @returns {} = {ozone:{obj}, appnexus:{obj}, ... }
+ * @returns {} = {ozone|320x600:{obj}, ozone|320x250:{obj}, appnexus|300x250:{obj}, ... }
  */
 export function ozoneGetAllBidsForBidId(matchBidId, serverResponseSeatBid) {
   let objBids = {};
@@ -785,7 +927,14 @@ export function ozoneGetAllBidsForBidId(matchBidId, serverResponseSeatBid) {
     let thisSeat = serverResponseSeatBid[j].seat;
     for (let k = 0; k < theseBids.length; k++) {
       if (theseBids[k].impid === matchBidId) {
-        objBids[thisSeat] = theseBids[k];
+        if (objBids.hasOwnProperty(thisSeat)) { // > 1 bid for an adunit from a bidder - only use the one with the highest bid
+        //   objBids[`${thisSeat}${theseBids[k].w}x${theseBids[k].h}`] = theseBids[k];
+          if (objBids[thisSeat]['price'] < theseBids[k].price) {
+            objBids[thisSeat] = theseBids[k];
+          }
+        } else {
+          objBids[thisSeat] = theseBids[k];
+        }
       }
     }
   }
@@ -822,7 +971,7 @@ export function getRoundedBid(price, mediaType) {
   };
   if (granularityNamePriceStringsKeyMapping.hasOwnProperty(theConfigKey)) {
     let priceStringsKey = granularityNamePriceStringsKeyMapping[theConfigKey];
-    utils.logInfo('OZONE: looking for priceStringsKey:', priceStringsKey);
+    utils.logInfo('OZONE: getRoundedBid: looking for priceStringsKey:', priceStringsKey);
     return priceStringsObj[priceStringsKey];
   }
   return priceStringsObj['auto'];
@@ -880,26 +1029,6 @@ export function ozoneAddStandardProperties(seatBid, defaultWidth, defaultHeight)
   return seatBid;
 }
 
-function createObjectForInternalVideoRender(bid) {
-  let obj = {
-    url: OZONE_RENDERER_URL,
-    callback: () => onOutstreamRendererLoaded(bid)
-  }
-  return obj;
-}
-
-function onOutstreamRendererLoaded(bid) {
-  try {
-    bid.renderer.setRender(outstreamRender);
-  } catch (err) {
-    utils.logWarn('Prebid Error calling setRender on renderer', err)
-  }
-}
-
-function outstreamRender(bid) {
-  window.ozoneVideo.outstreamRender(bid);
-}
-
 /**
  *
  * @param objVideo will be like {"playerSize":[640,480],"mimes":["video/mp4"],"context":"outstream"} or POSSIBLY {"playerSize":[[640,480]],"mimes":["video/mp4"],"context":"outstream"}
@@ -947,16 +1076,44 @@ export function playerSizeIsNestedArray(objVideo) {
  */
 function getPlayerSizeFromObject(objVideo) {
   utils.logInfo('OZONE: getPlayerSizeFromObject received object', objVideo);
-  if (!objVideo.hasOwnProperty('playerSize')) {
-    utils.logError('OZONE: getPlayerSizeFromObject FAILED: no playerSize in video object', objVideo);
+  let playerSize = utils.deepAccess(objVideo, 'playerSize');
+  if (!playerSize) {
+    playerSize = utils.deepAccess(objVideo, 'ext.playerSize');
+  }
+  if (!playerSize) {
+    utils.logError('OZONE: getPlayerSizeFromObject FAILED: no playerSize in video object or ext', objVideo);
     return null;
   }
-  let playerSize = objVideo.playerSize;
   if (typeof playerSize !== 'object') {
     utils.logError('OZONE: getPlayerSizeFromObject FAILED: playerSize is not an object/array', objVideo);
     return null;
   }
   return playerSize;
+}
+/*
+  Rendering video ads - create a renderer instance, mark it as not loaded, set a renderer function.
+  The renderer function will not assume that the renderer script is loaded - it will push() the ultimate render function call
+ */
+function newRenderer(adUnitCode, rendererOptions = {}) {
+  const renderer = Renderer.install({
+    url: OZONE_RENDERER_URL,
+    config: rendererOptions,
+    loaded: false,
+    adUnitCode
+  });
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    utils.logWarn('OZONE Prebid Error calling setRender on renderer', err);
+  }
+  return renderer;
+}
+function outstreamRender(bid) {
+  utils.logInfo('OZONE: outstreamRender called. Going to push the call to window.ozoneVideo.outstreamRender(bid) bid =', bid);
+  // push to render queue because ozoneVideo may not be loaded yet
+  bid.renderer.push(() => {
+    window.ozoneVideo.outstreamRender(bid);
+  });
 }
 
 registerBidder(spec);

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -407,12 +407,12 @@ export const spec = {
             if (isVideo) {
               adserverTargeting['oz_' + bidderName + '_vid'] = videoContext; // outstream or instream
             }
-            let flr = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.floor');
-            if (flr) {
-              adserverTargeting['oz_' + bidderName + '_flr'] = flr ? 1 : 0;
+            let flr = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.floor', null);
+            if (flr != null) {
+              adserverTargeting['oz_' + bidderName + '_flr'] = flr;
             }
-            let rid = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.ruleId');
-            if (rid) {
+            let rid = utils.deepAccess(allBidsForThisBidid[bidderName], 'ext.bidder.ozone.ruleId', null);
+            if (rid != null) {
               adserverTargeting['oz_' + bidderName + '_rid'] = rid;
             }
             if (bidderName.match(/^ozappnexus/)) {

--- a/modules/ozoneBidAdapter.md
+++ b/modules/ozoneBidAdapter.md
@@ -37,7 +37,7 @@ adUnits = [{
                             siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
                             placementId: '0420420421', /* an ID used to identify the piece of inventory - required - for appnexus test use 13144370. */
 							customData: [{"settings": {}, "targeting": {"key": "value", "key2": ["value1", "value2"]}}],/* optional array with 'targeting' placeholder for passing publisher specific key-values for targeting. */                            
-                            lotameData: {"key1": "value1", "key2": "value2"} /* optional JSON placeholder for passing Lotame DMP data */
+                            lotameData: {"Profile": {"tpid":"value","pid":"value","Audiences": {"Audience":[{"id":"value"},{"id":"value2"}]}}}, /* optional JSON placeholder for passing Lotame DMP data */
                         }
                     }]
                 }];
@@ -64,8 +64,7 @@ adUnits = [{
                             siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
 							customData: [{"settings": {}, "targeting": { "key": "value", "key2": ["value1", "value2"]}}]
                             placementId: '0440440442', /* an ID used to identify the piece of inventory - required - for unruly test use 0440440442. */
-							customData: [{"settings": {}, "targeting": {"key": "value", "key2": ["value1", "value2"]}}],/* optional array with 'targeting' placeholder for passing publisher specific key-values for targeting. */                            
-                            lotameData: {"key1": "value1", "key2": "value2"}, /* optional JSON placeholder for passing Lotame DMP data */
+                            lotameData: {"Profile": {"tpid":"value","pid":"value","Audiences": {"Audience":[{"id":"value"},{"id":"value2"}]}}}, /* optional JSON placeholder for passing Lotame DMP data */
 							video: {
                                 skippable: true, /* optional */
                                 playback_method: ['auto_play_sound_off'], /* optional */

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -21,7 +21,7 @@ var validBidRequests = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -36,7 +36,7 @@ var validBidRequestsMulti = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   },
@@ -49,7 +49,7 @@ var validBidRequestsMulti = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c0',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -63,7 +63,7 @@ var validBidRequestsWithUserIdData = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87',
     userId: {'pubcid': '12345678', 'id5id': 'ID5-someId', 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableid': 'parrableid123'}
@@ -91,7 +91,7 @@ var validBidRequestsNoSizes = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
 ];
@@ -105,7 +105,7 @@ var validBidRequestsWithBannerMediaType = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     mediaTypes: {banner: {sizes: [[300, 250], [300, 600]]}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -119,7 +119,7 @@ var validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo = [
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, video: {skippable: true, playback_method: ['auto_play_sound_off'], targetDiv: 'some-different-div-id-to-my-adunitcode'} } ] },
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, video: {skippable: true, playback_method: ['auto_play_sound_off'], targetDiv: 'some-different-div-id-to-my-adunitcode'} } ] },
     mediaTypes: {video: {mimes: ['video/mp4'], 'context': 'outstream', 'sizes': [640, 480], playerSize: [640, 480]}, native: {info: 'dummy data'}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
@@ -370,7 +370,7 @@ var validBidderRequest = {
       bidder: 'ozone',
       bidderRequestId: '1c1586b27a1b5c8',
       crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
       sizes: [[300, 250], [300, 600]],
       transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
     }],
@@ -399,7 +399,7 @@ var bidderRequestWithFullGdpr = {
       bidder: 'ozone',
       bidderRequestId: '1c1586b27a1b5c8',
       crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
       sizes: [[300, 250], [300, 600]],
       transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
     }],
@@ -498,8 +498,7 @@ var bidderRequestWithPartialGdpr = {
               'Audience': [{'id': '99999', 'abbr': 'sports'}, {
                 'id': '88888',
                 'abbr': 'movie'
-              }, {'id': '77777', 'abbr': 'blogger'}],
-              'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]
+              }, {'id': '77777', 'abbr': 'blogger'}]
             }
           }
         },
@@ -1590,7 +1589,7 @@ describe('ozone Adapter', function () {
         publisherId: '9876abcd12-3',
         siteId: '1234567890',
         customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}],
-        lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}},
+        lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}},
       },
       siteId: 1234567890
     }
@@ -2425,6 +2424,41 @@ describe('ozone Adapter', function () {
       const result = spec.interpretResponse(validResponse, request);
       expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_omp')).to.be.undefined;
     });
+    it('should handle ext.bidder.ozone.floor correctly, setting flr & rid as necessary', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let vres = JSON.parse(JSON.stringify(validResponse));
+      vres.body.seatbid[0].bid[0].ext.bidder.ozone = {floor: 1, ruleId: 'ZjbsYE1q'};
+      const result = spec.interpretResponse(vres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_flr')).to.equal(1);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_rid')).to.equal('ZjbsYE1q');
+      config.resetConfig();
+    });
+    it('should handle ext.bidder.ozone.floor correctly, inserting 0 as necessary', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let vres = JSON.parse(JSON.stringify(validResponse));
+      vres.body.seatbid[0].bid[0].ext.bidder.ozone = {floor: 0, ruleId: 'ZjbXXE1q'};
+      const result = spec.interpretResponse(vres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_flr')).to.equal(0);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_rid')).to.equal('ZjbXXE1q');
+      config.resetConfig();
+    });
+    it('should handle ext.bidder.ozone.floor correctly, inserting nothing as necessary', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let vres = JSON.parse(JSON.stringify(validResponse));
+      vres.body.seatbid[0].bid[0].ext.bidder.ozone = {};
+      const result = spec.interpretResponse(vres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_flr', null)).to.equal(null);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_rid', null)).to.equal(null);
+      config.resetConfig();
+    });
+    it('should handle ext.bidder.ozone.floor correctly, when bidder.ozone is not there', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let vres = JSON.parse(JSON.stringify(validResponse));
+      const result = spec.interpretResponse(vres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_flr', null)).to.equal(null);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_rid', null)).to.equal(null);
+      config.resetConfig();
+    });
     it('should handle a valid whitelist, removing items not on the list & leaving others', function () {
       config.setConfig({'ozone': {'oz_whitelist_adserver_keys': ['oz_appnexus_crid', 'oz_appnexus_adId']}});
       const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
@@ -2479,7 +2513,6 @@ describe('ozone Adapter', function () {
       expect(result[0]['price']).to.equal(0.9);
       expect(result[0]['adserverTargeting']['oz_ozappnexus_adId']).to.equal('2899ec066a91ff8-0-1');
     });
-
     it('should correctly process an auction with 2 adunits & multiple bidders one of which bids for both adslots', function() {
       let validres = JSON.parse(JSON.stringify(multiResponse1));
       let request = spec.buildRequests(multiRequest1, multiBidderRequest1.bidderRequest);

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -11,6 +11,7 @@ const BIDDER_CODE = 'ozone';
 NOTE - use firefox console to deep copy the objects to use here
 
  */
+var originalPropertyBag = {'lotameWasOverridden': 0, 'pageId': null};
 var validBidRequests = [
   {
     adUnitCode: 'div-gpt-ad-1460505748561-0',
@@ -19,6 +20,34 @@ var validBidRequests = [
     bidRequestsCount: 1,
     bidder: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    sizes: [[300, 250], [300, 600]],
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  }
+];
+var validBidRequestsMulti = [
+  {
+    testId: 1,
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff8',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
+    sizes: [[300, 250], [300, 600]],
+    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+  },
+  {
+    testId: 2,
+    adUnitCode: 'div-gpt-ad-1460505748561-0',
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    bidId: '2899ec066a91ff0',
+    bidRequestsCount: 1,
+    bidder: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c0',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
     params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
@@ -91,89 +120,324 @@ var validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo = [
     bidderRequestId: '1c1586b27a1b5c8',
     crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
     params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, video: {skippable: true, playback_method: ['auto_play_sound_off'], targetDiv: 'some-different-div-id-to-my-adunitcode'} } ] },
-    mediaTypes: {video: {mimes: ['video/mp4'], 'context': 'outstream', 'sizes': [640, 480]}, native: {info: 'dummy data'}},
+    mediaTypes: {video: {mimes: ['video/mp4'], 'context': 'outstream', 'sizes': [640, 480], playerSize: [640, 480]}, native: {info: 'dummy data'}},
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
   }
 ];
 
-var validBidderRequest = {
-  auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-  auctionStart: 1536838908986,
-  bidderCode: 'ozone',
-  bidderRequestId: '1c1586b27a1b5c8',
-  bids: [{
-    adUnitCode: 'div-gpt-ad-1460505748561-0',
+var validBidRequests1OutstreamVideo2020 = [
+  {
+    'bidder': 'ozone',
+    'testname': 'validBidRequests1OutstreamVideo2020',
+    'params': {
+      'publisherId': 'OZONERUP0001',
+      'placementId': '8000000009',
+      'siteId': '4204204201',
+      'video': {
+        'skippable': true,
+        'playback_method': [
+          'auto_play_sound_off'
+        ]
+      },
+      'customData': [
+        {
+          'settings': {},
+          'targeting': {
+            'sens': 'f',
+            'pt1': '/uk',
+            'pt2': 'uk',
+            'pt3': 'network-front',
+            'pt4': 'ng',
+            'pt5': [
+              'uk'
+            ],
+            'pt7': 'desktop',
+            'pt8': [
+              'tfmqxwj7q',
+              'penl4dfdk',
+              'sek9ghqwi'
+            ],
+            'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+          }
+        }
+      ],
+      'lotameData': {
+        'Profile': {
+          'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+          'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+          'Audiences': {
+            'Audience': [
+              {
+                'id': '439847',
+                'abbr': 'all'
+              },
+              {
+                'id': '446197',
+                'abbr': 'Arts, Culture & Literature'
+              },
+              {
+                'id': '446198',
+                'abbr': 'Business'
+              }
+            ]
+          }
+        }
+      }
+    },
+    'userId': {
+      'pubcid': '2ada6ae6-aeca-4e07-8922-a99b3aaf8a56'
+    },
+    'userIdAsEids': [
+      {
+        'source': 'pubcid.org',
+        'uids': [
+          {
+            'id': '2ada6ae6-aeca-4e07-8922-a99b3aaf8a56',
+            'atype': 1
+          }
+        ]
+      }
+    ],
+    'mediaTypes': {
+      'video': {
+        'playerSize': [
+          [
+            640,
+            480
+          ]
+        ],
+        'mimes': [
+          'video/mp4'
+        ],
+        'context': 'outstream'
+      }
+    },
+    'adUnitCode': 'video-ad',
+    'transactionId': '02c1ea7d-0bf2-451b-a122-1420040d1cf8',
+    'sizes': [
+      [
+        640,
+        480
+      ]
+    ],
+    'bidId': '2899ec066a91ff8',
+    'bidderRequestId': '1c1586b27a1b5c8',
+    'auctionId': '0456c9b7-5ab2-4fec-9e10-f418d3d1f04c',
+    'src': 'client',
+    'bidRequestsCount': 1,
+    'bidderRequestsCount': 1,
+    'bidderWinsCount': 0
+  }
+];
+
+// WHEN sent as bidderRequest to buildRequests you should send the child: .bidderRequest
+var validBidderRequest1OutstreamVideo2020 = {
+  bidderRequest: {
     auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-    bidId: '2899ec066a91ff8',
-    bidRequestsCount: 1,
-    bidder: 'ozone',
+    auctionStart: 1536838908986,
+    bidderCode: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
-    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
-    sizes: [[300, 250], [300, 600]],
-    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
-  }],
-  doneCbCallCount: 1,
-  start: 1536838908987,
-  timeout: 3000
+    bids: [
+      {
+        'bidder': 'ozone',
+        'params': {
+          'publisherId': 'OZONERUP0001',
+          'placementId': '8000000009',
+          'siteId': '4204204201',
+          'video': {
+            'skippable': true,
+            'playback_method': [
+              'auto_play_sound_off'
+            ]
+          },
+          'customData': [
+            {
+              'settings': {},
+              'targeting': {
+                'sens': 'f',
+                'pt1': '/uk',
+                'pt2': 'uk',
+                'pt3': 'network-front',
+                'pt4': 'ng',
+                'pt5': [
+                  'uk'
+                ],
+                'pt7': 'desktop',
+                'pt8': [
+                  'tfmqxwj7q',
+                  'penl4dfdk',
+                  'uayf5jmv3',
+                  'sek9ghqwi'
+                ],
+                'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+              }
+            }
+          ],
+          'lotameData': {
+            'Profile': {
+              'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+              'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+              'Audiences': {
+                'Audience': [
+                  {
+                    'id': '439847',
+                    'abbr': 'all'
+                  },
+                  {
+                    'id': '446197',
+                    'abbr': 'Arts, Culture & Literature'
+                  },
+                  {
+                    'id': '446198',
+                    'abbr': 'Business'
+                  }
+                ]
+              }
+            }
+          }
+        },
+        'userId': {
+          'id5id': 'ID5-ZHMOpSv9CkZNiNd1oR4zc62AzCgSS73fPjmQ6Od7OA',
+          'pubcid': '2ada6ae6-aeca-4e07-8922-a99b3aaf8a56'
+        },
+        'userIdAsEids': [
+          {
+            'source': 'id5-sync.com',
+            'uids': [
+              {
+                'id': 'ID5-ZHMOpSv9CkZNiNd1oR4zc62AzCgSS73fPjmQ6Od7OA',
+                'atype': 1
+              }
+            ]
+          },
+          {
+            'source': 'pubcid.org',
+            'uids': [
+              {
+                'id': '2ada6ae6-aeca-4e07-8922-a99b3aaf8a56',
+                'atype': 1
+              }
+            ]
+          }
+        ],
+        'mediaTypes': {
+          'video': {
+            'playerSize': [
+              [
+                640,
+                480
+              ]
+            ],
+            'mimes': [
+              'video/mp4'
+            ],
+            'context': 'outstream'
+          }
+        },
+        'adUnitCode': 'video-ad',
+        'transactionId': 'ec20cc65-de38-4410-b5b3-50de5b7df66a',
+        'sizes': [
+          [
+            640,
+            480
+          ]
+        ],
+        'bidId': '2899ec066a91ff8',
+        'bidderRequestId': '1c1586b27a1b5c8',
+        'auctionId': '0456c9b7-5ab2-4fec-9e10-f418d3d1f04c',
+        'src': 'client',
+        'bidRequestsCount': 1,
+        'bidderRequestsCount': 1,
+        'bidderWinsCount': 0
+      }],
+    doneCbCallCount: 1,
+    start: 1536838908987,
+    timeout: 3000
+  }
+};
+// WHEN sent as bidderRequest to buildRequests you should send the child: .bidderRequest
+var validBidderRequest = {
+  bidderRequest: {
+    auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+    auctionStart: 1536838908986,
+    bidderCode: 'ozone',
+    bidderRequestId: '1c1586b27a1b5c8',
+    bids: [{
+      adUnitCode: 'div-gpt-ad-1460505748561-0',
+      auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+      bidId: '2899ec066a91ff8',
+      bidRequestsCount: 1,
+      bidder: 'ozone',
+      bidderRequestId: '1c1586b27a1b5c8',
+      crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+      sizes: [[300, 250], [300, 600]],
+      transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+    }],
+    doneCbCallCount: 1,
+    start: 1536838908987,
+    timeout: 3000
+  }
 };
 
 // bidder request with GDPR - change the values for testing:
 // gdprConsent.gdprApplies (true/false)
 // gdprConsent.vendorData.purposeConsents (make empty, make null, remove it)
 // gdprConsent.vendorData.vendorConsents (remove 524, remove all, make the element null, remove it)
+// WHEN sent as bidderRequest to buildRequests you should send the child: .bidderRequest
 var bidderRequestWithFullGdpr = {
-  auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-  auctionStart: 1536838908986,
-  bidderCode: 'ozone',
-  bidderRequestId: '1c1586b27a1b5c8',
-  bids: [{
-    adUnitCode: 'div-gpt-ad-1460505748561-0',
+  bidderRequest: {
     auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-    bidId: '2899ec066a91ff8',
-    bidRequestsCount: 1,
-    bidder: 'ozone',
+    auctionStart: 1536838908986,
+    bidderCode: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
-    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
-    sizes: [[300, 250], [300, 600]],
-    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
-  }],
-  doneCbCallCount: 1,
-  start: 1536838908987,
-  timeout: 3000,
-  gdprConsent: {
-    'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
-    'vendorData': {
-      'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
-      'gdprApplies': true,
-      'hasGlobalScope': false,
-      'cookieVersion': '1',
-      'created': '2019-05-31T12:46:48.825',
-      'lastUpdated': '2019-05-31T12:46:48.825',
-      'cmpId': '28',
-      'cmpVersion': '1',
-      'consentLanguage': 'en',
-      'consentScreen': '1',
-      'vendorListVersion': 148,
-      'maxVendorId': 631,
-      'purposeConsents': {
-        '1': true,
-        '2': true,
-        '3': true,
-        '4': true,
-        '5': true
+    bids: [{
+      adUnitCode: 'div-gpt-ad-1460505748561-0',
+      auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+      bidId: '2899ec066a91ff8',
+      bidRequestsCount: 1,
+      bidder: 'ozone',
+      bidderRequestId: '1c1586b27a1b5c8',
+      crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+      params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
+      sizes: [[300, 250], [300, 600]],
+      transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+    }],
+    doneCbCallCount: 1,
+    start: 1536838908987,
+    timeout: 3000,
+    gdprConsent: {
+      'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+      'vendorData': {
+        'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+        'gdprApplies': true,
+        'hasGlobalScope': false,
+        'cookieVersion': '1',
+        'created': '2019-05-31T12:46:48.825',
+        'lastUpdated': '2019-05-31T12:46:48.825',
+        'cmpId': '28',
+        'cmpVersion': '1',
+        'consentLanguage': 'en',
+        'consentScreen': '1',
+        'vendorListVersion': 148,
+        'maxVendorId': 631,
+        'purposeConsents': {
+          '1': true,
+          '2': true,
+          '3': true,
+          '4': true,
+          '5': true
+        },
+        'vendorConsents': {
+          '468': true,
+          '522': true,
+          '524': true, /* 524 is ozone */
+          '565': true,
+          '591': true
+        }
       },
-      'vendorConsents': {
-        '468': true,
-        '522': true,
-        '524': true, /* 524 is ozone */
-        '565': true,
-        '591': true
-      }
-    },
-    'gdprApplies': true
-  },
+      'gdprApplies': true
+    }, }
 };
 
 var gdpr1 = {
@@ -211,33 +475,60 @@ var gdpr1 = {
 
 // simulating the Mirror
 var bidderRequestWithPartialGdpr = {
-  auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-  auctionStart: 1536838908986,
-  bidderCode: 'ozone',
-  bidderRequestId: '1c1586b27a1b5c8',
-  bids: [{
-    adUnitCode: 'div-gpt-ad-1460505748561-0',
+  bidderRequest: {
     auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
-    bidId: '2899ec066a91ff8',
-    bidRequestsCount: 1,
-    bidder: 'ozone',
+    auctionStart: 1536838908986,
+    bidderCode: 'ozone',
     bidderRequestId: '1c1586b27a1b5c8',
-    crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
-    params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { banner: { topframe: 1, w: 300, h: 250, format: [{ w: 300, h: 250 }, { w: 300, h: 600 }] }, id: '2899ec066a91ff8', secure: 1, tagid: 'undefined' } ] },
-    sizes: [[300, 250], [300, 600]],
-    transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
-  }],
-  doneCbCallCount: 1,
-  start: 1536838908987,
-  timeout: 3000,
-  gdprConsent: {
-    'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
-    'gdprApplies': true,
-    'vendorData': {
-      'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
-      'gdprApplies': true
+    bids: [{
+      adUnitCode: 'div-gpt-ad-1460505748561-0',
+      auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+      bidId: '2899ec066a91ff8',
+      bidRequestsCount: 1,
+      bidder: 'ozone',
+      bidderRequestId: '1c1586b27a1b5c8',
+      crumbs: {pubcid: '203a0692-f728-4856-87f6-9a25a6b63715'},
+      params: {
+        publisherId: '9876abcd12-3',
+        customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}],
+        lotameData: {
+          'Profile': {
+            'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4',
+            'Audiences': {
+              'Audience': [{'id': '99999', 'abbr': 'sports'}, {
+                'id': '88888',
+                'abbr': 'movie'
+              }, {'id': '77777', 'abbr': 'blogger'}],
+              'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]
+            }
+          }
+        },
+        placementId: '1310000099',
+        siteId: '1234567890',
+        id: 'fea37168-78f1-4a23-a40e-88437a99377e',
+        auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99',
+        imp: [{
+          banner: {topframe: 1, w: 300, h: 250, format: [{w: 300, h: 250}, {w: 300, h: 600}]},
+          id: '2899ec066a91ff8',
+          secure: 1,
+          tagid: 'undefined'
+        }]
+      },
+      sizes: [[300, 250], [300, 600]],
+      transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87'
+    }],
+    doneCbCallCount: 1,
+    start: 1536838908987,
+    timeout: 3000,
+    gdprConsent: {
+      'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+      'gdprApplies': true,
+      'vendorData': {
+        'metadata': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+        'gdprApplies': true
+      }
     }
-  },
+  }
 };
 
 // make sure the impid matches the request bidId
@@ -297,7 +588,8 @@ var validResponse = {
   },
   'headers': {}
 };
-var validOutstreamResponse = {
+
+var validResponse2Bids = {
   'body': {
     'id': 'd6198807-7a53-4141-b2db-d2cb754d68ba',
     'seatbid': [
@@ -322,28 +614,53 @@ var validOutstreamResponse = {
             'h': 600,
             'ext': {
               'prebid': {
-                'type': 'video'
+                'type': 'banner'
               },
               'bidder': {
-                'unruly': {
-                  'renderer': {
-                    'config': {
-                      'targetingUUID': 'aafd3388-afaf-41f4-b271-0ac8e0325a7f',
-                      'siteId': 1052815,
-                      'featureOverrides': {}
-                    },
-                    'url': 'https://video.unrulymedia.com/native/native-loader.js#supplyMode=prebid?cb=6284685353877994',
-                    'id': 'unruly_inarticle'
-                  },
-                  'vast_url': 'data:text/xml;base64,PD94bWwgdmVyc2lvbj0i'
+                'appnexus': {
+                  'brand_id': 555545,
+                  'auction_id': 6500448734132353000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
                 }
               }
             }
-          }
-        ],
-        'seat': 'unruly'
+          },
+          {
+            'id': '677903815252395010',
+            'impid': '2899ec066a91ff0',
+            'price': 0.9,
+            'adm': '<script src="test"></script>',
+            'adid': '98493580',
+            'adomain': [
+              'http://prebid.org'
+            ],
+            'iurl': 'https://fra1-ib.adnxs.com/cr?id=98493581',
+            'cid': '9320',
+            'crid': '98493580',
+            'cat': [
+              'IAB3-1'
+            ],
+            'w': 300,
+            'h': 600,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'appnexus': {
+                  'brand_id': 555540,
+                  'auction_id': 6500448734132353000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            }
+          } ],
+        'seat': 'appnexus'
       }
     ],
+    'cur': 'GBP', /* NOTE - this is where cur is, not in the seatbids. */
     'ext': {
       'responsetimemillis': {
         'appnexus': 47,
@@ -358,6 +675,189 @@ var validOutstreamResponse = {
   },
   'headers': {}
 };
+/*
+A bidder returns a bid for both sizes in an adunit
+ */
+var validResponse2BidsSameAdunit = {
+  'body': {
+    'id': 'd6198807-7a53-4141-b2db-d2cb754d68ba',
+    'seatbid': [
+      {
+        'bid': [
+          {
+            'id': '677903815252395017',
+            'impid': '2899ec066a91ff8',
+            'price': 0.5,
+            'adm': '<script src="src-1"></script>',
+            'adid': '98493581',
+            'adomain': [
+              'http://prebid.org'
+            ],
+            'iurl': 'https://fra1-ib.adnxs.com/cr?id=98493581',
+            'cid': '9325',
+            'crid': '98493581',
+            'cat': [
+              'IAB3-1'
+            ],
+            'w': 300,
+            'h': 600,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'appnexus': {
+                  'brand_id': 555545,
+                  'auction_id': 6500448734132353000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            }
+          },
+          {
+            'id': '677903815252395010',
+            'impid': '2899ec066a91ff8',
+            'price': 0.9,
+            'adm': '<script src="src-2"></script>',
+            'adid': '98493580',
+            'adomain': [
+              'http://prebid.org'
+            ],
+            'iurl': 'https://fra1-ib.adnxs.com/cr?id=98493581',
+            'cid': '9320',
+            'crid': '98493580',
+            'cat': [
+              'IAB3-1'
+            ],
+            'w': 300,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'appnexus': {
+                  'brand_id': 555540,
+                  'auction_id': 6500448734132353000,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            }
+          } ],
+        'seat': 'ozappnexus'
+      }
+    ],
+    'cur': 'GBP', /* NOTE - this is where cur is, not in the seatbids. */
+    'ext': {
+      'responsetimemillis': {
+        'appnexus': 47,
+        'openx': 30
+      }
+    },
+    'timing': {
+      'start': 1536848078.089177,
+      'end': 1536848078.142203,
+      'TimeTaken': 0.05302619934082031
+    }
+  },
+  'headers': {}
+};
+/*
+
+SPECIAL CONSIDERATION FOR VIDEO TESTS:
+
+DO NOT USE _validVideoResponse directly - the interpretResponse function will modify it (adding a renderer!!!) so all
+subsequent calls will already have a renderer attached!!!
+
+*/
+function getCleanValidVideoResponse() {
+  return JSON.parse(JSON.stringify(_validVideoResponse));
+}
+var _validVideoResponse = {
+  'body': {
+    'id': 'd6198807-7a53-4141-b2db-d2cb754d68ba',
+    'seatbid': [
+      {
+        'bid': [
+          {
+            'id': '2899ec066a91ff8',
+            'impid': '2899ec066a91ff8',
+            'price': 31.7,
+            'adm': '<VAST ...></VAST>',
+            'adomain': [
+              'sarr.properties'
+            ],
+            'crid': 'ozone-655',
+            'cat': [
+              'IAB21'
+            ],
+            'w': 640,
+            'h': 360,
+            'ext': {
+              'prebid': {
+                'type': 'video'
+              }
+            },
+            'adId': '2899ec066a91ff8-2',
+            'cpm': 31.7,
+            'bidId': '2899ec066a91ff8',
+            'requestId': '2899ec066a91ff8',
+            'width': 640,
+            'height': 360,
+            'ad': '<VAST  ...></VAST>',
+            'netRevenue': true,
+            'creativeId': 'ozone-655',
+            'currency': 'USD',
+            'ttl': 300,
+            'adserverTargeting': {
+              'oz_ozbeeswax': 'ozbeeswax',
+              'oz_ozbeeswax_pb': '31.7',
+              'oz_ozbeeswax_crid': 'ozone-655',
+              'oz_ozbeeswax_adv': 'sarr.properties',
+              'oz_ozbeeswax_imp_id': '49d16ccc28663a8',
+              'oz_ozbeeswax_adId': '49d16ccc28663a8-2',
+              'oz_ozbeeswax_pb_r': '20.00',
+              'oz_ozbeeswax_omp': '1',
+              'oz_ozbeeswax_vid': 'outstream',
+              'oz_auc_id': 'efa7fea0-7e87-4811-be86-fefb38c35fbb',
+              'oz_winner': 'ozbeeswax',
+              'oz_response_id': 'efa7fea0-7e87-4811-be86-fefb38c35fbb',
+              'oz_winner_auc_id': '49d16ccc28663a8',
+              'oz_winner_imp_id': '49d16ccc28663a8',
+              'oz_pb_v': '2.4.0',
+              'hb_bidder': 'ozone',
+              'hb_adid': '49d16ccc28663a8-2',
+              'hb_pb': '20.00',
+              'hb_size': '640x360',
+              'hb_source': 'client',
+              'hb_format': 'banner'
+            },
+            'originalCpm': 31.7,
+            'originalCurrency': 'USD'
+          }
+        ],
+        'seat': 'ozbeeswax'
+      }
+    ],
+    'ext': {
+      'responsetimemillis': {
+        'beeswax': 9,
+        'openx': 43,
+        'ozappnexus': 31,
+        'ozbeeswax': 7
+      }
+    },
+    'timing': {
+      'start': 1536848078.089177,
+      'end': 1536848078.142203,
+      'TimeTaken': 0.05302619934082031
+    }
+  },
+  'headers': {}
+};
+
 var validBidResponse1adWith2Bidders = {
   'body': {
     'id': '91221f96-b931-4acc-8f05-c2a1186fa5ac',
@@ -448,6 +948,623 @@ var validBidResponse1adWith2Bidders = {
   },
   'headers': {}
 };
+
+/*
+testing 2 ads, 2 bidders, one bidder bids for both slots in one adunit
+ */
+
+var multiRequest1 = [
+  {
+    'bidder': 'ozone',
+    'params': {
+      'publisherId': 'OZONERUP0001',
+      'siteId': '4204204201',
+      'placementId': '0420420421',
+      'customData': [
+        {
+          'settings': {},
+          'targeting': {
+            'sens': 'f',
+            'pt1': '/uk',
+            'pt2': 'uk',
+            'pt3': 'network-front',
+            'pt4': 'ng',
+            'pt5': [
+              'uk'
+            ],
+            'pt7': 'desktop',
+            'pt8': [
+              'tfmqxwj7q',
+              'penl4dfdk',
+              'uayf5jmv3',
+              't8nyiude5',
+              'sek9ghqwi'
+            ],
+            'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+          }
+        }
+      ],
+      'lotameData': {
+        'Profile': {
+          'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+          'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+          'Audiences': {
+            'Audience': [
+              {
+                'id': '439847',
+                'abbr': 'all'
+              },
+              {
+                'id': '446197',
+                'abbr': 'Arts, Culture & Literature'
+              },
+              {
+                'id': '446198',
+                'abbr': 'Business'
+              }
+            ]
+          }
+        }
+      }
+    },
+    'mediaTypes': {
+      'banner': {
+        'sizes': [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      }
+    },
+    'adUnitCode': 'mpu',
+    'transactionId': '6480bac7-31b5-4723-9145-ad8966660651',
+    'sizes': [
+      [
+        300,
+        250
+      ],
+      [
+        300,
+        600
+      ]
+    ],
+    'bidId': '2d30e86db743a8',
+    'bidderRequestId': '1d03a1dfc563fc',
+    'auctionId': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+    'src': 'client',
+    'bidRequestsCount': 1,
+    'bidderRequestsCount': 1,
+    'bidderWinsCount': 0
+  },
+  {
+    'bidder': 'ozone',
+    'params': {
+      'publisherId': 'OZONERUP0001',
+      'siteId': '4204204201',
+      'placementId': '0420420421',
+      'customData': [
+        {
+          'settings': {},
+          'targeting': {
+            'sens': 'f',
+            'pt1': '/uk',
+            'pt2': 'uk',
+            'pt3': 'network-front',
+            'pt4': 'ng',
+            'pt5': [
+              'uk'
+            ],
+            'pt7': 'desktop',
+            'pt8': [
+              'tfmqxwj7q',
+              'penl4dfdk',
+              't8nxz6qzd',
+              't8nyiude5',
+              'sek9ghqwi'
+            ],
+            'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+          }
+        }
+      ],
+      'lotameData': {
+        'Profile': {
+          'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+          'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+          'Audiences': {
+            'Audience': [
+              {
+                'id': '439847',
+                'abbr': 'all'
+              },
+              {
+                'id': '446197',
+                'abbr': 'Arts, Culture & Literature'
+              },
+              {
+                'id': '446198',
+                'abbr': 'Business'
+              }
+            ]
+          }
+        }
+      }
+    },
+    'mediaTypes': {
+      'banner': {
+        'sizes': [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            250
+          ]
+        ]
+      }
+    },
+    'adUnitCode': 'leaderboard',
+    'transactionId': 'a49988e6-ae7c-46c4-9598-f18db49892a0',
+    'sizes': [
+      [
+        728,
+        90
+      ],
+      [
+        970,
+        250
+      ]
+    ],
+    'bidId': '3025f169863b7f8',
+    'bidderRequestId': '1d03a1dfc563fc',
+    'auctionId': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+    'src': 'client',
+    'bidRequestsCount': 1,
+    'bidderRequestsCount': 1,
+    'bidderWinsCount': 0
+  }
+];
+
+// WHEN sent as bidderRequest to buildRequests you should send the child: .bidderRequest
+var multiBidderRequest1 = {
+  bidderRequest: {
+    'bidderCode': 'ozone',
+    'auctionId': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+    'bidderRequestId': '1d03a1dfc563fc',
+    'bids': [
+      {
+        'bidder': 'ozone',
+        'params': {
+          'publisherId': 'OZONERUP0001',
+          'siteId': '4204204201',
+          'placementId': '0420420421',
+          'customData': [
+            {
+              'settings': {},
+              'targeting': {
+                'sens': 'f',
+                'pt1': '/uk',
+                'pt2': 'uk',
+                'pt3': 'network-front',
+                'pt4': 'ng',
+                'pt5': [
+                  'uk'
+                ],
+                'pt7': 'desktop',
+                'pt8': [
+                  'tfmqxwj7q',
+                  'txeh7uyo0',
+                  't8nxz6qzd',
+                  't8nyiude5',
+                  'sek9ghqwi'
+                ],
+                'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+              }
+            }
+          ],
+          'lotameData': {
+            'Profile': {
+              'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+              'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+              'Audiences': {
+                'Audience': [
+                  {
+                    'id': '439847',
+                    'abbr': 'all'
+                  },
+                  {
+                    'id': '446197',
+                    'abbr': 'Arts, Culture & Literature'
+                  },
+                  {
+                    'id': '446198',
+                    'abbr': 'Business'
+                  }
+                ]
+              }
+            }
+          }
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [
+              [
+                300,
+                250
+              ],
+              [
+                300,
+                600
+              ]
+            ]
+          }
+        },
+        'adUnitCode': 'mpu',
+        'transactionId': '6480bac7-31b5-4723-9145-ad8966660651',
+        'sizes': [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ],
+        'bidId': '2d30e86db743a8',
+        'bidderRequestId': '1d03a1dfc563fc',
+        'auctionId': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+        'src': 'client',
+        'bidRequestsCount': 1,
+        'bidderRequestsCount': 1,
+        'bidderWinsCount': 0
+      },
+      {
+        'bidder': 'ozone',
+        'params': {
+          'publisherId': 'OZONERUP0001',
+          'siteId': '4204204201',
+          'placementId': '0420420421',
+          'customData': [
+            {
+              'settings': {},
+              'targeting': {
+                'sens': 'f',
+                'pt1': '/uk',
+                'pt2': 'uk',
+                'pt3': 'network-front',
+                'pt4': 'ng',
+                'pt5': [
+                  'uk'
+                ],
+                'pt7': 'desktop',
+                'pt8': [
+                  'tfmqxwj7q',
+                  'penl4dfdk',
+                  't8nxz6qzd',
+                  't8nyiude5',
+                  'sek9ghqwi'
+                ],
+                'pt9': '|k0xw2vqzp33kklb3j5w4|||'
+              }
+            }
+          ],
+          'lotameData': {
+            'Profile': {
+              'tpid': '4e5c21fc7c181c2b1eb3a73d543a27f6',
+              'pid': '3a45fd4872fa01f35c49586d8dcb7c60',
+              'Audiences': {
+                'Audience': [
+                  {
+                    'id': '439847',
+                    'abbr': 'all'
+                  },
+                  {
+                    'id': '446197',
+                    'abbr': 'Arts, Culture & Literature'
+                  },
+                  {
+                    'id': '446198',
+                    'abbr': 'Business'
+                  }
+                ]
+              }
+            }
+          }
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [
+              [
+                728,
+                90
+              ],
+              [
+                970,
+                250
+              ]
+            ]
+          }
+        },
+        'adUnitCode': 'leaderboard',
+        'transactionId': 'a49988e6-ae7c-46c4-9598-f18db49892a0',
+        'sizes': [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            250
+          ]
+        ],
+        'bidId': '3025f169863b7f8',
+        'bidderRequestId': '1d03a1dfc563fc',
+        'auctionId': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+        'src': 'client',
+        'bidRequestsCount': 1,
+        'bidderRequestsCount': 1,
+        'bidderWinsCount': 0
+      }
+    ],
+    'auctionStart': 1592918645574,
+    'timeout': 3000,
+    'refererInfo': {
+      'referer': 'http://ozone.ardm.io/adapter/2.4.0/620x350-switch.html?guardian=true&pbjs_debug=true',
+      'reachedTop': true,
+      'numIframes': 0,
+      'stack': [
+        'http://ozone.ardm.io/adapter/2.4.0/620x350-switch.html?guardian=true&pbjs_debug=true'
+      ]
+    },
+    'gdprConsent': {
+      'consentString': 'BOvy5sFO1dBa2AKAiBENDP-AAAAwVrv7_77-_9f-_f__9uj3Gr_v_f__32ccL5tv3h_7v-_7fi_-0nV4u_1tft9ydk1-5ctDztp507iakiPHmqNeb9n_mz1eZpRP58E09j53z7Ew_v8_v-b7BCPN_Y3v-8K96kA',
+      'vendorData': {
+        'metadata': 'BOvy5sFO1dBa2AKAiBENDPA',
+        'gdprApplies': true,
+        'hasGlobalConsent': false,
+        'hasGlobalScope': false,
+        'purposeConsents': {
+          '1': true,
+          '2': true,
+          '3': true,
+          '4': true,
+          '5': true
+        },
+        'vendorConsents': {
+          '1': true,
+          '2': true,
+          '3': false,
+          '4': true,
+          '5': true
+        }
+      },
+      'gdprApplies': true
+    },
+    'start': 1592918645578
+  }
+};
+
+var multiResponse1 = {
+  'body': {
+    'id': '592ee33b-fb2e-4c00-b2d5-383e99cac57f',
+    'seatbid': [
+      {
+        'bid': [
+          {
+            'id': '4419718600113204943',
+            'impid': '2d30e86db743a8',
+            'price': 0.2484,
+            'adm': '<scr .. .iv>',
+            'adid': '119683582',
+            'adomain': [
+              'https://ozoneproject.com'
+            ],
+            'iurl': 'https://ams1-ib.adnxs.com/cr?id=119683582',
+            'cid': '9979',
+            'crid': '119683582',
+            'cat': [
+              'IAB3'
+            ],
+            'w': 300,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'ozone': {},
+                'appnexus': {
+                  'brand_id': 734921,
+                  'auction_id': 2995348111857539600,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            },
+            'cpm': 0.2484,
+            'bidId': '2d30e86db743a8',
+            'requestId': '2d30e86db743a8',
+            'width': 300,
+            'height': 250,
+            'ad': '<scr...iv>',
+            'netRevenue': true,
+            'creativeId': '119683582',
+            'currency': 'USD',
+            'ttl': 300,
+            'originalCpm': 0.2484,
+            'originalCurrency': 'USD'
+          },
+          {
+            'id': '18552976939844681',
+            'impid': '3025f169863b7f8',
+            'price': 0.0621,
+            'adm': '<sc..this ad will lose to the next one.div>',
+            'adid': '120179216',
+            'adomain': [
+              'appnexus.com'
+            ],
+            'iurl': 'https://ams1-ib.adnxs.com/cr?id=120179216',
+            'cid': '9979',
+            'crid': '120179216',
+            'w': 970,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'ozone': {},
+                'appnexus': {
+                  'brand_id': 1,
+                  'auction_id': 3449036134472542700,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            },
+            'cpm': 0.0621,
+            'bidId': '3025f169863b7f8',
+            'requestId': '3025f169863b7f8',
+            'width': 970,
+            'height': 250,
+            'ad': '<scr...iv>',
+            'netRevenue': true,
+            'creativeId': '120179216',
+            'currency': 'USD',
+            'ttl': 300,
+            'originalCpm': 0.0621,
+            'originalCurrency': 'USD'
+          },
+          {
+            'id': '18552976939844999',
+            'impid': '3025f169863b7f8',
+            'price': 0.521,
+            'adm': '<sc. second bid for bidId 3025f169863b7f8 ..div>',
+            'adid': '120179216',
+            'adomain': [
+              'appnexus.com'
+            ],
+            'iurl': 'https://ams1-ib.adnxs.com/cr?id=120179216',
+            'cid': '9999',
+            'crid': '120179299',
+            'w': 728,
+            'h': 90,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'ozone': {},
+                'appnexus': {
+                  'brand_id': 1,
+                  'auction_id': 3449036134472542700,
+                  'bidder_id': 2,
+                  'bid_ad_type': 0
+                }
+              }
+            },
+            'cpm': 0.521,
+            'bidId': '3025f169863b7f8',
+            'requestId': '3025f169863b7f8',
+            'width': 728,
+            'height': 90,
+            'ad': '<scr...iv>',
+            'netRevenue': true,
+            'creativeId': '120179299',
+            'currency': 'USD',
+            'ttl': 300,
+            'originalCpm': 0.0621,
+            'originalCurrency': 'USD'
+          }
+        ],
+        'seat': 'ozappnexus'
+      },
+      {
+        'bid': [
+          {
+            'id': '1c605e8a-4992-4ec6-8a5c-f82e2938c2db',
+            'impid': '2d30e86db743a8',
+            'price': 0.01,
+            'adm': '<div  ... div>',
+            'crid': '540463358',
+            'w': 300,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'ozone': {}
+              }
+            },
+            'cpm': 0.01,
+            'bidId': '2d30e86db743a8',
+            'requestId': '2d30e86db743a8',
+            'width': 300,
+            'height': 250,
+            'ad': '<div ...div>',
+            'netRevenue': true,
+            'creativeId': '540463358',
+            'currency': 'USD',
+            'ttl': 300,
+            'originalCpm': 0.01,
+            'originalCurrency': 'USD'
+          },
+          {
+            'id': '3edeb4f7-d91d-44e2-8aeb-4a2f6d295ce5',
+            'impid': '3025f169863b7f8',
+            'price': 0.01,
+            'adm': '<div ... div>',
+            'crid': '540221061',
+            'w': 970,
+            'h': 250,
+            'ext': {
+              'prebid': {
+                'type': 'banner'
+              },
+              'bidder': {
+                'ozone': {}
+              }
+            },
+            'cpm': 0.01,
+            'bidId': '3025f169863b7f8',
+            'requestId': '3025f169863b7f8',
+            'width': 970,
+            'height': 250,
+            'ad': '<div ... div>',
+            'netRevenue': true,
+            'creativeId': '540221061',
+            'currency': 'USD',
+            'ttl': 300,
+            'originalCpm': 0.01,
+            'originalCurrency': 'USD'
+          }
+        ],
+        'seat': 'openx'
+      }
+    ],
+    'ext': {
+      'debug': {},
+      'responsetimemillis': {
+        'beeswax': 6,
+        'openx': 91,
+        'ozappnexus': 40,
+        'ozbeeswax': 6
+      }
+    }
+  },
+  'headers': {}
+};
+
+/*
+--------------------end of 2 slots, 2 ----------------------------
+ */
 
 describe('ozone Adapter', function () {
   describe('isBidRequestValid', function () {
@@ -854,26 +1971,26 @@ describe('ozone Adapter', function () {
 
   describe('buildRequests', function () {
     it('sends bid request to OZONEURI via POST', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request.url).to.equal(OZONEURI);
       expect(request.method).to.equal('POST');
     });
 
     it('sends data as a string', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request.data).to.be.a('string');
     });
 
     it('sends all bid parameters', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
     });
 
     it('adds all parameters inside the ext object only', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request.data).to.be.a('string');
       var data = JSON.parse(request.data);
-      expect(data.imp[0].ext.ozone.lotameData).to.be.an('object');
+      expect(data.ext.ozone.lotameData).to.be.an('object');
       expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(request).not.to.have.key('lotameData');
       expect(request).not.to.have.key('customData');
@@ -882,10 +1999,10 @@ describe('ozone Adapter', function () {
     it('ignores ozoneData in & after version 2.1.1', function () {
       let validBidRequestsWithOzoneData = validBidRequests;
       validBidRequestsWithOzoneData[0].params.ozoneData = {'networkID': '3048', 'dfpSiteID': 'd.thesun', 'sectionID': 'homepage', 'path': '/', 'sec_id': 'null', 'sec': 'sec', 'topics': 'null', 'kw': 'null', 'aid': 'null', 'search': 'null', 'article_type': 'null', 'hide_ads': '', 'article_slug': 'null'};
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request.data).to.be.a('string');
       var data = JSON.parse(request.data);
-      expect(data.imp[0].ext.ozone.lotameData).to.be.an('object');
+      expect(data.ext.ozone.lotameData).to.be.an('object');
       expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(data.imp[0].ext.ozone.ozoneData).to.be.undefined;
       expect(request).not.to.have.key('lotameData');
@@ -893,33 +2010,33 @@ describe('ozone Adapter', function () {
     });
 
     it('has correct bidder', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       expect(request.bidderRequest.bids[0].bidder).to.equal(BIDDER_CODE);
     });
 
     it('handles mediaTypes element correctly', function () {
-      const request = spec.buildRequests(validBidRequestsWithBannerMediaType, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsWithBannerMediaType, validBidderRequest.bidderRequest);
       expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
     });
 
     it('handles no ozone, lotame or custom data', function () {
-      const request = spec.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsMinimal, validBidderRequest.bidderRequest);
       expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
     });
 
     it('handles video mediaType element correctly, with outstream video', function () {
-      const request = spec.buildRequests(validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests1OutstreamVideo2020, validBidderRequest.bidderRequest);
       expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
     });
 
     it('should not crash when there is no sizes element at all', function () {
-      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
       expect(request).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
     });
 
     it('should be able to handle non-single requests', function () {
       config.setConfig({'ozone': {'singleRequest': false}});
-      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
       expect(request).to.be.a('array');
       expect(request[0]).to.have.all.keys(['bidderRequest', 'data', 'method', 'url']);
       // need to reset the singleRequest config flag:
@@ -928,7 +2045,7 @@ describe('ozone Adapter', function () {
 
     it('should add gdpr consent information to the request when ozone is true', function () {
       let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
+      let bidderRequest = validBidderRequest.bidderRequest;
       bidderRequest.gdprConsent = {
         consentString: consentString,
         gdprApplies: true,
@@ -947,9 +2064,9 @@ describe('ozone Adapter', function () {
     });
 
     // mirror
-    it('should add gdpr consent information to the request when ozone.oz_enforceGdpr is false and vendorData is missing vendorConsents (Mirror)', function () {
+    it('should add gdpr consent information to the request when vendorData is missing vendorConsents (Mirror)', function () {
       let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
+      let bidderRequest = validBidderRequest.bidderRequest;
       bidderRequest.gdprConsent = {
         consentString: consentString,
         gdprApplies: true,
@@ -964,43 +2081,9 @@ describe('ozone Adapter', function () {
       expect(payload.regs.ext.gdpr).to.equal(1);
       expect(payload.user.ext.consent).to.equal(consentString);
     });
-    it('should add gdpr consent information to the request when ozone.oz_enforceGdpr is NOT PRESENT and vendorData is missing vendorConsents (Mirror)', function () {
-      let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
-      bidderRequest.gdprConsent = {
-        consentString: consentString,
-        gdprApplies: true,
-        vendorData: {
-          metadata: consentString,
-          gdprApplies: true
-        }
-      }
-      const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
-      const payload = JSON.parse(request.data);
-      expect(payload.regs.ext.gdpr).to.equal(1);
-      expect(payload.user.ext.consent).to.equal(consentString);
-      config.resetConfig();
-    });
-    it('should kill the auction request when ozone.oz_enforceGdpr is true & vendorData is missing vendorConsents (Mirror)', function () {
-      let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
-      bidderRequest.gdprConsent = {
-        consentString: consentString,
-        gdprApplies: true,
-        vendorData: {
-          metadata: consentString,
-          gdprApplies: true
-        }
-      }
-      config.setConfig({'ozone': {'oz_enforceGdpr': true}});
-      const request = spec.buildRequests(validBidRequestsNoSizes, bidderRequest);
-      expect(request.length).to.equal(0);
-      config.resetConfig();
-    });
-
     it('should set regs.ext.gdpr flag to 0 when gdprApplies is false', function () {
       let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
+      let bidderRequest = validBidderRequest.bidderRequest;
       bidderRequest.gdprConsent = {
         consentString: consentString,
         gdprApplies: false,
@@ -1019,7 +2102,7 @@ describe('ozone Adapter', function () {
 
     it('should not have imp[N].ext.ozone.userId', function () {
       let consentString = 'BOcocyaOcocyaAfEYDENCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NphLgA==';
-      let bidderRequest = validBidderRequest;
+      let bidderRequest = validBidderRequest.bidderRequest;
       bidderRequest.gdprConsent = {
         consentString: consentString,
         gdprApplies: false,
@@ -1063,14 +2146,14 @@ describe('ozone Adapter', function () {
         // 'pubcid': '5555', // remove pubcid from here to emulate the OLD module & cause the failover code to kick in
         'tdid': '6666'
       };
-      const request = spec.buildRequests(bidRequests, validBidderRequest);
+      const request = spec.buildRequests(bidRequests, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.ext.ozone.pubcid).to.equal(bidRequests[0]['crumbs']['pubcid']);
       delete validBidRequests[0].userId; // tidy up now, else it will screw with other tests
     });
 
     it('should add a user.ext.eids object to contain user ID data in the new location (Nov 2019)', function() {
-      const request = spec.buildRequests(validBidRequestsWithUserIdData, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsWithUserIdData, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.user).to.exist;
       expect(payload.user.ext).to.exist;
@@ -1096,7 +2179,7 @@ describe('ozone Adapter', function () {
       spec.getGetParametersAsObject = function() {
         return {'oztestmode': 'mytestvalue_123'};
       };
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const data = JSON.parse(request.data);
       expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(data.imp[0].ext.ozone.customData[0].targeting.oztestmode).to.equal('mytestvalue_123');
@@ -1106,7 +2189,7 @@ describe('ozone Adapter', function () {
       spec.getGetParametersAsObject = function() {
         return {'oztestmode': 'mytestvalue_123'};
       };
-      const request = spec.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsMinimal, validBidderRequest.bidderRequest);
       const data = JSON.parse(request.data);
       expect(data.imp[0].ext.ozone.customData).to.be.an('array');
       expect(data.imp[0].ext.ozone.customData[0].targeting.oztestmode).to.equal('mytestvalue_123');
@@ -1117,7 +2200,7 @@ describe('ozone Adapter', function () {
       specMock.getGetParametersAsObject = function() {
         return {'ozstoredrequest': '1122334455'}; // 10 digits are valid
       };
-      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest.bidderRequest);
       const data = JSON.parse(request.data);
       expect(data.ext.ozone.oz_rw).to.equal(1);
       expect(data.imp[0].ext.prebid.storedrequest.id).to.equal('1122334455');
@@ -1127,7 +2210,7 @@ describe('ozone Adapter', function () {
       specMock.getGetParametersAsObject = function() {
         return {'ozstoredrequest': 'BADVAL'}; // 10 digits are valid
       };
-      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest);
+      const request = specMock.buildRequests(validBidRequestsMinimal, validBidderRequest.bidderRequest);
       const data = JSON.parse(request.data);
       expect(data.ext.ozone.oz_rw).to.equal(0);
       expect(data.imp[0].ext.prebid.storedrequest.id).to.equal('1310000099');
@@ -1137,9 +2220,9 @@ describe('ozone Adapter', function () {
       spec.getGetParametersAsObject = function() {
         return {'oz_lotameid': '123abc', 'oz_lotamepid': 'pid123', 'oz_lotametpid': '123eee'};
       };
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
+      expect(payload.ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
       expect(payload.ext.ozone.oz_lot_rw).to.equal(1);
     });
     it('should pick up the value of valid lotame override parameters when there is an empty lotame object', function () {
@@ -1148,11 +2231,11 @@ describe('ozone Adapter', function () {
       spec.getGetParametersAsObject = function() {
         return {'oz_lotameid': '123abc', 'oz_lotamepid': 'pid123', 'oz_lotametpid': '123eeetpid'};
       };
-      const request = spec.buildRequests(nolotameBidReq, validBidderRequest);
+      const request = spec.buildRequests(nolotameBidReq, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.tpid).to.equal('123eeetpid');
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.pid).to.equal('pid123');
+      expect(payload.ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
+      expect(payload.ext.ozone.lotameData.Profile.tpid).to.equal('123eeetpid');
+      expect(payload.ext.ozone.lotameData.Profile.pid).to.equal('pid123');
       expect(payload.ext.ozone.oz_lot_rw).to.equal(1);
     });
     it('should pick up the value of valid lotame override parameters when there is NO "lotame" key at all', function () {
@@ -1161,27 +2244,29 @@ describe('ozone Adapter', function () {
       spec.getGetParametersAsObject = function() {
         return {'oz_lotameid': '123abc', 'oz_lotamepid': 'pid123', 'oz_lotametpid': '123eeetpid'};
       };
-      const request = spec.buildRequests(nolotameBidReq, validBidderRequest);
+      const request = spec.buildRequests(nolotameBidReq, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.tpid).to.equal('123eeetpid');
-      expect(payload.imp[0].ext.ozone.lotameData.Profile.pid).to.equal('pid123');
+      expect(payload.ext.ozone.lotameData.Profile.Audiences.Audience[0].id).to.equal('123abc');
+      expect(payload.ext.ozone.lotameData.Profile.tpid).to.equal('123eeetpid');
+      expect(payload.ext.ozone.lotameData.Profile.pid).to.equal('pid123');
       expect(payload.ext.ozone.oz_lot_rw).to.equal(1);
+      spec.propertyBag = originalPropertyBag; // tidy up
     });
     // NOTE - only one negative test case;
     // you can't send invalid lotame params to buildRequests because 'validate' will have rejected them
     it('should not use lotame override parameters if they dont exist', function () {
+      expect(spec.propertyBag.lotameWasOverridden).to.equal(0);
       spec.getGetParametersAsObject = function() {
         return {}; //  no lotame override params
       };
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.ext.ozone.oz_lot_rw).to.equal(0);
     });
 
     it('should pick up the config value of coppa & set it in the request', function () {
       config.setConfig({'coppa': true});
-      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.regs).to.include.keys('coppa');
       expect(payload.regs.coppa).to.equal(1);
@@ -1189,22 +2274,75 @@ describe('ozone Adapter', function () {
     });
     it('should pick up the config value of coppa & only set it in the request if its true', function () {
       config.setConfig({'coppa': false});
-      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest);
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
       const payload = JSON.parse(request.data);
       expect(utils.deepAccess(payload, 'regs.coppa')).to.be.undefined;
       config.resetConfig();
+    });
+    it('should handle oz_omp_floor correctly', function () {
+      config.setConfig({'ozone': {'oz_omp_floor': 1.56}});
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(utils.deepAccess(payload, 'ext.ozone.oz_omp_floor')).to.equal(1.56);
+      config.resetConfig();
+    });
+    it('should ignore invalid oz_omp_floor values', function () {
+      config.setConfig({'ozone': {'oz_omp_floor': '1.56'}});
+      const request = spec.buildRequests(validBidRequestsNoSizes, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(utils.deepAccess(payload, 'ext.ozone.oz_omp_floor')).to.be.undefined;
+      config.resetConfig();
+    });
+    it('should should contain a unique page view id in the auction request which persists across calls', function () {
+      let request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let payload = JSON.parse(request.data);
+      expect(utils.deepAccess(payload, 'ext.ozone.pv')).to.be.a('string');
+      request = spec.buildRequests(validBidRequests1OutstreamVideo2020, validBidderRequest.bidderRequest);
+      let payload2 = JSON.parse(request.data);
+      expect(utils.deepAccess(payload2, 'ext.ozone.pv')).to.be.a('string');
+      expect(utils.deepAccess(payload2, 'ext.ozone.pv')).to.equal(utils.deepAccess(payload, 'ext.ozone.pv'));
+    });
+    it('should indicate that the whitelist was used when it contains valid data', function () {
+      config.setConfig({'ozone': {'oz_whitelist_adserver_keys': ['oz_ozappnexus_pb', 'oz_ozappnexus_imp_id']}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.ext.ozone.oz_kvp_rw).to.equal(1);
+      config.resetConfig();
+    });
+    it('should indicate that the whitelist was not used when it contains no data', function () {
+      config.setConfig({'ozone': {'oz_whitelist_adserver_keys': []}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.ext.ozone.oz_kvp_rw).to.equal(0);
+      config.resetConfig();
+    });
+    it('should indicate that the whitelist was not used when it is not set in the config', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.ext.ozone.oz_kvp_rw).to.equal(0);
+    });
+    it('should have openrtb video params', function() {
+      let allowed = ['mimes', 'minduration', 'maxduration', 'protocols', 'w', 'h', 'startdelay', 'placement', 'linearity', 'skip', 'skipmin', 'skipafter', 'sequence', 'battr', 'maxextended', 'minbitrate', 'maxbitrate', 'boxingallowed', 'playbackmethod', 'playbackend', 'delivery', 'pos', 'companionad', 'api', 'companiontype', 'ext'];
+      const request = spec.buildRequests(validBidRequests1OutstreamVideo2020, validBidderRequest.bidderRequest);
+      const payload = JSON.parse(request.data);
+      const vid = (payload.imp[0].video);
+      const keys = Object.keys(vid);
+      for (let i = 0; i < keys.length; i++) {
+        expect(allowed).to.include(keys[i]);
+      }
+      expect(payload.imp[0].video.ext).to.include({'context': 'outstream'});
     });
   });
 
   describe('interpretResponse', function () {
     it('should build bid array', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const result = spec.interpretResponse(validResponse, request);
       expect(result.length).to.equal(1);
     });
 
     it('should have all relevant fields', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const result = spec.interpretResponse(validResponse, request);
       const bid = result[0];
       expect(bid.cpm).to.equal(validResponse.body.seatbid[0].bid[0].cpm);
@@ -1213,16 +2351,15 @@ describe('ozone Adapter', function () {
     });
 
     it('should build bid array with gdpr', function () {
-      let validBR = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
+      let validBR = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr.bidderRequest));
       validBR.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBR); // works the old way, with GDPR not enforced by default
-      // const request = spec.buildRequests(validBidRequests, bidderRequestWithFullGdpr); // works with oz_enforceGdpr true by default
       const result = spec.interpretResponse(validResponse, request);
       expect(result.length).to.equal(1);
     });
 
     it('should build bid array with only partial gdpr', function () {
-      var validBidderRequestWithGdpr = bidderRequestWithPartialGdpr;
+      var validBidderRequestWithGdpr = bidderRequestWithPartialGdpr.bidderRequest;
       validBidderRequestWithGdpr.gdprConsent = {'gdprApplies': 1, 'consentString': 'This is the gdpr consent string'};
       const request = spec.buildRequests(validBidRequests, validBidderRequestWithGdpr);
     });
@@ -1239,23 +2376,129 @@ describe('ozone Adapter', function () {
       expect(result).to.be.empty;
     });
 
-    it('should have video renderer', function () {
-      const request = spec.buildRequests(validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo, validBidderRequest);
-      const result = spec.interpretResponse(validOutstreamResponse, request);
+    it('should have video renderer for outstream video', function () {
+      const request = spec.buildRequests(validBidRequests1OutstreamVideo2020, validBidderRequest1OutstreamVideo2020.bidderRequest);
+      const result = spec.interpretResponse(getCleanValidVideoResponse(), validBidderRequest1OutstreamVideo2020);
       const bid = result[0];
       expect(bid.renderer).to.be.an.instanceOf(Renderer);
     });
 
+    it('should have NO video renderer for instream video', function () {
+      let instreamRequestsObj = JSON.parse(JSON.stringify(validBidRequests1OutstreamVideo2020));
+      instreamRequestsObj[0].mediaTypes.video.context = 'instream';
+      let instreamBidderReq = JSON.parse(JSON.stringify(validBidderRequest1OutstreamVideo2020));
+      instreamBidderReq.bidderRequest.bids[0].mediaTypes.video.context = 'instream';
+      const request = spec.buildRequests(instreamRequestsObj, validBidderRequest1OutstreamVideo2020.bidderRequest);
+      const result = spec.interpretResponse(getCleanValidVideoResponse(), instreamBidderReq);
+      const bid = result[0];
+      expect(bid.hasOwnProperty('renderer')).to.be.false;
+    });
+
     it('should correctly parse response where there are more bidders than ad slots', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const result = spec.interpretResponse(validBidResponse1adWith2Bidders, request);
       expect(result.length).to.equal(2);
     });
 
     it('should have a ttl of 600', function () {
-      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const result = spec.interpretResponse(validResponse, request);
       expect(result[0].ttl).to.equal(300);
+    });
+
+    it('should handle oz_omp_floor_dollars correctly, inserting 1 as necessary', function () {
+      config.setConfig({'ozone': {'oz_omp_floor': 0.01}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_omp')).to.equal('1');
+      config.resetConfig();
+    });
+    it('should handle oz_omp_floor_dollars correctly, inserting 0 as necessary', function () {
+      config.setConfig({'ozone': {'oz_omp_floor': 2.50}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_omp')).to.equal('0');
+      config.resetConfig();
+    });
+    it('should handle missing oz_omp_floor_dollars correctly, inserting nothing', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_omp')).to.be.undefined;
+    });
+    it('should handle a valid whitelist, removing items not on the list & leaving others', function () {
+      config.setConfig({'ozone': {'oz_whitelist_adserver_keys': ['oz_appnexus_crid', 'oz_appnexus_adId']}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_adv')).to.be.undefined;
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_adId')).to.equal('2899ec066a91ff8-0-0');
+      config.resetConfig();
+    });
+    it('should ignore a whitelist if enhancedAdserverTargeting is false', function () {
+      config.setConfig({'ozone': {'oz_whitelist_adserver_keys': ['oz_appnexus_crid', 'oz_appnexus_imp_id'], 'enhancedAdserverTargeting': false}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_adv')).to.be.undefined;
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_imp_id')).to.be.undefined;
+      config.resetConfig();
+    });
+    it('should correctly handle enhancedAdserverTargeting being false', function () {
+      config.setConfig({'ozone': {'enhancedAdserverTargeting': false}});
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      const result = spec.interpretResponse(validResponse, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_adv')).to.be.undefined;
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_imp_id')).to.be.undefined;
+      config.resetConfig();
+    });
+    it('should add flr into ads request if floor exists in the auction response', function () {
+      const request = spec.buildRequests(validBidRequestsMulti, validBidderRequest.bidderRequest);
+      let validres = JSON.parse(JSON.stringify(validResponse2Bids));
+      validres.body.seatbid[0].bid[0].ext.bidder.ozone = {'floor': 1};
+      const result = spec.interpretResponse(validres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_flr')).to.equal(1);
+      expect(utils.deepAccess(result[1].adserverTargeting, 'oz_appnexus_flr', '')).to.equal('');
+    });
+    it('should add rid into ads request if ruleId exists in the auction response', function () {
+      const request = spec.buildRequests(validBidRequestsMulti, validBidderRequest.bidderRequest);
+      let validres = JSON.parse(JSON.stringify(validResponse2Bids));
+      validres.body.seatbid[0].bid[0].ext.bidder.ozone = {'ruleId': 123};
+      const result = spec.interpretResponse(validres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_appnexus_rid')).to.equal(123);
+      expect(utils.deepAccess(result[1].adserverTargeting, 'oz_appnexus_rid', '')).to.equal('');
+    });
+    it('should add oz_ozappnexus_sid (cid value) for all appnexus bids', function () {
+      const request = spec.buildRequests(validBidRequestsMulti, validBidderRequest.bidderRequest);
+      let validres = JSON.parse(JSON.stringify(validResponse2BidsSameAdunit));
+      const result = spec.interpretResponse(validres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'oz_ozappnexus_sid')).to.equal(result[0].cid);
+    });
+    it('should add unique adId values to each bid', function() {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
+      let validres = JSON.parse(JSON.stringify(validResponse2BidsSameAdunit));
+      const result = spec.interpretResponse(validres, request);
+      expect(result.length).to.equal(1);
+      expect(result[0]['price']).to.equal(0.9);
+      expect(result[0]['adserverTargeting']['oz_ozappnexus_adId']).to.equal('2899ec066a91ff8-0-1');
+    });
+
+    it('should correctly process an auction with 2 adunits & multiple bidders one of which bids for both adslots', function() {
+      let validres = JSON.parse(JSON.stringify(multiResponse1));
+      let request = spec.buildRequests(multiRequest1, multiBidderRequest1.bidderRequest);
+      let result = spec.interpretResponse(validres, request);
+      expect(result.length).to.equal(4); // one of the 5 bids will have been removed
+      expect(result[1]['price']).to.equal(0.521);
+      expect(result[1]['impid']).to.equal('3025f169863b7f8');
+      expect(result[1]['id']).to.equal('18552976939844999');
+      expect(result[1]['adserverTargeting']['oz_ozappnexus_adId']).to.equal('3025f169863b7f8-0-2');
+      // change the bid values so a different second bid for an impid by the same bidder gets dropped
+      validres = JSON.parse(JSON.stringify(multiResponse1));
+      validres.body.seatbid[0].bid[1].price = 1.1;
+      validres.body.seatbid[0].bid[1].cpm = 1.1;
+      request = spec.buildRequests(multiRequest1, multiBidderRequest1.bidderRequest);
+      result = spec.interpretResponse(validres, request);
+      expect(result[1]['price']).to.equal(1.1);
+      expect(result[1]['impid']).to.equal('3025f169863b7f8');
+      expect(result[1]['id']).to.equal('18552976939844681');
+      expect(result[1]['adserverTargeting']['oz_ozappnexus_adId']).to.equal('3025f169863b7f8-0-1');
     });
   });
 
@@ -1270,7 +2513,7 @@ describe('ozone Adapter', function () {
     });
     it('should append the various values if they exist', function() {
       // get the cookie bag populated
-      spec.buildRequests(validBidRequests, validBidderRequest);
+      spec.buildRequests(validBidRequests, validBidderRequest.bidderRequest);
       const result = spec.getUserSyncs({iframeEnabled: true}, 'good server response', gdpr1);
       expect(result).to.be.an('array');
       expect(result[0].url).to.include('publisherId=9876abcd12-3');
@@ -1383,83 +2626,7 @@ describe('ozone Adapter', function () {
       expect(result).to.be.false;
       config.resetConfig();
     });
-    it('should return true if oz_enforceGdpr is true and consentString is undefined', function() {
-      config.setConfig({'ozone': {'oz_enforceGdpr': true}});
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      delete req.gdprConsent.consentString;
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.true;
-      config.resetConfig();
-    });
-    it('should return false if oz_enforceGdpr is false and consentString is undefined', function() {
-      config.setConfig({'ozone': {'oz_enforceGdpr': false}});
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      delete req.gdprConsent.consentString;
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.false;
-      config.resetConfig();
-    });
-    it('should return false if oz_enforceGdpr is NOT SET (default) and consentString is undefined', function() {
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      delete req.gdprConsent.consentString;
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.false;
-    });
-    it('should return false if gdprApplies is false', function() {
-      config.setConfig({'ozone': {'oz_request': true}});
-      let req = {'gdprConsent': {'gdprApplies': false}};
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.false;
-      config.resetConfig();
-    });
-    it('should return false if gdprConsent key does not exist', function() {
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      config.setConfig({'ozone': {'oz_enforceGdpr': true}});
-      delete req.gdprConsent;
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.false;
-      config.resetConfig();
-    });
-    it('should return false if gdpr is set, and all is ok', function() {
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      config.setConfig({'ozone': {'oz_enforceGdpr': true}});
-      let result = spec.blockTheRequest(req);
-      expect(result).to.be.false;
-      config.resetConfig();
-    });
   });
-
-  describe('failsGdprCheck', function() {
-    it('should return false for a a fully accepted user', function () {
-      let result = spec.failsGdprCheck(bidderRequestWithFullGdpr);
-      expect(result).to.be.false;
-    });
-    it('should return false if gdprConsent is not present on the bidder object', function () {
-      let result = spec.failsGdprCheck(validBidderRequest);
-      expect(result).to.be.false;
-    });
-    it('should return true if gdpr applies and vendorData is not an array', function () {
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      req.gdprConsent.vendorData = null;
-      let result = spec.failsGdprCheck(req);
-      expect(result).to.be.true;
-    });
-    it('should return true if gdpr applies and purposeConsents do not contain all the required true values', function () {
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      req.gdprConsent.vendorData.purposeConsents[1] = false;
-      let result = spec.failsGdprCheck(req);
-      expect(result).to.be.true;
-    });
-    it('should return true if gdpr applies and vendorConsents[524] is not true', function () {
-      config.setConfig({'ozone': {'oz_enforceGdpr': true}});
-      let req = JSON.parse(JSON.stringify(bidderRequestWithFullGdpr));
-      req.gdprConsent.vendorData.vendorConsents[524] = false;
-      let result = spec.failsGdprCheck(req);
-      expect(result).to.be.true;
-      config.resetConfig();
-    });
-  });
-
   describe('makeLotameObjectFromOverride', function() {
     it('should update an object with valid lotame data', function () {
       let objLotameOverride = {'oz_lotametpid': '1234', 'oz_lotameid': '12345', 'oz_lotamepid': '123456'};
@@ -1496,6 +2663,127 @@ describe('ozone Adapter', function () {
       let obj = {'Profile': {'tpid': '', 'pid': '', 'Audiences': {'Audience': [{'abbr': 'marktest'}]}}};
       let result = spec.isLotameDataValid(obj);
       expect(result).to.be.false;
+    });
+  });
+  describe('getPageId', function() {
+    it('should return the same Page ID for multiple calls', function () {
+      let result = spec.getPageId();
+      expect(result).to.be.a('string');
+      let result2 = spec.getPageId();
+      expect(result2).to.equal(result);
+    });
+  });
+  describe('getBidRequestForBidId', function() {
+    it('should locate a bid inside a bid array', function () {
+      let result = spec.getBidRequestForBidId('2899ec066a91ff8', validBidRequestsMulti);
+      expect(result.testId).to.equal(1);
+      result = spec.getBidRequestForBidId('2899ec066a91ff0', validBidRequestsMulti);
+      expect(result.testId).to.equal(2);
+    });
+  });
+  describe('getVideoContextForBidId', function() {
+    it('should locate the video context inside a bid', function () {
+      let result = spec.getVideoContextForBidId('2899ec066a91ff8', validBidRequestsWithNonBannerMediaTypesAndValidOutstreamVideo);
+      expect(result).to.equal('outstream');
+    });
+  });
+  describe('getLotameOverrideParams', function() {
+    it('should get 3 valid lotame params that exist in GET params', function () {
+      // mock the getGetParametersAsObject function to simulate GET parameters for lotame overrides:
+      spec.getGetParametersAsObject = function() {
+        return {'oz_lotameid': '123abc', 'oz_lotamepid': 'pid123', 'oz_lotametpid': 'tpid123'};
+      };
+      let result = spec.getLotameOverrideParams();
+      expect(Object.keys(result).length).to.equal(3);
+    });
+    it('should get only 1 valid lotame param that exists in GET params', function () {
+      // mock the getGetParametersAsObject function to simulate GET parameters for lotame overrides:
+      spec.getGetParametersAsObject = function() {
+        return {'oz_lotameid': '123abc', 'xoz_lotamepid': 'pid123', 'xoz_lotametpid': 'tpid123'};
+      };
+      let result = spec.getLotameOverrideParams();
+      expect(Object.keys(result).length).to.equal(1);
+    });
+  });
+  describe('unpackVideoConfigIntoIABformat', function() {
+    it('should correctly unpack a usual video config', function () {
+      let mediaTypes = {
+        playerSize: [640, 480],
+        mimes: ['video/mp4'],
+        context: 'outstream',
+        testKey: 'parent value'
+      };
+      let bid_params_video = {
+        skippable: true,
+        playback_method: ['auto_play_sound_off'],
+        playbackmethod: 2, /* start on load, no sound */
+        minduration: 5,
+        maxduration: 60,
+        skipmin: 5,
+        skipafter: 5,
+        testKey: 'child value'
+      };
+      let result = spec.unpackVideoConfigIntoIABformat(mediaTypes, bid_params_video);
+      expect(result.mimes).to.be.an('array').that.includes('video/mp4');
+      expect(result.ext.context).to.equal('outstream');
+      expect(result.ext.skippable).to.be.true; // note - we add skip in a different step: addVideoDefaults
+      expect(result.ext.testKey).to.equal('child value');
+    });
+  });
+  describe('addVideoDefaults', function() {
+    it('should correctly add video defaults', function () {
+      let mediaTypes = {
+        playerSize: [640, 480],
+        mimes: ['video/mp4'],
+        context: 'outstream',
+      };
+      let bid_params_video = {
+        skippable: true,
+        playback_method: ['auto_play_sound_off'],
+        playbackmethod: 2, /* start on load, no sound */
+        minduration: 5,
+        maxduration: 60,
+        skipmin: 5,
+        skipafter: 5,
+        testKey: 'child value'
+      };
+      let result = spec.addVideoDefaults({}, mediaTypes, mediaTypes);
+      expect(result.placement).to.equal(3);
+      expect(result.skip).to.equal(0);
+      result = spec.addVideoDefaults({}, mediaTypes, bid_params_video);
+      expect(result.skip).to.equal(1);
+    });
+    it('should correctly add video defaults including skippable in parent', function () {
+      let mediaTypes = {
+        playerSize: [640, 480],
+        mimes: ['video/mp4'],
+        context: 'outstream',
+        skippable: true
+      };
+      let bid_params_video = {
+        playback_method: ['auto_play_sound_off'],
+        playbackmethod: 2, /* start on load, no sound */
+        minduration: 5,
+        maxduration: 60,
+        skipmin: 5,
+        skipafter: 5,
+        testKey: 'child value'
+      };
+      let result = spec.addVideoDefaults({}, mediaTypes, bid_params_video);
+      expect(result.placement).to.equal(3);
+      expect(result.skip).to.equal(1);
+    });
+  });
+  describe('removeSingleBidderMultipleBids', function() {
+    it('should remove the multi bid by ozappnexus for adslot 2d30e86db743a8', function() {
+      let validres = JSON.parse(JSON.stringify(multiResponse1));
+      expect(validres.body.seatbid[0].bid.length).to.equal(3);
+      expect(validres.body.seatbid[0].seat).to.equal('ozappnexus');
+      let response = spec.removeSingleBidderMultipleBids(validres.body.seatbid);
+      expect(response.length).to.equal(2);
+      expect(response[0].bid.length).to.equal(2);
+      expect(response[0].seat).to.equal('ozappnexus');
+      expect(response[1].bid.length).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
Type of change
 • Bugfix
 • Feature
 
Description of changes

• TCF 2.0 Support
• Video request updated to support oRTB standards
• Refactored outstream implementation
• Introduced additional custom key-value pairs for video to indicate if bid is for instream or outstream
• introduced additional key-value pair to support floor price controls.
• Deprecated key-values pairs the adapter previously was setting that are no longer required.
• Introduced a pageview ID to request payload.
• 'lotameData' now sent inside ext.ozone instead of imp.ext.ozone to reduce request payload length.

- engineering@ozone-project.com