### PR TITLE
Chrome 85.0.4183 fix for SameSite=None cookie rejection policy

### DIFF
--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -12,7 +12,7 @@ function setCookie(name, value, expires) {
   document.cookie = name + '=' + value +
     '; path=/' +
     (expires ? ('; expires=' + expires.toUTCString()) : '') +
-    '; SameSite=None';
+    '; SameSite=Lax';
 }
 
 describe('finteza analytics adapter', function () {


### PR DESCRIPTION
Tests for this Analytics Adapter fail **locally** without this change when a user is using Chrome 85 or newer. Chrome 85 added rejection of insecure SameSite=None cookies. `secure` probably could have been added to fix this issue but `SameSite=Lax` works as well for the test case.

https://developers.google.com/web/updates/2020/07/chrome-85-deps-rems
https://en.wikipedia.org/wiki/Google_Chrome_version_history

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other