### PR TITLE
Fix: check mandatory video params

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -18,8 +18,11 @@ function mapMediaType(seedtagMediaType) {
   else return seedtagMediaType;
 }
 
-function getMediaTypeFromBid(bid) {
-  return bid.mediaTypes && Object.keys(bid.mediaTypes)[0]
+function hasVideoMediaType(bid) {
+  return Object.keys(bid.mediaTypes)
+    .some(function(mt) {
+      return mt === VIDEO;
+    });
 }
 
 function hasMandatoryParams(params) {
@@ -34,7 +37,7 @@ function hasMandatoryParams(params) {
   );
 }
 
-function hasVideoMandatoryParams(mediaTypes) {
+function hasMandatoryVideoParams(mediaTypes) {
   const isVideoInStream =
     !!mediaTypes.video && mediaTypes.video.context === 'instream';
   const isPlayerSize =
@@ -65,7 +68,7 @@ function buildBidRequests(validBidRequests) {
       bidRequest.adPosition = params.adPosition;
     }
 
-    if (params.video) {
+    if (hasVideoMediaType(validBidRequest)) {
       bidRequest.videoParams = params.video || {};
       bidRequest.videoParams.w =
         validBidRequest.mediaTypes.video.playerSize[0][0];
@@ -124,8 +127,8 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid(bid) {
-    return getMediaTypeFromBid(bid) === VIDEO
-      ? hasMandatoryParams(bid.params) && hasVideoMandatoryParams(bid.mediaTypes)
+    return hasVideoMediaType(bid)
+      ? hasMandatoryParams(bid.params) && hasMandatoryVideoParams(bid.mediaTypes)
       : hasMandatoryParams(bid.params);
   },
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -19,10 +19,7 @@ function mapMediaType(seedtagMediaType) {
 }
 
 function hasVideoMediaType(bid) {
-  return Object.keys(bid.mediaTypes)
-    .some(function(mt) {
-      return mt === VIDEO;
-    });
+  return !!bid.mediaTypes && !!bid.mediaTypes.video
 }
 
 function hasMandatoryParams(params) {

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai'
 import { spec, getTimeoutUrl } from 'modules/seedtagBidAdapter.js'
 
+const PUBLISHER_ID = '0000-0000-01'
+const ADUNIT_ID = '000000'
+
 function getSlotConfigs(mediaTypes, params) {
   return {
     params: params,
@@ -16,10 +19,16 @@ function getSlotConfigs(mediaTypes, params) {
   }
 }
 
+function createVideoSlotConfig(mediaType) {
+  return getSlotConfigs(mediaType, {
+    publisherId: PUBLISHER_ID,
+    adUnitId: ADUNIT_ID,
+    placement: 'video'
+  })
+}
+
 describe('Seedtag Adapter', function() {
   describe('isBidRequestValid method', function() {
-    const PUBLISHER_ID = '0000-0000-01'
-    const ADUNIT_ID = '000000'
     describe('returns true', function() {
       describe('when banner slot config has all mandatory params', () => {
         describe('and placement has the correct value', function() {
@@ -66,13 +75,13 @@ describe('Seedtag Adapter', function() {
     })
     describe('returns false', function() {
       describe('when params are not correct', function() {
-        function createSlotconfig(params) {
+        function createSlotConfig(params) {
           return getSlotConfigs({ banner: {} }, params)
         }
         it('does not have the PublisherToken.', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createSlotconfig({
-              adUnitId: '000000',
+            createSlotConfig({
+              adUnitId: ADUNIT_ID,
               placement: 'banner'
             })
           )
@@ -80,8 +89,8 @@ describe('Seedtag Adapter', function() {
         })
         it('does not have the AdUnitId.', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createSlotconfig({
-              publisherId: '0000-0000-01',
+            createSlotConfig({
+              publisherId: PUBLISHER_ID,
               placement: 'banner'
             })
           )
@@ -89,18 +98,18 @@ describe('Seedtag Adapter', function() {
         })
         it('does not have the placement.', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createSlotconfig({
-              publisherId: '0000-0000-01',
-              adUnitId: '000000'
+            createSlotConfig({
+              publisherId: PUBLISHER_ID,
+              adUnitId: ADUNIT_ID
             })
           )
           expect(isBidRequestValid).to.equal(false)
         })
         it('does not have a the correct placement.', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createSlotconfig({
-              publisherId: '0000-0000-01',
-              adUnitId: '000000',
+            createSlotConfig({
+              publisherId: PUBLISHER_ID,
+              adUnitId: ADUNIT_ID,
               placement: 'another_thing'
             })
           )
@@ -117,19 +126,19 @@ describe('Seedtag Adapter', function() {
         }
         it('is a void object', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createVideoSlotconfig({ video: {} })
+            createVideoSlotConfig({ video: {} })
           )
           expect(isBidRequestValid).to.equal(false)
         })
         it('does not have playerSize.', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createVideoSlotconfig({ video: { context: 'instream' } })
+            createVideoSlotConfig({ video: { context: 'instream' } })
           )
           expect(isBidRequestValid).to.equal(false)
         })
         it('is not instream ', function() {
           const isBidRequestValid = spec.isBidRequestValid(
-            createVideoSlotconfig({
+            createVideoSlotConfig({
               video: {
                 context: 'outstream',
                 playerSize: [[600, 200]]
@@ -137,6 +146,20 @@ describe('Seedtag Adapter', function() {
             })
           )
           expect(isBidRequestValid).to.equal(false)
+        })
+        describe('order does not matter', function() {
+          it('when video is not the first slot', function() {
+            const isBidRequestValid = spec.isBidRequestValid(
+              createVideoSlotConfig({ banner: {}, video: {} })
+            )
+            expect(isBidRequestValid).to.equal(false)
+          })
+          it('when video is the first slot', function() {
+            const isBidRequestValid = spec.isBidRequestValid(
+              createVideoSlotConfig({ video: {}, banner: {} })
+            )
+            expect(isBidRequestValid).to.equal(false)
+          })
         })
       })
     })
@@ -148,8 +171,8 @@ describe('Seedtag Adapter', function() {
       timeout: 1000
     }
     const mandatoryParams = {
-      publisherId: '0000-0000-01',
-      adUnitId: '000000',
+      publisherId: PUBLISHER_ID,
+      adUnitId: ADUNIT_ID,
       placement: 'banner'
     }
     const inStreamParams = Object.assign({}, mandatoryParams, {


### PR DESCRIPTION
Co-authored-by: Miguel Angel Moreno <miguelmoreno@seedtag.com>

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Fix: check mandatory video params when there are multiple supply types.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

