### PR TITLE
Adhese: set gvlid && filter out empty params

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -4,10 +4,12 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'adhese';
+const GVLID = 553;
 const USER_SYNC_BASE_URL = 'https://user-sync.adhese.com/iframe/user_sync.html';
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO],
 
   isBidRequestValid: function(bid) {
@@ -112,12 +114,15 @@ function mergeTargets(targets, target) {
   if (target) {
     Object.keys(target).forEach(function (key) {
       const val = target[key];
-      const values = Array.isArray(val) ? val : [val];
-      if (targets[key]) {
-        const distinctValues = values.filter(v => targets[key].indexOf(v) < 0);
-        targets[key].push.apply(targets[key], distinctValues);
-      } else {
-        targets[key] = values;
+      const dirtyValues = Array.isArray(val) ? val : [val];
+      const values = dirtyValues.filter(v => v === 0 || v);
+      if (values.length > 0) {
+        if (targets[key]) {
+          const distinctValues = values.filter(v => targets[key].indexOf(v) < 0);
+          targets[key].push.apply(targets[key], distinctValues);
+        } else {
+          targets[key] = values;
+        }
       }
     });
   }

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -95,6 +95,14 @@ describe('AdheseAdapter', function () {
       expect(JSON.parse(req.data).parameters).to.deep.include({ 'ci': [ 'london', 'gent' ] });
     });
 
+    it('should filter out empty params', function () {
+      let req = spec.buildRequests([ bidWithParams({ 'aa': [], 'bb': null, 'cc': '', 'dd': [ '', '' ], 'ee': [ 0, 1, null ], 'ff': 0, 'gg': [ 'x', 'y', '' ] }) ], bidderRequest);
+
+      let params = JSON.parse(req.data).parameters;
+      expect(params).to.not.have.any.keys('aa', 'bb', 'cc', 'dd');
+      expect(params).to.deep.include({ 'ee': [ 0, 1 ], 'ff': [ 0 ], 'gg': [ 'x', 'y' ] });
+    });
+
     it('should include gdpr consent param', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Configure the gvlid for Adhese adapter
Reduce the outgoing request size in case the user provided empty parameters

