### PR TITLE
Integrate option to pass clickThrough urls to renderAd method

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -342,7 +342,7 @@ function emitAdRenderFail({ reason, message, bid, id }) {
  * @param  {string} id bid id to locate the ad
  * @alias module:pbjs.renderAd
  */
-$$PREBID_GLOBAL$$.renderAd = function (doc, id) {
+$$PREBID_GLOBAL$$.renderAd = function (doc, id, options) {
   utils.logInfo('Invoking $$PREBID_GLOBAL$$.renderAd', arguments);
   utils.logMessage('Calling renderAd with adId :' + id);
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -356,9 +356,11 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id, options) {
         bid.adUrl = utils.replaceAuctionPrice(bid.adUrl, bid.cpm);
 
         // replacing clickthrough if submitted
-        const { clickThrough } = options;
-        bid.ad = utils.replaceClickThrough(bid.ad, clickThrough);
-        bid.adUrl = utils.replaceClickThrough(bid.adUrl, clickThrough);
+        if (options && options.clickThrough) {
+          const { clickThrough } = options;
+          bid.ad = utils.replaceClickThrough(bid.ad, clickThrough);
+          bid.adUrl = utils.replaceClickThrough(bid.adUrl, clickThrough);
+        }
 
         // save winning bids
         auctionManager.addWinningBid(bid);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -354,6 +354,12 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id, options) {
         // replace macros according to openRTB with price paid = bid.cpm
         bid.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);
         bid.adUrl = utils.replaceAuctionPrice(bid.adUrl, bid.cpm);
+
+        // replacing clickthrough if submitted
+        const { clickThrough } = options;
+        bid.ad = utils.replaceClickThrough(bid.ad, clickThrough);
+        bid.adUrl = utils.replaceClickThrough(bid.adUrl, clickThrough);
+
         // save winning bids
         auctionManager.addWinningBid(bid);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -718,6 +718,11 @@ export function replaceAuctionPrice(str, cpm) {
   return str.replace(/\$\{AUCTION_PRICE\}/g, cpm);
 }
 
+export function replaceClickThrough(str, clicktag) {
+  if (!str) return;
+  return str.replace(/\$\{CLICKTHROUGH\}/g, clicktag);
+}
+
 export function timestamp() {
   return new Date().getTime();
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -719,8 +719,8 @@ export function replaceAuctionPrice(str, cpm) {
 }
 
 export function replaceClickThrough(str, clicktag) {
-  if (!str) return;
-  return str.replace(/\$\{CLICKTHROUGH\}/g, clicktag);
+  if (!str || !clicktag || typeof clicktag !== 'string') return;
+  return str.replace(/\${CLICKTHROUGH}/g, clicktag);
 }
 
 export function timestamp() {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1197,6 +1197,14 @@ describe('Unit: Prebid Module', function () {
       assert.deepEqual($$PREBID_GLOBAL$$.getAllWinningBids()[0], adResponse);
     });
 
+    it('should replace ${CLICKTHROUGH} macro in winning bids response', function () {
+      pushBidResponseToAuction({
+        ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js?clickthrough=${CLICKTHROUGH}'></script>"
+      });
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId, {clickThrough: 'https://someadserverclickurl.com'});
+      expect(adResponse).to.have.property('ad').and.to.match(/https:\/\/someadserverclickurl\.com/i);
+    });
+
     it('fires billing url if present on s2s bid', function () {
       const burl = 'http://www.example.com/burl';
       pushBidResponseToAuction({


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This change enables publishers/marketers to count clicks on prebid inventory in their distributing adserver.
The publisher may call render ad with a third param accepting an object where right now only clickThrough will be checked but can be extended.
If this property is set we will replace any occurrence of ${CLICKTHROUGH} inside the properties ad and adUrl with the transmitted option.
If no occurrence is found nothing will be replaced.

## Other information
To make use of this feature bidAdpaters just have to respond with tags including this macro to pass it to their param and system
