### PR TITLE
Change craftBidAdapter request URL

### DIFF
--- a/modules/craftBidAdapter.js
+++ b/modules/craftBidAdapter.js
@@ -7,7 +7,7 @@ import includes from 'core-js-pure/features/array/includes.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'craft';
-const URL = 'https://gacraft.jp/prebid-v3';
+const URL_BASE = 'https://gacraft.jp/prebid-v3';
 const TTL = 360;
 const storage = getStorageManager();
 
@@ -143,10 +143,11 @@ function formatRequest(payload, bidderRequest) {
       withCredentials: false
     };
   }
+
   const payloadString = JSON.stringify(payload);
   return {
     method: 'POST',
-    url: URL,
+    url: `${URL_BASE}/${payload.tags[0].sitekey}`,
     data: payloadString,
     bidderRequest,
     options

--- a/test/spec/modules/craftBidAdapter_spec.js
+++ b/test/spec/modules/craftBidAdapter_spec.js
@@ -81,7 +81,7 @@ describe('craftAdapter', function () {
     it('sends bid request to ENDPOINT via POST', function () {
       let request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.method).to.equal('POST');
-      expect(request.url).to.equal('https://gacraft.jp/prebid-v3');
+      expect(request.url).to.equal('https://gacraft.jp/prebid-v3/craft-prebid-example');
       let data = JSON.parse(request.data);
       expect(data.tags).to.deep.equals([{
         sitekey: 'craft-prebid-example',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Change request URL to realize the effective load balancing

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'craft',
  params: {
    sitekey: 'craft-prebid-example',
    placementId: '1234abcd'
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

https://www.gacraft.jp/publish/craft-prebid-example.html

- contact email of the adapter’s maintainer
system@gacraft.jp

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Prev PR https://github.com/prebid/Prebid.js/pull/5260
