### PR TITLE
Added support for userId modules in adform adapters

### DIFF
--- a/modules/adformOpenRTBBidAdapter.js
+++ b/modules/adformOpenRTBBidAdapter.js
@@ -61,6 +61,7 @@ export const spec = {
     const siteId = setOnAny(validBidRequests, 'params.siteId');
     const currency = config.getConfig('currency.adServerCurrency');
     const cur = currency && [ currency ];
+    const eids = setOnAny(validBidRequests, 'userIdAsEids');
 
     const imp = validBidRequests.map((bid, id) => {
       bid.netRevenue = pt;
@@ -131,6 +132,10 @@ export const spec = {
 
     if (bidderRequest.uspConsent) {
       utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+    }
+
+    if (eids) {
+      utils.deepSetValue(request, 'user.ext.eids', eids);
     }
 
     return {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {assert, expect} from 'chai';
 import {spec} from 'modules/adformBidAdapter.js';
 import { BANNER, VIDEO } from 'src/mediaTypes.js';
 import { config } from 'src/config.js';
+import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('Adform adapter', function () {
   let serverResponse, bidRequest, bidResponses;
@@ -127,6 +128,26 @@ describe('Adform adapter', function () {
       parsedUrl = parseUrl(request.url);
 
       assert.equal(parsedUrl.query.pt, 'gross');
+    });
+
+    it('should pass extended ids', function () {
+      bids[0].userId = {
+        tdid: 'TTD_ID_FROM_USER_ID_MODULE',
+        pubcid: 'pubCommonId_FROM_USER_ID_MODULE'
+      };
+      bids[0].userIdAsEids = createEidsArray(bids[0].userId);
+      let request = spec.buildRequests(bids);
+      let eids = parseUrl(request.url).query.eids;
+
+      assert.equal(eids, 'eyJhZHNlcnZlci5vcmciOnsiVFREX0lEX0ZST01fVVNFUl9JRF9NT0RVTEUiOlsxXX0sInB1YmNpZC5vcmciOnsicHViQ29tbW9uSWRfRlJPTV9VU0VSX0lEX01PRFVMRSI6WzFdfX0%3D');
+      assert.deepEqual(JSON.parse(atob(decodeURIComponent(eids))), {
+        'adserver.org': {
+          'TTD_ID_FROM_USER_ID_MODULE': [1]
+        },
+        'pubcid.org': {
+          'pubCommonId_FROM_USER_ID_MODULE': [1]
+        }
+      });
     });
 
     describe('user privacy', function () {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -131,11 +131,10 @@ describe('Adform adapter', function () {
     });
 
     it('should pass extended ids', function () {
-      bids[0].userId = {
+      bids[0].userIdAsEids = createEidsArray({
         tdid: 'TTD_ID_FROM_USER_ID_MODULE',
         pubcid: 'pubCommonId_FROM_USER_ID_MODULE'
-      };
-      bids[0].userIdAsEids = createEidsArray(bids[0].userId);
+      });
       let request = spec.buildRequests(bids);
       let eids = parseUrl(request.url).query.eids;
 

--- a/test/spec/modules/adformOpenRTBBidAdapter_spec.js
+++ b/test/spec/modules/adformOpenRTBBidAdapter_spec.js
@@ -3,6 +3,7 @@ import {assert, expect} from 'chai';
 import {spec} from 'modules/adformOpenRTBBidAdapter.js';
 import { NATIVE } from 'src/mediaTypes.js';
 import { config } from 'src/config.js';
+import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('AdformOpenRTB adapter', function () {
   let serverResponse, bidRequest, bidResponses;
@@ -164,6 +165,23 @@ describe('AdformOpenRTB adapter', function () {
         publisher: validBidRequests[0].params.publisher,
         id: validBidRequests[0].params.siteId
       });
+    });
+
+    it('should pass extended ids', function () {
+      let validBidRequests = [{
+        bidId: 'bidId',
+        params: {},
+        userIdAsEids: createEidsArray({
+          tdid: 'TTD_ID_FROM_USER_ID_MODULE',
+          pubcid: 'pubCommonId_FROM_USER_ID_MODULE'
+        })
+      }];
+
+      let request = JSON.parse(spec.buildRequests(validBidRequests, { refererInfo: { referer: 'page' } }).data);
+      assert.deepEqual(request.user.ext.eids, [
+        { source: 'adserver.org', uids: [ { id: 'TTD_ID_FROM_USER_ID_MODULE', atype: 1, ext: { rtiPartner: 'TDID' } } ] },
+        { source: 'pubcid.org', uids: [ { id: 'pubCommonId_FROM_USER_ID_MODULE', atype: 1 } ] }
+      ]);
     });
 
     it('should send currency if defined', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Adding support for user modules by getting all eids that are present and passing them to Adform endpoints.

- Scope.FL.Scripts@adform.com
- [x] official adapter submission

- https://github.com/prebid/prebid.github.io/pull/2095
