### PR TITLE
New feature: PBS anti alias

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -208,6 +208,11 @@ function prepareBidRequests(bidReq) {
     'AdType': mediaType,
     'Sizes': utils.parseSizesInput(sizes).join(',')
   };
+
+  bidReqParams.PlacementId = bidReq.adUnitCode;
+  if (bidReq.params.vpb_placement_id) {
+    bidReqParams.PlacementId = bidReq.params.vpb_placement_id;
+  }
   if (mediaType === VIDEO) {
     const context = utils.deepAccess(bidReq, 'mediaTypes.video.context');
     if (context === ADPOD) {

--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -18,10 +18,10 @@ const HOST_GETTERS = {
   appaloosa: function () {
     return 'ghb.hb.appaloosa.media';
   },
-  onefiftytwomedia: function() {
+  onefiftytwomedia: function () {
     return 'ghb.ads.152media.com';
   },
-  mediafuse: function() {
+  mediafuse: function () {
     return 'ghb.hbmp.mediafuse.com';
   }
 
@@ -40,7 +40,12 @@ const syncsCache = {};
 export const spec = {
   code: BIDDER_CODE,
   gvlid: 410,
-  aliases: ['onefiftytwomedia', 'selectmedia', 'appaloosa', 'mediafuse'],
+  aliases: ['onefiftytwomedia', 'selectmedia', 'appaloosa',
+    {
+      code: 'mediafuse',
+      skipPbsAliasing: true
+    }
+  ],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {
     return !!utils.deepAccess(bid, 'params.aid');

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -492,7 +492,10 @@ const OPEN_RTB_PROTOCOL = {
 
         // check for and store valid aliases to add to the request
         if (adapterManager.aliasRegistry[bid.bidder]) {
-          aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
+          const bidder = adapterManager.bidderRegistry[bid.bidder];
+          if(bidder && !bidder.getSpec().skipPbsAliasing){
+            aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
+          }
         }
       });
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -493,6 +493,8 @@ const OPEN_RTB_PROTOCOL = {
         // check for and store valid aliases to add to the request
         if (adapterManager.aliasRegistry[bid.bidder]) {
           const bidder = adapterManager.bidderRegistry[bid.bidder];
+          // adding alias only if alias source bidder exists and alias isn't configured to be standalone
+          // pbs adapter
           if (bidder && !bidder.getSpec().skipPbsAliasing) {
             aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
           }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -493,7 +493,7 @@ const OPEN_RTB_PROTOCOL = {
         // check for and store valid aliases to add to the request
         if (adapterManager.aliasRegistry[bid.bidder]) {
           const bidder = adapterManager.bidderRegistry[bid.bidder];
-          if(bidder && !bidder.getSpec().skipPbsAliasing){
+          if (bidder && !bidder.getSpec().skipPbsAliasing) {
             aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
           }
         }

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -453,7 +453,8 @@ adapterManager.aliasBidAdapter = function (bidderCode, alias, options) {
         } else {
           let spec = bidAdaptor.getSpec();
           let gvlid = options && options.gvlid;
-          newAdapter = newBidder(Object.assign({}, spec, { code: alias, gvlid }));
+          let skipPbsAliasing = options && options.skipPbsAliasing;
+          newAdapter = newBidder(Object.assign({}, spec, { code: alias, gvlid, skipPbsAliasing }));
           _aliasRegistry[alias] = bidderCode;
         }
         adapterManager.registerBidAdapter(newAdapter, alias, {

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -155,12 +155,14 @@ export function registerBidder(spec) {
     spec.aliases.forEach(alias => {
       let aliasCode = alias;
       let gvlid;
+      let skipPbsAliasing;
       if (isPlainObject(alias)) {
         aliasCode = alias.code;
         gvlid = alias.gvlid;
+        skipPbsAliasing = alias.skipPbsAliasing
       }
       adapterManager.aliasRegistry[aliasCode] = spec.code;
-      putBidder(Object.assign({}, spec, { code: aliasCode, gvlid }));
+      putBidder(Object.assign({}, spec, { code: aliasCode, gvlid, skipPbsAliasing }));
     });
   }
 }

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -294,7 +294,8 @@ describe('adtelligentBidAdapter', () => {
         CallbackId: '84ab500420319d',
         AdType: 'video',
         Aid: 12345,
-        Sizes: '480x360,640x480'
+        Sizes: '480x360,640x480',
+        PlacementId:'adunit-code'
       };
       expect(data.BidRequests[0]).to.deep.equal(eq);
     });
@@ -306,7 +307,8 @@ describe('adtelligentBidAdapter', () => {
         CallbackId: '84ab500420319d',
         AdType: 'display',
         Aid: 12345,
-        Sizes: '300x250'
+        Sizes: '300x250',
+        PlacementId:'adunit-code'
       };
 
       expect(data.BidRequests[0]).to.deep.equal(eq);
@@ -318,12 +320,14 @@ describe('adtelligentBidAdapter', () => {
         CallbackId: '84ab500420319d',
         AdType: 'display',
         Aid: 12345,
-        Sizes: '300x250'
+        Sizes: '300x250',
+        PlacementId:'adunit-code'
       }, {
         CallbackId: '84ab500420319d',
         AdType: 'video',
         Aid: 12345,
-        Sizes: '480x360,640x480'
+        Sizes: '480x360,640x480',
+        PlacementId:'adunit-code'
       }]
 
       expect(bidRequests.BidRequests).to.deep.equal(expectedBidReqs);

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -295,7 +295,7 @@ describe('adtelligentBidAdapter', () => {
         AdType: 'video',
         Aid: 12345,
         Sizes: '480x360,640x480',
-        PlacementId:'adunit-code'
+        PlacementId: 'adunit-code'
       };
       expect(data.BidRequests[0]).to.deep.equal(eq);
     });
@@ -308,7 +308,7 @@ describe('adtelligentBidAdapter', () => {
         AdType: 'display',
         Aid: 12345,
         Sizes: '300x250',
-        PlacementId:'adunit-code'
+        PlacementId: 'adunit-code'
       };
 
       expect(data.BidRequests[0]).to.deep.equal(eq);
@@ -321,13 +321,13 @@ describe('adtelligentBidAdapter', () => {
         AdType: 'display',
         Aid: 12345,
         Sizes: '300x250',
-        PlacementId:'adunit-code'
+        PlacementId: 'adunit-code'
       }, {
         CallbackId: '84ab500420319d',
         AdType: 'video',
         Aid: 12345,
         Sizes: '480x360,640x480',
-        PlacementId:'adunit-code'
+        PlacementId: 'adunit-code'
       }]
 
       expect(bidRequests.BidRequests).to.deep.equal(expectedBidReqs);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1015,6 +1015,67 @@ describe('S2S Adapter', function () {
       });
     });
 
+    it('skips pbs alias when skipPbsAliasing is enabled in adapter', function() {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({ s2sConfig: s2sConfig });
+
+      const aliasBidder = {
+        bidder: 'mediafuse',
+        params: { aid: 123 }
+      };
+
+      const request = utils.deepClone(REQUEST);
+      request.ad_units[0].bids = [aliasBidder];
+
+      adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
+
+      const requestBid = JSON.parse(server.requests[0].requestBody);
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          auctiontimestamp: 1510852447530,
+          targeting: {
+            includebidderkeys: false,
+            includewinners: true
+          }
+        }
+      });
+    });
+
+    it('skips dynamic aliases to request when skipPbsAliasing enabled', function () {
+      const s2sConfig = Object.assign({}, CONFIG, {
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+      });
+      config.setConfig({ s2sConfig: s2sConfig });
+
+      const alias = 'foobar_1';
+      const aliasBidder = {
+        bidder: alias,
+        params: { aid: 123456 }
+      };
+
+      const request = utils.deepClone(REQUEST);
+      request.ad_units[0].bids = [aliasBidder];
+
+      // TODO: stub this
+      $$PREBID_GLOBAL$$.aliasBidder('appnexus', alias, { skipPbsAliasing: true });
+      adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
+
+      const requestBid = JSON.parse(server.requests[0].requestBody);
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          auctiontimestamp: 1510852447530,
+          targeting: {
+            includebidderkeys: false,
+            includewinners: true
+          }
+        }
+      });
+    });
+
     it('converts appnexus params to expected format for PBS', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -673,6 +673,28 @@ describe('registerBidder', function () {
     expect(registerBidAdapterStub.getCall(2).args[0].getSpec().gvlid).to.equal(2);
     expect(registerBidAdapterStub.getCall(3).args[0].getSpec().gvlid).to.equal(undefined);
   })
+
+  it('should register alias with skipPbsAliasing', function() {
+    const aliases = [
+      {
+        code: 'foo',
+        skipPbsAliasing: true
+      },
+      {
+        code: 'bar',
+        skipPbsAliasing: false
+      },
+      {
+        code: 'baz'
+      }
+    ]
+    const thisSpec = Object.assign(newEmptySpec(), { aliases: aliases });
+    registerBidder(thisSpec);
+
+    expect(registerBidAdapterStub.getCall(1).args[0].getSpec().skipPbsAliasing).to.equal(true);
+    expect(registerBidAdapterStub.getCall(2).args[0].getSpec().skipPbsAliasing).to.equal(false);
+    expect(registerBidAdapterStub.getCall(3).args[0].getSpec().skipPbsAliasing).to.equal(undefined);
+  })
 })
 
 describe('validate bid response: ', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] [Doc PR](https://github.com/prebid/prebid.github.io/pull/2618)

## Description of change
PBS has an ability now to reuse server bidding adapter code, ak "server adapter alias". 
Consider following case e.g Mediafuse: 
1) Server adapter Mediafuse is an alias of adtelligent, defines its own bidding urls. https://github.com/prebid/prebid-server/pull/1635/files
2) And it also has prebid.js alias. 
3) Prebid.js bundle is built with parent adapter (e.g Adtelligent) and prebidServerBidAdapter

In this case, bid request sent to PBS includes ext   telling  mediafuse is alias of adtelligent, and this ext  forcing PBS to bid from Adtelligent adapter instead of Mediafuse. 

This feature tells prebidServerBidAdapter to skip PBS aliasing for those aliases who support PBS to bid through correct adapter builder, and return correct cookie sync url. 

## Examples
Prerequisites: run PBS locally. With Mediafuse [changes](https://github.com/prebid/prebid-server/pull/1635/files)  
Master: 
:white_check_mark: [prebidServerBidAdapter](http://player.adtcdn.com/examples/master-pbs.html)  pbjs has no clue about adtelligent and aliases so it sends straight to mediafuse.
:x: [prebidServerBidAdapter + adtelligentBidAdapter](http://player.adtcdn.com/examples/master-pbs-adt.html)  - **adtelligent adapter processing**


Feature:
:white_check_mark: [prebidServerBidAdapter](http://player.adtcdn.com/examples/feature-pbs.html) - mediafuse adapter processing (nothing changed)
:white_check_mark: [prebidServerBidAdapter + adtelligentBidAdapter](http://player.adtcdn.com/examples/feature-pbs-adt.html)  - mediafuse adapter processing
:white_check_mark: [prebidServerBidAdapter + adtelligentBidAdapter  & selectmedia req](http://player.adtcdn.com/examples/feature-pbs-adt-other.html) - adtelligent adapter processing


- g.moroz@atelligent.com
- [x] official adapter submission

Related PR: https://github.com/prebid/prebid-server/pull/1635/files