### PR TITLE
Rubicon Analytics: Convert Key Values to strings

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -384,8 +384,12 @@ function getUtmParams() {
 function getFpkvs() {
   rubiConf.fpkvs = Object.assign((rubiConf.fpkvs || {}), getUtmParams());
 
-  const isValid = rubiConf.fpkvs && typeof rubiConf.fpkvs === 'object' && Object.keys(rubiConf.fpkvs).every(key => typeof rubiConf.fpkvs[key] === 'string');
-  return isValid ? rubiConf.fpkvs : {};
+  // convert all values to strings
+  Object.keys(rubiConf.fpkvs).forEach(key => {
+    rubiConf.fpkvs[key] = rubiConf.fpkvs[key] + '';
+  });
+
+  return rubiConf.fpkvs;
 }
 
 let samplingFactor = 1;

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -1089,6 +1089,34 @@ describe('rubicon analytics adapter', function () {
         expect(message).to.deep.equal(expectedMessage);
       });
 
+      it('should convert kvs to strings before sending', function () {
+        config.setConfig({rubicon: {
+          fpkvs: {
+            number: 24,
+            boolean: false,
+            string: 'hello',
+            array: ['one', 2, 'three'],
+            object: {one: 'two'}
+          }
+        }});
+        performStandardAuction();
+        expect(server.requests.length).to.equal(1);
+        let request = server.requests[0];
+        let message = JSON.parse(request.requestBody);
+        validate(message);
+
+        let expectedMessage = utils.deepClone(ANALYTICS_MESSAGE);
+        expectedMessage.session.pvid = STUBBED_UUID.slice(0, 8);
+        expectedMessage.fpkvs = [
+          {key: 'number', value: '24'},
+          {key: 'boolean', value: 'false'},
+          {key: 'string', value: 'hello'},
+          {key: 'array', value: 'one,2,three'},
+          {key: 'object', value: '[object Object]'}
+        ]
+        expect(message).to.deep.equal(expectedMessage);
+      });
+
       it('should use the query utm param rubicon kv value and pass updated kv and pvid when defined', function () {
         sandbox.stub(utils, 'getWindowLocation').returns({'search': '?utm_source=other', 'pbjs_debug': 'true'});
 


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Instead of checking and validating all values are strings, we will now just convert any values in the fpkvs to strings. This way we do not lose data if just a single value happens to be a number or something.