### PR TITLE
ID5 User ID Module: pass a flag back to id5 servers if abTesting was enabled

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -57,7 +57,7 @@ export const id5IdSubmodule = {
     }
 
     // check for A/B testing configuration and hide ID if in Control Group
-    let abConfig = (config && config.params && config.params.abTesting) || { enabled: false };
+    let abConfig = getAbTestingConfig(config);
     let controlGroup = false;
     if (
       abConfig.enabled === true &&
@@ -128,6 +128,10 @@ export const id5IdSubmodule = {
       'us_privacy': uspDataHandler.getConsentData() || '',
       'v': '$prebid.version$'
     };
+
+    if (getAbTestingConfig(config).enabled === true) {
+      utils.deepSetValue(data, 'features.ab', 1);
+    }
 
     const resp = function (callback) {
       const callbacks = {
@@ -276,6 +280,16 @@ export function getFromLocalStorage(key) {
 export function storeInLocalStorage(key, value, expDays) {
   storage.setDataInLocalStorage(`${key}_exp`, expDaysStr(expDays));
   storage.setDataInLocalStorage(`${key}`, value);
+}
+
+/**
+ * gets the existing abTesting config or generates a default config with abTesting off
+ *
+ * @param {SubmoduleConfig|undefined} config
+ * @returns {(Object|undefined)}
+ */
+function getAbTestingConfig(config) {
+  return (config && config.params && config.params.abTesting) || { enabled: false };
 }
 
 submodule('userId', id5IdSubmodule);

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -236,6 +236,47 @@ describe('ID5 ID System', function() {
 
       expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
     });
+
+    it('should call the ID5 server with ab feature = 1 when abTesting is turned on', function () {
+      let id5Config = getId5FetchConfig();
+      id5Config.params.abTesting = { enabled: true, controlGroupPct: 10 }
+
+      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(requestBody.features.ab).to.eq(1);
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+    });
+
+    it('should call the ID5 server without ab feature when abTesting is turned off', function () {
+      let id5Config = getId5FetchConfig();
+      id5Config.params.abTesting = { enabled: false, controlGroupPct: 10 }
+
+      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(requestBody.features).to.be.undefined;
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+    });
+
+    it('should call the ID5 server without ab feature when when abTesting is not set', function () {
+      let id5Config = getId5FetchConfig();
+
+      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let requestBody = JSON.parse(request.requestBody);
+      expect(requestBody.features).to.be.undefined;
+
+      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+    });
   });
 
   describe('Request Bids Hook', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
this is so that ID5 can monitor the usage of the a/b testing feature in our module