### PR TITLE
Smaato BidAdapter: Add support for userIds

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -117,6 +117,11 @@ const buildOpenRtbBidRequestPayload = (validBidRequests, bidderRequest) => {
     utils.deepSetValue(request, 'device.ifa', ifa);
   }
 
+  const eids = utils.deepAccess(validBidRequests[0], 'userIdAsEids');
+  if (eids && eids.length) {
+    utils.deepSetValue(request, 'user.ext.eids', eids);
+  }
+
   utils.logInfo('[SMAATO] OpenRTB Request:', request);
   return JSON.stringify(request);
 }

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { spec } from 'modules/smaatoBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {config} from 'src/config.js';
+import {createEidsArray} from 'modules/userId/eids.js';
 
 const imageAd = {
   image: {
@@ -321,6 +322,37 @@ const inAppBidRequest = {
   bidderWinsCount: 0
 };
 
+const userIdBidRequest = {
+  bidder: 'smaato',
+  params: {
+    publisherId: 'publisherId',
+    adspaceId: 'adspaceId'
+  },
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 50]]
+    }
+  },
+  adUnitCode: '/19968336/header-bid-tag-0',
+  transactionId: 'transactionId',
+  sizes: [[300, 50]],
+  bidId: 'bidId',
+  bidderRequestId: 'bidderRequestId',
+  auctionId: 'auctionId',
+  src: 'client',
+  bidRequestsCount: 1,
+  bidderRequestsCount: 1,
+  bidderWinsCount: 0,
+  userId: {
+    criteoId: '123456',
+    tdid: '89145'
+  },
+  userIdAsEids: createEidsArray({
+    criteoId: '123456',
+    tdid: '89145'
+  })
+};
+
 describe('smaatoBidAdapterTest', () => {
   describe('isBidRequestValid', () => {
     it('has valid params', () => {
@@ -422,7 +454,11 @@ describe('smaatoBidAdapterTest', () => {
       expect(req_fpd.user.ext.consent).to.equal('HFIDUYFIUYIUYWIPOI87392DSU');
       expect(req_fpd.site.keywords).to.eql('power tools,drills');
       expect(req_fpd.site.publisher.id).to.equal('publisherId');
-    })
+    });
+
+    it('has no user ids', () => {
+      expect(this.req.user.ext.eids).to.not.exist;
+    });
   });
 
   describe('buildRequests for video imps', () => {
@@ -510,6 +546,14 @@ describe('smaatoBidAdapterTest', () => {
       let req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
       expect(req.device.geo).to.not.exist;
       expect(req.device.ifa).to.not.exist;
+    });
+  });
+
+  describe('user ids in requests', () => {
+    it('user ids are added to user.ext.eids', () => {
+      let req = JSON.parse(spec.buildRequests([userIdBidRequest], defaultBidderRequest).data);
+      expect(req.user.ext.eids).to.exist;
+      expect(req.user.ext.eids).to.have.length(2);
     });
   });
 


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

Sends the userIds as eid array to the Smaato bidder.

## Docs PR

https://github.com/prebid/prebid.github.io/pull/2462