### PR TITLE
Welect adapter

### DIFF
--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -1,0 +1,80 @@
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+const BIDDER_CODE = 'welect';
+const DEFAULT_DOMAIN = 'www.welect.de';
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['wlt'],
+  supportedMediaTypes: ['video'],
+
+  // short code
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    return utils.deepAccess(bid, 'mediaTypes.video.context') == 'instream' && !!(bid.params.placementAlias);
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests) {
+    return validBidRequests.map(bidRequest => {
+      let rawSize = utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') || bidRequest.sizes;
+      let size = utils.parseSizesInput(rawSize)[0].split('x');
+
+      let domain = bidRequest.params.domain || DEFAULT_DOMAIN;
+
+      let url = `https://${domain}/api/v2/preflight/by_alias/${bidRequest.params.placementAlias}`;
+
+      let gdprConsent = null;
+
+      if (bidRequest && bidRequest.gdprConsent) {
+        gdprConsent = {
+          gdpr_consent:
+           {
+             gdpr_applies: bidRequest.gdprConsent.gdprApplies,
+             gdpr_consent: bidRequest.gdprConsent.gdprConsent
+           }
+        }
+      }
+
+      const data = {
+        width: size[0],
+        height: size[1],
+        bid_id: bidRequest.bidId,
+        ...gdprConsent
+      }
+
+      return {
+        method: 'POST',
+        url: url,
+        data: data
+      };
+    });
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const responseBody = serverResponse.body;
+
+    if (typeof responseBody !== 'object' || responseBody.available !== 'true') {
+      return [];
+    }
+
+    const bidResponses = [];
+    const bidResponse = responseBody.bidResponse;
+    bidResponses.push(bidResponse);
+    return bidResponses;
+  }
+}
+registerBidder(spec);

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -1,7 +1,9 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+
 const BIDDER_CODE = 'welect';
 const DEFAULT_DOMAIN = 'www.welect.de';
+
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['wlt'],

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -17,7 +17,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return utils.deepAccess(bid, 'mediaTypes.video.context') == 'instream' && !!(bid.params.placementId);
+    return utils.deepAccess(bid, 'mediaTypes.video.context') === 'instream' && !!(bid.params.placementId);
   },
   /**
    * Make a server request from the list of BidRequests.

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -15,7 +15,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return utils.deepAccess(bid, 'mediaTypes.video.context') == 'instream' && !!(bid.params.placementAlias);
+    return utils.deepAccess(bid, 'mediaTypes.video.context') == 'instream' && !!(bid.params.placementId);
   },
   /**
    * Make a server request from the list of BidRequests.
@@ -30,7 +30,7 @@ export const spec = {
 
       let domain = bidRequest.params.domain || DEFAULT_DOMAIN;
 
-      let url = `https://${domain}/api/v2/preflight/by_alias/${bidRequest.params.placementAlias}`;
+      let url = `https://${domain}/api/v2/preflight/by_alias/${bidRequest.params.placementId}`;
 
       let gdprConsent = null;
 

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -54,8 +54,13 @@ export const spec = {
       return {
         method: 'POST',
         url: url,
-        data: data
-      };
+        data: data,
+        options: {
+          contentType: 'application/json',
+          withCredentials: false,
+          crossOrigin: true,
+        }
+      }
     });
   },
   /**

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -67,7 +67,7 @@ export const spec = {
   interpretResponse: function (serverResponse, bidRequest) {
     const responseBody = serverResponse.body;
 
-    if (typeof responseBody !== 'object' || responseBody.available !== 'true') {
+    if (typeof responseBody !== 'object' || responseBody.available !== true) {
       return [];
     }
 

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -27,8 +27,8 @@ export const spec = {
    */
   buildRequests: function (validBidRequests) {
     return validBidRequests.map(bidRequest => {
-      let rawSize = utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') || bidRequest.sizes;
-      let size = utils.parseSizesInput(rawSize)[0].split('x');
+      let rawSizes = utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') || bidRequest.sizes;
+      let size = rawSizes[0]
 
       let domain = bidRequest.params.domain || DEFAULT_DOMAIN;
 

--- a/modules/welectBidAdapter.md
+++ b/modules/welectBidAdapter.md
@@ -1,0 +1,34 @@
+# Overview
+
+```
+Module Name: Welect Bidder Adapter
+Module Type: Welect Adapter
+Maintainer: nick.duitz@9elements.com
+```
+
+# Description
+
+Module that connects to Welect's demand sources
+
+# Test Parameters
+```
+    var adUnits = [
+        {
+            code: 'test-video-instream',
+            sizes: [[640, 360]],
+            mediaTypes: {
+                video: {
+                    context: 'instream'
+                }
+            },
+            bids: [
+                {
+                    bidder: "Welect",
+                    params: {
+                        placementAlias: "prebid-preview",
+                        domaint: "www.welect.de"
+                    }
+                }
+            ]
+        }
+    ];

--- a/modules/welectBidAdapter.md
+++ b/modules/welectBidAdapter.md
@@ -12,23 +12,19 @@ Module that connects to Welect's demand sources
 
 # Test Parameters
 ```
-    var adUnits = [
-        {
-            code: 'test-video-instream',
-            sizes: [[640, 360]],
-            mediaTypes: {
-                video: {
-                    context: 'instream'
-                }
-            },
-            bids: [
-                {
-                    bidder: "Welect",
-                    params: {
-                        placementAlias: "prebid-preview",
-                        domaint: "www.welect.de"
-                    }
-                }
-            ]
-        }
-    ];
+var adUnits = [
+  {
+    bidder: 'welect',
+    params: {
+      placementId: 'exampleId',
+      domain: 'www.welect.de'
+    },
+    sizes: [[640, 360]],
+    mediaTypes: {
+      video: {
+        context: 'instream'
+      }
+    },
+  };
+];
+```

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -1,8 +1,5 @@
-// import or require modules necessary for the test, e.g.:
-
 import {expect} from 'chai';
 import {spec as adapter} from 'modules/welectBidAdapter.js';
-// import * as utils from 'src/utils.js';
 
 describe('WelectAdapter', function () {
   describe('Check methods existance', function () {

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -21,7 +21,7 @@ describe('WelectAdapter', function () {
     let bid = {
       bidder: 'welect',
       params: {
-        placementAlias: 'exampleAlias',
+        placementId: 'exampleAlias',
         domain: 'www.welect.de'
       },
       sizes: [[640, 360]],
@@ -58,7 +58,7 @@ describe('WelectAdapter', function () {
     let bid1 = {
       bidder: 'welect',
       params: {
-        placementAlias: 'exampleAlias'
+        placementId: 'exampleAlias'
       },
       sizes: [[640, 360]],
       mediaTypes: {
@@ -71,7 +71,7 @@ describe('WelectAdapter', function () {
     let bid2 = {
       bidder: 'welect',
       params: {
-        placementAlias: 'exampleAlias',
+        placementId: 'exampleAlias',
         domain: 'www.welect2.de'
       },
       sizes: [[640, 360]],

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -86,14 +86,14 @@ describe('WelectAdapter', function () {
 
     let data1 = {
       bid_id: 'abdc',
-      width: '640',
-      height: '360'
+      width: 640,
+      height: 360
     }
 
     let data2 = {
       bid_id: 'abdc',
-      width: '640',
-      height: '360',
+      width: 640,
+      height: 360,
       gdpr_consent: {
         gdpr_applies: 1,
         gdpr_consent: 'some_string'
@@ -150,12 +150,12 @@ describe('WelectAdapter', function () {
           cpm: 17,
           creativeId: 'svmpreview',
           currency: 'EUR',
-          height: '640',
           netRevenue: true,
           requestId: 'some bid id',
           ttl: 120,
           vastUrl: 'some vast url',
-          width: '320'
+          height: 640,
+          width: 320
         }
       }
     }
@@ -163,8 +163,8 @@ describe('WelectAdapter', function () {
     let bid = {
       data: {
         bid_id: 'some bid id',
-        width: '640',
-        height: '360',
+        width: 640,
+        height: 320,
         gdpr_consent: {
           gdpr_applies: 1,
           gdpr_consent: 'some_string'
@@ -186,12 +186,12 @@ describe('WelectAdapter', function () {
       cpm: 17,
       creativeId: 'svmpreview',
       currency: 'EUR',
-      height: '640',
+      height: 640,
       netRevenue: true,
       requestId: 'some bid id',
       ttl: 120,
       vastUrl: 'some vast url',
-      width: '320'
+      width: 320
     }
 
     it('if response reflects unavailability, should be empty', function () {

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -1,0 +1,193 @@
+// import or require modules necessary for the test, e.g.:
+
+import {expect} from 'chai';
+import {spec as adapter} from 'modules/welectBidAdapter.js';
+// import * as utils from 'src/utils.js';
+
+describe('WelectAdapter', function () {
+  describe('Check methods existance', function () {
+    it('exists and is a function', function () {
+      expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
+    });
+    it('exists and is a function', function () {
+      expect(adapter.buildRequests).to.exist.and.to.be.a('function');
+    });
+    it('exists and is a function', function () {
+      expect(adapter.interpretResponse).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('Check method isBidRequestValid return', function () {
+    let bid = {
+      bidder: 'welect',
+      params: {
+        placementAlias: 'exampleAlias',
+        domain: 'www.welect.de'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+    };
+    let bid2 = {
+      bidder: 'welect',
+      params: {
+        domain: 'www.welect.de'
+      },
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [640, 360]
+        }
+      },
+    };
+
+    it('should be true', function () {
+      expect(adapter.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should be false because the placementAlias is missing', function () {
+      expect(adapter.isBidRequestValid(bid2)).to.be.false;
+    });
+  });
+
+  describe('Check buildRequests method', function () {
+    // Bids to be formatted
+    let bid1 = {
+      bidder: 'welect',
+      params: {
+        placementAlias: 'exampleAlias'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+      bidId: 'abdc'
+    };
+    let bid2 = {
+      bidder: 'welect',
+      params: {
+        placementAlias: 'exampleAlias',
+        domain: 'www.welect2.de'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+      bidId: 'abdc',
+      gdprConsent: {
+        gdprApplies: 1,
+        gdprConsent: 'some_string'
+      }
+    };
+
+    let data1 = {
+      bid_id: 'abdc',
+      width: '640',
+      height: '360'
+    }
+
+    let data2 = {
+      bid_id: 'abdc',
+      width: '640',
+      height: '360',
+      gdpr_consent: {
+        gdpr_applies: 1,
+        gdpr_consent: 'some_string'
+      }
+    }
+
+    // Formatted requets
+    let request1 = {
+      method: 'POST',
+      url: 'https://www.welect.de/api/v2/preflight/by_alias/exampleAlias',
+      data: data1
+    };
+
+    let request2 = {
+      method: 'POST',
+      url: 'https://www.welect2.de/api/v2/preflight/by_alias/exampleAlias',
+      data: data2
+    }
+
+    it('defaults to www.welect.de, without gdpr object', function () {
+      expect(adapter.buildRequests([bid1])).to.deep.equal([request1]);
+    })
+
+    it('must return the right formatted requests, with gdpr object', function () {
+      expect(adapter.buildRequests([bid2])).to.deep.equal([request2]);
+    });
+  });
+
+//   describe('Check interpretResponse method return', function () {
+//     // Server's response
+//     let response = {
+//       body: {
+//         valid: true
+//       }
+//     };
+//     // bid Request
+//     let bid = {
+//       data: {
+//         pub_id: '3',
+//         zone_id: '12345',
+//         bid_id: 'abdc',
+//         floor_price: 5.50, // optional
+//         adUnitCode: 'code'
+//       },
+//       method: 'POST',
+//       url: 'https://player.mediabong.net/prebid/request'
+//     };
+//     // Formatted reponse
+//     let result = {
+//       requestId: 'abdc',
+//       cpm: 5.00,
+//       width: '640',
+//       height: '360',
+//       ttl: 60,
+//       creativeId: '2468',
+//       dealId: 'MDB-TEST-1357',
+//       netRevenue: true,
+//       currency: 'USD',
+//       vastUrl: 'https//player.mediabong.net/prebid/ad/a1b2c3d4',
+//       mediaType: 'video'
+//     };
+
+//     it('should equal to the expected formatted result', function () {
+//       expect(adapter.interpretResponse(response, bid)).to.deep.equal([result]);
+//     });
+
+//     it('should be empty because the status is missing or wrong', function () {
+//       let wrongResponse = utils.deepClone(response);
+//       wrongResponse.body.status = 'ko';
+//       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
+
+//       wrongResponse = utils.deepClone(response);
+//       delete wrongResponse.body.status;
+//       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
+//     });
+
+//     it('should be empty because the body is missing or wrong', function () {
+//       let wrongResponse = utils.deepClone(response);
+//       wrongResponse.body = [1, 2, 3];
+//       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
+
+//       wrongResponse = utils.deepClone(response);
+//       delete wrongResponse.body;
+//       expect(adapter.interpretResponse(wrongResponse, bid)).to.be.empty;
+//     });
+
+//     it('should equal to the expected formatted result', function () {
+//       response.body.renderer_url = 'vuble_renderer.js';
+//       result.adUnitCode = 'code';
+//       let formattedResponses = adapter.interpretResponse(response, bid);
+//       expect(formattedResponses[0].adUnitCode).to.equal(result.adUnitCode);
+//     });
+//   });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
New bidder adapter for [Welect](https://www.welect.de). This adapter, if successfully called, returns a VPaid instead of a simple VAST tag.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
  {
    bidder: 'welect',
    params: {
      placementId: 'svmpreview',
      domain: 'www.welect.de'
    },
    sizes: [[640, 360]],
    mediaTypes: {
      video: {
        context: 'instream'
      }
    },
  };
```

- contact email of the adapter’s maintainer: nick.duitz@9elements.com
