### PR TITLE
Adding sharedid to the pubcommon module

### DIFF
--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -16,8 +16,8 @@ const MODULE_NAME = 'pubCommonId';
 
 const SHAREDID_OPT_OUT_VALUE = '00000000000000000000000000';
 const SHAREDID_COOKIE_EXPIRATION = 2419200000; // 28 days in milliseconds
-const SHAREDID_COOKIE_NAME ="sharedid";
-const SHAREDID_URL = "https://id.sharedid.org/id";
+const SHAREDID_COOKIE_NAME = 'sharedid';
+const SHAREDID_URL = 'https://id.sharedid.org/id';
 
 const storage = getStorageManager(null, 'pubCommonId');
 
@@ -125,7 +125,7 @@ export const pubCommonIdSubmodule = {
    * @param {Object} storedId existing id
    * @returns {IdResponse|undefined}
    */
-  extendId: function({extend = false, pixelUrl} = {}, storedId) {
+  extendId: function ({extend = false, pixelUrl} = {}, storedId) {
     try {
       if (typeof window[PUB_COMMON_ID] === 'object') {
         // If the page includes its onw pubcid module, then there is nothing to do.

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -84,7 +84,7 @@ export const pubCommonIdSubmodule = {
    * @returns {{pubcid: {id:string, third:string}}}
    */
   decode(value) {
-    let res = {'pubcid': value}
+    const res = {'pubcid': value}
     utils.logInfo('PubcId: Decoded value ' + JSON.stringify(res));
     return res;
   },
@@ -103,7 +103,7 @@ export const pubCommonIdSubmodule = {
     } catch (e) {
     }
     const newId = (create && utils.hasDeviceAccess()) ? utils.generateUUID() : undefined;
-    let idObj = {
+    const idObj = {
       id: newId
     };
     return {
@@ -126,8 +126,8 @@ export const pubCommonIdSubmodule = {
       }
     } catch (e) {
     }
-    let pixelCallback = extend ? this.makeCallback(pixelUrl, storedId.id) : undefined;
-    let callback = storedId.third ? pixelCallback : getIdCallback(storedId, pixelCallback);
+    const pixelCallback = extend ? this.makeCallback(pixelUrl, storedId.id) : undefined;
+    const callback = storedId.third ? pixelCallback : getIdCallback(storedId, pixelCallback);
     // When extending, only one of response fields is needed
     return callback ? {callback: callback} : {id: storedId};
   },

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -126,11 +126,8 @@ export const pubCommonIdSubmodule = {
       }
     } catch (e) {
     }
-    let pixelCallback;
-    if (extend) {
-      pixelCallback = this.makeCallback(pixelUrl, storedId.id);
-    }
-    let callback = (storedId.third) ? pixelCallback : getIdCallback(storedId, pixelCallback);
+    let pixelCallback = extend ? this.makeCallback(pixelUrl, storedId.id) : undefined;
+    let callback = storedId.third ? pixelCallback : getIdCallback(storedId, pixelCallback);
     // When extending, only one of response fields is needed
     return callback ? {callback: callback} : {id: storedId};
   },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding sharedid to pubcommon module
Now it will use the same format for passing id to bidders as sharedid:
{
   pubcid: {
       id:string(pubcid), third:string(sharedid)
    }
}
It gets sharedid from https://id.sharedid.org/id and stores it along with pubcId