### PR TITLE
Adds advertiserDomains to kargo adapter

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -65,7 +65,8 @@ export const spec = {
       let meta;
       if (adUnit.metadata && adUnit.metadata.landingPageDomain) {
         meta = {
-          clickUrl: adUnit.metadata.landingPageDomain
+          clickUrl: adUnit.metadata.landingPageDomain,
+          advertiserDomains: [adUnit.metadata.landingPageDomain]
         };
       }
       bidResponses.push({

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -505,7 +505,8 @@ describe('kargo adapter tests', function () {
         netRevenue: true,
         currency: 'USD',
         meta: {
-          clickUrl: 'https://foobar.com'
+          clickUrl: 'https://foobar.com',
+          advertiserDomains: ['https://foobar.com']
         }
       }, {
         requestId: '3',


### PR DESCRIPTION
Clickurl was deprecated in #3115 in favor of advertiserDomains, an array. 

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other



<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Related to #4905 