### PR TITLE
feat: add the elapsed time to events for debugging

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -44,7 +44,8 @@ module.exports = (function () {
     eventsFired.push({
       eventType: eventString,
       args: eventPayload,
-      id: key
+      id: key,
+      elapsedTime: utils.now(),
     });
 
     /** Push each specific callback to the `callbacks` array.

--- a/src/events.js
+++ b/src/events.js
@@ -45,7 +45,7 @@ module.exports = (function () {
       eventType: eventString,
       args: eventPayload,
       id: key,
-      elapsedTime: utils.now(),
+      elapsedTime: utils.getPerformanceNow(),
     });
 
     /** Push each specific callback to the `callbacks` array.

--- a/src/utils.js
+++ b/src/utils.js
@@ -723,6 +723,14 @@ export function timestamp() {
 }
 
 /**
+ * The returned value represents the time elapsed since the time origin. @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+ * @returns {number}
+ */
+export function now() {
+  return (performance && performance.now && performance.now()) || 0;
+}
+
+/**
  * When the deviceAccess flag config option is false, no cookies should be read or set
  * @returns {boolean}
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -726,8 +726,8 @@ export function timestamp() {
  * The returned value represents the time elapsed since the time origin. @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
  * @returns {number}
  */
-export function now() {
-  return (performance && performance.now && performance.now()) || 0;
+export function getPerformanceNow() {
+  return (window.performance && window.performance.now && window.performance.now()) || 0;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add to the events a new field to track the elapsed time
It allows us to better understand the whole process of the auctions run on the page. 

The tracked value represents the time elapsed since the time origin. See here for more information https://developer.mozilla.org/en-US/docs/Web/API/Performance/now.
In case of the `performance.now()` is not supported, there is no fallback, the value 0 is simply logged instead.