### PR TITLE
Teads adapter : Support page referrer and network bandwidth

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -41,6 +41,8 @@ export const spec = {
     const bids = validBidRequests.map(buildRequestObject);
     const payload = {
       referrer: getReferrerInfo(bidderRequest),
+      pageReferrer: document.referrer,
+      networkBandwidth: getConnectionDownLink(window.navigator),
       data: bids,
       deviceWidth: screen.width,
       hb_version: '$prebid.version$'
@@ -115,6 +117,10 @@ function getReferrerInfo(bidderRequest) {
     ref = bidderRequest.refererInfo.referer;
   }
   return ref;
+}
+
+function getConnectionDownLink(nav) {
+  return nav && nav.connection && nav.connection.downlink >= 0 ? nav.connection.downlink.toString() : '';
 }
 
 function findGdprStatus(gdprApplies, gdprData, apiVersion) {

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -166,6 +166,29 @@ describe('teadsBidAdapter', () => {
       expect(payload.referrer).to.deep.equal('https://example.com/page.html')
     });
 
+    it('should add networkBandwidth info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderResquestDefault);
+      const payload = JSON.parse(request.data);
+
+      const bandwidth = window.navigator && window.navigator.connection && window.navigator.connection.downlink;
+
+      expect(payload.networkBandwidth).to.exist;
+
+      if (bandwidth) {
+        expect(payload.networkBandwidth).to.deep.equal(bandwidth.toString());
+      } else {
+        expect(payload.networkBandwidth).to.deep.equal('');
+      }
+    });
+
+    it('should add pageReferrer info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderResquestDefault);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.pageReferrer).to.exist;
+      expect(payload.pageReferrer).to.deep.equal(document.referrer);
+    });
+
     it('should send GDPR to endpoint with 11 status', function() {
       let consentString = 'JRJ8RKfDeBNsERRDCSAAZ+A==';
       let bidderRequest = {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Support Page referrer and Network bandwidth for teads adapter prebid (handle `bidResponse.pageReferrer` and `bidResponse.networkBandwidth` parameter)

contact email of the adapter’s maintainer : innov-ssp@teads.tv