### PR TITLE
allow publisher to define backup renderer

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -115,5 +115,5 @@ function isRendererPreferredFromAdUnit(adUnitCode) {
   const adUnit = find(adUnits, adUnit => {
     return adUnit.code === adUnitCode;
   });
-  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(adUnit.renderer.backupOnly && adUnit.renderer.backupOnly=='true'));
+  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(adUnit.renderer.backupOnly && adUnit.renderer.backupOnly === 'true'));
 }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -115,5 +115,5 @@ function isRendererPreferredFromAdUnit(adUnitCode) {
   const adUnit = find(adUnits, adUnit => {
     return adUnit.code === adUnitCode;
   });
-  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(isBoolean(adUnit.renderer.backupOnly) && adUnit.renderer.backupOnly));
+  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(utils.isBoolean(adUnit.renderer.backupOnly) && adUnit.renderer.backupOnly));
 }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -115,5 +115,5 @@ function isRendererPreferredFromAdUnit(adUnitCode) {
   const adUnit = find(adUnits, adUnit => {
     return adUnit.code === adUnitCode;
   });
-  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(adUnit.renderer.backupOnly && adUnit.renderer.backupOnly === 'true'));
+  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(isBoolean(adUnit.renderer.backupOnly) && adUnit.renderer.backupOnly));
 }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -39,7 +39,7 @@ export function Renderer(options) {
 
   // use a function, not an arrow, in order to be able to pass "arguments" through
   this.render = function () {
-    if (!isRendererDefinedOnAdUnit(adUnitCode)) {
+    if (!isRendererPreferredFromAdUnit(adUnitCode)) {
       // we expect to load a renderer url once only so cache the request to load script
       loadExternalScript(url, moduleCode, this.callback);
     } else {
@@ -110,10 +110,10 @@ export function executeRenderer(renderer, bid) {
   renderer.render(bid);
 }
 
-function isRendererDefinedOnAdUnit(adUnitCode) {
+function isRendererPreferredFromAdUnit(adUnitCode) {
   const adUnits = $$PREBID_GLOBAL$$.adUnits;
   const adUnit = find(adUnits, adUnit => {
     return adUnit.code === adUnitCode;
   });
-  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render);
+  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !adUnit.renderer.backupOnly);
 }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -115,5 +115,5 @@ function isRendererPreferredFromAdUnit(adUnitCode) {
   const adUnit = find(adUnits, adUnit => {
     return adUnit.code === adUnitCode;
   });
-  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !adUnit.renderer.backupOnly);
+  return !!(adUnit && adUnit.renderer && adUnit.renderer.url && adUnit.renderer.render && !(adUnit.renderer.backupOnly && adUnit.renderer.backupOnly=='true'));
 }

--- a/src/auction.js
+++ b/src/auction.js
@@ -512,7 +512,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   const bidReq = bidderRequest.bids && find(bidderRequest.bids, bid => bid.adUnitCode == adUnitCode);
   const adUnitRenderer = bidReq && bidReq.renderer;
 
-  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && adUnitRenderer.backupOnly == 'true' && bid.renderer)) {
+  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && adUnitRenderer.backupOnly === 'true' && bid.renderer)) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });
     bidObject.renderer.setRender(adUnitRenderer.render);
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -512,7 +512,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   const bidReq = bidderRequest.bids && find(bidderRequest.bids, bid => bid.adUnitCode == adUnitCode);
   const adUnitRenderer = bidReq && bidReq.renderer;
 
-  if (adUnitRenderer && adUnitRenderer.url) {
+  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && bid.renderer)) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });
     bidObject.renderer.setRender(adUnitRenderer.render);
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -512,7 +512,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   const bidReq = bidderRequest.bids && find(bidderRequest.bids, bid => bid.adUnitCode == adUnitCode);
   const adUnitRenderer = bidReq && bidReq.renderer;
 
-  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && bid.renderer)) {
+  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && adUnitRenderer.backupOnly == 'true' && bid.renderer)) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });
     bidObject.renderer.setRender(adUnitRenderer.render);
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -512,7 +512,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   const bidReq = bidderRequest.bids && find(bidderRequest.bids, bid => bid.adUnitCode == adUnitCode);
   const adUnitRenderer = bidReq && bidReq.renderer;
 
-  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && adUnitRenderer.backupOnly === 'true' && bid.renderer)) {
+  if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly && isBoolean(adUnitRenderer.backupOnly) && bid.renderer)) {
     bidObject.renderer = Renderer.install({ url: adUnitRenderer.url });
     bidObject.renderer.setRender(adUnitRenderer.render);
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -57,7 +57,7 @@
  * @property {function(): void} callBids - sends requests to all adapters for bids
  */
 
-import {flatten, timestamp, adUnitsFilter, deepAccess, getBidRequest, getValue, parseUrl} from './utils.js';
+import {flatten, timestamp, adUnitsFilter, deepAccess, getBidRequest, getValue, parseUrl, isBoolean} from './utils.js';
 import { getPriceBucketString } from './cpmBucketManager.js';
 import { getNativeTargeting } from './native.js';
 import { getCacheUrl, store } from './videoCache.js';

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -740,6 +740,29 @@ describe('auctionmanager.js', function () {
         assert.equal(addedBid.renderer.url, 'renderer.js');
       });
 
+      it('installs publisher-defined backup renderers on bids', function () {
+        let renderer = {
+          url: 'renderer.js',
+          backupOnly: 'true',
+          render: (bid) => bid
+        };
+        let bidRequests = [Object.assign({}, TEST_BID_REQS[0])];
+        bidRequests[0].bids[0] = Object.assign({ renderer }, bidRequests[0].bids[0]);
+        makeRequestsStub.returns(bidRequests);
+
+        let bids1 = Object.assign({},
+          bids[0],
+          {
+            bidderCode: BIDDER_CODE,
+            mediaType: 'video-outstream',
+          }
+        );
+        spec.interpretResponse.returns(bids1);
+        auction.callBids();
+        const addedBid = auction.getBidsReceived().pop();
+        assert.equal(addedBid.renderer.url, 'renderer.js');
+      });
+
       it('bid for a regular unit and a video unit', function() {
         let renderer = {
           url: 'renderer.js',

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1251,5 +1251,5 @@ describe('auctionmanager.js', function () {
       server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
       assert.equal(doneSpy.callCount, 1);
     })
-  });'tr
+  });
 });

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -743,7 +743,7 @@ describe('auctionmanager.js', function () {
       it('installs publisher-defined backup renderers on bids', function () {
         let renderer = {
           url: 'renderer.js',
-          backupOnly: 'true',
+          backupOnly: true,
           render: (bid) => bid
         };
         let bidRequests = [Object.assign({}, TEST_BID_REQS[0])];
@@ -1251,5 +1251,5 @@ describe('auctionmanager.js', function () {
       server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
       assert.equal(doneSpy.callCount, 1);
     })
-  });
+  });'tr
 });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -497,7 +497,7 @@ describe('S2S Adapter', function () {
       resetSyncedStatus();
     });
 
-    it('should not add outstrean without renderer', function () {
+    it('should not add outstream without renderer', function () {
       let ortb2Config = utils.deepClone(CONFIG);
       ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -132,6 +132,30 @@ describe('Renderer', function () {
       expect(utilsSpy.callCount).to.equal(1);
     });
 
+    it('should load renderer and not log warn message when backupOnly', function() {
+      $$PREBID_GLOBAL$$.adUnits = [{
+        code: 'video1',
+        renderer: {
+          url: 'http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
+          backupOnly: 'true',
+          render: sinon.spy()
+        }
+      }]
+
+      let testRenderer = Renderer.install({
+        url: 'https://httpbin.org/post',
+        config: { test: 'config1' },
+        id: 1,
+        adUnitCode: 'video1'
+
+      });
+      testRenderer.setRender(() => {})
+
+      testRenderer.render()
+      expect(loadExternalScript.called).to.be.true;
+      expect(utilsSpy.callCount).to.equal(0);
+    });
+
     it('should call loadExternalScript() for script not defined on adUnit, only when .render() is called', function() {
       $$PREBID_GLOBAL$$.adUnits = [{
         code: 'video1',

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -137,7 +137,7 @@ describe('Renderer', function () {
         code: 'video1',
         renderer: {
           url: 'http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
-          backupOnly: 'true',
+          backupOnly: true,
           render: sinon.spy()
         }
       }]

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -132,7 +132,7 @@ describe('Renderer', function () {
       expect(utilsSpy.callCount).to.equal(1);
     });
 
-    it('should load renderer and not log warn message when backupOnly', function() {
+    it('should load renderer adunit renderer when backupOnly', function() {
       $$PREBID_GLOBAL$$.adUnits = [{
         code: 'video1',
         renderer: {
@@ -153,7 +153,6 @@ describe('Renderer', function () {
 
       testRenderer.render()
       expect(loadExternalScript.called).to.be.true;
-      expect(utilsSpy.callCount).to.equal(0);
     });
 
     it('should call loadExternalScript() for script not defined on adUnit, only when .render() is called', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Publishers will be able to set an ad unit renderer to be "backup only" like this

`pbjs.addAdUnit({ code: 'video1', mediaTypes: { video: { context: 'outstream', playerSize: [640, 480] } }, renderer: { url: 'https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js', backupOnly: true, render: function (bid) { ANOutstreamVideo.renderAd({ targetId: bid.adUnitCode, adResponse: bid.adResponse, }); } }, ... });`

## Other information
Solves for #1924 , #2668, and #5375 