### PR TITLE
Adloox (adloox.com) RTD provider, analytic and adserver modules

### DIFF
--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Prebid Display/Video Merged Auction with Adloox Integration</title>
+
+        <script async src="http://localhost:9999/build/dev/prebid.js"></script>
+        <!-- <script async src="https://storage.googleapis.com/adloox-ads-js-test/prebid.js"></script> -->
+        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+
+        <script>
+            // set to 10s (rather than 100ms) only to assist development as 'Local Overrides' stalls for >1s :-/
+            var AUCTION_DELAY = 10000;	// recommended to be set to 100 in production
+            var PREBID_TIMEOUT = 1000;
+            var FAILSAFE_TIMEOUT = AUCTION_DELAY + (3 * PREBID_TIMEOUT);
+
+            var div_1_sizes = [ [728, 90] ];
+            var div_2_sizes = [ [300, 250] ];
+            var video_1_size = [ 640, 480 ];
+
+            var adUnits = [
+                {
+                    code: 'div-1',
+                    mediaTypes: {
+                        banner: {
+                            sizes: div_1_sizes
+                        }
+                    },
+                    bids: [
+                        {
+                            bidder: 'rubicon',
+                            params: {
+                                accountId: 14062,
+                                siteId: 70608,
+                                zoneId: 498816
+                            }
+                        }
+                    ]
+                },
+                {
+                    code: 'div-2',
+                    mediaTypes: {
+                        banner: {
+                            sizes: div_2_sizes
+                        }
+                    },
+                    bids: [
+                        {
+                            bidder: 'rubicon',
+                            params: {
+                                accountId: 14062,
+                                siteId: 70608,
+                                zoneId: 498816
+                            }
+                        }
+                    ]
+                }
+            ];
+
+            var videoAdUnit = {
+                code: 'video-1',
+                mediaTypes: {
+                    video: {
+                        context: 'instream',
+                        playerSize: [ 640, 480 ]
+                    }
+                },
+                fpd: {
+                    context: {
+                        pbAdSlot: '/19968336/prebid_cache_video_adunit'
+                    }
+                },
+                bids: [
+                    {
+                        bidder: 'spotx',
+                        params: {
+                            channel_id: 85394,
+                            ad_unit: 'instream'
+                        }
+                    }
+                ]
+            };
+
+            window.googletag = window.googletag || { cmd: [] };
+            googletag.cmd.push(function() {
+                googletag
+                    .defineSlot('/19968336/header-bid-tag-0', div_1_sizes, 'div-1')
+                    .addService(googletag.pubads());
+                googletag
+                    .defineSlot('/19968336/header-bid-tag-1', div_2_sizes, 'div-2')
+                    .addService(googletag.pubads());
+                googletag.pubads().disableInitialLoad();
+                googletag.pubads().enableSingleRequest();
+                googletag.enableServices();
+            });
+
+            var pbjs = pbjs || {};
+            pbjs.que = pbjs.que || [];
+
+            var tempTag = false;
+            var invokeVideoPlayer = function(url) {
+                tempTag = url;
+            };
+
+            function sendAdserverRequest(bids, timedOut, auctionId) {
+                if (pbjs.initAdserverSet) return;
+                pbjs.initAdserverSet = true;
+
+                googletag.cmd.push(function() {
+                    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync(adUnits);
+                    googletag.pubads().refresh();
+                });
+
+                var videoBids = bids[videoAdUnit.code];
+                if (videoBids) {
+                    var videoUrl = videoBids.bids[0].vastUrl;
+//                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+//                        adUnit: videoAdUnit,
+//                        params: {
+//                            iu: '/19968336/prebid_cache_video_adunit',
+//                            cust_params: {
+//                                section: 'blog',
+//                                anotherKey: 'anotherValue'
+//                            },
+//                            output: 'vast'
+//                        }
+//                    });
+                    invokeVideoPlayer(videoUrl);
+                }
+            }
+
+            // optionally wrap with googletag to have gpt-pre-auction
+            // automatically populate Prebid Ad Slot (pbAdSlot)
+            // https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html
+            // alternatively remove wrapping and set AdUnit.fpd.context.pbAdSlot
+            googletag.cmd.push(function() {
+                pbjs.que.push(function() {
+                    pbjs.setConfig({
+                        instreamTracking: {
+                            enabled: true
+                        },
+                        rubicon: {
+                            singleRequest: true
+                        }
+                    });
+                    pbjs.enableAnalytics({
+                        provider: 'adloox',
+                        options: {
+                            client: 'adlooxtest',
+                            clientid: 127,
+                            platformid: 0,
+                            tagid: 0
+                        }
+                    });
+                    pbjs.addAdUnits(adUnits);
+                    pbjs.addAdUnits(videoAdUnit);
+                    pbjs.requestBids({
+                        bidsBackHandler: sendAdserverRequest,
+                        timeout: PREBID_TIMEOUT
+                    })
+                });
+            });
+
+            setTimeout(function() {
+                sendAdserverRequest();
+            }, FAILSAFE_TIMEOUT);
+        </script>
+    </head>
+    <body>
+        <h1>Prebid Display/Video Merged Auction with Adloox Integration</h1>
+
+        <h2>div-1</h2>
+        <div id="div-1">
+            <script>
+                googletag.cmd.push(function() {
+                    googletag.display('div-1');
+                });
+            </script>
+        </div>
+
+        <h2>div-2</h2>
+        <div id="div-2">
+            <script>
+                googletag.cmd.push(function() {
+                    googletag.display('div-2');
+                });
+            </script>
+        </div>
+
+        <h2>video-1</h2>
+        <div id="video-1"></div>
+        <script src="https://content.jwplatform.com/libraries/72xIKEe6.js"></script>
+        <script>
+            var playerInstance = jwplayer('video-1');
+            invokeVideoPlayer = function(url) {
+                playerInstance.setup({
+                    "playlist": "https://content.jwplatform.com/feeds/ae4tmw2D.json",
+                    "width": 640,
+                    "height": 480,
+                    "advertising": {
+                        "client": "vast",
+                        "tag": url
+                    }
+                });
+            };
+            if (tempTag) {
+                invokeVideoPlayer(tempTag);
+                tempTag = false;
+            }
+        </script>
+    </body>
+</html>

--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -112,19 +112,21 @@
 
                 var videoBids = bids[videoAdUnit.code];
                 if (videoBids) {
-                    var videoUrl = videoBids.bids[0].vastUrl;
-//                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-//                        adUnit: videoAdUnit,
-//                        params: {
-//                            iu: '/19968336/prebid_cache_video_adunit',
-//                            cust_params: {
-//                                section: 'blog',
-//                                anotherKey: 'anotherValue'
-//                            },
-//                            output: 'vast'
-//                        }
-//                    });
-                    invokeVideoPlayer(videoUrl);
+                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+                        adUnit: videoAdUnit,
+                        params: {
+                            iu: '/19968336/prebid_cache_video_adunit',
+                            cust_params: {
+                                section: 'blog',
+                                anotherKey: 'anotherValue'
+                            },
+                            output: 'vast'
+                        }
+                    });
+                    pbjs.adServers.adloox.buildVideoUrl({
+                        adUnit: videoAdUnit,
+                        url: videoUrl
+                    }, invokeVideoPlayer);
                 }
             }
 

--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -112,17 +112,18 @@
 
                 var videoBids = bids[videoAdUnit.code];
                 if (videoBids) {
-                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-                        adUnit: videoAdUnit,
-                        params: {
-                            iu: '/19968336/prebid_cache_video_adunit',
-                            cust_params: {
-                                section: 'blog',
-                                anotherKey: 'anotherValue'
-                            },
-                            output: 'vast'
-                        }
-                    });
+                    var videoUrl = videoBids.bids[0].vastUrl;
+//                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+//                        adUnit: videoAdUnit,
+//                        params: {
+//                            iu: '/19968336/prebid_cache_video_adunit',
+//                            cust_params: {
+//                                section: 'blog',
+//                                anotherKey: 'anotherValue'
+//                            },
+//                            output: 'vast'
+//                        }
+//                    });
                     pbjs.adServers.adloox.buildVideoUrl({
                         adUnit: videoAdUnit,
                         url: videoUrl

--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -138,6 +138,14 @@
             googletag.cmd.push(function() {
                 pbjs.que.push(function() {
                     pbjs.setConfig({
+                        realTimeData: {
+                            auctionDelay: AUCTION_DELAY,
+                            dataProviders: [
+                                {
+                                    name: 'adloox'
+                                }
+                            ]
+                        },
                         instreamTracking: {
                             enabled: true
                         },

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -15,7 +15,8 @@ import * as utils from '../src/utils.js';
 
 const MODULE = 'adlooxAdserverVideo';
 
-const URL_VAST = 'https://j.adlooxtracking.com/ads/vast/tag.php';
+// const URL_VAST = 'https://j.adlooxtracking.com/ads/vast/tag.php';
+const URL_VAST = 'https://j.adlooxtracking.com/ads/vast/tag-dev.php';
 
 export function buildVideoUrl(options, callback) {
   utils.logInfo(MODULE, 'buildVideoUrl', options);

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -1,0 +1,214 @@
+/**
+ * This module adds [Adloox]{@link https://www.adloox.com/} Ad Server support for Video to Prebid
+ * @module modules/adlooxAdServerVideo
+ * @requires module:modules/adlooxAnalyticsAdapter
+ */
+
+/* eslint prebid/validate-imports: "warn" */
+
+import { registerVideoSupport } from '../src/adServerManager.js';
+import { command as analyticsCommand, COMMAND } from './adlooxAnalyticsAdapter.js';
+import { ajax } from '../src/ajax.js';
+import { EVENTS } from '../src/constants.json';
+import { targeting } from '../src/targeting.js';
+import * as utils from '../src/utils.js';
+
+const MODULE = 'adlooxAdserverVideo';
+
+const URL_VAST = 'https://j.adlooxtracking.com/ads/vast/tag.php';
+
+export function buildVideoUrl(options, callback) {
+  utils.logInfo(MODULE, 'buildVideoUrl', options);
+
+  if (!utils.isFn(callback)) {
+    utils.logError(MODULE, 'invalid callback');
+    return false;
+  }
+  if (!utils.isPlainObject(options)) {
+    utils.logError(MODULE, 'missing options');
+    return false;
+  }
+  if (!(options.url_vast === undefined || utils.isStr(options.url_vast))) {
+    utils.logError(MODULE, 'invalid url_vast options value');
+    return false;
+  }
+  if (!(utils.isPlainObject(options.adUnit) || utils.isPlainObject(options.bid))) {
+    utils.logError(MODULE, "requires either 'adUnit' or 'bid' options value");
+    return false;
+  }
+  if (!utils.isStr(options.url)) {
+    utils.logError(MODULE, 'invalid url options value');
+    return false;
+  }
+  if (!(options.wrap === undefined || utils.isBoolean(options.wrap))) {
+    utils.logError(MODULE, 'invalid wrap options value');
+    return false;
+  }
+  if (!(options.blob === undefined || utils.isBoolean(options.blob))) {
+    utils.logError(MODULE, 'invalid blob options value');
+    return false;
+  }
+
+  // same logic used in modules/dfpAdServerVideo.js
+  options.bid = options.bid || targeting.getWinningBids(options.adUnit.code)[0];
+
+  utils.deepSetValue(options.bid, 'ext.adloox.video.adserver', true);
+
+  if (options.wrap !== false) {
+    VASTWrapper(options, callback);
+  } else {
+    track(options, callback);
+  }
+
+  return true;
+}
+
+registerVideoSupport('adloox', {
+  buildVideoUrl: buildVideoUrl
+});
+
+function track(options, callback) {
+  callback(options.url);
+
+  const bid = utils.deepClone(options.bid);
+  bid.ext.adloox.video.adserver = false;
+
+  analyticsCommand(COMMAND.TRACK, {
+    eventType: EVENTS.BID_WON,
+    args: bid
+  });
+}
+
+function VASTWrapper(options, callback) {
+  const chain = [];
+
+  function process(result) {
+    function getAd(xml) {
+      if (!xml || xml.documentElement.tagName != 'VAST') {
+        utils.logError(MODULE, 'not a VAST tag, using non-wrapped tracking');
+        return;
+      }
+
+      const ads = xml.querySelectorAll('Ad');
+      if (!ads.length) {
+        utils.logError(MODULE, 'no VAST ads, using non-wrapped tracking');
+        return;
+      }
+
+      // get first Ad (VAST may be an Ad Pod so sort on sequence and pick lowest sequence number)
+      const ad = [...ads].sort(function(a, b) {
+        return parseInt(a.getAttribute('sequence'), 10) - parseInt(b.getAttribute('sequence'), 10);
+      }).shift();
+
+      return ad;
+    }
+
+    function getWrapper(ad) {
+      return ad.querySelector('VASTAdTagURI');
+    }
+
+    function durationToSeconds(duration) {
+      return Date.parse('1970-01-01 ' + duration + 'Z') / 1000;
+    }
+
+    function blobify() {
+      if (!(chain.length && options.blob !== false && utils.isFn(window.URL))) return;
+
+      const urls = [];
+
+      function toBlob(r) {
+        const text = new XMLSerializer().serializeToString(r.xml);
+        const url = URL.createObjectURL(new Blob([text], { type: r.type }));
+        urls.push(url);
+        return url;
+      }
+
+      let n = chain.length - 1; // do not process the linear
+      while (n-- > 0) {
+        const ad = getAd(chain[n].xml);
+        const wrapper = getWrapper(ad);
+        wrapper.textContent = toBlob(chain[n + 1]);
+      }
+
+      options.url = toBlob(chain[0]);
+
+      const epoch = utils.timestamp() - new Date().getTimezoneOffset() * 60 * 1000;
+      const expires0 = options.bid.ttl * 1000 - (epoch - options.bid.responseTimestamp);
+      const expires = Math.max(30 * 1000, expires0);
+      window.setTimeout(function() { urls.forEach(u => URL.revokeObjectURL(u)) }, expires);
+    }
+
+    if (!result) {
+      blobify();
+      return track(options, callback);
+    }
+
+    const ad = getAd(result.xml);
+    if (!ad) {
+      blobify();
+      return track(options, callback);
+    }
+
+    chain.push(result);
+
+    const wrapper = getWrapper(ad);
+    if (wrapper) return fetch(wrapper.textContent.trim());
+
+    blobify();
+
+    const version = chain[0].xml.documentElement.getAttribute('version');
+
+    const vpaid = ad.querySelector("MediaFiles > MediaFile[apiFramework='VPAID'][type='application/javascript']");
+
+    const duration = durationToSeconds(ad.querySelector('Duration').textContent.trim());
+
+    let skip = null;
+    const skipd = ad.querySelector('Linear').getAttribute('skipoffset');
+    if (skipd) skip = durationToSeconds(skipd.trim());
+
+    const args = [
+      [ 'client', '%%client%%' ],
+      [ 'platform_id', '%%platformid%%' ],
+      [ 'scriptname', 'adl_%%clientid%%' ],
+      [ 'tag_id', '%%tagid%%' ],
+      [ 'fwtype', 4 ],
+      [ 'vast', options.url ],
+      [ 'id11', 'video' ],
+      [ 'id12', '$ADLOOX_WEBSITE' ],
+      [ 'id18', (!skip || skip >= duration) ? 'fd' : 'od' ],
+      [ 'id19', 'na' ],
+      [ 'id20', 'na' ]
+    ];
+    if (version && version != 3) args.push([ 'version', version ]);
+    if (vpaid) args.push([ 'vpaid', 1 ]);
+    if (duration != 15) args.push([ 'duration', duration ]);
+    if (skip) args.push([ 'skip', skip ]);
+
+    analyticsCommand(COMMAND.URL, {
+      url: (options.url_vast || URL_VAST) + '?',
+      args: args,
+      bid: options.bid,
+      ids: true
+    }, callback);
+  }
+
+  function fetch(url, withoutcredentials) {
+    utils.logInfo(MODULE, `fetching VAST ${url}`);
+
+    ajax(url, {
+      success: function(responseText, q) {
+        process({ type: q.getResponseHeader('content-type'), xml: q.responseXML });
+      },
+      error: function(statusText, q) {
+        if (!withoutcredentials) {
+          utils.logWarn(MODULE, `unable to download (${statusText}), suspected CORS withCredentials problem, retrying without`);
+          return fetch(url, true);
+        }
+        utils.logError(MODULE, `failed to fetch (${statusText}), using non-wrapped tracking`);
+        process();
+      }
+    }, null, { withCredentials: !withoutcredentials });
+  }
+
+  fetch(options.url);
+}

--- a/modules/adlooxAdServerVideo.md
+++ b/modules/adlooxAdServerVideo.md
@@ -1,0 +1,92 @@
+# Overview
+
+    Module Name: Adloox Ad Server Video
+    Module Type: Ad Server Video
+    Maintainer: technique@adloox.com
+
+# Description
+
+Ad Server Video for adloox.com. Contact adops@adloox.com for information.
+
+This module pairs with the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) to provide video tracking and measurement.
+
+Prebid.js does not support [`bidWon` events for video](https://github.com/prebid/prebid.github.io/issues/1320) without the [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html) module that has the limitations:
+
+ * works only with instream video
+ * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+
+This module has two modes of operation configurable with the `wrap` parameter below:
+
+ * **`true` [default]:**
+     * provides MRC accredited viewability measurement of your [IAB](https://www.iab.com/) [VPAID](https://iabtechlab.com/standards/video-player-ad-interface-definition-vpaid/) and [OM SDK](https://iabtechlab.com/standards/open-measurement-sdk/) enabled inventory
+     * VAST tracking is collected by Adloox
+     * wraps the winning bid VAST URL with the Adloox VAST/VPAID wrapper (`https://j.adlooxtracking.com/ads/vast/tag-dev.php?...`)
+ * **`false`:**
+     * sends a `bidWon` event *only* to the Adloox Analytics Adapter
+     * inventory is measured
+     * viewability metrics are *not* MRC accredited.
+     * VAST tracking is *not* collected by Adloox
+
+**N.B.** this module is compatible for use alongside the Instream Video Ads Tracking module though not required in order to function
+
+## Example
+
+To view an example of an Adloox integration look at the example provided in the [Adloox Analytics Adapter documentation](./adlooxAnalyticsAdapter.md#example).
+
+# Integration
+
+To use this, you *must* also integrate the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) (and optionally the Instream Video Ads Tracking module) as shown below:
+
+    function sendAdserverRequest(bids, timedOut, auctionId) {
+      if (pbjs.initAdserverSet) return;
+      pbjs.initAdserverSet = true;
+
+      // handle display tags as usual
+      googletag.cmd.push(function() {
+        pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync(adUnits);
+        googletag.pubads().refresh();
+      });
+
+      // handle the bids on the video adUnit
+      var videoBids = bids[videoAdUnit.code];
+      if (videoBids) {
+        var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+          adUnit: videoAdUnit,
+          params: {
+            iu: '/19968336/prebid_cache_video_adunit',
+            cust_params: {
+              section: 'blog',
+              anotherKey: 'anotherValue'
+            },
+            output: 'vast'
+          }
+        });
+        pbjs.adServers.adloox.buildVideoUrl({
+          adUnit: videoAdUnit,
+          url: videoUrl
+        }, invokeVideoPlayer);
+      }
+    }
+
+The helper function takes the form:
+
+    pbjs.adServers.adloox.buildVideoUrl(options, callback)
+
+Where:
+
+ * **`options`:** configuration object:
+     * **`adUnit`:** ad unit that is being filled
+     * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.dfp.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
+     * **`url`:** VAST tag URL, typically the value returned by `pbjs.adServers.dfp.buildVideoUrl(...)`
+     * **`wrap`:**
+         * **`true` [default]:** VAST tag is be converted to an Adloox VAST wrapped tag
+         * **`false`:** VAST tag URL is returned as is
+     * **`blob`:**
+         * **`true` [default]:** [Blob URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) is returned so that the VAST tag is only fetched once
+             * only has an affect when `wrap` is set to `true`
+         * **`false`:** VAST tag may be fetched twice depending on your Ad Server and video player configuration
+             * use when the ad is served into a cross-origin (non-friendly) IFRAME
+             * use if during QAing you discover your video player does not supports Blob URLs; widely supported (including JW Player) so contact your player vendor to resolve this where possible for the best user and device experience
+ * **`callback`:** function you use to pass the VAST tag URL to your video player
+
+**N.B.** call `pbjs.adServers.adloox.buildVideoUrl(...)` as close as possible to starting the ad to reduce impression discrepancies

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -210,6 +210,11 @@ analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
 }
 
 analyticsAdapter[`handle_${EVENTS.BID_WON}`] = function(bid) {
+  if (utils.deepAccess(bid, 'ext.adloox.video.adserver')) {
+    utils.logMessage(MODULE, `measuring '${bid.mediaType}' ad unit code '${bid.adUnitCode}' via Ad Server module`);
+    return;
+  }
+
   const sl = analyticsAdapter.context.toselector(bid);
   let el;
   try {

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -1,0 +1,289 @@
+/**
+ * This module provides [Adloox]{@link https://www.adloox.com/} Analytics
+ * The module will inject Adloox's verification JS tag alongside slot at bidWin
+ * @module modules/adlooxAnalyticsAdapter
+ */
+
+import adapterManager from '../src/adapterManager.js';
+import adapter from '../src/AnalyticsAdapter.js';
+import { auctionManager } from '../src/auctionManager.js';
+import { AUCTION_COMPLETED } from '../src/auction.js';
+import { EVENTS } from '../src/constants.json';
+import find from 'core-js-pure/features/array/find.js';
+import * as utils from '../src/utils.js';
+
+const MODULE = 'adlooxAnalyticsAdapter';
+
+const URL_JS = 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js';
+
+const ADLOOX_VENDOR_ID = 93;
+
+const ADLOOX_MEDIATYPE = {
+  DISPLAY: 2,
+  VIDEO: 6
+};
+
+const MACRO = {};
+MACRO['client'] = function(b, c) {
+  return c.client;
+};
+MACRO['clientid'] = function(b, c) {
+  return c.clientid;
+};
+MACRO['tagid'] = function(b, c) {
+  return c.tagid;
+};
+MACRO['platformid'] = function(b, c) {
+  return c.platformid;
+};
+MACRO['targetelt'] = function(b, c) {
+  return c.toselector(b);
+};
+MACRO['creatype'] = function(b, c) {
+  return b.mediaType == 'video' ? ADLOOX_MEDIATYPE.VIDEO : ADLOOX_MEDIATYPE.DISPLAY;
+};
+MACRO['pbAdSlot'] = function(b, c) {
+  const adUnit = find(auctionManager.getAdUnits(), a => b.adUnitCode === a.code);
+  return utils.deepAccess(adUnit, 'fpd.context.pbAdSlot') || utils.getGptSlotInfoForAdUnitCode(b.adUnitCode).gptSlot || b.adUnitCode;
+};
+
+const PARAMS_DEFAULT = {
+  'id1': function(b) { return b.adUnitCode },
+  'id2': '%%pbAdSlot%%',
+  'id3': function(b) { return b.bidder },
+  'id4': function(b) { return b.adId },
+  'id5': function(b) { return b.dealId },
+  'id6': function(b) { return b.creativeId },
+  'id7': function(b) { return b.size },
+  'id11': '$ADLOOX_WEBSITE'
+};
+
+const NOOP = function() {};
+
+let analyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoint' }), {
+  track({ eventType, args }) {
+    if (!analyticsAdapter[`handle_${eventType}`]) return;
+
+    utils.logInfo(MODULE, 'track', eventType, args);
+
+    analyticsAdapter[`handle_${eventType}`](args);
+  }
+});
+
+analyticsAdapter.context = null;
+
+analyticsAdapter.originEnableAnalytics = analyticsAdapter.enableAnalytics;
+analyticsAdapter.enableAnalytics = function(config) {
+  analyticsAdapter.context = null;
+
+  utils.logInfo(MODULE, 'config', config);
+
+  if (!utils.isPlainObject(config.options)) {
+    utils.logError(MODULE, 'missing options');
+    return;
+  }
+  if (!(config.options.js === undefined || utils.isStr(config.options.js))) {
+    utils.logError(MODULE, 'invalid js options value');
+    return;
+  }
+  if (!(config.options.toselector === undefined || utils.isFn(config.options.toselector))) {
+    utils.logError(MODULE, 'invalid toselector options value');
+    return;
+  }
+  if (!utils.isStr(config.options.client)) {
+    utils.logError(MODULE, 'invalid client options value');
+    return;
+  }
+  if (!utils.isNumber(config.options.clientid)) {
+    utils.logError(MODULE, 'invalid clientid options value');
+    return;
+  }
+  if (!utils.isNumber(config.options.tagid)) {
+    utils.logError(MODULE, 'invalid tagid options value');
+    return;
+  }
+  if (!utils.isNumber(config.options.platformid)) {
+    utils.logError(MODULE, 'invalid platformid options value');
+    return;
+  }
+  if (!(config.options.params === undefined || utils.isPlainObject(config.options.params))) {
+    utils.logError(MODULE, 'invalid params options value');
+    return;
+  }
+
+  analyticsAdapter.context = {
+    js: config.options.js || URL_JS,
+    toselector: config.options.toselector || function(bid) {
+      let code = utils.getGptSlotInfoForAdUnitCode(bid.adUnitCode).divId || bid.adUnitCode;
+      // https://mathiasbynens.be/notes/css-escapes
+      code = code.replace(/^\d/, '\\3$& ');
+      return `#${code}`
+    },
+    client: config.options.client,
+    clientid: config.options.clientid,
+    tagid: config.options.tagid,
+    platformid: config.options.platformid,
+    params: []
+  };
+
+  config.options.params = utils.mergeDeep({}, PARAMS_DEFAULT, config.options.params || {});
+  Object
+    .keys(config.options.params)
+    .forEach(k => {
+      if (!Array.isArray(config.options.params[k])) {
+        config.options.params[k] = [ config.options.params[k] ];
+      }
+      config.options.params[k].forEach(v => analyticsAdapter.context.params.push([ k, v ]));
+    });
+
+  Object.keys(COMMAND_QUEUE).forEach(commandProcess);
+
+  analyticsAdapter.originEnableAnalytics(config);
+}
+
+analyticsAdapter.originDisableAnalytics = analyticsAdapter.disableAnalytics;
+analyticsAdapter.disableAnalytics = function() {
+  analyticsAdapter.context = null;
+
+  analyticsAdapter.originDisableAnalytics();
+}
+
+analyticsAdapter.url = function(url, args, bid) {
+  // utils.formatQS outputs PHP encoded querystrings... (╯°□°)╯ ┻━┻
+  function a2qs(a) {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+    function fixedEncodeURIComponent(str) {
+      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+        return '%' + c.charCodeAt(0).toString(16);
+      });
+    }
+
+    const args = [];
+    let n = a.length;
+    while (n-- > 0) {
+      if (!(a[n][1] === undefined || a[n][1] === null || a[n][1] === false)) {
+        args.unshift(fixedEncodeURIComponent(a[n][0]) + (a[n][1] !== true ? ('=' + fixedEncodeURIComponent(a[n][1])) : ''));
+      }
+    }
+
+    return args.join('&');
+  }
+
+  const macros = (str) => {
+    return str.replace(/%%([a-z]+)%%/gi, (match, p1) => MACRO[p1] ? MACRO[p1](bid, analyticsAdapter.context) : match);
+  };
+
+  url = macros(url);
+  args = args || [];
+
+  let n = args.length;
+  while (n-- > 0) {
+    if (utils.isFn(args[n][1])) {
+      try {
+        args[n][1] = args[n][1](bid);
+      } catch (_) {
+        utils.logError(MODULE, 'macro', args[n][0], _.message);
+        args[n][1] = `ERROR: ${_.message}`;
+      }
+    }
+    if (utils.isStr(args[n][1])) {
+      args[n][1] = macros(args[n][1]);
+    }
+  }
+
+  return url + a2qs(args);
+}
+
+analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
+  if (!(auctionDetails.auctionStatus == AUCTION_COMPLETED && auctionDetails.bidsReceived.length > 0)) return;
+  analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = NOOP;
+
+  utils.logMessage(MODULE, 'preloading verification JS');
+
+  const uri = utils.parseUrl(analyticsAdapter.url(`${analyticsAdapter.context.js}#`));
+
+  const link = document.createElement('link');
+  link.setAttribute('href', `${uri.protocol}://${uri.host}${uri.pathname}`);
+  link.setAttribute('rel', 'preload');
+  link.setAttribute('as', 'script');
+  utils.insertElement(link);
+}
+
+analyticsAdapter[`handle_${EVENTS.BID_WON}`] = function(bid) {
+  const sl = analyticsAdapter.context.toselector(bid);
+  let el;
+  try {
+    el = document.querySelector(sl);
+  } catch (_) { }
+  if (!el) {
+    utils.logWarn(MODULE, `unable to find ad unit code '${bid.adUnitCode}' slot using selector '${sl}' (use options.toselector to change), ignoring`);
+    return;
+  }
+
+  utils.logMessage(MODULE, `measuring '${bid.mediaType}' unit at '${bid.adUnitCode}'`);
+
+  const params = analyticsAdapter.context.params.concat([
+    [ 'tagid', '%%tagid%%' ],
+    [ 'platform', '%%platformid%%' ],
+    [ 'fwtype', 4 ],
+    [ 'targetelt', '%%targetelt%%' ],
+    [ 'creatype', '%%creatype%%' ]
+  ]);
+
+  const s = document.createElement('script');
+  s.src = analyticsAdapter.url(`${analyticsAdapter.context.js}#`, params, bid);
+  el.parentNode.insertBefore(s, el.nextSibling);
+}
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: analyticsAdapter,
+  code: 'adloox',
+  gvlid: ADLOOX_VENDOR_ID
+});
+
+export default analyticsAdapter;
+
+// src/events.js does not support custom events or handle races... (╯°□°)╯ ┻━┻
+const COMMAND_QUEUE = {};
+export const COMMAND = {
+  CONFIG: 'config',
+  URL: 'url',
+  TRACK: 'track'
+};
+export function command(cmd, data, callback0) {
+  const cid = utils.getUniqueIdentifierStr();
+  const callback = function() {
+    delete COMMAND_QUEUE[cid];
+    if (callback0) callback0.apply(null, arguments);
+  };
+  COMMAND_QUEUE[cid] = { cmd, data, callback };
+  if (analyticsAdapter.context) commandProcess(cid);
+}
+function commandProcess(cid) {
+  const { cmd, data, callback } = COMMAND_QUEUE[cid];
+
+  utils.logInfo(MODULE, 'command', cmd, data);
+
+  switch (cmd) {
+    case COMMAND.CONFIG:
+      const response = {
+        client: analyticsAdapter.context.client,
+        clientid: analyticsAdapter.context.clientid,
+        tagid: analyticsAdapter.context.tagid,
+        platformid: analyticsAdapter.context.platformid
+      };
+      callback(response);
+      break;
+    case COMMAND.URL:
+      if (data.ids) data.args = data.args.concat(analyticsAdapter.context.params.filter(p => /^id([1-9]|10)$/.test(p[0]))); // not >10
+      callback(analyticsAdapter.url(data.url, data.args, data.bid));
+      break;
+    case COMMAND.TRACK:
+      analyticsAdapter.track(data);
+      callback(); // drain queue
+      break;
+    default:
+      utils.logWarn(MODULE, 'command unknown', cmd);
+      // do not callback as arguments are unknown and to aid debugging
+  }
+}

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -18,17 +18,23 @@ The adapter adds an HTML `<script>` tag to load Adloox's post-buy verification J
 
 ## Video
 
-When tracking video you will need to enable the [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html) module but be aware that it is:
+When tracking video you have two options:
 
- * only suitable for instream video bids
- * VAST events are not collected by Adloox
- * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+ * [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html)
+     * only suitable for instream video bids
+     * VAST events are not collected by Adloox
+     * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+ * [Adloox Ad Server Video](./adlooxAdServerVideo.md)
+     * works by by wrapping the Ad Server VAST URL
+     * viewability metrics are MRC accredited for [IAB](https://www.iab.com/) [VPAID](https://iabtechlab.com/standards/video-player-ad-interface-definition-vpaid/) and [OM SDK](https://iabtechlab.com/standards/open-measurement-sdk/) enable inventory
+     * compatible for use alongside the Instream Video Ads Tracking module though not required in order to function
+     * slightly more complicated though straight forward to implement
 
 ## Example
 
 To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
 
-    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo
 
 **N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
 
@@ -55,7 +61,7 @@ You should be able to use this during the QA process of your own internal testin
 The main Prebid.js documentation is a bit opaque on this but you can use the following to test only Adloox's modules:
 
     gulp lint
-    gulp test-coverage --file test/spec/modules/adlooxAnalyticsAdapter_spec.js
+    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo}_spec.js'
     gulp view-coverage
 
 # Integration

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -34,7 +34,7 @@ When tracking video you have two options:
 
 To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
 
-    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,rtdModule,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo,adlooxRtdProvider
 
 **N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
 
@@ -43,6 +43,8 @@ Now point your browser at: http://localhost:9999/integrationExamples/gpt/adloox.
 ### Public Example
 
 The example is published publically at: https://storage.googleapis.com/adloox-ads-js-test/prebid.html?pbjs_debug=true
+
+**N.B.** this will show a [CORS error](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors) for the request `https://p.adlooxtracking.com/q?...` that is safe to ignore on the public example page; it is related to the [RTD integration](./adlooxRtdProvider.md) which requires pre-registration of your sites
 
 It is recommended you use [Google Chrome's 'Local Overrides' located in the Developer Tools panel](https://www.trysmudford.com/blog/chrome-local-overrides/) to explore the example without the inconvience of having to run your own web server.
 
@@ -61,7 +63,7 @@ You should be able to use this during the QA process of your own internal testin
 The main Prebid.js documentation is a bit opaque on this but you can use the following to test only Adloox's modules:
 
     gulp lint
-    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo}_spec.js'
+    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo,RtdProvider}_spec.js'
     gulp view-coverage
 
 # Integration
@@ -103,8 +105,8 @@ For example, you have a number of reporting breakdown slots available in the for
         platformid: 0,
         tagid: 0,
         params: {
-          id1: function(b) { return b.adUnitCode },
-          id2: '%%pbAdSlot%%',
+          id1: function(b) { return b.adUnitCode },  // do not change when using the Adloox RTD Provider
+          id2: '%%pbAdSlot%%',                       // do not change when using the Adloox RTD Provider
           id3: function(b) { return b.bidder },
           id4: function(b) { return b.adId },
           id5: function(b) { return b.dealId },
@@ -124,6 +126,7 @@ For example, you have a number of reporting breakdown slots available in the for
 The following macros are available
 
  * `%%pbAdSlot%%`: [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html) if set, otherwise returns [`AdUnit.code`](https://docs.prebid.org/dev-docs/adunit-reference.html)
+     * it is recommended you read the [Prebid Ad Slot section in the Adloox RTD Provider documentation](./adlooxRtdProvider.md#prebid-ad-slot)
 
 ### Functions
 

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -1,0 +1,146 @@
+# Overview
+
+    Module Name: Adloox Analytics Adapter
+    Module Type: Analytics Adapter
+    Maintainer: technique@adloox.com
+
+# Description
+
+Analytics adapter for adloox.com. Contact adops@adloox.com for information.
+
+This module can be used to track:
+
+ * Display
+ * Native
+ * Video (see below for further instructions)
+
+The adapter adds an HTML `<script>` tag to load Adloox's post-buy verification JavaScript (`https://j.adlooxtracking.com/ads/js/tfav_adl_X.js` at ~25kiB gzipped) when the [`bidWon` event](https://docs.prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.onEvent) is fired and placed immediately after the ad slot in the DOM.
+
+## Video
+
+When tracking video you will need to enable the [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html) module but be aware that it is:
+
+ * only suitable for instream video bids
+ * VAST events are not collected by Adloox
+ * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+
+## Example
+
+To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
+
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter
+
+**N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
+
+Now point your browser at: http://localhost:9999/integrationExamples/gpt/adloox.html?pbjs_debug=true
+
+### Public Example
+
+The example is published publically at: https://storage.googleapis.com/adloox-ads-js-test/prebid.html?pbjs_debug=true
+
+It is recommended you use [Google Chrome's 'Local Overrides' located in the Developer Tools panel](https://www.trysmudford.com/blog/chrome-local-overrides/) to explore the example without the inconvience of having to run your own web server.
+
+#### Pre-built `prebid.js`
+
+If you are unable to build code on your system, then you may wish to experiment with a full (all modules enabled) version of the `prebid.js` script with the above three Adloox modules included published at:
+
+    https://storage.googleapis.com/adloox-ads-js-test/prebid.js
+
+You should be able to use this during the QA process of your own internal testing sites.
+
+**N.B.** do *not* use this link or the code at it in production
+
+### Testing
+
+The main Prebid.js documentation is a bit opaque on this but you can use the following to test only Adloox's modules:
+
+    gulp lint
+    gulp test-coverage --file test/spec/modules/adlooxAnalyticsAdapter_spec.js
+    gulp view-coverage
+
+# Integration
+
+    pbjs.enableAnalytics({
+      provider: 'adloox',
+      options: {
+        //toselector: function(bid) { return '#' + bid.adUnitCode },
+        client: 'adlooxtest',
+        clientid: 127,
+        platformid: 0,
+        tagid: 0
+      }
+    });
+
+The options `client`, `clientid`, `platformid` and `tagid` are supplied by Adloox to you and *must* be provided in the configuration.
+
+### `toselector` Option
+
+For non-GPT integrations, the module expects the value of `adUnitCode` from the [bid object](https://docs.prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.getBidResponses) to match the div ID of the unit to facilitate measurements made against it.
+
+**N.B.** for GPT integrations the div ID is automatically discovered and you should *not* use this option
+
+When not true for your environment (you will see a warning stating 'unable to find ad unit code') you should provide a function through the option `toselector` that when passed the bid object it returns the [selector](https://www.javascripttutorial.net/javascript-dom/javascript-queryselector/) for the slot; internally the module will pass this value to [`document.querySelector()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) to obtain the actual slot.
+
+By example, the default handler used for `options.toselector` when not supplied is shown above though internally some [basic escaping](https://mathiasbynens.be/notes/css-escapes) is applied but omitted here for reasons of clarity; your own handler will need to provide its own escaping where necessary.
+
+## Parameters
+
+The Adloox 'Impression JavaScript Tag Integration Guidelines' provide details on parameters (for the `params` block) you can pass that configure the Adloox verification JavaScript for your inventory.
+
+For example, you have a number of reporting breakdown slots available in the form of `id{1->10}` that are configurable with:
+
+    pbjs.enableAnalytics({
+      provider: 'adloox',
+      options: {
+        client: 'adlooxtest',
+        clientid: 127,
+        platformid: 0,
+        tagid: 0,
+        params: {
+          id1: function(b) { return b.adUnitCode },
+          id2: '%%pbAdSlot%%',
+          id3: function(b) { return b.bidder },
+          id4: function(b) { return b.adId },
+          id5: function(b) { return b.dealId },
+          id6: function(b) { return b.creativeId },
+          id7: function(b) { return b.size },
+          id11: '$ADLOOX_WEBSITE'                    // do not change, Adloox internal use only
+        }
+      }
+    });
+
+**N.B.** `params` shown above is the default and may be omitted altogether if you wish to make no changes
+
+**N.B.** values that return `false`, `null`, or `undefined` are not sent whilst values of `true` return just the key
+
+### Macros
+
+The following macros are available
+
+ * `%%pbAdSlot%%`: [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html) if set, otherwise returns [`AdUnit.code`](https://docs.prebid.org/dev-docs/adunit-reference.html)
+
+### Functions
+
+You may also supply a function to dynamically generate the value of the parameter from the bid response; the function is passed a single argument that corresponds to the [BidResponse](https://docs.prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.getBidResponses) object seen at the `bidWon` event.
+
+You can look to the default `params` section above for examples of how to use this.
+
+If your function throws an exception, it will be caught and the value set (and observable in Adloox's reporting) to:
+
+    ERROR: <Error>
+
+Where `<Error>` is the value from [`Error.prototype.message`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message).
+
+### Multi-value
+
+Some parameters, such as `px_imp` and `bridge`, can take multiple values and can be described by providing an array:
+
+    params: {
+      ...
+      px_imp: [
+        'https://example.com/some/third/party/pixel.gif',
+        'https://example.net/other/third/party/pixel.png',
+        function(b){ return 'https://example.org/' + b.bidder + '/pixel.jpg' }
+      ],
+      ...
+    }

--- a/modules/adlooxRtdProvider.js
+++ b/modules/adlooxRtdProvider.js
@@ -1,0 +1,171 @@
+/**
+ * This module adds the Adloox provider to the real time data module
+ * This module adds the [Adloox]{@link https://www.adloox.com/} provider to the real time data module
+ * The {@link module:modules/realTimeData} module is required
+ * The module will inject Adloox's prebid API JS
+ * The module will fetch segments from Adloox's server
+ * @module modules/adlooxRtdProvider
+ * @requires module:modules/realTimeData
+ * @requires module:modules/adlooxAnalyticsAdapter
+ */
+
+/* eslint prebid/validate-imports: "warn" */
+
+import { command as analyticsCommand, COMMAND } from './adlooxAnalyticsAdapter.js';
+import { config as _config } from '../src/config.js';
+import { submodule } from '../src/hook.js';
+import includes from 'core-js-pure/features/array/includes.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import * as utils from '../src/utils.js';
+
+const MODULE = 'adlooxRtdProvider';
+
+let CONFIGURED = false;
+
+const URL_JS = 'https://p.adlooxtracking.com/gpt/a.js';
+
+function init(config, userConsent) {
+  utils.logInfo(MODULE, 'init', config, userConsent);
+
+  if (!utils.isPlainObject(config)) {
+    utils.logError(MODULE, 'missing config');
+    return false;
+  }
+  if (config.params === undefined) config.params = {};
+  if (!(utils.isPlainObject(config.params))) {
+    utils.logError(MODULE, 'invalid params');
+    return false;
+  }
+  if (!(config.params.js === undefined || utils.isStr(config.params.js))) {
+    utils.logError(MODULE, 'invalid js params value');
+    return false;
+  }
+  // legacy/deprecated configuration code path
+  if (config.params.params === undefined) {
+    config.params.params = {};
+  } else if (!utils.isPlainObject(config.params.params) || !(utils.isInteger(config.params.params.clientid) && utils.isInteger(config.params.params.tagid) && utils.isInteger(config.params.params.platformid))) {
+    utils.logError(MODULE, 'invalid subsection params block');
+    return false;
+  }
+
+  window.adloox_pubint = window.adloox_pubint || { cmd: [] };
+
+  const script = document.createElement('script');
+  script.src = config.params.js || URL_JS;
+  utils.insertElement(script);
+
+  function analyticsConfigCallback(data) {
+    CONFIGURED = true;
+
+    const params = utils.mergeDeep({}, config.params.params, data);
+
+    window.adloox_pubint.cmd.push(function() {
+      window.adloox_pubint.init(params);
+    });
+  }
+  if (Object.keys(config.params.params).length) {
+    utils.logWarn(MODULE, 'legacy/deprecated configuration (please migrate to adlooxAnalyticsAdapter)');
+    analyticsConfigCallback({});
+  } else {
+    analyticsCommand(COMMAND.CONFIG, null, analyticsConfigCallback);
+  }
+
+  return true;
+}
+
+function getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
+  if (!CONFIGURED) {
+    utils.logError(MODULE, 'getBidRequestData', 'called before configured, is analytics enabled?');
+    return;
+  }
+
+  utils.logInfo(MODULE, 'getBidRequestData', reqBidsConfigObj, callback, config, userConsent);
+
+  const context = {
+    set: function(n, x) {
+      utils.logInfo(MODULE, 'segment', 'context', n, x);
+      const data = _config.getConfig('fpd.context.data') || {};
+      delete data[n];
+      if (x !== undefined) data[n] = x;
+      _config.setConfig({ fpd: { context: { data: data } } });
+    }
+  };
+  const user = {
+    set: function(n, x) {
+      utils.logInfo(MODULE, 'segment', 'user', n, x);
+      const data = _config.getConfig('fpd.user.data') || {};
+      delete data[n];
+      if (x !== undefined) data[n] = x;
+      _config.setConfig({ fpd: { user: { data: data } } });
+    }
+  };
+  const slots = (reqBidsConfigObj.adUnits || getGlobal().adUnits).map(adUnit => {
+    return {
+      id: adUnit.code,
+      // modules/gptPreAuction.js does not update the AdUnits themselves... (╯°□°)╯ ┻━┻
+      name: utils.deepAccess(adUnit, 'fpd.context.pbAdSlot') || utils.getGptSlotInfoForAdUnitCode(adUnit.code).gptSlot || adUnit.code,
+      set: function(n, x) {
+        utils.logInfo(MODULE, 'segment', 'slot', adUnit.code, n, x);
+        const data = utils.deepAccess(adUnit, 'fpd.context.data', {});
+        delete data[n];
+        if (x !== undefined) data[n] = x;
+        utils.deepSetValue(adUnit, 'fpd.context.data', data);
+      }
+    };
+  });
+
+  window.adloox_pubint.cmd.push(function() {
+    window.adloox_pubint.seg(context, user, slots, callback);
+  });
+}
+
+function getTargetingData(adUnitArray, config, userConsent) {
+  utils.logInfo(MODULE, 'getTargetingData', adUnitArray, config, userConsent);
+
+  function add(pairs, dest) {
+    // targeting:getTargetingValues expects strings or arrays
+    Object.keys(pairs).filter(key => /^adl_/.test(key)).forEach(k => {
+      let v = pairs[k];
+      switch (true) {
+        case utils.isBoolean(v):
+          if (!v) break;
+          v = 1;
+        // falls through
+        case utils.isNumber(v):
+          if (!v) break;
+          v = v.toString();
+        // falls through
+        case utils.isStr(v):
+          if (!v.length) break;
+          v = [ v ];
+        // falls through
+        case utils.isArray(v):
+          let i = v.length;
+          if (!i) break;
+          while (i-- > 0) v[i] = v[i].toString();
+          dest[k] = v;
+        // falls through
+      }
+    });
+  }
+
+  const data0 = {};
+  add(_config.getConfig('fpd.context.data') || {}, data0);
+  add(_config.getConfig('fpd.user.data') || {}, data0);
+
+  return getGlobal().adUnits.filter(adUnit => includes(adUnitArray, adUnit.code)).reduce((data, adUnit) => {
+    data[adUnit.code] = utils.deepClone(data0);
+    const fpdContextData = utils.deepAccess(adUnit, 'fpd.context.data', {});
+    add(fpdContextData, data[adUnit.code]);
+    return data;
+  }, {});
+}
+
+export const subModuleObj = {
+  name: 'adloox',
+  init: init,
+  getBidRequestData: getBidRequestData,
+  getTargetingData: getTargetingData
+};
+
+submodule('realTimeData', subModuleObj);

--- a/modules/adlooxRtdProvider.md
+++ b/modules/adlooxRtdProvider.md
@@ -1,0 +1,85 @@
+# Overview
+
+    Module Name: Adloox RTD Provider
+    Module Type: RTD Provider
+    Maintainer: technique@adloox.com
+
+# Description
+
+RTD provider for adloox.com. Contact adops@adloox.com for information.
+
+In addition to populating the ad server key-value targeting, fetched segments (prefixed with `adl_...`) will also populate [First Party Data](https://docs.prebid.org/features/firstPartyData.html), some examples of the segments as described by the Adloox 'Google Publisher Tag Targeting Guidelines' and where they are placed are:
+
+ * Page/Device segments are placed into `fpd.context.data`, for example:
+     * **`adl_ivt`:** `fpd.context.data.adl_ivt` is a boolean
+     * **`adl_ua_old`:** `fpd.context.data.ua_old` is a boolean
+     * **`adl_ip`:** `fpd.context.data.adl_ip` is an array of strings
+ * AdUnit segments are placed into `AdUnit.fpd.context.data`, for example:
+     * **`adl_{dis,vid,aud}`:** `AdUnit.fpd.context.data.adl_{dis,vid,aud}` is an array of integers
+     * **`adl_atf`:** `AdUnit.fpd.context.data.adl_atf` is a boolean (or `-1` on no measure)
+
+**N.B.** this provider does not offer or utilise any user orientated data
+
+This module adds an HTML `<script>` tag to the page to fetch our JavaScript from `https://p.adlooxtracking.com/gpt/a.js` (~3kiB gzipped) to support this integration.
+
+## Example
+
+To view an example of an Adloox integration look at the example provided in the [Adloox Analytics Adapter documentation](./adlooxAnalyticsAdapter.md#example).
+
+# Integration
+
+To use this, you *must* also integrate the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) as shown below:
+
+    pbjs.setConfig({
+      ...
+
+      realTimeData: {
+        auctionDelay: 100,             // see below for guidance
+        dataProviders: [
+          {
+            name: 'adloox',
+            params: {
+              params: {                // optional
+                thresholds: [ 50, 80 ]
+              }
+            }
+          }
+        ]
+      },
+
+      ...
+    });
+    pbjs.enableAnalytics({
+      provider: 'adloox',
+      options: {
+        client: 'adlooxtest',
+        clientid: 127,
+        platformid: 0,
+        tagid: 0
+      }
+    });
+
+You may optionally pass a subsection `params` in the `params` block to the Adloox RTD Provider, these will be passed through to the segment handler as is and as described by the integration guidelines.
+
+**N.B.** If you pass `params` to the Adloox Analytics Adapter, `id1` (`AdUnit.code`) and `id2` (`%%pbAdSlot%%`) *must* describe a stable identifier otherwise no usable segments will be served and so they *must not* be changed; if `id1` for your inventory could contain a non-stable random number please consult with us before continuing
+
+Though our segment technology is fast (less than 10ms) the time it takes for the users device to connect to our service and fetch the segments may not be. For this reason we recommend setting `auctionDelay` no lower than 100ms and if possible you should explore using user-agent sourced information such as [NetworkInformation.{rtt,downlink,...}](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation) to dynamically tune this for each user.
+
+## Prebid Ad Slot
+
+To create reliable segments, a stable description for slots on your inventory needs to be supplied which is typically solved by using the [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html).
+
+You may use one of two ways to do achieve this:
+
+ * for display inventory [using GPT](https://developers.google.com/publisher-tag/guides/get-started) you may configure Prebid.js to automatically use the [full ad unit path](https://developers.google.com/publisher-tag/reference#googletag.Slot_getAdUnitPath)
+     1. include the [`gptPreAuction` module](https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html)
+     1. wrap both `pbjs.setConfig({...})` and `pbjs.enableAnalytics({...})` with `googletag.cmd.push(function() { ... })`
+ * set `pbAdSlot` in the [first party data](https://docs.prebid.org/dev-docs/adunit-reference.html#first-party-data) variable `AdUnit.fpd.context.pbAdSlot` for all your ad units
+
+## Timeouts
+
+It is strongly recommended you increase any [failsafe timeout](https://docs.prebid.org/dev-docs/faq.html#when-starting-out-what-should-my-timeouts-be) you use by at least the value you supply to `auctionDelay` above.
+
+Adloox recommends you use the following (based on [examples provided on the Prebid.js website](https://docs.prebid.org/dev-docs/examples/basic-example.html))
+
+    FAILSAFE_TIMEOUT = AUCTION_DELAY + (3 * PREBID_TIMEOUT)

--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -1,0 +1,305 @@
+import adapterManager from 'src/adapterManager.js';
+import analyticsAdapter from 'modules/adlooxAnalyticsAdapter.js';
+import { buildVideoUrl } from 'modules/adlooxAdServerVideo.js';
+import { expect } from 'chai';
+import events from 'src/events.js';
+import { server } from 'test/mocks/xhr.js';
+import { targeting } from 'src/targeting.js';
+import * as utils from 'src/utils.js';
+
+const analyticsAdapterName = 'adloox';
+
+describe('Adloox Ad Server Video', function () {
+  let sandbox;
+
+  const adUnit = {
+    code: 'ad-slot-1',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [ 640, 480 ]
+      }
+    },
+    bids: [
+      {
+        bidder: 'dummy'
+      }
+    ]
+  };
+
+  const bid = {
+    bidder: adUnit.bids[0].bidder,
+    adUnitCode: adUnit.code,
+    mediaType: 'video'
+  };
+
+  const analyticsOptions = {
+    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
+    client: 'adlooxtest',
+    clientid: 127,
+    platformid: 0,
+    tagid: 0
+  };
+
+  const creativeUrl = 'http://example.invalid/c';
+  const vastHeaders = {
+    'content-type': 'application/xml; charset=utf-8'
+  };
+
+  const vastUrl = 'http://example.invalid/w';
+  const vastContent =
+`<?xml version="1.0" encoding="UTF-8" ?>
+<VAST version="3.0">
+  <Ad id="main" sequence="1">
+    <InLine>
+      <Creatives>
+        <Creative>
+          <Linear skipoffset="00:00:05">
+            <Duration>00:00:30</Duration>
+            <MediaFiles>
+              <MediaFile apiFramework="VPAID" type="application/javascript">http://example.invalid/v.js</MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+  <Ad id="fallback">
+    <InLine>
+      <Creatives>
+        <Creative>
+          <Linear skipoffset="00:00:05">
+            <Duration>00:00:30</Duration>
+            <MediaFiles>
+              <MediaFile width="640" height="480" bitrate="1000" scalable="true" maintainAspectRatio="true" type="video/mp4" delivery="progressive">${creativeUrl}</MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>`
+
+  const wrapperUrl = 'http://example.invalid/w';
+  const wrapperContent =
+`<?xml version="1.0" encoding="UTF-8" ?>
+<VAST version="2.0">
+  <Ad id="Test">
+    <Wrapper>
+      <VASTAdTagURI><![CDATA[${vastUrl}]]></VASTAdTagURI>
+    </Wrapper>
+  </Ad>
+</VAST>`;
+
+  adapterManager.registerAnalyticsAdapter({
+    code: analyticsAdapterName,
+    adapter: analyticsAdapter
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(events, 'getEvents').returns([]);
+
+    adapterManager.enableAnalytics({
+      provider: analyticsAdapterName,
+      options: analyticsOptions
+    });
+    expect(analyticsAdapter.context).is.not.null;
+  });
+
+  afterEach(function () {
+    analyticsAdapter.disableAnalytics();
+    expect(analyticsAdapter.context).is.null;
+
+    sandbox.restore();
+    sandbox = undefined;
+  });
+
+  describe('buildVideoUrl', function () {
+    describe('invalid arguments', function () {
+      it('should require callback', function (done) {
+        const ret = buildVideoUrl();
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should require options', function (done) {
+        const ret = buildVideoUrl(undefined, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-string options.url_vast', function (done) {
+        const ret = buildVideoUrl({ url_vast: null }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should require options.adUnit or options.bid', function (done) {
+        sandbox.stub(targeting, 'getWinningBids').withArgs(adUnit.code).returns([ bid ]);
+
+        const ret = buildVideoUrl({ url: vastUrl }, function () {});
+        expect(ret).is.false;
+
+        const retAdUnit = buildVideoUrl({ url: vastUrl, adUnit: adUnit }, function () {})
+        expect(retAdUnit).is.true;
+
+        const retBid = buildVideoUrl({ url: vastUrl, bid: bid }, function () {});
+        expect(retBid).is.true;
+
+        done();
+      });
+
+      it('should reject non-string options.url', function (done) {
+        const ret = buildVideoUrl({ url: null, bid: bid }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-boolean options.wrap', function (done) {
+        const ret = buildVideoUrl({ wrap: null, url: vastUrl, bid: bid }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-boolean options.blob', function (done) {
+        const ret = buildVideoUrl({ blob: null, url: vastUrl, bid: bid }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+    });
+
+    describe('process VAST', function () {
+      it('should return URL unchanged for non-VAST', function (done) {
+        const ret = buildVideoUrl({ url: vastUrl, bid: bid }, function (url) {
+          expect(url).is.equal(vastUrl);
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const request = server.requests[0];
+        expect(request.url).is.equal(vastUrl);
+        request.respond(200, { 'content-type': 'application/octet-stream' }, 'notvast');
+      });
+
+      it('should return URL unchanged for empty VAST', function (done) {
+        const ret = buildVideoUrl({ url: vastUrl, bid: bid }, function (url) {
+          expect(url).is.equal(vastUrl);
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const request = server.requests[0];
+        expect(request.url).is.equal(vastUrl);
+        request.respond(200, vastHeaders, '<?xml version="1.0" encoding="UTF-8" ?>\n<VAST version="3.0"/>');
+      });
+
+      it('should fetch, retry on withoutCredentials, follow and return a wrapped blob that expires', function (done) {
+        const bidExpires = utils.deepClone(bid);
+        bidExpires.responseTimestamp = utils.timestamp();
+        bidExpires.ttl = 30;
+
+        const clock = sandbox.useFakeTimers(bidExpires.responseTimestamp);
+
+        const options = {
+          url_vast: 'https://j.adlooxtracking.com/ads/vast/tag-dev.php',
+          url: wrapperUrl,
+          bid: bidExpires
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url.substr(0, options.url_vast.length)).is.equal(options.url_vast);
+
+          const match = url.match(/[?&]vast=(blob%3A[^&]+)/);
+          expect(match).is.not.null;
+
+          let success = false;
+          const blob = decodeURIComponent(match[1]);
+          fetch(blob)
+            .then(function(response) {
+              expect(response.ok).is.true;
+              expect(response.headers.get('content-type')).is.equals(vastHeaders['content-type']);
+
+              success = true;
+
+              clock.tick(bidExpires.ttl * 1000 + 10);
+
+              return fetch(response.url);
+            })
+            .catch(function (error) {
+              expect(error).is.not.undefined;
+              expect(success).is.true;
+
+              done();
+            });
+        });
+        expect(ret).is.true;
+
+        const wrapperRequestCORS = server.requests[0];
+        expect(wrapperRequestCORS.url).is.equal(wrapperUrl);
+        expect(wrapperRequestCORS.withCredentials).is.true;
+        wrapperRequestCORS.respond(0);
+
+        const wrapperRequest = server.requests[1];
+        expect(wrapperRequest.url).is.equal(wrapperUrl);
+        expect(wrapperRequest.withCredentials).is.false;
+        wrapperRequest.respond(200, vastHeaders, wrapperContent);
+
+        const vastRequest = server.requests[2];
+        expect(vastRequest.url).is.equal(vastUrl);
+        vastRequest.respond(200, vastHeaders, vastContent);
+      });
+
+      it('should fetch, follow and return a wrapped non-blob', function (done) {
+        const options = {
+          url_vast: 'https://j.adlooxtracking.com/ads/vast/tag-dev.php',
+          url: wrapperUrl,
+          bid: bid,
+          blob: false
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url.substr(0, options.url_vast.length)).is.equal(options.url_vast);
+          expect(/[?&]vast=blob%3/.test(url)).is.false;
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const wrapperRequest = server.requests[0];
+        expect(wrapperRequest.url).is.equal(wrapperUrl);
+        wrapperRequest.respond(200, vastHeaders, wrapperContent);
+
+        const vastRequest = server.requests[1];
+        expect(vastRequest.url).is.equal(vastUrl);
+        vastRequest.respond(200, vastHeaders, vastContent);
+      });
+
+      it('should not follow and return URL unchanged for non-wrap', function (done) {
+        const options = {
+          url: wrapperUrl,
+          bid: bid,
+          wrap: false
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url).is.equal(options.url);
+
+          done();
+        });
+        expect(ret).is.true;
+      });
+    });
+  });
+});

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -177,6 +177,30 @@ describe('Adloox Analytics Adapter', function () {
 
         done();
       });
+
+      it('should not inject verification JS on BID_WON when handled via Ad Server module', function (done) {
+        const bidIgnore = utils.deepClone(bid);
+        utils.deepSetValue(bidIgnore, 'ext.adloox.video.adserver', true);
+
+        const parent = document.createElement('div');
+
+        const slot = document.createElement('div');
+        slot.id = bidIgnore.adUnitCode;
+        parent.appendChild(slot);
+
+        const script = document.createElement('script');
+        const createElementStub = sandbox.stub(document, 'createElement');
+        createElementStub.withArgs('script').returns(script);
+
+        const querySelectorStub = sandbox.stub(document, 'querySelector');
+        querySelectorStub.withArgs(`#${bid.adUnitCode}`).returns(slot);
+
+        events.emit(EVENTS.BID_WON, bidIgnore);
+
+        expect(parent.querySelector('script')).is.null;
+
+        done();
+      });
     });
 
     describe('command', function () {

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -1,0 +1,228 @@
+import adapterManager from 'src/adapterManager.js';
+import analyticsAdapter, { command as analyticsCommand, COMMAND } from 'modules/adlooxAnalyticsAdapter.js';
+import { AUCTION_COMPLETED } from 'src/auction.js';
+import { expect } from 'chai';
+import events from 'src/events.js';
+import { EVENTS } from 'src/constants.json';
+import * as utils from 'src/utils.js';
+
+const analyticsAdapterName = 'adloox';
+
+describe('Adloox Analytics Adapter', function () {
+  let sandbox;
+
+  const esplode = 'esplode';
+
+  const bid = {
+    bidder: 'dummy',
+    adUnitCode: 'ad-slot-1',
+    mediaType: 'display'
+  };
+
+  const auctionDetails = {
+    auctionStatus: AUCTION_COMPLETED,
+    bidsReceived: [
+      bid
+    ]
+  };
+
+  const analyticsOptions = {
+    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
+    client: 'adlooxtest',
+    clientid: 127,
+    platformid: 0,
+    tagid: 0,
+    params: {
+      dummy1: '%%client%%',
+      dummy2: '%%pbAdSlot%%',
+      dummy3: function(bid) { throw new Error(esplode) }
+    }
+  };
+
+  adapterManager.registerAnalyticsAdapter({
+    code: analyticsAdapterName,
+    adapter: analyticsAdapter
+  });
+
+  describe('enableAnalytics', function () {
+    describe('invalid options', function () {
+      it('should require options', function (done) {
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName
+        });
+        expect(analyticsAdapter.context).is.null;
+
+        done();
+      });
+
+      it('should reject non-string options.js', function (done) {
+        const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+        analyticsOptionsLocal.js = function () { };
+
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName,
+          options: analyticsOptionsLocal
+        });
+        expect(analyticsAdapter.context).is.null;
+
+        done();
+      });
+
+      it('should reject non-function options.toselector', function (done) {
+        const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+        analyticsOptionsLocal.toselector = esplode;
+
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName,
+          options: analyticsOptionsLocal
+        });
+        expect(analyticsAdapter.context).is.null;
+
+        done();
+      });
+
+      [ 'client', 'clientid', 'platformid', 'tagid' ].forEach(function (o) {
+        it('should require options.' + o, function (done) {
+          const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+          delete analyticsOptionsLocal[o];
+
+          adapterManager.enableAnalytics({
+            provider: analyticsAdapterName,
+            options: analyticsOptionsLocal
+          });
+          expect(analyticsAdapter.context).is.null;
+
+          done();
+        });
+      });
+
+      it('should reject non-object options.params', function (done) {
+        const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+        analyticsOptionsLocal.params = esplode;
+
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName,
+          options: analyticsOptionsLocal
+        });
+        expect(analyticsAdapter.context).is.null;
+
+        done();
+      });
+    });
+  });
+
+  describe('process', function () {
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+
+      sandbox.stub(events, 'getEvents').returns([]);
+
+      adapterManager.enableAnalytics({
+        provider: analyticsAdapterName,
+        options: utils.deepClone(analyticsOptions)
+      });
+
+      expect(analyticsAdapter.context).is.not.null;
+    });
+
+    afterEach(function () {
+      analyticsAdapter.disableAnalytics();
+      expect(analyticsAdapter.context).is.null;
+
+      sandbox.restore();
+      sandbox = undefined;
+    });
+
+    describe('event', function () {
+      it('should preload the script on AUCTION_END only once', function (done) {
+        const insertElementStub = sandbox.stub(utils, 'insertElement');
+
+        const uri = utils.parseUrl(analyticsAdapter.url(analyticsOptions.js));
+        const isLinkPreloadAsScript = arg => arg.tagName === 'LINK' && arg.rel === 'preload' && arg.as === 'script' && arg.href === `${uri.protocol}://${uri.host}${uri.pathname}`;
+
+        events.emit(EVENTS.AUCTION_END, auctionDetails);
+        expect(insertElementStub.calledWith(sinon.match(isLinkPreloadAsScript))).to.true;
+
+        events.emit(EVENTS.AUCTION_END, auctionDetails);
+        expect(insertElementStub.callCount).to.equal(1);
+
+        done();
+      });
+
+      it('should inject verification JS on BID_WON located immediately after slot', function (done) {
+        const url = analyticsAdapter.url(`${analyticsOptions.js}#`);
+
+        const parent = document.createElement('div');
+
+        const slot = document.createElement('div');
+        slot.id = bid.adUnitCode;
+        parent.appendChild(slot);
+
+        const dummy = document.createElement('div');
+        parent.appendChild(dummy);
+
+        const script = document.createElement('script');
+        const createElementStub = sandbox.stub(document, 'createElement');
+        createElementStub.withArgs('script').returns(script);
+
+        const querySelectorStub = sandbox.stub(document, 'querySelector');
+        querySelectorStub.withArgs(`#${bid.adUnitCode}`).returns(slot);
+
+        events.emit(EVENTS.BID_WON, bid);
+
+        expect(script.src.substr(0, url.length)).to.equal(url);
+        expect(slot.nextSibling).to.equal(script);
+        expect(/[#&]creatype=2(&|$)/.test(script.src)).to.true; // prebid 'display' -> adloox '2'
+        expect(new RegExp('[#&]dummy3=' + encodeURIComponent('ERROR: ' + esplode) + '(&|$)').test(script.src)).to.true;
+
+        done();
+      });
+    });
+
+    describe('command', function () {
+      it('should return config', function (done) {
+        const expected = utils.deepClone(analyticsOptions);
+        delete expected.js;
+        delete expected.toselector;
+        delete expected.params;
+
+        analyticsCommand(COMMAND.CONFIG, null, function (response) {
+          expect(utils.deepEqual(response, expected)).is.true;
+
+          done();
+        });
+      });
+
+      it('should return expanded URL', function (done) {
+        const data = {
+          url: 'https://example.com?',
+          args: [
+            [ 'client', '%%client%%' ]
+          ],
+          bid: bid,
+          ids: true
+        };
+        const expected = `${data.url}${data.args[0][0]}=${analyticsOptions.client}`;
+
+        analyticsCommand(COMMAND.URL, data, function (response) {
+          expect(response.substr(0, expected.length)).is.equal(expected);
+
+          done();
+        });
+      });
+
+      it('should inject tracking event', function (done) {
+        const data = {
+          eventType: EVENTS.BID_WON,
+          args: bid
+        };
+
+        analyticsCommand(COMMAND.TRACK, data, function (response) {
+          expect(response).is.undefined;
+
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/spec/modules/adlooxRtdProvider_spec.js
+++ b/test/spec/modules/adlooxRtdProvider_spec.js
@@ -1,0 +1,191 @@
+import adapterManager from 'src/adapterManager.js';
+import analyticsAdapter from 'modules/adlooxAnalyticsAdapter.js';
+import { config as _config } from 'src/config.js';
+import { expect } from 'chai';
+import events from 'src/events.js';
+import * as prebidGlobal from 'src/prebidGlobal.js';
+import { subModuleObj as rtdProvider } from 'modules/adlooxRtdProvider.js';
+import * as utils from 'src/utils.js';
+
+const analyticsAdapterName = 'adloox';
+
+describe('Adloox RTD Provider', function () {
+  let sandbox;
+
+  const analyticsOptions = {
+    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
+    client: 'adlooxtest',
+    clientid: 127,
+    platformid: 0,
+    tagid: 0
+  };
+
+  const config = {
+    params: {
+      js: 'https://p.adlooxtracking.com/gpt/a.js'
+    }
+  };
+
+  adapterManager.registerAnalyticsAdapter({
+    code: analyticsAdapterName,
+    adapter: analyticsAdapter
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(events, 'getEvents').returns([]);
+
+    adapterManager.enableAnalytics({
+      provider: analyticsAdapterName,
+      options: analyticsOptions
+    });
+    expect(analyticsAdapter.context).is.not.null;
+  });
+
+  afterEach(function () {
+    analyticsAdapter.disableAnalytics();
+    expect(analyticsAdapter.context).is.null;
+
+    sandbox.restore();
+    sandbox = undefined;
+  });
+
+  describe('init', function () {
+    describe('invalid config', function () {
+      it('should require config', function (done) {
+        const ret = rtdProvider.init();
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-object config.params', function (done) {
+        const ret = rtdProvider.init({ params: null });
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-string config.params.js', function (done) {
+        const ret = rtdProvider.init({ params: { js: null } });
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject invalid config.params.params (legacy/deprecated)', function (done) {
+        const ret = rtdProvider.init({ params: { params: { clientid: 0, tagid: 0 } } });
+
+        expect(ret).is.false;
+
+        done();
+      });
+    });
+  });
+
+  describe('getBidRequestData before init', function () {
+    it('should return undefined', function (done) {
+      let called = false;
+      const ret = rtdProvider.getBidRequestData({}, function () { called = true }, config);
+
+      expect(ret).is.undefined;
+      expect(called).is.false;
+
+      done();
+    });
+  });
+
+  describe('process segments', function () {
+    it('should inject JS and init script', function (done) {
+      const adUnit = {
+        code: 'ad-slot-1',
+        mediaTypes: {
+          banner: {
+            sizes: [ [300, 250] ]
+          }
+        },
+        bids: [
+          {
+            bidder: 'dummy'
+          }
+        ]
+      };
+
+      const adUnits = [
+        adUnit
+      ];
+
+      sandbox.stub(prebidGlobal, 'getGlobal').returns({
+        adUnits: adUnits
+      });
+
+      let __config = {
+        realTimeData: {
+          auctionDelay: 699
+        }
+      };
+      sandbox.stub(_config, 'getConfig').callsFake(function (path) {
+        return utils.deepAccess(__config, path);
+      });
+      sandbox.stub(_config, 'setConfig').callsFake(function (obj) {
+        utils.mergeDeep(__config, obj);
+      });
+
+      const insertElementStub = sandbox.stub(utils, 'insertElement');
+
+      const uri = utils.parseUrl(analyticsAdapter.url(analyticsOptions.js));
+      const isScript = arg => arg.tagName === 'SCRIPT' && arg.src === config.params.js;
+
+      let init = false;
+      window.adloox_pubint = {
+        init: function () {
+          init = true;
+        },
+        seg: function (context, user, slots, callback) {
+          context.set('adl_ok', true);
+          context.set('adl_nope', undefined);
+          user.set('adl_unused', false);
+          user.set('adl_nope', undefined);
+          slots[0].set('adl_dis', [ 60, 70, 80 ]);
+          slots[0].set('adl_nope', undefined);
+          callback();
+        },
+        cmd: {
+          push: function (callback) {
+            callback();
+          }
+        }
+      };
+
+      const ret = rtdProvider.init(config);
+
+      expect(ret).is.true;
+
+      expect(insertElementStub.calledWith(sinon.match(isScript))).to.true;
+
+      expect(init).is.true;
+
+      const callback = function () {
+        expect(__config.fpd.context.data.adl_ok).is.true;
+        expect(__config.fpd.context.data.adl_nope).is.undefined;
+        expect(__config.fpd.user.data.adl_unused).is.false;
+        expect(__config.fpd.user.data.adl_nope).is.undefined;
+        expect(adUnit.fpd.context.data.adl_dis.length).is.equals(3);
+        expect(adUnit.fpd.context.data.adl_nope).is.undefined;
+
+        const targetingData = rtdProvider.getTargetingData([ adUnit.code ], config);
+
+        expect(Object.keys(targetingData).length).is.equal(1)
+        expect(Object.keys(targetingData[adUnit.code]).length).is.equal(2)
+        expect(targetingData[adUnit.code].adl_ok[0]).is.equal('1')
+        expect(targetingData[adUnit.code].adl_dis.length).is.equal(3)
+
+        done();
+      };
+      rtdProvider.getBidRequestData({}, callback, config);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change

- [X] New [Analytics adapter](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAnalyticsAdapter.js) ([documentation](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAnalyticsAdapter.md))
  - [X] New [integration example](https://github.com/corememltd/Prebid.js/blob/feature/adloox/integrationExamples/gpt/adloox.html)
- [X] New [RTD provider](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxRtdProvider.js) ([documentation](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxRtdProvider.md))
- [X] New [Ad Server for Video](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAdServerVideo.js) ([documentation](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAdServerVideo.md))

**N.B.** not yet to be merged(!), submitting a PR to start the requests for comments and review process

## Description of change

Introduction of analytics, RTD provider and Ad Server for Video modules that support Adloox's publisher services.

* contact email of the adapter’s maintainer: contact@adloox.com and alex+adloox@coremem.com
* this is an official submission

Disclosures:

 * Analytics: on `BID_WON` adds the Adloox post-buy verification script (~25kB gzipped from `j.adlooxtracking.com`) and locates it immediately after the ad slot in the DOM
 * RTD: loads the generic segmentation script (~3kB gzipped from `p.adlooxtracking.com`) and provides no user orientated segments (only page, slot quality and IVT/fraud related); used to provide a consistent experience with our [GPT](https://developers.google.com/publisher-tag/guides/get-started) clients as it also includes observability/tracing for our monitoring purposes which would not be appropriate to be included here.

These modules automate the complex tasks an AdOps teams must perform when integrating with Adloox, including the script loading listed in the disclosures above. If the any of the scripts fail to load, it impacts only Adloox's measurement and does not affect the operation of Prebid.js or inventory fill for the publisher.

I do want to say, though early days for us with Prebid.js, it has been a positive experience from both the developer and AdOps perspectives. Our thanks go out to everyone involved in contributing and maintaining an exciting project that makes solving hard problems easy.

## Other information

 * analytics module provides a command processing queue to the other Adloox modules to provide configuration sharing and macro/URL expansion facilities
   * exists to reduce the burden on AdOps teams by preventing typos between each modules configuration that should be keep identical (eg. `{client,tag,platform}id`, `id[0-9]` parameters, ...)
   * created as `events.js` does not support custom events and is a shared event bus
   * works by exporting the same internal command array between all the modules; does not use the global namespace
     * these intra-module imports do trip the the eslint's 'prebid/validate-imports' check which I have made a warning for now to highlight them during the review process; the plan is to later to disable those checks pre-merge
 * Ad Server for Video module is required to bring [MRC accredited](http://www.mediaratingcouncil.org/) viewability metrics to video inventory
   * converts the VAST URL into an Adloox wrapped VAST/VPAID tag (`j.adlooxtracking.com/ads/vast/tag.php`)
   * optionally (enabled by default) walks the VAST chain and rewrites the fetched VAST tags in the chain to use [Blob URLs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) to avoid duplicate requests; solves the no-fill [`correlator`](https://support.google.com/admanager/table/9749596) related problems you get with [GAM](https://admanager.google.com/home/) tags
 * RTD module
   * Looking for feedback on what to do about `getGlobal().adUnits` in the RTD module; I looked to use `auctionManager.getAdUnits()` but it does not seem to be initialised early on enough to have any adunits in there and though [supposedly a no-no](https://docs.prebid.org/dev-docs/module-rules.html#global-module-rules) I see the other RTD modules are using `getGlobal()` so I just copied them on this one. Is there something better I could be doing here?
 * 8a2811f26b01b7eada888affc45ebeb9967b36a8 (slot hunting) and 2ad2d5dea9f54cd17b1e73c0f9fd60a3b8ceb541 (legacy) are planned to be squashed/fixed up into the main commit (69110f73ec07906af064ff27cc3a21e3b5111b8a) after some further review with clients
 * 'KLUDGE' commit (73217b764cef2c8e75d7f1d0553bae7b8a695fe8) will be removed once I figure out (advice welcomed!) a better integration example and merge the changes in `tag-dev.php` into `tag.php` in production on Adloox's infrastructure