### PR TITLE
pubgenius: remove video cache key

### DIFF
--- a/modules/pubgeniusBidAdapter.js
+++ b/modules/pubgeniusBidAdapter.js
@@ -253,10 +253,6 @@ function interpretBid(bid) {
         bidResponse.vastXml = bid.adm;
       }
 
-      if (pbadapter.cacheKey) {
-        bidResponse.videoCacheKey = pbadapter.cacheKey;
-      }
-
       bidResponse.mediaType = VIDEO;
       break;
     default: // banner by default


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Bugfix

## Description of change
Remove video cache key as per comments of #6040 

- contact email of the adapter’s maintainer: meng@pubgenius.io
- [x] official adapter submission
