### PR TITLE
Add Pub-X Bid adapter

### DIFF
--- a/modules/pubxBidAdapter.js
+++ b/modules/pubxBidAdapter.js
@@ -1,10 +1,8 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'pubx';
-const ALIAS_BIDDER_CODE = ['pbx'];
 const BID_ENDPOINT = 'https://api.primecaster.net/adlogue/api/slot/bid';
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ALIAS_BIDDER_CODE, // short code
   isBidRequestValid: function(bid) {
     if (!(bid.params.sid)) {
       return false;

--- a/modules/pubxBidAdapter.js
+++ b/modules/pubxBidAdapter.js
@@ -1,0 +1,50 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+const BIDDER_CODE = 'pubx';
+const ALIAS_BIDDER_CODE = ['pbx'];
+const BID_ENDPOINT = 'https://api.primecaster.net/adlogue/api/slot/bid';
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ALIAS_BIDDER_CODE, // short code
+  isBidRequestValid: function(bid) {
+    if (!(bid.params.sid)) {
+      return false;
+    } else { return true }
+  },
+  buildRequests: function(validBidRequests) {
+    return validBidRequests.map(bidRequest => {
+      const bidId = bidRequest.bidId;
+      const params = bidRequest.params;
+      const sid = params.sid;
+      const payload = {
+        sid: sid
+      };
+      return {
+        id: bidId,
+        method: 'GET',
+        url: BID_ENDPOINT,
+        data: payload,
+      }
+    });
+  },
+  interpretResponse: function(serverResponse, bidRequest) {
+    const body = serverResponse.body;
+    const bidResponses = [];
+    if (body.cid) {
+      const bidResponse = {
+        requestId: bidRequest.id,
+        cpm: body.cpm,
+        currency: body.currency,
+        width: body.width,
+        height: body.height,
+        creativeId: body.cid,
+        netRevenue: true,
+        ttl: body.TTL,
+        ad: body.adm
+      };
+      bidResponses.push(bidResponse);
+    } else {};
+    // console.log(bidResponses);
+    return bidResponses;
+  }
+}
+registerBidder(spec);

--- a/modules/pubxBidAdapter.js
+++ b/modules/pubxBidAdapter.js
@@ -43,7 +43,6 @@ export const spec = {
       };
       bidResponses.push(bidResponse);
     } else {};
-    // console.log(bidResponses);
     return bidResponses;
   }
 }

--- a/modules/pubxBidAdapter.md
+++ b/modules/pubxBidAdapter.md
@@ -1,0 +1,32 @@
+# Overview
+
+Module Name: pubx Bid Adapter
+
+Maintainer: x@pub-x.io
+
+# Description
+
+Module that connects to Pub-X's demand sources
+Supported MediaTypes: banner only
+
+# Test Parameters
+```javascript
+	var adUnits = [
+    {
+      code: 'test',
+      mediaTypes: {
+        banner: {
+          sizes: [300,250]
+        }
+      },
+      bids: [
+        {
+          bidder: 'pubx',
+          params: {
+            sid: 'eDMR' //ID should be provided by Pub-X
+          }
+        }
+      ]
+    }
+  ];
+```

--- a/test/spec/modules/pubxBidAdapter_spec.js
+++ b/test/spec/modules/pubxBidAdapter_spec.js
@@ -1,0 +1,111 @@
+import {expect} from 'chai';
+import {spec} from 'modules/pubxBidAdapter.js';
+import {newBidder} from 'src/adapters/bidderFactory.js';
+
+describe('pubxAdapter', function () {
+  const adapter = newBidder(spec);
+  const ENDPOINT = 'https://api.primecaster.net/adlogue/api/slot/bid';
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      bidder: 'pubx',
+      params: {
+        sid: '12345abc'
+      }
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidRequests = [
+      {
+        id: '26c1ee0038ac11',
+        params: {
+          sid: '12345abc'
+        }
+      }
+    ];
+
+    const data = {
+      banner: {
+        sid: '12345abc'
+      }
+    };
+
+    it('sends bid request to ENDPOINT via GET', function () {
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should attach params to the banner request', function () {
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.data).to.deep.equal(data.banner);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const serverResponse = {
+      body: {
+        TTL: 300,
+        adm: '<div>some creative</div>',
+        cid: 'TKmB',
+        cpm: 500,
+        currency: 'JPY',
+        height: 250,
+        width: 300,
+      }
+    }
+
+    const bidRequests = [
+      {
+        id: '26c1ee0038ac11',
+        params: {
+          sid: '12345abc'
+        }
+      }
+    ];
+
+    const bidResponses = [
+      {
+        requestId: '26c1ee0038ac11',
+        cpm: 500,
+        currency: 'JPY',
+        width: 300,
+        height: 250,
+        creativeId: 'TKmB',
+        netRevenue: true,
+        ttl: 300,
+        ad: '<div>some creative</div>'
+      }
+    ];
+
+    it('handles banner responses', function () {
+      const result = spec.interpretResponse(serverResponse, bidRequests[0])[0];
+      expect(result.requestId).to.equal(bidResponses[0].requestId);
+      expect(result.width).to.equal(bidResponses[0].width);
+      expect(result.height).to.equal(bidResponses[0].height);
+      expect(result.creativeId).to.equal(bidResponses[0].creativeId);
+      expect(result.currency).to.equal(bidResponses[0].currency);
+      expect(result.netRevenue).to.equal(bidResponses[0].netRevenue);
+      expect(result.ttl).to.equal(bidResponses[0].ttl);
+      expect(result.ad).to.equal(bidResponses[0].ad);
+    });
+  });
+});

--- a/test/spec/modules/pubxBidAdapter_spec.js
+++ b/test/spec/modules/pubxBidAdapter_spec.js
@@ -95,7 +95,21 @@ describe('pubxAdapter', function () {
         ad: '<div>some creative</div>'
       }
     ];
-
+    it('should return empty array when required param is empty', function () {
+      const serverResponseWithCidEmpty = {
+        body: {
+          TTL: 300,
+          adm: '<div>some creative</div>',
+          cid: '',
+          cpm: '',
+          currency: 'JPY',
+          height: 250,
+          width: 300,
+        }
+      }
+      const result = spec.interpretResponse(serverResponseWithCidEmpty, bidRequests[0]);
+      expect(result).to.be.empty;
+    });
     it('handles banner responses', function () {
       const result = spec.interpretResponse(serverResponse, bidRequests[0])[0];
       expect(result.requestId).to.equal(bidResponses[0].requestId);


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter 

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding Pub-X Bid Adapter
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'pubx',
  params: {
    sid: 'eDMR'
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
x@pub-x.io
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/2287

