### PR TITLE
Add GDPR parameters to yieldlab delivery adtag

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -68,7 +68,8 @@ export const spec = {
     return {
       method: 'GET',
       url: `${ENDPOINT}/yp/${adslots}?${queryString}`,
-      validBidRequests: validBidRequests
+      validBidRequests: validBidRequests,
+      queryParams: query
     }
   },
 
@@ -80,6 +81,7 @@ export const spec = {
   interpretResponse: function (serverResponse, originalBidRequest) {
     const bidResponses = []
     const timestamp = Date.now()
+    const reqParams = originalBidRequest.queryParams
 
     originalBidRequest.validBidRequests.forEach(function (bidRequest) {
       if (!serverResponse.body) {
@@ -95,6 +97,8 @@ export const spec = {
         const customsize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : primarysize
         const extId = bidRequest.params.extId !== undefined ? '&id=' + bidRequest.params.extId : ''
         const adType = matchedBid.adtype !== undefined ? matchedBid.adtype : ''
+        const gdprApplies = reqParams.gdpr ? '&gdpr=' + reqParams.gdpr : ''
+        const gdprConsent = reqParams.consent ? '&consent=' + reqParams.consent : ''
 
         const bidResponse = {
           requestId: bidRequest.bidId,
@@ -107,7 +111,7 @@ export const spec = {
           netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
-          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}"></script>`
+          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}"></script>`
         }
 
         if (isVideo(bidRequest, adType)) {
@@ -117,7 +121,7 @@ export const spec = {
             bidResponse.height = playersize[1]
           }
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}`
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}`
 
           if (isOutstream(bidRequest)) {
             const renderer = Renderer.install({

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -47,6 +47,16 @@ const VIDEO_RESPONSE = Object.assign({}, RESPONSE, {
   'adtype': 'VIDEO'
 })
 
+const REQPARAMS = {
+  json: true,
+  ts: 1234567890
+}
+
+const REQPARAMS_GDPR = Object.assign({}, REQPARAMS, {
+  gdpr: true,
+  consent: 'BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA'
+})
+
 describe('yieldlabBidAdapter', function () {
   const adapter = newBidder(spec)
 
@@ -131,7 +141,7 @@ describe('yieldlabBidAdapter', function () {
     })
 
     it('should get correct bid response', function () {
-      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST]})
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST], queryParams: REQPARAMS})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
@@ -147,6 +157,13 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].ad).to.include('&id=abc')
     })
 
+    it('should append gdpr parameters to adtag', function () {
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST], queryParams: REQPARAMS_GDPR})
+
+      expect(result[0].ad).to.include('&gdpr=true')
+      expect(result[0].ad).to.include('&consent=BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA')
+    })
+
     it('should get correct bid response when passing more than one size', function () {
       const REQUEST2 = Object.assign({}, REQUEST, {
         'sizes': [
@@ -155,7 +172,7 @@ describe('yieldlabBidAdapter', function () {
           [970, 90],
         ]
       })
-      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST2]})
+      const result = spec.interpretResponse({body: [RESPONSE]}, {validBidRequests: [REQUEST2], queryParams: REQPARAMS})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
@@ -179,13 +196,27 @@ describe('yieldlabBidAdapter', function () {
           }
         }
       })
-      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST]})
+      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST], queryParams: REQPARAMS})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
       expect(result[0].mediaType).to.equal('video')
       expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
       expect(result[0].vastUrl).to.include('&id=abc')
+    })
+
+    it('should append gdpr parameters to vastUrl', function () {
+      const VIDEO_REQUEST = Object.assign({}, REQUEST, {
+        'mediaTypes': {
+          'video': {
+            'context': 'instream'
+          }
+        }
+      })
+      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST], queryParams: REQPARAMS_GDPR})
+
+      expect(result[0].vastUrl).to.include('&gdpr=true')
+      expect(result[0].vastUrl).to.include('&consent=BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA')
     })
 
     it('should add renderer if outstream context', function () {
@@ -197,7 +228,7 @@ describe('yieldlabBidAdapter', function () {
           }
         }
       })
-      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [OUTSTREAM_REQUEST]})
+      const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [OUTSTREAM_REQUEST], queryParams: REQPARAMS})
 
       expect(result[0].renderer.id).to.equal('2d925f27f5079f')
       expect(result[0].renderer.url).to.equal('https://ad2.movad.net/dynamic.ad?a=o193092&ma_loadEvent=ma-start-event')


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Additionally to the bid request endpoint, we also need to append the GDPR parameters to the actual adtag URIs, so we can make sure we have at least consent for Purpose1 (cookies needed for the delivery of the creative)