### PR TITLE
remove pubcommon optout from user id module checks

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -134,6 +134,7 @@ const CONSENT_DATA_COOKIE_STORAGE_CONFIG = {
   name: '_pbjs_userid_consent_data',
   expires: 30 // 30 days expiration, which should match how often consent is refreshed by CMPs
 };
+export const PBJS_USER_ID_OPTOUT_NAME = '_pbjs_id_optout';
 export const coreStorage = getCoreStorageManager('userid');
 
 /** @type {string[]} */
@@ -701,15 +702,15 @@ export function init(config) {
   ].filter(i => i !== null);
 
   // exit immediately if opt out cookie or local storage keys exists.
-  if (validStorageTypes.indexOf(COOKIE) !== -1 && (coreStorage.getCookie('_pbjs_id_optout') || coreStorage.getCookie('_pubcid_optout'))) {
+  if (validStorageTypes.indexOf(COOKIE) !== -1 && coreStorage.getCookie(PBJS_USER_ID_OPTOUT_NAME)) {
     utils.logInfo(`${MODULE_NAME} - opt-out cookie found, exit module`);
     return;
   }
-  // _pubcid_optout is checked for compatibility with pubCommonId
-  if (validStorageTypes.indexOf(LOCAL_STORAGE) !== -1 && (coreStorage.getDataFromLocalStorage('_pbjs_id_optout') || coreStorage.getDataFromLocalStorage('_pubcid_optout'))) {
+  if (validStorageTypes.indexOf(LOCAL_STORAGE) !== -1 && coreStorage.getDataFromLocalStorage(PBJS_USER_ID_OPTOUT_NAME)) {
     utils.logInfo(`${MODULE_NAME} - opt-out localStorage found, exit module`);
     return;
   }
+
   // listen for config userSyncs to be set
   config.getConfig(conf => {
     // Note: support for 'usersync' was dropped as part of Prebid.js 4.0

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -7,7 +7,8 @@ import {
   setStoredConsentData,
   setStoredValue,
   setSubmoduleRegistry,
-  syncDelay
+  syncDelay,
+  PBJS_USER_ID_OPTOUT_NAME
 } from 'modules/userId/index.js';
 import {createEidsArray} from 'modules/userId/eids.js';
 import {config} from 'src/config.js';
@@ -91,9 +92,7 @@ describe('User ID', function () {
   }
 
   before(function () {
-    coreStorage.setCookie('_pubcid_optout', '', EXPIRED_COOKIE_DATE);
-    localStorage.removeItem('_pbjs_id_optout');
-    localStorage.removeItem('_pubcid_optout');
+    localStorage.removeItem(PBJS_USER_ID_OPTOUT_NAME);
   });
 
   beforeEach(function () {
@@ -413,7 +412,7 @@ describe('User ID', function () {
 
   describe('Opt out', function () {
     before(function () {
-      coreStorage.setCookie('_pbjs_id_optout', '1', (new Date(Date.now() + 5000).toUTCString()));
+      coreStorage.setCookie(PBJS_USER_ID_OPTOUT_NAME, '1', (new Date(Date.now() + 5000).toUTCString()));
     });
 
     beforeEach(function () {
@@ -422,14 +421,10 @@ describe('User ID', function () {
 
     afterEach(function () {
       // removed cookie
-      coreStorage.setCookie('_pbjs_id_optout', '', EXPIRED_COOKIE_DATE);
+      coreStorage.setCookie(PBJS_USER_ID_OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
       $$PREBID_GLOBAL$$.requestBids.removeAll();
       utils.logInfo.restore();
       config.resetConfig();
-    });
-
-    after(function () {
-      coreStorage.setCookie('_pbjs_id_optout', '', EXPIRED_COOKIE_DATE);
     });
 
     it('fails initialization if opt out cookie exists', function () {


### PR DESCRIPTION
Per https://github.com/prebid/Prebid.js/issues/5991, there's no reason to include checks for pub common's opt out when running the optout checks for the entire user id module