### PR TITLE
Allow selection of supported default targeting keys at configuration time.

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -188,9 +188,10 @@ export function newTargeting(auctionManager) {
    * @return {targetingArray} filtered targeting
    */
   function getAllowedTargetingKeyValues(targeting, allowedKeys) {
-    logInfo(`Allowed default targeting keys [ ${allowedKeys.join(', ')}]`);
     const defaultKeyring = Object.assign({}, CONSTANTS.TARGETING_KEYS, CONSTANTS.NATIVE_KEYS);
     const defaultKeys = Object.keys(defaultKeyring);
+    const keyDispositions = {};
+    logInfo(`allowTargetingKeys - allowed keys [ ${allowedKeys.map(k => defaultKeyring[k]).join(', ')} ]`);
     targeting.map(adUnit => {
       const adUnitCode = Object.keys(adUnit)[0];
       const keyring = adUnit[adUnitCode];
@@ -206,18 +207,17 @@ export function newTargeting(auctionManager) {
           const found = key.indexOf(allowedKeyName) === 0;
           return found;
         });
-        const keyDisposition = found ? 'Keeping' : 'Removing';
-        const keyType = isCustom ? 'custom' : 'default';
-        logInfo(`${keyDisposition} ${keyType} targeting key ${key} for ${adUnitCode} adserverTargeting object`);
+        keyDispositions[key] = !found;
         return found;
       });
       adUnit[adUnitCode] = keys;
     });
+    const removedKeys = Object.keys(keyDispositions).filter(d => keyDispositions[d]);
+    logInfo(`allowTargetingKeys - removed keys [ ${removedKeys.join(', ')} ]`);
+    // remove any empty targeting objects, as they're unnecessary.
     const filteredTargeting = targeting.filter(adUnit => {
       const adUnitCode = Object.keys(adUnit)[0];
       const keyring = adUnit[adUnitCode];
-      const targetingObjectDisposition = keyring.length > 0 ? 'Keeping populated' : 'Removing empty';
-      logInfo(`${targetingObjectDisposition} ${adUnitCode} adserverTargeting object`);
       return keyring.length > 0;
     });
     return filteredTargeting

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -416,6 +416,46 @@ describe('targeting tests', function () {
       });
     });
 
+    describe('targetingControls.allowTargetingKeys', function () {
+      let bid4;
+
+      beforeEach(function() {
+        bid4 = utils.deepClone(bid1);
+        bid4.adserverTargeting = {
+          hb_deal: '4321',
+          hb_pb: '0.1',
+          hb_adid: '567891011',
+          hb_bidder: 'appnexus',
+        };
+        bid4.bidder = bid4.bidderCode = 'appnexus';
+        bid4.cpm = 0.1; // losing bid so not included if enableSendAllBids === false
+        bid4.dealId = '4321';
+        enableSendAllBids = true;
+        config.setConfig({
+          targetingControls: {
+            allowTargetingKeys: ['BIDDER', 'AD_ID', 'PRICE_BUCKET']
+          }
+        });
+        bidsReceived.push(bid4);
+      });
+
+      it('targeting should include custom keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('foobar');
+      });
+
+      it('targeting should include explicily listed default targeting keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_rubicon', 'hb_adid_rubicon', 'hb_pb_rubicon');
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_appnexus', 'hb_adid_appnexus', 'hb_pb_appnexus');
+      });
+
+      it('targeting should not include unlisted default targeting keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_deal_appnexus', 'hb_deal_rubicon']);
+      });
+    });
+
     describe('targetingControls.alwaysIncludeDeals', function () {
       let bid4;
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -444,13 +444,13 @@ describe('targeting tests', function () {
         expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('foobar');
       });
 
-      it('targeting should include explicily listed default targeting keys', function () {
+      it('targeting should include keys prefixed by allowed default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
         expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_rubicon', 'hb_adid_rubicon', 'hb_pb_rubicon');
         expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_appnexus', 'hb_adid_appnexus', 'hb_pb_appnexus');
       });
 
-      it('targeting should not include unlisted default targeting keys', function () {
+      it('targeting should not include keys prefixed by disallowed default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
         expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_deal_appnexus', 'hb_deal_rubicon']);
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Prebid default targeting includes keys that are not be needed by all publishers. The inclusion of these keys and their corresponding values can lead to /gampad/ads requests being truncated. Publishers in this situation would benefit from an option that allows them to select which default keys they would like to employ.

The change allows publishers to select the default keys they would like to support, without changing how those keys are generated or subsequently managed.

Prebid.github.io PR here:
https://github.com/prebid/prebid.github.io/pull/2346

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Based on I2I here: https://github.com/prebid/Prebid.js/issues/5670
