### PR TITLE
Pass Referer to bidding endpoint for Yieldlab Adapter

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -49,10 +49,16 @@ export const spec = {
       }
     })
 
-    if (bidderRequest && bidderRequest.gdprConsent) {
-      query.gdpr = (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
-      if (query.gdpr) {
-        query.consent = bidderRequest.gdprConsent.consentString
+    if (bidderRequest) {
+      if (bidderRequest.refererInfo && bidderRequest.refererInfo.referer) {
+        query.pubref = bidderRequest.refererInfo.referer
+      }
+
+      if (bidderRequest.gdprConsent) {
+        query.gdpr = (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+        if (query.gdpr) {
+          query.consent = bidderRequest.gdprConsent.consentString
+        }
       }
     }
 

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -96,6 +96,20 @@ describe('yieldlabBidAdapter', function () {
       expect(request.url).to.include('extraParam=true&foo=bar')
     })
 
+    const refererRequest = spec.buildRequests(bidRequests, {
+      refererInfo: {
+        canonicalUrl: undefined,
+        numIframes: 0,
+        reachedTop: true,
+        referer: 'https://www.yieldlab.de/test?with=querystring',
+        stack: ['https://www.yieldlab.de/test?with=querystring']
+      }
+    })
+
+    it('passes encoded referer to bid request', function () {
+      expect(refererRequest.url).to.include('pubref=https%3A%2F%2Fwww.yieldlab.de%2Ftest%3Fwith%3Dquerystring')
+    })
+
     const gdprRequest = spec.buildRequests(bidRequests, {
       gdprConsent: {
         consentString: 'BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
We want the referer, that prebid.js gets client-side via javascript, to be passed to yieldlab's bidding endpoint, as the days of getting the full referer via headers are counted (https://www.chromestatus.com/feature/6251880185331712).

- contact email of the adapter’s maintainer
solutions@yieldlab.de