### PR TITLE
update quantcastBidAdapter to make user sync flag non-constant

### DIFF
--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -101,6 +101,8 @@ function checkTCFv2(tcData) {
   return !!(vendorConsent && purposeConsent);
 }
 
+let hasUserSynced = false;
+
 /**
  * The documentation for Prebid.js Adapter 1.0 can be found at link below,
  * http://prebid.org/dev-docs/bidder-adapter-1.html
@@ -109,7 +111,6 @@ export const spec = {
   code: BIDDER_CODE,
   GVLID: 11,
   supportedMediaTypes: ['banner', 'video'],
-  hasUserSynced: false,
 
   /**
    * Verify the `AdUnits.bids` response with `true` for valid request and `false`
@@ -271,7 +272,7 @@ export const spec = {
   },
   getUserSyncs(syncOptions, serverResponses) {
     const syncs = []
-    if (!this.hasUserSynced && syncOptions.pixelEnabled) {
+    if (!hasUserSynced && syncOptions.pixelEnabled) {
       const responseWithUrl = find(serverResponses, serverResponse =>
         utils.deepAccess(serverResponse.body, 'userSync.url')
       );
@@ -283,12 +284,12 @@ export const spec = {
           url: url
         });
       }
-      this.hasUserSynced = true;
+      hasUserSynced = true;
     }
     return syncs;
   },
   resetUserSync() {
-    this.hasUserSynced = false;
+    hasUserSynced = false;
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This PR updates quantcastBidAdapter to move `hasUserSynced` flag out of the spec object and make it non-constant. Otherwise, the adapter throws an error with the following message, when the flag's value is changed in strict mode: "Uncaught TypeError: "hasUserSynced" is read-only"