### PR TITLE
fix includes and find references in various files

### DIFF
--- a/modules/adxpremiumAnalyticsAdapter.js
+++ b/modules/adxpremiumAnalyticsAdapter.js
@@ -3,6 +3,7 @@ import adapter from '../src/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const analyticsType = 'endpoint';
 const defaultUrl = 'https://adxpremium.services/graphql';
@@ -211,7 +212,7 @@ function deviceType() {
 }
 
 function clearSlot(elementId) {
-  if (elementIds.includes(elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); utils.logInfo('AdxPremium Analytics - Done with: ' + elementId); }
+  if (includes(elementIds, elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); utils.logInfo('AdxPremium Analytics - Done with: ' + elementId); }
   if (elementIds.length == 0 && !requestSent && !timeoutBased) {
     requestSent = true;
     sendEvent(completeObject);

--- a/modules/cleanmedianetBidAdapter.js
+++ b/modules/cleanmedianetBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 export const helper = {
   getTopWindowDomain: function (url) {
@@ -119,7 +120,7 @@ export const spec = {
 
       const hasFavoredMediaType =
         params.favoredMediaType &&
-        this.supportedMediaTypes.includes(params.favoredMediaType);
+        includes(this.supportedMediaTypes, params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const ENDPOINTS = {
   'gamoshi': 'https://rtb.gamoshi.io'
@@ -111,7 +112,7 @@ export const spec = {
       };
 
       const hasFavoredMediaType =
-        params.favoredMediaType && this.supportedMediaTypes.includes(params.favoredMediaType);
+        params.favoredMediaType && includes(this.supportedMediaTypes, params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/medianetAnalyticsAdapter.js
+++ b/modules/medianetAnalyticsAdapter.js
@@ -4,7 +4,8 @@ import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { getRefererInfo } from '../src/refererDetection.js';
-import { AUCTION_COMPLETED, AUCTION_IN_PROGRESS, getPriceGranularity } from '../src/auction.js'
+import { AUCTION_COMPLETED, AUCTION_IN_PROGRESS, getPriceGranularity } from '../src/auction.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const analyticsType = 'endpoint';
 const ENDPOINT = 'https://pb-logs.media.net/log?logid=kfk&evtid=prebid_analytics_events_client';
@@ -125,7 +126,7 @@ class Configure {
       this.setDataFromResponse(response);
       this.overrideDomainLevelData(response);
       this.overrideToDebug(this.mnetDebugConfig);
-      this.urlToConsume = VALID_URL_KEY.includes(response.urlKey) ? response.urlKey : this.urlToConsume;
+      this.urlToConsume = includes(VALID_URL_KEY, response.urlKey) ? response.urlKey : this.urlToConsume;
       this.ajaxState = CONFIG_PASS;
     } catch (e) {
       this.ajaxState = CONFIG_ERROR;

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
+import strIncludes from 'core-js-pure/features/string/includes.js';
 
 const BIDDER_CODE = 'sspBC';
 const BIDDER_URL = 'https://ssp.wp.pl/bidder/';
@@ -314,7 +315,7 @@ const spec = {
             site.slot = serverBid.ext.slotid || site.slot;
           }
 
-          if (bidRequest && site.id && !site.id.includes('bidid')) {
+          if (bidRequest && site.id && !strIncludes(site.id, 'bidid')) {
             // store site data for future notification
             oneCodeDetection[bidRequest.bidId] = [site.id, site.slot];
 

--- a/modules/verizonMediaIdSystem.js
+++ b/modules/verizonMediaIdSystem.js
@@ -8,6 +8,7 @@
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const MODULE_NAME = 'verizonMediaId';
 const VENDOR_ID = 25;
@@ -55,7 +56,7 @@ export const verizonMediaIdSubmodule = {
     }
 
     const data = {
-      '1p': [1, '1', true].includes(params['1p']) ? '1' : '0',
+      '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
       he: params.he,
       gdpr: isEUConsentRequired(consentData) ? '1' : '0',
       euconsent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import includes from 'core-js-pure/features/array/includes';
+import find from 'core-js-pure/features/array/find.js';
 
 const BIDDER_CODE = 'yieldmo';
 const CURRENCY = 'USD';
@@ -197,7 +198,7 @@ function createNewBannerBid(response) {
  * @param bidRequest server request
  */
 function createNewVideoBid(response, bidRequest) {
-  const imp = (utils.deepAccess(bidRequest, 'data.imp') || []).find(imp => imp.id === response.impid);
+  const imp = find((utils.deepAccess(bidRequest, 'data.imp') || []), imp => imp.id === response.impid);
   return {
     requestId: imp.id,
     cpm: response.price,

--- a/modules/yuktamediaAnalyticsAdapter.js
+++ b/modules/yuktamediaAnalyticsAdapter.js
@@ -5,6 +5,7 @@ import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import strIncludes from 'core-js-pure/features/string/includes.js';
 
 const storage = getStorageManager();
 const yuktamediaAnalyticsVersion = 'v3.1.0';
@@ -152,7 +153,7 @@ var yuktamediaAnalyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoin
               bidResponse.responseTimestamp = args.responseTimestamp;
               bidResponse.bidForSize = args.size;
               for (const [adserverTargetingKey, adserverTargetingValue] of Object.entries(args.adserverTargeting)) {
-                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !adserverTargetingKey.includes(ele))) {
+                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !strIncludes(adserverTargetingKey, ele))) {
                   bidResponse['adserverTargeting-' + adserverTargetingKey] = adserverTargetingValue;
                 }
               }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -5,6 +5,7 @@ import { auctionManager } from './auctionManager.js';
 import { sizeSupported } from './sizeMapping.js';
 import { ADPOD } from './mediaTypes.js';
 import includes from 'core-js-pure/features/array/includes.js';
+import find from 'core-js-pure/features/array/find.js';
 
 const utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -200,7 +201,7 @@ export function newTargeting(auctionManager) {
         // check if key is in default keys, if not, it's custom, we won't remove it.
         const isCustom = defaultKeys.filter(defaultKey => key.indexOf(defaultKeyring[defaultKey]) === 0).length === 0;
         // check if key explicitly allowed, if not, we'll remove it.
-        const found = isCustom || allowedKeys.find(allowedKey => {
+        const found = isCustom || find(allowedKeys, allowedKey => {
           const allowedKeyName = defaultKeyring[allowedKey];
           // we're looking to see if the key exactly starts with one of our default keys.
           // (which hopefully means it's not custom)

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import {spec} from 'modules/stroeerCoreBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {BANNER, VIDEO} from '../../../src/mediaTypes.js';
+import find from 'core-js-pure/features/array/find.js';
 
 describe('stroeerCore bid adapter', function () {
   let sandbox;
@@ -123,7 +124,7 @@ describe('stroeerCore bid adapter', function () {
           }
         },
         referrer,
-        getElementById: id => placementElements.find(el => el.id === id)
+        getElementById: id => find(placementElements, el => el.id === id)
       }
     };
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -22,6 +22,7 @@ import {
   setConsentConfig
 } from 'modules/consentManagement.js';
 import {server} from 'test/mocks/xhr.js';
+import find from 'core-js-pure/features/array/find.js';
 import {unifiedIdSubmodule} from 'modules/unifiedIdSystem.js';
 import {pubCommonIdSubmodule} from 'modules/pubCommonIdSystem.js';
 import {britepoolIdSubmodule} from 'modules/britepoolIdSystem.js';
@@ -86,7 +87,7 @@ describe('User ID', function () {
   }
 
   function findEid(eids, source) {
-    return eids.find((eid) => {
+    return find(eids, (eid) => {
       if (eid.source === source) { return true; }
     });
   }


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
There were numerous instances where files were using the `array.includes`, `array.find`, `string.includes` functions which are not compliant in IE11.  

I replaced these references with the compliant versions of these functions.

