### PR TITLE
ATS-analytics - fix check for safari browser

### DIFF
--- a/modules/atsAnalyticsAdapter.js
+++ b/modules/atsAnalyticsAdapter.js
@@ -42,7 +42,7 @@ export function browserIsFirefox() {
   if (typeof InstallTrigger !== 'undefined') {
     return 'Firefox';
   } else {
-    return false;
+    return 'Unknown';
   }
 }
 
@@ -54,7 +54,7 @@ export function browserIsEdge() {
   if (!browserIsIE() && !!window.StyleMedia) {
     return 'Edge';
   } else {
-    return false;
+    return 'Unknown';
   }
 }
 
@@ -62,7 +62,7 @@ export function browserIsChrome() {
   if ((!!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime)) || (/Android/i.test(navigator.userAgent) && !!window.chrome)) {
     return 'Chrome';
   } else {
-    return false;
+    return 'Unknown';
   }
 }
 
@@ -70,7 +70,7 @@ export function browserIsSafari() {
   if (window.safari !== undefined) {
     return 'Safari'
   } else {
-    return false;
+    return 'Unknown';
   }
 }
 

--- a/modules/atsAnalyticsAdapter.js
+++ b/modules/atsAnalyticsAdapter.js
@@ -67,7 +67,7 @@ export function browserIsChrome() {
 }
 
 export function browserIsSafari() {
-  if (navigator.vendor.indexOf('Apple') !== -1) {
+  if (window.safari !== undefined) {
     return 'Safari'
   } else {
     return false;

--- a/modules/atsAnalyticsAdapter.js
+++ b/modules/atsAnalyticsAdapter.js
@@ -67,7 +67,7 @@ export function browserIsChrome() {
 }
 
 export function browserIsSafari() {
-  if (navigator.vendor.indexOf('Apple')) {
+  if (navigator.vendor.indexOf('Apple') !== -1) {
     return 'Safari'
   } else {
     return false;

--- a/modules/atsAnalyticsAdapter.js
+++ b/modules/atsAnalyticsAdapter.js
@@ -18,7 +18,7 @@ function bidRequestedHandler(args) {
       bidder: bid.bidder,
       bid_id: bid.bidId,
       auction_id: args.auctionId,
-      user_browser: (browserIsFirefox() || browserIsEdge() || browserIsChrome() || browserIsSafari()),
+      user_browser: checkUserBrowser(),
       user_platform: navigator.platform,
       auction_start: new Date(args.auctionStart).toJSON(),
       domain: window.location.hostname,
@@ -38,11 +38,29 @@ function bidResponseHandler(args) {
   };
 }
 
+export function checkUserBrowser() {
+  let firefox = browserIsFirefox();
+  let chrome = browserIsChrome();
+  let edge = browserIsEdge();
+  let safari = browserIsSafari();
+  if (firefox) {
+    return firefox;
+  } if (chrome) {
+    return chrome;
+  } if (edge) {
+    return edge;
+  } if (safari) {
+    return safari;
+  } else {
+    return 'Unknown'
+  }
+}
+
 export function browserIsFirefox() {
   if (typeof InstallTrigger !== 'undefined') {
     return 'Firefox';
   } else {
-    return 'Unknown';
+    return false;
   }
 }
 
@@ -54,7 +72,7 @@ export function browserIsEdge() {
   if (!browserIsIE() && !!window.StyleMedia) {
     return 'Edge';
   } else {
-    return 'Unknown';
+    return false;
   }
 }
 
@@ -62,7 +80,7 @@ export function browserIsChrome() {
   if ((!!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime)) || (/Android/i.test(navigator.userAgent) && !!window.chrome)) {
     return 'Chrome';
   } else {
-    return 'Unknown';
+    return false;
   }
 }
 
@@ -70,7 +88,7 @@ export function browserIsSafari() {
   if (window.safari !== undefined) {
     return 'Safari'
   } else {
-    return 'Unknown';
+    return false;
   }
 }
 

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -146,5 +146,44 @@ describe('ats analytics adapter', function () {
       expect(atsAnalyticsAdapter.context.host).to.equal(initOptions.host);
       expect(atsAnalyticsAdapter.context.pid).to.equal(initOptions.pid);
     })
+    it('check browser is not safari', function () {
+      let browser = browserIsSafari();
+      expect(browser).to.equal(false);
+    })
+    it('check browser is safari', function () {
+      Object.defineProperty(window.navigator, 'vendor', {
+        value: 'Apple Computer, Inc.',
+        writable: true
+      });
+      let browser = browserIsSafari();
+      expect(browser).to.equal('Safari');
+    })
+    it('check browser is not chrome', function () {
+      let browser = browserIsChrome();
+      expect(browser).to.equal(false);
+    })
+    it('check browser is chrome', function () {
+      window.chrome = {
+        app: {},
+        webstore: {},
+        runtime: {}
+      };
+      let browser = browserIsChrome();
+      expect(browser).to.equal('Chrome');
+    })
+    it('check browser is edge', function () {
+      Object.defineProperty(window, 'StyleMedia', {
+        value: {},
+        writable: true
+      });
+      document.documentMode = undefined;
+      let browser = browserIsEdge();
+      expect(browser).to.equal('Edge');
+    })
+    it('check browser is not edge', function () {
+      document.documentMode = {};
+      let browser = browserIsEdge();
+      expect(browser).to.equal(false);
+    })
   })
 })

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -149,7 +149,7 @@ describe('ats analytics adapter', function () {
     it('check browser is not safari', function () {
       window.safari = undefined;
       let browser = browserIsSafari();
-      expect(browser).to.equal(false);
+      expect(browser).to.equal('Unknown');
     })
     it('check browser is safari', function () {
       window.safari = {};
@@ -163,7 +163,7 @@ describe('ats analytics adapter', function () {
         runtime: undefined
       };
       let browser = browserIsChrome();
-      expect(browser).to.equal(false);
+      expect(browser).to.equal('Unknown');
     })
     it('check browser is chrome', function () {
       window.chrome = {
@@ -192,7 +192,7 @@ describe('ats analytics adapter', function () {
         writable: true
       });
       let browser = browserIsEdge();
-      expect(browser).to.equal(false);
+      expect(browser).to.equal('Unknown');
     })
   })
 })

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -147,18 +147,12 @@ describe('ats analytics adapter', function () {
       expect(atsAnalyticsAdapter.context.pid).to.equal(initOptions.pid);
     })
     it('check browser is not safari', function () {
-      Object.defineProperty(window.navigator, 'vendor', {
-        value: 'Google Inc.',
-        writable: true
-      });
+      window.safari = undefined;
       let browser = browserIsSafari();
       expect(browser).to.equal(false);
     })
     it('check browser is safari', function () {
-      Object.defineProperty(window.navigator, 'vendor', {
-        value: 'Apple Computer, Inc.',
-        writable: true
-      });
+      window.safari = {};
       let browser = browserIsSafari();
       expect(browser).to.equal('Safari');
     })

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -2,7 +2,7 @@ import atsAnalyticsAdapter from '../../../modules/atsAnalyticsAdapter.js';
 import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
 import {server} from '../../mocks/xhr.js';
-import {checkUserBrowser, browserIsChrome, browserIsEdge, browserIsSafari} from '../../../modules/atsAnalyticsAdapter.js';
+import {checkUserBrowser, browserIsChrome, browserIsEdge, browserIsSafari, browserIsFirefox} from '../../../modules/atsAnalyticsAdapter.js';
 let events = require('src/events');
 let constants = require('src/constants.json');
 
@@ -192,6 +192,16 @@ describe('ats analytics adapter', function () {
         writable: true
       });
       let browser = browserIsEdge();
+      expect(browser).to.equal(false);
+    })
+    it('check browser is firefox', function () {
+      global.InstallTrigger = {};
+      let browser = browserIsFirefox();
+      expect(browser).to.equal('Firefox');
+    })
+    it('check browser is not firefox', function () {
+      global.InstallTrigger = undefined;
+      let browser = browserIsFirefox();
       expect(browser).to.equal(false);
     })
   })

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -147,6 +147,10 @@ describe('ats analytics adapter', function () {
       expect(atsAnalyticsAdapter.context.pid).to.equal(initOptions.pid);
     })
     it('check browser is not safari', function () {
+      Object.defineProperty(window.navigator, 'vendor', {
+        value: 'Google Inc.',
+        writable: true
+      });
       let browser = browserIsSafari();
       expect(browser).to.equal(false);
     })
@@ -159,6 +163,11 @@ describe('ats analytics adapter', function () {
       expect(browser).to.equal('Safari');
     })
     it('check browser is not chrome', function () {
+      window.chrome = {
+        app: undefined,
+        webstore: undefined,
+        runtime: undefined
+      };
       let browser = browserIsChrome();
       expect(browser).to.equal(false);
     })
@@ -176,12 +185,18 @@ describe('ats analytics adapter', function () {
         value: {},
         writable: true
       });
-      document.documentMode = undefined;
+      Object.defineProperty(document, 'documentMode', {
+        value: undefined,
+        writable: true
+      });
       let browser = browserIsEdge();
       expect(browser).to.equal('Edge');
     })
     it('check browser is not edge', function () {
-      document.documentMode = {};
+      Object.defineProperty(document, 'documentMode', {
+        value: {},
+        writable: true
+      });
       let browser = browserIsEdge();
       expect(browser).to.equal(false);
     })

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -2,7 +2,7 @@ import atsAnalyticsAdapter from '../../../modules/atsAnalyticsAdapter.js';
 import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
 import {server} from '../../mocks/xhr.js';
-import {browserIsChrome, browserIsEdge, browserIsFirefox, browserIsSafari} from '../../../modules/atsAnalyticsAdapter.js';
+import {checkUserBrowser, browserIsChrome, browserIsEdge, browserIsSafari} from '../../../modules/atsAnalyticsAdapter.js';
 let events = require('src/events');
 let constants = require('src/constants.json');
 
@@ -77,7 +77,7 @@ describe('ats analytics adapter', function () {
           'bidder': 'appnexus',
           'bid_id': '30c77d079cdf17',
           'auction_id': 'a5b849e5-87d7-4205-8300-d063084fcfb7',
-          'user_browser': (browserIsFirefox() || browserIsEdge() || browserIsChrome() || browserIsSafari()),
+          'user_browser': checkUserBrowser(),
           'user_platform': navigator.platform,
           'auction_start': '2020-02-03T14:14:25.161Z',
           'domain': window.location.hostname,
@@ -149,7 +149,7 @@ describe('ats analytics adapter', function () {
     it('check browser is not safari', function () {
       window.safari = undefined;
       let browser = browserIsSafari();
-      expect(browser).to.equal('Unknown');
+      expect(browser).to.equal(false);
     })
     it('check browser is safari', function () {
       window.safari = {};
@@ -163,7 +163,7 @@ describe('ats analytics adapter', function () {
         runtime: undefined
       };
       let browser = browserIsChrome();
-      expect(browser).to.equal('Unknown');
+      expect(browser).to.equal(false);
     })
     it('check browser is chrome', function () {
       window.chrome = {
@@ -192,7 +192,7 @@ describe('ats analytics adapter', function () {
         writable: true
       });
       let browser = browserIsEdge();
-      expect(browser).to.equal('Unknown');
+      expect(browser).to.equal(false);
     })
   })
 })


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change
Safari is reporting a value of “false” for userBrowser in ATS Analytics. 

## Other information

@bretg 