### PR TITLE
Fix timeToFirstByte unit test

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -133,8 +133,8 @@ function getTimeToFirstByte(win) {
     performance.getEntriesByType('navigation')[0] &&
     performance.getEntriesByType('navigation')[0].responseStart &&
     performance.getEntriesByType('navigation')[0].requestStart &&
-    performance.getEntriesByType('navigation')[0].responseStart >= 0 &&
-    performance.getEntriesByType('navigation')[0].requestStart >= 0 &&
+    performance.getEntriesByType('navigation')[0].responseStart > 0 &&
+    performance.getEntriesByType('navigation')[0].requestStart > 0 &&
     Math.round(
       performance.getEntriesByType('navigation')[0].responseStart - performance.getEntriesByType('navigation')[0].requestStart
     );
@@ -146,8 +146,8 @@ function getTimeToFirstByte(win) {
   const ttfbWithTimingV1 = performance &&
     performance.timing.responseStart &&
     performance.timing.requestStart &&
-    performance.timing.responseStart >= 0 &&
-    performance.timing.requestStart >= 0 &&
+    performance.timing.responseStart > 0 &&
+    performance.timing.requestStart > 0 &&
     performance.timing.responseStart - performance.timing.requestStart;
 
   return ttfbWithTimingV1 ? ttfbWithTimingV1.toString() : '';

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -200,8 +200,8 @@ describe('teadsBidAdapter', () => {
         performance.getEntriesByType('navigation')[0] &&
         performance.getEntriesByType('navigation')[0].responseStart &&
         performance.getEntriesByType('navigation')[0].requestStart &&
-        performance.getEntriesByType('navigation')[0].responseStart >= 0 &&
-        performance.getEntriesByType('navigation')[0].requestStart >= 0 &&
+        performance.getEntriesByType('navigation')[0].responseStart > 0 &&
+        performance.getEntriesByType('navigation')[0].requestStart > 0 &&
         Math.round(
           performance.getEntriesByType('navigation')[0].responseStart - performance.getEntriesByType('navigation')[0].requestStart
         );
@@ -214,8 +214,8 @@ describe('teadsBidAdapter', () => {
         const ttfbWithTimingV1 = performance &&
             performance.timing.responseStart &&
             performance.timing.requestStart &&
-            performance.timing.responseStart >= 0 &&
-            performance.timing.requestStart >= 0 &&
+            performance.timing.responseStart > 0 &&
+            performance.timing.requestStart > 0 &&
             performance.timing.responseStart - performance.timing.requestStart;
         const ttfbExpectedV1 = ttfbWithTimingV1 ? ttfbWithTimingV1.toString() : '';
 

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -211,9 +211,15 @@ describe('teadsBidAdapter', () => {
       if (ttfbExpectedV2) {
         expect(payload.timeToFirstByte).to.deep.equal(ttfbExpectedV2.toString());
       } else {
-        const ttfbExpectedV1 = performance.timing.responseStart - performance.timing.requestStart;
+        const ttfbWithTimingV1 = performance &&
+            performance.timing.responseStart &&
+            performance.timing.requestStart &&
+            performance.timing.responseStart >= 0 &&
+            performance.timing.requestStart >= 0 &&
+            performance.timing.responseStart - performance.timing.requestStart;
+        const ttfbExpectedV1 = ttfbWithTimingV1 ? ttfbWithTimingV1.toString() : '';
 
-        expect(payload.timeToFirstByte).to.deep.equal(ttfbExpectedV1.toString());
+        expect(payload.timeToFirstByte).to.deep.equal(ttfbExpectedV1);
       }
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
In rare cases, the time to first byte unit test could end up with a value of 0 which in the Teads adapter code is not possible as we handle this case specifically by discarding the value and fallbacking on the empty string.
This change has for goal to add this fallback logic on the unit test in order to fix it.