### PR TITLE
Allow developers to disable caching of TCF consentData

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -13,12 +13,14 @@ import strIncludes from 'core-js-pure/features/string/includes.js';
 const DEFAULT_CMP = 'iab';
 const DEFAULT_CONSENT_TIMEOUT = 10000;
 const DEFAULT_ALLOW_AUCTION_WO_CONSENT = true;
+const DEFAULT_CACHE_CONSENT_DATA = true;
 
 export let userCMP;
 export let consentTimeout;
 export let allowAuction;
 export let gdprScope;
 export let staticConsentData;
+export let cacheConsentData;
 
 let cmpVersion = 0;
 let consentData;
@@ -257,7 +259,7 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
   };
 
   // in case we already have consent (eg during bid refresh)
-  if (consentData) {
+  if (consentData && cacheConsentData) {
     utils.logInfo('User consent information already known.  Pulling internally stored information...');
     return exitModule(null, hookConfig);
   }
@@ -479,6 +481,13 @@ export function setConsentConfig(config) {
       utils.logError(`consentManagement config with cmpApi: 'static' did not specify consentData. No consents will be available to adapters.`);
     }
   }
+
+  if (utils.isBoolean(config.cacheConsentData)) {
+    cacheConsentData = config.cacheConsentData;
+  } else {
+    cacheConsentData = DEFAULT_CACHE_CONSENT_DATA;
+  }
+
   if (!addedConsentHook) {
     $$PREBID_GLOBAL$$.requestBids.before(requestBidsHook, 50);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
This pull requests allows developers to disable the caching of consentdata. The behavior of consentManagement actually tries to fetch consents only once and keep the retrieved consents (or non retrieved consents) cached for ever, which is fine for most people.

However there are 2 valid use cases when you might want to disable that:

* If you run an auction immediately after the user entered the site, before you got any consent (it's fine) but want the next refresh to use consents you got in the meantime,
* If you run an auction after you got the consent, but then the user removes it, you don't want to allow 3rd parties to use personnal data at the next refresh.

<!--For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/-->

PR for docs repo: prebid/prebid.github.io#2143

## Other information
This has been spotted in a few issues (#4577, #4858 and perhaps others too).

Thanks for your help,