### PR TITLE
SpotX Bid Adapter: default to 4/3 aspect ratio when response doesn't contain w or h

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -51,7 +51,7 @@ export const spec = {
           return false;
         }
         if (!utils.getBidIdParameter('slot', bid.params.outstream_options)) {
-          utils.logError(BIDDER_CODE + ': please define parameters slot outstream_options object in the configuration.');
+          utils.logError(BIDDER_CODE + ': please define parameter slot in outstream_options object in the configuration.');
           return false;
         }
       }
@@ -382,7 +382,7 @@ export const spec = {
                 }
               });
             } catch (err) {
-              utils.logWarn('Prebid Error calling setRender or setEve,tHandlers on renderer', err);
+              utils.logWarn('Prebid Error calling setRender or setEventHandlers on renderer', err);
             }
             bid.renderer = renderer;
           }
@@ -408,7 +408,7 @@ function createOutstreamScript(bid) {
   dataSpotXParams['data-spotx_content_page_url'] = bid.renderer.config.content_page_url;
   dataSpotXParams['data-spotx_ad_unit'] = 'incontent';
 
-  utils.logMessage('[SPOTX][renderer] Default beahavior');
+  utils.logMessage('[SPOTX][renderer] Default behavior');
   if (utils.getBidIdParameter('ad_mute', bid.renderer.config.outstream_options)) {
     dataSpotXParams['data-spotx_ad_mute'] = '1';
   }
@@ -419,30 +419,26 @@ function createOutstreamScript(bid) {
 
   const playersizeAutoAdapt = utils.getBidIdParameter('playersize_auto_adapt', bid.renderer.config.outstream_options);
   if (playersizeAutoAdapt && utils.isBoolean(playersizeAutoAdapt) && playersizeAutoAdapt === true) {
-    if (bid.width && utils.isNumber(bid.width) && bid.height && utils.isNumber(bid.height)) {
-      const ratio = bid.width / bid.height;
-      const slotClientWidth = window.document.getElementById(slot).clientWidth;
-      let playerWidth = bid.renderer.config.player_width;
-      let playerHeight = bid.renderer.config.player_height;
-      let contentWidth = 0;
-      let contentHeight = 0;
-      if (slotClientWidth < playerWidth) {
-        playerWidth = slotClientWidth;
-        playerHeight = playerWidth / ratio;
-      }
-      if (ratio <= 1) {
-        contentWidth = Math.round(playerHeight * ratio);
-        contentHeight = playerHeight;
-      } else {
-        contentWidth = playerWidth;
-        contentHeight = Math.round(playerWidth / ratio);
-      }
-
-      dataSpotXParams['data-spotx_content_width'] = '' + contentWidth;
-      dataSpotXParams['data-spotx_content_height'] = '' + contentHeight;
-    } else {
-      utils.logWarn('[SPOTX][renderer] PlayerSize auto adapt: bid.width and bid.height are incorrect');
+    const ratio = bid.width && utils.isNumber(bid.width) && bid.height && utils.isNumber(bid.height) ? bid.width / bid.height : 4 / 3;
+    const slotClientWidth = window.document.getElementById(slot).clientWidth;
+    let playerWidth = bid.renderer.config.player_width;
+    let playerHeight = bid.renderer.config.player_height;
+    let contentWidth = 0;
+    let contentHeight = 0;
+    if (slotClientWidth < playerWidth) {
+      playerWidth = slotClientWidth;
+      playerHeight = playerWidth / ratio;
     }
+    if (ratio <= 1) {
+      contentWidth = Math.round(playerHeight * ratio);
+      contentHeight = playerHeight;
+    } else {
+      contentWidth = playerWidth;
+      contentHeight = Math.round(playerWidth / ratio);
+    }
+
+    dataSpotXParams['data-spotx_content_width'] = '' + contentWidth;
+    dataSpotXParams['data-spotx_content_height'] = '' + contentHeight;
   }
 
   const customOverride = utils.getBidIdParameter('custom_override', bid.renderer.config.outstream_options);

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -542,65 +542,10 @@ describe('the spotx adapter', function () {
       };
     });
 
-    it('should adjust width and height to slot\'s clientWidth if playersize_auto_adapt is used', function() {
-      var scriptTag;
-      sinon.stub(window.document, 'getElementById').returns({
-        clientWidth: 200,
-        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
-      });
-      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
-
-      responses[0].renderer.render(responses[0]);
-
-      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
-      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
-      expect(scriptTag.getAttribute('data-spotx_channel_id')).to.equal('12345');
-      expect(scriptTag.getAttribute('data-spotx_vast_url')).to.equal('https://search.spotxchange.com/ad/vast.html?key=cache123');
-      expect(scriptTag.getAttribute('data-spotx_ad_unit')).to.equal('incontent');
-      expect(scriptTag.getAttribute('data-spotx_collapse')).to.equal('0');
-      expect(scriptTag.getAttribute('data-spotx_autoplay')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_blocked_autoplay_override_mode')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_video_slot_can_autoplay')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
-      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
-      expect(scriptTag.getAttribute('data-spotx_ad_mute')).to.equal('1');
-      window.document.getElementById.restore();
-    });
-
-    it('should use a default 4/3 ratio if playersize_auto_adapt is used and response does not contain width or height', function() {
-      delete serverResponse.body.seatbid[0].bid[0].w;
-      delete serverResponse.body.seatbid[0].bid[0].h;
-
-      var scriptTag;
-      sinon.stub(window.document, 'getElementById').returns({
-        clientWidth: 200,
-        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
-      });
-      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
-
-      responses[0].renderer.render(responses[0]);
-
-      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
-      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
-      expect(scriptTag.getAttribute('data-spotx_channel_id')).to.equal('12345');
-      expect(scriptTag.getAttribute('data-spotx_vast_url')).to.equal('https://search.spotxchange.com/ad/vast.html?key=cache123');
-      expect(scriptTag.getAttribute('data-spotx_ad_unit')).to.equal('incontent');
-      expect(scriptTag.getAttribute('data-spotx_collapse')).to.equal('0');
-      expect(scriptTag.getAttribute('data-spotx_autoplay')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_blocked_autoplay_override_mode')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_video_slot_can_autoplay')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
-      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
-      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
-      expect(scriptTag.getAttribute('data-spotx_ad_mute')).to.equal('1');
-      window.document.getElementById.restore();
-    });
-
     it('should attempt to insert the EASI script', function() {
       var scriptTag;
       sinon.stub(window.document, 'getElementById').returns({
-        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
+        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script; })
       });
       var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
 
@@ -628,7 +573,7 @@ describe('the spotx adapter', function () {
         nodeName: 'IFRAME',
         contentDocument: {
           body: {
-            appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
+            appendChild: sinon.stub().callsFake(function(script) { scriptTag = script; })
           }
         }
       });
@@ -651,6 +596,43 @@ describe('the spotx adapter', function () {
       expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
       expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('400');
       expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('300');
+      window.document.getElementById.restore();
+    });
+
+    it('should adjust width and height to match slot clientWidth if playersize_auto_adapt is used', function() {
+      var scriptTag;
+      sinon.stub(window.document, 'getElementById').returns({
+        clientWidth: 200,
+        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script; })
+      });
+      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
+
+      responses[0].renderer.render(responses[0]);
+
+      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
+      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
+      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
+      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
+      window.document.getElementById.restore();
+    });
+
+    it('should use a default 4/3 ratio if playersize_auto_adapt is used and response does not contain width or height', function() {
+      delete serverResponse.body.seatbid[0].bid[0].w;
+      delete serverResponse.body.seatbid[0].bid[0].h;
+
+      var scriptTag;
+      sinon.stub(window.document, 'getElementById').returns({
+        clientWidth: 200,
+        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script; })
+      });
+      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
+
+      responses[0].renderer.render(responses[0]);
+
+      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
+      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
+      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
+      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
       window.document.getElementById.restore();
     });
   });

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -488,7 +488,7 @@ describe('the spotx adapter', function () {
     });
   });
 
-  describe('oustreamRender', function() {
+  describe('outstreamRender', function() {
     var serverResponse, bidderRequestObj;
 
     beforeEach(function() {
@@ -540,6 +540,61 @@ describe('the spotx adapter', function () {
           }]
         }
       };
+    });
+
+    it('should adjust width and height to slot\'s clientWidth if playersize_auto_adapt is used', function() {
+      var scriptTag;
+      sinon.stub(window.document, 'getElementById').returns({
+        clientWidth: 200,
+        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
+      });
+      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
+
+      responses[0].renderer.render(responses[0]);
+
+      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
+      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
+      expect(scriptTag.getAttribute('data-spotx_channel_id')).to.equal('12345');
+      expect(scriptTag.getAttribute('data-spotx_vast_url')).to.equal('https://search.spotxchange.com/ad/vast.html?key=cache123');
+      expect(scriptTag.getAttribute('data-spotx_ad_unit')).to.equal('incontent');
+      expect(scriptTag.getAttribute('data-spotx_collapse')).to.equal('0');
+      expect(scriptTag.getAttribute('data-spotx_autoplay')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_blocked_autoplay_override_mode')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_video_slot_can_autoplay')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
+      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
+      expect(scriptTag.getAttribute('data-spotx_ad_mute')).to.equal('1');
+      window.document.getElementById.restore();
+    });
+
+    it('should use a default 4/3 ratio if playersize_auto_adapt is used and response does not contain width or height', function() {
+      delete serverResponse.body.seatbid[0].bid[0].w;
+      delete serverResponse.body.seatbid[0].bid[0].h;
+
+      var scriptTag;
+      sinon.stub(window.document, 'getElementById').returns({
+        clientWidth: 200,
+        appendChild: sinon.stub().callsFake(function(script) { scriptTag = script })
+      });
+      var responses = spec.interpretResponse(serverResponse, bidderRequestObj);
+
+      responses[0].renderer.render(responses[0]);
+
+      expect(scriptTag.getAttribute('type')).to.equal('text/javascript');
+      expect(scriptTag.getAttribute('src')).to.equal('https://js.spotx.tv/easi/v1/12345.js');
+      expect(scriptTag.getAttribute('data-spotx_channel_id')).to.equal('12345');
+      expect(scriptTag.getAttribute('data-spotx_vast_url')).to.equal('https://search.spotxchange.com/ad/vast.html?key=cache123');
+      expect(scriptTag.getAttribute('data-spotx_ad_unit')).to.equal('incontent');
+      expect(scriptTag.getAttribute('data-spotx_collapse')).to.equal('0');
+      expect(scriptTag.getAttribute('data-spotx_autoplay')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_blocked_autoplay_override_mode')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_video_slot_can_autoplay')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_digitrust_opt_out')).to.equal('1');
+      expect(scriptTag.getAttribute('data-spotx_content_width')).to.equal('200');
+      expect(scriptTag.getAttribute('data-spotx_content_height')).to.equal('150');
+      expect(scriptTag.getAttribute('data-spotx_ad_mute')).to.equal('1');
+      window.document.getElementById.restore();
     });
 
     it('should attempt to insert the EASI script', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
In certain scenarios the SpotX server response does not include a width and height. For an outstream ad using playersize_auto_adapt, we currently log an error if we don't receive w and h, and the ad player does not expand. This change uses a default 4/3 ratio if we don't receive w or h, so the player can still expand.

- contact email of the adapter’s maintainer: adillon@spotx.tv
