### PR TITLE
appnexusBidAdapter - add support for test flag

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -498,6 +498,12 @@ function formatRequest(payload, bidderRequest) {
     }
   }
 
+  if (utils.getParameterByName('apn_test').toUpperCase() === 'TRUE' || config.getConfig('apn_test') === true) {
+    options.customHeaders = {
+      'X-Is-Test': 1
+    }
+  }
+
   if (payload.tags.length > MAX_IMPS_PER_REQUEST) {
     const clonedPayload = utils.deepClone(payload);
 

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -784,6 +784,18 @@ describe('AppNexusAdapter', function () {
       config.getConfig.restore();
     });
 
+    it('should set the X-Is-Test customHeader if test flag is enabled', function () {
+      let bidRequest = Object.assign({}, bidRequests[0]);
+      sinon.stub(config, 'getConfig')
+        .withArgs('apn_test')
+        .returns(true);
+
+      const request = spec.buildRequests([bidRequest]);
+      expect(request.options.customHeaders).to.deep.equal({'X-Is-Test': 1});
+
+      config.getConfig.restore();
+    });
+
     it('should set withCredentials to false if purpose 1 consent is not given', function () {
       let consentString = 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==';
       let bidderRequest = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Add support to enable a test flag for the appnexus bidder.  

This can be enabled in either of two ways:
- append `apn_test=true` to the query string of the page URL (much like the `pbjs_debug` param)
- include `apn_test: true` to the `setConfig` like ```pbjs.setConfig({apn_test: true});```

When either option is used, it will append a special custom header to the request made to the appnexus ad-server.