### PR TITLE
SpotX: Set ad_mute correctly.

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -392,7 +392,7 @@ function createOutstreamScript(bid) {
 
   utils.logMessage('[SPOTX][renderer] Default beahavior');
   if (utils.getBidIdParameter('ad_mute', bid.renderer.config.outstream_options)) {
-    dataSpotXParams['data-spotx_ad_mute'] = '0';
+    dataSpotXParams['data-spotx_ad_mute'] = '1';
   }
   dataSpotXParams['data-spotx_collapse'] = '0';
   dataSpotXParams['data-spotx_autoplay'] = '1';

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -511,6 +511,7 @@ describe('the spotx adapter', function () {
       expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
       expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('400');
       expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('300');
+      expect(scriptTag.getAttribute('data-spotx_ad_mute')).to.equal('1');
       window.document.getElementById.restore();
     });
 


### PR DESCRIPTION
In the SpotX Prebid adapter, `data-spotx_ad_mute` was being set to
'0' instead of '1', in scenarios where the user passed in 'ad_mute'.

## Type of change
- [ X] Bugfix


## Description of change
In the SpotX Prebid adapter, data-spotx_ad_mute was being set to
'0' instead of '1', in scenarios where the user passed in 'ad_mute'.

## Other information

