### PR TITLE
update parameter field from consentManagement iframe call

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -200,13 +200,12 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
 
     /* Setup up a __cmp function to do the postMessage and stash the callback.
       This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
-    window[apiName] = function (cmd, arg, callback) {
+    window[apiName] = function (cmd, callback) {
       let callId = Math.random() + '';
       let callName = `${apiName}Call`;
       let msg = {
         [callName]: {
           command: cmd,
-          parameter: arg,
           callId: callId
         }
       };
@@ -220,7 +219,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     window.addEventListener('message', readPostMessageResponse, false);
 
     // call CMP
-    window[apiName](commandName, null, moduleCallback);
+    window[apiName](commandName, moduleCallback);
 
     function readPostMessageResponse(event) {
       let cmpDataPkgName = `${apiName}Return`;

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -200,12 +200,13 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
 
     /* Setup up a __cmp function to do the postMessage and stash the callback.
       This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
-    window[apiName] = function (cmd, callback) {
+    window[apiName] = function (cmd, arg, callback) {
       let callId = Math.random() + '';
       let callName = `${apiName}Call`;
       let msg = {
         [callName]: {
           command: cmd,
+          parameter: arg,
           callId: callId
         }
       };
@@ -219,7 +220,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     window.addEventListener('message', readPostMessageResponse, false);
 
     // call CMP
-    window[apiName](commandName, moduleCallback);
+    window[apiName](commandName, undefined, moduleCallback);
 
     function readPostMessageResponse(event) {
       let cmpDataPkgName = `${apiName}Return`;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixes #5292

The `parameter` field in the iframe call used by the consentManagement module was causing some issues to the Quantcast CMP (specifically when it was set to `null`).  From reviewing our use of the field, we don't actually use the field in any v1 or v2 CMP calls (as we were just hard-coding the value to `null` in all use-cases anyway).  

From the community's testing, removing the field entirely addresses the issue with the Quantcast CMP.  From my testing, removing the field didn't show any issues for other CMPs - so this removal should be safe to implement.