### PR TITLE
Add apacdex bid adapter & Merge valueimpression, quantumdex to apacdex

### DIFF
--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -1,7 +1,11 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-const BIDDER_CODE = 'quantumdex';
+const BIDDER_CODE = 'apacdex';
 const CONFIG = {
+  'apacdex': {
+    'ENDPOINT': 'https://useast.quantumdex.io/auction/apacdex',
+    'USERSYNC': 'https://sync.quantumdex.io/usersync/apacdex'
+  },
   'quantumdex': {
     'ENDPOINT': 'https://useast.quantumdex.io/auction/quantumdex',
     'USERSYNC': 'https://sync.quantumdex.io/usersync/quantumdex'
@@ -12,14 +16,14 @@ const CONFIG = {
   }
 };
 
-var bidderConfig = CONFIG['quantumdex'];
+var bidderConfig = CONFIG[BIDDER_CODE];
 var bySlotTargetKey = {};
 var bySlotSizesCount = {}
 
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: ['banner', 'video'],
-  aliases: ['valueimpression'],
+  aliases: ['quantumdex', 'valueimpression'],
   isBidRequestValid: function (bid) {
     if (!bid.params) {
       return false;
@@ -30,7 +34,7 @@ export const spec = {
     if (!utils.deepAccess(bid, 'mediaTypes.banner') && !utils.deepAccess(bid, 'mediaTypes.video')) {
       return false;
     }
-    if (utils.deepAccess(bid, 'mediaTypes.banner')) { // Quantumdex does not support multi type bids, favor banner over video
+    if (utils.deepAccess(bid, 'mediaTypes.banner')) { // Not support multi type bids, favor banner over video
       if (!utils.deepAccess(bid, 'mediaTypes.banner.sizes')) {
         // sizes at the banner is required.
         return false;

--- a/modules/apacdexBidAdapter.md
+++ b/modules/apacdexBidAdapter.md
@@ -1,15 +1,15 @@
 # Overview
 
 ```
-Module Name: Quantum Digital Exchange Bidder Adapter
+Module Name: APAC Digital Exchange Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: ken@quantumdex.io
+Maintainer: ken@apacdex.com
 ```
 
 # Description
 
-Connects to Quantum Digital Exchange for bids.
-Quantumdex bid adapter supports Banner and Video (Instream and Outstream) ads.
+Connects to APAC Digital Exchange for bids.
+Apacdex bid adapter supports Banner and Video (Instream and Outstream) ads.
 
 # Test Parameters
 ```
@@ -23,9 +23,9 @@ var adUnits = [
     },
     bids: [
       {
-          bidder: 'quantumdex',
+          bidder: 'apacdex',
           params: {
-              siteId: 'quantumdex-site-id', // siteId provided by Quantumdex
+              siteId: 'apacdex1234', // siteId provided by Apacdex
           }
       }
     ]
@@ -46,9 +46,9 @@ var videoAdUnit = {
   },
   bids: [
     {
-      bidder: 'quantumdex',
+      bidder: 'apacdex',
       params: {
-        siteId: 'quantumdex-site-id', // siteId provided by Quantumdex
+        siteId: 'apacdex1234', // siteId provided by Apacdex
       }
     }
   ]

--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai'
-import { spec } from 'modules/quantumdexBidAdapter.js'
+import { spec } from 'modules/apacdexBidAdapter.js'
 import { newBidder } from 'src/adapters/bidderFactory.js'
 import { userSync } from '../../../src/userSync.js';
 
-describe('QuantumdexBidAdapter', function () {
+describe('ApacdexBidAdapter', function () {
   const adapter = newBidder(spec)
 
   describe('.code', function () {
-    it('should return a bidder code of quantumdex', function () {
-      expect(spec.code).to.equal('quantumdex')
+    it('should return a bidder code of apacdex', function () {
+      expect(spec.code).to.equal('apacdex')
     })
   })
 
@@ -21,7 +21,7 @@ describe('QuantumdexBidAdapter', function () {
   describe('.isBidRequestValid', function () {
     it('should return false if there are no params', () => {
       const bid = {
-        'bidder': 'quantumdex',
+        'bidder': 'apacdex',
         'adUnitCode': 'adunit-code',
         'mediaTypes': {
           banner: {
@@ -37,7 +37,7 @@ describe('QuantumdexBidAdapter', function () {
 
     it('should return false if there is no siteId param', () => {
       const bid = {
-        'bidder': 'quantumdex',
+        'bidder': 'apacdex',
         'adUnitCode': 'adunit-code',
         params: {
           site_id: '1a2b3c4d5e6f1a2b3c4d',
@@ -56,7 +56,7 @@ describe('QuantumdexBidAdapter', function () {
 
     it('should return false if there is no mediaTypes', () => {
       const bid = {
-        'bidder': 'quantumdex',
+        'bidder': 'apacdex',
         'adUnitCode': 'adunit-code',
         params: {
           siteId: '1a2b3c4d5e6f1a2b3c4d'
@@ -72,7 +72,7 @@ describe('QuantumdexBidAdapter', function () {
 
     it('should return true if the bid is valid', () => {
       const bid = {
-        'bidder': 'quantumdex',
+        'bidder': 'apacdex',
         'adUnitCode': 'adunit-code',
         params: {
           siteId: '1a2b3c4d5e6f1a2b3c4d'
@@ -92,7 +92,7 @@ describe('QuantumdexBidAdapter', function () {
     describe('banner', () => {
       it('should return false if there are no banner sizes', () => {
         const bid = {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'adUnitCode': 'adunit-code',
           params: {
             siteId: '1a2b3c4d5e6f1a2b3c4d'
@@ -111,7 +111,7 @@ describe('QuantumdexBidAdapter', function () {
 
       it('should return true if there is banner sizes', () => {
         const bid = {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'adUnitCode': 'adunit-code',
           params: {
             siteId: '1a2b3c4d5e6f1a2b3c4d'
@@ -132,7 +132,7 @@ describe('QuantumdexBidAdapter', function () {
     describe('video', () => {
       it('should return false if there is no playerSize defined in the video mediaType', () => {
         const bid = {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'adUnitCode': 'adunit-code',
           params: {
             siteId: '1a2b3c4d5e6f1a2b3c4d',
@@ -152,7 +152,7 @@ describe('QuantumdexBidAdapter', function () {
 
       it('should return true if there is playerSize defined on the video mediaType', () => {
         const bid = {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'adUnitCode': 'adunit-code',
           params: {
             siteId: '1a2b3c4d5e6f1a2b3c4d',
@@ -196,7 +196,7 @@ describe('QuantumdexBidAdapter', function () {
           },
         ]
       },
-      'bidder': 'quantumdex',
+      'bidder': 'apacdex',
       'params': {
         'siteId': '1a2b3c4d5e6f1a2b3c4d',
       },
@@ -206,7 +206,7 @@ describe('QuantumdexBidAdapter', function () {
       'bidId': '30b31c1838de1f',
     },
     {
-      'bidder': 'quantumdex',
+      'bidder': 'apacdex',
       'params': {
         'ad_unit': '/7780971/sparks_prebid_LB',
         'sizes': [[300, 250], [300, 600]],
@@ -235,14 +235,14 @@ describe('QuantumdexBidAdapter', function () {
 
     it('should return a properly formatted request', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
+      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/apacdex')
       expect(bidRequests.method).to.equal('POST')
       expect(bidRequests.bidderRequests).to.eql(bidRequest);
     })
 
     it('should return a properly formatted request with GDPR applies set to true', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
+      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/apacdex')
       expect(bidRequests.method).to.equal('POST')
       expect(bidRequests.data.gdpr.gdprApplies).to.equal(true)
       expect(bidRequests.data.gdpr.consentString).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
@@ -251,7 +251,7 @@ describe('QuantumdexBidAdapter', function () {
     it('should return a properly formatted request with GDPR applies set to false', function () {
       bidderRequests.gdprConsent.gdprApplies = false;
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
+      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/apacdex')
       expect(bidRequests.method).to.equal('POST')
       expect(bidRequests.data.gdpr.gdprApplies).to.equal(false)
       expect(bidRequests.data.gdpr.consentString).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==')
@@ -271,7 +271,7 @@ describe('QuantumdexBidAdapter', function () {
         }
       };
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
+      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/apacdex')
       expect(bidRequests.method).to.equal('POST')
       expect(bidRequests.data.gdpr.gdprApplies).to.equal(false)
       expect(bidRequests.data.gdpr).to.not.include.keys('consentString')
@@ -291,7 +291,7 @@ describe('QuantumdexBidAdapter', function () {
         }
       };
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/quantumdex')
+      expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/apacdex')
       expect(bidRequests.method).to.equal('POST')
       expect(bidRequests.data.gdpr.gdprApplies).to.equal(true)
       expect(bidRequests.data.gdpr).to.not.include.keys('consentString')
@@ -309,7 +309,7 @@ describe('QuantumdexBidAdapter', function () {
   describe('.interpretResponse', function () {
     const bidRequests = {
       'method': 'POST',
-      'url': 'https://useast.quantumdex.io/auction/quantumdex',
+      'url': 'https://useast.quantumdex.io/auction/apacdex',
       'withCredentials': true,
       'data': {
         'device': {
@@ -328,7 +328,7 @@ describe('QuantumdexBidAdapter', function () {
       },
       'bidderRequests': [
         {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'params': {
             'siteId': '343'
           },
@@ -363,7 +363,7 @@ describe('QuantumdexBidAdapter', function () {
           }
         },
         {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'params': {
             'siteId': '343'
           },
@@ -398,7 +398,7 @@ describe('QuantumdexBidAdapter', function () {
           }
         },
         {
-          'bidder': 'quantumdex',
+          'bidder': 'apacdex',
           'params': {
             'siteId': '343'
           },
@@ -464,12 +464,12 @@ describe('QuantumdexBidAdapter', function () {
             'cpm': 1.07,
             'width': 160,
             'height': 600,
-            'ad': `<div>Quantumdex AD</div>`,
+            'ad': `<div>Apacdex AD</div>`,
             'ttl': 500,
             'creativeId': '1234abcd',
             'netRevenue': true,
             'currency': 'USD',
-            'dealId': 'quantumdex',
+            'dealId': 'apacdex',
             'mediaType': 'banner'
           },
           {
@@ -477,12 +477,12 @@ describe('QuantumdexBidAdapter', function () {
             'cpm': 1,
             'width': 300,
             'height': 250,
-            'ad': `<div>Quantumdex AD</div>`,
+            'ad': `<div>Apacdex AD</div>`,
             'ttl': 500,
             'creativeId': '1234abcd',
             'netRevenue': true,
             'currency': 'USD',
-            'dealId': 'quantumdex',
+            'dealId': 'apacdex',
             'mediaType': 'banner'
           },
           {
@@ -490,12 +490,12 @@ describe('QuantumdexBidAdapter', function () {
             'cpm': 1.25,
             'width': 300,
             'height': 250,
-            'vastXml': '<VAST><Ad id="20001"><InLine><AdSystem version="4.0">quantumdex</AdSystem></InLine></Ad></VAST>',
+            'vastXml': '<VAST><Ad id="20001"><InLine><AdSystem version="4.0">apacdex</AdSystem></InLine></Ad></VAST>',
             'ttl': 500,
             'creativeId': '30292e432662bd5f86d90774b944b038',
             'netRevenue': true,
             'currency': 'USD',
-            'dealId': 'quantumdex',
+            'dealId': 'apacdex',
             'mediaType': 'video'
           }
         ],
@@ -512,12 +512,12 @@ describe('QuantumdexBidAdapter', function () {
         'cpm': 1.07,
         'width': 160,
         'height': 600,
-        'ad': `<div>Quantumdex AD</div>`,
+        'ad': `<div>Apacdex AD</div>`,
         'ttl': 500,
         'creativeId': '1234abcd',
         'netRevenue': true,
         'currency': 'USD',
-        'dealId': 'quantumdex',
+        'dealId': 'apacdex',
         'mediaType': 'banner'
       },
       {
@@ -525,12 +525,12 @@ describe('QuantumdexBidAdapter', function () {
         'cpm': 1,
         'width': 300,
         'height': 250,
-        'ad': `<div>Quantumdex AD</div>`,
+        'ad': `<div>Apacdex AD</div>`,
         'ttl': 500,
         'creativeId': '1234abcd',
         'netRevenue': true,
         'currency': 'USD',
-        'dealId': 'quantumdex',
+        'dealId': 'apacdex',
         'mediaType': 'banner'
       },
       {
@@ -538,12 +538,12 @@ describe('QuantumdexBidAdapter', function () {
         'cpm': 1.25,
         'width': 300,
         'height': 250,
-        'vastXml': '<VAST><Ad id="20001"><InLine><AdSystem version="4.0">quantumdex</AdSystem></InLine></Ad></VAST>',
+        'vastXml': '<VAST><Ad id="20001"><InLine><AdSystem version="4.0">apacdex</AdSystem></InLine></Ad></VAST>',
         'ttl': 500,
         'creativeId': '30292e432662bd5f86d90774b944b038',
         'netRevenue': true,
         'currency': 'USD',
-        'dealId': 'quantumdex',
+        'dealId': 'apacdex',
         'mediaType': 'video'
       }
     ];
@@ -561,10 +561,10 @@ describe('QuantumdexBidAdapter', function () {
         expect(resp.currency).to.equal(prebidResponse[i].currency);
         expect(resp.dealId).to.equal(prebidResponse[i].dealId);
         if (resp.mediaType === 'video') {
-          expect(resp.vastXml.indexOf('quantumdex')).to.be.greaterThan(0);
+          expect(resp.vastXml.indexOf('apacdex')).to.be.greaterThan(0);
         }
         if (resp.mediaType === 'banner') {
-          expect(resp.ad.indexOf('Quantumdex AD')).to.be.greaterThan(0);
+          expect(resp.ad.indexOf('Apacdex AD')).to.be.greaterThan(0);
         }
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
1. Add new bid adapter for Apacdex

<!-- For new bidder adapters, please provide the following -->
- Test parameters for validating bids
Banner Test Parameters
```
var adUnits = [
  {
    code: 'test-div',
    mediaTypes: {
      banner: {
        sizes: [[300, 250], [300,600]]
      }
    },
    bids: [
      {
          bidder: 'apacdex',
          params: {
              siteId: 'apacdex1234',
          }
      }
    ]
  }
];
```

Video Test Parameters
```
var videoAdUnit = {
  code: 'test-div',
  sizes: [[640, 480]],
  mediaTypes: {
    video: {
      playerSize: [[640, 480]],
      context: 'instream'
    },
  },
  bids: [
    {
      bidder: 'apacdex',
      params: {
        siteId: 'apacdex1234',
      }
    }
  ]
};
```

- contact email of the adapter’s maintainer: ken@apacdex.com
- [x] official adapter submission
- PR link on the docs repo: https://github.com/prebid/prebid.github.io/pull/2447

2. Valueimpression Adapter and Quantumdex Adapter become alias of Apacdex Adapter
After reviewing our current business situation. We decided to make the Valueimpression Adapter and Quantumdex Adapter an alias of the Apacdex Adapter
