### PR TITLE
AdButler Bid Adapter: Add ability to include extra query params

### DIFF
--- a/modules/adbutlerBidAdapter.js
+++ b/modules/adbutlerBidAdapter.js
@@ -25,6 +25,7 @@ export const spec = {
     let requestURI;
     let serverRequests = [];
     let zoneCounters = {};
+    let extraParams = {};
 
     for (i = 0; i < validBidRequests.length; i++) {
       bidRequest = validBidRequests[i];
@@ -32,6 +33,7 @@ export const spec = {
       accountID = utils.getBidIdParameter('accountID', bidRequest.params);
       keyword = utils.getBidIdParameter('keyword', bidRequest.params);
       domain = utils.getBidIdParameter('domain', bidRequest.params);
+      extraParams = utils.getBidIdParameter('extra', bidRequest.params);
 
       if (!(zoneID in zoneCounters)) {
         zoneCounters[zoneID] = 0;
@@ -50,6 +52,13 @@ export const spec = {
       // append the keyword for targeting if one was passed in
       if (keyword !== '') {
         requestURI += 'kw=' + encodeURIComponent(keyword) + ';';
+      }
+
+      for (let key in extraParams) {
+        if (extraParams.hasOwnProperty(key)) {
+          let val = encodeURIComponent(extraParams[key]);
+          requestURI += `${key}=${val};`;
+        }
       }
 
       zoneCounters[zoneID]++;

--- a/modules/adbutlerBidAdapter.md
+++ b/modules/adbutlerBidAdapter.md
@@ -23,6 +23,9 @@ Module that connects to an AdButler zone to fetch bids.
                            keyword: 'red', //optional
                            minCPM: '1.00', //optional
                            maxCPM: '5.00' //optional
+                           extra: { // optional
+                                foo: "bar" 
+                           }
                        }
                    }
                ]

--- a/test/spec/modules/adbutlerBidAdapter_spec.js
+++ b/test/spec/modules/adbutlerBidAdapter_spec.js
@@ -13,7 +13,10 @@ describe('AdButler adapter', function () {
           zoneID: '210093',
           keyword: 'red',
           minCPM: '1.00',
-          maxCPM: '5.00'
+          maxCPM: '5.00',
+          extra: {
+            foo: 'bar',
+          }
         },
         placementCode: '/19968336/header-bid-tag-1',
         mediaTypes: {
@@ -91,6 +94,13 @@ describe('AdButler adapter', function () {
           requestURL = requests[0].url;
 
         expect(requestURL).to.have.string(';kw=red;');
+      });
+
+      it('should set the extra parameter', () => {
+        let requests = spec.buildRequests(bidRequests);
+        let requestURL = requests[0].url;
+
+        expect(requestURL).to.have.string(';foo=bar;');
       });
 
       it('should increment the count for the same zone', function () {


### PR DESCRIPTION

## Type of change
- [x] Feature

## Description of change
This change will allow users of the AdButler Bid Adapter to pass other potentially necessary parameters in their ad requests.

