### PR TITLE
Reconciliation Real Time Data Provider

### DIFF
--- a/integrationExamples/gpt/reconciliationRtdProvider_example.html
+++ b/integrationExamples/gpt/reconciliationRtdProvider_example.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script async src="../../build/dev/prebid.js"></script>
+    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <meta charset="UTF-8">
+    <title>Reconciliation RTD Provider Example</title>
+    <script>
+      var FAILSAFE_TIMEOUT = 3300;
+      var PREBID_TIMEOUT = 1000;
+
+      var adUnits = [{
+        code: "/21834411153/rsdk-2",
+        mediaTypes: {
+        banner: {
+            sizes: [
+            [300, 250],
+            [728, 90],
+            ],
+        },
+        },
+        // Replace this object to test a new Adapter!
+        bids: [{
+          bidder: 'appnexus',
+          params: {
+            placementId: 13144370
+          }
+        }]
+
+      }];
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+
+    </script>
+
+    <script>
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+      });
+
+      pbjs.que.push(function() {
+        pbjs.setConfig({
+          realTimeData: {
+            auctionDelay: 0,
+            dataProviders: [
+              {
+                name: "reconciliation",
+                params: {
+                  publisherMemberId: "test_prebid_publisher",
+                  allowAccess: true
+                },
+              },
+            ],
+          },
+        });
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({
+          bidsBackHandler: sendAdserverRequest,
+          timeout: PREBID_TIMEOUT
+        });
+      });
+
+      function sendAdserverRequest() {
+        if (pbjs.adserverRequestSent) return;
+        pbjs.adserverRequestSent = true;
+        googletag.cmd.push(function() {
+          pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        });
+      }
+
+      setTimeout(function() {
+        sendAdserverRequest();
+      }, FAILSAFE_TIMEOUT);
+
+    </script>
+
+    <script>
+      googletag.cmd.push(function () {
+        googletag.defineSlot('/21834411153/rsdk-2', [[300, 250], [728, 90]], 'div-gpt-ad-rsdk-1').addService(googletag.pubads());
+
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+    </script>
+</head>
+
+<body>
+<h5>Div-1</h5>
+<div id='div-gpt-ad-rsdk-1'>
+    <script type='text/javascript'>
+      googletag.cmd.push(function() { googletag.display('div-gpt-ad-rsdk-1'); });
+    </script>
+</div>
+</body>
+</html>

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -24,6 +24,7 @@
   "rtdModule": [
     "browsiRtdProvider",
     "audigentRtdProvider",
-    "jwplayerRtdProvider"
+    "jwplayerRtdProvider",
+    "reconciliationRtdProvider"
   ]
 }

--- a/modules/reconciliationRtdProvider.js
+++ b/modules/reconciliationRtdProvider.js
@@ -1,0 +1,338 @@
+/**
+ * This module adds reconciliation provider to the real time data module
+ * The {@link module:modules/realTimeData} module is required
+ * The module will add custom targetings to ad units
+ * The module will listen to post messages from rendered creatives with Reconciliation Tag
+ * The module will call tracking pixels to log info needed for reconciliation matching
+ * @module modules/reconciliationRtdProvider
+ * @requires module:modules/realTimeData
+ */
+
+/**
+ * @typedef {Object} ModuleParams
+ * @property {string} publisherMemberId
+ * @property {?string} initUrl
+ * @property {?string} impressionUrl
+ * @property {?boolean} allowAccess
+ */
+
+import { submodule } from '../src/hook.js';
+import { config } from '../src/config.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import * as utils from '../src/utils.js';
+import find from 'core-js-pure/features/array/find.js';
+
+/** @type {string} */
+const MODULE_NAME = 'realTimeData';
+/** @type {string} */
+const SUBMODULE_NAME = 'reconciliation';
+/** @type {Object} */
+const MessageType = {
+  IMPRESSION_REQUEST: 'rsdk:impression:req',
+  IMPRESSION_RESPONSE: 'rsdk:impression:res',
+};
+/** @type {ModuleParams} */
+const DEFAULT_PARAMS = {
+  initUrl: 'https://confirm.fiduciadlt.com/init',
+  impressionUrl: 'https://confirm.fiduciadlt.com/imp',
+  allowAccess: false,
+};
+/** @type {ModuleParams} */
+let _moduleParams = {};
+
+/**
+ * Handle postMesssage from ad creative, track impression
+ * and send response to reconciliation ad tag
+ * @param {Event} e
+ */
+function handleAdMessage(e) {
+  let data = {};
+  let adUnitId = '';
+  let adDeliveryId = '';
+
+  try {
+    data = JSON.parse(e.data);
+  } catch (e) {
+    return;
+  }
+
+  if (data.type === MessageType.IMPRESSION_REQUEST) {
+    if (utils.isGptPubadsDefined()) {
+      // 1. Find the last iframed window before window.top where the tracker was injected
+      // (the tracker could be injected in nested iframes)
+      const adWin = getTopIFrameWin(e.source);
+      if (adWin && adWin !== window.top) {
+        // 2. Find the GPT slot for the iframed window
+        const adSlot = getSlotByWin(adWin);
+        // 3. Get AdUnit IDs for the selected slot
+        if (adSlot) {
+          adUnitId = adSlot.getAdUnitPath();
+          adDeliveryId = adSlot.getTargeting('RSDK_ADID');
+          adDeliveryId = adDeliveryId.length
+            ? adDeliveryId[0]
+            : utils.generateUUID();
+        }
+      }
+    }
+
+    // Call local impression callback
+    const args = Object.assign({}, data.args, {
+      publisherDomain: window.location.hostname,
+      publisherMemberId: _moduleParams.publisherMemberId,
+      adUnitId,
+      adDeliveryId,
+    });
+
+    utils.triggerPixel(`${_moduleParams.impressionUrl}?${stringify(args)}`);
+
+    // Send response back to the Advertiser tag
+    let response = {
+      type: MessageType.IMPRESSION_RESPONSE,
+      id: data.id,
+      args: Object.assign(
+        {
+          publisherDomain: window.location.hostname,
+        },
+        data.args
+      ),
+    };
+
+    // If access is allowed - add ad unit id to response
+    if (_moduleParams.allowAccess) {
+      Object.assign(response.args, {
+        adUnitId,
+        adDeliveryId,
+      });
+    }
+
+    e.source.postMessage(JSON.stringify(response), '*');
+  }
+}
+
+/**
+ * Get top iframe window for nested Window object
+ * - top
+ * -- iframe.window  <-- top iframe window
+ * --- iframe.window
+ * ---- iframe.window <-- win
+ *
+ * @param {Window} win nested iframe window object
+ */
+export function getTopIFrameWin(win) {
+  if (!win) {
+    return null;
+  }
+
+  try {
+    while (win.parent !== win.top) {
+      win = win.parent;
+    }
+    return win;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * get all slots on page
+ * @return {Object[]} slot GoogleTag slots
+ */
+function getAllSlots() {
+  return utils.isGptPubadsDefined() && window.googletag.pubads().getSlots();
+}
+
+/**
+ * get GPT slot by placement id
+ * @param {string} code placement id
+ * @return {?Object}
+ */
+function getSlotByCode(code) {
+  const slots = getAllSlots();
+  if (!slots || !slots.length) {
+    return null;
+  }
+  return (
+    find(
+      slots,
+      (s) => s.getSlotElementId() === code || s.getAdUnitPath() === code
+    ) || null
+  );
+}
+
+/**
+ * get GPT slot by iframe window
+ * @param {Window} win
+ * @return {?Object}
+ */
+function getSlotByWin(win) {
+  const slots = getAllSlots();
+
+  if (!slots || !slots.length) {
+    return null;
+  }
+
+  return (
+    find(slots, (s) => {
+      let slotElement = document.getElementById(s.getSlotElementId());
+
+      if (slotElement) {
+        let slotIframe = slotElement.querySelector('iframe');
+
+        if (slotIframe && slotIframe.contentWindow === win) {
+          return true;
+        }
+      }
+
+      return false;
+    }) || null
+  );
+}
+
+/**
+ * serialize object and return query params string
+ * @param {Object} data
+ * @return {string}
+ */
+export function stringify(query) {
+  const parts = [];
+
+  for (let key in query) {
+    if (query.hasOwnProperty(key)) {
+      let val = query[key];
+      if (typeof query[key] !== 'object') {
+        parts.push(`${key}=${encodeURIComponent(val)}`);
+      } else {
+        parts.push(`${key}=${encodeURIComponent(stringify(val))}`);
+      }
+    }
+  }
+  return parts.join('&');
+}
+/**
+ * Init Reconciliation post messages listeners to handle
+ * impressions messages from ad creative
+ */
+function initListeners() {
+  window.addEventListener('message', handleAdMessage, false);
+}
+
+/**
+ * Send init event to log
+ * @param {Object} adUnitsDict
+ */
+function trackInit(adUnitsDict) {
+  const adUnits = Object.keys(adUnitsDict).map((k) => {
+    const adUnit = adUnitsDict[k];
+
+    return {
+      adUnitId: adUnit['RSDK_AUID'],
+      adDeliveryId: adUnit['RSDK_ADID'],
+    };
+  });
+
+  track.trackPost(
+    _moduleParams.initUrl,
+    {
+      adUnits,
+      publisherDomain: window.location.hostname,
+      publisherMemberId: _moduleParams.publisherMemberId,
+    }
+  );
+}
+
+/**
+ * Track event via POST request
+ * wrap method to allow stubbing in tests
+ * @param {string} url
+ * @param {Object} data
+ */
+export const track = {
+  trackPost(url, data) {
+    const ajax = ajaxBuilder();
+
+    ajax(
+      url,
+      function() {},
+      JSON.stringify(data),
+      {
+        method: 'POST',
+      }
+    );
+  }
+}
+
+/**
+ * Set custom targetings for provided adUnits
+ * call callback (onDone) when ready
+ * @param {adUnit[]} adUnits
+ * @param {function} onDone callback function
+ */
+function getReconciliationData(adUnits, onDone) {
+  let dataToReturn = adUnits.reduce((rp, cau) => {
+    const adUnitCode = cau && cau.code;
+
+    if (!adUnitCode) {
+      return rp;
+    }
+
+    const adSlot = getSlotByCode(adUnitCode);
+    rp[adUnitCode] = {
+      RSDK_ADID:
+        cau.transactionId || utils.generateUUID(),
+      RSDK_AUID: adSlot ? adSlot.getAdUnitPath() : adUnitCode,
+    };
+
+    return rp;
+  }, {});
+
+  // Track init event
+  trackInit(dataToReturn);
+
+  return onDone(dataToReturn);
+}
+
+/** @type {RtdSubmodule} */
+export const reconciliationSubmodule = {
+  /**
+   * used to link submodule with realTimeData
+   * @type {string}
+   */
+  name: SUBMODULE_NAME,
+  /**
+   * get data and send back to realTimeData module
+   * @function
+   * @param {adUnit[]} adUnits
+   * @param {function} onDone
+   */
+  getData: getReconciliationData,
+  init
+};
+
+function init(config, gdpr, usp) {
+  return true;
+}
+
+export function beforeInit(config) {
+  const confListener = config.getConfig(MODULE_NAME, ({ realTimeData }) => {
+    try {
+      const params =
+        realTimeData.dataProviders &&
+        realTimeData.dataProviders.filter(
+          (pr) => pr.name && pr.name.toLowerCase() === SUBMODULE_NAME
+        )[0].params;
+      _moduleParams = Object.assign({}, DEFAULT_PARAMS, params);
+    } catch (e) {
+      _moduleParams = {};
+    }
+
+    if (_moduleParams.publisherMemberId) {
+      confListener();
+      initListeners();
+    } else {
+      utils.logError('missing params for Reconciliation provider');
+    }
+  });
+}
+
+submodule('realTimeData', reconciliationSubmodule);
+beforeInit(config);

--- a/modules/reconciliationRtdProvider.js
+++ b/modules/reconciliationRtdProvider.js
@@ -78,7 +78,7 @@ function handleAdMessage(e) {
       adDeliveryId,
     });
 
-    utils.triggerPixel(`${_moduleParams.impressionUrl}?${stringify(args)}`);
+    track.trackGet(_moduleParams.impressionUrl, args);
 
     // Send response back to the Advertiser tag
     let response = {
@@ -112,14 +112,17 @@ function handleAdMessage(e) {
  * ---- iframe.window <-- win
  *
  * @param {Window} win nested iframe window object
+ * @param {Window} topWin top window
  */
-export function getTopIFrameWin(win) {
+export function getTopIFrameWin(win, topWin) {
+  topWin = topWin || window;
+
   if (!win) {
     return null;
   }
 
   try {
-    while (win.parent !== win.top) {
+    while (win.parent !== topWin) {
       win = win.parent;
     }
     return win;
@@ -159,7 +162,7 @@ function getSlotByCode(code) {
  * @param {Window} win
  * @return {?Object}
  */
-function getSlotByWin(win) {
+export function getSlotByWin(win) {
   const slots = getAllSlots();
 
   if (!slots || !slots.length) {
@@ -233,6 +236,9 @@ function trackInit(adUnits) {
  * @param {Object} data
  */
 export const track = {
+  trackGet(url, data) {
+    utils.triggerPixel(`${url}?${stringify(data)}`);
+  },
   trackPost(url, data) {
     const ajax = ajaxBuilder();
 

--- a/modules/reconciliationRtdProvider.md
+++ b/modules/reconciliationRtdProvider.md
@@ -1,0 +1,49 @@
+The purpose of this Real Time Data Provider is to allow publishers to match impressions accross the supply chain.
+
+**Reconciliation SDK**
+The purpose of Reconciliation SDK module is to collect supply chain structure information and vendor-specific impression IDs from suppliers participating in ad creative delivery and report it to the Reconciliation Service, allowing publishers, advertisers and other supply chain participants to match and reconcile ad server, SSP, DSP and veritifation system log file records. Reconciliation SDK was created as part of TAG DLT initiative ( https://www.tagtoday.net/pressreleases/dlt_9_7_2020 ).
+
+**Usage for Publishers:**
+
+Compile the Reconciliation Provider into your Prebid build:
+
+`gulp build --modules=reconciliationRtdProvider`
+
+Add Reconciliation real time data provider configuration by setting up a Prebid Config:
+
+```javascript
+const reconciliationDataProvider = {
+    name: "reconciliation",
+    params: {
+        publisherMemberId: "test_prebid_publisher", // required
+        allowAccess: true, //optional
+    }
+};
+
+pbjs.setConfig({
+    ...,
+    realTimeData: {
+      dataProviders: [
+          reconciliationDataProvider
+      ]
+    }
+});
+```
+
+where:
+- `publisherMemberId` (required) - ID associated with the publisher
+- `access` (optional) true/false - Whether ad markup will recieve Ad Unit Id's via Reconciliation Tag
+  
+**Example:**
+
+To view an example:
+ 
+- in your cli run:
+
+`gulp serve --modules=reconciliationRtdProvider,appnexusBidAdapter`
+
+Your could also change 'appnexusBidAdapter' to another one.
+
+- in your browser, navigate to:
+
+`http://localhost:9999/integrationExamples/gpt/reconciliationRtdProvider_example.html`

--- a/test/spec/modules/reconciliationRtdProvider_spec.js
+++ b/test/spec/modules/reconciliationRtdProvider_spec.js
@@ -1,0 +1,135 @@
+import { reconciliationSubmodule, track } from 'modules/reconciliationRtdProvider.js';
+import { config } from 'src/config.js';
+import { makeSlot } from '../integration/faker/googletag.js';
+
+describe('reconciliationRtdProvider', function () {
+  let trackPostStub;
+
+  beforeEach(function () {
+    trackPostStub = sinon.stub(track, 'trackPost');
+  });
+
+  afterEach(function () {
+    trackPostStub.restore();
+  });
+
+  describe('reconciliationSubmodule', function () {
+    it('successfully instantiates', function () {
+      expect(reconciliationSubmodule.init()).to.equal(true);
+    });
+
+    describe('getData', function () {
+      it('should return data in proper format', function (done) {
+        const adUnit1 = {
+          code: '/adunit1',
+          transactionId: 'transactionId1'
+        };
+        const adUnit2 = {
+          code: '/adunit1',
+          transactionId: 'transactionId2'
+        };
+
+        const expectedData = {
+          [adUnit1.code]: {
+            RSDK_AUID: adUnit1.code,
+            RSDK_ADID: adUnit1.transactionId
+          },
+          [adUnit2.code]: {
+            RSDK_AUID: adUnit2.code,
+            RSDK_ADID: adUnit2.transactionId
+          }
+        };
+
+        reconciliationSubmodule.getData([adUnit1, adUnit2], onDone);
+
+        function onDone(data) {
+          expect(data).to.eql(expectedData);
+          done();
+        }
+      });
+
+      it('should generate deliveryId if transactionId is empty', function (done) {
+        const adUnit = {
+          code: '/adunit'
+        };
+
+        reconciliationSubmodule.getData([adUnit], onDone);
+
+        function onDone(data) {
+          expect(data[adUnit.code].RSDK_AUID).to.eql(adUnit.code);
+          expect(data[adUnit.code].RSDK_ADID).to.be.a('string');
+          done();
+        }
+      });
+
+      it('should return unit path as adUnitId', function (done) {
+        const adUnitCode = '/adunit1';
+        const adUnitId = 'ad1';
+        const adUnit = {
+          code: adUnitId,
+          transactionId: 'transactionId1'
+        };
+        const slot = makeSlot({ code: adUnitCode, divId: adUnitId });
+        window.googletag.pubads().setSlots([slot]);
+        const expectedData = {
+          [adUnit.code]: {
+            RSDK_AUID: adUnitCode,
+            RSDK_ADID: adUnit.transactionId
+          }
+        };
+
+        reconciliationSubmodule.getData([adUnit], onDone);
+        function onDone(data) {
+          expect(data).to.eql(expectedData);
+          done();
+        }
+      });
+    });
+
+    describe('track events', function() {
+      const conf = {
+        'realTimeData': {
+          'dataProviders': [{
+            'name': 'reconciliation',
+            'params': {
+              'publisherMemberId': 'test_prebid_publisher'
+            },
+          }]
+        }
+      };
+
+      beforeEach(function () {
+        config.setConfig(conf);
+      });
+
+      after(function () {
+        config.resetConfig();
+      });
+
+      it('should track init event with data', function () {
+        const adUnit1 = {
+          code: '/adunit1',
+          transactionId: 'transactionId1'
+        };
+        const expectedData = {
+          adUnits: [
+            {
+              adUnitId: '/adunit1',
+              adDeliveryId: 'transactionId1'
+            }
+          ],
+          publisherMemberId: 'test_prebid_publisher'
+        };
+        const onDone = sinon.spy();
+
+        reconciliationSubmodule.getData([adUnit1], onDone);
+
+        expect(onDone.calledOnce).to.be.true;
+        expect(trackPostStub.calledOnce).to.be.true;
+        expect(trackPostStub.getCalls()[0].args[0]).to.eql('https://confirm.fiduciadlt.com/init');
+        expect(trackPostStub.getCalls()[0].args[1].adUnits).to.eql(expectedData.adUnits);
+        expect(trackPostStub.getCalls()[0].args[1].publisherMemberId).to.eql('test_prebid_publisher');
+      });
+    });
+  });
+});

--- a/test/spec/modules/reconciliationRtdProvider_spec.js
+++ b/test/spec/modules/reconciliationRtdProvider_spec.js
@@ -1,5 +1,12 @@
-import { reconciliationSubmodule, track } from 'modules/reconciliationRtdProvider.js';
+import {
+  reconciliationSubmodule,
+  track,
+  stringify,
+  getTopIFrameWin,
+  getSlotByWin
+} from 'modules/reconciliationRtdProvider.js';
 import { makeSlot } from '../integration/faker/googletag.js';
+import * as utils from 'src/utils.js';
 
 describe('Reconciliation Real time data submodule', function () {
   const conf = {
@@ -11,19 +18,38 @@ describe('Reconciliation Real time data submodule', function () {
     }]
   };
 
-  let trackPostStub;
+  let trackPostStub, trackGetStub;
 
   beforeEach(function () {
     trackPostStub = sinon.stub(track, 'trackPost');
+    trackGetStub = sinon.stub(track, 'trackGet');
   });
 
   afterEach(function () {
     trackPostStub.restore();
+    trackGetStub.restore();
   });
 
   describe('reconciliationSubmodule', function () {
-    it('successfully instantiates', function () {
-      expect(reconciliationSubmodule.init(conf.dataProviders[0])).to.equal(true);
+    describe('initialization', function () {
+      let utilsLogErrorSpy;
+
+      before(function () {
+        utilsLogErrorSpy = sinon.spy(utils, 'logError');
+      });
+
+      after(function () {
+        utils.logError.restore();
+      });
+
+      it('successfully instantiates', function () {
+        expect(reconciliationSubmodule.init(conf.dataProviders[0])).to.equal(true);
+      });
+
+      it('should log error if initializied without parameters', function () {
+        expect(reconciliationSubmodule.init({'name': 'reconciliation', 'params': {}})).to.equal(true);
+        expect(utilsLogErrorSpy.calledOnce).to.be.true;
+      });
     });
 
     describe('getData', function () {
@@ -42,9 +68,16 @@ describe('Reconciliation Real time data submodule', function () {
         expect(targetingData['reconciliationAd2'].RSDK_AUID).to.eql('/reconciliationAdunit2');
         expect(targetingData['reconciliationAd2'].RSDK_ADID).to.be.a('string');
       });
+
+      it('should skip empty adUnit id', function () {
+        makeSlot({code: '/reconciliationAdunit3', divId: 'reconciliationAd3'});
+
+        const targetingData = reconciliationSubmodule.getTargetingData(['reconciliationAd3', '']);
+        expect(targetingData).to.have.all.keys('reconciliationAd3');
+      });
     });
 
-    describe('track events', function() {
+    describe('track events', function () {
       it('should track init event with data', function () {
         const adUnit = {
           code: '/adunit'
@@ -57,6 +90,139 @@ describe('Reconciliation Real time data submodule', function () {
         expect(trackPostStub.getCalls()[0].args[1].adUnits[0].adUnitId).to.eql(adUnit.code);
         expect(trackPostStub.getCalls()[0].args[1].adUnits[0].adDeliveryId).be.a('string');
         expect(trackPostStub.getCalls()[0].args[1].publisherMemberId).to.eql('test_prebid_publisher');
+      });
+    });
+
+    describe('stringify parameters', function () {
+      it('should return query for flat object', function () {
+        const parameters = {
+          adUnitId: '/adunit',
+          adDeliveryId: '12345'
+        };
+
+        expect(stringify(parameters)).to.eql('adUnitId=%2Fadunit&adDeliveryId=12345');
+      });
+
+      it('should return query with nested parameters', function () {
+        const parameters = {
+          adUnitId: '/adunit',
+          adDeliveryId: '12345',
+          ext: {
+            adSize: '300x250',
+            adType: 'banner'
+          }
+        };
+
+        expect(stringify(parameters)).to.eql('adUnitId=%2Fadunit&adDeliveryId=12345&ext=adSize%3D300x250%26adType%3Dbanner');
+      });
+    });
+
+    describe('get topmost iframe', function () {
+      /**
+       * - top
+       * -- iframe.window  <-- top iframe window
+       * --- iframe.window
+       * ---- iframe.window <-- win
+       */
+      const mockFrameWin = (topWin, parentWin) => {
+        return {
+          top: topWin,
+          parent: parentWin
+        }
+      }
+
+      it('should return null if called with null', function() {
+        expect(getTopIFrameWin(null)).to.be.null;
+      });
+
+      it('should return null if there is an error in frames chain', function() {
+        const topWin = {};
+        const iframe1Win = mockFrameWin(topWin, null); // break chain
+        const iframe2Win = mockFrameWin(topWin, iframe1Win);
+
+        expect(getTopIFrameWin(iframe1Win, topWin)).to.be.null;
+      });
+
+      it('should get the topmost iframe', function () {
+        const topWin = {};
+        const iframe1Win = mockFrameWin(topWin, topWin);
+        const iframe2Win = mockFrameWin(topWin, iframe1Win);
+
+        expect(getTopIFrameWin(iframe2Win, topWin)).to.eql(iframe1Win);
+      });
+    });
+
+    describe('get slot by nested iframe window', function () {
+      it('should return the slot', function () {
+        const adSlotElement = document.createElement('div');
+        const adSlotIframe = document.createElement('iframe');
+
+        adSlotElement.id = 'reconciliationAd';
+        adSlotElement.appendChild(adSlotIframe);
+        document.body.appendChild(adSlotElement);
+
+        const adSlot = makeSlot({code: '/reconciliationAdunit', divId: adSlotElement.id});
+
+        expect(getSlotByWin(adSlotIframe.contentWindow)).to.eql(adSlot);
+      });
+
+      it('should return null if the slot is not found', function () {
+        const adSlotElement = document.createElement('div');
+        const adSlotIframe = document.createElement('iframe');
+
+        adSlotElement.id = 'reconciliationAd';
+        document.body.appendChild(adSlotElement);
+        document.body.appendChild(adSlotIframe); // iframe is not in ad slot
+
+        const adSlot = makeSlot({code: '/reconciliationAdunit', divId: adSlotElement.id});
+
+        expect(getSlotByWin(adSlotIframe.contentWindow)).to.be.null;
+      });
+    });
+
+    describe('handle postMessage from Reconciliation Tag in ad iframe', function () {
+      it('should track impression pixel with parameters', function (done) {
+        const adSlotElement = document.createElement('div');
+        const adSlotIframe = document.createElement('iframe');
+
+        adSlotElement.id = 'reconciliationAdMessage';
+        adSlotElement.appendChild(adSlotIframe);
+        document.body.appendChild(adSlotElement);
+
+        const adSlot = makeSlot({code: '/reconciliationAdunit', divId: adSlotElement.id});
+        // Fix targeting methods
+        adSlot.targeting = {};
+        adSlot.setTargeting = function(key, value) {
+          this.targeting[key] = [value];
+        };
+        adSlot.getTargeting = function(key) {
+          return this.targeting[key];
+        };
+
+        adSlot.setTargeting('RSDK_AUID', '/reconciliationAdunit');
+        adSlot.setTargeting('RSDK_ADID', '12345');
+        adSlotIframe.contentDocument.open();
+        adSlotIframe.contentDocument.write(`<script>
+          window.parent.postMessage(JSON.stringify({
+            type: 'rsdk:impression:req',
+            args: {
+              sourceMemberId: 'test_member_id',
+              sourceImpressionId: '123'
+            }
+          }), '*');
+        </script>`);
+        adSlotIframe.contentDocument.close();
+
+        setTimeout(() => {
+          expect(trackGetStub.calledOnce).to.be.true;
+          expect(trackGetStub.getCalls()[0].args[0]).to.eql('https://confirm.fiduciadlt.com/imp');
+          expect(trackGetStub.getCalls()[0].args[1].adUnitId).to.eql('/reconciliationAdunit');
+          expect(trackGetStub.getCalls()[0].args[1].adDeliveryId).to.eql('12345');
+          expect(trackGetStub.getCalls()[0].args[1].sourceMemberId).to.eql('test_member_id'); ;
+          expect(trackGetStub.getCalls()[0].args[1].sourceImpressionId).to.eql('123'); ;
+          expect(trackGetStub.getCalls()[0].args[1].publisherMemberId).to.eql('test_prebid_publisher');
+          done();
+        }, 100);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Reconciliation RTD provider allows publishers to integrate Reconciliation SDK via Prebid.js.
The purpose of Reconciliation SDK module is to collect supply chain structure information and vendor-specific impression IDs from suppliers participating in ad creative delivery and report it to the Reconciliation Service, allowing publishers, advertisers and other supply chain participants to match and reconcile ad server, SSP, DSP and veritifation system log file records. Reconciliation SDK was created as part of TAG DLT initiative ( https://www.tagtoday.net/pressreleases/dlt_9_7_2020 ).

- contact email of the adapter’s maintainer
vladimir.fedoseev@fiducia.eco

## Docs PR
https://github.com/prebid/prebid.github.io/pull/2395