### PR TITLE
Add skip params to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -14,7 +14,7 @@ export const VIDEO_ENDPOINT = 'https://reachms.bfmio.com/bid.json?exchange_id=';
 export const BANNER_ENDPOINT = 'https://display.bfmio.com/prebid_display';
 export const OUTSTREAM_SRC = 'https://player-cdn.beachfrontmedia.com/playerapi/loader/outstream.js';
 
-export const VIDEO_TARGETING = ['mimes', 'playbackmethod', 'maxduration', 'placement'];
+export const VIDEO_TARGETING = ['mimes', 'playbackmethod', 'maxduration', 'placement', 'skip', 'skipmin', 'skipafter'];
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 
 let appId = '';
@@ -258,12 +258,19 @@ function getTopWindowReferrer() {
 }
 
 function getVideoTargetingParams(bid) {
-  return Object.keys(Object(bid.params.video))
-    .filter(param => includes(VIDEO_TARGETING, param))
-    .reduce((obj, param) => {
-      obj[ param ] = bid.params.video[ param ];
-      return obj;
-    }, {});
+  const result = {};
+  const excludeProps = ['playerSize', 'context'];
+  Object.keys(Object(bid.mediaTypes.video))
+    .filter(key => !includes(excludeProps, key))
+    .forEach(key => {
+      result[ key ] = bid.mediaTypes.video[ key ];
+    });
+  Object.keys(Object(bid.params.video))
+    .filter(key => includes(VIDEO_TARGETING, key))
+    .forEach(key => {
+      result[ key ] = bid.params.video[ key ];
+    });
+  return result;
 }
 
 function createVideoRequestData(bid, bidderRequest) {

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -6,7 +6,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes.js';
 import find from 'core-js-pure/features/array/find.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
-const ADAPTER_VERSION = '1.11';
+const ADAPTER_VERSION = '1.12';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -259,7 +259,7 @@ function getTopWindowReferrer() {
 
 function getVideoTargetingParams(bid) {
   const result = {};
-  const excludeProps = ['playerSize', 'context'];
+  const excludeProps = ['playerSize', 'context', 'w', 'h'];
   Object.keys(Object(bid.mediaTypes.video))
     .filter(key => !includes(excludeProps, key))
     .forEach(key => {

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -223,17 +223,33 @@ describe('BeachfrontAdapter', function () {
         expect(data.imp[0].video).to.deep.contain({ w: width, h: height });
       });
 
-      it('must override video targeting params', function () {
+      it('must set video params from the standard object', function () {
         const bidRequest = bidRequests[0];
         const mimes = ['video/webm'];
         const playbackmethod = 2;
         const maxduration = 30;
         const placement = 4;
-        bidRequest.mediaTypes = { video: {} };
-        bidRequest.params.video = { mimes, playbackmethod, maxduration, placement };
+        const skip = 1;
+        bidRequest.mediaTypes = {
+          video: { mimes, playbackmethod, maxduration, placement, skip }
+        };
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
-        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod, maxduration, placement });
+        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod, maxduration, placement, skip });
+      });
+
+      it('must override video params from the bidder object', function () {
+        const bidRequest = bidRequests[0];
+        const mimes = ['video/webm'];
+        const playbackmethod = 2;
+        const maxduration = 30;
+        const placement = 4;
+        const skip = 1;
+        bidRequest.mediaTypes = { video: { placement: 3, skip: 0 } };
+        bidRequest.params.video = { mimes, playbackmethod, maxduration, placement, skip };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.imp[0].video).to.deep.contain({ mimes, playbackmethod, maxduration, placement, skip });
       });
 
       it('must add US privacy data to the request', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds bidder params for skip, skipmin, and skipafter. Also modifies the adapter to read video params from the standard `mediaTypes.video` object.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
PR for docs:
prebid/prebid.github.io#2412