### PR TITLE
Yieldlab - Update Adsize Handling

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -96,8 +96,8 @@ export const spec = {
       })
 
       if (matchedBid) {
-        const primarysize = bidRequest.sizes.length === 2 && !utils.isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0]
-        const customsize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : primarysize
+        const adUnitSize = bidRequest.sizes.length === 2 && !utils.isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0]
+        const adSize = bidRequest.params.adSize !== undefined ? parseSize(bidRequest.params.adSize) : (matchedBid.adsize !== undefined) ? parseSize(matchedBid.adsize) : adUnitSize
         const extId = bidRequest.params.extId !== undefined ? '&id=' + bidRequest.params.extId : ''
         const adType = matchedBid.adtype !== undefined ? matchedBid.adtype : ''
         const gdprApplies = reqParams.gdpr ? '&gdpr=' + reqParams.gdpr : ''
@@ -106,15 +106,15 @@ export const spec = {
         const bidResponse = {
           requestId: bidRequest.bidId,
           cpm: matchedBid.price / 100,
-          width: customsize[0],
-          height: customsize[1],
+          width: adSize[0],
+          height: adSize[1],
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
           netRevenue: false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
-          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}"></script>`
+          ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}"></script>`
         }
 
         if (isVideo(bidRequest, adType)) {
@@ -124,8 +124,7 @@ export const spec = {
             bidResponse.height = playersize[1]
           }
           bidResponse.mediaType = VIDEO
-          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/${customsize[0]}x${customsize[1]}?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}`
-
+          bidResponse.vastUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}`
           if (isOutstream(bidRequest)) {
             const renderer = Renderer.install({
               id: bidRequest.bidId,

--- a/modules/yieldlabBidAdapter.md
+++ b/modules/yieldlabBidAdapter.md
@@ -21,7 +21,6 @@ Module that connects to Yieldlab's demand sources
                    params: {
                        adslotId: "5220336",
                        supplyId: "1381604",
-                       adSize: "728x90",
                        targeting: {
                            key1: "value1",
                            key2: "value2"
@@ -41,8 +40,7 @@ Module that connects to Yieldlab's demand sources
                    bidder: "yieldlab",
                    params: {
                        adslotId: "5220339",
-                       supplyId: "1381604",
-                       adSize: "640x480"
+                       supplyId: "1381604"
                    }
                }]
            }

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -7,7 +7,6 @@ const REQUEST = {
   'params': {
     'adslotId': '1111',
     'supplyId': '2222',
-    'adSize': '728x90',
     'targeting': {
       'key1': 'value1',
       'key2': 'value2',
@@ -57,6 +56,7 @@ const RESPONSE = {
   id: 1111,
   price: 1,
   pid: 2222,
+  adsize: '728x90',
   adtype: 'BANNER'
 }
 
@@ -88,8 +88,7 @@ describe('yieldlabBidAdapter', function () {
       const request = {
         'params': {
           'adslotId': '1111',
-          'supplyId': '2222',
-          'adSize': '728x90'
+          'supplyId': '2222'
         }
       }
       expect(spec.isBidRequestValid(request)).to.equal(true)
@@ -180,7 +179,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].netRevenue).to.equal(false)
       expect(result[0].ttl).to.equal(300)
       expect(result[0].referrer).to.equal('')
-      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/?ts=')
       expect(result[0].ad).to.include('&id=abc')
     })
 
@@ -211,7 +210,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].netRevenue).to.equal(false)
       expect(result[0].ttl).to.equal(300)
       expect(result[0].referrer).to.equal('')
-      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/?ts=')
       expect(result[0].ad).to.include('&id=abc')
     })
 
@@ -228,7 +227,7 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].requestId).to.equal('2d925f27f5079f')
       expect(result[0].cpm).to.equal(0.01)
       expect(result[0].mediaType).to.equal('video')
-      expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/728x90?ts=')
+      expect(result[0].vastUrl).to.include('https://ad.yieldlab.net/d/1111/2222/?ts=')
       expect(result[0].vastUrl).to.include('&id=abc')
     })
 


### PR DESCRIPTION
We are passing the adsize in the bid response. For multisize placements its better to use the adsize passed in the response, but as we do not want to break current integration, we will still support use params.adSize to be able to override sizes.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Bid responses from Yieldlab now usually contain the size of the winning ad for a given placement, making it unnecessary to include the sizes of Yieldlab adslots in the publisher's configuration. In order to not break existing setups, if present the size from the configuration is still being used (meaning a publisher only has to remove the adSize parameter from their configuration for Yieldlab adslots in order to use the returned size of the winning ad). As before, the first stated size from the respective ad unit is used as a fallback should neither of the two aforementioned sizes be present.

- contact email of the adapter’s maintainer: solutions@yieldlab.de
- [X] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- Link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/: https://github.com/prebid/prebid.github.io/pull/2575

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
