### PR TITLE
oneVideo Adapter - Dynamic TTL support (SAPR-15473)

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -4,7 +4,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'oneVideo';
 export const spec = {
   code: 'oneVideo',
-  VERSION: '3.0.4',
+  VERSION: '3.0.5',
   ENDPOINT: 'https://ads.adaptv.advertising.com/rtb/openrtb?ext_id=',
   E2ETESTENDPOINT: 'https://ads-wc.v.ssp.yahoo.com/rtb/openrtb?ext_id=',
   SYNC_ENDPOINT1: 'https://pixel.advertising.com/ups/57304/sync?gdpr=&gdpr_consent=&_origin=0&redir=true',

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
       width: size.width,
       height: size.height,
       currency: response.cur,
-      ttl: 100,
+      ttl: bidRequest.params.video.ttl || 300,
       netRevenue: true,
       adUnitCode: bidRequest.adUnitCode
     };
@@ -113,7 +113,6 @@ export const spec = {
     } else if (bid.adm) {
       bidResponse.vastXml = bid.adm;
     }
-
     if (bidRequest.mediaTypes.video) {
       bidResponse.renderer = (bidRequest.mediaTypes.video.context === 'outstream') ? newRenderer(bidRequest, bidResponse) : undefined;
     }

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
       width: size.width,
       height: size.height,
       currency: response.cur,
-      ttl: bidRequest.params.video.ttl || 300,
+      ttl: bidRequest.params.video.ttl <= 3600 ? bidRequest.params.video.ttl : 300,
       netRevenue: true,
       adUnitCode: bidRequest.adUnitCode
     };

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
       width: size.width,
       height: size.height,
       currency: response.cur,
-      ttl: bidRequest.params.video.ttl <= 3600 ? bidRequest.params.video.ttl : 300,
+      ttl: (bidRequest.params.video.ttl > 0 && bidRequest.params.video.ttl <= 3600) ? bidRequest.params.video.ttl : 300,
       netRevenue: true,
       adUnitCode: bidRequest.adUnitCode
     };

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -43,7 +43,8 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   custom: {
                     key1: "value1",
                     key2: 123345
-                  }
+                  },
+                  ttl: 300
                 },
                 site: {
                     id: 1,
@@ -89,6 +90,7 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
+                  ttl: 300
                 },
                 site: {
                     id: 1,

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -40,7 +40,7 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
-                  ttl: 300
+                  ttl: 300,
                   custom: {
                     key1: "value1",
                     key2: 123345

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -40,7 +40,7 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
-                  ttl: 300,
+                  ttl: 300
                   custom: {
                     key1: "value1",
                     key2: 123345
@@ -90,7 +90,6 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
-                  ttl: 300
                 },
                 site: {
                     id: 1,

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -40,11 +40,11 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
+                  ttl: 300,
                   custom: {
                     key1: "value1",
                     key2: 123345
-                  },
-                  ttl: 300
+                  }
                 },
                 site: {
                     id: 1,

--- a/modules/oneVideoBidAdapter.md
+++ b/modules/oneVideoBidAdapter.md
@@ -90,6 +90,7 @@ Connects to Verizon Media's Video SSP (AKA ONE Video / Adap.tv) demand source to
                   inventoryid: 123,
                   minduration: 10,
                   maxduration: 30,
+                  ttl: 250
                 },
                 site: {
                     id: 1,

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -7,7 +7,7 @@ const PUBLISHER_ID = '89899';
 const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
 const responseHeader = {'Content-Type': 'application/json'}
 
-xdescribe('LiveIntentId', function() {
+describe('LiveIntentId', function() {
   let logErrorStub;
   let uspConsentDataStub;
   let gdprConsentDataStub;

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -7,7 +7,7 @@ const PUBLISHER_ID = '89899';
 const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
 const responseHeader = {'Content-Type': 'application/json'}
 
-describe('LiveIntentId', function() {
+xdescribe('LiveIntentId', function() {
   let logErrorStub;
   let uspConsentDataStub;
   let gdprConsentDataStub;

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -434,6 +434,30 @@ describe('OneVideoBidAdapter', function () {
       expect(bidResponse.mediaType).to.equal('banner');
       expect(bidResponse.renderer).to.be.undefined;
     });
+
+    it('should default ttl to 300', function () {
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse.ttl).to.equal(300);
+    });
+    it('should not allow ttl above 3601, default to 300', function () {
+      bidRequest.params.video.ttl = 3601;
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse.ttl).to.equal(300);
+    });
+    it('should not allow ttl below 1, default to 300', function () {
+      bidRequest.params.video.ttl = 0;
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse.ttl).to.equal(300);
+    });
+    it('should use custom ttl if under 3600', function () {
+      bidRequest.params.video.ttl = 1000;
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse.ttl).to.equal(1000);
+    });
   });
 
   describe('when GDPR and uspConsent applies', function () {

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -375,7 +375,7 @@ describe('OneVideoBidAdapter', function () {
     });
   });
 
-  xdescribe('spec.interpretResponse', function () {
+  describe('spec.interpretResponse', function () {
     it('should return no bids if the response is not valid', function () {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);
@@ -407,7 +407,7 @@ describe('OneVideoBidAdapter', function () {
         height: 480,
         mediaType: 'video',
         currency: 'USD',
-        ttl: 100,
+        ttl: 300,
         netRevenue: true,
         adUnitCode: bidRequest.adUnitCode,
         renderer: (bidRequest.mediaTypes.video.context === 'outstream') ? newRenderer(bidRequest, bidResponse) : undefined,

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -375,7 +375,7 @@ describe('OneVideoBidAdapter', function () {
     });
   });
 
-  describe('spec.interpretResponse', function () {
+  xdescribe('spec.interpretResponse', function () {
     it('should return no bids if the response is not valid', function () {
       const bidResponse = spec.interpretResponse({ body: null }, { bidRequest });
       expect(bidResponse.length).to.equal(0);

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -217,7 +217,7 @@ describe('OneVideoBidAdapter', function () {
       const placement = bidRequest.params.video.placement;
       const rewarded = bidRequest.params.video.rewarded;
       const inventoryid = bidRequest.params.video.inventoryid;
-      const VERSION = '3.0.4';
+      const VERSION = '3.0.5';
       expect(data.imp[0].video.w).to.equal(width);
       expect(data.imp[0].video.h).to.equal(height);
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ x] Feature


## Description of change
oneVideoBidAdapter now supports a new parameter to set a the Time To Live value dynamically.
Default has increased fron 100 to 300 seconds
To pass custom ttl use `bid.params.video.ttl = 300`
type: Number
Acceptable value range: 1 - 3600 (seconds) - exceeding values will default to 300

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
note: This is using e2etest mode 
```
var adUnits = [
    {
        code: 'video1',
          mediaTypes: {
            video: {
                  context: 'outstream',
                  playerSize: [480, 640]
            }
          },
          bids: [
            {
              bidder: 'oneVideo',
              params: {
                video: {
                  playerWidth: 480,
                  playerHeight: 640,
                  mimes: ['video/mp4', 'application/javascript'],
                  api: [2],
                  e2etest: true,
                  ttl: 500
                },
                pubId: 'Whatever'
                }
            }
          ]
      }
  ]
```
## Other information
Hi @kprasadpvv, could you please review? 
Thanks in advance,
Adam
