### PR TITLE
qcadapter - tcf2 remove germany specific logic

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -85,11 +85,6 @@ function checkTCFv1(vendorData) {
 }
 
 function checkTCFv2(tcData) {
-  if (tcData.purposeOneTreatment && tcData.publisherCC === 'DE') {
-    // special purpose 1 treatment for Germany
-    return true;
-  }
-
   let restrictions = tcData.publisher ? tcData.publisher.restrictions : {};
   let qcRestriction = restrictions && restrictions[PURPOSE_DATA_COLLECT]
     ? restrictions[PURPOSE_DATA_COLLECT][QUANTCAST_VENDOR_ID]

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -430,26 +430,6 @@ describe('Quantcast adapter', function () {
     expect(requests).to.equal(undefined);
   });
 
-  it('allows TCF v2 request from Germany for purpose 1', function () {
-    const bidderRequest = {
-      gdprConsent: {
-        gdprApplies: true,
-        consentString: 'consentString',
-        vendorData: {
-          publisherCC: 'DE',
-          purposeOneTreatment: true
-        },
-        apiVersion: 2
-      }
-    };
-
-    const requests = qcSpec.buildRequests([bidRequest], bidderRequest);
-    const parsed = JSON.parse(requests[0].data);
-
-    expect(parsed.gdprSignal).to.equal(1);
-    expect(parsed.gdprConsent).to.equal('consentString');
-  });
-
   it('allows TCF v2 request when Quantcast has consent for purpose 1', function() {
     const bidderRequest = {
       gdprConsent: {


### PR DESCRIPTION
#4951  Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
We had a special treatment for Germany when deciding on a consent using TCF2, this specific logic doesn't apply anymore and hence it is removed

