### PR TITLE
PBJS Core: canBidderRegisterSync ignoring iframe sync disabled by default

### DIFF
--- a/src/userSync.js
+++ b/src/userSync.js
@@ -226,13 +226,8 @@ export function newUserSync(userSyncDependencies) {
       return checkForFiltering[filterType](biddersToFilter, bidder);
     }
 
-    // iframes are disabled by default.
-    // so if the iframe config is invalid, we should use the permittedPixels object to tell us if the bidder should be blocked when trying to register an iframe pixel.
-    if (!isFilterConfigValid(filterConfig, type) && type === 'iframe') {
-      return !permittedPixels[type];
-    }
+    return !permittedPixels[type];
 
-    return false;
   }
 
   /**

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -225,6 +225,13 @@ export function newUserSync(userSyncDependencies) {
       }
       return checkForFiltering[filterType](biddersToFilter, bidder);
     }
+
+    // iframes are disabled by default.
+    // so if the iframe config is invalid, we should use the permittedPixels object to tell us if the bidder should be blocked when trying to register an iframe pixel.
+    if (!isFilterConfigValid(filterConfig, type) && type === 'iframe') {
+      return !permittedPixels[type];
+    }
+
     return false;
   }
 

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -475,6 +475,14 @@ describe('user sync', function () {
           });
           expect(userSync.canBidderRegisterSync('iframe', 'otherTestBidder')).to.equal(false);
         });
+
+        it('should return false for iframe if the default filter settings are enabled', function () {
+          const userSync = newUserSync({
+            config: USERSYNC_DEFAULT_CONFIG
+          });
+          expect(userSync.canBidderRegisterSync('iframe', 'otherTestBidder')).to.equal(false);
+        });
+
         it('should return true if filter settings does allow it', function () {
           const userSync = newUserSync({
             config: {

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -476,10 +476,22 @@ describe('user sync', function () {
           expect(userSync.canBidderRegisterSync('iframe', 'otherTestBidder')).to.equal(false);
         });
 
-        it('should return false for iframe if the default filter settings are enabled', function () {
+        it('should return false for iframe if there is no iframe filterSettings', function () {
           const userSync = newUserSync({
-            config: USERSYNC_DEFAULT_CONFIG
+            config: {
+              syncEnabled: true,
+              filterSettings: {
+                image: {
+                  bidders: '*',
+                  filter: 'include'
+                }
+              },
+              syncsPerBidder: 5,
+              syncDelay: 3000,
+              auctionDelay: 0
+            }
           });
+
           expect(userSync.canBidderRegisterSync('iframe', 'otherTestBidder')).to.equal(false);
         });
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
The method userSync.canBidderRegisterSync returns true if there is no iframe filteredSettings defined. Since iframe user syncs are disabled by default, this method should return false when no iframe filteredSettings are defined.

