### PR TITLE
userId module: fix auctionDelay submodules with callbacks

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -319,7 +319,13 @@ function hasGDPRConsent(consentData) {
  * @param {function} cb - callback for after processing is done.
  */
 function processSubmoduleCallbacks(submodules, cb) {
-  const done = cb ? utils.delayExecution(cb, submodules.length) : function () { };
+  let done = () => {};
+  if (cb) {
+    done = utils.delayExecution(() => {
+      clearTimeout(timeoutID);
+      cb();
+    }, submodules.length);
+  }
   submodules.forEach(function (submodule) {
     submodule.callback(function callbackCompleted(idObj) {
       // if valid, id data should be saved to cookie/html storage
@@ -338,7 +344,6 @@ function processSubmoduleCallbacks(submodules, cb) {
     // clear callback, this prop is used to test if all submodule callbacks are complete below
     submodule.callback = undefined;
   });
-  clearTimeout(timeoutID);
 }
 
 /**

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -611,6 +611,7 @@ describe('User ID', function () {
     beforeEach(function () {
       sandbox = sinon.createSandbox();
       sandbox.stub(global, 'setTimeout').returns(2);
+      sandbox.stub(global, 'clearTimeout');
       sandbox.stub(events, 'on');
       sandbox.stub(coreStorage, 'getCookie');
 
@@ -662,6 +663,7 @@ describe('User ID', function () {
       requestBidsHook(auctionSpy, {adUnits});
 
       // check auction was delayed
+      global.clearTimeout.calledOnce.should.equal(false);
       global.setTimeout.calledOnce.should.equal(true);
       global.setTimeout.calledWith(sinon.match.func, 33);
       auctionSpy.calledOnce.should.equal(false);
@@ -696,6 +698,7 @@ describe('User ID', function () {
 
       // check auction was delayed
       // global.setTimeout.calledOnce.should.equal(true);
+      global.clearTimeout.calledOnce.should.equal(false);
       global.setTimeout.calledWith(sinon.match.func, 33);
       auctionSpy.calledOnce.should.equal(false);
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

If the userId submodule provides callback, but it never executes that callback, pbjs will get stuck and it won't request bids.  

This was detected with `identityLink` userId submodule in issue #5882.  

piece of code:

```
if (!storage.getCookie('_lr_retry_request')) {
  setRetryCookie();
  utils.logInfo('A 3P retrieval is attempted!');
  ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
}
```

So, for this userId submodule, if there exists `_lr_retry_request` cookie, it will block prebid from requesting bids, because `callbacks` are never called.  

At first, this seems like a bug in submodule, but further digging down in userId module, I found that that there is `setTimeout` for `auctionDelay`, which gets cleared few lines of code afterwards.  

## Description of change
<!-- Describe the change proposed in this pull request -->
Proposed solution is to call `clearTimeout` only after all submodules have executed their callbacks.  
