### PR TITLE
Update padsquad for meta.advertiserDomains

### DIFF
--- a/modules/padsquadBidAdapter.js
+++ b/modules/padsquadBidAdapter.js
@@ -83,6 +83,7 @@ export const spec = {
           ad: bid.adm,
           ttl: DEFAULT_BID_TTL,
           creativeId: bid.crid,
+          meta: { advertiserDomains : bid.adomain },
           netRevenue: DEFAULT_NET_REVENUE,
           currency: DEFAULT_CURRENCY,
         })

--- a/modules/padsquadBidAdapter.js
+++ b/modules/padsquadBidAdapter.js
@@ -83,7 +83,7 @@ export const spec = {
           ad: bid.adm,
           ttl: DEFAULT_BID_TTL,
           creativeId: bid.crid,
-          meta: { advertiserDomains : bid.adomain },
+          meta: { advertiserDomains: bid.adomain },
           netRevenue: DEFAULT_NET_REVENUE,
           currency: DEFAULT_CURRENCY,
         })

--- a/test/spec/modules/padsquadBidAdapter_spec.js
+++ b/test/spec/modules/padsquadBidAdapter_spec.js
@@ -212,6 +212,7 @@ describe('Padsquad bid adapter', function () {
         expect(bids[index]).to.have.property('height', RESPONSE.body.seatbid[0].bid[index].h);
         expect(bids[index]).to.have.property('ad', RESPONSE.body.seatbid[0].bid[index].adm);
         expect(bids[index]).to.have.property('creativeId', RESPONSE.body.seatbid[0].bid[index].crid);
+        expect(bids[index].meta.advertiserDomains).to.deep.equal(RESPONSE.body.seatbid[0].bid[index].adomain);
         expect(bids[index]).to.have.property('ttl', 30);
         expect(bids[index]).to.have.property('netRevenue', true);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
populates meta.advertiserDomains for padsquad adapter