### PR TITLE
[AD-963] - Update JW Player RTD Provider for compliance with RTD Module Phase 3

### DIFF
--- a/integrationExamples/gpt/jwplayerRtdProvider_example.html
+++ b/integrationExamples/gpt/jwplayerRtdProvider_example.html
@@ -32,7 +32,6 @@
 
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
-
     </script>
 
     <script>
@@ -45,8 +44,10 @@
       pbjs.que.push(function() {
         pbjs.setConfig({
           realTimeData: {
+            auctionDelay: 5000,
             dataProviders: [{
               name: "jwplayer",
+              waitForIt: true,
               params: {
                 mediaIDs: ['abc', 'def', 'ghi', 'jkl']
               }

--- a/integrationExamples/gpt/jwplayerRtdProvider_example.html
+++ b/integrationExamples/gpt/jwplayerRtdProvider_example.html
@@ -12,6 +12,7 @@
       var adUnits = [{
         code: 'div-gpt-ad-1460505748561-0',
         jwTargeting: {
+          // Note: the following Ids are placeholders and should be replaced with your Ids.
           playerID: '123',
           mediaID: 'abc'
         },
@@ -49,6 +50,7 @@
               name: "jwplayer",
               waitForIt: true,
               params: {
+                // Note: the following media Ids are placeholders and should be replaced with your Ids.
                 mediaIDs: ['abc', 'def', 'ghi', 'jkl']
               }
             }]

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -344,17 +344,17 @@ function buildNewRequest(validBidRequests, bidderRequest) {
     if (!userId) {
       userId = bid.userId;
     }
-    const {params: {uid, keywords}, mediaTypes, bidId, adUnitCode, realTimeData} = bid;
+    const {params: {uid, keywords}, mediaTypes, bidId, adUnitCode, jwTargeting} = bid;
     bidsMap[bidId] = bid;
     if (!pageKeywords && !utils.isEmpty(keywords)) {
       pageKeywords = utils.transformBidderParamKeywords(keywords);
     }
-    if (realTimeData && realTimeData.jwTargeting) {
-      if (!jwpseg && realTimeData.jwTargeting.segments) {
-        jwpseg = realTimeData.jwTargeting.segments;
+    if (jwTargeting) {
+      if (!jwpseg && jwTargeting.segments) {
+        jwpseg = jwTargeting.segments;
       }
-      if (!content && realTimeData.jwTargeting.content) {
-        content = realTimeData.jwTargeting.content;
+      if (!content && jwTargeting.content) {
+        content = jwTargeting.content;
       }
     }
     let impObj = {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -146,7 +146,7 @@ function enrichBidRequest(bidReqConfig, onDone) {
  * @param {adUnit[]} adUnits
  * @param {function} onDone
  */
-function enrichAdUnits(adUnits) {
+export function enrichAdUnits(adUnits) {
   adUnits.forEach(adUnit => {
     const onVatResponse = function (vat) {
       if (!vat) {
@@ -181,17 +181,20 @@ function loadVatForPendingRequest(playerID, mediaID, callback) {
   }
 }
 
-function getVatFromCache(mediaID) {
-  let segments = segCache[mediaID];
-  if (segments) {
-    return {
-      segments,
-      mediaID
-    };
+export function getVatFromCache(mediaID) {
+  const segments = segCache[mediaID];
+
+  if (!segments) {
+    return null;
   }
+
+  return {
+    segments,
+    mediaID
+  };
 }
 
-function getVatFromPlayer(playerID, mediaID) {
+export function getVatFromPlayer(playerID, mediaID) {
   const player = getPlayer(playerID);
   if (!player) {
     return null;
@@ -214,7 +217,7 @@ function getVatFromPlayer(playerID, mediaID) {
   };
 }
 
-function formatTargetingResponse(vat) {
+export function formatTargetingResponse(vat) {
   const { segments, mediaID } = vat;
   const targeting = {};
   if (segments && segments.length) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -17,7 +17,6 @@ import find from 'core-js-pure/features/array/find.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 
 const SUBMODULE_NAME = 'jwplayer';
-let requestTimeout = 150;
 const segCache = {};
 const pendingRequests = {};
 let activeRequestCount = 0;
@@ -47,8 +46,6 @@ config.getConfig('realTimeData', ({realTimeData}) => {
   if (!params) {
     return;
   }
-  const rtdModuleTimeout = params.auctionDelay || params.timeout || realTimeData.auctionDelay;
-  requestTimeout = rtdModuleTimeout === undefined ? requestTimeout : Math.max(rtdModuleTimeout - 1, 0);
   fetchTargetingInformation(params);
 });
 
@@ -69,7 +66,7 @@ export function fetchTargetingInformation(jwTargeting) {
 }
 
 export function fetchTargetingForMediaId(mediaId) {
-  const ajax = ajaxBuilder(requestTimeout);
+  const ajax = ajaxBuilder();
   // TODO: Avoid checking undefined vs null by setting a callback to pendingRequests.
   pendingRequests[mediaId] = null;
   ajax(`https://cdn.jwplayer.com/v2/media/${mediaId}`, {
@@ -166,7 +163,6 @@ function loadVat(params, onCompletion) {
   }
 
   const { playerID, mediaID } = params;
-
   if (pendingRequests[mediaID] !== undefined) {
     loadVatForPendingRequest(playerID, mediaID, onCompletion);
     return;

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -1,5 +1,5 @@
 The purpose of this Real Time Data Provider is to allow publishers to target against their JW Player media without 
-having to integrate with the VPB product. This prebid module makes JW Player's video ad targeting information accessible 
+having to integrate with the Player Bidding product. This prebid module makes JW Player's video ad targeting information accessible 
 to Bid Adapters.
 
 #Usage for Publishers:
@@ -112,3 +112,5 @@ To view an example:
 - in your browser, navigate to:
 
 `http://localhost:9999/integrationExamples/gpt/jwplayerRtdProvider_example.html`
+
+**Note:** the mediaIds in the example are placeholder values; replace them with your existing IDs.

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -2,7 +2,7 @@ The purpose of this Real Time Data Provider is to allow publishers to target aga
 having to integrate with the VPB product. This prebid module makes JW Player's video ad targeting information accessible 
 to Bid Adapters.
 
-**Usage for Publishers:**
+#Usage for Publishers:
 
 Compile the JW Player RTD Provider into your Prebid build:
 
@@ -25,17 +25,6 @@ pbjs.setConfig({
     }
 });
 ```
-
-In order to prefetch targeting information for certain media, include the media IDs in the `jwplayerDataProvider` var:
-
-```javascript
-const jwplayerDataProvider = {
-  name: "jwplayer",
-  params: {
-    mediaIDs: ['abc', 'def', 'ghi', 'jkl']
-  }
-};
-```
 Lastly, include the content's media ID and/or the player's ID in the matching AdUnit:
 
 ```javascript
@@ -43,6 +32,7 @@ const adUnit = {
   code: '/19968336/prebid_native_example_1',
   ...
   jwTargeting: {
+    waitForIt: true,
     playerID: 'abcd',
     mediaID: '1234'
   }
@@ -55,26 +45,54 @@ pbjs.que.push(function() {
     });
 });
 ``` 
+##Prefetching
+In order to prefetch targeting information for certain media, include the media IDs in the `jwplayerDataProvider` var:
 
-**Usage for Bid Adapters:**
+```javascript
+const jwplayerDataProvider = {
+  name: "jwplayer",
+  params: {
+    mediaIDs: ['abc', 'def', 'ghi', 'jkl']
+  }
+};
+```
+
+To ensure that the prefetched targeting information is added to your bid, we strongly suggest setting 
+`jwTargeting.waitForIt` to `true`. If the prefetch is still in progress at the time of the bid request, the auction will
+be delayed until the targeting information specific to the requested adUnits has been obtained.
+
+```javascript
+jwTargeting: {
+    waitForIt: true,
+    ...
+}
+```
+
+You must also set a value to `auctionDelay` in the config's `realTimeData` object 
+
+```javascript
+realTimeData = {
+  auctionDelay: 1000,
+  ...
+};
+```
+
+#Usage for Bid Adapters:
 
 Implement the `buildRequests` function. When it is called, the `bidRequests` param will be an array of bids.
 Each bid for which targeting information was found will conform to the following object structure:
 
 ```javascript
 {
-     adUnitCode: 'xyz',
-     bidId: 'abc',
-     ...
-     realTimeData: {
-          ...,
-          jwTargeting: {
-               segments: ['123', '456'],
-               content: {
-                  id: 'jw_abc123'
-               }
-          }
-     }
+    adUnitCode: 'xyz',
+    bidId: 'abc',
+    ...,
+    jwTargeting: {
+      segments: ['123', '456'],
+      content: {
+        id: 'jw_abc123'
+      }
+    }
 }
 ```
 

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -579,16 +579,14 @@ describe('TheMediaGrid Adapter', function () {
       expect(payload.source.ext.schain).to.deep.equal(schain);
     });
 
-    it('if content and segment is present in realTimeData.jwTargeting, payload must have right params', function () {
+    it('if content and segment is present in jwTargeting, payload must have right params', function () {
       const jsContent = {id: 'test_jw_content_id'};
       const jsSegments = ['test_seg_1', 'test_seg_2'];
       const bidRequestsWithUserIds = bidRequests.map((bid) => {
         return Object.assign({
-          realTimeData: {
-            jwTargeting: {
-              segments: jsSegments,
-              content: jsContent
-            }
+          jwTargeting: {
+            segments: jsSegments,
+            content: jsContent
           }
         }, bid);
       });

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -1,4 +1,5 @@
-import { fetchTargetingForMediaId, getTargetingForBid,
+import { fetchTargetingForMediaId, enrichBidRequest,
+  getVatFromCache, formatTargetingResponse,
   fetchTargetingInformation, jwplayerSubmodule } from 'modules/jwplayerRtdProvider.js';
 import { server } from 'test/mocks/xhr.js';
 
@@ -39,11 +40,7 @@ describe('jwplayerRtdProvider', function() {
           })
         );
 
-        const targetingInfo = getTargetingForBid({
-          jwTargeting: {
-            mediaID: testIdForSuccess
-          }
-        });
+        const targetingInfo = getVatFromCache(testIdForSuccess);
 
         const validTargeting = {
           segments: validSegments,
@@ -62,21 +59,13 @@ describe('jwplayerRtdProvider', function() {
 
       it('should not write to cache when response is malformed', function() {
         request.respond('{]');
-        const targetingInfo = getTargetingForBid({
-          jwTargeting: {
-            mediaID: testIdForFailure
-          }
-        });
+        const targetingInfo = getVatFromCache(testIdForFailure);
         expect(targetingInfo).to.be.null;
       });
 
       it('should not write to cache when playlist is absent', function() {
         request.respond({});
-        const targetingInfo = getTargetingForBid({
-          jwTargeting: {
-            mediaID: testIdForFailure
-          }
-        });
+        const targetingInfo = getVatFromCache(testIdForFailure);
         expect(targetingInfo).to.be.null;
       });
 
@@ -92,21 +81,13 @@ describe('jwplayerRtdProvider', function() {
             ]
           })
         );
-        const targetingInfo = getTargetingForBid({
-          jwTargeting: {
-            mediaID: testIdForFailure
-          }
-        });
+        const targetingInfo = getVatFromCache(testIdForFailure);
         expect(targetingInfo).to.be.null;
       });
 
       it('should not write to cache when request errors', function() {
         request.error();
-        const targetingInfo = getTargetingForBid({
-          jwTargeting: {
-            mediaID: testIdForFailure
-          }
-        });
+        const targetingInfo = getVatFromCache(testIdForFailure);
         expect(targetingInfo).to.be.null;
       });
     });
@@ -393,6 +374,170 @@ describe('jwplayerRtdProvider', function() {
 
         jwplayerSubmodule.getData([adUnitWithMediaId, adUnitEmpty], bidRequestSpy);
         expect(bidRequestSpy.calledOnceWithExactly({})).to.be.true;
+      });
+    });
+  });
+
+  describe('Format targeting response', function () {
+    it('should exclude segment key when absent', function () {
+      const targeting = formatTargetingResponse({ mediaID: 'test' });
+      expect(targeting).to.not.have.property('segments');
+    });
+
+    it('should exclude content block when mediaId is absent', function () {
+      const targeting = formatTargetingResponse({ segments: ['test'] });
+      expect(targeting).to.not.have.property('content');
+    });
+
+    it('should return proper format', function () {
+      const segments = ['123'];
+      const mediaID = 'test';
+      const expectedContentId = 'jw_' + mediaID;
+      const expectedContent = {
+        id: expectedContentId
+      };
+      const targeting = formatTargetingResponse({
+        segments,
+        mediaID
+      });
+      expect(targeting).to.have.deep.property('segments', segments);
+      expect(targeting).to.have.deep.property('content', expectedContent);
+    });
+  });
+
+  describe('Get VAT from player', function () {
+    it('returns null when jwplayer.js is absent from page', function () {
+      const targeting = getTargetingForBid({
+        jwTargeting: {
+          playerID: invalidPlayerID,
+          mediaID: mediaIdNotCached
+        }
+      });
+      expect(targeting).to.be.null;
+    });
+
+    describe('When jwplayer.js is on page', function () {
+      const playlistItemWithSegmentMock = {
+        mediaid: mediaIdWithSegment,
+        jwpseg: validSegments
+      };
+
+      const targetingForMediaWithSegment = {
+        segments: validSegments,
+        mediaID: mediaIdWithSegment
+      };
+
+      const playlistItemNoSegmentMock = {
+        mediaid: mediaIdNoSegment
+      };
+
+      const currentItemSegments = ['test_seg_3', 'test_seg_4'];
+      const currentPlaylistItemMock = {
+        mediaid: mediaIdForCurrentItem,
+        jwpseg: currentItemSegments
+      };
+      const targetingForCurrentItem = {
+        segments: currentItemSegments,
+        mediaID: mediaIdForCurrentItem
+      };
+
+      const playerInstanceMock = {
+        getPlaylist: function () {
+          return [playlistItemWithSegmentMock, playlistItemNoSegmentMock];
+        },
+
+        getPlaylistItem: function () {
+          return currentPlaylistItemMock;
+        }
+      };
+
+      const jwplayerMock = function(playerID) {
+        if (playerID === validPlayerID) {
+          return playerInstanceMock;
+        } else {
+          return {};
+        }
+      };
+
+      beforeEach(function () {
+        window.jwplayer = jwplayerMock;
+      });
+
+      it('returns null when player ID does not match player on page', function () {
+        const targeting = getTargetingForBid({
+          jwTargeting: {
+            playerID: invalidPlayerID,
+            mediaID: mediaIdNotCached
+          }
+        });
+        expect(targeting).to.be.null;
+      });
+
+      it('returns segments when media ID matches a playlist item with segments', function () {
+        const targeting = getTargetingForBid({
+          jwTargeting: {
+            playerID: validPlayerID,
+            mediaID: mediaIdWithSegment
+          }
+        });
+        expect(targeting).to.deep.equal(targetingForMediaWithSegment);
+      });
+
+      it('caches segments media ID matches a playist item with segments', function () {
+        getTargetingForBid({
+          jwTargeting: {
+            playerID: validPlayerID,
+            mediaID: mediaIdWithSegment
+          }
+        });
+
+        window.jwplayer = null;
+        const targeting2 = getTargetingForBid({
+          jwTargeting: {
+            playerID: invalidPlayerID,
+            mediaID: mediaIdWithSegment
+          }
+        });
+        expect(targeting2).to.deep.equal(targetingForMediaWithSegment);
+      });
+
+      it('returns segments of current item when media ID is missing', function () {
+        const targeting = getTargetingForBid({
+          jwTargeting: {
+            playerID: validPlayerID
+          }
+        });
+        expect(targeting).to.deep.equal(targetingForCurrentItem);
+      });
+
+      it('caches segments from the current item', function () {
+        getTargetingForBid({
+          jwTargeting: {
+            playerID: validPlayerID
+          }
+        });
+
+        window.jwplayer = null;
+        const targeting2 = getTargetingForBid({
+          jwTargeting: {
+            playerID: invalidPlayerID,
+            mediaID: mediaIdForCurrentItem
+          }
+        });
+        expect(targeting2).to.deep.equal(targetingForCurrentItem);
+      });
+
+      it('returns undefined segments when segments are absent', function () {
+        const targeting = getTargetingForBid({
+          jwTargeting: {
+            playerID: validPlayerID,
+            mediaID: mediaIdNoSegment
+          }
+        });
+        expect(targeting).to.deep.equal({
+          mediaID: mediaIdNoSegment,
+          segments: undefined
+        });
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This PR is a side-effect of the changes proposed in #5783 and should be merged with it. 
It modifies the JW Player RTD Provider to conform to the desired interface and behavior dictated by the RTD Module 

Additionally, it updates the `gridBidAdapter.js`'s implementation to use the updated  `jwTargeting` property in bid instances instead of the obsolete `realTimeData`. A member from The Media Grid will review these changes.

- contact email of the adapter’s maintainer
karim@jwplayer.com

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
Prerequisite PR: #5783 
Documentation PR: https://github.com/prebid/prebid.github.io/pull/2427
sample mediaid for testing: `'2XZFlRuo'`
