### PR TITLE
Adagio Bid Adapter: hotfix - detect support for intersectionObserver

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -697,8 +697,11 @@ export const spec = {
       return false;
     }
 
-    const { organizationId, site, placement } = params;
-    const adUnitElementId = params.adUnitElementId || internal.autoDetectAdUnitElementId(adUnitCode);
+    const { organizationId, site } = params;
+    const adUnitElementId = (params.useAdUnitCodeAsAdUnitElementId === true)
+      ? adUnitCode
+      : params.adUnitElementId || internal.autoDetectAdUnitElementId(adUnitCode);
+    const placement = (params.useAdUnitCodeAsPlacement === true) ? adUnitCode : params.placement;
     const environment = params.environment || internal.autoDetectEnvironment();
     const supportIObs = internal.supportIObs();
 
@@ -707,6 +710,7 @@ export const spec = {
       ...params,
       adUnitElementId,
       environment,
+      placement,
       supportIObs
     };
 

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -496,7 +496,9 @@ function autoDetectEnvironment() {
 };
 
 function supportIObs() {
-  return !!(internal.getCurrentWindow().IntersectionObserver);
+  const currentWindow = internal.getCurrentWindow();
+  return !!(currentWindow && currentWindow.IntersectionObserver && currentWindow.IntersectionObserverEntry &&
+    currentWindow.IntersectionObserverEntry.prototype && 'intersectionRatio' in currentWindow.IntersectionObserverEntry.prototype);
 }
 
 function getFeatures(bidRequest, bidderRequest) {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -495,6 +495,10 @@ function autoDetectEnvironment() {
   return environment;
 };
 
+function supportIObs() {
+  return !!(internal.getCurrentWindow().IntersectionObserver);
+}
+
 function getFeatures(bidRequest, bidderRequest) {
   const { adUnitCode, params } = bidRequest;
   const { adUnitElementId } = params;
@@ -569,6 +573,7 @@ export const internal = {
   getRefererInfo,
   adagioScriptFromLocalStorageCb,
   getCurrentWindow,
+  supportIObs,
   canAccessTopWindow,
   isRendererPreferredFromPublisher
 };
@@ -695,12 +700,14 @@ export const spec = {
     const { organizationId, site, placement } = params;
     const adUnitElementId = params.adUnitElementId || internal.autoDetectAdUnitElementId(adUnitCode);
     const environment = params.environment || internal.autoDetectEnvironment();
+    const supportIObs = internal.supportIObs();
 
     // insure auto-detected params are kept in `bid` object.
     bid.params = {
       ...params,
       adUnitElementId,
-      environment
+      environment,
+      supportIObs
     };
 
     const debugData = () => ({

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -38,6 +38,8 @@ Connects to Adagio demand source to fetch bids.
             category: 'sport', // Recommended. Category of the content displayed in the page.
             subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
             postBid: false, // Optional. Use it in case of Post-bid integration only.
+            useAdUnitCodeAsAdUnitElementId: false // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
+            useAdUnitCodeAsPlacement: false // Optional. Use it to by-pass placement and use the adUnit code as value
             // Optional debug mode, used to get a bid response with expected cpm.
             debug: {
               enabled: true,
@@ -76,6 +78,8 @@ Connects to Adagio demand source to fetch bids.
             category: 'sport', // Recommended. Category of the content displayed in the page.
             subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
             postBid: false, // Optional. Use it in case of Post-bid integration only.
+            useAdUnitCodeAsAdUnitElementId: false // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
+            useAdUnitCodeAsPlacement: false // Optional. Use it to by-pass placement and use the adUnit code as value
             video: {
               skip: 0
               // OpenRTB 2.5 video options defined here override ones defined in mediaTypes.

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -144,6 +144,19 @@ describe('Adagio bid adapter', () => {
       sinon.assert.callCount(utils.logWarn, 1);
     });
 
+    it('should use adUnit code for adUnitElementId and placement params', function() {
+      const bid01 = new BidRequestBuilder({ params: {
+        organizationId: '1000',
+        site: 'site-name',
+        useAdUnitCodeAsPlacement: true,
+        useAdUnitCodeAsAdUnitElementId: true
+      }}).build();
+
+      expect(spec.isBidRequestValid(bid01)).to.equal(true);
+      expect(bid01.params.adUnitElementId).to.equal('adunit-code');
+      expect(bid01.params.placement).to.equal('adunit-code');
+    })
+
     it('should return false when a required param is missing', function() {
       const bid01 = new BidRequestBuilder({ params: {
         organizationId: '1000',

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -262,6 +262,7 @@ describe('Adagio bid adapter', () => {
 
       it('should store bids config once by bid in window.top if it accessible', function() {
         sandbox.stub(adagio, 'getCurrentWindow').returns(window.top);
+        sandbox.stub(adagio, 'supportIObs').returns(true);
 
         // replace by the values defined in beforeEach
         window.top.ADAGIO = {
@@ -279,6 +280,7 @@ describe('Adagio bid adapter', () => {
       it('should detect IntersectionObserver support', function() {
         sandbox.stub(adagio, 'getCurrentWindow').returns(window.top);
         sandbox.stub(adagio, 'supportIObs').returns(false);
+
         window.top.ADAGIO = {
           ...window.ADAGIO
         };
@@ -290,6 +292,7 @@ describe('Adagio bid adapter', () => {
 
       it('should store bids config once by bid in current window', function() {
         sandbox.stub(adagio, 'getCurrentWindow').returns(window.self);
+        sandbox.stub(adagio, 'supportIObs').returns(true);
 
         spec.isBidRequestValid(bid01);
         spec.isBidRequestValid(bid02);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -229,7 +229,8 @@ describe('Adagio bid adapter', () => {
               placement: 'PAVE_ATF',
               site: 'SITE-NAME',
               adUnitElementId: 'gpt-adunit-code',
-              environment: 'desktop'
+              environment: 'desktop',
+              supportIObs: true
             }
           }],
           auctionId: '4fd1ca2d-846c-4211-b9e5-321dfe1709c9',
@@ -249,7 +250,8 @@ describe('Adagio bid adapter', () => {
               placement: 'PAVE_ATF',
               site: 'SITE-NAME',
               adUnitElementId: 'gpt-adunit-code',
-              environment: 'desktop'
+              environment: 'desktop',
+              supportIObs: true
             }
           }],
           auctionId: '4fd1ca2d-846c-4211-b9e5-321dfe1709c9',
@@ -272,6 +274,18 @@ describe('Adagio bid adapter', () => {
 
         expect(find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-01')).to.deep.eql(expected[0]);
         expect(find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-02')).to.deep.eql(expected[1]);
+      });
+
+      it('should detect IntersectionObserver support', function() {
+        sandbox.stub(adagio, 'getCurrentWindow').returns(window.top);
+        sandbox.stub(adagio, 'supportIObs').returns(false);
+        window.top.ADAGIO = {
+          ...window.ADAGIO
+        };
+
+        spec.isBidRequestValid(bid01);
+        const validBidReq = find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-01');
+        expect(validBidReq.bids[0].params.supportIObs).to.equal(false);
       });
 
       it('should store bids config once by bid in current window', function() {
@@ -740,7 +754,8 @@ describe('Adagio bid adapter', () => {
             pagetype: 'ARTICLE',
             category: 'NEWS',
             subcategory: 'SPORT',
-            environment: 'desktop'
+            environment: 'desktop',
+            supportIObs: true
           },
           adUnitCode: 'adunit-code',
           mediaTypes: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Other

## Description of change
Add a computed param to pass to our SSP information about intersectionObserver support in the current browser.
This PR is related to the recently merged PR #6038 as this detection impacts on the behavior of our player in a video oustream context.

- contact email of the adapter’s maintainer: dev@adagio.io
