### PR TITLE
pubGENIUS bid adapter: support video

### DIFF
--- a/modules/pubgeniusBidAdapter.js
+++ b/modules/pubgeniusBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { ajax } from '../src/ajax.js';
 import { config } from '../src/config.js';
-import { BANNER } from '../src/mediaTypes.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import {
   deepAccess,
   deepSetValue,
@@ -12,15 +12,16 @@ import {
   isStr,
   logError,
   parseQueryStringParameters,
+  pick,
 } from '../src/utils.js';
 
-const BIDDER_VERSION = '1.0.0';
+const BIDDER_VERSION = '1.1.0';
 const BASE_URL = 'https://ortb.adpearl.io';
 
 export const spec = {
   code: 'pubgenius',
 
-  supportedMediaTypes: [ BANNER ],
+  supportedMediaTypes: [ BANNER, VIDEO ],
 
   isBidRequestValid(bid) {
     const adUnitId = bid.params.adUnitId;
@@ -29,8 +30,13 @@ export const spec = {
       return false;
     }
 
-    const sizes = deepAccess(bid, 'mediaTypes.banner.sizes');
-    return !!(sizes && sizes.length) && sizes.every(size => isArrayOfNums(size, 2));
+    const { mediaTypes } = bid;
+
+    if (mediaTypes.banner) {
+      return isValidBanner(mediaTypes.banner);
+    }
+
+    return isValidVideo(mediaTypes.video, bid.params.video);
   },
 
   buildRequests: function (bidRequests, bidderRequest) {
@@ -141,15 +147,43 @@ export const spec = {
   },
 };
 
+function buildVideoParams(videoMediaType, videoParams) {
+  videoMediaType = videoMediaType || {};
+  const params = pick(videoMediaType, ['api', 'mimes', 'protocols', 'playbackmethod']);
+
+  switch (videoMediaType.context) {
+    case 'instream':
+      params.placement = 1;
+      break;
+    case 'outstream':
+      params.placement = 2;
+      break;
+    default:
+      break;
+  }
+
+  if (videoMediaType.playerSize) {
+    params.w = videoMediaType.playerSize[0][0];
+    params.h = videoMediaType.playerSize[0][1];
+  }
+
+  return Object.assign(params, videoParams);
+}
+
 function buildImp(bid) {
   const imp = {
     id: bid.bidId,
-    banner: {
-      format: deepAccess(bid, 'mediaTypes.banner.sizes').map(size => ({ w: size[0], h: size[1] })),
-      topframe: numericBoolean(!inIframe()),
-    },
     tagid: String(bid.params.adUnitId),
   };
+
+  if (bid.mediaTypes.banner) {
+    imp.banner = {
+      format: bid.mediaTypes.banner.sizes.map(size => ({ w: size[0], h: size[1] })),
+      topframe: numericBoolean(!inIframe()),
+    };
+  } else {
+    imp.video = buildVideoParams(bid.mediaTypes.video, bid.params.video);
+  }
 
   const bidFloor = bid.params.bidFloor;
   if (isNumber(bidFloor)) {
@@ -197,7 +231,6 @@ function interpretBid(bid) {
     cpm: bid.price,
     width: bid.w,
     height: bid.h,
-    ad: bid.adm,
     ttl: bid.exp,
     creativeId: bid.crid,
     netRevenue: true,
@@ -207,6 +240,28 @@ function interpretBid(bid) {
     bidResponse.meta = {
       advertiserDomains: bid.adomain,
     };
+  }
+
+  const pbadapter = deepAccess(bid, 'ext.pbadapter') || {};
+  switch (pbadapter.mediaType) {
+    case 'video':
+      if (bid.nurl) {
+        bidResponse.vastUrl = bid.nurl;
+      }
+
+      if (bid.adm) {
+        bidResponse.vastXml = bid.adm;
+      }
+
+      if (pbadapter.cacheKey) {
+        bidResponse.videoCacheKey = pbadapter.cacheKey;
+      }
+
+      bidResponse.mediaType = VIDEO;
+      break;
+    default: // banner by default
+      bidResponse.ad = bid.adm;
+      break;
   }
 
   return bidResponse;
@@ -219,6 +274,24 @@ function numericBoolean(value) {
 function getBaseUrl() {
   const pubg = config.getConfig('pubgenius');
   return (pubg && pubg.endpoint) || BASE_URL;
+}
+
+function isValidSize(size) {
+  return isArrayOfNums(size, 2) && size[0] > 0 && size[1] > 0;
+}
+
+function isValidBanner(banner) {
+  const sizes = banner.sizes;
+  return !!(sizes && sizes.length) && sizes.every(isValidSize);
+}
+
+function isValidVideo(videoMediaType, videoParams) {
+  const params = buildVideoParams(videoMediaType, videoParams);
+
+  return !!(params.placement &&
+    isValidSize([params.w, params.h]) &&
+    params.mimes && params.mimes.length &&
+    isArrayOfNums(params.protocols) && params.protocols.length);
 }
 
 registerBidder(spec);

--- a/modules/pubgeniusBidAdapter.md
+++ b/modules/pubgeniusBidAdapter.md
@@ -72,6 +72,13 @@ var adUnits = [
           // other video parameters as in OpenRTB v2.5 spec
           video: {
             skip: 1
+
+            // the following overrides mediaTypes.video of the ad unit
+            placement: 1,
+            w: 640,
+            h: 360,
+            mimes: ['video/mp4'],
+            protocols: [3],
           }
         }
       }

--- a/modules/pubgeniusBidAdapter.md
+++ b/modules/pubgeniusBidAdapter.md
@@ -50,7 +50,33 @@ var adUnits = [
         }
       }
     ]
-  }
+  },
+  {
+    code: 'test-video',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [640, 360],
+        mimes: ['video/mp4'],
+        protocols: [3],
+      }
+    },
+    bids: [
+      {
+        bidder: 'pubgenius',
+        params: {
+          adUnitId: '1001',
+          bidFloor: 1,
+          test: true,
+
+          // other video parameters as in OpenRTB v2.5 spec
+          video: {
+            skip: 1
+          }
+        }
+      }
+    ]
+  },
 ];
 ```
 

--- a/test/spec/modules/pubgeniusBidAdapter_spec.js
+++ b/test/spec/modules/pubgeniusBidAdapter_spec.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 
 import { spec } from 'modules/pubgeniusBidAdapter.js';
-import { deepClone, parseQueryStringParameters } from 'src/utils.js';
 import { config } from 'src/config.js';
+import { VIDEO } from 'src/mediaTypes.js';
+import { deepClone, parseQueryStringParameters } from 'src/utils.js';
 import { server } from 'test/mocks/xhr.js';
 
 const {
@@ -23,8 +24,8 @@ describe('pubGENIUS adapter', () => {
   });
 
   describe('supportedMediaTypes', () => {
-    it('should contain only banner', () => {
-      expect(supportedMediaTypes).to.deep.equal(['banner']);
+    it('should contain banner and video', () => {
+      expect(supportedMediaTypes).to.deep.equal(['banner', 'video']);
     });
   });
 
@@ -74,6 +75,51 @@ describe('pubGENIUS adapter', () => {
 
     it('should return false with invalid size', () => {
       bid.mediaTypes.banner.sizes = [[300, 600, 250]];
+
+      expect(isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('should return false without banner or video', () => {
+      bid.mediaTypes = {};
+
+      expect(isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('should return true with valid video media type', () => {
+      bid.mediaTypes = {
+        video: {
+          context: 'instream',
+          playerSize: [[100, 100]],
+          mimes: ['video/mp4'],
+          protocols: [1],
+        },
+      };
+
+      expect(isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should return true with valid video params', () => {
+      bid.params.video = {
+        placement: 1,
+        w: 200,
+        h: 200,
+        mimes: ['video/mp4'],
+        protocols: [1],
+      };
+
+      expect(isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should return false without video protocols', () => {
+      bid.mediaTypes = {
+        video: {
+          context: 'instream',
+          playerSize: [[100, 100]],
+        },
+      };
+      bid.params.video = {
+        mimes: ['video/mp4'],
+      };
 
       expect(isBidRequestValid(bid)).to.be.false;
     });
@@ -143,7 +189,7 @@ describe('pubGENIUS adapter', () => {
           tmax: 1200,
           ext: {
             pbadapter: {
-              version: '1.0.0',
+              version: '1.1.0',
             },
           },
         },
@@ -314,6 +360,44 @@ describe('pubGENIUS adapter', () => {
 
       expect(buildRequests([bidRequest], bidderRequest)).to.deep.equal(expectedRequest);
     });
+
+    it('should build video imp', () => {
+      bidRequest.mediaTypes = {
+        video: {
+          context: 'instream',
+          playerSize: [[200, 100]],
+          mimes: ['video/mp4'],
+          protocols: [2, 3],
+          api: [1, 2],
+          playbackmethod: [3, 4],
+        },
+      };
+      bidRequest.params.video = {
+        minduration: 5,
+        maxduration: 100,
+        skip: 1,
+        skipafter: 1,
+        startdelay: -1,
+      };
+
+      delete expectedRequest.data.imp[0].banner;
+      expectedRequest.data.imp[0].video = {
+        mimes: ['video/mp4'],
+        minduration: 5,
+        maxduration: 100,
+        protocols: [2, 3],
+        w: 200,
+        h: 100,
+        startdelay: -1,
+        placement: 1,
+        skip: 1,
+        skipafter: 1,
+        playbackmethod: [3, 4],
+        api: [1, 2],
+      };
+
+      expect(buildRequests([bidRequest], bidderRequest)).to.deep.equal(expectedRequest);
+    });
   });
 
   describe('interpretResponse', () => {
@@ -369,6 +453,30 @@ describe('pubGENIUS adapter', () => {
 
     it('should interpret no bids', () => {
       expect(interpretResponse({ body: {} })).to.deep.equal([]);
+    });
+
+    it('should interpret video response', () => {
+      serverResponse.body.seatbid[0].bid[0] = {
+        ...serverResponse.body.seatbid[0].bid[0],
+        nurl: 'http://vasturl/cache?id=x',
+        ext: {
+          pbadapter: {
+            mediaType: 'video',
+            cacheKey: 'x',
+          },
+        },
+      };
+
+      delete expectedBidResponse.ad;
+      expectedBidResponse = {
+        ...expectedBidResponse,
+        vastUrl: 'http://vasturl/cache?id=x',
+        vastXml: 'fake_creative',
+        videoCacheKey: 'x',
+        mediaType: VIDEO,
+      };
+
+      expect(interpretResponse(serverResponse)).to.deep.equal([expectedBidResponse]);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
pubGENIUS bid adapter supports video mediaType with this PR.

- test parameters for validating bids
```
{
  bidder: 'pubgenius',
  params: {
    adUnitId: '1001',
    bidFloor: 1,
    test: true,

    // other video parameters as in OpenRTB v2.5 spec
    video: {
      placement: 1,
      w: 640,
      h: 360,
      mimes: ['video/mp4'],
      protocols: [3],
      skip: 1
    }
  }
}
```

- contact email of the adapter’s maintainer: meng@pubgenius.io
- [x] official adapter submission
- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/2539

## Other information
@kevinstubbs for team 