### PR TITLE
support IE in aol spec

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -116,7 +116,7 @@ function resolveEndpointCode(bid) {
 
 function getSupportedEids(bid) {
   return bid.userIdAsEids.filter(eid => {
-    return SUPPORTED_USER_ID_SOURCES.includes(eid.source)
+    return SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1
   });
 }
 

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -490,7 +490,7 @@ describe('AolAdapter', function () {
           '&param1=val1&param2=val2&param3=val3&param4=val4');
       });
 
-      for (const [source, idValue] of Object.entries(SUPPORTED_USER_ID_SOURCES)) {
+      Object.keys(SUPPORTED_USER_ID_SOURCES).forEach(source => {
         it(`should set the user ID query param for ${source}`, function () {
           let bidRequest = createCustomBidRequest({
             params: getNexageGetBidParams()
@@ -498,9 +498,9 @@ describe('AolAdapter', function () {
           bidRequest.bids[0].userId = {};
           bidRequest.bids[0].userIdAsEids = createEidsArray(USER_ID_DATA);
           let [request] = spec.buildRequests(bidRequest.bids);
-          expect(request.url).to.contain(`&eid${source}=${encodeURIComponent(idValue)}`);
+          expect(request.url).to.contain(`&eid${source}=${encodeURIComponent(SUPPORTED_USER_ID_SOURCES[source])}`);
         });
-      }
+      });
 
       it('should return request object for One Mobile POST endpoint when POST configuration is present', function () {
         let bidConfig = getNexagePostBidParams();


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
IE 11 does not support `Object.entries`

Change to simple `forEach`