### PR TITLE
appnexus bid adapter: move criteo data back to tpuids

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -220,15 +220,17 @@ export const spec = {
       });
     }
 
-    let eids = [];
     const criteoId = utils.deepAccess(bidRequests[0], `userId.criteoId`);
     if (criteoId) {
-      eids.push({
-        source: 'criteo.com',
-        id: criteoId
+      let tpuids = [];
+      tpuids.push({
+        'provider': 'criteo',
+        'user_id': criteoId
       });
+      payload.tpuids = tpuids;
     }
 
+    let eids = [];
     const tdid = utils.deepAccess(bidRequests[0], `userId.tdid`);
     if (tdid) {
       eids.push({

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -808,7 +808,7 @@ describe('AppNexusAdapter', function () {
       expect(request.options).to.deep.equal({withCredentials: false});
     });
 
-    it('should populate eids array when ttd id and criteo is available', function () {
+    it('should populate eids and tpuids when ttd id and criteo is available', function () {
       const bidRequest = Object.assign({}, bidRequests[0], {
         userId: {
           tdid: 'sample-userid',
@@ -824,9 +824,9 @@ describe('AppNexusAdapter', function () {
         rti_partner: 'TDID'
       });
 
-      expect(payload.eids).to.deep.include({
-        source: 'criteo.com',
-        id: 'sample-criteo-userid',
+      expect(payload.tpuids).to.deep.include({
+        provider: 'criteo',
+        user_id: 'sample-criteo-userid',
       });
     });
   })


### PR DESCRIPTION

## Type of change
- [x] Bugfix

## Description of change
Partial revert from #5346 

We're re-implementing the manner we are passing the criteo userId information to the appnexus endpoint.  We're currently leaving the ttd implementation as is (for now).