### PR TITLE
FreeWheel Bid Adapter: add support for campaignId, bannerId, and dealId

### DIFF
--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -323,7 +323,10 @@ describe('freewheelSSP BidAdapter Test', () => {
     '  <InLine>' +
     '   <AdSystem>Adswizz</AdSystem>' +
     '   <Impression id="dmp-1617899169-2513"></Impression>' +
-    '   <Impression id="user-sync-1617899169-1">https://ads.stickyadstv.com/auto-user-sync?dealId=NRJ-PRO-00008</Impression>' +
+    '   <Impression id="user-sync-1617899169-1">https://ads.stickyadstv.com/auto-user-sync?dealId=NRJ-PRO-12008</Impression>' +
+    '   <Impression id="727435745">' +
+    '   <![CDATA[ https://ads.stickyadstv.com/www/delivery/swfIndex.php?reqType=AdsDisplayStarted&dealId=NRJ-PRO-00008&campaignId=SMF-WOW-55555&adId=12345&viewKey=1607626986121029-54&sessionId=e3230a6bef6e0d2327422ff5282435&zoneId=2003&impId=1&cb=1932360&trackingIds=19651873%2C28161297%2C28161329%2C29847601%2C29967745%2C61392385&listenerId=eddf2aebad29655bb2b6abac276c50ef& ]]>' +
+    '   </Impression>' +
     '   <Creatives>' +
     '    <Creative id=\'28517153\' sequence=\'1\'>' +
     '     <Linear>' +
@@ -358,6 +361,8 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           dealId: 'NRJ-PRO-00008',
+          campaignId: 'SMF-WOW-55555',
+          bannerId: '12345',
           ad: ad
         }
       ];
@@ -365,6 +370,8 @@ describe('freewheelSSP BidAdapter Test', () => {
       let result = spec.interpretResponse(response, request[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
       expect(result[0].dealId).to.equal('NRJ-PRO-00008');
+      expect(result[0].campaignId).to.equal('SMF-WOW-55555');
+      expect(result[0].bannerId).to.equal('12345');
     });
 
     it('should get correct bid response with formated ad', () => {
@@ -381,6 +388,8 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           dealId: 'NRJ-PRO-00008',
+          campaignId: 'SMF-WOW-55555',
+          bannerId: '12345',
           ad: formattedAd
         }
       ];
@@ -388,6 +397,8 @@ describe('freewheelSSP BidAdapter Test', () => {
       let result = spec.interpretResponse(response, request[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
       expect(result[0].dealId).to.equal('NRJ-PRO-00008');
+      expect(result[0].campaignId).to.equal('SMF-WOW-55555');
+      expect(result[0].bannerId).to.equal('12345');
     });
 
     it('handles nobid responses', () => {
@@ -398,6 +409,7 @@ describe('freewheelSSP BidAdapter Test', () => {
       expect(result.length).to.equal(0);
     });
   });
+
   describe('interpretResponseForVideo', () => {
     let bidRequests = [
       {
@@ -461,6 +473,12 @@ describe('freewheelSSP BidAdapter Test', () => {
     '   <AdSystem>Adswizz</AdSystem>' +
     '   <Impression id="dmp-1617899169-2513"></Impression>' +
     '   <Impression id="user-sync-1617899169-1">https://ads.stickyadstv.com/auto-user-sync?dealId=NRJ-PRO-00008</Impression>' +
+    '   <Impression id="727435745">' +
+    '   <![CDATA[ https://ads.stickyadstv.com/www/delivery/swfIndex.php?reqType=AdsDisplayStarted&dealId=NRJ-PRO-00008&campaignId=SMF-WOW-55555&adId=12345&rootViewKey=1607626986121029-54&sessionId=e3230a6bef6e0d2327422ff5282435&zoneId=2003&impId=1&cb=1932360&trackingIds=19651873%2C28161297%2C28161329%2C29847601%2C29967745%2C61392385&listenerId=eddf2aebad29655bb2b6abac276c50ef& ]]>' +
+    '   </Impression>' +
+    '   <Impression id="727435745">' +
+    '   <![CDATA[ https://ads.stickyadstv.com/www/delivery/swfIndex.php?reqType=AdsDisplayStarted&dealId=NRJ-PRO-00128&campaignId=SMF-WOW-22222&adId=77777&sessionId=e3230a6bef6e0d2327422ff5282435&zoneId=2003&impId=1&cb=1932360&trackingIds=19651873%2C28161297%2C28161329%2C29847601%2C29967745%2C61392385&listenerId=eddf2aebad29655bb2b6abac276c50ef& ]]>' +
+    '   </Impression>' +
     '   <Creatives>' +
     '    <Creative id=\'28517153\' sequence=\'1\'>' +
     '     <Linear>' +
@@ -495,6 +513,8 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           dealId: 'NRJ-PRO-00008',
+          campaignId: 'SMF-WOW-55555',
+          bannerId: '12345',
           vastXml: response,
           mediaType: 'video',
           ad: ad
@@ -504,6 +524,8 @@ describe('freewheelSSP BidAdapter Test', () => {
       let result = spec.interpretResponse(response, request[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
       expect(result[0].dealId).to.equal('NRJ-PRO-00008');
+      expect(result[0].campaignId).to.equal('SMF-WOW-55555');
+      expect(result[0].bannerId).to.equal('12345');
     });
 
     it('should get correct bid response with formated ad', () => {
@@ -520,6 +542,8 @@ describe('freewheelSSP BidAdapter Test', () => {
           netRevenue: true,
           ttl: 360,
           dealId: 'NRJ-PRO-00008',
+          campaignId: 'SMF-WOW-55555',
+          bannerId: '12345',
           vastXml: response,
           mediaType: 'video',
           ad: formattedAd
@@ -529,6 +553,8 @@ describe('freewheelSSP BidAdapter Test', () => {
       let result = spec.interpretResponse(response, request[0]);
       expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
       expect(result[0].dealId).to.equal('NRJ-PRO-00008');
+      expect(result[0].campaignId).to.equal('SMF-WOW-55555');
+      expect(result[0].bannerId).to.equal('12345');
     });
 
     it('handles nobid responses', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
* Refactored dealId code to modularize obtaining ids from the Impression node
* Added support for obtaining bannerId and campaignId
* Added logic to prioritize Impression nodes with a rootViewKey
* Added test cases to cover new logic for obtaining dealId, bannerId, and campaignId
<!-- For new bidder adapters, please provide the following -->


<!-- ## Other information -->
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
