### PR TITLE
remove cmpuishown event for tcf2 logic

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -100,11 +100,8 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   function v2CmpResponseCallback(tcfData, success) {
     utils.logInfo('Received a response from CMP', tcfData);
     if (success) {
-      if (tcfData.gdprApplies === false) {
+      if (tcfData.gdprApplies === false || tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
         cmpSuccess(tcfData, hookConfig);
-      } else if (tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
-        cmpSuccess(tcfData, hookConfig);
-      }
     } else {
       cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);
     }

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -104,8 +104,6 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
         cmpSuccess(tcfData, hookConfig);
       } else if (tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
         cmpSuccess(tcfData, hookConfig);
-      } else if (tcfData.eventStatus === 'cmpuishown') {
-        cmpSuccess(tcfData); // store consent, but don't continue to next hook
       }
     } else {
       cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);
@@ -334,20 +332,6 @@ function processCmpData(consentObject, hookConfig) {
     utils.logInfo(`'allowAuctionWithoutConsent' using system default: (${DEFAULT_ALLOW_AUCTION_WO_CONSENT}).`);
   }
 
-  // if no hookConfig, store consent, but don't continue to next hook    
-  if (!hookConfig) {
-    if (utils.isFn(checkFn)) {
-      if (checkFn(consentObject)) {
-        utils.logWarn('CMP returned unexpected value during lookup process.', consentObject);
-      } else {
-        storeConsentData(consentObject);
-      }
-    } else {
-      utils.logWarn('Unable to derive CMP version to process data.  Consent object does not conform to TCF v1 or v2 specs.', consentObject);
-    }
-    return;
-  }
-        
   if (utils.isFn(checkFn)) {
     if (checkFn(consentObject)) {
       cmpFailed(`CMP returned unexpected value during lookup process.`, hookConfig, consentObject);

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -104,6 +104,8 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
         cmpSuccess(tcfData, hookConfig);
       } else if (tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
         cmpSuccess(tcfData, hookConfig);
+      } else if (tcfData.eventStatus === 'cmpuishown') {
+        cmpSuccess(tcfData); // store consent, but don't continue to next hook
       }
     } else {
       cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);
@@ -332,6 +334,20 @@ function processCmpData(consentObject, hookConfig) {
     utils.logInfo(`'allowAuctionWithoutConsent' using system default: (${DEFAULT_ALLOW_AUCTION_WO_CONSENT}).`);
   }
 
+  // if no hookConfig, store consent, but don't continue to next hook    
+  if (!hookConfig) {
+    if (utils.isFn(checkFn)) {
+      if (checkFn(consentObject)) {
+        utils.logWarn('CMP returned unexpected value during lookup process.', consentObject);
+      } else {
+        storeConsentData(consentObject);
+      }
+    } else {
+      utils.logWarn('Unable to derive CMP version to process data.  Consent object does not conform to TCF v1 or v2 specs.', consentObject);
+    }
+    return;
+  }
+        
   if (utils.isFn(checkFn)) {
     if (checkFn(consentObject)) {
       cmpFailed(`CMP returned unexpected value during lookup process.`, hookConfig, consentObject);

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -104,8 +104,6 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
         cmpSuccess(tcfData, hookConfig);
       } else if (tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
         cmpSuccess(tcfData, hookConfig);
-      } else if (tcfData.eventStatus === 'cmpuishown' && tcfData.tcString && tcfData.purposeOneTreatment === true) {
-        cmpSuccess(tcfData, hookConfig);
       }
     } else {
       cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -102,6 +102,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     if (success) {
       if (tcfData.gdprApplies === false || tcfData.eventStatus === 'tcloaded' || tcfData.eventStatus === 'useractioncomplete') {
         cmpSuccess(tcfData, hookConfig);
+      }
     } else {
       cmpError('CMP unable to register callback function.  Please check CMP setup.', hookConfig);
     }


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
A follow-up from #5564 - this change removes the event logic for `cmpuishown` as further review determined it's not really needed for Prebid.js.  

Please see this [comment](https://github.com/prebid/Prebid.js/pull/5564#issuecomment-673519661) from the previous ticket for additional context.