### PR TITLE
Quantumdex Bid Adapter: Change the data type of gdpr and schain object in Payload

### DIFF
--- a/modules/quantumdexBidAdapter.js
+++ b/modules/quantumdexBidAdapter.js
@@ -85,14 +85,14 @@ export const spec = {
     // Apply GDPR parameters to request.
     payload.gdpr = {};
     if (bidderRequest && bidderRequest.gdprConsent) {
-      payload.gdpr.gdprApplies = bidderRequest.gdprConsent.gdprApplies ? 'true' : 'false';
+      payload.gdpr.gdprApplies = !!bidderRequest.gdprConsent.gdprApplies;
       if (bidderRequest.gdprConsent.consentString) {
         payload.gdpr.consentString = bidderRequest.gdprConsent.consentString;
       }
     }
     // Apply schain.
     if (bids[0].schain) {
-      payload.schain = JSON.stringify(bids[0].schain)
+      payload.schain = bids[0].schain
     }
     // Apply us_privacy.
     if (bidderRequest && bidderRequest.uspConsent) {

--- a/test/spec/modules/quantumdexBidAdapter_spec.js
+++ b/test/spec/modules/quantumdexBidAdapter_spec.js
@@ -244,7 +244,7 @@ describe('QuantumdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
       expect(bidRequests.method).to.equal('POST')
-      expect(bidRequests.data.gdpr.gdprApplies).to.equal('true')
+      expect(bidRequests.data.gdpr.gdprApplies).to.equal(true)
       expect(bidRequests.data.gdpr.consentString).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
     })
 
@@ -253,7 +253,7 @@ describe('QuantumdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
       expect(bidRequests.method).to.equal('POST')
-      expect(bidRequests.data.gdpr.gdprApplies).to.equal('false')
+      expect(bidRequests.data.gdpr.gdprApplies).to.equal(false)
       expect(bidRequests.data.gdpr.consentString).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
     })
     it('should return a properly formatted request with GDPR applies set to false with no consent_string param', function () {
@@ -273,7 +273,7 @@ describe('QuantumdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
       expect(bidRequests.method).to.equal('POST')
-      expect(bidRequests.data.gdpr.gdprApplies).to.equal('false')
+      expect(bidRequests.data.gdpr.gdprApplies).to.equal(false)
       expect(bidRequests.data.gdpr).to.not.include.keys('consentString')
     })
     it('should return a properly formatted request with GDPR applies set to true with no consentString param', function () {
@@ -293,12 +293,12 @@ describe('QuantumdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
       expect(bidRequests.method).to.equal('POST')
-      expect(bidRequests.data.gdpr.gdprApplies).to.equal('true')
+      expect(bidRequests.data.gdpr.gdprApplies).to.equal(true)
       expect(bidRequests.data.gdpr).to.not.include.keys('consentString')
     })
     it('should return a properly formatted request with schain defined', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(JSON.parse(bidRequests.data.schain)).to.deep.equal(bidRequest[0].schain)
+      expect(bidRequests.data.schain).to.deep.equal(bidRequest[0].schain)
     });
     it('should return a properly formatted request with us_privacy included', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
I update a little bit of data type of object gdpr and object schain in Payload data sent to endpoint. This helps to normalize my endpoint data handling
