### PR TITLE
adform adapter - allow to pass custom eids param

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -23,7 +23,7 @@ export const spec = {
     const eids = getEncodedEIDs(utils.deepAccess(validBidRequests, '0.userIdAsEids'));
 
     var request = [];
-    var globalParams = [ [ 'adxDomain', 'adx.adform.net' ], [ 'fd', 1 ], [ 'url', null ], [ 'tid', null ] ];
+    var globalParams = [ [ 'adxDomain', 'adx.adform.net' ], [ 'fd', 1 ], [ 'url', null ], [ 'tid', null ], [ 'eids', eids ] ];
     var bids = JSON.parse(JSON.stringify(validBidRequests));
     var bidder = (bids[0] && bids[0].bidder) || BIDDER_CODE;
     for (i = 0, l = bids.length; i < l; i++) {
@@ -65,10 +65,6 @@ export const spec = {
       request.push('us_privacy=' + bidderRequest.uspConsent);
     }
 
-    if (eids) {
-      request.push('eids=' + eids);
-    }
-
     for (i = 1, l = globalParams.length; i < l; i++) {
       _key = globalParams[i][0];
       _value = globalParams[i][1];
@@ -100,7 +96,7 @@ export const spec = {
     function getEncodedEIDs(eids) {
       if (utils.isArray(eids) && eids.length > 0) {
         const parsed = parseEIDs(eids);
-        return encodeURIComponent(btoa(JSON.stringify(parsed)));
+        return btoa(JSON.stringify(parsed));
       }
     }
 

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -149,6 +149,14 @@ describe('Adform adapter', function () {
       });
     });
 
+    it('should allow to pass custom extended ids', function () {
+      bids[0].params.eids = 'some_id_value';
+      let request = spec.buildRequests(bids);
+      let eids = parseUrl(request.url).query.eids;
+
+      assert.equal(eids, 'some_id_value');
+    });
+
     describe('user privacy', function () {
       it('should send GDPR Consent data to adform if gdprApplies', function () {
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Allow sending the first party ids to adform without userId module.

- contact email of the adapter’s maintainer
Scope.FL.Scripts@adform.com
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
Docs would be updated once prebid-server supports this functionality. 
