### PR TITLE
Add Automatic Release Drafter Functionality to Prebid Repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@ tag-template: '$RESOLVED_VERSION'
 categories:
   - title: '🚀 New Features'
     label: 'feature'
-  - title: '🧰 Maintenance'
+  - title: '🛠 Maintenance'
     label: 'chore'    
   - title: '🐛 Bug Fixes'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,7 +5,7 @@ categories:
   - title: '🚀 New Features'
     label: 'feature'
   - title: '🛠 Maintenance'
-    label: 'chore'    
+    label: 'maintenance'    
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+
+name-template: 'Prebid $RESOLVED_VERSION Release'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 New Features'
+    label: 'feature'
+  - title: '🧰 Maintenance'
+    label: 'chore'    
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'      
+change-template: '- $TITLE (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## In This Release
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+         config-name: release-drafter.yml         
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds release drafter functionality to the project. With this functionality enabled all merges into master will generate a new draft release based on semver and categorized by the label. This will improve accuracy of release notes and reduce process steps required for Prebid code.

More info on Release Drafter is here:

https://github.com/release-drafter/release-drafter

If this PR is accepted then labels will need to be created for bugfix, fix, bug, feature, maintenance and the semver levels major, minor, patch. These labels will need to be assigned prior to the merge to properly categorize changes and manage semver versions.
