### PR TITLE
changed vdo.ai bidder code to vdoai

### DIFF
--- a/modules/vdoaiBidAdapter.js
+++ b/modules/vdoaiBidAdapter.js
@@ -3,7 +3,7 @@ import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 
-const BIDDER_CODE = 'vdo.ai';
+const BIDDER_CODE = 'vdoai';
 const ENDPOINT_URL = 'https://prebid.vdo.ai/auction';
 
 export const spec = {

--- a/modules/vdoaiBidAdapter.md
+++ b/modules/vdoaiBidAdapter.md
@@ -22,9 +22,9 @@ Module that connects to VDO.AI's demand sources
             },
             bids: [
                 {
-                    bidder: "vdo.ai",
+                    bidder: "vdoai",
                     params: {
-                        placement: 'newsdv77',
+                        placementId: 'newsdv77',
                         bidFloor: 0.01  // Optional
                     }
                 }
@@ -47,9 +47,9 @@ var videoAdUnit = {
   },
   bids: [
     {
-        bidder: "vdo.ai",
+        bidder: "vdoai",
         params: {
-            placement: 'newsdv77'
+            placementId: 'newsdv77'
         }
     }
   ]

--- a/test/spec/modules/vdoaiBidAdapter_spec.js
+++ b/test/spec/modules/vdoaiBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('vdoaiBidAdapter', function () {
   const adapter = newBidder(spec);
   describe('isBidRequestValid', function () {
     let bid = {
-      'bidder': 'vdo.ai',
+      'bidder': 'vdoai',
       'params': {
         placementId: 'testPlacementId'
       },
@@ -27,7 +27,7 @@ describe('vdoaiBidAdapter', function () {
   describe('buildRequests', function () {
     let bidRequests = [
       {
-        'bidder': 'vdo.ai',
+        'bidder': 'vdoai',
         'params': {
           placementId: 'testPlacementId'
         },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Clients experience issues while downloading Prebid including our vdoaiBidAdapter.
 `{"error":"Prebid file not built properly","requestId":"f4b72cda-abdd-477f-b553-d28207cd080b"}`
Based on this issue ( [3039](https://github.com/prebid/Prebid.js/issues/3039) ) we changed the bidder code to vdoai.

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
- https://github.com/prebid/prebid.github.io/pull/2584

