### PR TITLE
[Sharethrough] Add Support for badv/bcat and Identity Link User ID

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -56,6 +56,10 @@ export const sharethroughAdapterSpec = {
         query.pubcid = bidRequest.crumbs.pubcid;
       }
 
+      if (bidRequest.userId && bidRequest.userId.idl_env) {
+        query.idluid = bidRequest.userId.idl_env;
+      }
+
       if (bidRequest.schain) {
         query.schain = JSON.stringify(bidRequest.schain);
       }

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 
-const VERSION = '3.2.1';
+const VERSION = '3.3.0';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];
@@ -64,6 +64,14 @@ export const sharethroughAdapterSpec = {
         query.bidfloor = parseFloat(bidRequest.bidfloor);
       }
 
+      if (bidRequest.params.badv) {
+        query.badv = bidRequest.params.badv;
+      }
+
+      if (bidRequest.params.bcat) {
+        query.bcat = bidRequest.params.bcat;
+      }
+
       // Data that does not need to go to the server,
       // but we need as part of interpretResponse()
       const strData = {
@@ -73,7 +81,7 @@ export const sharethroughAdapterSpec = {
       };
 
       return {
-        method: 'GET',
+        method: 'POST',
         url: STR_ENDPOINT,
         data: query,
         strData: strData

--- a/modules/sharethroughBidAdapter.md
+++ b/modules/sharethroughBidAdapter.md
@@ -29,7 +29,13 @@ Module that connects to Sharethrough's demand sources
             // OPTIONAL - If iframeSize is provided, we'll use this size for the iframe
             // otherwise we'll grab the largest size from the sizes array
             // This is ignored if iframe: false
-            iframeSize: [250, 250]
+            iframeSize: [250, 250],
+
+            // OPTIONAL - Blocked Advertiser Domains
+            badv: ['domain1.com', 'domain2.com'],
+
+            // OPTIONAL - Blocked Categories (IAB codes)
+            bcat: ['IAB1-1', 'IAB1-2'],
           }
         }
       ]

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -40,12 +40,32 @@ const bidRequests = [
       iframe: true,
       iframeSize: [500, 500]
     }
-  }
+  },
+  {
+    bidder: 'sharethrough',
+    bidId: 'bidId4',
+    sizes: [[700, 400]],
+    placementCode: 'bar',
+    params: {
+      pkey: 'dddd4444',
+      badv: ['domain1.com', 'domain2.com']
+    }
+  },
+  {
+    bidder: 'sharethrough',
+    bidId: 'bidId5',
+    sizes: [[700, 400]],
+    placementCode: 'bar',
+    params: {
+      pkey: 'eeee5555',
+      bcat: ['IAB1-1', 'IAB1-2']
+    }
+  },
 ];
 
 const prebidRequests = [
   {
-    method: 'GET',
+    method: 'POST',
     url: 'https://btlr.sharethrough.com/WYu2BXv1/v1',
     data: {
       bidId: 'bidId',
@@ -57,7 +77,7 @@ const prebidRequests = [
     }
   },
   {
-    method: 'GET',
+    method: 'POST',
     url: 'https://btlr.sharethrough.com/WYu2BXv1/v1',
     data: {
       bidId: 'bidId',
@@ -69,7 +89,7 @@ const prebidRequests = [
     }
   },
   {
-    method: 'GET',
+    method: 'POST',
     url: 'https://btlr.sharethrough.com/WYu2BXv1/v1',
     data: {
       bidId: 'bidId',
@@ -82,7 +102,7 @@ const prebidRequests = [
     }
   },
   {
-    method: 'GET',
+    method: 'POST',
     url: 'https://btlr.sharethrough.com/WYu2BXv1/v1',
     data: {
       bidId: 'bidId',
@@ -94,7 +114,7 @@ const prebidRequests = [
     }
   },
   {
-    method: 'GET',
+    method: 'POST',
     url: 'https://btlr.sharethrough.com/WYu2BXv1/v1',
     data: {
       bidId: 'bidId',
@@ -225,7 +245,7 @@ describe('sharethrough adapter spec', function() {
 
       expect(builtBidRequests[0].url).to.eq('https://btlr.sharethrough.com/WYu2BXv1/v1');
       expect(builtBidRequests[1].url).to.eq('https://btlr.sharethrough.com/WYu2BXv1/v1');
-      expect(builtBidRequests[0].method).to.eq('GET');
+      expect(builtBidRequests[0].method).to.eq('POST');
     });
 
     it('should set the instant_play_capable parameter correctly based on browser userAgent string', function() {
@@ -344,6 +364,18 @@ describe('sharethrough adapter spec', function() {
 
       const builtBidRequest = spec.buildRequests([bidRequest])[0];
       expect(builtBidRequest.data.schain).to.eq(JSON.stringify(bidRequest.schain));
+    });
+
+    it('should add badv if provided', () => {
+      const builtBidRequest = spec.buildRequests([bidRequests[3]])[0];
+
+      expect(builtBidRequest.data.badv).to.have.members(['domain1.com', 'domain2.com'])
+    });
+
+    it('should add bcat if provided', () => {
+      const builtBidRequest = spec.buildRequests([bidRequests[4]])[0];
+
+      expect(builtBidRequest.data.bcat).to.have.members(['IAB1-1', 'IAB1-2'])
     });
 
     it('should not add a supply chain parameter if schain is missing', function() {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -14,7 +14,8 @@ const bidRequests = [
     },
     userId: {
       tdid: 'fake-tdid',
-      pubcid: 'fake-pubcid'
+      pubcid: 'fake-pubcid',
+      idl_env: 'fake-identity-link'
     },
     crumbs: {
       pubcid: 'fake-pubcid-in-crumbs-obj'
@@ -333,6 +334,11 @@ describe('sharethrough adapter spec', function() {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       delete bidRequest.userId;
       expect(bidRequest.data.pubcid).to.eq('fake-pubcid');
+    });
+
+    it('should add the idluid parameter if a bid request contains a value for Identity Link from Live Ramp', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data.idluid).to.eq('fake-identity-link');
     });
 
     it('should add Sharethrough specific parameters', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
- Add support for blocked advertiser domains and blocked categories
- Add support for LiveRamp's Identity Link User ID

pubgrowth.engineering@sharethrough.com

- PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/2560
