### PR TITLE
add quantcast ID submodule

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -83,9 +83,10 @@
         var adUnits = [
             {
                 code: 'test-div',
-                sizes: [[300,250],[300,600],[728,90]],
                 mediaTypes: {
-                    banner: {}
+                    banner: {
+                        sizes: [[300,250],[300,600],[728,90]]
+                    }
                 },
                 bids: [
                     {
@@ -230,6 +231,9 @@
                         name: "_li_pbid",
                         expires: 28
                       }
+                    },
+                    {
+                      name: "quantcastId"
                     }],
                     syncDelay: 5000,
                     auctionDelay: 1000

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -12,7 +12,8 @@
     "netIdSystem",
     "identityLinkIdSystem",
     "sharedIdSystem",
-    "intentIqIdSystem"
+    "intentIqIdSystem",
+    "quantcastIdSystem"
   ],
   "adpod": [
     "freeWheelAdserverVideo",

--- a/modules/quantcastIdSystem.js
+++ b/modules/quantcastIdSystem.js
@@ -1,0 +1,43 @@
+/**
+ * This module adds QuantcastID to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/quantcastIdSystem
+ * @requires module:modules/userId
+ */
+
+import {submodule} from '../src/hook.js'
+import { getStorageManager } from '../src/storageManager.js';
+
+const QUANTCAST_FPA = '__qca';
+
+export const storage = getStorageManager();
+
+/** @type {Submodule} */
+export const quantcastIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: 'quantcastId',
+
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @returns {{quantcastId: string} | undefined}
+   */
+  decode(value) {
+    return value;
+  },
+
+  /**
+   * read Quantcast first party cookie and pass it along in quantcastId
+   * @function
+   * @returns {{id: {quantcastId: string} | undefined}}}
+   */
+  getId() {
+    let fpa = storage.getCookie(QUANTCAST_FPA);
+    return { id: fpa ? { quantcastId: fpa } : undefined }
+  }
+};
+
+submodule('userId', quantcastIdSubmodule);

--- a/modules/quantcastIdSystem.js
+++ b/modules/quantcastIdSystem.js
@@ -35,6 +35,7 @@ export const quantcastIdSubmodule = {
    * @returns {{id: {quantcastId: string} | undefined}}}
    */
   getId() {
+    // Consent signals are currently checked on the server side.
     let fpa = storage.getCookie(QUANTCAST_FPA);
     return { id: fpa ? { quantcastId: fpa } : undefined }
   }

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -123,6 +123,12 @@ const USER_IDS_CONFIG = {
         third: data.third
       } : undefined;
     }
+  },
+
+  // quantcastId
+  'quantcastId': {
+    source: 'quantcast.com',
+    atype: 1
   }
 };
 

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -95,6 +95,14 @@ userIdAsEids = [
                 third: 'some-random-id-value'
              }
          }]
-    }
+    },
+
+    {
+        source: 'quantcast.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
+        }]
+    },
 ]
 ```

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -192,6 +192,17 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+  it('quantcastId', function () {
+    const userId = {
+      quantcastId: 'some-random-id-value',
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'quantcast.com',
+      uids: [{ id: 'some-random-id-value', atype: 1 }],
+    });
+  });
 });
 
 describe('Negative case', function() {

--- a/test/spec/modules/quantcastIdSystem_spec.js
+++ b/test/spec/modules/quantcastIdSystem_spec.js
@@ -1,0 +1,19 @@
+import { quantcastIdSubmodule, storage } from 'modules/quantcastIdSystem.js';
+
+describe('QuantcastId module', function () {
+  beforeEach(function() {
+    window.document.cookie = '__qca= ; expires = Thu, 01 Jan 1970 00:00:00 GMT;';
+  });
+
+  it('getId() should return a quantcast id when the Quantcast first party cookie exists', function () {
+    storage.setCookie('__qca', 'P0-TestFPA');
+
+    const id = quantcastIdSubmodule.getId();
+    expect(id).to.be.deep.equal({id: {quantcastId: 'P0-TestFPA'}});
+  });
+
+  it('getId() should return an empty id when the Quantcast first party cookie is missing', function () {
+    const id = quantcastIdSubmodule.getId();
+    expect(id).to.be.deep.equal({id: undefined});
+  });
+});

--- a/test/spec/modules/quantcastIdSystem_spec.js
+++ b/test/spec/modules/quantcastIdSystem_spec.js
@@ -2,7 +2,7 @@ import { quantcastIdSubmodule, storage } from 'modules/quantcastIdSystem.js';
 
 describe('QuantcastId module', function () {
   beforeEach(function() {
-    window.document.cookie = '__qca= ; expires = Thu, 01 Jan 1970 00:00:00 GMT;';
+    storage.setCookie('__qca', '', 'Thu, 01 Jan 1970 00:00:00 GMT');
   });
 
   it('getId() should return a quantcast id when the Quantcast first party cookie exists', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
This adds quantcast user ID submodule. The submodule reads Quantcast first party cookie and passes the value to prebid bidding adapters. Currently, the submodule doesn't need any configuration parameters. The code is tested using with unit tests and userId_example.html. The code coverage on the submodule is 85.71%. Please contact asig@quantcast.com for any issues.

Link to the documentation PR: https://github.com/prebid/prebid.github.io/pull/2339 