### PR TITLE
Add check for consentManagement config to make sure it's defined

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -451,7 +451,7 @@ export function resetConsentData() {
 export function setConsentConfig(config) {
   // if `config.gdpr` or `config.usp` exist, assume new config format.
   // else for backward compatability, just use `config`
-  config = config.gdpr || config.usp ? config.gdpr : config;
+  config = config && (config.gdpr || config.usp ? config.gdpr : config);
   if (!config || typeof config !== 'object') {
     utils.logWarn('consentManagement config not defined, exiting consent manager');
     return;

--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -269,7 +269,7 @@ export function resetConsentData() {
  * @param {object} config required; consentManagementUSP module config settings; usp (string), timeout (int), allowAuctionWithoutConsent (boolean)
  */
 export function setConsentConfig(config) {
-  config = config.usp;
+  config = config && config.usp;
   if (!config || typeof config !== 'object') {
     utils.logWarn('consentManagement.usp config not defined, exiting usp consent manager');
     return;

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -64,6 +64,13 @@ describe('consentManagement', function () {
         sinon.assert.calledOnce(utils.logWarn);
         sinon.assert.notCalled(utils.logInfo);
       });
+
+      it('should exit consentManagementUsp module if config is "undefined"', function() {
+        setConsentConfig(undefined);
+        expect(consentAPI).to.be.undefined;
+        sinon.assert.calledOnce(utils.logWarn);
+        sinon.assert.notCalled(utils.logInfo);
+      });
     });
 
     describe('valid setConsentConfig value', function () {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -39,6 +39,12 @@ describe('consentManagement', function () {
         expect(userCMP).to.be.undefined;
         sinon.assert.calledOnce(utils.logWarn);
       });
+
+      it('should exit consentManagement module if config is "undefined"', function() {
+        setConsentConfig(undefined);
+        expect(userCMP).to.be.undefined;
+        sinon.assert.calledOnce(utils.logWarn);
+      });
     });
 
     describe('valid setConsentConfig value', function () {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change

If a publisher decides to set consentManagement config to `undefined` in setConfig, Prebid throws an uncaught error on the console. This PR fixes that!

Resolves https://github.com/prebid/Prebid.js/issues/5832