### PR TITLE
user id module refresh ids when consent changes

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -368,7 +368,7 @@ function addIdDataToAdUnitBids(adUnits, submodules) {
 }
 
 /**
- * This is a common function that will initalize subModules if not already done and it will also execute subModule callbacks
+ * This is a common function that will initialize subModules if not already done and it will also execute subModule callbacks
  */
 function initializeSubmodulesAndExecuteCallbacks(continueAuction) {
   let delayed = false;
@@ -633,7 +633,7 @@ export function init(config) {
     utils.logInfo(`${MODULE_NAME} - opt-out cookie found, exit module`);
     return;
   }
-  // _pubcid_optout is checked for compatiblility with pubCommonId
+  // _pubcid_optout is checked for compatibility with pubCommonId
   if (validStorageTypes.indexOf(LOCAL_STORAGE) !== -1 && (coreStorage.getDataFromLocalStorage('_pbjs_id_optout') || coreStorage.getDataFromLocalStorage('_pubcid_optout'))) {
     utils.logInfo(`${MODULE_NAME} - opt-out localStorage found, exit module`);
     return;

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1546,6 +1546,7 @@ describe('User ID', function() {
 
       // init consent management
       window.__cmp = function () { };
+      delete window.__tcfapi;
       testConsentData = {
         gdprApplies: true,
         consentData: 'xyz',

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -6,7 +6,8 @@ import {
   setSubmoduleRegistry,
   syncDelay,
   coreStorage,
-  setStoredValue
+  setStoredValue,
+  setStoredConsentData
 } from 'modules/userId/index.js';
 import {createEidsArray} from 'modules/userId/eids.js';
 import {config} from 'src/config.js';
@@ -14,6 +15,8 @@ import * as utils from 'src/utils.js';
 import events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
 import {getGlobal} from 'src/prebidGlobal.js';
+import {setConsentConfig, requestBidsHook as consentManagementRequestBidsHook, resetConsentData} from 'modules/consentManagement.js';
+import {gdprDataHandler} from 'src/adapterManager.js';
 import {unifiedIdSubmodule} from 'modules/unifiedIdSystem.js';
 import {pubCommonIdSubmodule} from 'modules/pubCommonIdSystem.js';
 import {britepoolIdSubmodule} from 'modules/britepoolIdSystem.js';
@@ -28,6 +31,7 @@ import {server} from 'test/mocks/xhr.js';
 let assert = require('chai').assert;
 let expect = require('chai').expect;
 const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
+const CONSENT_LOCAL_STORAGE_NAME = '_pbjs_id_consent_data';
 
 describe('User ID', function() {
   function getConfigMock(configArr1, configArr2, configArr3, configArr4, configArr5, configArr6, configArr7, configArr8) {
@@ -85,6 +89,10 @@ describe('User ID', function() {
     coreStorage.setCookie('_pubcid_optout', '', EXPIRED_COOKIE_DATE);
     localStorage.removeItem('_pbjs_id_optout');
     localStorage.removeItem('_pubcid_optout');
+  });
+
+  beforeEach(function() {
+    coreStorage.setCookie(CONSENT_LOCAL_STORAGE_NAME, '', EXPIRED_COOKIE_DATE);
   });
 
   describe('Decorate Ad Units', function() {
@@ -211,8 +219,9 @@ describe('User ID', function() {
           });
         });
       });
-      // Because the cookie exists already, there should be no setCookie call by default
-      expect(coreStorage.setCookie.callCount).to.equal(0);
+      // Because the cookie exists already, there should be no setCookie call by default; the only setCookie call is
+      // to store consent data
+      expect(coreStorage.setCookie.callCount).to.equal(1);
     });
 
     it('Extend cookie', function() {
@@ -237,8 +246,9 @@ describe('User ID', function() {
           });
         });
       });
-      // Because extend is true, the cookie will be updated even if it exists already
-      expect(coreStorage.setCookie.callCount).to.equal(1);
+      // Because extend is true, the cookie will be updated even if it exists already. The second setCookie call
+      // is for storing consentData
+      expect(coreStorage.setCookie.callCount).to.equal(2);
     });
 
     it('Disable auto create', function() {
@@ -259,7 +269,8 @@ describe('User ID', function() {
           expect(bid).to.not.have.deep.nested.property('userIdAsEids');
         });
       });
-      expect(coreStorage.setCookie.callCount).to.equal(0);
+      // setCookie is called once in order to store consentData
+      expect(coreStorage.setCookie.callCount).to.equal(1);
     });
 
     it('pbjs.getUserIds', function() {
@@ -1447,16 +1458,16 @@ describe('User ID', function() {
 
   describe('Set cookie behavior', function() {
     let coreStorageSpy;
-    beforeEach(function() {
+    beforeEach(function () {
       coreStorageSpy = sinon.spy(coreStorage, 'setCookie');
     });
-    afterEach(function() {
+    afterEach(function () {
       coreStorageSpy.restore();
     });
     it('should allow submodules to override the domain', function () {
       const submodule = {
         submodule: {
-          domainOverride: function() {
+          domainOverride: function () {
             return 'foo.com'
           }
         },
@@ -1472,9 +1483,7 @@ describe('User ID', function() {
 
     it('should pass null for domain if submodule does not override the domain', function () {
       const submodule = {
-        submodule: {
-
-        },
+        submodule: {},
         config: {
           storage: {
             type: 'cookie'
@@ -1483,6 +1492,193 @@ describe('User ID', function() {
       }
       setStoredValue(submodule, 'bar');
       expect(coreStorage.setCookie.getCall(0).args[4]).to.equal(null);
+    });
+  });
+
+  describe('Consent changes determine getId refreshes', function() {
+    const mockIdCookieName = 'MOCKID';
+    let expStr;
+    let adUnits;
+    let mockGetId = sinon.stub();
+    let mockDecode = sinon.stub();
+    let mockExtendId = sinon.stub();
+    let cmpStub;
+    let testConsentData;
+    const consentConfig = {
+      cmpApi: 'iab',
+      timeout: 7500,
+      allowAuctionWithoutConsent: false
+    };
+    const userIdConfig = {
+      userSync: {
+        userIds: [{
+          name: 'mockId',
+          storage: {
+            name: 'MOCKID',
+            type: 'cookie',
+            refreshInSeconds: 30
+          }
+        }],
+        auctionDelay: 5
+      }
+    };
+    const mockIdSystem = {
+      name: 'mockId',
+      getId: mockGetId,
+      decode: mockDecode,
+      extendId: mockExtendId
+    };
+
+    beforeEach(function () {
+      // clear cookies
+      expStr = (new Date(Date.now() + 25000).toUTCString());
+      coreStorage.setCookie(mockIdCookieName, '', EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, '', EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(CONSENT_LOCAL_STORAGE_NAME, '', EXPIRED_COOKIE_DATE);
+
+      // init
+      adUnits = [getAdUnitMock()];
+      init(config);
+
+      // init id system
+      attachIdSystem(mockIdSystem);
+      config.setConfig(userIdConfig);
+
+      // init consent management
+      window.__cmp = function () { };
+      testConsentData = {
+        gdprApplies: true,
+        consentData: 'xyz',
+        apiVersion: 1
+      };
+      cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
+        args[2](testConsentData);
+      });
+      setConsentConfig(consentConfig);
+    });
+
+    afterEach(function () {
+      config.resetConfig();
+      mockGetId.reset();
+      mockDecode.reset();
+      mockExtendId.reset();
+      delete window.__cmp;
+      cmpStub.restore();
+      resetConsentData();
+    });
+
+    it('does not call getId if no stored consent data and refresh is not needed', function () {
+      coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+
+      let innerAdUnits;
+      consentManagementRequestBidsHook(() => { }, { });
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      sinon.assert.notCalled(mockGetId);
+      sinon.assert.calledOnce(mockDecode);
+      sinon.assert.calledOnce(mockExtendId);
+
+      let consent = gdprDataHandler.getConsentData();
+      let userIdStoredConsent = JSON.parse(coreStorage.getCookie(CONSENT_LOCAL_STORAGE_NAME));
+      expect(userIdStoredConsent.gdprApplies).to.equal(consent.gdprApplies);
+      expect(userIdStoredConsent.gdprApplies).to.equal(testConsentData.gdprApplies);
+      expect(userIdStoredConsent.consentString).to.equal(consent.consentString);
+      expect(userIdStoredConsent.consentString).to.equal(testConsentData.consentData);
+    });
+
+    it('calls getId if no stored consent data but refresh is needed', function () {
+      coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 60 * 1000).toUTCString()), expStr);
+
+      let innerAdUnits;
+      consentManagementRequestBidsHook(() => { }, { });
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      sinon.assert.calledOnce(mockGetId);
+      sinon.assert.calledOnce(mockDecode);
+      sinon.assert.notCalled(mockExtendId);
+
+      let consent = gdprDataHandler.getConsentData();
+      let userIdStoredConsent = JSON.parse(coreStorage.getCookie(CONSENT_LOCAL_STORAGE_NAME));
+      expect(userIdStoredConsent.gdprApplies).to.equal(consent.gdprApplies);
+      expect(userIdStoredConsent.gdprApplies).to.equal(testConsentData.gdprApplies);
+      expect(userIdStoredConsent.consentString).to.equal(consent.consentString);
+      expect(userIdStoredConsent.consentString).to.equal(testConsentData.consentData);
+    });
+
+    it('calls getId if empty stored consent and refresh not needed', function () {
+      coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+
+      setStoredConsentData();
+
+      let innerAdUnits;
+      consentManagementRequestBidsHook(() => { }, { });
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      sinon.assert.calledOnce(mockGetId);
+      sinon.assert.calledOnce(mockDecode);
+      sinon.assert.notCalled(mockExtendId);
+
+      let consent = gdprDataHandler.getConsentData();
+      let userIdStoredConsent = JSON.parse(coreStorage.getCookie(CONSENT_LOCAL_STORAGE_NAME));
+      expect(userIdStoredConsent.gdprApplies).to.equal(consent.gdprApplies);
+      expect(userIdStoredConsent.gdprApplies).to.equal(testConsentData.gdprApplies);
+      expect(userIdStoredConsent.consentString).to.equal(consent.consentString);
+      expect(userIdStoredConsent.consentString).to.equal(testConsentData.consentData);
+    });
+
+    it('calls getId if stored consent does not match current consent and refresh not needed', function () {
+      coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+
+      setStoredConsentData({
+        gdprApplies: testConsentData.gdprApplies,
+        consentString: 'abc',
+        apiVersion: testConsentData.apiVersion
+      });
+
+      let innerAdUnits;
+      consentManagementRequestBidsHook(() => { }, { });
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      sinon.assert.calledOnce(mockGetId);
+      sinon.assert.calledOnce(mockDecode);
+      sinon.assert.notCalled(mockExtendId);
+
+      let consent = gdprDataHandler.getConsentData();
+      let userIdStoredConsent = JSON.parse(coreStorage.getCookie(CONSENT_LOCAL_STORAGE_NAME));
+      expect(userIdStoredConsent.gdprApplies).to.equal(consent.gdprApplies);
+      expect(userIdStoredConsent.gdprApplies).to.equal(testConsentData.gdprApplies);
+      expect(userIdStoredConsent.consentString).to.equal(consent.consentString);
+      expect(userIdStoredConsent.consentString).to.equal(testConsentData.consentData);
+    });
+
+    it('does not call getId if stored consent matches current consent and refresh not needed', function () {
+      coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+      coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+
+      setStoredConsentData({
+        gdprApplies: testConsentData.gdprApplies,
+        consentString: testConsentData.consentData,
+        apiVersion: testConsentData.apiVersion
+      });
+
+      let innerAdUnits;
+      consentManagementRequestBidsHook(() => { }, { });
+      requestBidsHook((config) => { innerAdUnits = config.adUnits }, {adUnits});
+
+      sinon.assert.notCalled(mockGetId);
+      sinon.assert.calledOnce(mockDecode);
+      sinon.assert.calledOnce(mockExtendId);
+
+      let consent = gdprDataHandler.getConsentData();
+      let userIdStoredConsent = JSON.parse(coreStorage.getCookie(CONSENT_LOCAL_STORAGE_NAME));
+      expect(userIdStoredConsent.gdprApplies).to.equal(consent.gdprApplies);
+      expect(userIdStoredConsent.gdprApplies).to.equal(testConsentData.gdprApplies);
+      expect(userIdStoredConsent.consentString).to.equal(consent.consentString);
+      expect(userIdStoredConsent.consentString).to.equal(testConsentData.consentData);
     });
   });
 });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -31,7 +31,7 @@ import {server} from 'test/mocks/xhr.js';
 let assert = require('chai').assert;
 let expect = require('chai').expect;
 const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
-const CONSENT_LOCAL_STORAGE_NAME = '_pbjs_id_consent_data';
+const CONSENT_LOCAL_STORAGE_NAME = '_pbjs_userid_consent_data';
 
 describe('User ID', function() {
   function getConfigMock(configArr1, configArr2, configArr3, configArr4, configArr5, configArr6, configArr7, configArr8) {


### PR DESCRIPTION
## Type of change
- [ X ] Feature

## Description of change
Per https://github.com/prebid/Prebid.js/issues/5420, this is an attempt to force a refresh of IDs when consent changes. To handle this, the consent received when entering the userId module is stored in a cookie, which is then used to compare on the next call to the userId module. If the stored consent is different from the current consent, the `getId` method will be called, regardless of whether a refresh was needed or not. If there is nothing stored in the cookie, though, the `getId` call is not forced - the intention here is that we don't want to force a refresh on every user as soon as this code is rolled out. After the first call with the new code, the current consent is stored, so after that it can be properly compared.

