### PR TITLE
Rubicon Analytics: Pass along floor provider to analytics

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -40,8 +40,6 @@ const cache = {
   timeouts: {},
 };
 
-const validFloorProviders = ['rubicon', 'rubi', 'magnite', 'mgni'];
-
 export function getHostNameFromReferer(referer) {
   try {
     rubiconAdapter.referrerHostname = utils.parseUrl(referer, {noDecodeWholeURL: true}).hostname;
@@ -205,12 +203,13 @@ function sendMessage(auctionId, bidWonId) {
       } else {
         auction.floors = utils.pick(auctionCache.floorData, [
           'location',
-          'modelName', () => auctionCache.floorData.modelVersion,
+          'modelVersion as modelName',
           'skipped',
           'enforcement', () => utils.deepAccess(auctionCache.floorData, 'enforcements.enforceJS'),
           'dealsEnforced', () => utils.deepAccess(auctionCache.floorData, 'enforcements.floorDeals'),
           'skipRate',
-          'fetchStatus'
+          'fetchStatus',
+          'floorProvider as provider'
         ]);
       }
     }
@@ -285,7 +284,7 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
   if (previousBidResponse && previousBidResponse.bidPriceUSD > responsePrice) {
     return previousBidResponse;
   }
-  let bidResponse = utils.pick(bid, [
+  return utils.pick(bid, [
     'bidPriceUSD', () => responsePrice,
     'dealId',
     'status',
@@ -295,12 +294,9 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
       'height'
     ]),
     'seatBidId',
+    'floorValue', () => utils.deepAccess(bid, 'floorData.floorValue'),
+    'floorRule', () => utils.debugTurnedOn() ? utils.deepAccess(bid, 'floorData.floorRule') : undefined
   ]);
-  if (auctionFloorData) {
-    bidResponse.floorValue = utils.deepAccess(bid, 'floorData.floorValue');
-    bidResponse.floorRule = utils.debugTurnedOn() ? utils.deepAccess(bid, 'floorData.floorRule') : undefined
-  }
-  return bidResponse;
 }
 
 let samplingFactor = 1;
@@ -380,9 +376,9 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         cacheEntry.bids = {};
         cacheEntry.bidsWon = {};
         cacheEntry.referrer = args.bidderRequests[0].refererInfo.referer;
-        const floorProvider = utils.deepAccess(args, 'bidderRequests.0.bids.0.floorData.floorProvider');
-        if (validFloorProviders.indexOf(floorProvider) !== -1) {
-          cacheEntry.floorData = {...args.bidderRequests[0].bids[0].floorData};
+        const floorData = utils.deepAccess(args, 'bidderRequests.0.bids.0.floorData');
+        if (floorData) {
+          cacheEntry.floorData = {...floorData};
         }
         cache.auctions[args.auctionId] = cacheEntry;
         break;
@@ -468,7 +464,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
           bid.adUnit.adSlot = args.floorData.matchedFields.gptSlot;
         }
         // if we have not set enforcements yet set it
-        if (auctionEntry.floorData && !auctionEntry.floorData.enforcements && utils.deepAccess(args, 'floorData.enforcements')) {
+        if (!utils.deepAccess(auctionEntry, 'floorData.enforcements') && utils.deepAccess(args, 'floorData.enforcements')) {
           auctionEntry.floorData.enforcements = {...args.floorData.enforcements};
         }
         if (!bid) {
@@ -492,7 +488,7 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
             };
         }
         bid.clientLatencyMillis = Date.now() - cache.auctions[args.auctionId].timestamp;
-        bid.bidResponse = parseBidResponse(args, bid.bidResponse, auctionEntry.floorData);
+        bid.bidResponse = parseBidResponse(args, bid.bidResponse);
         break;
       case BIDDER_DONE:
         args.bids.forEach(bid => {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -743,7 +743,8 @@ describe('rubicon analytics adapter', function () {
         enforcement: true,
         dealsEnforced: false,
         skipRate: 15,
-        fetchStatus: 'error'
+        fetchStatus: 'error',
+        provider: 'rubicon'
       });
       // first adUnit's adSlot
       expect(message.auctions[0].adUnits[0].adSlot).to.equal('12345/sports');
@@ -765,19 +766,28 @@ describe('rubicon analytics adapter', function () {
       expect(message.auctions[0].adUnits[1].bids[0].bidResponse.bidPriceUSD).to.equal(1.52);
     });
 
-    it('should not send floor info if provider is not rubicon', function () {
+    it('should still send floor info if provider is not rubicon', function () {
       let message = performFloorAuction('randomProvider')
 
       // verify our floor stuff is passed
       // top level floor info
-      expect(message.auctions[0].floors).to.be.undefined;
+      expect(message.auctions[0].floors).to.deep.equal({
+        location: 'setConfig',
+        modelName: 'someModelName',
+        skipped: false,
+        enforcement: true,
+        dealsEnforced: false,
+        skipRate: 15,
+        fetchStatus: 'error',
+        provider: 'randomProvider'
+      });
       // first adUnit's adSlot
       expect(message.auctions[0].adUnits[0].adSlot).to.equal('12345/sports');
       // since no other bids, we set adUnit status to no-bid
       expect(message.auctions[0].adUnits[0].status).to.equal('no-bid');
       // first adUnits bid is rejected
       expect(message.auctions[0].adUnits[0].bids[0].status).to.equal('rejected');
-      expect(message.auctions[0].adUnits[0].bids[0].bidResponse.floorValue).to.be.undefined;
+      expect(message.auctions[0].adUnits[0].bids[0].bidResponse.floorValue).to.equal(4);
       // if bid rejected should take cpmAfterAdjustments val
       expect(message.auctions[0].adUnits[0].bids[0].bidResponse.bidPriceUSD).to.equal(2.1);
 
@@ -787,7 +797,7 @@ describe('rubicon analytics adapter', function () {
       expect(message.auctions[0].adUnits[1].status).to.equal('success');
       // second adUnits bid is success
       expect(message.auctions[0].adUnits[1].bids[0].status).to.equal('success');
-      expect(message.auctions[0].adUnits[1].bids[0].bidResponse.floorValue).to.be.undefined;
+      expect(message.auctions[0].adUnits[1].bids[0].bidResponse.floorValue).to.equal(1);
       expect(message.auctions[0].adUnits[1].bids[0].bidResponse.bidPriceUSD).to.equal(1.52);
     });
 


### PR DESCRIPTION

## Type of change
- [X] Feature

## Description of change
Rubicon will now log any floor information that comes through, and will just log floor provider so data can be segregated downstream.