### PR TITLE
pubGENIUS bid adapter: fix bug that requestBids timeout is not respected

### DIFF
--- a/modules/pubgeniusBidAdapter.js
+++ b/modules/pubgeniusBidAdapter.js
@@ -37,7 +37,7 @@ export const spec = {
     const data = {
       id: bidderRequest.auctionId,
       imp: bidRequests.map(buildImp),
-      tmax: config.getConfig('bidderTimeout'),
+      tmax: bidderRequest.timeout,
       ext: {
         pbadapter: {
           version: BIDDER_VERSION,

--- a/test/spec/modules/pubgeniusBidAdapter_spec.js
+++ b/test/spec/modules/pubgeniusBidAdapter_spec.js
@@ -122,6 +122,7 @@ describe('pubGENIUS adapter', () => {
         bidderCode: 'pubgenius',
         bidderRequestId: 'fakebidderrequestid',
         refererInfo: {},
+        timeout: 1200,
       };
 
       expectedRequest = {
@@ -149,7 +150,7 @@ describe('pubGENIUS adapter', () => {
       };
 
       config.setConfig({
-        bidderTimeout: 1200,
+        bidderTimeout: 1000,
         pageUrl: undefined,
         coppa: undefined,
       });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Our adapter timeouts with publishers that only specify timeout on calling requestBids. We then figured that this is the better way to get auction timeout in adapter. Please correct me if I am wrong.

- contact email of the adapter’s maintainer: meng@pubgenius.io
- [x] official adapter submission

## Other information
@kevinstubbs for team awareness.