### PR TITLE
.babelrc.js - changed IE target from 10 to 11

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -20,7 +20,7 @@ module.exports = {
             "safari >=8",
             "edge >= 14",
             "ff >= 57",
-            "ie >= 10",
+            "ie >= 11",
             "ios >= 8"
           ]
         }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
IE 10 support was dropped a long time ago
