### PR TITLE
Beachfront adapter: Add banner tagid param

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -6,7 +6,7 @@ import { VIDEO, BANNER } from '../src/mediaTypes.js';
 import find from 'core-js-pure/features/array/find.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
-const ADAPTER_VERSION = '1.14';
+const ADAPTER_VERSION = '1.15';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -387,6 +387,7 @@ function createBannerRequestData(bids, bidderRequest) {
       slot: bid.adUnitCode,
       id: getBannerBidParam(bid, 'appId'),
       bidfloor: getBannerBidParam(bid, 'bidfloor'),
+      tagid: getBannerBidParam(bid, 'tagid'),
       sizes: getBannerSizes(bid)
     };
   });

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -336,6 +336,7 @@ describe('BeachfrontAdapter', function () {
         const width = 300;
         const height = 250;
         const bidRequest = bidRequests[0];
+        bidRequest.params.tagid = '7cd7a7b4-ef3f-4aeb-9565-3627f255fa10';
         bidRequest.mediaTypes = {
           banner: {
             sizes: [ width, height ]
@@ -354,6 +355,7 @@ describe('BeachfrontAdapter', function () {
             slot: bidRequest.adUnitCode,
             id: bidRequest.params.appId,
             bidfloor: bidRequest.params.bidfloor,
+            tagid: bidRequest.params.tagid,
             sizes: [{ w: width, h: height }]
           }
         ]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds an optional bidder param to pass tagid for banner ad units.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

PR for docs:
prebid/prebid.github.io#2553