### PR TITLE
Upgrade Circle CI resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
       docker:
         # specify the version you desire here
         - image: circleci/node:12.16.1
-        
+      resource_class: xlarge
         # Specify service dependencies here if necessary
         # CircleCI maintains a library of pre-built images
         # documented at https://circleci.com/docs/2.0/circleci-images/


### PR DESCRIPTION
## Type of change
- [X] CI related changes

## Description of change
We were using less resource on our circle ci container (2 cpus and 4GB RAM). I have upgraded it to use (8cpu and 16GB RAM). The pipeline is executing a little bit faster now.

Here's a comparison:

### Before:

<img width="1404" alt="Screenshot 2020-09-10 at 6 40 08 PM" src="https://user-images.githubusercontent.com/14229985/92733447-5205a600-f395-11ea-8801-3f17826f1a2a.png">

### After:

<img width="1406" alt="Screenshot 2020-09-10 at 6 40 57 PM" src="https://user-images.githubusercontent.com/14229985/92733478-58941d80-f395-11ea-856c-eda6414ac10b.png">

<br/>

Since the tests run on Browserstack, the timings are also limited by the resource we've available there, and if two or more Circle CI jobs are running in parallel, the tests will timeout or take longer than usual. That explains one test running ~ 16m even after the upgrade.

## NOTE: 
This PR does not have any effect on the tests that are currently failing intermittently.