### PR TITLE
Fix double encoded targeting string for Yieldlab adapter

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -37,7 +37,7 @@ export const spec = {
     utils._each(validBidRequests, function (bid) {
       adslotIds.push(bid.params.adslotId)
       if (bid.params.targeting) {
-        query.t = createQueryString(bid.params.targeting)
+        query.t = createTargetingString(bid.params.targeting)
       }
       if (bid.userIdAsEids && Array.isArray(bid.userIdAsEids)) {
         query.ids = createUserIdString(bid.userIdAsEids)
@@ -193,6 +193,23 @@ function createQueryString (obj) {
   for (var p in obj) {
     if (obj.hasOwnProperty(p)) {
       str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]))
+    }
+  }
+  return str.join('&')
+}
+
+/**
+ * Creates an unencoded targeting string out of an object with key-values
+ * @param {Object} obj
+ * @returns {String}
+ */
+function createTargetingString (obj) {
+  let str = []
+  for (var p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      let key = p
+      let val = obj[p]
+      str.push(key + '=' + val)
     }
   }
   return str.join('&')

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -10,7 +10,8 @@ const REQUEST = {
     'adSize': '728x90',
     'targeting': {
       'key1': 'value1',
-      'key2': 'value2'
+      'key2': 'value2',
+      'notDoubleEncoded': 'value3,value4'
     },
     'customParams': {
       'extraParam': true,
@@ -84,8 +85,8 @@ describe('yieldlabBidAdapter', function () {
       expect(request.validBidRequests).to.eql([REQUEST])
     })
 
-    it('passes targeting to bid request', function () {
-      expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2')
+    it('passes single-encoded targeting to bid request', function () {
+      expect(request.url).to.include('t=key1%3Dvalue1%26key2%3Dvalue2%26notDoubleEncoded%3Dvalue3%2Cvalue4')
     })
 
     it('passes userids to bid request', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Values in the targeting string can include comma (',') and we do not want to double encode those as we will encode again when we build the querystring with createQueryString().

- contact email of the adapter’s maintainer
solutions@yieldlab.de