### PR TITLE
Add Kubient bid adapter, Remove alias from Fidelity bid adapter.

### DIFF
--- a/modules/fidelityBidAdapter.js
+++ b/modules/fidelityBidAdapter.js
@@ -6,7 +6,6 @@ const BIDDER_SERVER = 'x.fidelity-media.com';
 const FIDELITY_VENDOR_ID = 408;
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['kubient'],
   gvlid: 408,
   isBidRequestValid: function isBidRequestValid(bid) {
     return !!(bid && bid.params && bid.params.zoneid);

--- a/modules/kubientBidAdapter.js
+++ b/modules/kubientBidAdapter.js
@@ -1,0 +1,115 @@
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER} from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'kubient';
+const END_POINT = 'https://kssp.kbntx.ch/pbjs';
+const VERSION = '1.0';
+const VENDOR_ID = 794;
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: VENDOR_ID,
+  supportedMediaTypes: [BANNER],
+  isBidRequestValid: function (bid) {
+    return !!(bid && bid.params);
+  },
+  buildRequests: function (validBidRequests, bidderRequest) {
+    if (!validBidRequests || !bidderRequest) {
+      return;
+    }
+    var result = validBidRequests.map(function (bid) {
+      let data = {
+        v: VERSION,
+        requestId: bid.bidderRequestId,
+        adSlots: [{
+          bidId: bid.bidId,
+          zoneId: bid.params.zoneid || '',
+          floor: bid.params.floor || 0.0,
+          sizes: bid.sizes || [],
+          schain: bid.schain || {},
+          mediaTypes: bid.mediaTypes
+        }],
+        referer: (bidderRequest.refererInfo && bidderRequest.refererInfo.referer) ? bidderRequest.refererInfo.referer : null,
+        tmax: bidderRequest.timeout,
+        gdpr: (bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) ? 1 : 0,
+        consent: (bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString) ? bidderRequest.gdprConsent.consentString : null,
+        consentGiven: kubientGetConsentGiven(bidderRequest.gdprConsent),
+        uspConsent: bidderRequest.uspConsent
+      };
+      return {
+        method: 'POST',
+        url: END_POINT,
+        data: JSON.stringify(data)
+      };
+    });
+    return result;
+  },
+  interpretResponse: function interpretResponse(serverResponse, request) {
+    if (!serverResponse || !serverResponse.body || !serverResponse.body.seatbid) {
+      return [];
+    }
+    let bidResponses = [];
+    serverResponse.body.seatbid.forEach(seatbid => {
+      let bids = seatbid.bid || [];
+      bids.forEach(bid => {
+        bidResponses.push({
+          requestId: bid.bidId,
+          cpm: bid.price,
+          currency: bid.cur,
+          width: bid.w,
+          height: bid.h,
+          creativeId: bid.creativeId,
+          netRevenue: bid.netRevenue,
+          ttl: bid.ttl,
+          ad: bid.adm
+        });
+      });
+    });
+    return bidResponses;
+  },
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
+    var syncs = [];
+    var gdprParams = '';
+    if (gdprConsent && typeof gdprConsent.consentString === 'string') {
+      gdprParams = `?consent_str=${gdprConsent.consentString}`;
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        gdprParams = gdprParams + `&gdpr=${Number(gdprConsent.gdprApplies)}`;
+      }
+      gdprParams = gdprParams + `&consent_given=` + kubientGetConsentGiven(gdprConsent);
+    }
+    if (syncOptions.iframeEnabled) {
+      syncs.push({
+        type: 'iframe',
+        url: 'https://kdmp.kbntx.ch/init.html' + gdprParams
+      });
+    }
+    if (syncOptions.pixelEnabled) {
+      syncs.push({
+        type: 'image',
+        url: 'https://kdmp.kbntx.ch/init.png' + gdprParams
+      });
+    }
+    return syncs;
+  }
+};
+
+function kubientGetConsentGiven(gdprConsent) {
+  let consentGiven = 0;
+  if (
+    gdprConsent.apiVersion === 1 &&
+    gdprConsent.vendorData &&
+    gdprConsent.vendorData.vendorConsents &&
+    typeof gdprConsent.vendorData.vendorConsents[VENDOR_ID.toString(10)] !== 'undefined'
+  ) {
+    consentGiven = gdprConsent.vendorData.vendorConsents[VENDOR_ID.toString(10)] ? 1 : 0;
+  } else if (
+    gdprConsent.apiVersion === 2 &&
+    gdprConsent.vendorData &&
+    gdprConsent.vendorData.vendor &&
+    gdprConsent.vendorData.vendor.consents &&
+    typeof gdprConsent.vendorData.vendor.consents[VENDOR_ID.toString(10)] !== 'undefined'
+  ) {
+    consentGiven = gdprConsent.vendorData.vendor.consents[VENDOR_ID.toString(10)] ? 1 : 0;
+  }
+  return consentGiven;
+}
+registerBidder(spec);

--- a/modules/kubientBidAdapter.md
+++ b/modules/kubientBidAdapter.md
@@ -1,0 +1,26 @@
+# Overview
+​
+**Module Name**: Kubient Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**:  artem.aleksashkin@kubient.com
+​
+# Description
+​
+Connects to Kubient KSSP demand source to fetch bids.  
+​
+# Test Parameters
+```
+    var adUnits = [{
+      code: 'banner-ad-div',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250],[728, 90]],
+        }
+      },
+            bids: [{
+                "bidder": "kubient",
+                "params": {
+                    "zoneid": "5fbb948f1e22b",
+                }   
+            }]      
+        }];         

--- a/test/spec/modules/kubientBidAdapter_spec.js
+++ b/test/spec/modules/kubientBidAdapter_spec.js
@@ -1,0 +1,259 @@
+import { expect, assert } from 'chai';
+import { spec } from 'modules/kubientBidAdapter.js';
+
+describe('KubientAdapter', function () {
+  let bid = {
+    bidId: '2dd581a2b6281d',
+    bidder: 'kubient',
+    bidderRequestId: '145e1d6a7837c9',
+    params: {
+      zoneid: '5678',
+      floor: 0.05,
+    },
+    auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    transactionId: '3bb2f6da-87a6-4029-aeb0-bfe951372e62',
+    schain: {
+      ver: '1.0',
+      complete: 1,
+      nodes: [
+        {
+          asi: 'example.com',
+          sid: '0',
+          hp: 1,
+          rid: 'bidrequestid',
+          domain: 'example.com'
+        }
+      ]
+    }
+  };
+  let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
+  let uspConsentData = '1YCC';
+  let bidderRequest = {
+    bidderCode: 'kubient',
+    auctionId: 'fffffff-ffff-ffff-ffff-ffffffffffff',
+    bidderRequestId: 'ffffffffffffff',
+    start: 1472239426002,
+    auctionStart: 1472239426000,
+    timeout: 5000,
+    refererInfo: {
+      referer: 'http://www.example.com',
+      reachedTop: true,
+    },
+    gdprConsent: {
+      consentString: consentString,
+      gdprApplies: true
+    },
+    uspConsent: uspConsentData,
+    bids: [bid]
+  };
+  describe('buildRequests', function () {
+    let serverRequests = spec.buildRequests([bid], bidderRequest);
+    it('Creates a ServerRequest object with method, URL and data', function () {
+      expect(serverRequests).to.be.an('array');
+    });
+    for (let i = 0; i < serverRequests.length; i++) {
+      let serverRequest = serverRequests[i];
+      it('Creates a ServerRequest object with method, URL and data', function () {
+        expect(serverRequest.method).to.be.a('string');
+        expect(serverRequest.url).to.be.a('string');
+        expect(serverRequest.data).to.be.a('string');
+      });
+      it('Returns POST method', function () {
+        expect(serverRequest.method).to.equal('POST');
+      });
+      it('Returns valid URL', function () {
+        expect(serverRequest.url).to.equal('https://kssp.kbntx.ch/pbjs');
+      });
+      it('Returns valid data if array of bids is valid', function () {
+        let data = JSON.parse(serverRequest.data);
+        expect(data).to.be.an('object');
+        expect(data).to.have.all.keys('v', 'requestId', 'adSlots', 'gdpr', 'referer', 'tmax', 'consent', 'consentGiven', 'uspConsent');
+        expect(data.v).to.exist.and.to.be.a('string');
+        expect(data.requestId).to.exist.and.to.be.a('string');
+        expect(data.referer).to.be.a('string');
+        expect(data.tmax).to.exist.and.to.be.a('number');
+        expect(data.gdpr).to.exist.and.to.be.within(0, 1);
+        expect(data.consent).to.equal(consentString);
+        expect(data.uspConsent).to.exist.and.to.equal(uspConsentData);
+        for (let j = 0; j < data['adSlots'].length; j++) {
+          let adSlot = data['adSlots'][i];
+          expect(adSlot).to.have.all.keys('bidId', 'zoneId', 'floor', 'sizes', 'schain', 'mediaTypes');
+          expect(adSlot.bidId).to.be.a('string');
+          expect(adSlot.zoneId).to.be.a('string');
+          expect(adSlot.floor).to.be.a('number');
+          expect(adSlot.sizes).to.be.an('array');
+          expect(adSlot.schain).to.be.an('object');
+          expect(adSlot.mediaTypes).to.be.an('object');
+        }
+      });
+    }
+  });
+
+  describe('isBidRequestValid', function () {
+    it('Should return true when required params are found', function () {
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+    it('Should return false when required params are not found', function () {
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+    it('Should return false when params are not found', function () {
+      delete bid.params;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('Should interpret response', function () {
+      const serverResponse = {
+        body:
+          {
+            seatbid: [
+              {
+                bid: [
+                  {
+                    bidId: '000',
+                    price: 1.5,
+                    adm: '<div>test</div>',
+                    creativeId: 'creativeId',
+                    w: 300,
+                    h: 250,
+                    cur: 'USD',
+                    netRevenue: false,
+                    ttl: 360
+                  }
+                ]
+              }
+            ]
+          }
+      };
+      let bannerResponses = spec.interpretResponse(serverResponse);
+      expect(bannerResponses).to.be.an('array').that.is.not.empty;
+      let dataItem = bannerResponses[0];
+      expect(dataItem).to.have.all.keys('requestId', 'cpm', 'ad', 'creativeId', 'width', 'height', 'currency', 'netRevenue', 'ttl');
+      expect(dataItem.requestId).to.exist.and.to.be.a('string').and.to.equal(serverResponse.body.seatbid[0].bid[0].bidId);
+      expect(dataItem.cpm).to.exist.and.to.be.a('number').and.to.equal(serverResponse.body.seatbid[0].bid[0].price);
+      expect(dataItem.ad).to.exist.and.to.be.a('string').and.to.have.string(serverResponse.body.seatbid[0].bid[0].adm);
+      expect(dataItem.creativeId).to.exist.and.to.be.a('string').and.to.equal(serverResponse.body.seatbid[0].bid[0].creativeId);
+      expect(dataItem.width).to.exist.and.to.be.a('number').and.to.equal(serverResponse.body.seatbid[0].bid[0].w);
+      expect(dataItem.height).to.exist.and.to.be.a('number').and.to.equal(serverResponse.body.seatbid[0].bid[0].h);
+      expect(dataItem.currency).to.exist.and.to.be.a('string').and.to.equal(serverResponse.body.seatbid[0].bid[0].cur);
+      expect(dataItem.netRevenue).to.exist.and.to.be.a('boolean').and.to.equal(serverResponse.body.seatbid[0].bid[0].netRevenue);
+      expect(dataItem.ttl).to.exist.and.to.be.a('number').and.to.equal(serverResponse.body.seatbid[0].bid[0].ttl);
+    });
+
+    it('Should return no ad when not given a server response', function () {
+      const ads = spec.interpretResponse(null);
+      expect(ads).to.be.an('array').and.to.have.length(0);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('should register the sync iframe without gdpr', function () {
+      let syncOptions = {
+        iframeEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        consentString: consentString
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.html?consent_str=' + consentString + '&consent_given=0');
+    });
+    it('should register the sync iframe with gdpr', function () {
+      let syncOptions = {
+        iframeEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        gdprApplies: true,
+        consentString: consentString
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.html?consent_str=' + consentString + '&gdpr=1&consent_given=0');
+    });
+    it('should register the sync iframe with gdpr vendor', function () {
+      let syncOptions = {
+        iframeEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        gdprApplies: true,
+        consentString: consentString,
+        apiVersion: 1,
+        vendorData: {
+          vendorConsents: {
+            794: 1
+          }
+        }
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.html?consent_str=' + consentString + '&gdpr=1&consent_given=1');
+    });
+    it('should register the sync image without gdpr', function () {
+      let syncOptions = {
+        pixelEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        consentString: consentString
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('image');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.png?consent_str=' + consentString + '&consent_given=0');
+    });
+    it('should register the sync image with gdpr', function () {
+      let syncOptions = {
+        pixelEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        gdprApplies: true,
+        consentString: consentString
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('image');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.png?consent_str=' + consentString + '&gdpr=1&consent_given=0');
+    });
+    it('should register the sync image with gdpr vendor', function () {
+      let syncOptions = {
+        pixelEnabled: true
+      };
+      let serverResponses = null;
+      let gdprConsent = {
+        gdprApplies: true,
+        consentString: consentString,
+        apiVersion: 2,
+        vendorData: {
+          vendor: {
+            consents: {
+              794: 1
+            }
+          }
+        }
+      };
+      let uspConsent = null;
+      let syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent);
+      expect(syncs).to.be.an('array').and.to.have.length(1);
+      expect(syncs[0].type).to.equal('image');
+      expect(syncs[0].url).to.equal('https://kdmp.kbntx.ch/init.png?consent_str=' + consentString + '&gdpr=1&consent_given=1');
+    });
+  })
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding native Kubient pbjs adapter, removing alias from Fidelity adapter in the same PR as the steps depend on each other.

- test parameters for validating bids
```
    var adUnits = [{
      code: 'banner-ad-div',
      mediaTypes: {
        banner: {
          sizes: [[300, 250],[728, 90]],
        }
      },
            bids: [{
                "bidder": "kubient",
                "params": {
                    "zoneid": "5fbb948f1e22b",
                }   
            }]      
        }];      
```

- contact email of the adapter’s maintainer: artem.aleksashkin@kubient.com
- contact email for organizational matters: oleg.naydenov@kubient.com
- [x] official adapter submission
- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/2552

