### PR TITLE
add verizon alias to aol

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -63,7 +63,7 @@ function template(strings, ...keys) {
 function _isMarketplaceBidder(bidderCode) {
   return bidderCode === AOL_BIDDERS_CODES.AOL ||
     bidderCode === AOL_BIDDERS_CODES.VERIZON ||
-    bidderCode === AOL_BIDDERS_CODES.ONEDISPLAY
+    bidderCode === AOL_BIDDERS_CODES.ONEDISPLAY;
 }
 
 function _isOneMobileBidder(bidderCode) {

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -4,6 +4,7 @@ import { BANNER } from '../src/mediaTypes.js';
 
 const AOL_BIDDERS_CODES = {
   AOL: 'aol',
+  VERIZON: 'verizon',
   ONEMOBILE: 'onemobile',
   ONEDISPLAY: 'onedisplay'
 };
@@ -48,10 +49,10 @@ const NUMERIC_VALUES = {
 };
 
 function template(strings, ...keys) {
-  return function(...values) {
+  return function (...values) {
     let dict = values[values.length - 1] || {};
     let result = [strings[0]];
-    keys.forEach(function(key, i) {
+    keys.forEach(function (key, i) {
       let value = utils.isInteger(key) ? values[key] : dict[key];
       result.push(value, strings[i + 1]);
     });
@@ -59,12 +60,16 @@ function template(strings, ...keys) {
   };
 }
 
-function _isMarketplaceBidder(bidder) {
-  return bidder === AOL_BIDDERS_CODES.AOL || bidder === AOL_BIDDERS_CODES.ONEDISPLAY;
+function _isMarketplaceBidder(bidderCode) {
+  return bidderCode === AOL_BIDDERS_CODES.AOL ||
+    bidderCode === AOL_BIDDERS_CODES.VERIZON ||
+    bidderCode === AOL_BIDDERS_CODES.ONEDISPLAY
 }
 
 function _isOneMobileBidder(bidderCode) {
-  return bidderCode === AOL_BIDDERS_CODES.AOL || bidderCode === AOL_BIDDERS_CODES.ONEMOBILE;
+  return bidderCode === AOL_BIDDERS_CODES.AOL ||
+    bidderCode === AOL_BIDDERS_CODES.VERIZON ||
+    bidderCode === AOL_BIDDERS_CODES.ONEMOBILE;
 }
 
 function _isNexageRequestPost(bid) {
@@ -101,7 +106,11 @@ function resolveEndpointCode(bid) {
 export const spec = {
   code: AOL_BIDDERS_CODES.AOL,
   gvlid: 25,
-  aliases: [AOL_BIDDERS_CODES.ONEMOBILE, AOL_BIDDERS_CODES.ONEDISPLAY],
+  aliases: [
+    AOL_BIDDERS_CODES.ONEMOBILE,
+    AOL_BIDDERS_CODES.ONEDISPLAY,
+    AOL_BIDDERS_CODES.VERIZON
+  ],
   supportedMediaTypes: [BANNER],
   isBidRequestValid(bid) {
     return isMarketplaceBid(bid) || isMobileBid(bid);
@@ -121,7 +130,7 @@ export const spec = {
       }
     });
   },
-  interpretResponse({body}, bidRequest) {
+  interpretResponse({ body }, bidRequest) {
     if (!body) {
       utils.logError('Empty bid response', bidRequest.bidderCode, body);
     } else {
@@ -216,11 +225,11 @@ export const spec = {
     }));
   },
   buildOneMobileGetUrl(bid, consentData) {
-    let {dcn, pos, ext} = bid.params;
+    let { dcn, pos, ext } = bid.params;
     let nexageApi = this.buildOneMobileBaseUrl(bid);
     if (dcn && pos) {
       let dynamicParams = this.formatOneMobileDynamicParams(ext, consentData);
-      nexageApi += nexageGetApiTemplate({dcn, pos, dynamicParams});
+      nexageApi += nexageGetApiTemplate({ dcn, pos, dynamicParams });
     }
     return nexageApi;
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other (quality of life)

## Description of change
<!-- Describe the change proposed in this pull request -->
AOL is Verizon. Adds a Verizon alias to their bid adapter. Quality of life change.

- Adapter's maintainer email: hb-fe-tech@oath.com

