### PR TITLE
Sonobi - removed digitrust from sonobi adapter

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -8,7 +8,6 @@ import { userSync } from '../src/userSync.js';
 const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
 const PAGEVIEW_ID = generateUUID();
-const SONOBI_DIGITRUST_KEY = 'fhnS5drwmH';
 const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/sbi_outstream_renderer.js';
 
 export const spec = {
@@ -112,13 +111,6 @@ export const spec = {
       if (bidderRequest.gdprConsent.consentString) {
         payload.consent_string = bidderRequest.gdprConsent.consentString;
       }
-    }
-
-    const digitrust = _getDigiTrustObject(SONOBI_DIGITRUST_KEY);
-
-    if (digitrust) {
-      payload.digid = digitrust.id;
-      payload.digkeyv = digitrust.keyv;
     }
 
     if (validBidRequests[0].schain) {
@@ -334,20 +326,6 @@ export function _getPlatform(context = window) {
     return 'tablet'
   }
   return 'desktop';
-}
-
-// https://github.com/digi-trust/dt-cdn/wiki/Integration-Guide
-function _getDigiTrustObject(key) {
-  function getDigiTrustId() {
-    let digiTrustUser = window.DigiTrust && (config.getConfig('digiTrustId') || window.DigiTrust.getUser({member: key}));
-    return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
-  }
-  let digiTrustId = getDigiTrustId();
-  // Verify there is an ID and this user has not opted out
-  if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) {
-    return null;
-  }
-  return digiTrustId;
 }
 
 function newRenderer(adUnitCode, bid, rendererOptions = {}) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -303,47 +303,6 @@ describe('SonobiBidAdapter', function () {
       },
       uspConsent: 'someCCPAString'
     };
-    it('should include the digitrust id and keyv', () => {
-      window.DigiTrust = {
-        getUser: function () {
-        }
-      };
-      let sandbox = sinon.sandbox.create();
-      sandbox.stub(window.DigiTrust, 'getUser').callsFake(() =>
-        ({
-          success: true,
-          identity: {
-            id: 'Vb0YJIxTMJV4W0GHRdJ3MwyiOVYJjYEgc2QYdBSG',
-            keyv: 4,
-            version: 2,
-            privacy: {}
-          }
-        })
-      );
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.data.digid).to.equal('Vb0YJIxTMJV4W0GHRdJ3MwyiOVYJjYEgc2QYdBSG');
-      expect(bidRequests.data.digkeyv).to.equal(4);
-      sandbox.restore();
-      delete window.DigiTrust;
-    });
-
-    it('should not include the digitrust id and keyv', () => {
-      window.DigiTrust = {
-        getUser: function () {
-        }
-      };
-      let sandbox = sinon.sandbox.create();
-      sandbox.stub(window.DigiTrust, 'getUser').callsFake(() =>
-        ({
-          success: false
-        })
-      );
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.data.digid).to.be.undefined;
-      expect(bidRequests.data.digkeyv).to.be.undefined;
-      sandbox.restore();
-      delete window.DigiTrust;
-    });
 
     it('should return a properly formatted request', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Removed looking up the digitrust id in the sonobi bidder adapter.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- apex.prebid@sonobi.com
- [x] official adapter submission
