### PR TITLE
Convert id5id to an object to support passing additional data points to platforms

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -150,8 +150,8 @@ function getAccount(validBidRequests) {
 }
 
 function getId5Id(validBidRequests) {
-  if (validBidRequests[0] && validBidRequests[0].userId && validBidRequests[0].userId.id5id) {
-    return validBidRequests[0].userId.id5id;
+  if (validBidRequests[0] && validBidRequests[0].userId && validBidRequests[0].userId.id5id && validBidRequests[0].userId.id5id.uid) {
+    return validBidRequests[0].userId.id5id.uid;
   }
 }
 

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -170,8 +170,8 @@ export const spec = {
       beaconParams.tdid = validBidRequests[0].userId.tdid;
     }
 
-    if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.id5id'))) {
-      beaconParams.id5id = validBidRequests[0].userId.id5id;
+    if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.id5id.uid'))) {
+      beaconParams.id5id = validBidRequests[0].userId.id5id.uid;
     }
 
     if (utils.isStr(utils.deepAccess(validBidRequests, '0.userId.idl_env'))) {

--- a/modules/avocetBidAdapter.js
+++ b/modules/avocetBidAdapter.js
@@ -77,8 +77,8 @@ export const spec = {
 
     // ID5 identifier
     let id5id;
-    if (bidRequests[0].userId && bidRequests[0].userId.id5id) {
-      id5id = bidRequests[0].userId.id5id;
+    if (bidRequests[0].userId && bidRequests[0].userId.id5id && bidRequests[0].userId.id5id.uid) {
+      id5id = bidRequests[0].userId.id5id.uid;
     }
 
     // Build the avocet ext object

--- a/modules/colossussspBidAdapter.js
+++ b/modules/colossussspBidAdapter.js
@@ -102,7 +102,7 @@ export const spec = {
       if (bid.userId) {
         getUserId(placement.eids, bid.userId.britepoolid, 'britepool.com');
         getUserId(placement.eids, bid.userId.idl_env, 'identityLink');
-        getUserId(placement.eids, bid.userId.id5id, 'id5-sync.com')
+        getUserId(placement.eids, utils.deepAccess(bid, 'userId.id5id.uid'), 'id5-sync.com', utils.deepAccess(bid, 'userId.id5id.ext'));
         getUserId(placement.eids, bid.userId.tdid, 'adserver.org', {
           rtiPartner: 'TDID'
         });

--- a/modules/districtmDMXBidAdapter.js
+++ b/modules/districtmDMXBidAdapter.js
@@ -106,7 +106,7 @@ export const spec = {
     let eids = [];
     if (bidRequest[0] && bidRequest[0].userId) {
       bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.idl_env`), 'liveramp.com', 1);
-      bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.id5id`), 'id5-sync.com', 1);
+      bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.id5id.uid`), 'id5-sync.com', 1);
       bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.pubcid`), 'pubcid.org', 1);
       bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.tdid`), 'adserver.org', 1);
       bindUserId(eids, utils.deepAccess(bidRequest[0], `userId.criteoId`), 'criteo.com', 1);

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -157,7 +157,7 @@ export const spec = {
 
       let eids = [];
       if (bidRequest && bidRequest.userId) {
-        addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id`), 'id5-sync.com', 'ID5ID');
+        addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id.uid`), 'id5-sync.com', 'ID5ID');
         addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.tdid`), 'adserver.org', 'TDID');
       }
       if (eids.length > 0) {

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -431,8 +431,8 @@ function buildNewRequest(validBidRequests, bidderRequest) {
     if (userId.tdid) {
       userExt.unifiedid = userId.tdid;
     }
-    if (userId.id5id) {
-      userExt.id5id = userId.id5id;
+    if (userId.id5id && userId.id5id.uid) {
+      userExt.id5id = userId.id5id.uid;
     }
     if (userId.digitrustid && userId.digitrustid.data && userId.digitrustid.data.id) {
       userExt.digitrustid = userId.digitrustid.data.id;

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -39,14 +39,27 @@ export const id5IdSubmodule = {
    * @returns {(Object|undefined)}
    */
   decode(value) {
+    let uid;
+    let linkType = 0;
+
     if (value && typeof value.ID5ID === 'string') {
       // don't lose our legacy value from cache
-      return { 'id5id': value.ID5ID };
+      uid = value.ID5ID;
     } else if (value && typeof value.universal_uid === 'string') {
-      return { 'id5id': value.universal_uid };
+      uid = value.universal_uid;
+      linkType = value.link_type || linkType;
     } else {
       return undefined;
     }
+
+    return {
+      'id5id': {
+        'uid': uid,
+        'ext': {
+          'linkType': linkType
+        }
+      }
+    };
   },
 
   /**

--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -277,7 +277,7 @@ function handleEids(bidRequests) {
   const bidRequest = bidRequests[0];
   if (bidRequest && bidRequest.userId) {
     AddExternalUserId(eids, utils.deepAccess(bidRequest, `userId.pubcid`), 'pubcommon', 1); // Also add this to eids
-    AddExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id`), 'id5-sync.com', 1);
+    AddExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id.uid`), 'id5-sync.com', 1);
   }
   if (eids.length > 0) {
     return {user: {ext: {eids}}};

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -281,6 +281,9 @@ function appendUserIdsToQueryParams(queryParams, userIds) {
         case 'parrableId':
           queryParams[key] = userIdObjectOrValue.eid;
           break;
+        case 'id5id':
+          queryParams[key] = userIdObjectOrValue.uid;
+          break;
         default:
           queryParams[key] = userIdObjectOrValue;
       }

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -539,7 +539,7 @@ export const spec = {
    */
   findAllUserIds(bidRequest) {
     var ret = {};
-    let searchKeysSingle = ['pubcid', 'tdid', 'id5id', 'parrableId', 'idl_env', 'digitrustid', 'criteortus'];
+    let searchKeysSingle = ['pubcid', 'tdid', 'parrableId', 'idl_env', 'digitrustid', 'criteortus'];
     if (bidRequest.hasOwnProperty('userId')) {
       for (let arrayId in searchKeysSingle) {
         let key = searchKeysSingle[arrayId];
@@ -550,6 +550,10 @@ export const spec = {
       var lipbid = utils.deepAccess(bidRequest.userId, 'lipb.lipbid');
       if (lipbid) {
         ret['lipb'] = {'lipbid': lipbid};
+      }
+      var id5id = utils.deepAccess(bidRequest.userId, 'id5id.uid');
+      if (id5id) {
+        ret['id5id'] = id5id;
       }
     }
     if (!ret.hasOwnProperty('pubcid')) {
@@ -675,7 +679,7 @@ export const spec = {
     if (bidRequest && bidRequest.userId) {
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.pubcid`), 'pubcid', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.pubcid`), 'pubcommon', 1);
-      this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id`), 'id5-sync.com', 1);
+      this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.id5id.uid`), 'id5-sync.com', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.criteortus.${BIDDER_CODE}.userid`), 'criteortus', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.idl_env`), 'liveramp.com', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.lipb.lipbid`), 'liveintent.com', 1);

--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -420,7 +420,7 @@ function user(bidRequest, bidderRequest) {
       addExternalUserId(ext.eids, bidRequest.userId.britepoolid, 'britepool.com');
       addExternalUserId(ext.eids, bidRequest.userId.criteoId, 'criteo');
       addExternalUserId(ext.eids, bidRequest.userId.idl_env, 'identityLink');
-      addExternalUserId(ext.eids, bidRequest.userId.id5id, 'id5-sync.com');
+      addExternalUserId(ext.eids, utils.deepAccess(bidRequest, 'userId.id5id.uid'), 'id5-sync.com', utils.deepAccess(bidRequest, 'userId.id5id.ext'));
       addExternalUserId(ext.eids, utils.deepAccess(bidRequest, 'userId.parrableId.eid'), 'parrable.com');
       // liveintent
       if (bidRequest.userId.lipb && bidRequest.userId.lipb.lipbid) {

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -201,7 +201,7 @@ function raiSetEids(bid) {
   let eids = [];
 
   if (bid && bid.userId) {
-    raiSetUserId(bid, eids, 'id5-sync.com', utils.deepAccess(bid, `userId.id5id`));
+    raiSetUserId(bid, eids, 'id5-sync.com', utils.deepAccess(bid, `userId.id5id.uid`));
     raiSetUserId(bid, eids, 'pubcommon', utils.deepAccess(bid, `userId.pubcid`));
     raiSetUserId(bid, eids, 'criteo.com', utils.deepAccess(bid, `userId.criteoId`));
     raiSetUserId(bid, eids, 'liveramp.com', utils.deepAccess(bid, `userId.idl_env`));

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -228,14 +228,15 @@ export const spec = {
       }
 
       // ID5 fied
-      if (bid && bid.userId && bid.userId.id5id) {
+      if (utils.deepAccess(bid, 'userId.id5id.uid')) {
         userExt.eids = userExt.eids || [];
         userExt.eids.push(
           {
             source: 'id5-sync.com',
             uids: [{
-              id: bid.userId.id5id
-            }]
+              id: bid.userId.id5id.uid
+            }],
+            ext: bid.userId.id5id.ext || {}
           }
         )
       }

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -30,8 +30,16 @@ const USER_IDS_CONFIG = {
 
   // id5Id
   'id5id': {
+    getValue: function(data) {
+      return data.uid
+    },
     source: 'id5-sync.com',
-    atype: 1
+    atype: 1,
+    getEidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
+    }
   },
 
   // parrableId

--- a/modules/vidazooBidAdapter.js
+++ b/modules/vidazooBidAdapter.js
@@ -117,6 +117,9 @@ function appendUserIdsToRequestPayload(payloadRef, userIds) {
         case 'parrableId':
           payloadRef[key] = userId.eid;
           break;
+        case 'id5id':
+          payloadRef[key] = userId.uid;
+          break;
         default:
           payloadRef[key] = userId;
       }

--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -100,8 +100,8 @@ export const spec = {
       if (payloadUserId.tdid) {
         payload.tdid = payloadUserId.tdid;
       }
-      if (payloadUserId.id5id) {
-        payload.id5 = payloadUserId.id5id;
+      if (payloadUserId.id5id && payloadUserId.id5id.uid) {
+        payload.id5 = payloadUserId.id5id.uid;
       }
       if (payloadUserId.digitrustid && payloadUserId.digitrustid.data && payloadUserId.digitrustid.data.id) {
         payload.dtid = payloadUserId.digitrustid.data.id;

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -116,7 +116,7 @@ describe('AdheseAdapter', function () {
     });
 
     it('should include id5 id as /x5 param', function () {
-      let req = spec.buildRequests([ bidWithParams({}, { 'id5id': 'ID5-1234567890' }) ], bidderRequest);
+      let req = spec.buildRequests([ bidWithParams({}, { 'id5id': { 'uid': 'ID5-1234567890' } }) ], bidderRequest);
 
       expect(JSON.parse(req.data).parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
     });

--- a/test/spec/modules/adxcgBidAdapter_spec.js
+++ b/test/spec/modules/adxcgBidAdapter_spec.js
@@ -281,7 +281,7 @@ describe('AdxcgAdapter', function () {
     let bid = deepClone([bidBanner]);
     let bidderRequests = {};
 
-    bid[0].userId = {id5id: 'id5idsample'};
+    bid[0].userId = {id5id: {uid: 'id5idsample'}};
 
     it('should send pubcid if available', function () {
       let request = spec.buildRequests(bid, bidderRequests);

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -224,7 +224,7 @@ describe('AmxBidAdapter', () => {
         britepoolid: 'sample-britepool',
         criteoId: 'sample-criteo',
         digitrustid: {data: {id: 'sample-digitrust'}},
-        id5id: 'sample-id5',
+        id5id: {uid: 'sample-id5'},
         idl_env: 'sample-liveramp',
         lipb: {lipbid: 'sample-liveintent'},
         netId: 'sample-netid',

--- a/test/spec/modules/avocetBidAdapter_spec.js
+++ b/test/spec/modules/avocetBidAdapter_spec.js
@@ -69,7 +69,9 @@ describe('Avocet adapter', function () {
               placement: '012345678901234567890123',
             },
             userId: {
-              id5id: 'test'
+              id5id: {
+                uid: 'test'
+              }
             }
           },
           {

--- a/test/spec/modules/colossussspBidAdapter_spec.js
+++ b/test/spec/modules/colossussspBidAdapter_spec.js
@@ -108,7 +108,7 @@ describe('ColossussspAdapter', function () {
     bid.userId.britepoolid = 'britepoolid123';
     bid.userId.idl_env = 'idl_env123';
     bid.userId.tdid = 'tdid123';
-    bid.userId.id5id = 'id5id123'
+    bid.userId.id5id = { uid: 'id5id123' };
     let serverRequest = spec.buildRequests([bid], bidderRequest);
     it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;

--- a/test/spec/modules/districtmDmxBidAdapter_spec.js
+++ b/test/spec/modules/districtmDmxBidAdapter_spec.js
@@ -103,7 +103,9 @@ const bidRequest = [{
         id: {}
       }
     },
-    id5id: {},
+    id5id: {
+      uid: ''
+    },
     pubcid: {},
     tdid: {},
     criteoId: {},

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -29,15 +29,39 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
-  it('id5Id', function() {
-    const userId = {
-      id5id: 'some-random-id-value'
-    };
-    const newEids = createEidsArray(userId);
-    expect(newEids.length).to.equal(1);
-    expect(newEids[0]).to.deep.equal({
-      source: 'id5-sync.com',
-      uids: [{id: 'some-random-id-value', atype: 1}]
+  describe('id5Id', function() {
+    it('does not include an ext if not provided', function() {
+      const userId = {
+        id5id: {
+          uid: 'some-random-id-value'
+        }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'id5-sync.com',
+        uids: [{ id: 'some-random-id-value', atype: 1 }]
+      });
+    });
+
+    it('includes ext if provided', function() {
+      const userId = {
+        id5id: {
+          uid: 'some-random-id-value',
+          ext: {
+            linkType: 0
+          }
+        }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'id5-sync.com',
+        uids: [{ id: 'some-random-id-value', atype: 1 }],
+        ext: {
+          linkType: 0
+        }
+      });
     });
   });
 

--- a/test/spec/modules/gamoshiBidAdapter_spec.js
+++ b/test/spec/modules/gamoshiBidAdapter_spec.js
@@ -423,7 +423,7 @@ describe('GamoshiAdapter', () => {
     it('build request with ID5 Id', () => {
       const bidRequestClone = utils.deepClone(bidRequest);
       bidRequestClone.userId = {};
-      bidRequestClone.userId.id5id = 'id5-user-id';
+      bidRequestClone.userId.id5id = { uid: 'id5-user-id' };
       let request = spec.buildRequests([bidRequestClone], bidRequestClone)[0];
       expect(request.data.user.ext.eids).to.deep.equal([{
         'source': 'id5-sync.com',

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -536,7 +536,7 @@ describe('TheMediaGrid Adapter', function () {
       const bidRequestsWithUserIds = bidRequests.map((bid) => {
         return Object.assign({
           userId: {
-            id5id: 'id5id_1',
+            id5id: { uid: 'id5id_1' },
             tdid: 'tdid_1',
             digitrustid: {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
             lipb: {lipbid: 'lipb_1'}

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -50,7 +50,9 @@ describe('ID5 ID System', function() {
     return {
       name: ID5_MODULE_NAME,
       value: {
-        id5id: value
+        id5id: {
+          uid: value
+        }
       }
     }
   }
@@ -238,10 +240,13 @@ describe('ID5 ID System', function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-            expect(bid.userId.id5id).to.equal(ID5_STORED_ID);
+            expect(bid.userId.id5id.uid).to.equal(ID5_STORED_ID);
             expect(bid.userIdAsEids[0]).to.deep.equal({
               source: ID5_SOURCE,
-              uids: [{ id: ID5_STORED_ID, atype: 1 }]
+              uids: [{ id: ID5_STORED_ID, atype: 1 }],
+              ext: {
+                linkType: 0
+              }
             });
           });
         });
@@ -258,7 +263,7 @@ describe('ID5 ID System', function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-            expect(bid.userId.id5id).to.equal(ID5_STORED_ID);
+            expect(bid.userId.id5id.uid).to.equal(ID5_STORED_ID);
             expect(bid.userIdAsEids[0]).to.deep.equal({
               source: ID5_SOURCE,
               uids: [{ id: ID5_STORED_ID, atype: 1 }]
@@ -368,13 +373,13 @@ describe('ID5 ID System', function() {
   });
 
   describe('Decode stored object', function() {
-    const decodedObject = { 'id5id': ID5_STORED_ID };
+    const expectedDecodedObject = { id5id: { uid: ID5_STORED_ID, ext: { linkType: 0 } } };
 
     it('should properly decode from a stored object', function() {
-      expect(id5IdSubmodule.decode(ID5_STORED_OBJ)).to.deep.equal(decodedObject);
+      expect(id5IdSubmodule.decode(ID5_STORED_OBJ)).to.deep.equal(expectedDecodedObject);
     });
     it('should properly decode from a legacy stored object', function() {
-      expect(id5IdSubmodule.decode(ID5_LEGACY_STORED_OBJ)).to.deep.equal(decodedObject);
+      expect(id5IdSubmodule.decode(ID5_LEGACY_STORED_OBJ)).to.deep.equal(expectedDecodedObject);
     });
     it('should return undefined if passed a string', function() {
       expect(id5IdSubmodule.decode('somestring')).to.eq(undefined);

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -21,7 +21,9 @@ describe('justpremium adapter', function () {
       },
       userId: {
         tdid: '1111111',
-        id5id: '2222222',
+        id5id: {
+          uid: '2222222'
+        },
         digitrustid: {
           data: {
             id: '3333333'
@@ -84,7 +86,7 @@ describe('justpremium adapter', function () {
       expect(jpxRequest.version.jp_adapter).to.equal('1.7')
       expect(jpxRequest.pubcid).to.equal('0000000')
       expect(jpxRequest.uids.tdid).to.equal('1111111')
-      expect(jpxRequest.uids.id5id).to.equal('2222222')
+      expect(jpxRequest.uids.id5id.uid).to.equal('2222222')
       expect(jpxRequest.uids.digitrustid.data.id).to.equal('3333333')
       expect(jpxRequest.us_privacy).to.equal('1YYN')
     })

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -787,7 +787,7 @@ describe('Livewrapped adapter tests', function () {
     let testbidRequest = clone(bidderRequest);
     delete testbidRequest.bids[0].params.userId;
     testbidRequest.bids[0].userId = {};
-    testbidRequest.bids[0].userId.id5id = 'id5-user-id';
+    testbidRequest.bids[0].userId.id5id = { uid: 'id5-user-id' };
     let result = spec.buildRequests(testbidRequest.bids, testbidRequest);
     let data = JSON.parse(result.data);
 

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -53,7 +53,7 @@ describe('MediaSquare bid adapter tests', function () {
       canonicalUrl: 'https://www.prebid.org/the/link/to/the/page'
     },
     uspConsent: '111222333',
-    userId: {'id5id': '1111'},
+    userId: { 'id5id': { uid: '1111' } },
     schain: {
       'ver': '1.0',
       'complete': 1,

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1043,7 +1043,7 @@ describe('OpenxAdapter', function () {
         britepoolid: '1111-britepoolid',
         criteoId: '1111-criteoId',
         digitrustid: {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
-        id5id: '1111-id5id',
+        id5id: {uid: '1111-id5id'},
         idl_env: '1111-idl_env',
         lipb: {lipbid: '1111-lipb'},
         netId: 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
@@ -1095,6 +1095,9 @@ describe('OpenxAdapter', function () {
                 break;
               case 'parrableId':
                 userIdValue = EXAMPLE_DATA_BY_ATTR.parrableId.eid;
+                break;
+              case 'id5id':
+                userIdValue = EXAMPLE_DATA_BY_ATTR.id5id.uid;
                 break;
               default:
                 userIdValue = EXAMPLE_DATA_BY_ATTR[userIdProviderKey];

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -66,7 +66,7 @@ var validBidRequestsWithUserIdData = [
     params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87',
-    userId: {'pubcid': '12345678', 'id5id': 'ID5-someId', 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableId': {eid: 'parrableid123'}}
+    userId: {'pubcid': '12345678', 'id5id': { 'uid': 'ID5-someId' }, 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableId': {eid: 'parrableid123'}}
   }
 ];
 var validBidRequestsMinimal = [
@@ -297,7 +297,7 @@ var validBidderRequest1OutstreamVideo2020 = {
           }
         },
         'userId': {
-          'id5id': 'ID5-ZHMOpSv9CkZNiNd1oR4zc62AzCgSS73fPjmQ6Od7OA',
+          'id5id': { uid: 'ID5-ZHMOpSv9CkZNiNd1oR4zc62AzCgSS73fPjmQ6Od7OA' },
           'pubcid': '2ada6ae6-aeca-4e07-8922-a99b3aaf8a56'
         },
         'userIdAsEids': [
@@ -2118,7 +2118,7 @@ describe('ozone Adapter', function () {
       bidRequests[0]['userId'] = {
         'criteortus': '1111',
         'digitrustid': {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
-        'id5id': '2222',
+        'id5id': {'uid': '2222'},
         'idl_env': '3333',
         'lipb': {'lipbid': '4444'},
         'parrableId': {eid: 'eidVersion.encryptionKeyReference.encryptedValue'},
@@ -2138,7 +2138,7 @@ describe('ozone Adapter', function () {
       bidRequests[0]['userId'] = {
         'criteortus': '1111',
         'digitrustid': {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
-        'id5id': '2222',
+        'id5id': {'uid': '2222'},
         'idl_env': '3333',
         'lipb': {'lipbid': '4444'},
         'parrableId': {eid: 'eidVersion.encryptionKeyReference.encryptedValue'},

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1178,7 +1178,13 @@ describe('S2S Adapter', function () {
           lipbid: 'li-xyz',
           segments: ['segA', 'segB']
         },
-        idl_env: '0000-1111-2222-3333'
+        idl_env: '0000-1111-2222-3333',
+        id5id: {
+          uid: '11111',
+          ext: {
+            linkType: 'some-link-type'
+          }
+        }
       };
       userIdBidRequest[0].bids[0].userIdAsEids = createEidsArray(userIdBidRequest[0].bids[0].userId);
 
@@ -1199,6 +1205,9 @@ describe('S2S Adapter', function () {
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveintent.com')[0].ext.segments.length).is.equal(2);
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveintent.com')[0].ext.segments[0]).is.equal('segA');
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveintent.com')[0].ext.segments[1]).is.equal('segB');
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')).is.not.empty;
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')[0].uids[0].id).is.equal('11111');
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')[0].ext.linkType).is.equal('some-link-type');
       // LiveRamp should exist
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveramp.com')[0].uids[0].id).is.equal('0000-1111-2222-3333');
     });

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1605,7 +1605,7 @@ describe('PubMatic adapter', function () {
         describe('ID5 Id', function() {
           it('send the id5 id if it is present', function() {
             bidRequests[0].userId = {};
-            bidRequests[0].userId.id5id = 'id5-user-id';
+            bidRequests[0].userId.id5id = { uid: 'id5-user-id' };
             bidRequests[0].userIdAsEids = createEidsArray(bidRequests[0].userId);
             let request = spec.buildRequests(bidRequests, {});
             let data = JSON.parse(request.data);
@@ -1620,22 +1620,22 @@ describe('PubMatic adapter', function () {
 
           it('do not pass if not string', function() {
             bidRequests[0].userId = {};
-            bidRequests[0].userId.id5id = 1;
+            bidRequests[0].userId.id5id = { uid: 1 };
             bidRequests[0].userIdAsEids = createEidsArray(bidRequests[0].userId);
             let request = spec.buildRequests(bidRequests, {});
             let data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.id5id = [];
+            bidRequests[0].userId.id5id = { uid: [] };
             bidRequests[0].userIdAsEids = createEidsArray(bidRequests[0].userId);
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.id5id = null;
+            bidRequests[0].userId.id5id = { uid: null };
             bidRequests[0].userIdAsEids = createEidsArray(bidRequests[0].userId);
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.id5id = {};
+            bidRequests[0].userId.id5id = { uid: {} };
             bidRequests[0].userIdAsEids = createEidsArray(bidRequests[0].userId);
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -630,7 +630,7 @@ describe('PulsePoint Adapter Tests', function () {
       britepoolid: 'britepool_id123',
       criteoId: 'criteo_id234',
       idl_env: 'idl_id123',
-      id5id: 'id5id_234',
+      id5id: { uid: 'id5id_234' },
       parrableId: { eid: 'parrable_id234' },
       lipb: {
         lipbid: 'liveintent_id123'

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -357,7 +357,7 @@ describe('Richaudience adapter tests', function () {
     });
     it('Verify build id5', function () {
       DEFAULT_PARAMS_WO_OPTIONAL[0].userId = {};
-      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = 'id5-user-id';
+      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = { uid: 'id5-user-id' };
 
       var request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, DEFAULT_PARAMS_GDPR);
       var requestContent = JSON.parse(request[0].data);
@@ -369,13 +369,23 @@ describe('Richaudience adapter tests', function () {
 
       var request;
       DEFAULT_PARAMS_WO_OPTIONAL[0].userId = {};
-      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = 1;
+      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = { uid: 1 };
       request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, DEFAULT_PARAMS_GDPR);
       var requestContent = JSON.parse(request[0].data);
 
       expect(requestContent.user.eids).to.equal(undefined);
 
-      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = [];
+      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = { uid: [] };
+      request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, DEFAULT_PARAMS_GDPR);
+      requestContent = JSON.parse(request[0].data);
+      expect(requestContent.user.eids).to.equal(undefined);
+
+      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = { uid: null };
+      request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, DEFAULT_PARAMS_GDPR);
+      requestContent = JSON.parse(request[0].data);
+      expect(requestContent.user.eids).to.equal(undefined);
+
+      DEFAULT_PARAMS_WO_OPTIONAL[0].userId.id5id = { uid: {} };
       request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, DEFAULT_PARAMS_GDPR);
       requestContent = JSON.parse(request[0].data);
       expect(requestContent.user.eids).to.equal(undefined);

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -71,7 +71,7 @@ describe('Smart bid adapter tests', function () {
       britepoolid: '1111',
       criteoId: '1111',
       digitrustid: { data: { id: 'DTID', keyv: 4, privacy: { optout: false }, producer: 'ABC', version: 2 } },
-      id5id: '1111',
+      id5id: { uid: '1111' },
       idl_env: '1111',
       lipbid: '1111',
       parrableid: 'eidVersion.encryptionKeyReference.encryptedValue',

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -152,7 +152,7 @@ describe('the spotx adapter', function () {
       };
 
       bid.userId = {
-        id5id: 'id5id_1',
+        id5id: { uid: 'id5id_1' },
         tdid: 'tdid_1'
       };
 
@@ -202,7 +202,8 @@ describe('the spotx adapter', function () {
           source: 'id5-sync.com',
           uids: [{
             id: 'id5id_1'
-          }]
+          }],
+          ext: {}
         },
         {
           source: 'adserver.org',

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -94,7 +94,8 @@ const bidReqUserIds = [{
   userId: {
     idl_env: '1111',
     tdid: '123456',
-    digitrustid: {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}}
+    digitrustid: {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}},
+    id5id: { uid: '1111' }
   }
 },
 {
@@ -316,6 +317,7 @@ describe('Undertone Adapter', () => {
       expect(bidCommons.uids.tdid).to.equal('123456');
       expect(bidCommons.uids.idl_env).to.equal('1111');
       expect(bidCommons.uids.digitrustid.data.id).to.equal('DTID');
+      expect(bidCommons.uids.id5id.uid).to.equal('1111');
     });
     it('should send page sizes sizes correctly', function () {
       const request = spec.buildRequests(bidReqUserIds, bidderReq);

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1235,8 +1235,8 @@ describe('User ID', function() {
             expect(bid).to.have.deep.nested.property('userId.tdid');
             expect(bid.userId.tdid).to.equal('testunifiedid');
             // also check that Id5Id id data was copied to bid
-            expect(bid).to.have.deep.nested.property('userId.id5id');
-            expect(bid.userId.id5id).to.equal('testid5id');
+            expect(bid).to.have.deep.nested.property('userId.id5id.uid');
+            expect(bid.userId.id5id.uid).to.equal('testid5id');
             // check that identityLink id data was copied to bid
             expect(bid).to.have.deep.nested.property('userId.idl_env');
             expect(bid.userId.idl_env).to.equal('AiGNC8Z5ONyZKSpIPf');
@@ -1328,8 +1328,8 @@ describe('User ID', function() {
             expect(bid).to.have.deep.nested.property('userId.tdid');
             expect(bid.userId.tdid).to.equal('cookie-value-add-module-variations');
             // also check that Id5Id id data was copied to bid
-            expect(bid).to.have.deep.nested.property('userId.id5id');
-            expect(bid.userId.id5id).to.equal('testid5id');
+            expect(bid).to.have.deep.nested.property('userId.id5id.uid');
+            expect(bid.userId.id5id.uid).to.equal('testid5id');
             // also check that identityLink id data was copied to bid
             expect(bid).to.have.deep.nested.property('userId.idl_env');
             expect(bid.userId.idl_env).to.equal('AiGNC8Z5ONyZKSpIPf');
@@ -1461,8 +1461,8 @@ describe('User ID', function() {
             expect(bid).to.have.deep.nested.property('userId.tdid');
             expect(bid.userId.tdid).to.equal('cookie-value-add-module-variations');
             // also check that Id5Id id data was copied to bid
-            expect(bid).to.have.deep.nested.property('userId.id5id');
-            expect(bid.userId.id5id).to.equal('testid5id');
+            expect(bid).to.have.deep.nested.property('userId.id5id.uid');
+            expect(bid.userId.id5id.uid).to.equal('testid5id');
             // also check that identityLink id data was copied to bid
             expect(bid).to.have.deep.nested.property('userId.idl_env');
             expect(bid.userId.idl_env).to.equal('AiGNC8Z5ONyZKSpIPf');

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -79,7 +79,7 @@ const REQUEST = {
   }
 };
 
-describe('VidazooBidAdapter', function () {
+describe.only('VidazooBidAdapter', function () {
   describe('validtae spec', function () {
     it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
@@ -244,6 +244,7 @@ describe('VidazooBidAdapter', function () {
           case 'digitrustid': return { data: { id: id } };
           case 'lipb': return { lipbid: id };
           case 'parrableId': return { eid: id };
+          case 'id5id': return { uid: id };
           default: return id;
         }
       })();

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -79,7 +79,7 @@ const REQUEST = {
   }
 };
 
-describe.only('VidazooBidAdapter', function () {
+describe('VidazooBidAdapter', function () {
   describe('validtae spec', function () {
     it('exists and is a function', function () {
       expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -231,7 +231,7 @@ describe('VisxAdapter', function () {
       const schainBidRequests = [
         Object.assign({userId: {
           tdid: '111',
-          id5id: '222',
+          id5id: { uid: '222' },
           digitrustid: {data: {id: 'DTID', keyv: 4, privacy: {optout: false}, producer: 'ABC', version: 2}}
         }}, bidRequests[0]),
         bidRequests[1],

--- a/test/spec/modules/yuktamediaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/yuktamediaAnalyticsAdapter_spec.js
@@ -30,7 +30,7 @@ let prebidAuction = {
           }
         },
         'userId': {
-          'id5id': 'ID5-ZHMOxXeRXPe3inZKGD-Lj0g7y8UWdDbsYXQ_n6aWMQ',
+          'id5id': { uid: 'ID5-ZHMOxXeRXPe3inZKGD-Lj0g7y8UWdDbsYXQ_n6aWMQ' },
           'parrableid': '01.1595590997.46d951017bdc272ca50b88dbcfb0545cfc636bec3e3d8c02091fb1b413328fb2fd3baf65cb4114b3f782895fd09f82f02c9042b85b42c4654d08ba06dc77f0ded936c8ea3fc4085b4a99',
           'pubcid': '100a8bc9-f588-4c22-873e-a721cb68bc34'
         },


### PR DESCRIPTION
## Type of change
- [ x ] Feature
- [ x ] Refactoring (no functional changes, no api changes)

## Description of change
Updating the response that the ID5 ID modules provides to bid adapters from a simple string to an object. The purpose of this is to include other pieces of information that may be useful to bid adapters/SSPs and downstream DSPs as well. Extra values are placed in an `ext` in both the `userId.id5id` object and in the `userIdsAsEids` array. Currently, we are passing a `linkType` value in the extension, which represents the type of link we were able to make for the user across domains, indicating the strength/accuracy/value of the ID. In the future, we plan to include additional signals/data points as well.

In order to support this change, all bidder adapters currently listening to the ID5 ID were also modified. It is not required to listen to the `ext`, so in most cases the adapters (and / or their tests) were just updated to read the id string from the object to keep things simple. There should be no functional changes to any bidder adapter, except for those who already supported listening to extensions, they will now get the ID5 ID extension passed in.