### PR TITLE
Smaato bid adapter: Optional bidder params to support in-app webview use cases

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -110,6 +110,13 @@ const buildOpenRtbBidRequestPayload = (validBidRequests, bidderRequest) => {
     utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
   }
 
+  if (utils.deepAccess(validBidRequests[0], 'params.app')) {
+    const geo = utils.deepAccess(validBidRequests[0], 'params.app.geo');
+    utils.deepSetValue(request, 'device.geo', geo);
+    const ifa = utils.deepAccess(validBidRequests[0], 'params.app.ifa')
+    utils.deepSetValue(request, 'device.ifa', ifa);
+  }
+
   utils.logInfo('[SMAATO] OpenRTB Request:', request);
   return JSON.stringify(request);
 }
@@ -185,7 +192,7 @@ export const spec = {
           ttl: ttlSec,
           creativeId: b.crid,
           dealId: b.dealid || null,
-          netRevenue: true,
+          netRevenue: utils.deepAccess(b, 'ext.net', true),
           currency: res.cur,
           meta: {
             advertiserDomains: b.adomain,


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
We have clients who want to use Prebid.js inside an app's webview and transmit geo info or device ids that they may be able to use in this case.

In order to support this, we accept a new `app` object as an optional bidder param where they can add this additional info.
The params object of an adUnit making use of this feature would look like this:

```
  params: {
    publisherId: 'publisherId',
    adspaceId: 'adspaceId',
    app: {
      ifa: 'aDeviceId',
      geo: {
        lat: 33.3,
        lon: -88.8
      }
    }
  }
```

There is also a small change which will set the netRevenue in the bid we return dynamically depending on what the response of the endpoint was. Some of our publishers may have gross bids (also discovered we can't do this in prebid-server yet). 

There is a related PR in the docs repo: https://github.com/prebid/prebid.github.io/pull/2347