### PR TITLE
Add Optional Params to Concert Adapter

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -53,12 +53,12 @@ export const spec = {
         name: bidRequest.adUnitCode,
         bidId: bidRequest.bidId,
         transactionId: bidRequest.transactionId,
-        sizes: slot.params.sizes || bidRequest.sizes,
+        sizes: bidRequest.params.sizes || bidRequest.sizes,
         partnerId: bidRequest.params.partnerId,
         slotType: bidRequest.params.slotType,
-        adSlot: slot.params.slot || bidRequest.adUnitCode,
-        placementId: slot.params.placementId || '',
-        site: slot.params.site || bidderRequest.refererInfo.referer
+        adSlot: bidRequest.params.slot || bidRequest.adUnitCode,
+        placementId: bidRequest.params.placementId || '',
+        site: bidRequest.params.site || bidderRequest.refererInfo.referer
       }
 
       return slot;

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -42,7 +42,7 @@ export const spec = {
         debug: utils.debugTurnedOn(),
         uid: getUid(bidderRequest),
         optedOut: hasOptedOutOfPersonalization(),
-        adapterVersion: '1.1.0',
+        adapterVersion: '1.1.1',
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent
       }
@@ -53,9 +53,12 @@ export const spec = {
         name: bidRequest.adUnitCode,
         bidId: bidRequest.bidId,
         transactionId: bidRequest.transactionId,
-        sizes: bidRequest.sizes,
+        sizes: slot.params.sizes || bidRequest.sizes,
         partnerId: bidRequest.params.partnerId,
-        slotType: bidRequest.params.slotType
+        slotType: bidRequest.params.slotType,
+        adSlot: slot.params.slot || bidRequest.adUnitCode,
+        placementId: slot.params.placementId || '',
+        site: slot.params.site || bidderRequest.refererInfo.referer
       }
 
       return slot;

--- a/modules/concertBidAdapter.md
+++ b/modules/concertBidAdapter.md
@@ -26,7 +26,7 @@ Module that connects to Concert demand sources
           params: {
             partnerId: 'test_partner',
             site: 'site_name',
-            placementId: placement_id,
+            placementId: 1234567,
             slot: 'slot_name',
             sizes: [[1030, 590]]
           }

--- a/modules/concertBidAdapter.md
+++ b/modules/concertBidAdapter.md
@@ -23,8 +23,14 @@ Module that connects to Concert demand sources
       bids: [
         {
           bidder: "concert",
+        {
+          bidder: "concert",
           params: {
-            partnerId: 'test_partner'
+            partnerId: 'test_partner',
+            site: 'site_name',
+            placementId: placement_id,
+            slot: 'slot_name',
+            sizes: [[1030, 590]]
           }
         }
       ]

--- a/modules/concertBidAdapter.md
+++ b/modules/concertBidAdapter.md
@@ -23,8 +23,6 @@ Module that connects to Concert demand sources
       bids: [
         {
           bidder: "concert",
-        {
-          bidder: "concert",
           params: {
             partnerId: 'test_partner',
             site: 'site_name',


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Add optional params to Concert adapter.

- test parameters for validating bids
```
  var adUnits = [
    {
      code: 'desktop_leaderboard_variable',
      mediaTypes: {
        banner: {
          sizes: [[1030, 590]]
        }
      }
      bids: [
        {
          bidder: "concert",
          params: {
            partnerId: 'test_partner',
            site: 'site_name',
            placementId: 1234567,
            slot: 'slot_name',
            sizes: [[1030, 590]]
          }
        }
      ]
    }
  ];
}
```
- contact email of the adapter’s maintainer: support@concert.io

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/2542
