### PR TITLE
Allow hp:0 in supply chain nodes passed to Rubicon

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1166,7 +1166,7 @@ export function hasValidSupplyChainParams(schain) {
   if (!schain.nodes) return isValid;
   isValid = schain.nodes.reduce((status, node) => {
     if (!status) return status;
-    return requiredFields.every(field => node[field]);
+    return requiredFields.every(field => node.hasOwnProperty(field));
   }, true);
   if (!isValid) utils.logError('Rubicon: required schain params missing');
   return isValid;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Rubicon adapter does not pass a supply chain object of `hp` is set to `0`.
