### PR TITLE
Prebidmanager analytics adapter: fix console error when utm is null and collect page info

### DIFF
--- a/modules/prebidmanagerAnalyticsAdapter.js
+++ b/modules/prebidmanagerAnalyticsAdapter.js
@@ -83,7 +83,7 @@ function collectUtmTagData() {
     if (newUtm === false) {
       utmTags.forEach(function (utmKey) {
         let itemValue = localStorage.getItem(`pm_${utmKey}`);
-        if (itemValue !== null && typeof itemValue !== 'undefined' && itemValue.length !== 0) {
+        if (itemValue && itemValue.length !== 0) {
           pmUtmTags[utmKey] = itemValue;
         }
       });

--- a/modules/prebidmanagerAnalyticsAdapter.js
+++ b/modules/prebidmanagerAnalyticsAdapter.js
@@ -83,7 +83,7 @@ function collectUtmTagData() {
     if (newUtm === false) {
       utmTags.forEach(function (utmKey) {
         let itemValue = localStorage.getItem(`pm_${utmKey}`);
-        if (itemValue.length !== 0) {
+        if (itemValue !== null && typeof itemValue !== 'undefined' && itemValue.length !== 0) {
           pmUtmTags[utmKey] = itemValue;
         }
       });

--- a/modules/prebidmanagerAnalyticsAdapter.js
+++ b/modules/prebidmanagerAnalyticsAdapter.js
@@ -99,6 +99,16 @@ function collectUtmTagData() {
   return pmUtmTags;
 }
 
+function collectPageInfo() {
+  const pageInfo = {
+    domain: window.location.hostname,
+  }
+  if (document.referrer) {
+    pageInfo.referrerDomain = utils.parseUrl(document.referrer).hostname;
+  }
+  return pageInfo;
+}
+
 function flush() {
   if (!pmAnalyticsEnabled) {
     return;
@@ -111,6 +121,7 @@ function flush() {
       bundleId: initOptions.bundleId,
       events: _eventQueue,
       utmTags: collectUtmTagData(),
+      pageInfo: collectPageInfo(),
     };
 
     ajax(

--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -1,6 +1,8 @@
 import prebidmanagerAnalytics from 'modules/prebidmanagerAnalyticsAdapter.js';
 import {expect} from 'chai';
 import {server} from 'test/mocks/xhr.js';
+import * as utils from 'src/utils.js';
+
 let events = require('src/events');
 let constants = require('src/constants.json');
 
@@ -133,6 +135,25 @@ describe('Prebid Manager Analytics Adapter', function () {
       expect(pmEvents.utmTags.utm_campaign).to.equal('utm_camp');
       expect(pmEvents.utmTags.utm_term).to.equal('');
       expect(pmEvents.utmTags.utm_content).to.equal('');
+    });
+  });
+
+  describe('build page info', function () {
+    afterEach(function () {
+      prebidmanagerAnalytics.disableAnalytics()
+    });
+    it('should build page info', function () {
+      prebidmanagerAnalytics.enableAnalytics({
+        provider: 'prebidmanager',
+        options: {
+          bundleId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+        }
+      });
+
+      const pmEvents = JSON.parse(server.requests[0].requestBody.substring(2));
+
+      expect(pmEvents.pageInfo.domain).to.equal(window.location.hostname);
+      expect(pmEvents.pageInfo.referrerDomain).to.equal(utils.parseUrl(document.referrer).hostname);
     });
   });
 });

--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -98,7 +98,7 @@ describe('Prebid Manager Analytics Adapter', function () {
       events.emit(constants.EVENTS.AUCTION_END, {});
       events.emit(constants.EVENTS.BID_TIMEOUT, {});
 
-      sinon.assert.callCount(prebidmanagerAnalytics.track, 7);
+      sinon.assert.callCount(prebidmanagerAnalytics.track, 6);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

- fix console error when utm data in local storage is null
prebid.js:3 Prebid ERROR: Prebid Manager Analytics: Error TypeError: Cannot read property 'length' of null

- add collecting of page info (domain & referrer)

```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
