### PR TITLE
[CriteoId] Add local storage check and migrate cookie check to use StorageManager API 

### DIFF
--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -17,18 +17,10 @@ export const storage = getStorageManager(gvlid, bidderCode);
 
 const bididStorageKey = 'cto_bidid';
 const bundleStorageKey = 'cto_bundle';
-const cookieWriteableKey = 'cto_test_cookie';
 const cookiesMaxAge = 13 * 30 * 24 * 60 * 60 * 1000;
 
 const pastDateString = new Date(0).toString();
 const expirationString = new Date(utils.timestamp() + cookiesMaxAge).toString();
-
-function areCookiesWriteable() {
-  storage.setCookie(cookieWriteableKey, '1');
-  const canWrite = storage.getCookie(cookieWriteableKey) === '1';
-  storage.setCookie(cookieWriteableKey, '', pastDateString);
-  return canWrite;
-}
 
 function extractProtocolHost (url, returnOnlyHost = false) {
   const parsedUrl = utils.parseUrl(url, {noDecodeWholeURL: true})
@@ -74,7 +66,7 @@ function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isL
 }
 
 function callCriteoUserSync(parsedCriteoData, gdprString) {
-  const cw = areCookiesWriteable();
+  const cw = storage.cookiesAreEnabled();
   const lsw = storage.localStorageIsEnabled();
   const topUrl = extractProtocolHost(getRefererInfo().referer);
   const domain = extractProtocolHost(document.location.href, true);

--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -60,20 +60,22 @@ function getCriteoDataFromAllStorages() {
   }
 }
 
-function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isPublishertagPresent, gdprString) {
+function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isLocalStorageWritable, isPublishertagPresent, gdprString) {
   const url = 'https://gum.criteo.com/sid/json?origin=prebid' +
     `${topUrl ? '&topUrl=' + encodeURIComponent(topUrl) : ''}` +
     `${domain ? '&domain=' + encodeURIComponent(domain) : ''}` +
     `${bundle ? '&bundle=' + encodeURIComponent(bundle) : ''}` +
     `${gdprString ? '&gdprString=' + encodeURIComponent(gdprString) : ''}` +
     `${areCookiesWriteable ? '&cw=1' : ''}` +
-    `${isPublishertagPresent ? '&pbt=1' : ''}`
+    `${isPublishertagPresent ? '&pbt=1' : ''}` +
+    `${isLocalStorageWritable ? '&lsw=1' : ''}`;
 
   return url;
 }
 
 function callCriteoUserSync(parsedCriteoData, gdprString) {
   const cw = areCookiesWriteable();
+  const lsw = storage.localStorageIsEnabled();
   const topUrl = extractProtocolHost(getRefererInfo().referer);
   const domain = extractProtocolHost(document.location.href, true);
   const isPublishertagPresent = typeof criteo_pubtag !== 'undefined'; // eslint-disable-line camelcase
@@ -83,6 +85,7 @@ function callCriteoUserSync(parsedCriteoData, gdprString) {
     domain,
     parsedCriteoData.bundle,
     cw,
+    lsw,
     isPublishertagPresent,
     gdprString
   );

--- a/test/spec/modules/criteoIdSystem_spec.js
+++ b/test/spec/modules/criteoIdSystem_spec.js
@@ -71,7 +71,6 @@ describe('CriteoId module', function () {
   });
 
   it('should call user sync url with the right params', function () {
-    getCookieStub.withArgs('cto_test_cookie').returns('1');
     getCookieStub.withArgs('cto_bundle').returns('bundle');
     window.criteo_pubtag = {}
 

--- a/test/spec/modules/criteoIdSystem_spec.js
+++ b/test/spec/modules/criteoIdSystem_spec.js
@@ -80,7 +80,7 @@ describe('CriteoId module', function () {
     ajaxBuilderStub.callsFake(mockResponse(undefined, ajaxStub))
 
     criteoIdSubmodule.getId();
-    const expectedUrl = `https://gum.criteo.com/sid/json?origin=prebid&topUrl=https%3A%2F%2Ftestdev.com%2F&domain=testdev.com&bundle=bundle&cw=1&pbt=1`;
+    const expectedUrl = `https://gum.criteo.com/sid/json?origin=prebid&topUrl=https%3A%2F%2Ftestdev.com%2F&domain=testdev.com&bundle=bundle&cw=1&pbt=1&lsw=1`;
 
     expect(ajaxStub.calledWith(expectedUrl)).to.be.true;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Changes in the CriteoIdSystem:
- Add check to know whether local storage is writable.
- [Upgrade] Use the StorageManager API for cookie check, deprecating the previous one.

## Contacts
- Jesús Alberto Polo (ja.pologarcia@criteo.com)
- Hugo Duthil (h.duthil@criteo.com)
