### PR TITLE
update teadsBidAdapter

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -150,7 +150,7 @@ function getTimeToFirstByte(win) {
     performance.timing.requestStart >= 0 &&
     performance.timing.responseStart - performance.timing.requestStart;
 
-  return ttfbWithTimingV1 ? ttfbWithTimingV1.toString() : '';
+  return ttfbWithTimingV1 ? ttfbWithTimingV1.toString() : '0';
 }
 
 function findGdprStatus(gdprApplies, gdprData, apiVersion) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
update teadsBidAdapter to return '0' instead of '' as fallback for getTimeToFirstByte method because it fails in unit tests
see #5796