### PR TITLE
Fix iframe __tcfapi arguments

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -199,29 +199,56 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   function callCmpWhileInIframe(commandName, cmpFrame, moduleCallback) {
     let apiName = (cmpVersion === 2) ? '__tcfapi' : '__cmp';
 
+    let callId = Math.random() + '';
+    let callName = `${apiName}Call`;
+
     /* Setup up a __cmp function to do the postMessage and stash the callback.
       This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
-    window[apiName] = function (cmd, arg, callback) {
-      let callId = Math.random() + '';
-      let callName = `${apiName}Call`;
-      let msg = {
-        [callName]: {
-          command: cmd,
-          parameter: arg,
-          callId: callId
-        }
-      };
-      if (cmpVersion !== 1) msg[callName].version = cmpVersion;
+    if (cmpVersion === 2) {
+      window[apiName] = function (cmd, cmpVersion, callback, arg) {
+        let msg = {
+          [callName]: {
+            command: cmd,
+            version: cmpVersion,
+            parameter: arg,
+            callId: callId
+          }
+        };
 
-      cmpCallbacks[callId] = callback;
-      cmpFrame.postMessage(msg, '*');
+        cmpCallbacks[callId] = callback;
+        cmpFrame.postMessage(msg, '*');
+      }
+
+      /** when we get the return message, call the stashed callback */
+      window.addEventListener('message', readPostMessageResponse, false);
+
+      // call CMP
+      window[apiName](commandName, cmpVersion, moduleCallback);
+
+    } else {
+      window[apiName] = function (cmd, arg, callback) {
+        let msg = {
+          [callName]: {
+            command: cmd,
+            parameter: arg,
+            callId: callId
+          }
+        };
+
+        cmpCallbacks[callId] = callback;
+        cmpFrame.postMessage(msg, '*');
+      }
+
+      /** when we get the return message, call the stashed callback */
+      window.addEventListener('message', readPostMessageResponse, false);
+
+      // call CMP
+      window[apiName](commandName, undefined, moduleCallback);
     }
 
-    /** when we get the return message, call the stashed callback */
-    window.addEventListener('message', readPostMessageResponse, false);
 
-    // call CMP
-    window[apiName](commandName, undefined, moduleCallback);
+
+
 
     function readPostMessageResponse(event) {
       let cmpDataPkgName = `${apiName}Return`;

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -224,7 +224,6 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
 
       // call CMP
       window[apiName](commandName, cmpVersion, moduleCallback);
-
     } else {
       window[apiName] = function (cmd, arg, callback) {
         let msg = {
@@ -245,10 +244,6 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
       // call CMP
       window[apiName](commandName, undefined, moduleCallback);
     }
-
-
-
-
 
     function readPostMessageResponse(event) {
       let cmpDataPkgName = `${apiName}Return`;

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -537,6 +537,15 @@ describe('consentManagement', function () {
         // from CMP window postMessage listener.
         testIFramedPage('with/JSON response', false, 'encoded_consent_data_via_post_message', 1);
         testIFramedPage('with/String response', true, 'encoded_consent_data_via_post_message', 1);
+
+        it('should contain correct V1 CMP definition', (done) => {
+          setConsentConfig(goodConfigWithAllowAuction);
+          requestBidsHook(() => {
+            const nbArguments = window.__cmp.toString().split('\n')[0].split(', ').length;
+            expect(nbArguments).to.equal(3);
+            done();
+          }, {});
+        });
       });
 
       describe('v2 CMP workflow for iframe pages:', function () {
@@ -562,6 +571,15 @@ describe('consentManagement', function () {
 
         testIFramedPage('with/JSON response', false, 'abc12345234', 2);
         testIFramedPage('with/String response', true, 'abc12345234', 2);
+
+        it('should contain correct v2 CMP definition', (done) => {
+          setConsentConfig(goodConfigWithAllowAuction);
+          requestBidsHook(() => {
+            const nbArguments = window.__tcfapi.toString().split('\n')[0].split(', ').length;
+            expect(nbArguments).to.equal(4);
+            done();
+          }, {});
+        });
       });
     });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
When prebid is loaded in an iframe, a __cmp or __tcfapi function is created to forward calls to the parent frame CMP using the locator. The created __tcfapi function have the arguments of the CMP v1 specification.
This fix change the function declaration anduse 4 arguments according to spec
https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-does-the-cmp-provide-the-api

## Other information

issue #5976 
