### PR TITLE
adot: add publisher id retrieval from bidder config

### DIFF
--- a/modules/adotBidAdapter.js
+++ b/modules/adotBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {isStr, isArray, isNumber, isPlainObject, isBoolean, logError, replaceAuctionPrice} from '../src/utils.js';
 import find from 'core-js-pure/features/array/find.js';
+import { config } from '../src/config.js';
 
 const ADAPTER_VERSION = 'v1.0.0';
 const BID_METHOD = 'POST';
@@ -334,13 +335,17 @@ function generateSiteFromAdUnitContext(adUnitContext) {
   if (!adUnitContext || !adUnitContext.refererInfo) return null;
 
   const domain = extractSiteDomainFromURL(adUnitContext.refererInfo.referer);
+  const publisherId = config.getConfig('adot.publisherId');
 
   if (!domain) return null;
 
   return {
     page: adUnitContext.refererInfo.referer,
     domain: domain,
-    name: domain
+    name: domain,
+    publisher: {
+      id: publisherId
+    }
   };
 }
 

--- a/modules/adotBidAdapter.md
+++ b/modules/adotBidAdapter.md
@@ -214,3 +214,20 @@ const adUnit = {
     }]
 }
 ```
+
+### PublisherId
+
+You can set a publisherId using `pbjs.setBidderConfig` for the bidder `adot`
+
+#### Example
+
+```javascript
+pbjs.setBidderConfig({
+    bidders: ['adot'],
+    config: {
+        adot: {
+            publisherId: '__MY_PUBLISHER_ID__'
+        }
+    }
+});
+```


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

Partners can now set a `publisherId` for `adot` using `pbjs.setBidderConfig` so it can be retrieved by the adapter and added to the generated bid requests.

```javascript
pbjs.setBidderConfig({
    bidders: ['adot'],
    config: {
        adot: {
            publisherId: '__PARTNER_PUBLISHER_ID__'
        }
    }
});
```