### PR TITLE
Improve __uspapi behavior in iframe

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -44,6 +44,34 @@ function lookupStaticConsentData(cmpSuccess, cmpError, hookConfig) {
  * @param {object} hookConfig contains module related variables (see comment in requestBidsHook function)
  */
 function lookupUspConsent(uspSuccess, uspError, hookConfig) {
+  function findUsp() {
+    let f = window;
+    let uspapiFrame;
+    let uspapiFunction;
+
+    while (!uspapiFrame) {
+      try {
+        if (typeof f.__uspapi === 'function') {
+          uspapiFunction = f.__uspapi;
+          uspapiFrame = f;
+          break;
+        }
+      } catch (e) {}
+      try {
+        if (f.frames['__uspapiLocator']) {
+          uspapiFrame = f;
+          break;
+        }
+      } catch (e) {}
+      if (f === window.top) break;
+      f = f.parent;
+    }
+    return {
+      uspapiFrame,
+      uspapiFunction,
+    };
+  }
+
   function handleUspApiResponseCallbacks() {
     const uspResponse = {};
 
@@ -61,12 +89,18 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
           uspResponse.usPrivacy = consentResponse.uspString;
         }
         afterEach();
-      }
+      },
     };
   }
 
   let callbackHandler = handleUspApiResponseCallbacks();
   let uspapiCallbacks = {};
+
+  let { uspapiFrame, uspapiFunction } = findUsp();
+
+  if (!uspapiFrame) {
+    return uspError('USP CMP not found.', hookConfig);
+  }
 
   // to collect the consent information from the user, we perform a call to USPAPI
   // to collect the user's consent choices represented as a string (via getUSPData)
@@ -76,26 +110,22 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
   // - if USPAPI is not found, the iframe function will call the uspError exit callback to abort the rest of the USPAPI workflow
   // - try to call the __uspapi() function directly, otherwise use the postMessage() api
   // find the CMP frame/window
-
-  try {
-    // try to call __uspapi directly
-    window.__uspapi('getUSPData', USPAPI_VERSION, callbackHandler.consentDataCallback);
-  } catch (e) {
-    // must not have been accessible, try using postMessage() api
-    let f = window;
-    let uspapiFrame;
-    while (!uspapiFrame) {
-      try {
-        if (f.frames['__uspapiLocator']) uspapiFrame = f;
-      } catch (e) { }
-      if (f === window.top) break;
-      f = f.parent;
-    }
-
-    if (!uspapiFrame) {
-      return uspError('USP CMP not found.', hookConfig);
-    }
-    callUspApiWhileInIframe('getUSPData', uspapiFrame, callbackHandler.consentDataCallback);
+  if (utils.isFn(uspapiFunction)) {
+    utils.logInfo('Detected USP CMP is directly accessible, calling it now...');
+    uspapiFunction(
+      'getUSPData',
+      USPAPI_VERSION,
+      callbackHandler.consentDataCallback
+    );
+  } else {
+    utils.logInfo(
+      'Detected USP CMP is outside the current iframe where Prebid.js is located, calling it now...'
+    );
+    callUspApiWhileInIframe(
+      'getUSPData',
+      uspapiFrame,
+      callbackHandler.consentDataCallback
+    );
   }
 
   function callUspApiWhileInIframe(commandName, uspapiFrame, moduleCallback) {
@@ -107,19 +137,19 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
         __uspapiCall: {
           command: cmd,
           version: ver,
-          callId: callId
-        }
+          callId: callId,
+        },
       };
 
       uspapiCallbacks[callId] = callback;
       uspapiFrame.postMessage(msg, '*');
-    }
+    };
 
     /** when we get the return message, call the stashed callback */
     window.addEventListener('message', readPostMessageResponse, false);
 
     // call uspapi
-    window.__uspapi(commandName, USPAPI_VERSION, uspapiCallback);
+    window.__uspapi(commandName, USPAPI_VERSION, moduleCallback);
 
     function readPostMessageResponse(event) {
       const res = event && event.data && event.data.__uspapiReturn;
@@ -129,11 +159,6 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
           delete uspapiCallbacks[res.callId];
         }
       }
-    }
-
-    function uspapiCallback(consentObject, success) {
-      window.removeEventListener('message', readPostMessageResponse, false);
-      moduleCallback(consentObject, success);
     }
   }
 }

--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -57,6 +57,7 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
           break;
         }
       } catch (e) {}
+
       try {
         if (f.frames['__uspapiLocator']) {
           uspapiFrame = f;
@@ -106,10 +107,10 @@ function lookupUspConsent(uspSuccess, uspError, hookConfig) {
   // to collect the user's consent choices represented as a string (via getUSPData)
 
   // the following code also determines where the USPAPI is located and uses the proper workflow to communicate with it:
-  // - use the USPAPI locator code to see if USP's located in the current window or an ancestor window. This works in friendly or cross domain iframes
+  // - use the USPAPI locator code to see if USP's located in the current window or an ancestor window.
+  // - else assume prebid is in an iframe, and use the locator to see if the CMP is located in a higher parent window. This works in cross domain iframes.
   // - if USPAPI is not found, the iframe function will call the uspError exit callback to abort the rest of the USPAPI workflow
-  // - try to call the __uspapi() function directly, otherwise use the postMessage() api
-  // find the CMP frame/window
+
   if (utils.isFn(uspapiFunction)) {
     utils.logInfo('Detected USP CMP is directly accessible, calling it now...');
     uspapiFunction(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
This fixes the following two issues:

* https://github.com/prebid/Prebid.js/issues/6051
* https://github.com/prebid/Prebid.js/issues/6050

I've aligned the locator code with the `consentManagement.js` module so that use similar logic in finding where the `uspapi` function resides.

I've removed the code that removes the event listener after the consent information has been retrieved, as this breaks the `__uspapi` function that we installed on the current window. As a result, external libraries would think that the current window has a uspapi, call it, but never get a response.



## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

The existing unit tests already cover the cases of finding the uspapi in an iframe and directly, and still pass.
I've also tested this in a real world setup, and both the case of accessing the api directly and cross iframe work.