### PR TITLE
floorProvider can come from data obj now

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -514,6 +514,7 @@ export function handleFetchResponse(fetchResponse) {
     _floorsConfig.data = fetchData;
     // set skipRate override if necessary
     _floorsConfig.skipRate = utils.isNumber(fetchData.skipRate) ? fetchData.skipRate : _floorsConfig.skipRate;
+    _floorsConfig.floorProvider = fetchData.floorProvider || _floorsConfig.floorProvider;
   }
 
   // if any auctions are waiting for fetch to finish, we need to continue them!
@@ -569,7 +570,7 @@ export function handleSetFloorsConfig(config) {
   _floorsConfig = utils.pick(config, [
     'enabled', enabled => enabled !== false, // defaults to true
     'auctionDelay', auctionDelay => auctionDelay || 0,
-    'floorProvider',
+    'floorProvider', floorProvider => utils.deepAccess(config, 'data.floorProvider', floorProvider),
     'endpoint', endpoint => endpoint || {},
     'skipRate', () => !isNaN(utils.deepAccess(config, 'data.skipRate')) ? config.data.skipRate : config.skipRate || 0,
     'enforcement', enforcement => utils.pick(enforcement || {}, [


### PR DESCRIPTION
Adding to #5538 
Type of change
- [X] Feature

## Description of change
About 1 hour after merging #5538 @bszekely1 realized we also want the `floorProvider` to be able to be set at the `data` level of floor configs.

This way, a fetch can indicate who the `floorProvider` is as well as just the top level.

It works similarly as `skipRate`, being the data level field takes precedence over the top level `setConfig` field.