### PR TITLE
Prebid Server returns exp, not ttl

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -822,9 +822,9 @@ const OPEN_RTB_PROTOCOL = {
           bidObject.meta = bidObject.meta || {};
           if (bid.adomain) { bidObject.meta.advertiserDomains = bid.adomain; }
 
-          // TODO: Remove when prebid-server returns ttl and netRevenue
           const configTtl = _s2sConfig.defaultTtl || DEFAULT_S2S_TTL;
-          bidObject.ttl = (bid.ttl) ? bid.ttl : configTtl;
+          // the OpenRTB location for "TTL" as understood by Prebid.js is "exp" (expiration).
+          bidObject.ttl = (bid.exp) ? bid.exp : configTtl;
           bidObject.netRevenue = (bid.netRevenue) ? bid.netRevenue : DEFAULT_S2S_NETREVENUE;
 
           bids.push({ adUnit: bid.impid, bid: bidObject });


### PR DESCRIPTION
# Type of change
- [ X ] Bugfix

## Description of change

Updating how pbsBidAdapter sets the "TTL" for bids. 

TTL in PBJS terms is how long the bid can stay in cache. However, the OpenRTB standard location for this value is `exp`.

Related to https://github.com/prebid/prebid-server/issues/1386