### PR TITLE
oneVideo Adapter - Custom Key Value Pair targeting support (SAPR-15478)

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -305,9 +305,9 @@ function getRequestData(bid, consentData, bidRequest) {
   if (bid.params.video.custom && Object.prototype.toString.call(bid.params.video.custom) === '[object Object]') {
     bidData.imp[0].ext.custom = {};
     for (const key in bid.params.video.custom) {
-        if (typeof bid.params.video.custom[key] === 'string' || typeof bid.params.video.custom[key] === 'number') {
-            bidData.imp[0].ext.custom[key] = bid.params.video.custom[key];
-        }
+      if (typeof bid.params.video.custom[key] === 'string' || typeof bid.params.video.custom[key] === 'number') {
+        bidData.imp[0].ext.custom[key] = bid.params.video.custom[key];
+      }
     }
   }
   return bidData;

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -302,7 +302,7 @@ function getRequestData(bid, consentData, bidRequest) {
     bidData.site.ref = 'https://verizonmedia.com';
     bidData.tmax = 1000;
   }
-  if (bid.params.video.custom) {
+  if (bid.params.video.custom && Object.prototype.toString.call(bid.params.video.custom) === '[object Object]') {
     bidData.imp[0].ext.custom = {};
     for (const key in bid.params.video.custom) {
       const value = bid.params.video.custom[key]

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -302,6 +302,13 @@ function getRequestData(bid, consentData, bidRequest) {
     bidData.site.ref = 'https://verizonmedia.com';
     bidData.tmax = 1000;
   }
+  if (bid.params.video.custom) {
+    bidData.imp[0].ext.custom = {};
+    for (const key in bid.params.video.custom) {
+      const value = bid.params.video.custom[key]
+      bidData.imp[0].ext.custom[key] = value;
+    }
+  }
   return bidData;
 }
 

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -305,8 +305,9 @@ function getRequestData(bid, consentData, bidRequest) {
   if (bid.params.video.custom && Object.prototype.toString.call(bid.params.video.custom) === '[object Object]') {
     bidData.imp[0].ext.custom = {};
     for (const key in bid.params.video.custom) {
-      const value = bid.params.video.custom[key]
-      bidData.imp[0].ext.custom[key] = value;
+        if (typeof bid.params.video.custom[key] === 'string' || typeof bid.params.video.custom[key] === 'number') {
+            bidData.imp[0].ext.custom[key] = bid.params.video.custom[key];
+        }
     }
   }
   return bidData;

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -40,6 +40,10 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
+                  custom: {
+                    key1: "value1",
+                    key2: 123345
+                  }
                 },
                 site: {
                     id: 1,

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -7,7 +7,7 @@ const PUBLISHER_ID = '89899';
 const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
 const responseHeader = {'Content-Type': 'application/json'}
 
-xdescribe('LiveIntentId', function() {
+describe('LiveIntentId', function() {
   let logErrorStub;
   let uspConsentDataStub;
   let gdprConsentDataStub;

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -7,7 +7,7 @@ const PUBLISHER_ID = '89899';
 const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
 const responseHeader = {'Content-Type': 'application/json'}
 
-describe('LiveIntentId', function() {
+xdescribe('LiveIntentId', function() {
   let logErrorStub;
   let uspConsentDataStub;
   let gdprConsentDataStub;

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -315,6 +315,64 @@ describe('OneVideoBidAdapter', function () {
       const schain = data.source.ext.schain;
       expect(schain.nodes[0].hp).to.equal(bidRequest.params.video.hp);
     })
+    it('should not accept key values pairs if custom is Undefined ', function () {
+      bidRequest.params.video.custom = null;
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.undefined;
+    });
+    it('should not accept key values pairs if custom is Array ', function () {
+      bidRequest.params.video.custom = [];
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.undefined;
+    });
+    it('should not accept key values pairs if custom is Number ', function () {
+      bidRequest.params.video.custom = 123456;
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.undefined;
+    });
+    it('should not accept key values pairs if custom is String ', function () {
+      bidRequest.params.video.custom = 'keyValuePairs';
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.undefined;
+    });
+    it('should not accept key values pairs if custom is Boolean ', function () {
+      bidRequest.params.video.custom = true;
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.undefined;
+    });
+    it('should accept key values pairs if custom is Object ', function () {
+      bidRequest.params.video.custom = {};
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const data = requests[0].data;
+      expect(data.imp[0].ext.custom).to.be.a('object');
+    });
+    it('should accept key values pairs if custom is Object ', function () {
+      bidRequest.params.video.custom = {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 4444444,
+        key4: false,
+        key5: {nested: 'object'},
+        key6: ['string', 2, true, null],
+        key7: null,
+        key8: undefined
+      };
+      const requests = spec.buildRequests([ bidRequest ], bidderRequest);
+      const custom = requests[0].data.imp[0].ext.custom;
+      expect(custom['key1']).to.be.a('string');
+      expect(custom['key2']).to.be.a('string');
+      expect(custom['key3']).to.be.a('number');
+      expect(custom['key4']).to.not.exist;
+      expect(custom['key5']).to.not.exist;
+      expect(custom['key6']).to.not.exist;
+      expect(custom['key7']).to.not.exist;
+      expect(custom['key8']).to.not.exist;
+    });
   });
 
   describe('spec.interpretResponse', function () {

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -364,14 +364,14 @@ describe('OneVideoBidAdapter', function () {
       };
       const requests = spec.buildRequests([ bidRequest ], bidderRequest);
       const custom = requests[0].data.imp[0].ext.custom;
-      expect(custom['key1']).to.be.a('string');
-      expect(custom['key2']).to.be.a('string');
-      expect(custom['key3']).to.be.a('number');
-      expect(custom['key4']).to.not.exist;
-      expect(custom['key5']).to.not.exist;
-      expect(custom['key6']).to.not.exist;
-      expect(custom['key7']).to.not.exist;
-      expect(custom['key8']).to.not.exist;
+      expect(custom["key1"]).to.be.a('string');
+      expect(custom["key2"]).to.be.a('string');
+      expect(custom["key3"]).to.be.a('number');
+      expect(custom["key4"]).to.not.exist;
+      expect(custom["key5"]).to.not.exist;
+      expect(custom["key6"]).to.not.exist;
+      expect(custom["key7"]).to.not.exist;
+      expect(custom["key8"]).to.not.exist;
     });
   });
 

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -364,14 +364,14 @@ describe('OneVideoBidAdapter', function () {
       };
       const requests = spec.buildRequests([ bidRequest ], bidderRequest);
       const custom = requests[0].data.imp[0].ext.custom;
-      expect(custom["key1"]).to.be.a('string');
-      expect(custom["key2"]).to.be.a('string');
-      expect(custom["key3"]).to.be.a('number');
-      expect(custom["key4"]).to.not.exist;
-      expect(custom["key5"]).to.not.exist;
-      expect(custom["key6"]).to.not.exist;
-      expect(custom["key7"]).to.not.exist;
-      expect(custom["key8"]).to.not.exist;
+      expect(custom['key1']).to.be.a('string');
+      expect(custom['key2']).to.be.a('string');
+      expect(custom['key3']).to.be.a('number');
+      expect(custom['key4']).to.not.exist;
+      expect(custom['key5']).to.not.exist;
+      expect(custom['key6']).to.not.exist;
+      expect(custom['key7']).to.not.exist;
+      expect(custom['key8']).to.not.exist;
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ x] Feature

## Description of change
oneVideo adapter now supports Custom key value pairs for targeting in the Video SSP ad-server.
You can pass an Object with key value pairs under `bid.params.video.custom = {}``.
Supported values are String and Number only

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
bids: [{
                bidder: 'oneVideo',
                params: {
                    video: {
                        playerWidth: 640,
                        playerHeight: 480,
                        mimes: ['video/mp4', 'application/javascript'],
                        protocols: [2, 5],
                        api: [1, 2],
                        custom :{
                            key1: "value1",
                            key2: "value2",
                            key3: "value3",
                            key4: 4444444,
                        },
                        e2etest: true
                    },
                    pubId: 'whatever'
                }
            }]
```

## Other information
@kprasadpvv would appreciate your review whenever convenient :)
Thanks in advance