### PR TITLE
Price Floors: Fix bug when caching floor lookup

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -103,7 +103,7 @@ export function getFirstMatchingFloor(floorData, bidObject, responseObject = {})
   // if we already have gotten the matching rule from this matching input then use it! No need to look again
   let previousMatch = utils.deepAccess(floorData, `matchingInputs.${matchingInput}`);
   if (previousMatch) {
-    return previousMatch;
+    return {...previousMatch};
   }
   let allPossibleMatches = generatePossibleEnumerations(fieldValues, utils.deepAccess(floorData, 'schema.delimiter') || '|');
   let matchingRule = find(allPossibleMatches, hashValue => floorData.values.hasOwnProperty(hashValue));

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -192,7 +192,7 @@ describe('the price floors module', function () {
           matchingData: 'banner',
           matchingRule: 'banner'
         });
-        // make sure a post retrieval adjustment does not alter the cahced floor
+        // make sure a post retrieval adjustment does not alter the cached floor
         result.matchingFloor = result.matchingFloor * modifier;
       });
     });

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -182,6 +182,20 @@ describe('the price floors module', function () {
         matchingRule: '*'
       });
     });
+    it('does not alter cached matched input if conversion occurs', function () {
+      let inputData = {...basicFloorData};
+      [0.2, 0.4, 0.6, 0.8].forEach(modifier => {
+        let result = getFirstMatchingFloor(inputData, basicBidRequest, {mediaType: 'banner', size: '*'});
+        // result should always be the same
+        expect(result).to.deep.equal({
+          matchingFloor: 1.0,
+          matchingData: 'banner',
+          matchingRule: 'banner'
+        });
+        // make sure a post retrieval adjustment does not alter the cahced floor
+        result.matchingFloor = result.matchingFloor * modifier;
+      });
+    });
     it('selects the right floor for different sizes', function () {
       let inputFloorData = {
         currency: 'USD',


### PR DESCRIPTION


## Type of change
- [X] Bugfix

## Description of change
When a floor is initially looked up, the input request params are saved as an offset so we do not have to run the lookup again.

When we find a cached lookup, we were passing the reference of the object, thus any currency adjustments were overwriting the cached value.

Now we pass back a copy of it.