### PR TITLE
Add video response type param to Beachfront adapter

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -6,7 +6,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes.js';
 import find from 'core-js-pure/features/array/find.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
-const ADAPTER_VERSION = '1.13';
+const ADAPTER_VERSION = '1.14';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 
@@ -61,18 +61,17 @@ export const spec = {
     response = response.body;
 
     if (isVideoBid(bidRequest)) {
-      if (!response || !response.url || !response.bidPrice) {
+      if (!response || !response.bidPrice) {
         utils.logWarn(`No valid video bids from ${spec.code} bidder`);
         return [];
       }
       let sizes = getVideoSizes(bidRequest);
       let firstSize = getFirstSize(sizes);
       let context = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
-      return {
+      let responseType = getVideoBidParam(bidRequest, 'responseType') || 'both';
+      let bidResponse = {
         requestId: bidRequest.bidId,
         bidderCode: spec.code,
-        vastUrl: response.url,
-        vastXml: response.vast,
         cpm: response.bidPrice,
         width: firstSize.w,
         height: firstSize.h,
@@ -83,6 +82,16 @@ export const spec = {
         netRevenue: true,
         ttl: 300
       };
+
+      if (responseType === 'nurl' || responseType === 'both') {
+        bidResponse.vastUrl = response.url;
+      }
+
+      if (responseType === 'adm' || responseType === 'both') {
+        bidResponse.vastXml = response.vast;
+      }
+
+      return bidResponse;
     } else {
       if (!response || !response.length) {
         utils.logWarn(`No valid banner bids from ${spec.code} bidder`);

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -530,16 +530,6 @@ describe('BeachfrontAdapter', function () {
         expect(bidResponse.length).to.equal(0);
       });
 
-      it('should return no bids if the response "url" is missing', function () {
-        const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = { video: {} };
-        const serverResponse = {
-          bidPrice: 5.00
-        };
-        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
-        expect(bidResponse.length).to.equal(0);
-      });
-
       it('should return no bids if the response "bidPrice" is missing', function () {
         const bidRequest = bidRequests[0];
         bidRequest.mediaTypes = { video: {} };
@@ -562,6 +552,7 @@ describe('BeachfrontAdapter', function () {
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
+          vast: '<VAST version="3.0"></VAST>',
           crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
@@ -571,7 +562,7 @@ describe('BeachfrontAdapter', function () {
           cpm: serverResponse.bidPrice,
           creativeId: serverResponse.crid,
           vastUrl: serverResponse.url,
-          vastXml: undefined,
+          vastXml: serverResponse.vast,
           width: width,
           height: height,
           renderer: null,
@@ -602,7 +593,7 @@ describe('BeachfrontAdapter', function () {
         });
       });
 
-      it('should return vast xml if found on the bid response', () => {
+      it('should return only vast url if the response type is "nurl"', () => {
         const width = 640;
         const height = 480;
         const bidRequest = bidRequests[0];
@@ -611,6 +602,7 @@ describe('BeachfrontAdapter', function () {
             playerSize: [ width, height ]
           }
         };
+        bidRequest.params.video = { responseType: 'nurl' };
         const serverResponse = {
           bidPrice: 5.00,
           url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
@@ -618,10 +610,29 @@ describe('BeachfrontAdapter', function () {
           crid: '123abc'
         };
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
-        expect(bidResponse).to.deep.contain({
-          vastUrl: serverResponse.url,
-          vastXml: serverResponse.vast
-        });
+        expect(bidResponse.vastUrl).to.equal(serverResponse.url);
+        expect(bidResponse.vastXml).to.equal(undefined);
+      });
+
+      it('should return only vast xml if the response type is "adm"', () => {
+        const width = 640;
+        const height = 480;
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
+        bidRequest.params.video = { responseType: 'adm' };
+        const serverResponse = {
+          bidPrice: 5.00,
+          url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
+          vast: '<VAST version="3.0"></VAST>',
+          crid: '123abc'
+        };
+        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+        expect(bidResponse.vastUrl).to.equal(undefined);
+        expect(bidResponse.vastXml).to.equal(serverResponse.vast);
       });
 
       it('should return a renderer for outstream video bids', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds an optional bidder param to specify the video response type.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

PR for docs:
prebid/prebid.github.io#2530