### PR TITLE
[IdentityLinkIdSystem] - pass tcfv2 consent string to envelope api

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -17,6 +17,11 @@ export const identityLinkSubmodule = {
    */
   name: 'identityLink',
   /**
+   * used to specify vendor id
+   * @type {number}
+   */
+  gvlid: 97,
+  /**
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
@@ -39,8 +44,13 @@ export const identityLinkSubmodule = {
     }
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
+    const tcfPolicyV2 = !!((consentData && consentData.vendorData && consentData.vendorData.tcfPolicyVersion && consentData.vendorData.tcfPolicyVersion === 2));
     // use protocol relative urls for http or https
-    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? '&ct=1&cv=' + gdprConsentString : ''}`;
+    if (hasGdpr && (!gdprConsentString || gdprConsentString === '')) {
+      utils.logInfo('Consent string is required to call envelope API.');
+      return;
+    }
+    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}`;
     let resp;
     resp = function(callback) {
       // Check ats during callback so it has a chance to initialise.

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -6,8 +6,8 @@
  */
 
 import * as utils from '../src/utils.js'
-import {ajax} from '../src/ajax.js';
-import {submodule} from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
 
 /** @type {Submodule} */
 export const identityLinkSubmodule = {
@@ -44,7 +44,7 @@ export const identityLinkSubmodule = {
     }
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
-    const tcfPolicyV2 = !!((consentData && consentData.vendorData && consentData.vendorData.tcfPolicyVersion && consentData.vendorData.tcfPolicyVersion === 2));
+    const tcfPolicyV2 = utils.deepAccess(consentData, 'vendorData.tcfPolicyVersion') === 2;
     // use protocol relative urls for http or https
     if (hasGdpr && (!gdprConsentString || gdprConsentString === '')) {
       utils.logInfo('Consent string is required to call envelope API.');
@@ -52,7 +52,7 @@ export const identityLinkSubmodule = {
     }
     const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}`;
     let resp;
-    resp = function(callback) {
+    resp = function (callback) {
       // Check ats during callback so it has a chance to initialise.
       // If ats library is available, use it to retrieve envelope. If not use standard third party endpoint
       if (window.ats) {
@@ -70,7 +70,7 @@ export const identityLinkSubmodule = {
       }
     };
 
-    return {callback: resp};
+    return { callback: resp };
   }
 };
 // return envelope from third party endpoint
@@ -93,7 +93,7 @@ function getEnvelope(url, callback) {
       callback();
     }
   };
-  ajax(url, callbacks, undefined, {method: 'GET', withCredentials: true});
+  ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
 }
 
 submodule('userId', identityLinkSubmodule);

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -41,7 +41,22 @@ describe('IdentityLinkId tests', function () {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
-  it('should call the LiveRamp envelope endpoint with consent string', function () {
+  it('should NOT call the LiveRamp envelope endpoint if gdpr applies but consent string is empty string', function () {
+    let consentData = {
+      gdprApplies: true,
+      consentString: ''
+    };
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData);
+    expect(submoduleCallback).to.be.undefined;
+  });
+
+  it('should NOT call the LiveRamp envelope endpoint if gdpr applies but consent string is missing', function () {
+    let consentData = { gdprApplies: true };
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData);
+    expect(submoduleCallback).to.be.undefined;
+  });
+
+  it('should call the LiveRamp envelope endpoint with IAB consent string v1', function () {
     let callBackSpy = sinon.spy();
     let consentData = {
       gdprApplies: true,
@@ -51,6 +66,27 @@ describe('IdentityLinkId tests', function () {
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&ct=1&cv=BOkIpDSOkIpDSADABAENCc-AAAApOAFAAMAAsAMIAcAA_g');
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should call the LiveRamp envelope endpoint with IAB consent string v2', function () {
+    let callBackSpy = sinon.spy();
+    let consentData = {
+      gdprApplies: true,
+      consentString: 'CO4VThZO4VTiuADABBENAzCgAP_AAEOAAAAAAwwAgAEABhAAgAgAAA.YAAAAAAAAAA',
+      vendorData: {
+        tcfPolicyVersion: 2
+      }
+    };
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&ct=4&cv=CO4VThZO4VTiuADABBENAzCgAP_AAEOAAAAAAwwAgAEABhAAgAgAAA.YAAAAAAAAAA');
     request.respond(
       200,
       responseHeader,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Passing TCF v2 consent string to the envelope API.
Not calling envelope API if gdpr applies but consent string is missing.
Added gvlid.