### PR TITLE
oneVideo Adapter Added 3rd party Schain support (SAPR-13809)

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -244,19 +244,29 @@ function getRequestData(bid, consentData, bidRequest) {
     bidData.imp[0].ext.inventoryid = bid.params.video.inventoryid
   }
   if (bid.params.video.sid) {
-    bidData.source = {
-      ext: {
-        schain: {
-          complete: 1,
-          nodes: [{
-            sid: bid.params.video.sid,
-            rid: bidData.id,
-          }]
-        }
-      }
+    let vsspNode = {
+      sid: bid.params.video.sid,
+      rid: bid.id
     }
     if (bid.params.video.hp == 1) {
-      bidData.source.ext.schain.nodes[0].hp = bid.params.video.hp;
+      vsspNode.hp = bid.params.video.hp;
+    }
+    if (bid.params.video.schain) {
+      bidData.source = {
+        ext: {
+          schain: bid.params.video.schain
+        }
+      }
+      bidData.source.ext.schain.nodes.push(vsspNode);
+    } else {
+      bidData.source = {
+        ext: {
+          schain: {
+            complete: 1,
+            nodes: [vsspNode]
+          }
+        }
+      }
     }
   }
   if (bid.params.site && bid.params.site.id) {

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -246,7 +246,7 @@ function getRequestData(bid, consentData, bidRequest) {
   if (bid.params.video.sid) {
     let vsspNode = {
       sid: bid.params.video.sid,
-      rid: bid.id
+      rid: bidData.id
     }
     if (bid.params.video.hp == 1) {
       vsspNode.hp = bid.params.video.hp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.23.0-pre",
+  "version": "3.24.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.24.0-pre",
+  "version": "3.23.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -266,8 +266,8 @@ describe('OneVideoBidAdapter', function () {
       const data = requests[0].data;
       const nodes = data.source.ext.schain.nodes;
       expect(nodes.length).to.equal(1);
-      expect(nodes[nodes.length - 1].sid).to.equal(bidRequest.params.video.sid);
-      expect(nodes[nodes.length - 1].rid).to.equal(bidRequest.bidId);
+      expect(nodes[0].sid).to.equal(bidRequest.params.video.sid);
+      expect(nodes[0].rid).to.equal(data.id);
     });
 
     it('should not send video.params.schain if sid is missing', function () {
@@ -275,7 +275,7 @@ describe('OneVideoBidAdapter', function () {
       bidRequest.params.video.schain = { complete: 1, nodes: [{demoNode: 123}] };
       const requests = spec.buildRequests([ bidRequest ], bidderRequest);
       const data = requests[0].data;
-      expect(data.source.ext.schain).to.not.exist;
+      expect(data.source).to.not.exist
     })
 
     it('should generate new schain node based on sid, and append video.params.schain that is passed', function () {
@@ -284,7 +284,7 @@ describe('OneVideoBidAdapter', function () {
       const nodes = data.source.ext.schain.nodes;
       expect(nodes.length).to.equal(2);
       expect(nodes[nodes.length - 1].sid).to.equal(bidRequest.params.video.sid);
-      expect(nodes[nodes.length - 1].rid).to.equal(bidRequest.bidId);
+      expect(nodes[nodes.length - 1].rid).to.equal(data.id);
     })
 
     it('should append hp to vssp schain if video.params.hp is passed', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ x] Feature

## Description of change
oneVideoBidAdapter now supports passing of "schain" objects from authorized resellers.
For publishers using 3rd party Prebid Server solutions and/or Player Prebid solutions.

Previously you could only pass "bid.params.video.sid" with an integer value indicating the Partner's Organization ID within Video SSP (AKA oneVideo). Using the sid (org id) the adapter would generate a new schain object that would be sent in the outgoing bid-request.
Today, a Partner can choose to pass an existing "schain" object using "bid.params.video.schain" to the oneVideo adapter and that schain object (that will be extended with the Video SSP node using the sid value) and sent in the outgoing bid-request.

**Important!** You must pass "sid" if you intend to pass an "schain" object as well. 
This is because we will generate the schain node for Video SSP (oneVidoe) and append that as the last child to your existing schain.

### Logic
![image](https://user-images.githubusercontent.com/19834421/86354969-9cbac180-bc72-11ea-995d-a3199195c33c.png)

### Test parameters for validating bids
Important! the test creative only responds in geo US west Coast.
```
var adUnits = [{
                code: 'video1',
                mediaTypes: {
                    video: {
                        context: 'outstream',
                        playerSize: [300, 250]
                    },
                },
                bids: [
                    {
                        bidder: 'oneVideo',
                        params: {
                            video: {
                                playerWidth: 300,
                                playerHeight: 250,
                                mimes: ['video/mp4', 'application/javascript'],
                                protocols: [2, 5],
                                api: [1, 2],
                                sid: 28530,
                                schain: {
                                    complete: 1,
                                    nodes: [
                                        {
                                            sid: 1234567890,
                                            rid: '2b86bc23-6dcf-4704-ad9d-7dd39d7d2789',
                                            asi: 'some-ssp.com',
                                            hp: 1
                                        }
                                    ]
                                }
                            },
                            pubId: 'HBExchange',
                            site: {
                                page: 'http://www.verizonmedia.com'
                            },
                        }
                    }
                ]
            }];
```

## Other information
Hi @DeepthiNeeladri could you please review?
I have confirmed this business flow with Marcel & Carin.

Thank you
Adam