### PR TITLE
Documentation: update readme recommendation to install with 'npm ci'

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ prebid.requestBids({
 
     $ git clone https://github.com/prebid/Prebid.js.git
     $ cd Prebid.js
-    $ npm install
+    $ npm ci
 
 *Note:* You need to have `NodeJS` 12.16.1 or greater installed.
 
-*Note:* In the 1.24.0 release of Prebid.js we have transitioned to using gulp 4.0 from using gulp 3.9.1.  To comply with gulp's recommended setup for 4.0, you'll need to have `gulp-cli` installed globally prior to running the general `npm install`.  This shouldn't impact any other projects you may work on that use an earlier version of gulp in its setup.
+*Note:* In the 1.24.0 release of Prebid.js we have transitioned to using gulp 4.0 from using gulp 3.9.1.  To comply with gulp's recommended setup for 4.0, you'll need to have `gulp-cli` installed globally prior to running the general `npm ci`.  This shouldn't impact any other projects you may work on that use an earlier version of gulp in its setup.
 
 If you have a previous version of `gulp` installed globally, you'll need to remove it before installing `gulp-cli`.  You can check if this is installed by running `gulp -v` and seeing the version that's listed in the `CLI` field of the output.  If you have the `gulp` package installed globally, it's likely the same version that you'll see in the `Local` field.  If you already have `gulp-cli` installed, it should be a lower major version (it's at version `2.0.1` at the time of the transition).
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Refactoring (no functional changes, no api changes)
- [ x ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
With the recent upgrade of npm we should be using the 'npm ci' option to install modules. This provides a more reliable deployment that does not update modules on install. It will reduce check-ins of improper package-lock.json and provide greater assurance that a stable node_modules is deployed.
