### PR TITLE
add AdTrue bid adapter

### DIFF
--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -1,0 +1,637 @@
+import * as utils from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
+import {config} from '../src/config.js';
+import {getStorageManager} from '../src/storageManager.js';
+
+const storage = getStorageManager();
+const BIDDER_CODE = 'adtrue';
+const ADTRUE_CURRENCY = 'USD';
+const ENDPOINT_URL = 'https://hb.adtrue.com/prebid/auction';
+const LOG_WARN_PREFIX = 'AdTrue: ';
+const AUCTION_TYPE = 1;
+const UNDEFINED = undefined;
+const DEFAULT_WIDTH = 0;
+const DEFAULT_HEIGHT = 0;
+const NET_REVENUE = false;
+const USER_SYNC_URL_IFRAME = 'https://hb.adtrue.com/prebid/usersync?t=iframe&p=';
+const USER_SYNC_URL_IMAGE = 'https://hb.adtrue.com/prebid/usersync?t=img&p=';
+let publisherId = 0;
+let NATIVE_ASSET_ID_TO_KEY_MAP = {};
+const DATA_TYPES = {
+  'NUMBER': 'number',
+  'STRING': 'string',
+  'BOOLEAN': 'boolean',
+  'ARRAY': 'array',
+  'OBJECT': 'object'
+};
+const VIDEO_CUSTOM_PARAMS = {
+  'mimes': DATA_TYPES.ARRAY,
+  'minduration': DATA_TYPES.NUMBER,
+  'maxduration': DATA_TYPES.NUMBER,
+  'startdelay': DATA_TYPES.NUMBER,
+  'playbackmethod': DATA_TYPES.ARRAY,
+  'api': DATA_TYPES.ARRAY,
+  'protocols': DATA_TYPES.ARRAY,
+  'w': DATA_TYPES.NUMBER,
+  'h': DATA_TYPES.NUMBER,
+  'battr': DATA_TYPES.ARRAY,
+  'linearity': DATA_TYPES.NUMBER,
+  'placement': DATA_TYPES.NUMBER,
+  'minbitrate': DATA_TYPES.NUMBER,
+  'maxbitrate': DATA_TYPES.NUMBER
+}
+
+const NATIVE_ASSETS = {
+  'TITLE': {ID: 1, KEY: 'title', TYPE: 0},
+  'IMAGE': {ID: 2, KEY: 'image', TYPE: 0},
+  'ICON': {ID: 3, KEY: 'icon', TYPE: 0},
+  'SPONSOREDBY': {ID: 4, KEY: 'sponsoredBy', TYPE: 1}, // please note that type of SPONSORED is also 1
+  'BODY': {ID: 5, KEY: 'body', TYPE: 2}, // please note that type of DESC is also set to 2
+  'CLICKURL': {ID: 6, KEY: 'clickUrl', TYPE: 0},
+  'VIDEO': {ID: 7, KEY: 'video', TYPE: 0},
+  'EXT': {ID: 8, KEY: 'ext', TYPE: 0},
+  'DATA': {ID: 9, KEY: 'data', TYPE: 0},
+  'LOGO': {ID: 10, KEY: 'logo', TYPE: 0},
+  'SPONSORED': {ID: 11, KEY: 'sponsored', TYPE: 1}, // please note that type of SPONSOREDBY is also set to 1
+  'DESC': {ID: 12, KEY: 'data', TYPE: 2}, // please note that type of BODY is also set to 2
+  'RATING': {ID: 13, KEY: 'rating', TYPE: 3},
+  'LIKES': {ID: 14, KEY: 'likes', TYPE: 4},
+  'DOWNLOADS': {ID: 15, KEY: 'downloads', TYPE: 5},
+  'PRICE': {ID: 16, KEY: 'price', TYPE: 6},
+  'SALEPRICE': {ID: 17, KEY: 'saleprice', TYPE: 7},
+  'PHONE': {ID: 18, KEY: 'phone', TYPE: 8},
+  'ADDRESS': {ID: 19, KEY: 'address', TYPE: 9},
+  'DESC2': {ID: 20, KEY: 'desc2', TYPE: 10},
+  'DISPLAYURL': {ID: 21, KEY: 'displayurl', TYPE: 11},
+  'CTA': {ID: 22, KEY: 'cta', TYPE: 12}
+};
+
+function _getDomainFromURL(url) {
+  let anchor = document.createElement('a');
+  anchor.href = url;
+  return anchor.hostname;
+}
+
+function _parseSlotParam(paramName, paramValue) {
+  switch (paramName) {
+    case 'reserve':
+      return parseFloat(paramValue) || UNDEFINED;
+    default:
+      return paramValue;
+  }
+}
+
+let platform = (function getPlatform() {
+  var ua = navigator.userAgent;
+  if (ua.indexOf('Android') > -1 || ua.indexOf('Adr') > -1) {
+    return 'Android'
+  }
+  if (ua.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/)) {
+    return 'iOS'
+  }
+  return 'windows'
+})();
+
+function _generateGUID() {
+  var d = new Date().getTime();
+  var guid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = (d + Math.random() * 16) % 16 | 0;
+    d = Math.floor(d / 16);
+    return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+  })
+  return guid;
+}
+
+function _isMobile() {
+  return (/(ios|ipod|ipad|iphone|android)/i).test(navigator.userAgent);
+}
+
+function _isConnectedTV() {
+  return (/(smart[-]?tv|hbbtv|appletv|googletv|hdmi|netcast\.tv|viera|nettv|roku|\bdtv\b|sonydtv|inettvbrowser|\btv\b)/i).test(navigator.userAgent);
+}
+
+function _parseAdSlot(bid) {
+  bid.params.width = 0;
+  bid.params.height = 0;
+  // check if size is mentioned in sizes array. in that case do not check for @ in adslot
+  if (bid.hasOwnProperty('mediaTypes') &&
+    bid.mediaTypes.hasOwnProperty(BANNER) &&
+    bid.mediaTypes.banner.hasOwnProperty('sizes')) {
+    var i = 0;
+    var sizeArray = [];
+    for (; i < bid.mediaTypes.banner.sizes.length; i++) {
+      if (bid.mediaTypes.banner.sizes[i].length === 2) { // sizes[i].length will not be 2 in case where size is set as fluid, we want to skip that entry
+        sizeArray.push(bid.mediaTypes.banner.sizes[i]);
+      }
+    }
+    bid.mediaTypes.banner.sizes = sizeArray;
+    if (bid.mediaTypes.banner.sizes.length >= 1) {
+      // set the first size in sizes array in bid.params.width and bid.params.height. These will be sent as primary size.
+      // The rest of the sizes will be sent in format array.
+      bid.params.width = bid.mediaTypes.banner.sizes[0][0];
+      bid.params.height = bid.mediaTypes.banner.sizes[0][1];
+      bid.mediaTypes.banner.sizes = bid.mediaTypes.banner.sizes.splice(1, bid.mediaTypes.banner.sizes.length - 1);
+    }
+  }
+}
+
+function _initConf(refererInfo) {
+  return {
+    pageURL: (refererInfo && refererInfo.referer) ? refererInfo.referer : window.location.href,
+    refURL: window.document.referrer
+  };
+}
+
+function _getLanguage() {
+  const language = navigator.language ? 'language' : 'userLanguage';
+  return navigator[language].split('-')[0];
+}
+
+function _createOrtbTemplate(conf) {
+  var guid;
+  if (storage.getDataFromLocalStorage('adtrue_user_id') == null) {
+    storage.setDataInLocalStorage('adtrue_user_id', _generateGUID())
+  }
+  guid = storage.getDataFromLocalStorage('adtrue_user_id')
+
+  return {
+    id: '' + new Date().getTime(),
+    at: AUCTION_TYPE,
+    cur: [ADTRUE_CURRENCY],
+    imp: [],
+    site: {
+      page: conf.pageURL,
+      ref: conf.refURL,
+      publisher: {}
+    },
+    device: {
+      ip: '',
+      ua: navigator.userAgent,
+      os: platform,
+      js: 1,
+      dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+      h: screen.height,
+      w: screen.width,
+      language: _getLanguage(),
+      devicetype: _isMobile() ? 1 : _isConnectedTV() ? 3 : 2,
+      geo: {
+        country: '{country_code}',
+        type: 0,
+        ipservice: 1,
+        region: '',
+        city: '',
+      },
+    },
+    user: {
+      id: guid
+    },
+    ext: {}
+  };
+}
+
+function _checkParamDataType(key, value, datatype) {
+  var errMsg = 'Ignoring param key: ' + key + ', expects ' + datatype + ', found ' + typeof value;
+  var functionToExecute;
+  switch (datatype) {
+    case DATA_TYPES.BOOLEAN:
+      functionToExecute = utils.isBoolean;
+      break;
+    case DATA_TYPES.NUMBER:
+      functionToExecute = utils.isNumber;
+      break;
+    case DATA_TYPES.STRING:
+      functionToExecute = utils.isStr;
+      break;
+    case DATA_TYPES.ARRAY:
+      functionToExecute = utils.isArray;
+      break;
+  }
+  if (functionToExecute(value)) {
+    return value;
+  }
+  utils.logWarn(LOG_WARN_PREFIX + errMsg);
+  return UNDEFINED;
+}
+
+function _parseNativeResponse(bid, newBid) {
+  newBid.native = {};
+  if (bid.hasOwnProperty('adm')) {
+    var adm = '';
+    try {
+      adm = JSON.parse(bid.adm.replace(/\\/g, ''));
+    } catch (ex) {
+      // utils.logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native reponse for ad response: ' + newBid.adm);
+      return;
+    }
+    if (adm && adm.native && adm.native.assets && adm.native.assets.length > 0) {
+      newBid.mediaType = NATIVE;
+      for (let i = 0, len = adm.native.assets.length; i < len; i++) {
+        switch (adm.native.assets[i].id) {
+          case NATIVE_ASSETS.TITLE.ID:
+            newBid.native.title = adm.native.assets[i].title && adm.native.assets[i].title.text;
+            break;
+          case NATIVE_ASSETS.IMAGE.ID:
+            newBid.native.image = {
+              url: adm.native.assets[i].img && adm.native.assets[i].img.url,
+              height: adm.native.assets[i].img && adm.native.assets[i].img.h,
+              width: adm.native.assets[i].img && adm.native.assets[i].img.w,
+            };
+            break;
+          case NATIVE_ASSETS.ICON.ID:
+            newBid.native.icon = {
+              url: adm.native.assets[i].img && adm.native.assets[i].img.url,
+              height: adm.native.assets[i].img && adm.native.assets[i].img.h,
+              width: adm.native.assets[i].img && adm.native.assets[i].img.w,
+            };
+            break;
+          case NATIVE_ASSETS.SPONSOREDBY.ID:
+          case NATIVE_ASSETS.BODY.ID:
+          case NATIVE_ASSETS.LIKES.ID:
+          case NATIVE_ASSETS.DOWNLOADS.ID:
+          case NATIVE_ASSETS.PRICE:
+          case NATIVE_ASSETS.SALEPRICE.ID:
+          case NATIVE_ASSETS.PHONE.ID:
+          case NATIVE_ASSETS.ADDRESS.ID:
+          case NATIVE_ASSETS.DESC2.ID:
+          case NATIVE_ASSETS.CTA.ID:
+          case NATIVE_ASSETS.RATING.ID:
+          case NATIVE_ASSETS.DISPLAYURL.ID:
+            newBid.native[NATIVE_ASSET_ID_TO_KEY_MAP[adm.native.assets[i].id]] = adm.native.assets[i].data && adm.native.assets[i].data.value;
+            break;
+        }
+      }
+      newBid.native.clickUrl = adm.native.link && adm.native.link.url;
+      newBid.native.clickTrackers = (adm.native.link && adm.native.link.clicktrackers) || [];
+      newBid.native.impressionTrackers = adm.native.imptrackers || [];
+      newBid.native.jstracker = adm.native.jstracker || [];
+      if (!newBid.width) {
+        newBid.width = DEFAULT_WIDTH;
+      }
+      if (!newBid.height) {
+        newBid.height = DEFAULT_HEIGHT;
+      }
+    }
+  }
+}
+
+function _createBannerRequest(bid) {
+  var sizes = bid.mediaTypes.banner.sizes;
+  var format = [];
+  var bannerObj;
+  if (sizes !== UNDEFINED && utils.isArray(sizes)) {
+    bannerObj = {};
+    if (!bid.params.width && !bid.params.height) {
+      if (sizes.length === 0) {
+        // i.e. since bid.params does not have width or height, and length of sizes is 0, need to ignore this banner imp
+        bannerObj = UNDEFINED;
+        utils.logWarn(LOG_WARN_PREFIX + 'Error: mediaTypes.banner.size missing for adunit: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
+        return bannerObj;
+      } else {
+        bannerObj.w = parseInt(sizes[0][0], 10);
+        bannerObj.h = parseInt(sizes[0][1], 10);
+        sizes = sizes.splice(1, sizes.length - 1);
+      }
+    } else {
+      bannerObj.w = bid.params.width;
+      bannerObj.h = bid.params.height;
+    }
+    if (sizes.length > 0) {
+      format = [];
+      sizes.forEach(function (size) {
+        if (size.length > 1) {
+          format.push({w: size[0], h: size[1]});
+        }
+      });
+      if (format.length > 0) {
+        bannerObj.format = format;
+      }
+    }
+    bannerObj.pos = 0;
+    bannerObj.topframe = utils.inIframe() ? 0 : 1;
+  } else {
+    utils.logWarn(LOG_WARN_PREFIX + 'Error: mediaTypes.banner.size missing for adunit: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
+    bannerObj = UNDEFINED;
+  }
+  return bannerObj;
+}
+
+function _createVideoRequest(bid) {
+  var videoData = bid.params.video;
+  var videoObj;
+
+  if (videoData !== UNDEFINED) {
+    videoObj = {};
+    for (var key in VIDEO_CUSTOM_PARAMS) {
+      if (videoData.hasOwnProperty(key)) {
+        videoObj[key] = _checkParamDataType(key, videoData[key], VIDEO_CUSTOM_PARAMS[key]);
+      }
+    }
+    // read playersize and assign to h and w.
+    if (utils.isArray(bid.mediaTypes.video.playerSize[0])) {
+      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0][0], 10);
+      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[0][1], 10);
+    } else if (utils.isNumber(bid.mediaTypes.video.playerSize[0])) {
+      videoObj.w = parseInt(bid.mediaTypes.video.playerSize[0], 10);
+      videoObj.h = parseInt(bid.mediaTypes.video.playerSize[1], 10);
+    }
+    if (bid.params.video.hasOwnProperty('skippable')) {
+      videoObj.ext = {
+        'video_skippable': bid.params.video.skippable ? 1 : 0
+      };
+    }
+  } else {
+    videoObj = UNDEFINED;
+    utils.logWarn(LOG_WARN_PREFIX + 'Error: Video config params missing for adunit: ' + bid.params.adUnit + ' with mediaType set as video. Ignoring video impression in the adunit.');
+  }
+  return videoObj;
+}
+
+function _checkMediaType(adm, newBid) {
+  var admStr = '';
+  var videoRegex = new RegExp(/VAST\s+version/);
+  newBid.mediaType = BANNER;
+  if (videoRegex.test(adm)) {
+    newBid.mediaType = VIDEO;
+  } else {
+    try {
+      admStr = JSON.parse(adm.replace(/\\/g, ''));
+      if (admStr && admStr.native) {
+        newBid.mediaType = NATIVE;
+      }
+    } catch (e) {
+      utils.logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native reponse for ad response: ' + adm);
+    }
+  }
+}
+
+function _createImpressionObject(bid, conf) {
+  var impObj = {};
+  var bannerObj;
+  var videoObj;
+  var sizes = bid.hasOwnProperty('sizes') ? bid.sizes : [];
+  var mediaTypes = '';
+  var format = [];
+
+  impObj = {
+    id: bid.bidId,
+    tagid: String(bid.params.zoneId || undefined),
+    bidfloor: _parseSlotParam('reserve', bid.params.reserve),
+    secure: 1,
+    ext: {},
+    bidfloorcur: ADTRUE_CURRENCY
+  };
+
+  if (bid.hasOwnProperty('mediaTypes')) {
+    for (mediaTypes in bid.mediaTypes) {
+      switch (mediaTypes) {
+        case BANNER:
+          bannerObj = _createBannerRequest(bid);
+          if (bannerObj !== UNDEFINED) {
+            impObj.banner = bannerObj;
+          }
+          break;
+        case VIDEO:
+          videoObj = _createVideoRequest(bid);
+          if (videoObj !== UNDEFINED) {
+            impObj.video = videoObj;
+          }
+          break;
+      }
+    }
+  } else {
+    // mediaTypes is not present, so this is a banner only impression
+    // this part of code is required for older testcases with no 'mediaTypes' to run succesfully.
+    bannerObj = {
+      pos: 0,
+      w: bid.params.width,
+      h: bid.params.height,
+      topframe: utils.inIframe() ? 0 : 1
+    };
+    if (utils.isArray(sizes) && sizes.length > 1) {
+      sizes = sizes.splice(1, sizes.length - 1);
+      sizes.forEach(size => {
+        format.push({
+          w: size[0],
+          h: size[1]
+        });
+      });
+      bannerObj.format = format;
+    }
+    impObj.banner = bannerObj;
+  }
+
+  return impObj.hasOwnProperty(BANNER) ||
+  impObj.hasOwnProperty(NATIVE) ||
+  impObj.hasOwnProperty(VIDEO) ? impObj : UNDEFINED;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: ['banner', 'video'],
+
+  isBidRequestValid: function (bid) {
+    if (bid && bid.params) {
+      if (!bid.params.zoneId) {
+        utils.logWarn(LOG_WARN_PREFIX + 'Error: missing zoneId');
+        return false;
+      }
+      if (!bid.params.publisherId) {
+        utils.logWarn(LOG_WARN_PREFIX + 'Error: missing publisherId');
+        return false;
+      }
+      return true;
+    }
+    return false;
+  },
+
+  buildRequests: function (validBidRequests, bidderRequest) {
+    let refererInfo;
+    if (bidderRequest && bidderRequest.refererInfo) {
+      refererInfo = bidderRequest.refererInfo;
+    }
+    let conf = _initConf(refererInfo);
+    let payload = _createOrtbTemplate(conf);
+    let bidCurrency = '';
+    let bid;
+    validBidRequests.forEach(originalBid => {
+      bid = utils.deepClone(originalBid);
+      _parseAdSlot(bid);
+
+      conf.zoneId = conf.zoneId || bid.params.zoneId;
+      conf.pubId = conf.pubId || bid.params.publisherId;
+
+      conf.transactionId = bid.transactionId;
+      if (bidCurrency === '') {
+        bidCurrency = bid.params.currency || UNDEFINED;
+      } else if (bid.params.hasOwnProperty('currency') && bidCurrency !== bid.params.currency) {
+        utils.logWarn(LOG_WARN_PREFIX + 'Currency specifier ignored. Only one currency permitted.');
+      }
+      bid.params.currency = bidCurrency;
+
+      var impObj = _createImpressionObject(bid, conf);
+      if (impObj) {
+        payload.imp.push(impObj);
+      }
+    });
+    if (payload.imp.length == 0) {
+      return;
+    }
+    publisherId = conf.pubId.trim();
+
+    payload.site.publisher.id = conf.pubId.trim();
+    payload.ext.wrapper = {};
+
+    payload.ext.wrapper.transactionId = conf.transactionId;
+    payload.ext.wrapper.wiid = conf.wiid || bidderRequest.auctionId;
+    payload.ext.wrapper.wp = 'pbjs';
+
+    payload.user.geo = {};
+    payload.device.geo = payload.user.geo;
+    payload.site.page = conf.pageURL;
+    payload.site.domain = _getDomainFromURL(payload.site.page);
+
+    if (typeof config.getConfig('content') === 'object') {
+      payload.site.content = config.getConfig('content');
+    }
+
+    if (typeof config.getConfig('device') === 'object') {
+      payload.device = Object.assign(payload.device, config.getConfig('device'));
+    }
+
+    utils.deepSetValue(payload, 'source.tid', conf.transactionId);
+
+    // test bids
+    if (window.location.href.indexOf('adtrueTest=true') !== -1) {
+      payload.test = 1;
+    }
+    // adding schain object
+    if (validBidRequests[0].schain) {
+      utils.deepSetValue(payload, 'source.ext.schain', validBidRequests[0].schain);
+    }
+
+    // Attaching GDPR Consent Params
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      utils.deepSetValue(payload, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
+      utils.deepSetValue(payload, 'regs.ext.gdpr', (bidderRequest.gdprConsent.gdprApplies ? 1 : 0));
+    }
+
+    // CCPA
+    if (bidderRequest && bidderRequest.uspConsent) {
+      utils.deepSetValue(payload, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+    }
+
+    // coppa compliance
+    if (config.getConfig('coppa') === true) {
+      utils.deepSetValue(payload, 'regs.coppa', 1);
+    }
+
+    return {
+      method: 'POST',
+      url: ENDPOINT_URL,
+      data: JSON.stringify(payload),
+      bidderRequests: bidderRequest
+    };
+  },
+  interpretResponse: function (serverResponses, bidderRequest) {
+    const bidResponses = [];
+    var respCur = ADTRUE_CURRENCY;
+    let parsedRequest = JSON.parse(bidderRequest.data);
+    let parsedReferrer = parsedRequest.site && parsedRequest.site.ref ? parsedRequest.site.ref : '';
+    try {
+      if (serverResponses.body && serverResponses.body.seatbid && utils.isArray(serverResponses.body.seatbid)) {
+        // Supporting multiple bid responses for same adSize
+        respCur = serverResponses.body.cur || respCur;
+        serverResponses.body.seatbid.forEach(seatbidder => {
+          seatbidder.bid &&
+          utils.isArray(seatbidder.bid) &&
+          seatbidder.bid.forEach(bid => {
+            let newBid = {
+              requestId: bid.impid,
+              cpm: (parseFloat(bid.price) || 0).toFixed(2),
+              width: bid.w,
+              height: bid.h,
+              creativeId: bid.crid || bid.id,
+              dealId: bid.dealid,
+              currency: respCur,
+              netRevenue: NET_REVENUE,
+              ttl: 300,
+              referrer: parsedReferrer,
+              ad: bid.adm,
+              partnerImpId: bid.id || '' // partner impression Id
+            };
+            if (parsedRequest.imp && parsedRequest.imp.length > 0) {
+              parsedRequest.imp.forEach(req => {
+                if (bid.impid === req.id) {
+                  _checkMediaType(bid.adm, newBid);
+                  switch (newBid.mediaType) {
+                    case BANNER:
+                      break;
+                    case VIDEO:
+                      break;
+                    case NATIVE:
+                      _parseNativeResponse(bid, newBid);
+                      break;
+                  }
+                }
+              });
+            }
+
+            newBid.meta = {};
+            if (bid.ext && bid.ext.dspid) {
+              newBid.meta.networkId = bid.ext.dspid;
+            }
+            if (bid.ext && bid.ext.advid) {
+              newBid.meta.buyerId = bid.ext.advid;
+            }
+            if (bid.adomain && bid.adomain.length > 0) {
+              newBid.meta.advertiserDomains = bid.adomain;
+              newBid.meta.clickUrl = bid.adomain[0];
+            }
+
+            // adserverTargeting
+            if (seatbidder.ext && seatbidder.ext.buyid) {
+              newBid.adserverTargeting = {
+                'hb_buyid_adtrue': seatbidder.ext.buyid
+              };
+            }
+
+            bidResponses.push(newBid);
+          });
+        });
+      }
+    } catch (error) {
+      utils.logError(error);
+    }
+    return bidResponses;
+  },
+  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent) {
+    let syncurl = '' + publisherId;
+
+    if (gdprConsent) {
+      syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+      syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+    }
+    if (uspConsent) {
+      syncurl += '&us_privacy=' + encodeURIComponent(uspConsent);
+    }
+
+    // coppa compliance
+    if (config.getConfig('coppa') === true) {
+      syncurl += '&coppa=1';
+    }
+
+    if (syncOptions.iframeEnabled) {
+      return [{
+        type: 'iframe',
+        url: USER_SYNC_URL_IFRAME + syncurl
+      }];
+    } else {
+      return [{
+        type: 'image',
+        url: USER_SYNC_URL_IMAGE + syncurl
+      }];
+    }
+  }
+};
+registerBidder(spec);

--- a/modules/adtrueBidAdapter.md
+++ b/modules/adtrueBidAdapter.md
@@ -1,0 +1,36 @@
+# Overview
+
+```
+Module Name: AdTrue Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: ssp@adtrue.com
+```
+
+# Description
+
+Connects to AdTrue exchange for bids.
+AdTrue bid adapter supports Banner currently.
+
+# Test Parameters
+```
+var adUnits = [
+  {
+    code: 'banner-div',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    bids: [
+      {
+          bidder: 'adtrue',
+          params: {
+              zoneId: '21423', // required, Zone Id provided by AdTrue
+              publisherId: '1491', // required, Publisher Id provided by AdTrue  
+              reserve: 0.1         // optional  
+          }
+      }
+    ]
+  }
+];
+```

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -1,0 +1,371 @@
+import {expect} from 'chai'
+import {spec} from 'modules/adtrueBidAdapter.js'
+import {newBidder} from 'src/adapters/bidderFactory.js'
+import * as utils from '../../../src/utils.js';
+import {config} from 'src/config.js';
+
+describe('AdTrueBidAdapter', function () {
+  const adapter = newBidder(spec)
+  let bidRequests;
+  let bidResponses;
+  beforeEach(function () {
+    bidRequests = [
+      {
+        bidder: 'adtrue',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]]
+          }
+        },
+        params: {
+          publisherId: '1212',
+          zoneId: '21423',
+          reserve: 0.2
+        },
+        placementCode: 'adunit-code-1',
+        sizes: [[300, 250]],
+        bidId: '23acc48ad47af5',
+        requestId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
+        bidderRequestId: '1c56ad30b9b8ca8',
+        transactionId: '92489f71-1bf2-49a0-adf9-000cea934729',
+        schain: {
+          'ver': '1.0',
+          'complete': 1,
+          'nodes': [
+            {
+              'asi': 'indirectseller.com',
+              'sid': '00001',
+              'hp': 1
+            },
+
+            {
+              'asi': 'indirectseller-2.com',
+              'sid': '00002',
+              'hp': 2
+            }
+          ]
+        }
+      }
+    ];
+    bidResponses = {
+      'body': {
+        'id': '1610681506302',
+        'seatbid': [
+          {
+            'bid': [
+              {
+                'id': '1',
+                'impid': '201fb513ca24e9',
+                'price': 2.880000114440918,
+                'burl': 'https://hb.adtrue.com/prebid/win-notify?impid=1610681506302&wp=${AUCTION_PRICE}',
+                'adm': '<a href=\'https://adtrue.com?ref=pbjs\' target=\'_blank\'><img src=\'http://cdn.adtrue.com/img/prebid_sample_300x250.jpg?v=1.2\' style=\' width: 300px; \' /></a>',
+                'adid': '1610681506302',
+                'adomain': [
+                  'adtrue.com'
+                ],
+                'cid': 'f6l0r6n',
+                'crid': 'abc77au4',
+                'attr': [],
+                'w': 300,
+                'h': 250
+              }
+            ],
+            'seat': 'adtrue',
+            'group': 0
+          }
+        ],
+        'bidid': '1610681506302',
+        'cur': 'USD'
+      }
+    };
+  });
+
+  describe('.code', function () {
+    it('should return a bidder code of adtrue', function () {
+      expect(spec.code).to.equal('adtrue')
+    })
+  })
+
+  describe('inherited functions', function () {
+    it('should exist and be a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function')
+    })
+  })
+  describe('implementation', function () {
+    describe('Bid validations', function () {
+      it('valid bid case', function () {
+        let validBid = {
+            bidder: 'adtrue',
+            params: {
+              zoneId: '21423',
+              publisherId: '1212'
+            }
+          },
+          isValid = spec.isBidRequestValid(validBid);
+        expect(isValid).to.equal(true);
+      });
+      it('invalid bid case: publisherId not passed', function () {
+        let validBid = {
+            bidder: 'adtrue',
+            params: {
+              zoneId: '21423'
+            }
+          },
+          isValid = spec.isBidRequestValid(validBid);
+        expect(isValid).to.equal(false);
+      });
+      it('valid bid case: zoneId is not passed', function () {
+        let validBid = {
+            bidder: 'adtrue',
+            params: {
+              publisherId: '1212'
+            }
+          },
+          isValid = spec.isBidRequestValid(validBid);
+        expect(isValid).to.equal(false);
+      });
+      it('should return false if there are no params', () => {
+        const bid = {
+          'bidder': 'adtrue',
+          'adUnitCode': 'adunit-code',
+          'mediaTypes': {
+            banner: {
+              sizes: [[300, 250]]
+            }
+          },
+          'bidId': '30b31c1838de1e',
+          'bidderRequestId': '22edbae2733bf6',
+          'auctionId': '1d1a030790a475',
+        };
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+      it('should return false if there is no publisherId param', () => {
+        const bid = {
+          'bidder': 'adtrue',
+          'adUnitCode': 'adunit-code',
+          params: {
+            zoneId: '21423',
+          },
+          'mediaTypes': {
+            banner: {
+              sizes: [[300, 250]]
+            }
+          },
+          'bidId': '30b31c1838de1e',
+          'bidderRequestId': '22edbae2733bf6',
+          'auctionId': '1d1a030790a475',
+        };
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+      it('should return false if there is no zoneId param', () => {
+        const bid = {
+          'bidder': 'adtrue',
+          'adUnitCode': 'adunit-code',
+          params: {
+            publisherId: '1212',
+          },
+          'mediaTypes': {
+            banner: {
+              sizes: [[300, 250]]
+            }
+          },
+          'bidId': '30b31c1838de1e',
+          'bidderRequestId': '22edbae2733bf6',
+          'auctionId': '1d1a030790a475',
+        };
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+      it('should return true if the bid is valid', () => {
+        const bid = {
+          'bidder': 'adtrue',
+          'adUnitCode': 'adunit-code',
+          params: {
+            zoneId: '21423',
+            publisherId: '1212',
+          },
+          'mediaTypes': {
+            banner: {
+              sizes: [[300, 250]]
+            }
+          },
+          'bidId': '30b31c1838de1e',
+          'bidderRequestId': '22edbae2733bf6',
+          'auctionId': '1d1a030790a475',
+        };
+        expect(spec.isBidRequestValid(bid)).to.equal(true);
+      });
+    });
+    describe('Request formation', function () {
+      it('buildRequests function should not modify original bidRequests object', function () {
+        let originalBidRequests = utils.deepClone(bidRequests);
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+        expect(bidRequests).to.deep.equal(originalBidRequests);
+      });
+
+      it('Endpoint/method checking', function () {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+        expect(request.url).to.equal('https://hb.adtrue.com/prebid/auction');
+        expect(request.method).to.equal('POST');
+      });
+
+      it('test flag not sent when adtrueTest=true is absent in page url', function () {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+        let data = JSON.parse(request.data);
+        expect(data.test).to.equal(undefined);
+      });
+      it('Request params check', function () {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+        let data = JSON.parse(request.data);
+        expect(data.at).to.equal(1); // auction type
+        expect(data.cur[0]).to.equal('USD'); // currency
+        expect(data.site.domain).to.be.a('string'); // domain should be set
+        expect(data.site.publisher.id).to.equal(bidRequests[0].params.publisherId); // publisher Id
+        expect(data.ext.wrapper.transactionId).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.source.tid).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
+        expect(data.imp[0].bidfloor).to.equal(bidRequests[0].params.reserve); // reverse
+        expect(data.imp[0].tagid).to.equal(bidRequests[0].params.zoneId); // zoneId
+        expect(data.imp[0].banner.w).to.equal(300); // width
+        expect(data.imp[0].banner.h).to.equal(250); // height
+        expect(data.source.ext.schain).to.deep.equal(bidRequests[0].schain);
+      });
+      it('Request params check with GDPR Consent', function () {
+        let bidRequest = {
+          gdprConsent: {
+            consentString: 'kjfdniwjnifwenrif3',
+            gdprApplies: true
+          }
+        };
+        let request = spec.buildRequests(bidRequests, bidRequest);
+        let data = JSON.parse(request.data);
+        expect(data.user.ext.consent).to.equal('kjfdniwjnifwenrif3');
+        expect(data.at).to.equal(1); // auction type
+        expect(data.cur[0]).to.equal('USD'); // currency
+        expect(data.site.domain).to.be.a('string'); // domain should be set
+        expect(data.site.publisher.id).to.equal(bidRequests[0].params.publisherId); // publisher Id
+        expect(data.ext.wrapper.transactionId).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.source.tid).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
+        expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.reserve)); // reverse
+        expect(data.imp[0].tagid).to.equal(bidRequests[0].params.zoneId); // zoneId
+        expect(data.imp[0].banner.w).to.equal(300); // width
+        expect(data.imp[0].banner.h).to.equal(250); // height
+        expect(data.source.ext.schain).to.deep.equal(bidRequests[0].schain);
+      });
+      it('Request params check with USP/CCPA Consent', function () {
+        let bidRequest = {
+          uspConsent: '1NYN'
+        };
+        let request = spec.buildRequests(bidRequests, bidRequest);
+        let data = JSON.parse(request.data);
+        expect(data.regs.ext.us_privacy).to.equal('1NYN');// USP/CCPAs
+        expect(data.at).to.equal(1); // auction type
+        expect(data.cur[0]).to.equal('USD'); // currency
+        expect(data.site.domain).to.be.a('string'); // domain should be set
+        expect(data.site.publisher.id).to.equal(bidRequests[0].params.publisherId); // publisher Id
+        expect(data.ext.wrapper.transactionId).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.source.tid).to.equal(bidRequests[0].transactionId); // Prebid TransactionId
+        expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
+        expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.reserve)); // reverse
+        expect(data.imp[0].tagid).to.equal(bidRequests[0].params.zoneId); // zoneId
+        expect(data.imp[0].banner.w).to.equal(300); // width
+        expect(data.imp[0].banner.h).to.equal(250); // height
+        expect(data.source.ext.schain).to.deep.equal(bidRequests[0].schain);
+      });
+
+      it('should NOT include coppa flag in bid request if coppa config is not present', () => {
+        const request = spec.buildRequests(bidRequests, {});
+        let data = JSON.parse(request.data);
+        if (data.regs) {
+          // in case GDPR is set then data.regs will exist
+          expect(data.regs.coppa).to.equal(undefined);
+        } else {
+          expect(data.regs).to.equal(undefined);
+        }
+      });
+      it('should include coppa flag in bid request if coppa is set to true', () => {
+        let sandbox = sinon.sandbox.create();
+        sandbox.stub(config, 'getConfig').callsFake(key => {
+          const config = {
+            'coppa': true
+          };
+          return config[key];
+        });
+        const request = spec.buildRequests(bidRequests, {});
+        let data = JSON.parse(request.data);
+        expect(data.regs.coppa).to.equal(1);
+        sandbox.restore();
+      });
+      it('should NOT include coppa flag in bid request if coppa is set to false', () => {
+        let sandbox = sinon.sandbox.create();
+        sandbox.stub(config, 'getConfig').callsFake(key => {
+          const config = {
+            'coppa': false
+          };
+          return config[key];
+        });
+        const request = spec.buildRequests(bidRequests, {});
+        let data = JSON.parse(request.data);
+        if (data.regs) {
+          // in case GDPR is set then data.regs will exist
+          expect(data.regs.coppa).to.equal(undefined);
+        } else {
+          expect(data.regs).to.equal(undefined);
+        }
+        sandbox.restore();
+      });
+    });
+  });
+  describe('Response checking', function () {
+    it('should check for valid response values', function () {
+      let request = spec.buildRequests(bidRequests, {
+        auctionId: 'new-auction-id'
+      });
+      let data = JSON.parse(request.data);
+      let response = spec.interpretResponse(bidResponses, request);
+      expect(response).to.be.an('array').with.length.above(0);
+      expect(response[0].requestId).to.equal(bidResponses.body.seatbid[0].bid[0].impid);
+      expect(response[0].width).to.equal(bidResponses.body.seatbid[0].bid[0].w);
+      expect(response[0].height).to.equal(bidResponses.body.seatbid[0].bid[0].h);
+      if (bidResponses.body.seatbid[0].bid[0].crid) {
+        expect(response[0].creativeId).to.equal(bidResponses.body.seatbid[0].bid[0].crid);
+      } else {
+        expect(response[0].creativeId).to.equal(bidResponses.body.seatbid[0].bid[0].id);
+      }
+      expect(response[0].currency).to.equal('USD');
+      expect(response[0].ttl).to.equal(300);
+      expect(response[0].meta.clickUrl).to.equal('adtrue.com');
+      expect(response[0].meta.advertiserDomains[0]).to.equal('adtrue.com');
+      // expect(response[0].referrer).to.include(data.site.page);
+      expect(response[0].ad).to.equal(bidResponses.body.seatbid[0].bid[0].adm);
+      expect(response[0].partnerImpId).to.equal(bidResponses.body.seatbid[0].bid[0].id);
+    });
+  });
+  describe('getUserSyncs', function () {
+    let USER_SYNC_URL_IFRAME = 'https://hb.adtrue.com/prebid/usersync?t=iframe&p=1212';
+    let USER_SYNC_URL_IMAGE = 'https://hb.adtrue.com/prebid/usersync?t=img&p=1212';
+    let sandbox;
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+    afterEach(function () {
+      sandbox.restore();
+    });
+    it('execute as per config', function () {
+      expect(spec.getUserSyncs({iframeEnabled: true}, {}, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: USER_SYNC_URL_IFRAME
+      }]);
+      expect(spec.getUserSyncs({iframeEnabled: false}, {}, undefined, undefined)).to.deep.equal([{
+        type: 'image', url: USER_SYNC_URL_IMAGE
+      }]);
+    });
+  });
+});

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -344,7 +344,6 @@ describe('AdTrueBidAdapter', function () {
       expect(response[0].ttl).to.equal(300);
       expect(response[0].meta.clickUrl).to.equal('adtrue.com');
       expect(response[0].meta.advertiserDomains[0]).to.equal('adtrue.com');
-      // expect(response[0].referrer).to.include(data.site.page);
       expect(response[0].ad).to.equal(bidResponses.body.seatbid[0].bid[0].adm);
       expect(response[0].partnerImpId).to.equal(bidResponses.body.seatbid[0].bid[0].id);
     });

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -224,7 +224,7 @@ describe('AdTrueBidAdapter', function () {
           auctionId: 'new-auction-id'
         });
         let data = JSON.parse(request.data);
-        expect(data.at).to.equal(1); // auction type
+        expect(data.at).to.equal(1); // auction  type
         expect(data.cur[0]).to.equal('USD'); // currency
         expect(data.site.domain).to.be.a('string'); // domain should be set
         expect(data.site.publisher.id).to.equal(bidRequests[0].params.publisherId); // publisher Id


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter


## Description of change
add new adtrue bidder
- test parameters for validating bids
```
{
  bidder: 'adtrue',
  params: {
                  zoneId: '21423',
                  publisherId: '1212',
                  reserve: 0.2
                  }
}
```
- contact email of the adapter’s maintainer: ssp@adtrue.com
- [x] official adapter submission

PR for update prebid dev-docs: https://github.com/prebid/prebid.github.io/pull/2603
