### PR TITLE
Update dfpAdServerVideo.js to allow for vast4

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -42,7 +42,7 @@ import { auctionManager } from '../src/auctionManager.js';
 const defaultParamConstants = {
   env: 'vp',
   gdfp_req: 1,
-  output: 'xml_vast3',
+  output: 'vast',
   unviewed_position_start: 1,
 };
 

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -38,7 +38,7 @@ describe('The DFP video support module', function () {
     expect(queryParams).to.have.property('env', 'vp');
     expect(queryParams).to.have.property('gdfp_req', '1');
     expect(queryParams).to.have.property('iu', 'my/adUnit');
-    expect(queryParams).to.have.property('output', 'xml_vast3');
+    expect(queryParams).to.have.property('output', 'vast');
     expect(queryParams).to.have.property('sz', '640x480');
     expect(queryParams).to.have.property('unviewed_position_start', '1');
     expect(queryParams).to.have.property('url');

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -375,7 +375,7 @@ describe('The DFP video support module', function () {
         expect(queryParams).to.have.property('env', 'vp');
         expect(queryParams).to.have.property('gdfp_req', '1');
         expect(queryParams).to.have.property('iu', 'my/adUnit');
-        expect(queryParams).to.have.property('output', 'xml_vast3');
+        expect(queryParams).to.have.property('output', 'vast');
         expect(queryParams).to.have.property('sz', '640x480');
         expect(queryParams).to.have.property('unviewed_position_start', '1');
         expect(queryParams).to.have.property('url');


### PR DESCRIPTION
This had a bug in which all requests were hardcoded to vast 3, although pubs may have selected vast 3 or 4. This allows DFP to respond with the DFP set default Vast version. 

References:
https://support.google.com/admanager/answer/7358411?hl=en&ref_topic=7544527
https://support.google.com/admanager/answer/4517679?hl=en&ref_topic=7544527
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other
