### PR TITLE
Add host to gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,6 +110,7 @@ function watch(done) {
   connect.server({
     https: argv.https,
     port: port,
+    host: argv.host,
     root: './',
     livereload: true
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ function watch(done) {
   connect.server({
     https: argv.https,
     port: port,
-    host: argv.host,
+    host: FAKE_SERVER_HOST,
     root: './',
     livereload: true
   });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Build related changes

## Description of change
Add host parameter in building server. When we run prebid.js in docker on mac (our sandbox), we need address 0.0.0.0, localhost does not work.
