### PR TITLE
ZeopTapId: Fix broken unit tests

### DIFF
--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -9,7 +9,7 @@ import {submodule} from '../src/hook.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const ZEOTAP_COOKIE_NAME = 'IDP';
-const storage = getStorageManager();
+export const storage = getStorageManager();
 
 function readCookie() {
   return storage.cookiesAreEnabled ? storage.getCookie(ZEOTAP_COOKIE_NAME) : null;


### PR DESCRIPTION


## Type of change
- [X] Bugfix

## Description of change
The zeoTap Id system was relying on storageManager to be directly writing cookies in all browsers. This caused circleCi to fail.

So, the real thing all UNIT tests should be doing is mocking their storage manager.

This PR mocks the storage utilities necessary in the zeotap spec file.