### PR TITLE
Introduce moduleType checks when initialising storageManager [DO NOT MERGE]

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -10,13 +10,15 @@ import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { getStorageManager } from '../src/storageManager.js';
+import CONSTANTS from '../src/constants.json';
 
 const MODULE_NAME = 'id5Id';
 const GVLID = 131;
 const BASE_NB_COOKIE_NAME = 'id5id.1st';
 const NB_COOKIE_EXP_DAYS = (30 * 24 * 60 * 60 * 1000); // 30 days
+const MODULE_TYPE = CONSTANTS.MODULE_TYPE.USERID_SUBMODULE;
 
-const storage = getStorageManager(GVLID, MODULE_NAME);
+const storage = getStorageManager(GVLID, MODULE_NAME, MODULE_TYPE);
 
 /** @type {Submodule} */
 export const id5IdSubmodule = {

--- a/src/constants.json
+++ b/src/constants.json
@@ -98,5 +98,12 @@
     "BID_TARGETING_SET": "targetingSet",
     "RENDERED": "rendered",
     "BID_REJECTED": "bidRejected"
+  },
+  "MODULE_TYPE": {
+    "CORE": "core",
+    "PREBID_MODULE": "prebid_module",
+    "BID_ADAPTER": "bid_adapter",
+    "USERID_SUBMODULE": "userid_submodule",
+    "ANALYTICS_ADAPTER": "analytics_adapter"
   }
 }

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -1,8 +1,11 @@
 import { hook } from './hook.js';
 import * as utils from './utils.js';
 import includes from 'core-js-pure/features/array/includes.js';
+import { MODULE_TYPE } from './constants.json'
 
-const moduleTypeWhiteList = ['core', 'prebid-module'];
+const { CORE, PREBID_MODULE } = MODULE_TYPE;
+
+const moduleTypeWhiteList = [CORE, PREBID_MODULE];
 
 export let storageCallbacks = [];
 
@@ -34,7 +37,7 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
       let hookDetails = {
         hasEnforcementHook: false
       }
-      validateStorageEnforcement(gvlid, moduleName, hookDetails, function(result) {
+      validateStorageEnforcement(gvlid, moduleName, moduleType, hookDetails, function(result) {
         if (result && result.hasEnforcementHook) {
           value = cb(result);
         } else {
@@ -284,7 +287,7 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
 /**
  * This hook validates the storage enforcement if gdprEnforcement module is included
  */
-export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, hookDetails, callback) {
+export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, moduleType, hookDetails, callback) {
   callback(hookDetails);
 }, 'validateStorageEnforcement');
 
@@ -293,17 +296,18 @@ export const validateStorageEnforcement = hook('async', function(gvlid, moduleNa
  * @param {string} moduleName Module name
  */
 export function getCoreStorageManager(moduleName) {
-  return newStorageManager({moduleName: moduleName, moduleType: 'core'});
+  return newStorageManager({moduleName: moduleName, moduleType: CORE});
 }
 
 /**
  * Note: Core modules or Prebid modules like Currency, SizeMapping should use getCoreStorageManager
- * This function returns storage functions to access cookies and localstorage. Bidders and User id modules should import this and use it in their module if needed. GVL ID and Module name are optional param but gvl id is needed for when gdpr enforcement module is used.
+ * This function returns storage functions to access cookies and localstorage. Bidders and User id modules should import this and use it in their module if needed. GVL ID, Module name and Module type are optional params but all are needed when gdpr enforcement module is used.
  * @param {Number=} gvlid Vendor id
  * @param {string=} moduleName BidderCode or module name
+ * @param {string=} moduleType Indicates if the module is a bid adapter or an userId submodule or an analytics adapter.
  */
-export function getStorageManager(gvlid, moduleName) {
-  return newStorageManager({gvlid: gvlid, moduleName: moduleName});
+export function getStorageManager(gvlid, moduleName, moduleType) {
+  return newStorageManager({gvlid: gvlid, moduleName: moduleName, moduleType: moduleType});
 }
 
 export function resetData() {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Related https://github.com/prebid/Prebid.js/issues/5615

The `deviceAccessHook` in the GDPR Enforcement module had a bug where it was trying to call the function `getGvlid()`, a function which returns GVL ID only for bid adapters, but the hook can be triggered by any module: it can be a bid adapter, user id submodule or an analytics adapter. Basically, any module which initialises the `storageManager` by calling, `getStorageManager` would trigger a call to deviceAccessHook if gdprEnforcement module is included in the build.

Each type of module has it own GVL ID getter function, so, if we call the `getGvlid()` function for a user id module, it'll return `undefined` since user id module should call its own function, ie,`getGvlidForUserIdModule()`. Same for analytics adatpers as well.

I propose a slight change where we include the `MODULE_TYPE`, along with `GVL_ID` and `MODULE_NAME` when calling the `getStorageManager` function. All three are optional fields and should be included if GDPR Enforcement is part of the build. That way, the `deviceAccessHook` will have a way of determining which GVL ID getter function to call based on the module type. If no module type is found, it'll default to calling the `getGvlIdForBidAdapter()` function.

If everyone's fine with this approach, I plan to add a commit to this PR where I go and make the change for the modules that have specified a gvl id and are initialising the storageManager, to add the third parameter, MODULE_TYPE, in the call.

This fixes the issue with id5Id, but https://github.com/prebid/Prebid.js/issues/5615, also mentions that `Criteo` and `pubCommonId` are blocked despite having consent. That's because both haven't specified GVL ID when registering their user id submodules.

I plan to create an issue calling out all the adapters & modules which haven't listed their GVL IDs. Without GVL ID, gdprEnforcement will block the module unless it's specifically listed under `vendorExceptions` by the publisher.

### Alternate Approach

Have a single getter function for GVL ID for all three module types: Bid Adapter, User ID Submodule & Analytics Adapter. Pros & Cons to this approach:

##### Pros:
 - Clean, less code since we'll have only one GVL ID getter function.
 - No need to introduce extra parameter `moduleType` when initializing `getStorageManager()`

##### Cons:
  - No way to differentiate between a GVL ID for a Appnexus Bid Adapter or an Appnexus Analytics Adapter. Both will be same. Similarly, Rubicon Bid Adapter and Rubicon Analytics Adapter will have the same GVLID. Essentially, any module with the same identifier, (`code` for bid adapter, `provider` for analytics adapter and `name` for userId submodule), we can't give them a different GVL ID. For example, `appnexus` (bidAdapter) can't have GVL ID as `1` & `appnexus` (analyticsAdapter) have GVL ID as `2`. Both should be either 1 or 2.

If it is alright for all the modules of a single entity to have the same GVL ID, then the alternate approach works. But if, we wanna provide flexibility in terms of assigning different GVL ID to a bidAdapter and a analyticsAdapter for the same entity (ex - Appnexus), then this approach fails.