### PR TITLE
AdButler Bid Adapter: Add Doceree as alias

### DIFF
--- a/modules/adbutlerBidAdapter.js
+++ b/modules/adbutlerBidAdapter.js
@@ -9,7 +9,7 @@ const BIDDER_CODE = 'adbutler';
 export const spec = {
   code: BIDDER_CODE,
   pageID: Math.floor(Math.random() * 10e6),
-  aliases: ['divreach'],
+  aliases: ['divreach', 'doceree'],
 
   isBidRequestValid: function (bid) {
     return !!(bid.params.accountID && bid.params.zoneID);

--- a/modules/docereeBidAdapter.md
+++ b/modules/docereeBidAdapter.md
@@ -1,0 +1,32 @@
+# Overview
+
+Module Name: Doceree Bidder Adapter  
+Module Type: Bidder Adapter  
+
+# Description
+
+Connects to Doceree demand source to fetch bids.  
+Please use ```doceree``` as the bidder code.  
+
+# Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'desktop-banner-ad-div',
+               sizes: [[300, 250]],
+               bids: [
+                   {
+                       bidder: "doceree",
+                       params: {
+                           accountID: '167283',
+                           zoneID: '445501',
+                           domain: 'adbserver.doceree.com',
+                           extra: {
+                               tuid: '1234-abcd'
+                           }
+                       }
+                   }
+               ]
+           },
+       ];
+```


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
Add Doceree as an alias to the AdButler Bid Adapter

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: "doceree",
  params: {
    accountID: '167283',
    zoneID: '445501',
    domain: 'adbserver.doceree.com',
    extra: {
      tuid: '1234-abcd'
    }
  }
}
```
