### PR TITLE
Improve warning and documentation for pubmatic publisherId

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -847,7 +847,7 @@ export const spec = {
   isBidRequestValid: bid => {
     if (bid && bid.params) {
       if (!utils.isStr(bid.params.publisherId)) {
-        utils.logWarn(LOG_WARN_PREFIX + 'Error: publisherId is mandatory and cannot be numeric. Call to OpenBid will not be sent for ad unit: ' + JSON.stringify(bid));
+        utils.logWarn(LOG_WARN_PREFIX + 'Error: publisherId is mandatory and cannot be numeric (wrap it in quotes in your config). Call to OpenBid will not be sent for ad unit: ' + JSON.stringify(bid));
         return false;
       }
       // video ad validation

--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -24,7 +24,7 @@ var adUnits = [
     bids: [{
       bidder: 'pubmatic',
       params: {
-        publisherId: '156209',               // required
+        publisherId: '156209',               // required, must be wrapped in quotes
         oustreamAU: 'renderer_test_pubmatic',   // required if mediaTypes-> video-> context is 'outstream'. This value can be get by BlueBillyWig Team.
         adSlot: 'pubmatic_test2',            // optional
         pmzoneid: 'zone1, zone11',           // optional


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- The warning message you get if you use pubmatic config with a publisherId that is a JS numeric instead of a JS string is not
  super helpful if you aren't familiar with JS internals. Update the warning message to give a suggestion
  on a solution, and update the markdown documentation to explictly state that the ID needs to be wrapped
  in quotes.


