### PR TITLE
Add User ID Targeting to googletag.cmd as a fallback when GPT API is not ready

### DIFF
--- a/modules/userIdTargeting.js
+++ b/modules/userIdTargeting.js
@@ -26,9 +26,9 @@ export function userIdTargeting(userIds, config) {
     window.googletag = window.googletag || {};
     googletag.cmd = googletag.cmd || [];
     GAM_API = function (key, value) {
-        googletag.cmd.push(function () {
-            googletag.pubads().setTargeting(key, value);
-        });
+      googletag.cmd.push(function () {
+        googletag.pubads().setTargeting(key, value);
+      });
     };
   }
 

--- a/modules/userIdTargeting.js
+++ b/modules/userIdTargeting.js
@@ -20,14 +20,16 @@ export function userIdTargeting(userIds, config) {
 
   if (!SHARE_WITH_GAM) {
     logInfo(MODULE_NAME + ': Not enabled for ' + GAM);
-  }
-
-  if (window.googletag && isFn(window.googletag.pubads) && hasOwn(window.googletag.pubads(), 'setTargeting') && isFn(window.googletag.pubads().setTargeting)) {
+  } else if (window.googletag && isFn(window.googletag.pubads) && hasOwn(window.googletag.pubads(), 'setTargeting') && isFn(window.googletag.pubads().setTargeting)) {
     GAM_API = window.googletag.pubads().setTargeting;
   } else {
-    SHARE_WITH_GAM = false;
-    logInfo(MODULE_NAME + ': Could not find googletag.pubads().setTargeting API. Not adding User Ids in targeting.')
-    return;
+    window.googletag = window.googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    GAM_API = function (key, value) {
+        googletag.cmd.push(function () {
+            googletag.pubads().setTargeting(key, value);
+        });
+    };
   }
 
   Object.keys(userIds).forEach(function(key) {

--- a/modules/userIdTargeting.js
+++ b/modules/userIdTargeting.js
@@ -24,10 +24,10 @@ export function userIdTargeting(userIds, config) {
     GAM_API = window.googletag.pubads().setTargeting;
   } else {
     window.googletag = window.googletag || {};
-    googletag.cmd = googletag.cmd || [];
+    window.googletag.cmd = window.googletag.cmd || [];
     GAM_API = function (key, value) {
-      googletag.cmd.push(function () {
-        googletag.pubads().setTargeting(key, value);
+      window.googletag.cmd.push(function () {
+        window.googletag.pubads().setTargeting(key, value);
       });
     };
   }

--- a/test/spec/modules/shareUserIds_spec.js
+++ b/test/spec/modules/shareUserIds_spec.js
@@ -50,6 +50,16 @@ describe('#userIdTargeting', function() {
     pubads.setTargeting('test', ['TEST']);
     config.GAM_KEYS.tdid = '';
     userIdTargeting(userIds, config);
+    expect(pubads.getTargeting('tdid')).to.be.an('array').that.is.empty;
     expect(pubads.getTargeting('test')).to.deep.equal(['TEST']);
+  });
+
+  it('User Id Targeting is added to googletag queue when GPT is not ready', function() {
+    let pubads = window.googletag.pubads;
+    delete window.googletag.pubads;
+    userIdTargeting(userIds, config);
+    window.googletag.pubads = pubads;
+    window.googletag.cmd.map(command => command());
+    expect(window.googletag.pubads().getTargeting('TD_ID')).to.deep.equal(['my-tdid']);
   });
 });


### PR DESCRIPTION
## Type of change 
- [x] Feature

## Description of change
Currently, when the `userIdTargeting` module is included and `SHARE_WITH_GAM` is set to `true`, the module checks if the GPT API is ready. If it isn't, then the value of `SHARE_WITH_GAM` is changed to `false` and User IDs are not sent to GAM.

The proposed change handles the cases in which the GPT API is not ready, by adding a fallback, which defines `googletag` and `googletag.cmd`, and pushes the `pubads().setTargeting()` function to `googletag.cmd`. The purpose of the change is to allow the `userIdTargeting` module to function even when the GPT API isn't ready and/or when `googletag` has not been defined yet.