### PR TITLE
expose full user id config (including storage) to user id modules

### DIFF
--- a/modules/britepoolIdSystem.js
+++ b/modules/britepoolIdSystem.js
@@ -29,7 +29,7 @@ export const britepoolIdSubmodule = {
   /**
    * Performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [submoduleConfig]
+   * @param {SubmoduleConfig} [submoduleConfig]
    * @param {ConsentData|undefined} consentData
    * @returns {function(callback:function)}
    */
@@ -85,7 +85,7 @@ export const britepoolIdSubmodule = {
   },
   /**
    * Helper method to create params for our API call
-   * @param {SubmoduleParams} [submoduleConfigParams]
+   * @param {SubmoduleConfig} [submoduleConfigParams]
    * @param {ConsentData|undefined} consentData
    * @returns {object} Object with parsed out params
    */

--- a/modules/britepoolIdSystem.js
+++ b/modules/britepoolIdSystem.js
@@ -85,7 +85,7 @@ export const britepoolIdSubmodule = {
   },
   /**
    * Helper method to create params for our API call
-   * @param {SubmoduleConfig} [submoduleConfigParams]
+   * @param {SubmoduleParams} [submoduleConfigParams]
    * @param {ConsentData|undefined} consentData
    * @returns {object} Object with parsed out params
    */

--- a/modules/britepoolIdSystem.js
+++ b/modules/britepoolIdSystem.js
@@ -29,11 +29,12 @@ export const britepoolIdSubmodule = {
   /**
    * Performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [submoduleConfigParams]
+   * @param {SubmoduleParams} [submoduleConfig]
    * @param {ConsentData|undefined} consentData
    * @returns {function(callback:function)}
    */
-  getId(submoduleConfigParams, consentData) {
+  getId(submoduleConfig, consentData) {
+    const submoduleConfigParams = (submoduleConfig && submoduleConfig.params) || {};
     const { params, headers, url, getter, errors } = britepoolIdSubmodule.createParams(submoduleConfigParams, consentData);
     let getterResponse = null;
     if (typeof getter === 'function') {

--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -126,7 +126,7 @@ export const criteoIdSubmodule = {
   /**
    * get the Criteo Id from local storages and initiate a new user sync
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @returns {{id: {criteoId: string} | undefined}}}
    */

--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -126,11 +126,11 @@ export const criteoIdSubmodule = {
   /**
    * get the Criteo Id from local storages and initiate a new user sync
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @returns {{id: {criteoId: string} | undefined}}}
    */
-  getId(configParams, consentData) {
+  getId(config, consentData) {
     const hasGdprData = consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies;
     const gdprConsentString = hasGdprData ? consentData.consentString : undefined;
 

--- a/modules/haloIdSystem.js
+++ b/modules/haloIdSystem.js
@@ -30,10 +30,10 @@ export const haloIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams) {
+  getId(config) {
     const url = `https://id.halo.ad.gt/api/v1/pbhid`;
 
     const resp = function (callback) {

--- a/modules/haloIdSystem.js
+++ b/modules/haloIdSystem.js
@@ -30,7 +30,7 @@ export const haloIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
   getId(config) {

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -65,7 +65,7 @@ export const id5IdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
@@ -124,7 +124,7 @@ export const id5IdSubmodule = {
    *  If IdResponse#callback is defined, then it'll called at the end of auction.
    *  It's permissible to return neither, one, or both fields.
    * @function extendId
-   * @param {SubmoduleParams} config
+   * @param {SubmoduleConfig} config
    * @param {Object} cacheIdObj - existing id, if any
    * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
    */

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -65,12 +65,13 @@ export const id5IdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
-  getId(configParams, consentData, cacheIdObj) {
+  getId(config, consentData, cacheIdObj) {
+    const configParams = (config && config.params) || {};
     if (!hasRequiredParams(configParams)) {
       return undefined;
     }
@@ -123,11 +124,12 @@ export const id5IdSubmodule = {
    *  If IdResponse#callback is defined, then it'll called at the end of auction.
    *  It's permissible to return neither, one, or both fields.
    * @function extendId
-   * @param {SubmoduleParams} configParams
+   * @param {SubmoduleParams} config
    * @param {Object} cacheIdObj - existing id, if any
    * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
    */
-  extendId(configParams, cacheIdObj) {
+  extendId(config, cacheIdObj) {
+    const configParams = (config && config.params) || {};
     incrementNb(configParams);
     return cacheIdObj;
   }

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -65,8 +65,8 @@ export const id5IdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
-   * @param {SubmoduleConfig} [config]
-   * @param {ConsentData} [consentData]
+   * @param {SubmoduleConfig} config
+   * @param {ConsentData} consentData
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -34,7 +34,7 @@ export const identityLinkSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {ConsentData} [consentData]
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
   getId(config, consentData) {

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -34,10 +34,11 @@ export const identityLinkSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {ConsentData} [consentData]
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams, consentData) {
+  getId(config, consentData) {
+    const configParams = (config && config.params) || {};
     if (!configParams || typeof configParams.pid !== 'string') {
       utils.logError('identityLink submodule requires partner id to be defined');
       return;

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -30,7 +30,7 @@ export const intentIqIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
   getId(config) {

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -30,10 +30,11 @@ export const intentIqIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams) {
+  getId(config) {
+    const configParams = (config && config.params) || {};
     if (!configParams || typeof configParams.partner !== 'number') {
       utils.logError('User ID - intentIqId submodule requires a valid partner to be defined');
       return;

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -100,10 +100,11 @@ export const liveIntentIdSubmodule = {
    * `publisherId` params.
    * @function
    * @param {{unifiedId:string}} value
-   * @param {SubmoduleParams|undefined} [configParams]
+   * @param {SubmoduleParams|undefined} [config]
    * @returns {{lipb:Object}}
    */
-  decode(value, configParams) {
+  decode(value, config) {
+    const configParams = (config && config.params) || {};
     function composeIdObject(value) {
       const base = { 'lipbid': value['unifiedId'] };
       delete value.unifiedId;
@@ -121,10 +122,11 @@ export const liveIntentIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams) {
+  getId(config) {
+    const configParams = (config && config.params) || {};
     const liveConnect = initializeLiveConnect(configParams);
     if (!liveConnect) {
       return;

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -122,7 +122,7 @@ export const liveIntentIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
   getId(config) {

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -100,7 +100,7 @@ export const liveIntentIdSubmodule = {
    * `publisherId` params.
    * @function
    * @param {{unifiedId:string}} value
-   * @param {SubmoduleParams|undefined} [config]
+   * @param {SubmoduleConfig|undefined} config
    * @returns {{lipb:Object}}
    */
   decode(value, config) {

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -154,19 +154,19 @@ export const lotamePanoramaIdSubmodule = {
    * @param {(Object|string)} value
    * @returns {(Object|undefined)}
    */
-  decode(value, configParams) {
+  decode(value, config) {
     return utils.isStr(value) ? { 'lotamePanoramaId': value } : undefined;
   },
 
   /**
    * Retrieve the Lotame Panorama Id
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
-  getId(configParams, consentData, cacheIdObj) {
+  getId(config, consentData, cacheIdObj) {
     let localCache = getLotameLocalCache();
 
     let refreshNeeded = Date.now() > localCache.expiryTimestampMs;

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -152,6 +152,7 @@ export const lotamePanoramaIdSubmodule = {
    * Decode the stored id value for passing to bid requests
    * @function decode
    * @param {(Object|string)} value
+   * @param {SubmoduleConfig|undefined} config
    * @returns {(Object|undefined)}
    */
   decode(value, config) {

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -161,7 +161,7 @@ export const lotamePanoramaIdSubmodule = {
   /**
    * Retrieve the Lotame Panorama Id
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}

--- a/modules/merkleIdSystem.js
+++ b/modules/merkleIdSystem.js
@@ -31,11 +31,12 @@ export const merkleIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams, consentData) {
+  getId(config, consentData) {
+    const configParams = (config && config.params) || {};
     if (!configParams || typeof configParams.pubid !== 'string') {
       utils.logError('User ID - merkleId submodule requires a valid pubid to be defined');
       return;

--- a/modules/merkleIdSystem.js
+++ b/modules/merkleIdSystem.js
@@ -31,7 +31,7 @@ export const merkleIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @returns {IdResponse|undefined}
    */

--- a/modules/netIdSystem.js
+++ b/modules/netIdSystem.js
@@ -26,12 +26,12 @@ export const netIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
-  getId(configParams) {
+  getId(config) {
     /* currently not possible */
     return {};
   }

--- a/modules/netIdSystem.js
+++ b/modules/netIdSystem.js
@@ -26,7 +26,7 @@ export const netIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}

--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -261,11 +261,12 @@ export const parrableIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {ConsentData} [consentData]
    * @returns {function(callback:function), id:ParrableId}
    */
-  getId(configParams, gdprConsentData, currentStoredId) {
+  getId(config, gdprConsentData, currentStoredId) {
+    const configParams = (config && config.params) || {};
     return fetchId(configParams);
   }
 };

--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -261,7 +261,7 @@ export const parrableIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]
    * @returns {function(callback:function), id:ParrableId}
    */

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -54,7 +54,7 @@ export const pubCommonIdSubmodule = {
   /**
    * performs action to obtain id
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse}
    */
   getId: function ({params: {create = true, pixelUrl} = {}} = {}) {

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -54,10 +54,10 @@ export const pubCommonIdSubmodule = {
   /**
    * performs action to obtain id
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse}
    */
-  getId: function ({create = true, pixelUrl} = {}) {
+  getId: function ({params: {create = true, pixelUrl} = {}} = {}) {
     try {
       if (typeof window[PUB_COMMON_ID] === 'object') {
         // If the page includes its own pubcid module, then save a copy of id.
@@ -75,11 +75,11 @@ export const pubCommonIdSubmodule = {
   /**
    * performs action to extend an id
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @param {Object} storedId existing id
    * @returns {IdResponse|undefined}
    */
-  extendId: function({extend = false, pixelUrl} = {}, storedId) {
+  extendId: function({params: {extend = false, pixelUrl} = {}} = {}, storedId) {
     try {
       if (typeof window[PUB_COMMON_ID] === 'object') {
         // If the page includes its onw pubcid module, then there is nothing to do.

--- a/modules/pubProvidedSystem.js
+++ b/modules/pubProvidedSystem.js
@@ -34,10 +34,11 @@ export const pubProvidedIdSubmodule = {
   /**
    * performs action to obtain id and return a value.
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {{id: array}}
    */
-  getId(configParams) {
+  getId(config) {
+    const configParams = (config && config.params) || {};
     let res = [];
     if (utils.isArray(configParams.eids)) {
       res = res.concat(configParams.eids);

--- a/modules/pubProvidedSystem.js
+++ b/modules/pubProvidedSystem.js
@@ -34,7 +34,7 @@ export const pubProvidedIdSubmodule = {
   /**
    * performs action to obtain id and return a value.
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {{id: array}}
    */
   getId(config) {

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -296,7 +296,7 @@ export const sharedIdSubmodule = {
   /**
    * performs action to obtain id and return a value.
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {sharedId}
    */
   getId(config) {

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -296,10 +296,10 @@ export const sharedIdSubmodule = {
   /**
    * performs action to obtain id and return a value.
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {sharedId}
    */
-  getId(configParams) {
+  getId(config) {
     const resp = function (callback) {
       utils.logInfo('SharedId: Sharedid doesnt exists, new cookie creation');
       ajax(ID_SVC, idGenerationCallback(callback), undefined, {method: 'GET', withCredentials: true});
@@ -309,11 +309,12 @@ export const sharedIdSubmodule = {
 
   /**
    * performs actions even if the id exists and returns a value
-   * @param configParams
+   * @param config
    * @param storedId
    * @returns {{callback: *}}
    */
-  extendId(configParams, storedId) {
+  extendId(config, storedId) {
+    const configParams = (config && config.params) || {};
     utils.logInfo('SharedId: Existing shared id ' + storedId.id);
     const resp = function (callback) {
       const needSync = isIdSynced(configParams, storedId);

--- a/modules/unifiedIdSystem.js
+++ b/modules/unifiedIdSystem.js
@@ -30,10 +30,11 @@ export const unifiedIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [configParams]
+   * @param {SubmoduleParams} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(configParams) {
+  getId(config) {
+    const configParams = (config && config.params) || {};
     if (!configParams || (typeof configParams.partner !== 'string' && typeof configParams.url !== 'string')) {
       utils.logError('User ID - unifiedId submodule requires either partner or url to be defined');
       return;

--- a/modules/unifiedIdSystem.js
+++ b/modules/unifiedIdSystem.js
@@ -30,7 +30,7 @@ export const unifiedIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [config]
+   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
   getId(config) {

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -27,7 +27,7 @@
  *  If IdResponse#callback is defined, then it'll called at the end of auction.
  *  It's permissible to return neither, one, or both fields.
  * @name Submodule#extendId
- * @param {SubmoduleParams} config
+ * @param {SubmoduleConfig} config
  * @param {Object} storedId - existing id, if any
  * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
  */
@@ -37,7 +37,7 @@
  * @summary decode a stored value for passing to bid requests
  * @name Submodule#decode
  * @param {Object|string} value
- * @param {SubmoduleParams|undefined} config
+ * @param {SubmoduleConfig|undefined} config
  * @return {(Object|undefined)}
  */
 
@@ -85,6 +85,7 @@
  * @property {(array|undefined)} identifiersToResolve - the identifiers from either ls|cookie to be attached to the getId query
  * @property {(string|undefined)} providedIdentifierName - defines the name of an identifier that can be found in local storage or in the cookie jar that can be sent along with the getId request. This parameter should be used whenever a customer is able to provide the most stable identifier possible
  * @property {(LiveIntentCollectConfig|undefined)} liCollectConfig - the config for LiveIntent's collect requests
+ * @property {(string|undefined)} pd - publisher provided data for reconciling ID5 IDs
  */
 
 /**

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -14,7 +14,7 @@
  *  If IdResponse#callback is defined, then it'll called at the end of auction.
  *  It's permissible to return neither, one, or both fields.
  * @name Submodule#getId
- * @param {SubmoduleParams} configParams
+ * @param {SubmoduleParams} config
  * @param {ConsentData|undefined} consentData
  * @param {(Object|undefined)} cacheIdObj
  * @return {(IdResponse|undefined)} A response object that contains id and/or callback.
@@ -27,7 +27,7 @@
  *  If IdResponse#callback is defined, then it'll called at the end of auction.
  *  It's permissible to return neither, one, or both fields.
  * @name Submodule#extendId
- * @param {SubmoduleParams} configParams
+ * @param {SubmoduleParams} config
  * @param {Object} storedId - existing id, if any
  * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
  */
@@ -37,7 +37,7 @@
  * @summary decode a stored value for passing to bid requests
  * @name Submodule#decode
  * @param {Object|string} value
- * @param {SubmoduleParams|undefined} configParams
+ * @param {SubmoduleParams|undefined} config
  * @return {(Object|undefined)}
  */
 
@@ -322,7 +322,7 @@ function processSubmoduleCallbacks(submodules, cb) {
           setStoredValue(submodule, idObj);
         }
         // cache decoded value (this is copied to every adUnit bid)
-        submodule.idObj = submodule.submodule.decode(idObj);
+        submodule.idObj = submodule.submodule.decode(idObj, submodule.config);
       } else {
         utils.logInfo(`${MODULE_NAME}: ${submodule.submodule.name} - request id responded with an empty value`);
       }
@@ -505,10 +505,10 @@ function initSubmodules(submodules, consentData) {
 
       if (!storedId || refreshNeeded || !storedConsentDataMatchesConsentData(storedConsentData, consentData)) {
         // No id previously saved, or a refresh is needed, or consent has changed. Request a new id from the submodule.
-        response = submodule.submodule.getId(submodule.config.params, consentData, storedId);
+        response = submodule.submodule.getId(submodule.config, consentData, storedId);
       } else if (typeof submodule.submodule.extendId === 'function') {
         // If the id exists already, give submodule a chance to decide additional actions that need to be taken
-        response = submodule.submodule.extendId(submodule.config.params, storedId);
+        response = submodule.submodule.extendId(submodule.config, storedId);
       }
 
       if (utils.isPlainObject(response)) {
@@ -526,16 +526,16 @@ function initSubmodules(submodules, consentData) {
 
       if (storedId) {
         // cache decoded value (this is copied to every adUnit bid)
-        submodule.idObj = submodule.submodule.decode(storedId, submodule.config.params);
+        submodule.idObj = submodule.submodule.decode(storedId, submodule.config);
       }
     } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
       submodule.idObj = submodule.config.value;
     } else {
-      const response = submodule.submodule.getId(submodule.config.params, consentData, undefined);
+      const response = submodule.submodule.getId(submodule.config, consentData, undefined);
       if (utils.isPlainObject(response)) {
         if (typeof response.callback === 'function') { submodule.callback = response.callback; }
-        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config.params); }
+        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config); }
       }
     }
     carry.push(submodule);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -14,7 +14,7 @@
  *  If IdResponse#callback is defined, then it'll called at the end of auction.
  *  It's permissible to return neither, one, or both fields.
  * @name Submodule#getId
- * @param {SubmoduleParams} config
+ * @param {SubmoduleConfig} config
  * @param {ConsentData|undefined} consentData
  * @param {(Object|undefined)} cacheIdObj
  * @return {(IdResponse|undefined)} A response object that contains id and/or callback.

--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -41,7 +41,7 @@ export const zeotapIdPlusSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} config
+   * @param {SubmoduleConfig} config
    * @return {{id: string | undefined} | undefined}
    */
   getId() {

--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -41,7 +41,7 @@ export const zeotapIdPlusSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} configParams
+   * @param {SubmoduleParams} config
    * @return {{id: string | undefined} | undefined}
    */
   getId() {

--- a/test/spec/modules/britepoolIdSystem_spec.js
+++ b/test/spec/modules/britepoolIdSystem_spec.js
@@ -28,17 +28,17 @@ describe('BritePool Submodule', () => {
   });
 
   it('trigger id resolution pixel when no identifiers set', () => {
-    britepoolIdSubmodule.getId({});
+    britepoolIdSubmodule.getId({ params: {} });
     expect(triggerPixelStub.called).to.be.true;
   });
 
   it('trigger id resolution pixel when no identifiers set with api_key param', () => {
-    britepoolIdSubmodule.getId({ api_key });
+    britepoolIdSubmodule.getId({ params: { api_key } });
     expect(triggerPixelStub.called).to.be.true;
   });
 
   it('does not trigger id resolution pixel when identifiers set', () => {
-    britepoolIdSubmodule.getId({ api_key, aaid });
+    britepoolIdSubmodule.getId({ params: { api_key, aaid } });
     expect(triggerPixelStub.called).to.be.false;
   });
 
@@ -110,7 +110,7 @@ describe('BritePool Submodule', () => {
     expect(getter).to.equal(getter_override);
     // Making sure it did not become part of params
     expect(params.getter).to.be.undefined;
-    const response = britepoolIdSubmodule.getId({ api_key, aaid, url: url_override, getter: getter_override });
+    const response = britepoolIdSubmodule.getId({ params: { api_key, aaid, url: url_override, getter: getter_override } });
     assert.deepEqual(response, { id: { 'primaryBPID': bpid } });
   });
 
@@ -119,7 +119,7 @@ describe('BritePool Submodule', () => {
     expect(getter).to.equal(getter_callback_override);
     // Making sure it did not become part of params
     expect(params.getter).to.be.undefined;
-    const response = britepoolIdSubmodule.getId({ api_key, aaid, url: url_override, getter: getter_callback_override });
+    const response = britepoolIdSubmodule.getId({ params: { api_key, aaid, url: url_override, getter: getter_callback_override } });
     expect(response.callback).to.not.be.undefined;
     response.callback(result => {
       assert.deepEqual(result, { 'primaryBPID': bpid });

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -95,10 +95,12 @@ describe('ID5 ID System', function() {
 
     it('should fail if no partner is provided in the config', function() {
       expect(id5IdSubmodule.getId()).to.be.eq(undefined);
+      expect(id5IdSubmodule.getId({ })).to.be.eq(undefined);
+      expect(id5IdSubmodule.getId({ params: { } })).to.be.eq(undefined);
     });
 
     it('should call the ID5 server with 1puid field for legacy storedObj format', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_LEGACY_STORED_OBJ).callback;
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_LEGACY_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];
@@ -115,7 +117,7 @@ describe('ID5 ID System', function() {
     });
 
     it('should call the ID5 server with signature field for new storedObj format', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];
@@ -134,8 +136,8 @@ describe('ID5 ID System', function() {
     it('should call the ID5 server with pd field when pd config is set', function () {
       const pubData = 'b50ca08271795a8e7e4012813f23d505193d75c0f2e2bb99baa63aa822f66ed3';
 
-      let config = getId5FetchConfig().params;
-      config.pd = pubData;
+      let config = getId5FetchConfig();
+      config.params.pd = pubData;
 
       let submoduleCallback = id5IdSubmodule.getId(config, undefined, ID5_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
@@ -154,8 +156,8 @@ describe('ID5 ID System', function() {
     });
 
     it('should call the ID5 server with empty pd field when pd config is not set', function () {
-      let config = getId5FetchConfig().params;
-      config.pd = undefined;
+      let config = getId5FetchConfig();
+      config.params.pd = undefined;
 
       let submoduleCallback = id5IdSubmodule.getId(config, undefined, ID5_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
@@ -174,7 +176,7 @@ describe('ID5 ID System', function() {
     it('should call the ID5 server with nb=1 when no stored value exists', function () {
       coreStorage.setCookie(ID5_NB_COOKIE_NAME, '', ID5_EXPIRED_COOKIE_DATE);
 
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];
@@ -194,7 +196,7 @@ describe('ID5 ID System', function() {
       let expStr = (new Date(Date.now() + 25000).toUTCString());
       coreStorage.setCookie(ID5_NB_COOKIE_NAME, '1', expStr);
 
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig().params, undefined, ID5_STORED_OBJ).callback;
+      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -3,7 +3,7 @@ import * as utils from 'src/utils.js';
 import {server} from 'test/mocks/xhr.js';
 
 const pid = '14';
-const defaultConfigParams = {pid: pid};
+const defaultConfigParams = { params: {pid: pid} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('IdentityLinkId tests', function () {
@@ -18,12 +18,12 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should log an error if no configParams were passed when getId', function () {
-    identityLinkSubmodule.getId();
+    identityLinkSubmodule.getId({ params: {} });
     expect(logErrorStub.calledOnce).to.be.true;
   });
 
   it('should log an error if pid configParam was not passed when getId', function () {
-    identityLinkSubmodule.getId({});
+    identityLinkSubmodule.getId({ params: {} });
     expect(logErrorStub.calledOnce).to.be.true;
   });
 

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -6,10 +6,10 @@ import {server} from 'test/mocks/xhr.js';
 const partner = 10;
 const pai = '11';
 const pcid = '12';
-const defaultConfigParams = {partner: partner};
-const paiConfigParams = {partner: partner, pai: pai};
-const pcidConfigParams = {partner: partner, pcid: pcid};
-const allConfigParams = {partner: partner, pai: pai, pcid: pcid};
+const defaultConfigParams = { params: {partner: partner} };
+const paiConfigParams = { params: {partner: partner, pai: pai} };
+const pcidConfigParams = { params: {partner: partner, pcid: pcid} };
+const allConfigParams = { params: {partner: partner, pai: pai, pcid: pcid} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('IntentIQ tests', function () {
@@ -24,19 +24,19 @@ describe('IntentIQ tests', function () {
   });
 
   it('should log an error if no configParams were passed when getId', function () {
-    let submodule = intentIqIdSubmodule.getId();
+    let submodule = intentIqIdSubmodule.getId({ params: {} });
     expect(logErrorStub.calledOnce).to.be.true;
     expect(submodule).to.be.undefined;
   });
 
   it('should log an error if partner configParam was not passed when getId', function () {
-    let submodule = intentIqIdSubmodule.getId({});
+    let submodule = intentIqIdSubmodule.getId({ params: {} });
     expect(logErrorStub.calledOnce).to.be.true;
     expect(submodule).to.be.undefined;
   });
 
   it('should log an error if partner configParam was not a numeric value', function () {
-    let submodule = intentIqIdSubmodule.getId({partner: '10'});
+    let submodule = intentIqIdSubmodule.getId({ params: {partner: '10'} });
     expect(logErrorStub.calledOnce).to.be.true;
     expect(submodule).to.be.undefined;
   });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -4,7 +4,7 @@ import {uspDataHandler} from '../../../src/adapterManager.js';
 import {server} from 'test/mocks/xhr.js';
 
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = {publisherId: PUBLISHER_ID};
+const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('LiveIntentId', function () {
@@ -55,8 +55,8 @@ describe('LiveIntentId', function () {
   });
 
   it('should initialize LiveConnect with the config params when decode and emit an event', function () {
-    liveIntentIdSubmodule.decode({}, {
-      ...defaultConfigParams,
+    liveIntentIdSubmodule.decode({}, { params: {
+      ...defaultConfigParams.params,
       ...{
         url: 'https://dummy.liveintent.com',
         liCollectConfig: {
@@ -64,7 +64,7 @@ describe('LiveIntentId', function () {
           collectorUrl: 'https://collector.liveintent.com'
         }
       }
-    });
+    } });
     expect(pixel.src).to.match(/https:\/\/collector.liveintent.com\/p\?aid=a-0001&wpn=prebid.*/)
   });
 
@@ -95,7 +95,7 @@ describe('LiveIntentId', function () {
   it('should call the Custom URL of the LiveIntent Identity Exchange endpoint', function () {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({...defaultConfigParams, ...{'url': 'https://dummy.liveintent.com/idex'}}).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899');
@@ -110,13 +110,13 @@ describe('LiveIntentId', function () {
   it('should call the default url of the LiveIntent Identity Exchange endpoint, with a partner', function () {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({
-      ...defaultConfigParams,
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
+      ...defaultConfigParams.params,
       ...{
         'url': 'https://dummy.liveintent.com/idex',
         'partner': 'rubicon'
       }
-    }).callback;
+    } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899');
@@ -179,12 +179,12 @@ describe('LiveIntentId', function () {
     const oldCookie = 'a-xxxx--123e4567-e89b-12d3-a456-426655440000'
     getDataFromLocalStorageStub.withArgs('_li_duid').returns(oldCookie);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns('third-pc');
-    const configParams = {
-      ...defaultConfigParams,
+    const configParams = { params: {
+      ...defaultConfigParams.params,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
-    };
+    }};
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
@@ -201,12 +201,12 @@ describe('LiveIntentId', function () {
   it('should include an additional identifier value to resolve even if it is an object', function () {
     getCookieStub.returns(null);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns({'key': 'value'});
-    const configParams = {
-      ...defaultConfigParams,
+    const configParams = { params: {
+      ...defaultConfigParams.params,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
-    };
+    }};
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -92,7 +92,7 @@ describe('Parrable ID System', function() {
       })
 
       it('creates xhr to Parrable that synchronizes the ID', function() {
-        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK.params);
+        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK);
 
         getIdResult.callback(callbackSpy);
 
@@ -128,7 +128,7 @@ describe('Parrable ID System', function() {
         let uspString = '1YNN';
         uspDataHandler.setConsentData(uspString);
         parrableIdSubmodule.getId(
-          P_CONFIG_MOCK.params,
+          P_CONFIG_MOCK,
           null,
           null
         ).callback(callbackSpy);
@@ -138,7 +138,7 @@ describe('Parrable ID System', function() {
 
       it('should log an error and continue to callback if ajax request errors', function () {
         let callBackSpy = sinon.spy();
-        let submoduleCallback = parrableIdSubmodule.getId({partner: 'prebid'}).callback;
+        let submoduleCallback = parrableIdSubmodule.getId({ params: {partner: 'prebid'} }).callback;
         submoduleCallback(callBackSpy);
         let request = server.requests[0];
         expect(request.url).to.contain('h.parrable.com');
@@ -155,7 +155,7 @@ describe('Parrable ID System', function() {
     describe('response id', function() {
       it('provides the stored Parrable values if a cookie exists', function() {
         writeParrableCookie({ eid: P_COOKIE_EID });
-        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK.params);
+        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK);
         removeParrableCookie();
 
         expect(getIdResult.id).to.deep.equal({
@@ -171,7 +171,7 @@ describe('Parrable ID System', function() {
         storage.setCookie(oldEidCookieName, oldEid);
         storage.setCookie(oldOptoutCookieName, 'true');
 
-        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK.params);
+        let getIdResult = parrableIdSubmodule.getId(P_CONFIG_MOCK);
         expect(getIdResult.id).to.deep.equal({
           eid: oldEid,
           ibaOptout: true
@@ -212,9 +212,9 @@ describe('Parrable ID System', function() {
     });
 
     it('permits an impression when no timezoneFilter is configured', function() {
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
     });
 
     it('permits an impression from a blocked timezone when a cookie exists', function() {
@@ -224,12 +224,12 @@ describe('Parrable ID System', function() {
 
       writeParrableCookie({ eid: P_COOKIE_EID });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedZones: [ blockedZone ]
         }
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
       expect(resolvedOptions.called).to.equal(false);
 
       removeParrableCookie();
@@ -240,12 +240,12 @@ describe('Parrable ID System', function() {
       const resolvedOptions = sinon.stub().returns({ timeZone: allowedZone });
       Intl.DateTimeFormat.returns({ resolvedOptions });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           allowedZones: [ allowedZone ]
         }
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
       expect(resolvedOptions.called).to.equal(true);
     });
 
@@ -254,12 +254,12 @@ describe('Parrable ID System', function() {
       const resolvedOptions = sinon.stub().returns({ timeZone: 'Iceland' });
       Intl.DateTimeFormat.returns({ resolvedOptions });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedZones: [ blockedZone ]
         }
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
       expect(resolvedOptions.called).to.equal(true);
     });
 
@@ -268,12 +268,12 @@ describe('Parrable ID System', function() {
       const resolvedOptions = sinon.stub().returns({ timeZone: blockedZone });
       Intl.DateTimeFormat.returns({ resolvedOptions });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedZones: [ blockedZone ]
         }
-      })).to.equal(null);
+      } })).to.equal(null);
       expect(resolvedOptions.called).to.equal(true);
     });
 
@@ -282,13 +282,13 @@ describe('Parrable ID System', function() {
       const resolvedOptions = sinon.stub().returns({ timeZone: timezone });
       Intl.DateTimeFormat.returns({ resolvedOptions });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           allowedZones: [ timezone ],
           blockedZones: [ timezone ]
         }
-      })).to.equal(null);
+      } })).to.equal(null);
       expect(resolvedOptions.called).to.equal(true);
     });
   });
@@ -312,12 +312,12 @@ describe('Parrable ID System', function() {
 
       writeParrableCookie({ eid: P_COOKIE_EID });
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedOffsets: [ blockedOffset ]
         }
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
 
       removeParrableCookie();
     });
@@ -326,12 +326,12 @@ describe('Parrable ID System', function() {
       const allowedOffset = -5;
       Date.prototype.getTimezoneOffset.returns(allowedOffset * 60);
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           allowedOffsets: [ allowedOffset ]
         }
-      })).to.have.property('callback');
+      } })).to.have.property('callback');
       expect(Date.prototype.getTimezoneOffset.called).to.equal(true);
     });
 
@@ -340,12 +340,12 @@ describe('Parrable ID System', function() {
       const blockedOffset = 5;
       Date.prototype.getTimezoneOffset.returns(allowedOffset * 60);
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedOffsets: [ blockedOffset ]
         }
-      })).to.have.property('callback');
+      }})).to.have.property('callback');
       expect(Date.prototype.getTimezoneOffset.called).to.equal(true);
     });
 
@@ -353,12 +353,12 @@ describe('Parrable ID System', function() {
       const blockedOffset = -5;
       Date.prototype.getTimezoneOffset.returns(blockedOffset * 60);
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           blockedOffsets: [ blockedOffset ]
         }
-      })).to.equal(null);
+      } })).to.equal(null);
       expect(Date.prototype.getTimezoneOffset.called).to.equal(true);
     });
 
@@ -366,13 +366,13 @@ describe('Parrable ID System', function() {
       const offset = -5;
       Date.prototype.getTimezoneOffset.returns(offset * 60);
 
-      expect(parrableIdSubmodule.getId({
+      expect(parrableIdSubmodule.getId({ params: {
         partner: 'prebid-test',
         timezoneFilter: {
           allowedOffset: [ offset ],
           blockedOffsets: [ offset ]
         }
-      })).to.equal(null);
+      } })).to.equal(null);
       expect(Date.prototype.getTimezoneOffset.called).to.equal(true);
     });
   });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1567,7 +1567,7 @@ describe('User ID', function () {
             'mid': value['MOCKID']
           };
         },
-        getId: function (params, storedId) {
+        getId: function (config, storedId) {
           if (storedId) return {};
           return {id: {'MOCKID': '1234'}};
         }


### PR DESCRIPTION
## Type of change
- [ x ] Feature


## Description of change
Today, user id modules only receive the `params` object from publisher configuration. However, the `storage` object can also be useful to allow the submodule to know the storage type / name being used, what the refresh settings are, etc. To accomplish this, we have to pass the entire config object to the submodule in `getId`, `extendId`, and `decode`. 

This PR also updates every submodule and their tests to ensure they are still working as they were previously.
