### PR TITLE
package-lock.json version should match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "3.27.0-pre",
+  "version": "4.8.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This drifted away for some reason, likely some quirk of update order, in a PR that added "deep-equal". https://github.com/prebid/Prebid.js/commit/477fe0c10d78d878aa8135cc4852957874447759

We should look at updating processes to require 'npm ci' unless a PR/dev is explicitly updating packages. This should improve this if not solve it. https://github.com/prebid/Prebid.js/pull/5697 - npm previously didn't have a differentiation between install and update, it does now in the version we upgraded to recently.
