### PR TITLE
[AD-1043] JW Player RTD - add targeting info to bid.rtd

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -72,11 +72,12 @@ export const spec = {
       if (!userId) {
         userId = bid.userId;
       }
-      const {params: {uid, keywords, bidFloor}, mediaTypes, bidId, adUnitCode, jwTargeting} = bid;
+      const {params: {uid, keywords, bidFloor}, mediaTypes, bidId, adUnitCode, realTimeData} = bid;
       bidsMap[bidId] = bid;
       if (!pageKeywords && !utils.isEmpty(keywords)) {
         pageKeywords = utils.transformBidderParamKeywords(keywords);
       }
+      const jwTargeting = realTimeData && realTimeData.jwplayer && realTimeData.jwplayer.targeting;
       if (jwTargeting) {
         if (!jwpseg && jwTargeting.segments) {
           jwpseg = jwTargeting.segments;

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -72,12 +72,12 @@ export const spec = {
       if (!userId) {
         userId = bid.userId;
       }
-      const {params: {uid, keywords, bidFloor}, mediaTypes, bidId, adUnitCode, realTimeData} = bid;
+      const {params: {uid, keywords, bidFloor}, mediaTypes, bidId, adUnitCode, rtd} = bid;
       bidsMap[bidId] = bid;
       if (!pageKeywords && !utils.isEmpty(keywords)) {
         pageKeywords = utils.transformBidderParamKeywords(keywords);
       }
-      const jwTargeting = realTimeData && realTimeData.jwplayer && realTimeData.jwplayer.targeting;
+      const jwTargeting = rtd && rtd.jwplayer && rtd.jwplayer.targeting;
       if (jwTargeting) {
         if (!jwpseg && jwTargeting.segments) {
           jwpseg = jwTargeting.segments;

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -251,10 +251,10 @@ function addTargetingToBids(bids, targeting) {
 }
 
 export function addTargetingToBid(bid, targeting) {
-  const rtd = bid.realTimeData || {};
+  const rtd = bid.rtd || {};
   const jwRtd = {};
   jwRtd[SUBMODULE_NAME] = Object.assign({}, rtd[SUBMODULE_NAME], { targeting });
-  bid.realTimeData = Object.assign({}, rtd, jwRtd);
+  bid.rtd = Object.assign({}, rtd, jwRtd);
 }
 
 function getPlayer(playerID) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -247,9 +247,14 @@ function addTargetingToBids(bids, targeting) {
     return;
   }
 
-  bids.forEach(bid => {
-    bid.jwTargeting = targeting;
-  });
+  bids.forEach(bid => addTargetingToBid(bid, targeting));
+}
+
+export function addTargetingToBid(bid, targeting) {
+  const rtd = bid.realTimeData || {};
+  const jwRtd = {};
+  jwRtd[SUBMODULE_NAME] = Object.assign({}, rtd[SUBMODULE_NAME], { targeting });
+  bid.realTimeData = Object.assign({}, rtd, jwRtd);
 }
 
 function getPlayer(playerID) {

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -86,11 +86,15 @@ Each bid for which targeting information was found will conform to the following
     adUnitCode: 'xyz',
     bidId: 'abc',
     ...,
-    jwTargeting: {
-      segments: ['123', '456'],
-      content: {
-        id: 'jw_abc123'
-      }
+    rtd: {
+        jwplayer: {
+            targeting: {
+                segments: ['123', '456'],
+                content: {
+                    id: 'jw_abc123'
+                }
+            }
+        }   
     }
 }
 ```

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -411,7 +411,7 @@ describe('TheMediaGrid Adapter', function () {
       const jsSegments = ['test_seg_1', 'test_seg_2'];
       const bidRequestsWithUserIds = bidRequests.map((bid) => {
         return Object.assign({
-          realTimeData: {
+          rtd: {
             jwplayer: {
               targeting: {
                 segments: jsSegments,

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -411,9 +411,13 @@ describe('TheMediaGrid Adapter', function () {
       const jsSegments = ['test_seg_1', 'test_seg_2'];
       const bidRequestsWithUserIds = bidRequests.map((bid) => {
         return Object.assign({
-          jwTargeting: {
-            segments: jsSegments,
-            content: jsContent
+          realTimeData: {
+            jwplayer: {
+              targeting: {
+                segments: jsSegments,
+                content: jsContent
+              }
+            }
           }
         }, bid);
       });

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -252,7 +252,7 @@ describe('jwplayerRtdProvider', function() {
           };
           jwplayerSubmodule.getBidRequestData({ adUnits: [adUnit] }, bidRequestSpy);
           expect(bidRequestSpy.calledOnce).to.be.true;
-          expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
+          expect(bid.rtd.jwplayer).to.have.deep.property('targeting', expectedTargeting);
           fakeServer.respond();
           expect(bidRequestSpy.calledOnce).to.be.true;
         });
@@ -313,8 +313,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1).to.not.have.property('realTimeData');
-      expect(bid2).to.not.have.property('realTimeData');
+      expect(bid1).to.not.have.property('rtd');
+      expect(bid2).to.not.have.property('rtd');
 
       const request = fakeServer.requests[0];
       request.respond(
@@ -330,8 +330,8 @@ describe('jwplayerRtdProvider', function() {
         })
       );
 
-      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
-      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid1.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid2.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
     });
 
     it('immediately adds cached targeting', function () {
@@ -373,8 +373,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
-      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid1.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid2.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
     });
 
     it('adds content block when segments are absent and no request is pending', function () {
@@ -407,8 +407,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
-      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
+      expect(bid1.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
+      expect(bid2.rtd.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
     });
   });
 
@@ -463,8 +463,8 @@ describe('jwplayerRtdProvider', function() {
       const targeting = {foo: 'bar'};
       const bid = {};
       addTargetingToBid(bid, targeting);
-      expect(bid).to.have.property('realTimeData');
-      expect(bid).to.have.nested.property('realTimeData.jwplayer.targeting', targeting);
+      expect(bid).to.have.property('rtd');
+      expect(bid).to.have.nested.property('rtd.jwplayer.targeting', targeting);
     });
 
     it('adds to existing realTimeData', function () {
@@ -475,14 +475,14 @@ describe('jwplayerRtdProvider', function() {
       };
 
       const bid = {
-        realTimeData: {
+        rtd: {
           otherRtd
         }
       };
 
       addTargetingToBid(bid, targeting);
-      expect(bid).to.have.property('realTimeData');
-      const rtd = bid.realTimeData;
+      expect(bid).to.have.property('rtd');
+      const rtd = bid.rtd;
       expect(rtd).to.have.property('jwplayer');
       expect(rtd).to.have.nested.property('jwplayer.targeting', targeting);
 
@@ -492,7 +492,7 @@ describe('jwplayerRtdProvider', function() {
     it('adds to existing realTimeData.jwplayer', function () {
       const otherInfo = { seg: 'rtd seg' };
       const bid = {
-        realTimeData: {
+        rtd: {
           jwplayer: {
             otherInfo
           }
@@ -500,8 +500,8 @@ describe('jwplayerRtdProvider', function() {
       };
       addTargetingToBid(bid, targeting);
 
-      expect(bid).to.have.property('realTimeData');
-      const rtd = bid.realTimeData;
+      expect(bid).to.have.property('rtd');
+      const rtd = bid.rtd;
       expect(rtd).to.have.property('jwplayer');
       expect(rtd).to.have.nested.property('jwplayer.otherInfo', otherInfo);
       expect(rtd).to.have.nested.property('jwplayer.targeting', targeting);
@@ -510,7 +510,7 @@ describe('jwplayerRtdProvider', function() {
     it('overrides existing jwplayer.targeting', function () {
       const otherInfo = { seg: 'rtd seg' };
       const bid = {
-        realTimeData: {
+        rtd: {
           jwplayer: {
             targeting: {
               otherInfo
@@ -520,18 +520,18 @@ describe('jwplayerRtdProvider', function() {
       };
       addTargetingToBid(bid, targeting);
 
-      expect(bid).to.have.property('realTimeData');
-      const rtd = bid.realTimeData;
+      expect(bid).to.have.property('rtd');
+      const rtd = bid.rtd;
       expect(rtd).to.have.property('jwplayer');
       expect(rtd).to.have.nested.property('jwplayer.targeting', targeting);
     });
 
     it('creates jwplayer when absent from realTimeData', function () {
-      const bid = { realTimeData: {} };
+      const bid = { rtd: {} };
       addTargetingToBid(bid, targeting);
 
-      expect(bid).to.have.property('realTimeData');
-      const rtd = bid.realTimeData;
+      expect(bid).to.have.property('rtd');
+      const rtd = bid.rtd;
       expect(rtd).to.have.property('jwplayer');
       expect(rtd).to.have.nested.property('jwplayer.targeting', targeting);
     });
@@ -659,7 +659,7 @@ describe('jwplayerRtdProvider', function() {
         };
         jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
+        expect(bid.rtd.jwplayer).to.have.deep.property('targeting', expectedTargeting);
       });
 
       it('excludes segments when absent', function () {
@@ -686,9 +686,9 @@ describe('jwplayerRtdProvider', function() {
 
         jwplayerSubmodule.getBidRequestData({ adUnits: [ adUnit ] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid.realTimeData.jwplayer.targeting).to.not.have.property('segments');
-        expect(bid.realTimeData.jwplayer.targeting).to.not.have.property('segments');
-        expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
+        expect(bid.rtd.jwplayer.targeting).to.not.have.property('segments');
+        expect(bid.rtd.jwplayer.targeting).to.not.have.property('segments');
+        expect(bid.rtd.jwplayer).to.have.deep.property('targeting', expectedTargeting);
       });
 
       it('does not modify bid when jwTargeting block is absent', function () {
@@ -718,9 +718,9 @@ describe('jwplayerRtdProvider', function() {
 
         jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty, adUnitEmptyfpd] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid1).to.not.have.property('realTimeData');
-        expect(bid2).to.not.have.property('realTimeData');
-        expect(bid3).to.not.have.property('realTimeData');
+        expect(bid1).to.not.have.property('rtd');
+        expect(bid2).to.not.have.property('rtd');
+        expect(bid3).to.not.have.property('rtd');
       });
     });
   });

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -252,7 +252,7 @@ describe('jwplayerRtdProvider', function() {
           };
           jwplayerSubmodule.getBidRequestData({ adUnits: [adUnit] }, bidRequestSpy);
           expect(bidRequestSpy.calledOnce).to.be.true;
-          expect(bid).to.have.deep.property('jwTargeting', expectedTargeting);
+          expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
           fakeServer.respond();
           expect(bidRequestSpy.calledOnce).to.be.true;
         });
@@ -313,8 +313,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1).to.not.have.property('jwTargeting');
-      expect(bid2).to.not.have.property('jwTargeting');
+      expect(bid1).to.not.have.property('realTimeData');
+      expect(bid2).to.not.have.property('realTimeData');
 
       const request = fakeServer.requests[0];
       request.respond(
@@ -330,8 +330,8 @@ describe('jwplayerRtdProvider', function() {
         })
       );
 
-      expect(bid1).to.have.deep.property('jwTargeting', expectedTargetingForSuccess);
-      expect(bid2).to.have.deep.property('jwTargeting', expectedTargetingForSuccess);
+      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
     });
 
     it('immediately adds cached targeting', function () {
@@ -373,8 +373,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1).to.have.deep.property('jwTargeting', expectedTargetingForSuccess);
-      expect(bid2).to.have.deep.property('jwTargeting', expectedTargetingForSuccess);
+      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
+      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForSuccess);
     });
 
     it('adds content block when segments are absent and no request is pending', function () {
@@ -407,8 +407,8 @@ describe('jwplayerRtdProvider', function() {
       enrichAdUnits([adUnit]);
       const bid1 = bids[0];
       const bid2 = bids[1];
-      expect(bid1).to.have.deep.property('jwTargeting', expectedTargetingForFailure);
-      expect(bid2).to.have.deep.property('jwTargeting', expectedTargetingForFailure);
+      expect(bid1.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
+      expect(bid2.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargetingForFailure);
     });
   });
 
@@ -659,7 +659,7 @@ describe('jwplayerRtdProvider', function() {
         };
         jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid).to.have.deep.property('jwTargeting', expectedTargeting);
+        expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
       });
 
       it('excludes segments when absent', function () {
@@ -686,9 +686,9 @@ describe('jwplayerRtdProvider', function() {
 
         jwplayerSubmodule.getBidRequestData({ adUnits: [ adUnit ] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid.jwTargeting).to.not.have.property('segments');
-        expect(bid.jwTargeting).to.not.have.property('segments');
-        expect(bid).to.have.deep.property('jwTargeting', expectedTargeting);
+        expect(bid.realTimeData.jwplayer.targeting).to.not.have.property('segments');
+        expect(bid.realTimeData.jwplayer.targeting).to.not.have.property('segments');
+        expect(bid.realTimeData.jwplayer).to.have.deep.property('targeting', expectedTargeting);
       });
 
       it('does not modify bid when jwTargeting block is absent', function () {
@@ -718,9 +718,9 @@ describe('jwplayerRtdProvider', function() {
 
         jwplayerSubmodule.getBidRequestData({ adUnits: [adUnitWithMediaId, adUnitEmpty, adUnitEmptyfpd] }, bidRequestSpy);
         expect(bidRequestSpy.calledOnce).to.be.true;
-        expect(bid1).to.not.have.property('jwTargeting');
-        expect(bid2).to.not.have.property('jwTargeting');
-        expect(bid3).to.not.have.property('jwTargeting');
+        expect(bid1).to.not.have.property('realTimeData');
+        expect(bid2).to.not.have.property('realTimeData');
+        expect(bid3).to.not.have.property('realTimeData');
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Per @bretg 's request, we are setting our targeting information to the bid's shared `rtd` object.
Since this is an API breaking change, we implemented the necessary changes for `gridBidAdapter` and will request that the owner @TheMediaGrid  review this PR. 



For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- link to the PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/2485

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
requesting review by @bretg and @TheMediaGrid 
docs PR: https://github.com/prebid/prebid.github.io/pull/2485