### PR TITLE
Check localstorage availability before accessing it

### DIFF
--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -154,7 +154,7 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
    */
   const setDataInLocalStorage = function (key, value, done) {
     let cb = function (result) {
-      if (result && result.valid) {
+      if (result && result.valid && hasLocalStorage()) {
         window.localStorage.setItem(key, value);
       }
     }
@@ -174,7 +174,7 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
    */
   const getDataFromLocalStorage = function (key, done) {
     let cb = function (result) {
-      if (result && result.valid) {
+      if (result && result.valid && hasLocalStorage()) {
         return window.localStorage.getItem(key);
       }
       return null;
@@ -194,7 +194,7 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
    */
   const removeDataFromLocalStorage = function (key, done) {
     let cb = function (result) {
-      if (result && result.valid) {
+      if (result && result.valid && hasLocalStorage()) {
         window.localStorage.removeItem(key);
       }
     }

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -46,18 +46,16 @@ describe('storage manager', function() {
 
   describe('localstorage forbidden access in 3rd-party context', function() {
     let errorLogSpy;
+    const originalLocalStorage = { get: () => window.localStorage };
+    const localStorageMock = { get: () => { throw Error } };
 
     beforeEach(function() {
-      var mock = {
-        get: function() {
-          throw Error;
-        }
-      };
-      Object.defineProperty(window, 'localStorage', mock);
+      Object.defineProperty(window, 'localStorage', localStorageMock);
       errorLogSpy = sinon.spy(utils, 'logError');
     });
 
     afterEach(function() {
+      Object.defineProperty(window, 'localStorage', originalLocalStorage);
       errorLogSpy.restore();
     })
 

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -42,5 +42,22 @@ describe('storage manager', function() {
     storage.setCookie('foo1', 'baz1');
     expect(deviceAccessSpy.calledOnce).to.equal(true);
     deviceAccessSpy.restore();
+  });
+
+  it('should not throw if the localstorage is not accessible when setting/getting/removing from localstorage', function() {
+    const coreStorage = getStorageManager();
+
+    const localstorageStub = sinon.stub(global.window, 'localStorage').get(() => { throw Error });
+    const errorLogSpy = sinon.spy(utils, 'logError');
+
+    coreStorage.setDataInLocalStorage('key', 'value');
+    const val = coreStorage.getDataFromLocalStorage('key');
+    coreStorage.removeDataFromLocalStorage('key');
+
+    expect(val).to.be.null;
+    sinon.assert.calledThrice(errorLogSpy);
+
+    localstorageStub.restore();
+    errorLogSpy.restore();
   })
 });

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -44,20 +44,32 @@ describe('storage manager', function() {
     deviceAccessSpy.restore();
   });
 
-  it('should not throw if the localstorage is not accessible when setting/getting/removing from localstorage', function() {
-    const coreStorage = getStorageManager();
+  describe('localstorage forbidden access in 3rd-party context', function() {
+    let errorLogSpy;
 
-    const localstorageStub = sinon.stub(global.window, 'localStorage').get(() => { throw Error });
-    const errorLogSpy = sinon.spy(utils, 'logError');
+    beforeEach(function() {
+      var mock = {
+        get: function() {
+          throw Error;
+        }
+      };
+      Object.defineProperty(window, 'localStorage', mock);
+      errorLogSpy = sinon.spy(utils, 'logError');
+    });
 
-    coreStorage.setDataInLocalStorage('key', 'value');
-    const val = coreStorage.getDataFromLocalStorage('key');
-    coreStorage.removeDataFromLocalStorage('key');
+    afterEach(function() {
+      errorLogSpy.restore();
+    })
 
-    expect(val).to.be.null;
-    sinon.assert.calledThrice(errorLogSpy);
+    it('should not throw if the localstorage is not accessible when setting/getting/removing from localstorage', function() {
+      const coreStorage = getStorageManager();
 
-    localstorageStub.restore();
-    errorLogSpy.restore();
+      coreStorage.setDataInLocalStorage('key', 'value');
+      const val = coreStorage.getDataFromLocalStorage('key');
+      coreStorage.removeDataFromLocalStorage('key');
+
+      expect(val).to.be.null;
+      sinon.assert.calledThrice(errorLogSpy);
+    })
   })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Chrome now throws an error when trying to access window.localstorage in a third-party context when third-party cookies are disabled (Private mode for instance). This PR checks whether the localStorage is available each time we try to access it.