### PR TITLE
appnexusBidAdapter - update segment param logic

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -107,7 +107,19 @@ export const spec = {
         .filter(param => includes(USER_PARAMS, param))
         .forEach((param) => {
           let uparam = utils.convertCamelToUnderscore(param);
-          userObj[uparam] = userObjBid.params.user[param]
+          if (param === 'segments' && utils.isArray(userObjBid.params.user[param])) {
+            let segs = [];
+            userObjBid.params.user[param].forEach(val => {
+              if (utils.isNumber(val)) {
+                segs.push({'id': val});
+              } else if (utils.isPlainObject(val)) {
+                segs.push(val);
+              }
+            });
+            userObj[uparam] = segs;
+          } else if (param !== 'segments') {
+            userObj[uparam] = userObjBid.params.user[param];
+          }
         });
     }
 

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -265,6 +265,7 @@ describe('AppNexusAdapter', function () {
             placementId: '10433394',
             user: {
               externalUid: '123',
+              segments: [123, { id: 987, value: 876 }],
               foobar: 'invalid'
             }
           }
@@ -277,6 +278,7 @@ describe('AppNexusAdapter', function () {
       expect(payload.user).to.exist;
       expect(payload.user).to.deep.equal({
         external_uid: '123',
+        segments: [{id: 123}, {id: 987, value: 876}]
       });
     });
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Added some extra logic to the `user.segments` bidder param.  

Previously it was documented that it should be passed as an array of numbers (eg `[123,234]`.  Ideally, though it should be passed an array of objects (eg `[{id: 123, value: 008}, {id: 234}]`).  The logic added will read the array of numbers (if passed that way) and transform the info into the object structure.  If they're passing an array of objects, it should go through.


