### PR TITLE
Rp adapter unit tests - userid mod support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
     "no-throw-literal": "off",
     "no-undef": 2,
     "no-useless-escape": "off",
-    "no-console": "off"
+    "no-console": "error"
   },
   "overrides": Object.keys(allowedModules).map((key) => ({
     "files": key + "/**/*.js",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
     "no-throw-literal": "off",
     "no-undef": 2,
     "no-useless-escape": "off",
-    "no-console": "error"
+    "no-console": "off"
   },
   "overrides": Object.keys(allowedModules).map((key) => ({
     "files": key + "/**/*.js",

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1245,9 +1245,9 @@ describe('the rubicon adapter', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
               // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{
-                source: "catchall",
+                source: 'catchall',
                 uids: [{
-                  id: "11111",
+                  id: '11111',
                   atype: 2
                 }]
               }]

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1240,6 +1240,24 @@ describe('the rubicon adapter', function () {
             });
           });
 
+          describe('UserID catchall support', function () {
+            it('should send user id with generic format', function () {
+              const clonedBid = utils.deepClone(bidderRequest.bids[0]);
+              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
+              clonedBid.userIdAsEids = [{
+                source: "catchall",
+                uids: [{
+                  id: "11111",
+                  atype: 2
+                }]
+              }]
+              let [request] = spec.buildRequests([clonedBid], bidderRequest);
+              let data = parseQuery(request.data);
+
+              expect(data['eid_catchall']).to.equal('11111^2');
+            });
+          });
+
           describe('Config user.id support', function () {
             it('should send ppuid when config defines user.id', function () {
               config.setConfig({user: {id: '123'}});

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1226,15 +1226,17 @@ describe('the rubicon adapter', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
               clonedBid.userId = {
                 id5id: {
-                  uid: '11111'
+                  uid: '11111',
+                  ext: {
+                    linkType: '22222'
+                  }
                 }
               };
               clonedBid.userIdAsEids = createEidsArray(clonedBid.userId);
-              console.log(clonedBid.userIdAsEids)
               let [request] = spec.buildRequests([clonedBid], bidderRequest);
               let data = parseQuery(request.data);
 
-              expect(data['eid_id5-sync.com']).to.equal('11111^1^');
+              expect(data['eid_id5-sync.com']).to.equal('11111^1^22222');
             });
           });
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1221,6 +1221,23 @@ describe('the rubicon adapter', function () {
             });
           });
 
+          describe('ID5 support', function () {
+            it('should send ID5 id when userIdAsEids contains ID5', function () {
+              const clonedBid = utils.deepClone(bidderRequest.bids[0]);
+              clonedBid.userId = {
+                id5id: {
+                  uid: '11111'
+                }
+              };
+              clonedBid.userIdAsEids = createEidsArray(clonedBid.userId);
+              console.log(clonedBid.userIdAsEids)
+              let [request] = spec.buildRequests([clonedBid], bidderRequest);
+              let data = parseQuery(request.data);
+
+              expect(data['eid_id5-sync.com']).to.equal('11111^1^');
+            });
+          });
+
           describe('Config user.id support', function () {
             it('should send ppuid when config defines user.id', function () {
               config.setConfig({user: {id: '123'}});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Added Rubicon adapter unit tests for [ID5 and Catchall scenarios](https://github.com/prebid/Prebid.js/pull/5923/files#diff-e4dbb62654fc2d8a7b5e6c2c66e0bae395cd945c1985f1509fd4484ecc79fa83R501) in support of User ID Module. 

## Other information
PR for Rubicon adapter to support all User ID modules: https://github.com/prebid/Prebid.js/pull/5923