### PR TITLE
rename simpleHash to cyrb53Hash

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -244,7 +244,7 @@ function makeStoredConsentDataHash(consentData) {
     storedConsentData.gdprApplies = consentData.gdprApplies;
     storedConsentData.apiVersion = consentData.apiVersion;
   }
-  return utils.simpleHash(JSON.stringify(storedConsentData));
+  return utils.cyrb53Hash(JSON.stringify(storedConsentData));
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1223,7 +1223,7 @@ export function mergeDeep(target, ...sources) {
  * @param seed (optional)
  * @returns {string}
  */
-export function simpleHash(str, seed = 0) {
+export function cyrb53Hash(str, seed = 0) {
   // IE doesn't support imul
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul#Polyfill
   let imul = function(opA, opB) {

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1178,23 +1178,23 @@ describe('Utils', function () {
       expect(utils.deepEqual(obj1, obj2)).to.equal(false);
     });
 
-    describe('simpleHash', function() {
+    describe('cyrb53Hash', function() {
       it('should return the same hash for the same string', function() {
         const stringOne = 'string1';
-        expect(utils.simpleHash(stringOne)).to.equal(utils.simpleHash(stringOne));
+        expect(utils.cyrb53Hash(stringOne)).to.equal(utils.cyrb53Hash(stringOne));
       });
       it('should return a different hash for the same string with different seeds', function() {
         const stringOne = 'string1';
-        expect(utils.simpleHash(stringOne, 1)).to.not.equal(utils.simpleHash(stringOne, 2));
+        expect(utils.cyrb53Hash(stringOne, 1)).to.not.equal(utils.cyrb53Hash(stringOne, 2));
       });
       it('should return a different hash for different strings with the same seed', function() {
         const stringOne = 'string1';
         const stringTwo = 'string2';
-        expect(utils.simpleHash(stringOne)).to.not.equal(utils.simpleHash(stringTwo));
+        expect(utils.cyrb53Hash(stringOne)).to.not.equal(utils.cyrb53Hash(stringTwo));
       });
       it('should return a string value, not a number', function() {
         const stringOne = 'string1';
-        expect(typeof utils.simpleHash(stringOne)).to.equal('string');
+        expect(typeof utils.cyrb53Hash(stringOne)).to.equal('string');
       });
     });
   });


### PR DESCRIPTION
related to https://github.com/prebid/Prebid.js/pull/5641, @patmmccann suggested that the name make it clearer which hash function was actually used...so renaming it appropriately