### PR TITLE
Rubicon Analytics Adapter: Custom Key Value reporting

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -54,7 +54,12 @@ const BID_REJECTED_IPF = 'rejected-ipf';
 let fpkvs = {};
 function updateFpkvs(fpkvs, newKvs) {
   const isValid = Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
-  return isValid ? {...fpkvs, ...newKvs} : fpkvs;
+  if (isValid) {
+    utils.logError('Rubicon Analytics: fpkvs must be object with string keys and values');
+    return fpkvs;
+  } else {
+    return {...fpkvs, ...newKvs};
+  }
 }
 
 let integration, ruleId, wrapperName;

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -53,7 +53,7 @@ const BID_REJECTED_IPF = 'rejected-ipf';
 
 let fpkvs = {};
 function updateFpkvs(fpkvs, newKvs) {
-  const isValid = Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
+  const isValid = typeof newKvs === 'object' && Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
   if (isValid) {
     utils.logError('Rubicon Analytics: fpkvs must be object with string keys and values');
     return fpkvs;

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -54,7 +54,7 @@ const BID_REJECTED_IPF = 'rejected-ipf';
 let fpkvs = {};
 function updateFpkvs(fpkvs, newKvs) {
   const isValid = typeof newKvs === 'object' && Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
-  if (isValid) {
+  if (!isValid) {
     utils.logError('Rubicon Analytics: fpkvs must be object with string keys and values');
     return fpkvs;
   } else {

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -51,6 +51,24 @@ const cache = {
 
 const BID_REJECTED_IPF = 'rejected-ipf';
 
+let fpkvs = {};
+function updateFpkvs(fpkvs, newKvs) {
+  const isValid = Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
+  return isValid ? {...fpkvs, ...newKvs} : fpkvs;
+}
+
+let integration, ruleId, wrapperName;
+// listen for any rubicon setConfig events and save them to appropriate fields!
+// we are saving these as global to this module so that if a pub accidentally overwrites the entire
+// rubicon object, then we do not lose other data
+config.getConfig('rubicon', config => {
+  let rubiConf = config.rubicon;
+  integration = rubiConf.int_type || integration || DEFAULT_INTEGRATION;
+  ruleId = rubiConf.rule_name || ruleId;
+  wrapperName = rubiConf.wrapperName || wrapperName;
+  fpkvs = rubiConf.fpkvs ? updateFpkvs(fpkvs, rubiConf.fpkvs) : fpkvs
+});
+
 export function getHostNameFromReferer(referer) {
   try {
     rubiconAdapter.referrerHostname = utils.parseUrl(referer, {noDecodeWholeURL: true}).hostname;
@@ -140,17 +158,14 @@ function sendMessage(auctionId, bidWonId) {
   let referrer = config.getConfig('pageUrl') || (auctionCache && auctionCache.referrer);
   let message = {
     eventTimeMillis: Date.now(),
-    integration: config.getConfig('rubicon.int_type') || DEFAULT_INTEGRATION,
-    ruleId: config.getConfig('rubicon.rule_name'),
+    integration,
+    ruleId,
     version: '$prebid.version$',
     referrerUri: referrer,
     referrerHostname: rubiconAdapter.referrerHostname || getHostNameFromReferer(referrer),
-    channel: 'web'
+    channel: 'web',
+    wrapperName
   };
-  const wrapperName = config.getConfig('rubicon.wrapperName');
-  if (wrapperName) {
-    message.wrapperName = wrapperName;
-  }
   if (auctionCache && !auctionCache.sent) {
     let adUnitMap = Object.keys(auctionCache.bids).reduce((adUnits, bidId) => {
       let bid = auctionCache.bids[bidId];
@@ -338,13 +353,6 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
   ]);
 }
 
-function getDynamicKvps() {
-  if (prebidGlobal.rp && typeof prebidGlobal.rp.getCustomTargeting === 'function') {
-    return prebidGlobal.rp.getCustomTargeting();
-  }
-  return {};
-}
-
 function getPageViewId() {
   if (prebidGlobal.rp && typeof prebidGlobal.rp.generatePageViewId === 'function') {
     return prebidGlobal.rp.generatePageViewId(false);
@@ -406,7 +414,7 @@ function updateRpaCookie() {
   // possible that decodedRpaCookie is undefined, and if it is, we probably are blocked by storage or some other exception
   if (Object.keys(decodedRpaCookie).length) {
     decodedRpaCookie.lastSeen = currentTime;
-    decodedRpaCookie.fpkvs = {...decodedRpaCookie.fpkvs, ...getDynamicKvps()};
+    decodedRpaCookie.fpkvs = {...decodedRpaCookie.fpkvs, ...fpkvs};
     decodedRpaCookie.pvid = getPageViewId();
     setRpaCookie(decodedRpaCookie)
   }
@@ -481,7 +489,8 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
   },
   disableAnalytics() {
     this.getUrl = baseAdapter.getUrl;
-    accountId = null;
+    accountId = integration = ruleId = wrapperName = undefined;
+    fpkvs = {};
     cache.gpt.registered = false;
     baseAdapter.disableAnalytics.apply(this, arguments);
   },

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -53,7 +53,7 @@ const BID_REJECTED_IPF = 'rejected-ipf';
 
 let fpkvs = {};
 function updateFpkvs(fpkvs, newKvs) {
-  const isValid = typeof newKvs === 'object' && Object.keys(newKvs).every(key => typeof key === 'string' && typeof newKvs[key] === 'string');
+  const isValid = typeof newKvs === 'object' && Object.keys(newKvs).every(key => typeof newKvs[key] === 'string');
   if (!isValid) {
     utils.logError('Rubicon Analytics: fpkvs must be object with string keys and values');
     return fpkvs;

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -865,11 +865,12 @@ describe('rubicon analytics adapter', function () {
 
       it('should should pass along custom rubicon kv and pvid when defined', function () {
         pvid = '1a2b3c';
-        kvps = {
-          source: 'fb',
-          link: 'email'
-        };
-
+        config.setConfig({rubicon: {
+          fpkvs: {
+            source: 'fb',
+            link: 'email'
+          }
+        }});
         performStandardAuction();
         expect(server.requests.length).to.equal(1);
         let request = server.requests[0];
@@ -897,10 +898,11 @@ describe('rubicon analytics adapter', function () {
         getDataFromLocalStorageStub.withArgs('rpaSession').returns(btoa(JSON.stringify(inputlocalStorage)));
 
         pvid = '1a2b3c';
-        kvps = {
-          link: 'email' // should merge this with what is in the localStorage!
-        };
-
+        config.setConfig({rubicon: {
+          fpkvs: {
+            link: 'email' // should merge this with what is in the localStorage!
+          }
+        }});
         performStandardAuction();
         expect(server.requests.length).to.equal(1);
         let request = server.requests[0];
@@ -949,9 +951,11 @@ describe('rubicon analytics adapter', function () {
         getDataFromLocalStorageStub.withArgs('rpaSession').returns(btoa(JSON.stringify(inputlocalStorage)));
 
         pvid = '1a2b3c';
-        kvps = {
-          link: 'email' // should merge this with what is in the localStorage!
-        };
+        config.setConfig({rubicon: {
+          fpkvs: {
+            link: 'email' // should merge this with what is in the localStorage!
+          }
+        }});
 
         performStandardAuction();
         expect(server.requests.length).to.equal(1);
@@ -998,9 +1002,11 @@ describe('rubicon analytics adapter', function () {
         getDataFromLocalStorageStub.withArgs('rpaSession').returns(btoa(JSON.stringify(inputlocalStorage)));
 
         pvid = '1a2b3c';
-        kvps = {
-          link: 'email' // should merge this with what is in the localStorage!
-        };
+        config.setConfig({rubicon: {
+          fpkvs: {
+            link: 'email' // should merge this with what is in the localStorage!
+          }
+        }});
 
         performStandardAuction();
         expect(server.requests.length).to.equal(1);
@@ -1335,12 +1341,9 @@ describe('rubicon analytics adapter', function () {
 
   describe('config with integration type', () => {
     it('should use the integration type provided in the config instead of the default', () => {
-      sandbox.stub(config, 'getConfig').callsFake(function (key) {
-        const config = {
-          'rubicon.int_type': 'testType'
-        };
-        return config[key];
-      });
+      config.setConfig({rubicon: {
+        int_type: 'testType'
+      }})
 
       rubiconAnalyticsAdapter.enableAnalytics({
         options: {


### PR DESCRIPTION

## Type of change
- [X] Feature

## Description of change
Originally we were only allowing publishers on the Rubicon proprietary wrapper.

This change adds support for Prebid.js Analytics Adapter.