### PR TITLE
FID-251: Update Reconciliation RTD Provider to 2.1

### DIFF
--- a/integrationExamples/gpt/reconciliationRtdProvider_example.html
+++ b/integrationExamples/gpt/reconciliationRtdProvider_example.html
@@ -82,8 +82,9 @@
 
     <script>
       googletag.cmd.push(function () {
-        googletag.defineSlot('/21834411153/rsdk-2', [[300, 250], [728, 90]], 'div-gpt-ad-rsdk-1').addService(googletag.pubads());
-
+        googletag.defineSlot('/21834411153/rsdk-2', [[300, 250], [728, 90]], 'div-gpt-ad-rsdk-1')
+          .addService(googletag.pubads())
+          .setTargeting('RSDK_VER', '2.1');
         googletag.pubads().enableSingleRequest();
         googletag.enableServices();
       });

--- a/modules/reconciliationRtdProvider.js
+++ b/modules/reconciliationRtdProvider.js
@@ -29,7 +29,7 @@ const MessageType = {
 /** @type {ModuleParams} */
 const DEFAULT_PARAMS = {
   initUrl: 'https://confirm.fiduciadlt.com/init',
-  impressionUrl: 'https://confirm.fiduciadlt.com/imp',
+  impressionUrl: 'https://confirm.fiduciadlt.com/pimp',
   allowAccess: false,
 };
 /** @type {ModuleParams} */
@@ -78,7 +78,7 @@ function handleAdMessage(e) {
       adDeliveryId,
     });
 
-    track.trackGet(_moduleParams.impressionUrl, args);
+    track.trackPost(_moduleParams.impressionUrl, args);
 
     // Send response back to the Advertiser tag
     let response = {
@@ -187,26 +187,6 @@ export function getSlotByWin(win) {
 }
 
 /**
- * serialize object and return query params string
- * @param {Object} data
- * @return {string}
- */
-export function stringify(query) {
-  const parts = [];
-
-  for (let key in query) {
-    if (query.hasOwnProperty(key)) {
-      let val = query[key];
-      if (typeof query[key] !== 'object') {
-        parts.push(`${key}=${encodeURIComponent(val)}`);
-      } else {
-        parts.push(`${key}=${encodeURIComponent(stringify(val))}`);
-      }
-    }
-  }
-  return parts.join('&');
-}
-/**
  * Init Reconciliation post messages listeners to handle
  * impressions messages from ad creative
  */
@@ -236,9 +216,6 @@ function trackInit(adUnits) {
  * @param {Object} data
  */
 export const track = {
-  trackGet(url, data) {
-    utils.triggerPixel(`${url}?${stringify(data)}`);
-  },
   trackPost(url, data) {
     const ajax = ajaxBuilder();
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Reconciliation RTD provider was changed to support new Reconciliation protocol:

1) track events via POST request
2) update 'imp' tracking endpoint

- contact email of the adapter’s maintainer
vladimir.fedoseev@fiducia.eco

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
https://github.com/prebid/Prebid.js/pull/5774
