### PR TITLE
Remove 'only' to run all tests

### DIFF
--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { spec } from 'modules/ixBidAdapter.js';
 
-describe.only('IndexexchangeAdapter', function () {
+describe('IndexexchangeAdapter', function () {
   const IX_SECURE_ENDPOINT = 'https://htlb.casalemedia.com/cygnus';
   const VIDEO_ENDPOINT_VERSION = 8.1;
   const BANNER_ENDPOINT_VERSION = 7.2;


### PR DESCRIPTION
## Type of change

- [X] CI Related
- [X] Other

## Description of change

Removes `only` from [this](https://github.com/ix-prebid-support/Prebid.js/blob/ac924b08655d8375cc177cccbf837fec8ecd5eb9/test/spec/modules/ixBidAdapter_spec.js) test file so all unit tests can run. Currently, only the tests in that file are running.

Introduced with the merge of https://github.com/prebid/Prebid.js/pull/5856