### PR TITLE
ID5 ID module - pass gdpr and usp parameters in body instead of querystring

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -81,10 +81,12 @@ export const id5IdSubmodule = {
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
     const usp = uspDataHandler.getConsentData() || '';
-    const url = `https://id5-sync.com/g/v2/${config.params.partner}.json?gdpr_consent=${gdprConsentString}&gdpr=${hasGdpr}&us_privacy=${usp}`;
+    const url = `https://id5-sync.com/g/v2/${config.params.partner}.json`;
     const referer = getRefererInfo();
     const signature = (cacheIdObj && cacheIdObj.signature) ? cacheIdObj.signature : getLegacyCookieSignature();
     const data = {
+      'gdpr': hasGdpr,
+      'gdpr_consent': gdprConsentString,
       'partner': config.params.partner,
       'nbPage': incrementNb(config.params.partner),
       'o': 'pbjs',
@@ -94,6 +96,7 @@ export const id5IdSubmodule = {
       's': signature,
       'top': referer.reachedTop ? 1 : 0,
       'u': referer.stack[0] || window.location.href,
+      'us_privacy': usp,
       'v': '$prebid.version$'
     };
 

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -78,15 +78,13 @@ export const id5IdSubmodule = {
       return undefined;
     }
 
-    const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
-    const gdprConsentString = hasGdpr ? consentData.consentString : '';
-    const usp = uspDataHandler.getConsentData() || '';
     const url = `https://id5-sync.com/g/v2/${config.params.partner}.json`;
+    const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const referer = getRefererInfo();
     const signature = (cacheIdObj && cacheIdObj.signature) ? cacheIdObj.signature : getLegacyCookieSignature();
     const data = {
       'gdpr': hasGdpr,
-      'gdpr_consent': gdprConsentString,
+      'gdpr_consent': hasGdpr ? consentData.consentString : '',
       'partner': config.params.partner,
       'nbPage': incrementNb(config.params.partner),
       'o': 'pbjs',
@@ -96,7 +94,7 @@ export const id5IdSubmodule = {
       's': signature,
       'top': referer.reachedTop ? 1 : 0,
       'u': referer.stack[0] || window.location.href,
-      'us_privacy': usp,
+      'us_privacy': uspDataHandler.getConsentData() || '',
       'v': '$prebid.version$'
     };
 

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -143,6 +143,9 @@ describe('ID5 ID System', function() {
       expect(requestBody.s).to.eq('');
       expect(requestBody.provider).to.eq('');
       expect(requestBody.v).to.eq('$prebid.version$');
+      expect(requestBody.gdpr).to.exist;
+      expect(requestBody.gdpr_consent).to.exist
+      expect(requestBody.us_privacy).to.exist;
 
       request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
       expect(callbackSpy.calledOnce).to.be.true;


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Since gdpr consent strings are getting long, we want to start passing them in the body of the POST rather than the querystring to avoid data loss