### PR TITLE
ATS-analytics - add retry logic to not fire request for envelope every time, and cut down analytics requests to 1/10

### DIFF
--- a/modules/atsAnalyticsAdapter.js
+++ b/modules/atsAnalyticsAdapter.js
@@ -126,13 +126,16 @@ let atsAnalyticsAdapter = Object.assign(adapter(
       callHandler(eventType, args);
     }
     if (eventType === CONSTANTS.EVENTS.AUCTION_END) {
-      // send data to ats analytic endpoint
-      try {
-        let dataToSend = {'Data': atsAnalyticsAdapter.context.events};
-        let strJSON = JSON.stringify(dataToSend);
-        ajax(atsAnalyticsAdapter.context.host, function () {
-        }, strJSON, {method: 'POST', contentType: 'application/json'});
-      } catch (err) {
+      if (atsAnalyticsAdapter.shouldFireRequest()) {
+        // send data to ats analytic endpoint
+        try {
+          let dataToSend = {'Data': atsAnalyticsAdapter.context.events};
+          let strJSON = JSON.stringify(dataToSend);
+          utils.logInfo('atsAnalytics tried to send analytics data!');
+          ajax(atsAnalyticsAdapter.context.host, function () {
+          }, strJSON, {method: 'POST', contentType: 'application/json'});
+        } catch (err) {
+        }
       }
     }
   }
@@ -140,6 +143,11 @@ let atsAnalyticsAdapter = Object.assign(adapter(
 
 // save the base class function
 atsAnalyticsAdapter.originEnableAnalytics = atsAnalyticsAdapter.enableAnalytics;
+
+// add check to not fire request every time, but instead to send 1/10 events
+atsAnalyticsAdapter.shouldFireRequest = function () {
+  return (Math.floor((Math.random() * 11)) === 10);
+}
 
 // override enableAnalytics so we can get access to the config passed in from the page
 atsAnalyticsAdapter.enableAnalytics = function (config) {

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -8,6 +8,9 @@
 import * as utils from '../src/utils.js'
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
+import {getStorageManager} from '../src/storageManager.js';
+
+export const storage = getStorageManager();
 
 /** @type {Submodule} */
 export const identityLinkSubmodule = {
@@ -75,7 +78,6 @@ export const identityLinkSubmodule = {
 };
 // return envelope from third party endpoint
 function getEnvelope(url, callback) {
-  utils.logInfo('A 3P retrieval is attempted!');
   const callbacks = {
     success: response => {
       let responseObj;
@@ -93,7 +95,18 @@ function getEnvelope(url, callback) {
       callback();
     }
   };
-  ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
+
+  if (!storage.getCookie('_lr_retry_request')) {
+    setRetryCookie();
+    utils.logInfo('A 3P retrieval is attempted!');
+    ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
+  }
+}
+
+function setRetryCookie() {
+  let now = new Date();
+  now.setTime(now.getTime() + 3600000);
+  storage.setCookie('_lr_retry_request', 'true', now.toUTCString());
 }
 
 submodule('userId', identityLinkSubmodule);

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -18,7 +18,7 @@ describe('ats analytics adapter', function () {
 
   describe('track', function () {
     it('builds and sends request and response data', function () {
-      sinon.spy(atsAnalyticsAdapter, 'track');
+      sinon.stub(atsAnalyticsAdapter, 'shouldFireRequest').returns(true);
 
       let initOptions = {
         pid: '10433394',
@@ -134,7 +134,6 @@ describe('ats analytics adapter', function () {
       let requests = server.requests.filter(req => {
         return req.url.indexOf(initOptions.host) > -1;
       });
-
       expect(requests.length).to.equal(1);
 
       let realAfterBid = JSON.parse(requests[0].requestBody);

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -1,6 +1,9 @@
 import {identityLinkSubmodule} from 'modules/identityLinkIdSystem.js';
 import * as utils from 'src/utils.js';
 import {server} from 'test/mocks/xhr.js';
+import {getStorageManager} from '../../../src/storageManager.js';
+
+export const storage = getStorageManager();
 
 const pid = '14';
 const defaultConfigParams = {pid: pid};
@@ -11,6 +14,8 @@ describe('IdentityLinkId tests', function () {
 
   beforeEach(function () {
     logErrorStub = sinon.stub(utils, 'logError');
+    // remove _lr_retry_request cookie before test
+    storage.setCookie('_lr_retry_request', 'true', 'Thu, 01 Jan 1970 00:00:01 GMT');
   });
 
   afterEach(function () {
@@ -121,6 +126,31 @@ describe('IdentityLinkId tests', function () {
       503,
       responseHeader,
       'Unavailable'
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should not call the LiveRamp envelope endpoint if cookie _lr_retry_request exist', function () {
+    let now = new Date();
+    now.setTime(now.getTime() + 3000);
+    storage.setCookie('_lr_retry_request', 'true', now.toUTCString());
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request).to.be.eq(undefined);
+  });
+
+  it('should call the LiveRamp envelope endpoint if cookie _lr_retry_request does exist', function () {
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14');
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
   });

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -141,7 +141,7 @@ describe('IdentityLinkId tests', function () {
     expect(request).to.be.eq(undefined);
   });
 
-  it('should call the LiveRamp envelope endpoint if cookie _lr_retry_request does exist', function () {
+  it('should call the LiveRamp envelope endpoint if cookie _lr_retry_request does not exist', function () {
     let callBackSpy = sinon.spy();
     let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);


### PR DESCRIPTION
## Type of change

- Improvement

## Description of change
Add retry logic to not fire request for envelope every time in identityLinkSubmodule, instead to wait 1h, and cut down analytics requests to 1/10 in atsAnalyticsAdapter.

