### PR TITLE
GUMGUM: adds support for zone and pubId params

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -135,7 +135,8 @@ function isBidRequestValid (bid) {
     params,
     adUnitCode
   } = bid;
-  const id = params.inScreen || params.inScreenPubID || params.inSlot || params.ICV || params.video || params.inVideo;
+  const legacyParamID = params.inScreen || params.inScreenPubID || params.inSlot || params.ICV || params.video || params.inVideo;
+  const id = legacyParamID || params.slot || params.native || params.zone || params.pubID;
 
   if (invalidRequestIds[id]) {
     utils.logWarn(`[GumGum] Please check the implementation for ${id} for the placement ${adUnitCode}`);
@@ -143,6 +144,8 @@ function isBidRequestValid (bid) {
   }
 
   switch (true) {
+    case !!(params.zone): break;
+    case !!(params.pubId): break;
     case !!(params.inScreen): break;
     case !!(params.inScreenPubID): break;
     case !!(params.inSlot): break;
@@ -217,8 +220,8 @@ function _getFloor (mediaTypes, bidfloor, bid) {
     });
 
     if (typeof floorInfo === 'object' &&
-    floorInfo.currency === 'USD' &&
-    !isNaN(parseFloat(floorInfo.floor))) {
+      floorInfo.currency === 'USD' &&
+      !isNaN(parseFloat(floorInfo.floor))) {
       floor = Math.max(floor, parseFloat(floorInfo.floor));
     }
   }
@@ -255,6 +258,7 @@ function buildRequests (validBidRequests, bidderRequest) {
       sizes = mediaTypes.banner.sizes;
     } else if (mediaTypes.video) {
       sizes = mediaTypes.video.playerSize;
+      data = _getVidParams(mediaTypes.video);
     }
 
     if (pageViewId) {
@@ -265,48 +269,27 @@ function buildRequests (validBidRequests, bidderRequest) {
       data.fp = bidFloor;
     }
 
-    if (params.inScreenPubID) {
-      data.pubId = params.inScreenPubID;
-      data.pi = 2;
-    }
-    if (params.inScreen) {
-      data.t = params.inScreen;
-      data.pi = 2;
-    }
-    if (params.inSlot) {
-      data.si = parseInt(params.inSlot, 10);
-      // check for sizes and type
-      if (params.sizes && Array.isArray(params.sizes)) {
-        const bf = params.sizes.reduce(function(r, i) {
-          // only push if it's an array of length 2
-          if (Array.isArray(i) && i.length === 2) {
-            r.push(`${i[0]}x${i[1]}`);
-          }
-          return r;
-        }, []);
-        data.bf = bf.toString();
+    if (params.zone) {
+      data.t = params.zone;
+      data.pi = 2; // inscreen
+      // override pi if the following is found
+      if (params.slot) {
+        data.si = parseInt(params.slot, 10);
+        data.pi = 3;
+        data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
+      } else if (params.native) {
+        data.ni = parseInt(params.native, 10);
+        data.pi = 5;
+      } else if (mediaTypes.video) {
+        data.pi = mediaTypes.video.linearity === 1 ? 7 : 6; // video : invideo
       }
-      data.pi = 3;
+    } else if (params.pubId) {
+      data.pubId = params.pubId
+      data.pi = mediaTypes.video ? 7 : 2; // video : inscreen
+    } else { // legacy params
+      data = { ...data, ...handleLegacyParams(params, sizes) }
     }
-    if (params.ICV) {
-      data.ni = parseInt(params.ICV, 10);
-      data.pi = 5;
-    }
-    if (params.videoPubID) {
-      data = Object.assign(data, _getVidParams(mediaTypes.video));
-      data.pubId = params.videoPubID;
-      data.pi = 7;
-    }
-    if (params.video) {
-      data = Object.assign(data, _getVidParams(mediaTypes.video));
-      data.t = params.video;
-      data.pi = 7;
-    }
-    if (params.inVideo) {
-      data = Object.assign(data, _getVidParams(mediaTypes.video));
-      data.t = params.inVideo;
-      data.pi = 6;
-    }
+
     if (gdprConsent) {
       data.gdprApplies = gdprConsent.gdprApplies ? 1 : 0;
     }
@@ -335,6 +318,40 @@ function buildRequests (validBidRequests, bidderRequest) {
   return bids;
 }
 
+function handleLegacyParams (params, sizes) {
+  const data = {};
+  if (params.inScreenPubID) {
+    data.pubId = params.inScreenPubID;
+    data.pi = 2;
+  }
+  if (params.inScreen) {
+    data.t = params.inScreen;
+    data.pi = 2;
+  }
+  if (params.inSlot) {
+    data.si = parseInt(params.inSlot, 10);
+    data.pi = 3;
+    data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
+  }
+  if (params.ICV) {
+    data.ni = parseInt(params.ICV, 10);
+    data.pi = 5;
+  }
+  if (params.videoPubID) {
+    data.pubId = params.videoPubID;
+    data.pi = 7;
+  }
+  if (params.video) {
+    data.t = params.video;
+    data.pi = 7;
+  }
+  if (params.inVideo) {
+    data.t = params.inVideo;
+    data.pi = 6;
+  }
+  return data;
+}
+
 /**
  * Unpack the response from the server into a list of bids.
  *
@@ -347,7 +364,7 @@ function interpretResponse (serverResponse, bidRequest) {
 
   if (!serverResponseBody || serverResponseBody.err) {
     const data = bidRequest.data || {}
-    const id = data.t || data.si || data.ni || data.pubId;
+    const id = data.si || data.ni || data.t || data.pubId;
     const delayTime = serverResponseBody ? serverResponseBody.err.drt : DELAY_REQUEST_TIME;
     invalidRequestIds[id] = { productId: data.pi, timestamp: new Date().getTime() };
 
@@ -403,7 +420,7 @@ function interpretResponse (serverResponse, bidRequest) {
     bidResponses.push({
       // dealId: DEAL_ID,
       // referrer: REFERER,
-      ...(product === 7 && { vastXml: markup }),
+      ...(product === 7 && { vastXml: markup, mediaType: VIDEO }),
       ad: wrapper ? getWrapperCode(wrapper, Object.assign({}, serverResponseBody, { bidRequest })) : markup,
       ...(product === 6 && {ad: markup}),
       cpm: isTestUnit ? 0.1 : cpm,

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -33,7 +33,11 @@ describe('gumgumAdapter', function () {
     };
 
     it('should return true when required params found', function () {
+      const zoneBid = { ...bid, params: { 'zone': '123' } };
+      const pubIdBid = { ...bid, params: { 'pubId': '123' } };
       expect(spec.isBidRequestValid(bid)).to.equal(true);
+      expect(spec.isBidRequestValid(zoneBid)).to.equal(true);
+      expect(spec.isBidRequestValid(pubIdBid)).to.equal(true);
     });
 
     it('should return true when required params found', function () {
@@ -139,20 +143,68 @@ describe('gumgumAdapter', function () {
       }
     };
 
+    describe('zone param', function () {
+      const zoneParam = { 'zone': '123a' };
+
+      it('should set t and pi param', function () {
+        const request = { ...bidRequests[0], params: zoneParam };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.t).to.equal(zoneParam.zone);
+        expect(bidRequest.data.pi).to.equal(2);
+      });
+      it('should set the correct pi param if slot param is found', function () {
+        const request = { ...bidRequests[0], params: { ...zoneParam, 'slot': 1 } };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(3);
+      });
+      it('should set the correct pi param if native param is found', function () {
+        const request = { ...bidRequests[0], params: { ...zoneParam, 'native': 2 } };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(5);
+      });
+      it('should set the correct pi param for video', function () {
+        const request = { ...bidRequests[0], params: zoneParam, mediaTypes: vidMediaTypes };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(7);
+      });
+      it('should set the correct pi param for invideo', function () {
+        const invideo = { video: { ...vidMediaTypes.video, linearity: 2 } };
+        const request = { ...bidRequests[0], params: zoneParam, mediaTypes: invideo };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(6);
+      });
+    });
+
+    describe('pubId zone', function () {
+      const pubIdParam = { 'pubId': 'abc' };
+
+      it('should set t param', function () {
+        const request = { ...bidRequests[0], params: pubIdParam };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pubId).to.equal(pubIdParam.pubId);
+      });
+
+      it('should set the correct pi depending on what is found in mediaTypes', function () {
+        const request = { ...bidRequests[0], params: pubIdParam };
+        const bidRequest = spec.buildRequests([request])[0];
+        const vidRequest = { ...bidRequests[0], mediaTypes: vidMediaTypes, params: { 'videoPubID': 123 } };
+        const vidBidRequest = spec.buildRequests([vidRequest])[0];
+
+        expect(bidRequest.data.pi).to.equal(2);
+        expect(vidBidRequest.data.pi).to.equal(7);
+      });
+    });
+
     it('should return a defined sizes field for video', function () {
       const request = { ...bidRequests[0], mediaTypes: vidMediaTypes, params: { 'videoPubID': 123 } };
       const bidRequest = spec.buildRequests([request])[0];
       expect(bidRequest.sizes).to.equal(vidMediaTypes.video.playerSize);
     });
     it('should handle multiple sizes for inslot', function () {
-      const request = Object.assign({}, bidRequests[0]);
-      delete request.params;
-      request.params = {
-        'inSlot': '123',
-        'sizes': [[0, 1], [0, 2]]
-      };
+      const mediaTypes = { banner: { sizes: [[300, 250], [300, 600]] } }
+      const request = { ...bidRequests[0], mediaTypes };
       const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.bf).to.equal('0x1,0x2');
+      expect(bidRequest.data.bf).to.equal('300x250,300x600');
     });
     describe('floorModule', function () {
       const floorTestData = {
@@ -163,9 +215,8 @@ describe('gumgumAdapter', function () {
         return floorTestData;
       };
       it('should return the value from getFloor if present', function () {
-        const request = { ...bidRequests[0] };
-        const bidRequest = spec.buildRequests([request])[0];
-        expect(bidRequest.data.fp).to.equal(floorTestData.floor);
+        const request = spec.buildRequests(bidRequests)[0];
+        expect(request.data.fp).to.equal(floorTestData.floor);
       });
       it('should return the getFloor.floor value if it is greater than bidfloor', function () {
         const bidfloor = 0.80;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds support for new param fields (zone and pubId) while keeping legacy params still viable
Adds `mediatype: video` for video product
Small modification for data.bf cc @estavillo 


For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
PR for prebid.github.io coming soon!

