### PR TITLE
Blue Billywig bid adapter update

### DIFF
--- a/modules/bluebillywigBidAdapter.js
+++ b/modules/bluebillywigBidAdapter.js
@@ -1,14 +1,25 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+<<<<<<< HEAD
 import { VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import { createEidsArray } from './userId/eids.js';
+=======
+import adapterManager from '../src/adapterManager.js';
+import { VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
+import { Renderer } from '../src/Renderer.js';
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 
 const DEV_MODE = window.location.search.match(/bbpbs_debug=true/);
 
 // Blue Billywig Constants
+<<<<<<< HEAD
 const BB_CONSTANTS = {
+=======
+export const BB_CONSTANTS = {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
   SYNC_URL: '$$URL_STARTpbs.bluebillywig.com/static/cookie-sync.html?pub=$$PUBLICATION',
@@ -25,6 +36,7 @@ const getConfig = config.getConfig;
 
 // Helper Functions
 export const BB_HELPERS = {
+<<<<<<< HEAD
   addSiteAppDevice: function(request, pageUrl) {
     if (!request) return;
 
@@ -34,25 +46,46 @@ export const BB_HELPERS = {
       if (typeof getConfig('site') === 'object') request.site = getConfig('site');
       if (pageUrl) request.site.page = pageUrl;
     }
+=======
+  addSiteAppDevice: (request, pageUrl) => {
+    if (!request) return;
+
+    if (typeof getConfig('app') === 'object') request.app = getConfig('app');
+    else if (pageUrl) request.site = { page: pageUrl };
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 
     if (typeof getConfig('device') === 'object') request.device = getConfig('device');
     if (!request.device) request.device = {};
     if (!request.device.w) request.device.w = window.innerWidth;
     if (!request.device.h) request.device.h = window.innerHeight;
   },
+<<<<<<< HEAD
   addSchain: function(request, validBidRequests) {
+=======
+  addSchain: (request, validBidRequests) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     if (!request) return;
 
     const schain = utils.deepAccess(validBidRequests, '0.schain');
     if (schain) request.source.ext = { schain: schain };
   },
+<<<<<<< HEAD
   addCurrency: function(request) {
+=======
+  addAliases: (request, aliases) => {
+    if (!request) return;
+
+    if (!utils.isEmpty(aliases)) request.ext.prebid.aliases = aliases;
+  },
+  addCurrency: (request) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     if (!request) return;
 
     const adServerCur = getConfig('currency.adServerCurrency');
     if (adServerCur && typeof adServerCur === 'string') request.cur = [adServerCur];
     else if (Array.isArray(adServerCur) && adServerCur.length) request.cur = [adServerCur[0]];
   },
+<<<<<<< HEAD
   addUserIds: function(request, validBidRequests) {
     if (!request) return;
 
@@ -80,6 +113,140 @@ export const BB_HELPERS = {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
   },
   getDigiTrustParams: function(bidRequest) {
+=======
+  addUserIds: (request, validBidRequests) => {
+    if (!request) return;
+
+    // NB straight rip from prebidServerAdapter, keep track for updates
+    const bidUserId = utils.deepAccess(validBidRequests, '0.userId');
+
+    if (bidUserId && typeof bidUserId === 'object' && (bidUserId.tdid || bidUserId.pubcid || bidUserId.parrableid || bidUserId.lipb || bidUserId.id5id || bidUserId.criteoId || bidUserId.britepoolid || bidUserId.idl_env)) {
+      utils.deepSetValue(request, 'user.ext.eids', []);
+
+      if (bidUserId.tdid) {
+        request.user.ext.eids.push({
+          source: 'adserver.org',
+          uids: [{
+            id: bidUserId.tdid,
+            ext: {
+              rtiPartner: 'TDID'
+            }
+          }]
+        });
+      }
+
+      if (bidUserId.pubcid) {
+        request.user.ext.eids.push({
+          source: 'pubcid.org',
+          uids: [{
+            id: bidUserId.pubcid,
+          }]
+        });
+      }
+
+      if (bidUserId.parrableid) {
+        request.user.ext.eids.push({
+          source: 'parrable.com',
+          uids: [{
+            id: bidUserId.parrableid
+          }]
+        });
+      }
+
+      if (bidUserId.lipb && bidUserId.lipb.lipbid) {
+        const liveIntent = {
+          source: 'liveintent.com',
+          uids: [{
+            id: bidUserId.lipb.lipbid
+          }]
+        };
+
+        if (Array.isArray(bidUserId.lipb.segments) && bidUserId.lipb.segments.length) {
+          liveIntent.ext = {
+            segments: bidUserId.lipb.segments
+          };
+        }
+        request.user.ext.eids.push(liveIntent);
+      }
+
+      if (bidUserId.id5id) {
+        request.user.ext.eids.push({
+          source: 'id5-sync.com',
+          uids: [{
+            id: bidUserId.id5id,
+          }]
+        });
+      }
+
+      if (bidUserId.criteoId) {
+        request.user.ext.eids.push({
+          source: 'criteo.com',
+          uids: [{
+            id: bidUserId.criteoId
+          }]
+        });
+      }
+
+      if (bidUserId.britepoolid) {
+        request.user.ext.eids.push({
+          source: 'britepool.com',
+          uids: [{
+            id: bidUserId.britepoolid
+          }]
+        });
+      }
+
+      if (bidUserId.idl_env) {
+        request.user.ext.eids.push({
+          source: 'liveramp.com',
+          uids: [{
+            id: bidUserId.idl_env
+          }]
+        });
+      }
+
+      if (bidUserId.netId) {
+        request.user.ext.eids.push({
+          source: 'netid.de',
+          uids: [{
+            id: bidUserId.netId
+          }]
+        });
+      }
+    }
+  },
+  addDigiTrust: (request, bidRequests) => {
+    const digiTrust = BB_HELPERS.getDigiTrustParams(bidRequests && bidRequests[0]);
+    if (digiTrust) utils.deepSetValue(request, 'user.ext.digitrust', digiTrust);
+  },
+  substituteUrl: (url, publication, renderer) => {
+    return url.replace('$$URL_START', (DEV_MODE) ? 'https://dev.' : 'https://').replace('$$PUBLICATION', publication).replace('$$RENDERER', renderer);
+  },
+  getAuctionUrl: (publication) => {
+    return BB_HELPERS.substituteUrl(BB_CONSTANTS.AUCTION_URL, publication);
+  },
+  getSyncUrl: (publication) => {
+    return BB_HELPERS.substituteUrl(BB_CONSTANTS.SYNC_URL, publication);
+  },
+  getRendererUrl: (publication, renderer) => {
+    return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
+  },
+  getAliasesFromRegistry: (name) => {
+    if (!name) return null;
+
+    let aliases = adapterManager.aliasRegistry[name];
+
+    if (aliases) return aliases;
+    else return null;
+  },
+  getBidAdapterFromManager: (name) => {
+    if (!name) return null;
+
+    const adapter = adapterManager.getBidAdapter && adapterManager.getBidAdapter(name);
+    return adapter || null;
+  },
+  getDigiTrustParams: (bidRequest) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     const digiTrustId = BB_HELPERS.getDigiTrustId(bidRequest);
 
     if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) return null;
@@ -88,14 +255,29 @@ export const BB_HELPERS = {
       keyv: digiTrustId.keyv
     }
   },
+<<<<<<< HEAD
   getDigiTrustId: function(bidRequest) {
+=======
+  getDigiTrustId: (bidRequest) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     const bidRequestDigiTrust = utils.deepAccess(bidRequest, 'userId.digitrustid.data');
     if (bidRequestDigiTrust) return bidRequestDigiTrust;
 
     const digiTrustUser = getConfig('digiTrustId');
     return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
   },
+<<<<<<< HEAD
   transformRTBToPrebidProps: function(bid, serverResponse) {
+=======
+  transformBidParams: (adapter, bidRequest, name) => {
+    if (adapter && typeof adapter.getSpec().transformBidParams === 'function') {
+      if (bidRequest.params && bidRequest.params[name]) {
+        bidRequest.params[name] = adapter.getSpec().transformBidParams(bidRequest.params[name], true);
+      }
+    }
+  },
+  transformRTBToPrebidProps: (bid, serverResponse) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     bid.cpm = bid.price; delete bid.price;
     bid.bidId = bid.impid;
     bid.requestId = bid.impid; delete bid.impid;
@@ -119,7 +301,11 @@ export const BB_HELPERS = {
 
 // Renderer Functions
 const BB_RENDERER = {
+<<<<<<< HEAD
   bootstrapPlayer: function(bid) {
+=======
+  bootstrapPlayer: (bid) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     const config = {
       code: bid.adUnitCode,
     };
@@ -135,6 +321,7 @@ const BB_RENDERER = {
     const rendererId = BB_RENDERER.getRendererId(bid.publicationName, bid.rendererCode);
 
     const ele = document.getElementById(bid.adUnitCode); // NB convention
+<<<<<<< HEAD
 
     let renderer;
 
@@ -144,11 +331,18 @@ const BB_RENDERER = {
         break;
       }
     }
+=======
+    const renderer = window.bluebillywig.renderers.find((renderer) => renderer._id === rendererId);
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 
     if (renderer) renderer.bootstrap(config, ele);
     else utils.logWarn(`${BB_CONSTANTS.BIDDER_CODE}: Couldn't find a renderer with ${rendererId}`);
   },
+<<<<<<< HEAD
   newRenderer: function(rendererUrl, adUnitCode) {
+=======
+  newRenderer: (rendererUrl, adUnitCode) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     const renderer = Renderer.install({
       url: rendererUrl,
       loaded: false,
@@ -163,10 +357,17 @@ const BB_RENDERER = {
 
     return renderer;
   },
+<<<<<<< HEAD
   outstreamRender: function(bid) {
     bid.renderer.push(function() { BB_RENDERER.bootstrapPlayer(bid) });
   },
   getRendererId: function(pub, renderer) {
+=======
+  outstreamRender: (bid) => {
+    bid.renderer.push(() => BB_RENDERER.bootstrapPlayer(bid));
+  },
+  getRendererId: (pub, renderer) => {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     return `${pub}-${renderer}`; // NB convention!
   }
 };
@@ -212,8 +413,12 @@ export const spec = {
         utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: connections is not of type array. Rejecting bid: `, bid);
         return false;
       } else {
+<<<<<<< HEAD
         for (let connectionIndex = 0; connectionIndex < bid.params.connections.length; connectionIndex++) {
           const connection = bid.params.connections[connectionIndex];
+=======
+        for (const connection of bid.params.connections) {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
           if (!bid.params.hasOwnProperty(connection)) {
             utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: connection specified in params.connections, but not configured in params. Rejecting bid: `, bid);
             return false;
@@ -244,6 +449,7 @@ export const spec = {
   },
   buildRequests(validBidRequests, bidderRequest) {
     const imps = [];
+<<<<<<< HEAD
 
     for (let validBidRequestIndex = 0; validBidRequestIndex < validBidRequests.length; validBidRequestIndex++) {
       const validBidRequest = validBidRequests[validBidRequestIndex];
@@ -252,6 +458,22 @@ export const spec = {
       const ext = validBidRequest.params.connections.reduce(function(extBuilder, connection) {
         extBuilder[connection] = validBidRequest.params[connection];
 
+=======
+    const aliases = {};
+
+    for (const validBidRequest of validBidRequests) {
+      const _this = this;
+
+      const ext = validBidRequest.params.connections.reduce((extBuilder, connection) => {
+        const adapter = BB_HELPERS.getBidAdapterFromManager(connection);
+        BB_HELPERS.transformBidParams(adapter, validBidRequest, connection);
+        extBuilder[connection] = validBidRequest.params[connection];
+
+        // check for and store valid aliases to add to the request
+        let connectionAliases = BB_HELPERS.getAliasesFromRegistry(connection);
+        if (connectionAliases) aliases[connection] = connectionAliases;
+
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
         if (_this.syncStore.bidders.indexOf(connection) === -1) _this.syncStore.bidders.push(connection);
 
         return extBuilder;
@@ -291,6 +513,10 @@ export const spec = {
     // Enrich the request with any external data we may have
     BB_HELPERS.addSiteAppDevice(request, bidderRequest.refererInfo && bidderRequest.refererInfo.referer);
     BB_HELPERS.addSchain(request, validBidRequests);
+<<<<<<< HEAD
+=======
+    BB_HELPERS.addAliases(request, aliases);
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     BB_HELPERS.addCurrency(request);
     BB_HELPERS.addUserIds(request, validBidRequests);
     BB_HELPERS.addDigiTrust(request, validBidRequests);
@@ -311,6 +537,7 @@ export const spec = {
 
     const bids = [];
 
+<<<<<<< HEAD
     for (let seatbidIndex = 0; seatbidIndex < serverResponse.seatbid.length; seatbidIndex++) {
       const seatbid = serverResponse.seatbid[seatbidIndex];
       if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
@@ -330,6 +557,18 @@ export const spec = {
           bid.rendererCode = bidParams.rendererCode;
           bid.accountId = bidParams.accountId;
         }
+=======
+    for (const seatbid of serverResponse.seatbid) {
+      if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
+      for (const bid of seatbid.bid) {
+        BB_HELPERS.transformRTBToPrebidProps(bid, serverResponse);
+
+        const bidParams = request.bidderRequest.bids.find(_bid => _bid.bidId === bid.bidId).params;
+
+        bid.publicationName = bidParams.publicationName;
+        bid.rendererCode = bidParams.rendererCode;
+        bid.accountId = bidParams.accountId;
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 
         const rendererUrl = BB_HELPERS.getRendererUrl(bid.publicationName, bid.rendererCode);
 
@@ -352,10 +591,15 @@ export const spec = {
     const serverResponse = serverResponses[0];
     if (!serverResponse.body || !serverResponse.body.seatbid) return [];
 
+<<<<<<< HEAD
     for (let seatbidIndex = 0; seatbidIndex < serverResponse.body.seatbid.length; seatbidIndex++) {
       const seatbid = serverResponse.body.seatbid[seatbidIndex];
       for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
         const bid = seatbid.bid[bidIndex];
+=======
+    for (const seatbid of serverResponse.body.seatbid) {
+      for (const bid of seatbid.bid) {
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
         accountId = bid.accountId || null;
         publication = bid.publicationName || null;
 

--- a/modules/bluebillywigBidAdapter.js
+++ b/modules/bluebillywigBidAdapter.js
@@ -585,14 +585,20 @@ export const spec = {
     if (!serverResponse.body || !serverResponse.body.seatbid) return [];
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 4772e9bc... Remove the last for .. of in bluebillywigBidAdapter.js, hopefully...
     for (let seatbidIndex = 0; seatbidIndex < serverResponse.body.seatbid.length; seatbidIndex++) {
       const seatbid = serverResponse.body.seatbid[seatbidIndex];
       for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
         const bid = seatbid.bid[bidIndex];
+<<<<<<< HEAD
 =======
     for (const seatbid of serverResponse.body.seatbid) {
       for (const bid of seatbid.bid) {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+>>>>>>> 4772e9bc... Remove the last for .. of in bluebillywigBidAdapter.js, hopefully...
         accountId = bid.accountId || null;
         publication = bid.publicationName || null;
 

--- a/modules/bluebillywigBidAdapter.js
+++ b/modules/bluebillywigBidAdapter.js
@@ -1,36 +1,15 @@
 import * as utils from '../src/utils.js';
+import find from 'core-js-pure/features/array/find.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import { createEidsArray } from './userId/eids.js';
-=======
-import adapterManager from '../src/adapterManager.js';
-import { VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
-import { Renderer } from '../src/Renderer.js';
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-import { VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
-import { Renderer } from '../src/Renderer.js';
-import { createEidsArray } from './userId/eids.js';
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 
 const DEV_MODE = window.location.search.match(/bbpbs_debug=true/);
 
 // Blue Billywig Constants
-<<<<<<< HEAD
-<<<<<<< HEAD
 const BB_CONSTANTS = {
-=======
-export const BB_CONSTANTS = {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-const BB_CONSTANTS = {
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
   SYNC_URL: '$$URL_STARTpbs.bluebillywig.com/static/cookie-sync.html?pub=$$PUBLICATION',
@@ -39,7 +18,10 @@ const BB_CONSTANTS = {
   DEFAULT_TTL: 300,
   DEFAULT_WIDTH: 768,
   DEFAULT_HEIGHT: 432,
-  DEFAULT_NET_REVENUE: true
+  DEFAULT_NET_REVENUE: true,
+  VIDEO_PARAMS: ['mimes', 'minduration', 'maxduration', 'protocols', 'w', 'h', 'startdelay', 'placement', 'linearity', 'skip', 'skipmin',
+    'skipafter', 'sequence', 'battr', 'maxextended', 'minbitrate', 'maxbitrate', 'boxingallowed', 'playbackmethod', 'playbackend', 'delivery', 'pos', 'companionad',
+    'api', 'companiontype', 'ext']
 };
 
 // Aliasing
@@ -47,85 +29,35 @@ const getConfig = config.getConfig;
 
 // Helper Functions
 export const BB_HELPERS = {
-<<<<<<< HEAD
-<<<<<<< HEAD
   addSiteAppDevice: function(request, pageUrl) {
-    if (!request) return;
-
     if (typeof getConfig('app') === 'object') request.app = getConfig('app');
     else {
       request.site = {};
       if (typeof getConfig('site') === 'object') request.site = getConfig('site');
       if (pageUrl) request.site.page = pageUrl;
     }
-=======
-  addSiteAppDevice: (request, pageUrl) => {
-=======
-  addSiteAppDevice: function(request, pageUrl) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    if (!request) return;
-
-    if (typeof getConfig('app') === 'object') request.app = getConfig('app');
-    else if (pageUrl) request.site = { page: pageUrl };
->>>>>>> 1ae44aa5... add Blue Billywig adapter
 
     if (typeof getConfig('device') === 'object') request.device = getConfig('device');
     if (!request.device) request.device = {};
     if (!request.device.w) request.device.w = window.innerWidth;
     if (!request.device.h) request.device.h = window.innerHeight;
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
   addSchain: function(request, validBidRequests) {
-=======
-  addSchain: (request, validBidRequests) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  addSchain: function(request, validBidRequests) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    if (!request) return;
-
     const schain = utils.deepAccess(validBidRequests, '0.schain');
     if (schain) request.source.ext = { schain: schain };
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   addCurrency: function(request) {
-=======
-  addAliases: (request, aliases) => {
-    if (!request) return;
-
-    if (!utils.isEmpty(aliases)) request.ext.prebid.aliases = aliases;
-  },
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
-  addCurrency: (request) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  addCurrency: function(request) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    if (!request) return;
-
     const adServerCur = getConfig('currency.adServerCurrency');
     if (adServerCur && typeof adServerCur === 'string') request.cur = [adServerCur];
     else if (Array.isArray(adServerCur) && adServerCur.length) request.cur = [adServerCur[0]];
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
   addUserIds: function(request, validBidRequests) {
-    if (!request) return;
-
     const bidUserId = utils.deepAccess(validBidRequests, '0.userId');
     const eids = createEidsArray(bidUserId);
 
     if (eids.length) {
       utils.deepSetValue(request, 'user.ext.eids', eids);
     }
-  },
-  addDigiTrust: function(request, bidRequests) {
-    const digiTrust = BB_HELPERS.getDigiTrustParams(bidRequests && bidRequests[0]);
-    if (digiTrust) utils.deepSetValue(request, 'user.ext.digitrust', digiTrust);
   },
   substituteUrl: function (url, publication, renderer) {
     return url.replace('$$URL_START', (DEV_MODE) ? 'https://dev.' : 'https://').replace('$$PUBLICATION', publication).replace('$$RENDERER', renderer);
@@ -139,117 +71,65 @@ export const BB_HELPERS = {
   getRendererUrl: function(publication, renderer) {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
   },
-  getDigiTrustParams: function(bidRequest) {
-=======
-  addUserIds: (request, validBidRequests) => {
-=======
-  addUserIds: function(request, validBidRequests) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    if (!request) return;
+  transformVideoParams: function(videoParams, videoParamsExt) {
+    videoParams = utils.deepClone(videoParams);
 
-    const bidUserId = utils.deepAccess(validBidRequests, '0.userId');
-    const eids = createEidsArray(bidUserId);
+    let playerSize = videoParams.playerSize || [BB_CONSTANTS.DEFAULT_WIDTH, BB_CONSTANTS.DEFAULT_HEIGHT];
+    if (Array.isArray(playerSize[0])) playerSize = playerSize[0];
 
-    if (eids.length) {
-      utils.deepSetValue(request, 'user.ext.eids', eids);
-    }
-  },
-  addDigiTrust: function(request, bidRequests) {
-    const digiTrust = BB_HELPERS.getDigiTrustParams(bidRequests && bidRequests[0]);
-    if (digiTrust) utils.deepSetValue(request, 'user.ext.digitrust', digiTrust);
-  },
-  substituteUrl: function (url, publication, renderer) {
-    return url.replace('$$URL_START', (DEV_MODE) ? 'https://dev.' : 'https://').replace('$$PUBLICATION', publication).replace('$$RENDERER', renderer);
-  },
-  getAuctionUrl: function(publication) {
-    return BB_HELPERS.substituteUrl(BB_CONSTANTS.AUCTION_URL, publication);
-  },
-  getSyncUrl: function(publication) {
-    return BB_HELPERS.substituteUrl(BB_CONSTANTS.SYNC_URL, publication);
-  },
-  getRendererUrl: function(publication, renderer) {
-    return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
-  },
-<<<<<<< HEAD
-  getDigiTrustParams: (bidRequest) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  getDigiTrustParams: function(bidRequest) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    const digiTrustId = BB_HELPERS.getDigiTrustId(bidRequest);
+    videoParams.w = playerSize[0];
+    videoParams.h = playerSize[1];
+    videoParams.placement = 3;
 
-    if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) return null;
-    return {
-      id: digiTrustId.id,
-      keyv: digiTrustId.keyv
-    }
-  },
-<<<<<<< HEAD
-<<<<<<< HEAD
-  getDigiTrustId: function(bidRequest) {
-=======
-  getDigiTrustId: (bidRequest) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  getDigiTrustId: function(bidRequest) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    const bidRequestDigiTrust = utils.deepAccess(bidRequest, 'userId.digitrustid.data');
-    if (bidRequestDigiTrust) return bidRequestDigiTrust;
+    if (videoParamsExt) videoParams = Object.assign(videoParams, videoParamsExt);
 
-    const digiTrustUser = getConfig('digiTrustId');
-    return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
+    const videoParamsProperties = Object.keys(videoParams);
+
+    videoParamsProperties.forEach(property => {
+      if (BB_CONSTANTS.VIDEO_PARAMS.indexOf(property) === -1) delete videoParams[property];
+    });
+
+    return videoParams;
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   transformRTBToPrebidProps: function(bid, serverResponse) {
-=======
-  transformBidParams: (adapter, bidRequest, name) => {
-    if (adapter && typeof adapter.getSpec().transformBidParams === 'function') {
-      if (bidRequest.params && bidRequest.params[name]) {
-        bidRequest.params[name] = adapter.getSpec().transformBidParams(bidRequest.params[name], true);
-      }
+    const bidObject = {
+      cpm: bid.price,
+      currency: serverResponse.cur,
+      netRevenue: BB_CONSTANTS.DEFAULT_NET_REVENUE,
+      bidId: bid.impid,
+      requestId: bid.impid,
+      creativeId: bid.crid,
+      mediaType: VIDEO,
+      width: bid.w || BB_CONSTANTS.DEFAULT_WIDTH,
+      height: bid.h || BB_CONSTANTS.DEFAULT_HEIGHT,
+      ttl: BB_CONSTANTS.DEFAULT_TTL
+    };
+
+    const extPrebidTargeting = utils.deepAccess(bid, 'ext.prebid.targeting');
+    const extPrebidCache = utils.deepAccess(bid, 'ext.prebid.cache');
+
+    if (extPrebidCache && typeof extPrebidCache.vastXml === 'object' && extPrebidCache.vastXml.cacheId && extPrebidCache.vastXml.url) {
+      bidObject.videoCacheKey = extPrebidCache.vastXml.cacheId;
+      bidObject.vastUrl = extPrebidCache.vastXml.url;
+    } else if (extPrebidTargeting && extPrebidTargeting.hb_uuid && extPrebidTargeting.hb_cache_host && extPrebidTargeting.hb_cache_path) {
+      bidObject.videoCacheKey = extPrebidTargeting.hb_uuid;
+      bidObject.vastUrl = `https://${extPrebidTargeting.hb_cache_host}${extPrebidTargeting.hb_cache_path}?uuid=${extPrebidTargeting.hb_uuid}`;
     }
-  },
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
-  transformRTBToPrebidProps: (bid, serverResponse) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  transformRTBToPrebidProps: function(bid, serverResponse) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-    bid.cpm = bid.price; delete bid.price;
-    bid.bidId = bid.impid;
-    bid.requestId = bid.impid; delete bid.impid;
-    bid.width = bid.w || BB_CONSTANTS.DEFAULT_WIDTH;
-    bid.height = bid.h || BB_CONSTANTS.DEFAULT_HEIGHT;
     if (bid.adm) {
-      bid.ad = bid.adm;
-      bid.vastXml = bid.adm;
-      delete bid.adm;
+      bidObject.ad = bid.adm;
+      bidObject.vastXml = bid.adm;
     }
-    if (bid.nurl && !bid.adm) { // ad markup is on win notice url, and adm is ommited according to OpenRTB 2.5
-      bid.vastUrl = bid.nurl;
-      delete bid.nurl;
+    if (!bidObject.vastUrl && bid.nurl && !bid.adm) { // ad markup is on win notice url, and adm is ommited according to OpenRTB 2.5
+      bidObject.vastUrl = bid.nurl;
     }
-    bid.netRevenue = BB_CONSTANTS.DEFAULT_NET_REVENUE;
-    bid.creativeId = bid.crid; delete bid.crid;
-    bid.currency = serverResponse.cur;
-    bid.ttl = BB_CONSTANTS.DEFAULT_TTL;
+
+    return bidObject;
   },
 };
 
 // Renderer Functions
 const BB_RENDERER = {
-<<<<<<< HEAD
-<<<<<<< HEAD
   bootstrapPlayer: function(bid) {
-=======
-  bootstrapPlayer: (bid) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  bootstrapPlayer: function(bid) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const config = {
       code: bid.adUnitCode,
     };
@@ -262,41 +142,19 @@ const BB_RENDERER = {
       return;
     }
 
-    const rendererId = BB_RENDERER.getRendererId(bid.publicationName, bid.rendererCode);
-
-    const ele = document.getElementById(bid.adUnitCode); // NB convention
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-
-    let renderer;
-
-    for (let rendererIndex = 0; rendererIndex < window.bluebillywig.renderers.length; rendererIndex++) {
-      if (window.bluebillywig.renderers[rendererIndex]._id === rendererId) {
-        renderer = window.bluebillywig.renderers[rendererIndex];
-        break;
-      }
+    if (!(window.bluebillywig && window.bluebillywig.renderers)) {
+      utils.logWarn(`${BB_CONSTANTS.BIDDER_CODE}: renderer code failed to initialize...`);
+      return;
     }
-<<<<<<< HEAD
-=======
-    const renderer = window.bluebillywig.renderers.find((renderer) => renderer._id === rendererId);
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
+
+    const rendererId = BB_RENDERER.getRendererId(bid.publicationName, bid.rendererCode);
+    const ele = document.getElementById(bid.adUnitCode); // NB convention
+    const renderer = find(window.bluebillywig.renderers, r => r._id === rendererId);
 
     if (renderer) renderer.bootstrap(config, ele);
     else utils.logWarn(`${BB_CONSTANTS.BIDDER_CODE}: Couldn't find a renderer with ${rendererId}`);
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
   newRenderer: function(rendererUrl, adUnitCode) {
-=======
-  newRenderer: (rendererUrl, adUnitCode) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  newRenderer: function(rendererUrl, adUnitCode) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const renderer = Renderer.install({
       url: rendererUrl,
       loaded: false,
@@ -311,24 +169,10 @@ const BB_RENDERER = {
 
     return renderer;
   },
-<<<<<<< HEAD
-<<<<<<< HEAD
   outstreamRender: function(bid) {
     bid.renderer.push(function() { BB_RENDERER.bootstrapPlayer(bid) });
   },
   getRendererId: function(pub, renderer) {
-=======
-  outstreamRender: (bid) => {
-    bid.renderer.push(() => BB_RENDERER.bootstrapPlayer(bid));
-  },
-  getRendererId: (pub, renderer) => {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-  outstreamRender: function(bid) {
-    bid.renderer.push(function() { BB_RENDERER.bootstrapPlayer(bid) });
-  },
-  getRendererId: function(pub, renderer) {
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     return `${pub}-${renderer}`; // NB convention!
   }
 };
@@ -374,18 +218,8 @@ export const spec = {
         utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: connections is not of type array. Rejecting bid: `, bid);
         return false;
       } else {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        for (let connectionIndex = 0; connectionIndex < bid.params.connections.length; connectionIndex++) {
-          const connection = bid.params.connections[connectionIndex];
-=======
-        for (const connection of bid.params.connections) {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-        for (let connectionIndex = 0; connectionIndex < bid.params.connections.length; connectionIndex++) {
-          const connection = bid.params.connections[connectionIndex];
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
-          if (!bid.params.hasOwnProperty(connection)) {
+        for (let i = 0; i < bid.params.connections.length; i++) {
+          if (!bid.params.hasOwnProperty(bid.params.connections[i])) {
             utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: connection specified in params.connections, but not configured in params. Rejecting bid: `, bid);
             return false;
           }
@@ -393,6 +227,11 @@ export const spec = {
       }
     } else {
       utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: no connections specified in bid. Rejecting bid: `, bid);
+      return false;
+    }
+
+    if (bid.params.hasOwnProperty('video') && (bid.params.video === null || typeof bid.params.video !== 'object')) {
+      utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: params.video must be of type object. Rejecting bid: `, bid);
       return false;
     }
 
@@ -415,43 +254,22 @@ export const spec = {
   },
   buildRequests(validBidRequests, bidderRequest) {
     const imps = [];
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-    for (let validBidRequestIndex = 0; validBidRequestIndex < validBidRequests.length; validBidRequestIndex++) {
-      const validBidRequest = validBidRequests[validBidRequestIndex];
-      const _this = this;
+    validBidRequests.forEach(validBidRequest => {
+      if (!this.syncStore.publicationName) this.syncStore.publicationName = validBidRequest.params.publicationName;
+      if (!this.syncStore.accountId) this.syncStore.accountId = validBidRequest.params.accountId;
 
-      const ext = validBidRequest.params.connections.reduce(function(extBuilder, connection) {
+      const ext = validBidRequest.params.connections.reduce((extBuilder, connection) => {
         extBuilder[connection] = validBidRequest.params[connection];
 
-=======
-    const aliases = {};
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
-
-    for (let validBidRequestIndex = 0; validBidRequestIndex < validBidRequests.length; validBidRequestIndex++) {
-      const validBidRequest = validBidRequests[validBidRequestIndex];
-      const _this = this;
-
-      const ext = validBidRequest.params.connections.reduce(function(extBuilder, connection) {
-        extBuilder[connection] = validBidRequest.params[connection];
-
-<<<<<<< HEAD
-        // check for and store valid aliases to add to the request
-        let connectionAliases = BB_HELPERS.getAliasesFromRegistry(connection);
-        if (connectionAliases) aliases[connection] = connectionAliases;
-
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
-        if (_this.syncStore.bidders.indexOf(connection) === -1) _this.syncStore.bidders.push(connection);
+        if (this.syncStore.bidders.indexOf(connection) === -1) this.syncStore.bidders.push(connection);
 
         return extBuilder;
       }, {});
 
-      imps.push({ id: validBidRequest.bidId, ext, secure: window.location.protocol === 'https' ? 1 : 0, video: utils.deepAccess(validBidRequest, 'mediaTypes.video') });
-    }
+      const videoParams = BB_HELPERS.transformVideoParams(utils.deepAccess(validBidRequest, 'mediaTypes.video'), utils.deepAccess(validBidRequest, 'params.video'));
+      imps.push({ id: validBidRequest.bidId, ext, secure: window.location.protocol === 'https' ? 1 : 0, video: videoParams });
+    });
 
     const request = {
       id: bidderRequest.auctionId,
@@ -484,16 +302,8 @@ export const spec = {
     // Enrich the request with any external data we may have
     BB_HELPERS.addSiteAppDevice(request, bidderRequest.refererInfo && bidderRequest.refererInfo.referer);
     BB_HELPERS.addSchain(request, validBidRequests);
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    BB_HELPERS.addAliases(request, aliases);
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
     BB_HELPERS.addCurrency(request);
     BB_HELPERS.addUserIds(request, validBidRequests);
-    BB_HELPERS.addDigiTrust(request, validBidRequests);
 
     return {
       method: 'POST',
@@ -511,117 +321,43 @@ export const spec = {
 
     const bids = [];
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    for (let seatbidIndex = 0; seatbidIndex < serverResponse.seatbid.length; seatbidIndex++) {
-      const seatbid = serverResponse.seatbid[seatbidIndex];
-      if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
-      for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
-        const bid = seatbid.bid[bidIndex];
-        BB_HELPERS.transformRTBToPrebidProps(bid, serverResponse);
+    serverResponse.seatbid.forEach(seatbid => {
+      if (!seatbid.bid || !Array.isArray(seatbid.bid)) return;
+      seatbid.bid.forEach(bid => {
+        bid = BB_HELPERS.transformRTBToPrebidProps(bid, serverResponse);
 
-        let bidParams;
-        for (let bidderRequestBidsIndex = 0; bidderRequestBidsIndex < request.bidderRequest.bids.length; bidderRequestBidsIndex++) {
-          if (request.bidderRequest.bids[bidderRequestBidsIndex].bidId === bid.bidId) {
-            bidParams = request.bidderRequest.bids[bidderRequestBidsIndex].params;
-          }
-        }
-
-        if (bidParams) {
-          bid.publicationName = bidParams.publicationName;
-          bid.rendererCode = bidParams.rendererCode;
-          bid.accountId = bidParams.accountId;
-        }
-=======
-    for (const seatbid of serverResponse.seatbid) {
-=======
-    for (let seatbidIndex = 0; seatbidIndex < serverResponse.seatbid.length; seatbidIndex++) {
-      const seatbid = serverResponse.seatbid[seatbidIndex];
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
-      if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
-      for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
-        const bid = seatbid.bid[bidIndex];
-        BB_HELPERS.transformRTBToPrebidProps(bid, serverResponse);
-
-        let bidParams;
-        for (let bidderRequestBidsIndex = 0; bidderRequestBidsIndex < request.bidderRequest.bids.length; bidderRequestBidsIndex++) {
-          if (request.bidderRequest.bids[bidderRequestBidsIndex].bidId === bid.bidId) {
-            bidParams = request.bidderRequest.bids[bidderRequestBidsIndex].params;
-          }
-        }
-
-<<<<<<< HEAD
+        const bidParams = find(request.bidderRequest.bids, bidderRequestBid => bidderRequestBid.bidId === bid.bidId).params;
         bid.publicationName = bidParams.publicationName;
         bid.rendererCode = bidParams.rendererCode;
         bid.accountId = bidParams.accountId;
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-        if (bidParams) {
-          bid.publicationName = bidParams.publicationName;
-          bid.rendererCode = bidParams.rendererCode;
-          bid.accountId = bidParams.accountId;
-        }
->>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
 
         const rendererUrl = BB_HELPERS.getRendererUrl(bid.publicationName, bid.rendererCode);
-
         bid.renderer = BB_RENDERER.newRenderer(rendererUrl, bid.adUnitCode);
 
         bids.push(bid);
-      }
-    }
+      });
+    });
 
     return bids;
   },
   getUserSyncs(syncOptions, serverResponses, gdpr) {
-    if (!serverResponses || !serverResponses.length) return [];
     if (!syncOptions.iframeEnabled) return [];
 
     const queryString = [];
-    let accountId;
-    let publication;
-
-    const serverResponse = serverResponses[0];
-    if (!serverResponse.body || !serverResponse.body.seatbid) return [];
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 4772e9bc... Remove the last for .. of in bluebillywigBidAdapter.js, hopefully...
-    for (let seatbidIndex = 0; seatbidIndex < serverResponse.body.seatbid.length; seatbidIndex++) {
-      const seatbid = serverResponse.body.seatbid[seatbidIndex];
-      for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
-        const bid = seatbid.bid[bidIndex];
-<<<<<<< HEAD
-=======
-    for (const seatbid of serverResponse.body.seatbid) {
-      for (const bid of seatbid.bid) {
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
->>>>>>> 4772e9bc... Remove the last for .. of in bluebillywigBidAdapter.js, hopefully...
-        accountId = bid.accountId || null;
-        publication = bid.publicationName || null;
-
-        if (publication && accountId) break;
-      }
-      if (publication && accountId) break;
-    }
-
-    if (!publication || !accountId) return [];
 
     if (gdpr.gdprApplies) queryString.push(`gdpr=${gdpr.gdprApplies ? 1 : 0}`);
     if (gdpr.gdprApplies && gdpr.consentString) queryString.push(`gdpr_consent=${gdpr.consentString}`);
 
     if (this.syncStore.uspConsent) queryString.push(`usp_consent=${this.syncStore.uspConsent}`);
 
-    queryString.push(`accountId=${accountId}`);
+    queryString.push(`accountId=${this.syncStore.accountId}`);
     queryString.push(`bidders=${btoa(JSON.stringify(this.syncStore.bidders))}`);
     queryString.push(`cb=${Date.now()}-${Math.random().toString().replace('.', '')}`);
 
     if (DEV_MODE) queryString.push('bbpbs_debug=true');
 
     // NB syncUrl by default starts with ?pub=$$PUBLICATION
-    const syncUrl = `${BB_HELPERS.getSyncUrl(publication)}&${queryString.join('&')}`;
+    const syncUrl = `${BB_HELPERS.getSyncUrl(this.syncStore.publicationName)}&${queryString.join('&')}`;
 
     return [{
       type: 'iframe',

--- a/modules/bluebillywigBidAdapter.js
+++ b/modules/bluebillywigBidAdapter.js
@@ -1,6 +1,7 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
@@ -11,15 +12,25 @@ import { VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+import { VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
+import { Renderer } from '../src/Renderer.js';
+import { createEidsArray } from './userId/eids.js';
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 
 const DEV_MODE = window.location.search.match(/bbpbs_debug=true/);
 
 // Blue Billywig Constants
 <<<<<<< HEAD
+<<<<<<< HEAD
 const BB_CONSTANTS = {
 =======
 export const BB_CONSTANTS = {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+const BB_CONSTANTS = {
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
   SYNC_URL: '$$URL_STARTpbs.bluebillywig.com/static/cookie-sync.html?pub=$$PUBLICATION',
@@ -70,6 +81,7 @@ export const BB_HELPERS = {
     if (schain) request.source.ext = { schain: schain };
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   addCurrency: function(request) {
 =======
   addAliases: (request, aliases) => {
@@ -77,6 +89,8 @@ export const BB_HELPERS = {
 
     if (!utils.isEmpty(aliases)) request.ext.prebid.aliases = aliases;
   },
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   addCurrency: (request) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
     if (!request) return;
@@ -117,102 +131,11 @@ export const BB_HELPERS = {
   addUserIds: (request, validBidRequests) => {
     if (!request) return;
 
-    // NB straight rip from prebidServerAdapter, keep track for updates
     const bidUserId = utils.deepAccess(validBidRequests, '0.userId');
+    const eids = createEidsArray(bidUserId);
 
-    if (bidUserId && typeof bidUserId === 'object' && (bidUserId.tdid || bidUserId.pubcid || bidUserId.parrableid || bidUserId.lipb || bidUserId.id5id || bidUserId.criteoId || bidUserId.britepoolid || bidUserId.idl_env)) {
-      utils.deepSetValue(request, 'user.ext.eids', []);
-
-      if (bidUserId.tdid) {
-        request.user.ext.eids.push({
-          source: 'adserver.org',
-          uids: [{
-            id: bidUserId.tdid,
-            ext: {
-              rtiPartner: 'TDID'
-            }
-          }]
-        });
-      }
-
-      if (bidUserId.pubcid) {
-        request.user.ext.eids.push({
-          source: 'pubcid.org',
-          uids: [{
-            id: bidUserId.pubcid,
-          }]
-        });
-      }
-
-      if (bidUserId.parrableid) {
-        request.user.ext.eids.push({
-          source: 'parrable.com',
-          uids: [{
-            id: bidUserId.parrableid
-          }]
-        });
-      }
-
-      if (bidUserId.lipb && bidUserId.lipb.lipbid) {
-        const liveIntent = {
-          source: 'liveintent.com',
-          uids: [{
-            id: bidUserId.lipb.lipbid
-          }]
-        };
-
-        if (Array.isArray(bidUserId.lipb.segments) && bidUserId.lipb.segments.length) {
-          liveIntent.ext = {
-            segments: bidUserId.lipb.segments
-          };
-        }
-        request.user.ext.eids.push(liveIntent);
-      }
-
-      if (bidUserId.id5id) {
-        request.user.ext.eids.push({
-          source: 'id5-sync.com',
-          uids: [{
-            id: bidUserId.id5id,
-          }]
-        });
-      }
-
-      if (bidUserId.criteoId) {
-        request.user.ext.eids.push({
-          source: 'criteo.com',
-          uids: [{
-            id: bidUserId.criteoId
-          }]
-        });
-      }
-
-      if (bidUserId.britepoolid) {
-        request.user.ext.eids.push({
-          source: 'britepool.com',
-          uids: [{
-            id: bidUserId.britepoolid
-          }]
-        });
-      }
-
-      if (bidUserId.idl_env) {
-        request.user.ext.eids.push({
-          source: 'liveramp.com',
-          uids: [{
-            id: bidUserId.idl_env
-          }]
-        });
-      }
-
-      if (bidUserId.netId) {
-        request.user.ext.eids.push({
-          source: 'netid.de',
-          uids: [{
-            id: bidUserId.netId
-          }]
-        });
-      }
+    if (eids && eids.length) {
+      utils.deepSetValue(request, 'user.ext.eids', eids);
     }
   },
   addDigiTrust: (request, bidRequests) => {
@@ -230,20 +153,6 @@ export const BB_HELPERS = {
   },
   getRendererUrl: (publication, renderer) => {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
-  },
-  getAliasesFromRegistry: (name) => {
-    if (!name) return null;
-
-    let aliases = adapterManager.aliasRegistry[name];
-
-    if (aliases) return aliases;
-    else return null;
-  },
-  getBidAdapterFromManager: (name) => {
-    if (!name) return null;
-
-    const adapter = adapterManager.getBidAdapter && adapterManager.getBidAdapter(name);
-    return adapter || null;
   },
   getDigiTrustParams: (bidRequest) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
@@ -267,6 +176,7 @@ export const BB_HELPERS = {
     return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   transformRTBToPrebidProps: function(bid, serverResponse) {
 =======
   transformBidParams: (adapter, bidRequest, name) => {
@@ -276,6 +186,8 @@ export const BB_HELPERS = {
       }
     }
   },
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   transformRTBToPrebidProps: (bid, serverResponse) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
     bid.cpm = bid.price; delete bid.price;
@@ -414,11 +326,16 @@ export const spec = {
         return false;
       } else {
 <<<<<<< HEAD
+<<<<<<< HEAD
         for (let connectionIndex = 0; connectionIndex < bid.params.connections.length; connectionIndex++) {
           const connection = bid.params.connections[connectionIndex];
 =======
         for (const connection of bid.params.connections) {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+        for (let connectionIndex = 0; connectionIndex < bid.params.connections.length; connectionIndex++) {
+          const connection = bid.params.connections[connectionIndex];
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
           if (!bid.params.hasOwnProperty(connection)) {
             utils.logError(`${BB_CONSTANTS.BIDDER_CODE}: connection specified in params.connections, but not configured in params. Rejecting bid: `, bid);
             return false;
@@ -450,6 +367,7 @@ export const spec = {
   buildRequests(validBidRequests, bidderRequest) {
     const imps = [];
 <<<<<<< HEAD
+<<<<<<< HEAD
 
     for (let validBidRequestIndex = 0; validBidRequestIndex < validBidRequests.length; validBidRequestIndex++) {
       const validBidRequest = validBidRequests[validBidRequestIndex];
@@ -460,20 +378,24 @@ export const spec = {
 
 =======
     const aliases = {};
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 
-    for (const validBidRequest of validBidRequests) {
+    for (let validBidRequestIndex = 0; validBidRequestIndex < validBidRequests.length; validBidRequestIndex++) {
+      const validBidRequest = validBidRequests[validBidRequestIndex];
       const _this = this;
 
       const ext = validBidRequest.params.connections.reduce((extBuilder, connection) => {
-        const adapter = BB_HELPERS.getBidAdapterFromManager(connection);
-        BB_HELPERS.transformBidParams(adapter, validBidRequest, connection);
         extBuilder[connection] = validBidRequest.params[connection];
 
+<<<<<<< HEAD
         // check for and store valid aliases to add to the request
         let connectionAliases = BB_HELPERS.getAliasesFromRegistry(connection);
         if (connectionAliases) aliases[connection] = connectionAliases;
 
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
         if (_this.syncStore.bidders.indexOf(connection) === -1) _this.syncStore.bidders.push(connection);
 
         return extBuilder;
@@ -514,9 +436,12 @@ export const spec = {
     BB_HELPERS.addSiteAppDevice(request, bidderRequest.refererInfo && bidderRequest.refererInfo.referer);
     BB_HELPERS.addSchain(request, validBidRequests);
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     BB_HELPERS.addAliases(request, aliases);
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
     BB_HELPERS.addCurrency(request);
     BB_HELPERS.addUserIds(request, validBidRequests);
     BB_HELPERS.addDigiTrust(request, validBidRequests);

--- a/modules/bluebillywigBidAdapter.js
+++ b/modules/bluebillywigBidAdapter.js
@@ -48,6 +48,7 @@ const getConfig = config.getConfig;
 // Helper Functions
 export const BB_HELPERS = {
 <<<<<<< HEAD
+<<<<<<< HEAD
   addSiteAppDevice: function(request, pageUrl) {
     if (!request) return;
 
@@ -59,6 +60,9 @@ export const BB_HELPERS = {
     }
 =======
   addSiteAppDevice: (request, pageUrl) => {
+=======
+  addSiteAppDevice: function(request, pageUrl) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     if (!request) return;
 
     if (typeof getConfig('app') === 'object') request.app = getConfig('app');
@@ -71,15 +75,20 @@ export const BB_HELPERS = {
     if (!request.device.h) request.device.h = window.innerHeight;
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   addSchain: function(request, validBidRequests) {
 =======
   addSchain: (request, validBidRequests) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  addSchain: function(request, validBidRequests) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     if (!request) return;
 
     const schain = utils.deepAccess(validBidRequests, '0.schain');
     if (schain) request.source.ext = { schain: schain };
   },
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
   addCurrency: function(request) {
@@ -93,12 +102,16 @@ export const BB_HELPERS = {
 >>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   addCurrency: (request) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  addCurrency: function(request) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     if (!request) return;
 
     const adServerCur = getConfig('currency.adServerCurrency');
     if (adServerCur && typeof adServerCur === 'string') request.cur = [adServerCur];
     else if (Array.isArray(adServerCur) && adServerCur.length) request.cur = [adServerCur[0]];
   },
+<<<<<<< HEAD
 <<<<<<< HEAD
   addUserIds: function(request, validBidRequests) {
     if (!request) return;
@@ -129,33 +142,40 @@ export const BB_HELPERS = {
   getDigiTrustParams: function(bidRequest) {
 =======
   addUserIds: (request, validBidRequests) => {
+=======
+  addUserIds: function(request, validBidRequests) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     if (!request) return;
 
     const bidUserId = utils.deepAccess(validBidRequests, '0.userId');
     const eids = createEidsArray(bidUserId);
 
-    if (eids && eids.length) {
+    if (eids.length) {
       utils.deepSetValue(request, 'user.ext.eids', eids);
     }
   },
-  addDigiTrust: (request, bidRequests) => {
+  addDigiTrust: function(request, bidRequests) {
     const digiTrust = BB_HELPERS.getDigiTrustParams(bidRequests && bidRequests[0]);
     if (digiTrust) utils.deepSetValue(request, 'user.ext.digitrust', digiTrust);
   },
-  substituteUrl: (url, publication, renderer) => {
+  substituteUrl: function (url, publication, renderer) {
     return url.replace('$$URL_START', (DEV_MODE) ? 'https://dev.' : 'https://').replace('$$PUBLICATION', publication).replace('$$RENDERER', renderer);
   },
-  getAuctionUrl: (publication) => {
+  getAuctionUrl: function(publication) {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.AUCTION_URL, publication);
   },
-  getSyncUrl: (publication) => {
+  getSyncUrl: function(publication) {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.SYNC_URL, publication);
   },
-  getRendererUrl: (publication, renderer) => {
+  getRendererUrl: function(publication, renderer) {
     return BB_HELPERS.substituteUrl(BB_CONSTANTS.RENDERER_URL, publication, renderer);
   },
+<<<<<<< HEAD
   getDigiTrustParams: (bidRequest) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  getDigiTrustParams: function(bidRequest) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const digiTrustId = BB_HELPERS.getDigiTrustId(bidRequest);
 
     if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) return null;
@@ -165,16 +185,21 @@ export const BB_HELPERS = {
     }
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   getDigiTrustId: function(bidRequest) {
 =======
   getDigiTrustId: (bidRequest) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  getDigiTrustId: function(bidRequest) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const bidRequestDigiTrust = utils.deepAccess(bidRequest, 'userId.digitrustid.data');
     if (bidRequestDigiTrust) return bidRequestDigiTrust;
 
     const digiTrustUser = getConfig('digiTrustId');
     return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
   },
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
   transformRTBToPrebidProps: function(bid, serverResponse) {
@@ -190,6 +215,9 @@ export const BB_HELPERS = {
 >>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
   transformRTBToPrebidProps: (bid, serverResponse) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  transformRTBToPrebidProps: function(bid, serverResponse) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     bid.cpm = bid.price; delete bid.price;
     bid.bidId = bid.impid;
     bid.requestId = bid.impid; delete bid.impid;
@@ -214,10 +242,14 @@ export const BB_HELPERS = {
 // Renderer Functions
 const BB_RENDERER = {
 <<<<<<< HEAD
+<<<<<<< HEAD
   bootstrapPlayer: function(bid) {
 =======
   bootstrapPlayer: (bid) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  bootstrapPlayer: function(bid) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const config = {
       code: bid.adUnitCode,
     };
@@ -234,6 +266,9 @@ const BB_RENDERER = {
 
     const ele = document.getElementById(bid.adUnitCode); // NB convention
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
 
     let renderer;
 
@@ -243,18 +278,25 @@ const BB_RENDERER = {
         break;
       }
     }
+<<<<<<< HEAD
 =======
     const renderer = window.bluebillywig.renderers.find((renderer) => renderer._id === rendererId);
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
 
     if (renderer) renderer.bootstrap(config, ele);
     else utils.logWarn(`${BB_CONSTANTS.BIDDER_CODE}: Couldn't find a renderer with ${rendererId}`);
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   newRenderer: function(rendererUrl, adUnitCode) {
 =======
   newRenderer: (rendererUrl, adUnitCode) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  newRenderer: function(rendererUrl, adUnitCode) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     const renderer = Renderer.install({
       url: rendererUrl,
       loaded: false,
@@ -270,6 +312,7 @@ const BB_RENDERER = {
     return renderer;
   },
 <<<<<<< HEAD
+<<<<<<< HEAD
   outstreamRender: function(bid) {
     bid.renderer.push(function() { BB_RENDERER.bootstrapPlayer(bid) });
   },
@@ -280,6 +323,12 @@ const BB_RENDERER = {
   },
   getRendererId: (pub, renderer) => {
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+  outstreamRender: function(bid) {
+    bid.renderer.push(function() { BB_RENDERER.bootstrapPlayer(bid) });
+  },
+  getRendererId: function(pub, renderer) {
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
     return `${pub}-${renderer}`; // NB convention!
   }
 };
@@ -385,7 +434,7 @@ export const spec = {
       const validBidRequest = validBidRequests[validBidRequestIndex];
       const _this = this;
 
-      const ext = validBidRequest.params.connections.reduce((extBuilder, connection) => {
+      const ext = validBidRequest.params.connections.reduce(function(extBuilder, connection) {
         extBuilder[connection] = validBidRequest.params[connection];
 
 <<<<<<< HEAD
@@ -463,6 +512,7 @@ export const spec = {
     const bids = [];
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     for (let seatbidIndex = 0; seatbidIndex < serverResponse.seatbid.length; seatbidIndex++) {
       const seatbid = serverResponse.seatbid[seatbidIndex];
       if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
@@ -484,16 +534,34 @@ export const spec = {
         }
 =======
     for (const seatbid of serverResponse.seatbid) {
+=======
+    for (let seatbidIndex = 0; seatbidIndex < serverResponse.seatbid.length; seatbidIndex++) {
+      const seatbid = serverResponse.seatbid[seatbidIndex];
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
       if (!seatbid.bid || !Array.isArray(seatbid.bid)) continue;
-      for (const bid of seatbid.bid) {
+      for (let bidIndex = 0; bidIndex < seatbid.bid.length; bidIndex++) {
+        const bid = seatbid.bid[bidIndex];
         BB_HELPERS.transformRTBToPrebidProps(bid, serverResponse);
 
-        const bidParams = request.bidderRequest.bids.find(_bid => _bid.bidId === bid.bidId).params;
+        let bidParams;
+        for (let bidderRequestBidsIndex = 0; bidderRequestBidsIndex < request.bidderRequest.bids.length; bidderRequestBidsIndex++) {
+          if (request.bidderRequest.bids[bidderRequestBidsIndex].bidId === bid.bidId) {
+            bidParams = request.bidderRequest.bids[bidderRequestBidsIndex].params;
+          }
+        }
 
+<<<<<<< HEAD
         bid.publicationName = bidParams.publicationName;
         bid.rendererCode = bidParams.rendererCode;
         bid.accountId = bidParams.accountId;
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+        if (bidParams) {
+          bid.publicationName = bidParams.publicationName;
+          bid.rendererCode = bidParams.rendererCode;
+          bid.accountId = bidParams.accountId;
+        }
+>>>>>>> b52c832d... Blue Billywig Adapter - update to try and pass CircleCI
 
         const rendererUrl = BB_HELPERS.getRendererUrl(bid.publicationName, bid.rendererCode);
 

--- a/modules/bluebillywigBidAdapter.md
+++ b/modules/bluebillywigBidAdapter.md
@@ -28,7 +28,11 @@ Prebid Blue Billywig Bidder Adapter
                     bidder: 'bluebillywig',
                     params: {
 			publicationName: "bbprebid",
+<<<<<<< HEAD
 			rendererCode: "renderer",
+=======
+			renderer: "renderer",
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 			accountId: 642,
   			connections: [ 'bluebillywig' ],
 			bluebillywig: {}

--- a/modules/bluebillywigBidAdapter.md
+++ b/modules/bluebillywigBidAdapter.md
@@ -28,11 +28,7 @@ Prebid Blue Billywig Bidder Adapter
                     bidder: 'bluebillywig',
                     params: {
 			publicationName: "bbprebid",
-<<<<<<< HEAD
 			rendererCode: "renderer",
-=======
-			renderer: "renderer",
->>>>>>> 1ae44aa5... add Blue Billywig adapter
 			accountId: 642,
   			connections: [ 'bluebillywig' ],
 			bluebillywig: {}

--- a/test/spec/modules/bluebillywigBidAdapter_spec.js
+++ b/test/spec/modules/bluebillywigBidAdapter_spec.js
@@ -1,11 +1,16 @@
 import { expect } from 'chai';
+<<<<<<< HEAD
 import { spec } from 'modules/bluebillywigBidAdapter.js';
+=======
+import { spec, BB_CONSTANTS } from 'modules/bluebillywigBidAdapter.js';
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 import * as bidderFactory from 'src/adapters/bidderFactory.js';
 import { auctionManager } from 'src/auctionManager.js';
 import { deepClone, deepAccess } from 'src/utils.js';
 import { config } from 'src/config.js';
 import { VIDEO } from 'src/mediaTypes.js';
 
+<<<<<<< HEAD
 const BB_CONSTANTS = {
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
@@ -18,6 +23,8 @@ const BB_CONSTANTS = {
   DEFAULT_NET_REVENUE: true
 };
 
+=======
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 describe('BlueBillywigAdapter', () => {
   describe('isBidRequestValid', () => {
     const baseValidBid = {
@@ -358,6 +365,7 @@ describe('BlueBillywigAdapter', () => {
       expect(payload.device.h).to.be.a('number');
     });
 
+<<<<<<< HEAD
     it('should add site when specified in config', () => {
       config.setConfig({ site: { name: 'Blue Billywig', domain: 'bluebillywig.com', page: 'https://bluebillywig.com/', publisher: { id: 'abc', name: 'Blue Billywig', domain: 'bluebillywig.com' } } });
 
@@ -376,6 +384,8 @@ describe('BlueBillywigAdapter', () => {
       config.resetConfig();
     });
 
+=======
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
     it('should add app when specified in config', () => {
       config.setConfig({ app: { bundle: 'org.prebid.mobile.demoapp', domain: 'prebid.org' } });
 
@@ -493,7 +503,11 @@ describe('BlueBillywigAdapter', () => {
       const userId = { tdid: 123 };
 
       const newBaseValidBidRequests = deepClone(baseValidBidRequests);
+<<<<<<< HEAD
       newBaseValidBidRequests[0].userId = { criteoId: 'sample-userid' };
+=======
+      newBaseValidBidRequests[0].userId = userId;
+>>>>>>> 1ae44aa5... add Blue Billywig adapter
 
       const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
       const payload = JSON.parse(request.data);

--- a/test/spec/modules/bluebillywigBidAdapter_spec.js
+++ b/test/spec/modules/bluebillywigBidAdapter_spec.js
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { spec } from 'modules/bluebillywigBidAdapter.js';
 =======
 import { spec, BB_CONSTANTS } from 'modules/bluebillywigBidAdapter.js';
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+import { spec } from 'modules/bluebillywigBidAdapter.js';
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 import * as bidderFactory from 'src/adapters/bidderFactory.js';
 import { auctionManager } from 'src/auctionManager.js';
 import { deepClone, deepAccess } from 'src/utils.js';
@@ -11,6 +15,9 @@ import { config } from 'src/config.js';
 import { VIDEO } from 'src/mediaTypes.js';
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 const BB_CONSTANTS = {
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
@@ -23,8 +30,11 @@ const BB_CONSTANTS = {
   DEFAULT_NET_REVENUE: true
 };
 
+<<<<<<< HEAD
 =======
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 describe('BlueBillywigAdapter', () => {
   describe('isBidRequestValid', () => {
     const baseValidBid = {
@@ -504,10 +514,14 @@ describe('BlueBillywigAdapter', () => {
 
       const newBaseValidBidRequests = deepClone(baseValidBidRequests);
 <<<<<<< HEAD
+<<<<<<< HEAD
       newBaseValidBidRequests[0].userId = { criteoId: 'sample-userid' };
 =======
       newBaseValidBidRequests[0].userId = userId;
 >>>>>>> 1ae44aa5... add Blue Billywig adapter
+=======
+      newBaseValidBidRequests[0].userId = { criteoId: 'sample-userid' };
+>>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 
       const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
       const payload = JSON.parse(request.data);

--- a/test/spec/modules/bluebillywigBidAdapter_spec.js
+++ b/test/spec/modules/bluebillywigBidAdapter_spec.js
@@ -1,23 +1,11 @@
 import { expect } from 'chai';
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { spec } from 'modules/bluebillywigBidAdapter.js';
-=======
-import { spec, BB_CONSTANTS } from 'modules/bluebillywigBidAdapter.js';
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-import { spec } from 'modules/bluebillywigBidAdapter.js';
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 import * as bidderFactory from 'src/adapters/bidderFactory.js';
 import { auctionManager } from 'src/auctionManager.js';
 import { deepClone, deepAccess } from 'src/utils.js';
 import { config } from 'src/config.js';
 import { VIDEO } from 'src/mediaTypes.js';
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 const BB_CONSTANTS = {
   BIDDER_CODE: 'bluebillywig',
   AUCTION_URL: '$$URL_STARTpbs.bluebillywig.com/openrtb2/auction?pub=$$PUBLICATION',
@@ -30,11 +18,6 @@ const BB_CONSTANTS = {
   DEFAULT_NET_REVENUE: true
 };
 
-<<<<<<< HEAD
-=======
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 describe('BlueBillywigAdapter', () => {
   describe('isBidRequestValid', () => {
     const baseValidBid = {
@@ -55,6 +38,13 @@ describe('BlueBillywigAdapter', () => {
 
     it('should return true when required params found', () => {
       expect(spec.isBidRequestValid(baseValidBid)).to.equal(true);
+    });
+
+    it('should return false when params missing', () => {
+      const bid = deepClone(baseValidBid);
+      delete bid.params;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
     it('should return false when publicationName is missing', () => {
@@ -199,6 +189,25 @@ describe('BlueBillywigAdapter', () => {
       const bid = deepClone(baseValidBid);
 
       bid.mediaTypes[VIDEO].context = 'instream';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should fail if video is specified but is not an object', () => {
+      const bid = deepClone(baseValidBid);
+
+      bid.params.video = null;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.video = 'string';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.video = 123;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.video = false;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.video = void (0);
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
   });
@@ -375,7 +384,6 @@ describe('BlueBillywigAdapter', () => {
       expect(payload.device.h).to.be.a('number');
     });
 
-<<<<<<< HEAD
     it('should add site when specified in config', () => {
       config.setConfig({ site: { name: 'Blue Billywig', domain: 'bluebillywig.com', page: 'https://bluebillywig.com/', publisher: { id: 'abc', name: 'Blue Billywig', domain: 'bluebillywig.com' } } });
 
@@ -394,8 +402,6 @@ describe('BlueBillywigAdapter', () => {
       config.resetConfig();
     });
 
-=======
->>>>>>> 1ae44aa5... add Blue Billywig adapter
     it('should add app when specified in config', () => {
       config.setConfig({ app: { bundle: 'org.prebid.mobile.demoapp', domain: 'prebid.org' } });
 
@@ -513,15 +519,7 @@ describe('BlueBillywigAdapter', () => {
       const userId = { tdid: 123 };
 
       const newBaseValidBidRequests = deepClone(baseValidBidRequests);
-<<<<<<< HEAD
-<<<<<<< HEAD
       newBaseValidBidRequests[0].userId = { criteoId: 'sample-userid' };
-=======
-      newBaseValidBidRequests[0].userId = userId;
->>>>>>> 1ae44aa5... add Blue Billywig adapter
-=======
-      newBaseValidBidRequests[0].userId = { criteoId: 'sample-userid' };
->>>>>>> 263aeaec... Blue Billywig Adapter - update according to review feedback
 
       const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
       const payload = JSON.parse(request.data);
@@ -538,30 +536,64 @@ describe('BlueBillywigAdapter', () => {
       expect(deepAccess(payload, 'user.ext.eids')).to.be.undefined;
     });
 
-    it('should set digitrust when present on bid', () => {
-      const digiTrust = {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}};
-
+    it('should set imp.0.video.[w|h|placement] by default', () => {
       const newBaseValidBidRequests = deepClone(baseValidBidRequests);
-	    newBaseValidBidRequests[0].userId = { digitrustid: digiTrust };
 
       const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(payload).to.have.nested.property('user.ext.digitrust');
-      expect(payload.user.ext.digitrust.id).to.equal(digiTrust.data.id);
-      expect(payload.user.ext.digitrust.keyv).to.equal(digiTrust.data.keyv);
+      expect(deepAccess(payload, 'imp.0.video.w')).to.equal(768);
+      expect(deepAccess(payload, 'imp.0.video.h')).to.equal(432);
+      expect(deepAccess(payload, 'imp.0.video.placement')).to.equal(3);
     });
 
-    it('should not set digitrust when opted out', () => {
-      const digiTrust = {data: {id: 'DTID', keyv: 4, privacy: {optout: true}, producer: 'ABC', version: 2}};
-
+    it('should update imp0.video.[w|h] when present in config', () => {
       const newBaseValidBidRequests = deepClone(baseValidBidRequests);
-	    newBaseValidBidRequests[0].userId = { digitrustid: digiTrust };
+      newBaseValidBidRequests[0].mediaTypes.video.playerSize = [1, 1];
 
       const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(deepAccess(payload, 'user.ext.digitrust')).to.be.undefined;
+      expect(deepAccess(payload, 'imp.0.video.w')).to.equal(1);
+      expect(deepAccess(payload, 'imp.0.video.h')).to.equal(1);
+    });
+
+    it('should allow overriding any imp0.video key through params.video', () => {
+      const newBaseValidBidRequests = deepClone(baseValidBidRequests);
+      newBaseValidBidRequests[0].params.video = {
+        w: 2,
+        h: 2,
+        placement: 1,
+        minduration: 15,
+        maxduration: 30
+      };
+
+      const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(deepAccess(payload, 'imp.0.video.w')).to.equal(2);
+      expect(deepAccess(payload, 'imp.0.video.h')).to.equal(2);
+      expect(deepAccess(payload, 'imp.0.video.placement')).to.equal(1);
+      expect(deepAccess(payload, 'imp.0.video.minduration')).to.equal(15);
+      expect(deepAccess(payload, 'imp.0.video.maxduration')).to.equal(30);
+    });
+
+    it('should not allow placing any non-OpenRTB 2.5 keys on imp.0.video through params.video', () => {
+      const newBaseValidBidRequests = deepClone(baseValidBidRequests);
+      newBaseValidBidRequests[0].params.video = {
+        'true': true,
+        'testing': 'some',
+        123: {},
+        '': 'values'
+      };
+
+      const request = spec.buildRequests(newBaseValidBidRequests, validBidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(deepAccess(request, 'imp.0.video.true')).to.be.undefined;
+      expect(deepAccess(payload, 'imp.0.video.testing')).to.be.undefined;
+      expect(deepAccess(payload, 'imp.0.video.123')).to.be.undefined;
+      expect(deepAccess(payload, 'imp.0.video.')).to.be.undefined;
     });
   });
   describe('interpretResponse', () => {
@@ -599,7 +631,7 @@ describe('BlueBillywigAdapter', () => {
         bidder: BB_CONSTANTS.BIDDER_CODE,
         bidderRequestId: '1a2345b67c8d9e0',
         params: baseValidBid.params,
-        sizes: [[768, 432], [640, 480], [630, 360]],
+        sizes: [[640, 480], [630, 360]],
         transactionId: '2b34c5de-f67a-8901-bcd2-34567efabc89'
       }],
       start: 11585918458869,
@@ -786,6 +818,101 @@ describe('BlueBillywigAdapter', () => {
 
         expect(result.length).to.equal(0);
       }
+    });
+
+    it('should take default width and height when w/h not present', () => {
+      const bidSizesMissing = deepClone(serverResponse);
+
+      delete bidSizesMissing.body.seatbid[0].bid[0].w;
+      delete bidSizesMissing.body.seatbid[0].bid[0].h;
+
+      const response = bidSizesMissing;
+      const request = spec.buildRequests(baseValidBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(response, request);
+
+      expect(deepAccess(result, '0.width')).to.equal(768);
+      expect(deepAccess(result, '0.height')).to.equal(432);
+    });
+
+    it('should take nurl value when adm not present', () => {
+      const bidAdmMissing = deepClone(serverResponse);
+
+      delete bidAdmMissing.body.seatbid[0].bid[0].adm;
+      bidAdmMissing.body.seatbid[0].bid[0].nurl = 'https://bluebillywig.com';
+
+      const response = bidAdmMissing;
+      const request = spec.buildRequests(baseValidBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(response, request);
+
+      expect(deepAccess(result, '0.vastXml')).to.be.undefined;
+      expect(deepAccess(result, '0.vastUrl')).to.equal('https://bluebillywig.com');
+    });
+
+    it('should not take nurl value when adm present', () => {
+      const bidAdmNurlPresent = deepClone(serverResponse);
+
+      bidAdmNurlPresent.body.seatbid[0].bid[0].nurl = 'https://bluebillywig.com';
+
+      const response = bidAdmNurlPresent;
+      const request = spec.buildRequests(baseValidBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(response, request);
+
+      expect(deepAccess(result, '0.vastXml')).to.equal(bidAdmNurlPresent.body.seatbid[0].bid[0].adm);
+      expect(deepAccess(result, '0.vastUrl')).to.be.undefined;
+    });
+
+    it('should take ext.prebid.cache data when present, ignore ext.prebid.targeting and nurl', () => {
+      const bidExtPrebidCache = deepClone(serverResponse);
+
+      delete bidExtPrebidCache.body.seatbid[0].bid[0].adm;
+      bidExtPrebidCache.body.seatbid[0].bid[0].nurl = 'https://notnurl.com';
+
+      bidExtPrebidCache.body.seatbid[0].bid[0].ext = {
+        prebid: {
+          cache: {
+            vastXml: {
+              url: 'https://bluebillywig.com',
+              cacheId: '12345'
+            }
+          },
+          targeting: {
+            hb_uuid: '23456',
+            hb_cache_host: 'bluebillywig.com',
+            hb_cache_path: '/cache'
+          }
+        }
+      };
+
+      const response = bidExtPrebidCache;
+      const request = spec.buildRequests(baseValidBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(response, request);
+
+      expect(deepAccess(result, '0.vastUrl')).to.equal('https://bluebillywig.com');
+      expect(deepAccess(result, '0.videoCacheKey')).to.equal('12345');
+    });
+
+    it('should take ext.prebid.targeting data when ext.prebid.cache not present, and ignore nurl', () => {
+      const bidExtPrebidTargeting = deepClone(serverResponse);
+
+      delete bidExtPrebidTargeting.body.seatbid[0].bid[0].adm;
+      bidExtPrebidTargeting.body.seatbid[0].bid[0].nurl = 'https://notnurl.com';
+
+      bidExtPrebidTargeting.body.seatbid[0].bid[0].ext = {
+        prebid: {
+          targeting: {
+            hb_uuid: '34567',
+            hb_cache_host: 'bluebillywig.com',
+            hb_cache_path: '/cache'
+          }
+        }
+      };
+
+      const response = bidExtPrebidTargeting;
+      const request = spec.buildRequests(baseValidBidRequests, validBidderRequest);
+      const result = spec.interpretResponse(response, request);
+
+      expect(deepAccess(result, '0.vastUrl')).to.equal('https://bluebillywig.com/cache?uuid=34567');
+      expect(deepAccess(result, '0.videoCacheKey')).to.equal('34567');
     });
   });
   describe('getUserSyncs', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Bit of a messy one, as it includes the following changes:

- General code quality upgrade (Code style update)
- Correctly flag returned bids as a video mediatype (Bugfix)
- Always hit user syncs, also if we don't get bid responses (Feature)
- Validate video params, and allow submitting them additionally on the bidder params (Feature)
- Recognize VAST URL on bids in a few more situations (Feature)
- Remove DigiTrust (Maintenance)

If this needs to be split into multiple PRs please let me know.

- contact email of the adapter’s maintainer: dev+prebid@bluebillywig.com

Docs PR:
https://github.com/prebid/prebid.github.io/pull/2198