### PR TITLE
Criteo: Re-enable ad building when mediation is off and remove enableSendAllBids condition

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -79,10 +79,6 @@ export const spec = {
     if (publisherTagAvailable()) {
       // eslint-disable-next-line no-undef
       const adapter = new Criteo.PubTag.Adapters.Prebid(PROFILE_ID_PUBLISHERTAG, ADAPTER_VERSION, bidRequests, bidderRequest, '$prebid.version$');
-      const enableSendAllBids = config.getConfig('enableSendAllBids');
-      if (adapter.setEnableSendAllBids && typeof adapter.setEnableSendAllBids === 'function' && typeof enableSendAllBids === 'boolean') {
-        adapter.setEnableSendAllBids(enableSendAllBids);
-      }
       url = adapter.buildCdbUrl();
       data = adapter.buildCdbRequest();
     } else {
@@ -133,8 +129,6 @@ export const spec = {
         if (slot.native) {
           if (bidRequest.params.nativeCallback) {
             bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
-          } else if (config.getConfig('enableSendAllBids') === true) {
-            return;
           } else {
             bid.native = createPrebidNativeAd(slot.native);
             bid.mediaType = NATIVE;
@@ -253,12 +247,14 @@ function buildCdbUrl(context) {
 
 function checkNativeSendId(bidRequest) {
   return !(bidRequest.nativeParams &&
-    ((bidRequest.nativeParams.image && bidRequest.nativeParams.image.sendId !== true) ||
-      (bidRequest.nativeParams.icon && bidRequest.nativeParams.icon.sendId !== true) ||
-      (bidRequest.nativeParams.clickUrl && bidRequest.nativeParams.clickUrl.sendId !== true) ||
-      (bidRequest.nativeParams.displayUrl && bidRequest.nativeParams.displayUrl.sendId !== true) ||
-      (bidRequest.nativeParams.privacyLink && bidRequest.nativeParams.privacyLink.sendId !== true) ||
-      (bidRequest.nativeParams.privacyIcon && bidRequest.nativeParams.privacyIcon.sendId !== true)));
+    (
+      (bidRequest.nativeParams.image && ((bidRequest.nativeParams.image.sendId !== true || bidRequest.nativeParams.image.sendTargetingKeys === true))) ||
+        (bidRequest.nativeParams.icon && ((bidRequest.nativeParams.icon.sendId !== true || bidRequest.nativeParams.icon.sendTargetingKeys === true))) ||
+        (bidRequest.nativeParams.clickUrl && ((bidRequest.nativeParams.clickUrl.sendId !== true || bidRequest.nativeParams.clickUrl.sendTargetingKeys === true))) ||
+        (bidRequest.nativeParams.displayUrl && ((bidRequest.nativeParams.displayUrl.sendId !== true || bidRequest.nativeParams.displayUrl.sendTargetingKeys === true))) ||
+        (bidRequest.nativeParams.privacyLink && ((bidRequest.nativeParams.privacyLink.sendId !== true || bidRequest.nativeParams.privacyLink.sendTargetingKeys === true))) ||
+        (bidRequest.nativeParams.privacyIcon && ((bidRequest.nativeParams.privacyIcon.sendId !== true || bidRequest.nativeParams.privacyIcon.sendTargetingKeys === true)))
+    ));
 }
 
 /**
@@ -416,6 +412,7 @@ function hasValidVideoMediaType(bidRequest) {
  */
 function createPrebidNativeAd(payload) {
   return {
+    sendTargetingKeys: false, // no key is added to KV by default
     title: payload.products[0].title,
     body: payload.products[0].description,
     sponsoredBy: payload.advertiser.description,

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -992,6 +992,7 @@ describe('The Criteo bidding adapter', function () {
             zoneid: 123,
             native: {
               'products': [{
+                'sendTargetingKeys': false,
                 'title': 'Product title',
                 'description': 'Product desc',
                 'price': '100',
@@ -1027,7 +1028,6 @@ describe('The Criteo bidding adapter', function () {
           native: true,
         }]
       };
-      config.setConfig({'enableSendAllBids': false});
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
       expect(bids[0].requestId).to.equal('test-bidId');
@@ -1036,61 +1036,87 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].mediaType).to.equal(NATIVE);
     });
 
-    it('should not parse bid response with native when enableSendAllBids is true', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            native: {}
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
+    it('should warn only once if sendTargetingKeys set to true on required fields for native bidRequest', () => {
+      const bidderRequest = { };
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
           params: {
             zoneId: 123,
+            publisherSubId: '123',
+            nativeCallback: function() {}
           },
-          native: true,
-        }]
-      };
-      config.setConfig({'enableSendAllBids': true});
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(0);
-    });
+        },
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-456',
+          transactionId: 'transaction-456',
+          sizes: [[728, 90]],
+          params: {
+            zoneId: 456,
+            publisherSubId: '456',
+            nativeCallback: function() {}
+          },
+        },
+      ];
 
-    it('should not parse bid response with native when enableSendAllBids is not set', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            native: {}
-          }],
+      const nativeParamsWithSendTargetingKeys = [
+        {
+          nativeParams: {
+            image: {
+              sendTargetingKeys: true
+            },
+          }
         },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: 123,
-          },
-          native: true,
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(0);
+        {
+          nativeParams: {
+            icon: {
+              sendTargetingKeys: true
+            },
+          }
+        },
+        {
+          nativeParams: {
+            clickUrl: {
+              sendTargetingKeys: true
+            },
+          }
+        },
+        {
+          nativeParams: {
+            displayUrl: {
+              sendTargetingKeys: true
+            },
+          }
+        },
+        {
+          nativeParams: {
+            privacyLink: {
+              sendTargetingKeys: true
+            },
+          }
+        },
+        {
+          nativeParams: {
+            privacyIcon: {
+              sendTargetingKeys: true
+            },
+          }
+        }
+      ];
+
+      utilsMock.expects('logWarn')
+        .withArgs('Criteo: all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)')
+        .exactly(nativeParamsWithSendTargetingKeys.length * bidRequests.length);
+      nativeParamsWithSendTargetingKeys.forEach(nativeParams => {
+        let transformedBidRequests = {...bidRequests};
+        transformedBidRequests = [Object.assign(transformedBidRequests[0], nativeParams), Object.assign(transformedBidRequests[1], nativeParams)];
+        spec.buildRequests(transformedBidRequests, bidderRequest);
+      });
+      utilsMock.verify();
     });
 
     it('should properly parse a bid response with a zoneId passed as a string', function () {


### PR DESCRIPTION
Following the recent native proposal, which would resolve our previous issue of native creatives on sending assets, we want to re-enable the feature while mediation mode is off.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- test parameters
```
{
  bidder: 'criteo',
  params: {
    ...
    nativeCallback: function() {}
  },
  nativeParams: {
    sendTargetingKeys: true/false
    image: {
      sendTargetingKeys: true/false
    },
    ...
  }
}
```
- contact: pi-direct@criteo.com

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Please merge this after https://github.com/prebid/Prebid.js/pull/5411