### PR TITLE
Teads adapter: support time to first byte

### DIFF
--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -189,6 +189,34 @@ describe('teadsBidAdapter', () => {
       expect(payload.pageReferrer).to.deep.equal(document.referrer);
     });
 
+    it('should add timeToFirstByte info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderResquestDefault);
+      const payload = JSON.parse(request.data);
+      const performance = window.performance || window.webkitPerformance || window.msPerformance || window.mozPerformance;
+
+      const ttfbExpectedV2 = performance &&
+        typeof performance.getEntriesByType === 'function' &&
+        Object.prototype.toString.call(performance.getEntriesByType) === '[object Function]' &&
+        performance.getEntriesByType('navigation')[0] &&
+        performance.getEntriesByType('navigation')[0].responseStart &&
+        performance.getEntriesByType('navigation')[0].requestStart &&
+        performance.getEntriesByType('navigation')[0].responseStart >= 0 &&
+        performance.getEntriesByType('navigation')[0].requestStart >= 0 &&
+        Math.round(
+          performance.getEntriesByType('navigation')[0].responseStart - performance.getEntriesByType('navigation')[0].requestStart
+        );
+
+      expect(payload.timeToFirstByte).to.exist;
+
+      if (ttfbExpectedV2) {
+        expect(payload.timeToFirstByte).to.deep.equal(ttfbExpectedV2.toString());
+      } else {
+        const ttfbExpectedV1 = performance.timing.responseStart - performance.timing.requestStart;
+
+        expect(payload.timeToFirstByte).to.deep.equal(ttfbExpectedV1.toString());
+      }
+    });
+
     it('should send GDPR to endpoint with 11 status', function() {
       let consentString = 'JRJ8RKfDeBNsERRDCSAAZ+A==';
       let bidderRequest = {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Support Time to first byte for teads adapter prebid (handle `bidResponse.timeToFirstByte` parameter)

contact email of the adapter’s maintainer : innov-ssp@teads.tv