### PR TITLE
[AD-1020] JWPlayer RTD: Obtain targeting params from FPD

### DIFF
--- a/integrationExamples/gpt/jwplayerRtdProvider_example.html
+++ b/integrationExamples/gpt/jwplayerRtdProvider_example.html
@@ -52,7 +52,7 @@
       pbjs.que.push(function() {
         pbjs.setConfig({
           realTimeData: {
-            auctionDelay: 500,
+            auctionDelay: 100,
             dataProviders: [{
               name: "jwplayer",
               waitForIt: true,

--- a/integrationExamples/gpt/jwplayerRtdProvider_example.html
+++ b/integrationExamples/gpt/jwplayerRtdProvider_example.html
@@ -11,11 +11,18 @@
 
       var adUnits = [{
         code: 'div-gpt-ad-1460505748561-0',
-        jwTargeting: {
-          // Note: the following Ids are placeholders and should be replaced with your Ids.
-          playerID: '123',
-          mediaID: 'abc'
+        fpd: {
+          context: {
+            data: {
+              jwTargeting: {
+                // Note: the following Ids are placeholders and should be replaced with your Ids.
+                playerID: '123',
+                mediaID: 'abc'
+              }
+            },
+          }
         },
+
         mediaTypes: {
           banner: {
             sizes: [[300, 250], [300,600]],
@@ -45,7 +52,7 @@
       pbjs.que.push(function() {
         pbjs.setConfig({
           realTimeData: {
-            auctionDelay: 5000,
+            auctionDelay: 500,
             dataProviders: [{
               name: "jwplayer",
               waitForIt: true,

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -144,6 +144,7 @@ function enrichBidRequest(bidReqConfig, onDone) {
  * @param {function} onDone
  */
 export function enrichAdUnits(adUnits) {
+  const jwTargetingFallback = config.getConfig('fpd.context.data.jwTargeting');
   adUnits.forEach(adUnit => {
     const onVatResponse = function (vat) {
       if (!vat) {
@@ -153,12 +154,14 @@ export function enrichAdUnits(adUnits) {
       addTargetingToBids(adUnit.bids, targeting);
     };
 
-    loadVat(adUnit.jwTargeting, onVatResponse);
+    const adUnitTargeting = adUnit.fpd && adUnit.fpd.context && adUnit.fpd.context.data && adUnit.fpd.context.data.jwTargeting;
+    const jwTargeting = Object.assign({}, jwTargetingFallback, adUnitTargeting);
+    loadVat(jwTargeting, onVatResponse);
   });
 }
 
 function loadVat(params, onCompletion) {
-  if (!params) {
+  if (!params || !Object.keys(params).length) {
     return;
   }
 

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -144,7 +144,7 @@ function enrichBidRequest(bidReqConfig, onDone) {
  * @param {function} onDone
  */
 export function enrichAdUnits(adUnits) {
-  const jwTargetingFallback = config.getConfig('fpd.context.data.jwTargeting');
+  const fpdFallback = config.getConfig('fpd.context.data.jwTargeting');
   adUnits.forEach(adUnit => {
     const onVatResponse = function (vat) {
       if (!vat) {
@@ -154,10 +154,17 @@ export function enrichAdUnits(adUnits) {
       addTargetingToBids(adUnit.bids, targeting);
     };
 
-    const adUnitTargeting = adUnit.fpd && adUnit.fpd.context && adUnit.fpd.context.data && adUnit.fpd.context.data.jwTargeting;
-    const jwTargeting = Object.assign({}, jwTargetingFallback, adUnitTargeting);
+    const jwTargeting = extractPublisherParams(adUnit, fpdFallback);
     loadVat(jwTargeting, onVatResponse);
   });
+}
+
+export function extractPublisherParams(adUnit, fallback) {
+  let adUnitTargeting;
+  try {
+    adUnitTargeting = adUnit.fpd.context.data.jwTargeting;
+  } catch (e) {}
+  return Object.assign({}, fallback, adUnitTargeting);
 }
 
 function loadVat(params, onCompletion) {

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -25,16 +25,22 @@ pbjs.setConfig({
     }
 });
 ```
-Lastly, include the content's media ID and/or the player's ID in the matching AdUnit:
+Lastly, include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data`:
 
 ```javascript
 const adUnit = {
   code: '/19968336/prebid_native_example_1',
   ...
-  jwTargeting: {
-    waitForIt: true,
-    playerID: 'abcd',
-    mediaID: '1234'
+  fpd: {
+    context: {
+      data: {
+        jwTargeting: {
+          // Note: the following Ids are placeholders and should be replaced with your Ids.
+          playerID: 'abcd',
+          mediaID: '1234'
+        }
+      }
+    }
   }
 };
 
@@ -46,33 +52,23 @@ pbjs.que.push(function() {
 });
 ``` 
 ##Prefetching
-In order to prefetch targeting information for certain media, include the media IDs in the `jwplayerDataProvider` var:
+In order to prefetch targeting information for certain media, include the media IDs in the `jwplayerDataProvider` var and set `waitForIt` to `true`:
 
 ```javascript
 const jwplayerDataProvider = {
   name: "jwplayer",
+  waitForIt: true,
   params: {
     mediaIDs: ['abc', 'def', 'ghi', 'jkl']
   }
 };
 ```
 
-To ensure that the prefetched targeting information is added to your bid, we strongly suggest setting 
-`jwTargeting.waitForIt` to `true`. If the prefetch is still in progress at the time of the bid request, the auction will
-be delayed until the targeting information specific to the requested adUnits has been obtained.
-
-```javascript
-jwTargeting: {
-    waitForIt: true,
-    ...
-}
-```
-
 You must also set a value to `auctionDelay` in the config's `realTimeData` object 
 
 ```javascript
 realTimeData = {
-  auctionDelay: 1000,
+  auctionDelay: 500,
   ...
 };
 ```

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -51,6 +51,9 @@ pbjs.que.push(function() {
     });
 });
 ``` 
+
+**Note**: You may also include `jwTargeting` information in the prebid config's `fpd.context.data`. Information provided in the adUnit will always supersede, and information in the config will be used as a fallback.
+ 
 ##Prefetching
 In order to prefetch targeting information for certain media, include the media IDs in the `jwplayerDataProvider` var and set `waitForIt` to `true`:
 

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -71,7 +71,7 @@ You must also set a value to `auctionDelay` in the config's `realTimeData` objec
 
 ```javascript
 realTimeData = {
-  auctionDelay: 500,
+  auctionDelay: 100,
   ...
 };
 ```

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -1,7 +1,8 @@
-import { fetchTargetingForMediaId, enrichBidRequest,
-  getVatFromCache, formatTargetingResponse, getVatFromPlayer, enrichAdUnits,
+import { fetchTargetingForMediaId, getVatFromCache,
+  formatTargetingResponse, getVatFromPlayer, enrichAdUnits,
   fetchTargetingInformation, jwplayerSubmodule } from 'modules/jwplayerRtdProvider.js';
 import { server } from 'test/mocks/xhr.js';
+import { config } from 'src/config.js';
 
 describe('jwplayerRtdProvider', function() {
   const testIdForSuccess = 'test_id_for_success';
@@ -229,9 +230,15 @@ describe('jwplayerRtdProvider', function() {
 
           const bid = {};
           const adUnit = {
-            jwTargeting: {
-              mediaID: mediaIdWithSegment,
-              playerID: validPlayerID
+            fpd: {
+              context: {
+                data: {
+                  jwTargeting: {
+                    mediaID: mediaIdWithSegment,
+                    playerID: validPlayerID
+                  }
+                }
+              }
             },
             bids: [
               bid
@@ -292,8 +299,14 @@ describe('jwplayerRtdProvider', function() {
         }
       ];
       const adUnit = {
-        jwTargeting: {
-          mediaID: testIdForSuccess
+        fpd: {
+          context: {
+            data: {
+              jwTargeting: {
+                mediaID: testIdForSuccess
+              }
+            }
+          }
         },
         bids
       };
@@ -333,8 +346,14 @@ describe('jwplayerRtdProvider', function() {
         }
       ];
       const adUnit = {
-        jwTargeting: {
-          mediaID: testIdForSuccess
+        fpd: {
+          context: {
+            data: {
+              jwTargeting: {
+                mediaID: testIdForSuccess
+              }
+            }
+          }
         },
         bids
       };
@@ -374,8 +393,14 @@ describe('jwplayerRtdProvider', function() {
         }
       ];
       const adUnit = {
-        jwTargeting: {
-          mediaID: testIdForFailure
+        fpd: {
+          context: {
+            data: {
+              jwTargeting: {
+                mediaID: testIdForFailure
+              }
+            }
+          }
         },
         bids
       };
@@ -404,16 +429,28 @@ describe('jwplayerRtdProvider', function() {
         bidReqConfig = {
           adUnits: [
             {
-              jwTargeting: {
-                mediaID: validMediaIDs[0]
+              fpd: {
+                context: {
+                  data: {
+                    jwTargeting: {
+                      mediaID: validMediaIDs[0]
+                    }
+                  }
+                }
               },
               bids: [
                 {}, {}
               ]
             },
             {
-              jwTargeting: {
-                mediaID: validMediaIDs[1]
+              fpd: {
+                context: {
+                  data: {
+                    jwTargeting: {
+                      mediaID: validMediaIDs[1]
+                    }
+                  }
+                }
               },
               bids: [
                 {}, {}
@@ -473,8 +510,14 @@ describe('jwplayerRtdProvider', function() {
       it('sets targeting data in proper structure', function () {
         const bid = {};
         const adUnitWithMediaId = {
-          jwTargeting: {
-            mediaID: testIdForSuccess
+          fpd: {
+            context: {
+              data: {
+                jwTargeting: {
+                  mediaID: testIdForSuccess
+                }
+              }
+            }
           },
           bids: [
             bid
@@ -499,12 +542,18 @@ describe('jwplayerRtdProvider', function() {
         const adUnitCode = 'test_ad_unit';
         const bid = {};
         const adUnit = {
-          jwTargeting: {
-            mediaID: testIdForFailure
+          fpd: {
+            context: {
+              data: {
+                jwTargeting: {
+                  mediaID: testIdForFailure
+                }
+              }
+            }
           },
           bids: [ bid ]
         };
-        const expectedContentId = 'jw_' + adUnit.jwTargeting.mediaID;
+        const expectedContentId = 'jw_' + adUnit.fpd.context.data.jwTargeting.mediaID;
         const expectedTargeting = {
           content: {
             id: expectedContentId
@@ -522,6 +571,7 @@ describe('jwplayerRtdProvider', function() {
         const adUnitCode = 'test_ad_unit';
         const bid1 = {};
         const bid2 = {};
+        const bid3 = {};
         const adUnitWithMediaId = {
           code: adUnitCode,
           mediaID: testIdForSuccess,
@@ -532,10 +582,21 @@ describe('jwplayerRtdProvider', function() {
           bids: [ bid2 ]
         };
 
-        jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty] }, bidRequestSpy);
+        const adUnitEmptyfpd = {
+          code: 'test_ad_unit_empty_fpd',
+          fpd: {
+            context: {
+              id: 'sthg'
+            }
+          },
+          bids: [ bid3 ]
+        };
+
+        jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty, adUnitEmptyfpd] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
         expect(bid1).to.not.have.property('jwTargeting');
         expect(bid2).to.not.have.property('jwTargeting');
+        expect(bid3).to.not.have.property('jwTargeting');
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Instead of expecting the publisher to set the `jwTargeting` block on the adUnit, we expect it to be set in `adUnit.fpd.context.data`


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
karim@jwplayer.com

doc changes: https://github.com/prebid/prebid.github.io/pull/2427

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Changes requested by @bretg 
