### PR TITLE
delete pubcommon test cookie for domainOverride after writing it in all cases

### DIFF
--- a/modules/lunamediahbBidAdapter.js
+++ b/modules/lunamediahbBidAdapter.js
@@ -70,7 +70,7 @@ export const spec = {
         schain: bid.schain || {},
       };
       const mediaType = bid.mediaTypes
-      
+
       if (mediaType && mediaType[BANNER] && mediaType[BANNER].sizes) {
         placement.sizes = mediaType[BANNER].sizes;
         placement.traffic = BANNER;

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -282,16 +282,19 @@ export const pubCommonIdSubmodule = {
   domainOverride: function () {
     const domainElements = document.domain.split('.');
     const cookieName = `_gd${Date.now()}`;
-    for (let i = 0, topDomain; i < domainElements.length; i++) {
+    for (let i = 0, topDomain, testCookie; i < domainElements.length; i++) {
       const nextDomain = domainElements.slice(i).join('.');
 
       // write test cookie
       storage.setCookie(cookieName, '1', undefined, undefined, nextDomain);
 
       // read test cookie to verify domain was valid
-      if (storage.getCookie(cookieName) === '1') {
-        // delete test cookie
-        storage.setCookie(cookieName, '', 'Thu, 01 Jan 1970 00:00:01 GMT', undefined, nextDomain);
+      testCookie = storage.getCookie(cookieName);
+
+      // delete test cookie
+      storage.setCookie(cookieName, '', 'Thu, 01 Jan 1970 00:00:01 GMT', undefined, nextDomain);
+
+      if (testCookie === '1') {
         // cookie was written successfully using test domain so the topDomain is updated
         topDomain = nextDomain;
       } else {

--- a/modules/pubCommonIdSystem.js
+++ b/modules/pubCommonIdSystem.js
@@ -37,7 +37,7 @@ function storeData(config, value) {
 
       if (config.storage.type === COOKIE) {
         if (storage.cookiesAreEnabled()) {
-          storage.setCookie(key, value, expiresStr, 'LAX', COOKIE_DOMAIN);
+          storage.setCookie(key, value, expiresStr, 'LAX', pubCommonIdSubmodule.domainOverride());
         }
       } else if (config.storage.type === LOCAL_STORAGE) {
         if (storage.hasLocalStorage()) {
@@ -304,7 +304,5 @@ export const pubCommonIdSubmodule = {
     }
   }
 };
-
-const COOKIE_DOMAIN = pubCommonIdSubmodule.domainOverride();
 
 submodule('userId', pubCommonIdSubmodule);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
As described in https://github.com/prebid/Prebid.js/issues/5942, pubcommon module is setting a domain override variable every time the module is registered (i.e. if pbjs is built with pubcommon, regardless of whether a pub activates it through configuration). There is a cookie check that happens by writing a test cookie and then if it's found, it would delete and try another domain. if it wasn't found, it assumed it didn't stick, but in fact it was leaving session cookies around. this PR will delete the test cookies regardless of condition.

I think we should also consider moving the line `const COOKIE_DOMAIN = pubCommonIdSubmodule.domainOverride();` INSIDE of the module code so it's only every run if the module is activated, as I'm sure this is adding overhead to pages that have not configured pubcommon but have built it with it.

## Other information
https://github.com/prebid/Prebid.js/issues/5942 (thanks to @mercuryyy for finding this)
