### PR TITLE
Added support for Liveramp userId submodule & read sizes from adUnit.mediaTypes.banner 

### DIFF
--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -393,14 +393,11 @@ FAQs
 
 ### Why do I have to input size in `adUnits[].bids[].params` for IX when the size is already in the ad unit?
 
-There are two important reasons why we require it:
+There is one important reason why we recommend it:
 
-1. An IX site ID maps to a single size, whereas an ad unit can have multiple
-sizes. To ensure that the right site ID is mapped to the correct size in the ad
-unit we require the size to be explicitly stated.
-
-2. An ad unit may have sizes that IX does not support. By explicitly stating the
-size, you can choose not to have IX bid on certain sizes that are invalid.
+1. An IX site ID is recommended to map to a single size, whereas an ad unit can have multiple
+sizes. To ensure that the right site ID is mapped to the correct size in the ad unit, 
+we require the size to be explicitly stated or our bidder will auto assign the site ID to sizes that are not assigned.
 
 ### How do I view IX's bid request in the network?
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -753,7 +753,7 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.source.ext.schain).to.deep.equal(SAMPLE_SCHAIN);
       expect(payload.imp).to.exist;
       expect(payload.imp).to.be.an('array');
-      expect(payload.imp).to.have.lengthOf(1);
+      expect(payload.imp).to.have.lengthOf(2);
     });
 
     it('payload should not include schain when not provided', function () {
@@ -927,6 +927,7 @@ describe('IndexexchangeAdapter', function () {
       const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], DEFAULT_VIDEO_VALID_BID[0]]);
 
       const bannerImp = JSON.parse(request[0].data.r).imp[0];
+      expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(2);
       expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
       expect(bannerImp.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
       expect(bannerImp.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
@@ -940,6 +941,80 @@ describe('IndexexchangeAdapter', function () {
       expect(videoImp.video).to.exist;
       expect(videoImp.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
       expect(videoImp.video.h).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[1]);
+    });
+
+    it('request should contain the extra banner ad sizes that IX is not configured for using the first site id in the ad unit', function () {
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.sizes.push([336, 280], [970, 90]);
+      bid.mediaTypes.banner.sizes.push([336, 280], [970, 90]);
+      const bid2 = utils.deepClone(bid);
+      bid2.params.siteId = '124';
+      bid2.params.size = [300, 600];
+      bid2.params.bidId = '2b3c4d5e';
+
+      const request = spec.buildRequests([bid, bid2], DEFAULT_OPTION)[0];
+      const impressions = JSON.parse(request.data.r).imp;
+
+      expect(impressions).to.be.an('array');
+      expect(impressions).to.have.lengthOf(4);
+
+      expect(impressions[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+      expect(impressions[1].ext.siteID).to.equal(bid2.params.siteId)
+      expect(impressions[2].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+      expect(impressions[3].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+
+      expect(impressions[0].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
+      expect(impressions[0].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
+      expect(impressions[1].banner.w).to.equal(bid2.params.size[0]);
+      expect(impressions[1].banner.h).to.equal(bid2.params.size[1]);
+      expect(impressions[2].banner.w).to.equal(bid.mediaTypes.banner.sizes[2][0]);
+      expect(impressions[2].banner.h).to.equal(bid.mediaTypes.banner.sizes[2][1]);
+      expect(impressions[3].banner.w).to.equal(bid.mediaTypes.banner.sizes[3][0]);
+      expect(impressions[3].banner.h).to.equal(bid.mediaTypes.banner.sizes[3][1]);
+    });
+
+    it('request should contain the extra banner ad sizes and their corresponding site ids when there is multiple ad units', function () {
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.params.siteId = '124';
+      bid.adUnitCode = 'div-gpt-ad-156456451554-1'
+      bid.transactionId = '152e36d1-1241-4242-t35e-y1dv34d12315';
+      bid.bidId = '2f6g5s5e';
+      bid.params.size = [336, 280]
+      bid.sizes = [[336, 280], [970, 90]]
+      bid.mediaTypes.banner.sizes = [[336, 280], [970, 90]]
+
+      const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], bid], DEFAULT_OPTION)[0];
+
+      const impressions = JSON.parse(request.data.r).imp;
+      expect(impressions).to.be.an('array');
+      expect(impressions).to.have.lengthOf(4);
+
+      expect(impressions[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+      expect(impressions[1].ext.siteID).to.equal(bid.params.siteId)
+      expect(impressions[2].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+      expect(impressions[3].ext.siteID).to.equal(bid.params.siteId)
+
+      expect(impressions[0].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
+      expect(impressions[0].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
+      expect(impressions[1].banner.w).to.equal(bid.params.size[0]);
+      expect(impressions[1].banner.h).to.equal(bid.params.size[1]);
+      expect(impressions[2].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][0]);
+      expect(impressions[2].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][1]);
+      expect(impressions[3].banner.w).to.equal(bid.mediaTypes.banner.sizes[1][0]);
+      expect(impressions[3].banner.h).to.equal(bid.mediaTypes.banner.sizes[1][1]);
+
+      expect(impressions[0].ext.sid).to.equal(`${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`);
+      expect(impressions[1].ext.sid).to.equal(`${bid.params.size[0].toString()}x${bid.params.size[1].toString()}`);
+      expect(impressions[2].ext.sid).to.equal(`${DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][0].toString()}x${DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][1].toString()}`);
+      expect(impressions[3].ext.sid).to.equal(`${bid.mediaTypes.banner.sizes[1][0].toString()}x${bid.mediaTypes.banner.sizes[1][1].toString()}`);
+    });
+
+    it('request should not contain the extra video ad sizes that IX is not configured for', function () {
+      const request = spec.buildRequests(DEFAULT_VIDEO_VALID_BID, DEFAULT_OPTION);
+      const impressions = JSON.parse(request[0].data.r).imp;
+
+      expect(impressions).to.be.an('array');
+      expect(impressions).to.have.lengthOf(1);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Added support for Liveramp userId submodule
- The adapter now reads sizes from adUnit.mediaTypes.banner directly and send any missing size(s) found as a part of the bid request as well 