### PR TITLE
Lotame TCF fall back to cookies when consent data is otherwise unavailable

### DIFF
--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -192,11 +192,22 @@ export const lotamePanoramaIdSubmodule = {
         queryParams.fp = storedUserId;
       }
 
-      if (consentData && utils.isBoolean(consentData.gdprApplies)) {
-        queryParams.gdpr_applies = consentData.gdprApplies;
-        if (consentData.gdprApplies) {
-          queryParams.gdpr_consent = consentData.consentString;
+      let consentString;
+      if (consentData) {
+        if (utils.isBoolean(consentData.gdprApplies)) {
+          queryParams.gdpr_applies = consentData.gdprApplies;
         }
+        consentString = consentData.consentString;
+      }
+      // If no consent string, try to read it from 1st party cookies
+      if (!consentString) {
+        consentString = getFromStorage('eupubconsent-v2');
+      }
+      if (!consentString) {
+        consentString = getFromStorage('euconsent-v2');
+      }
+      if (consentString) {
+        queryParams.gdpr_consent = consentString;
       }
       const url = utils.buildUrl({
         protocol: 'https',

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -440,10 +440,176 @@ describe('LotameId', function() {
     });
   });
 
-  it('should retrieve the id when decode is called', function() {
-    var id = lotamePanoramaIdSubmodule.decode('1234');
-    expect(id).to.be.eql({
-      'lotamePanoramaId': '1234'
+  describe('when gdpr applies and falls back to eupubconsent cookie', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData = {
+      gdprApplies: true,
+      consentString: undefined
+    };
+
+    beforeEach(function () {
+      getCookieStub
+        .withArgs('eupubconsent-v2')
+        .returns('consentGiven');
+
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass the gdpr consent string back', function() {
+      expect(request.url).to.be.eq(
+        'https://id.crwdcntrl.net/id?gdpr_applies=true&gdpr_consent=consentGiven'
+      );
+    });
+  });
+
+  describe('when gdpr applies and falls back to euconsent cookie', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData = {
+      gdprApplies: true,
+      consentString: undefined
+    };
+
+    beforeEach(function () {
+      getCookieStub
+        .withArgs('euconsent-v2')
+        .returns('consentGiven');
+
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass the gdpr consent string back', function() {
+      expect(request.url).to.be.eq(
+        'https://id.crwdcntrl.net/id?gdpr_applies=true&gdpr_consent=consentGiven'
+      );
+    });
+  });
+
+  describe('when gdpr applies but no consent string is available', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData = {
+      gdprApplies: true,
+      consentString: undefined
+    };
+
+    beforeEach(function () {
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should not include the gdpr consent string on the url', function() {
+      expect(request.url).to.be.eq(
+        'https://id.crwdcntrl.net/id?gdpr_applies=true'
+      );
+    });
+  });
+
+  describe('when no consentData and falls back to eupubconsent cookie', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData;
+
+    beforeEach(function () {
+      getCookieStub
+        .withArgs('eupubconsent-v2')
+        .returns('consentGiven');
+
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass the gdpr consent string back', function() {
+      expect(request.url).to.be.eq(
+        'https://id.crwdcntrl.net/id?gdpr_consent=consentGiven'
+      );
+    });
+  });
+
+  describe('when no consentData and falls back to euconsent cookie', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData;
+
+    beforeEach(function () {
+      getCookieStub
+        .withArgs('euconsent-v2')
+        .returns('consentGiven');
+
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass the gdpr consent string back', function() {
+      expect(request.url).to.be.eq(
+        'https://id.crwdcntrl.net/id?gdpr_consent=consentGiven'
+      );
+    });
+  });
+
+  describe('when no consentData and no cookies', function () {
+    let request;
+    let callBackSpy = sinon.spy();
+    let consentData;
+
+    beforeEach(function () {
+      let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, consentData).callback;
+      submoduleCallback(callBackSpy);
+
+      // the contents of the response don't matter for this
+      request = server.requests[0];
+      request.respond(200, responseHeader, '');
+    });
+
+    it('should call the remote server when getId is called', function () {
+      expect(callBackSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass the gdpr consent string back', function() {
+      expect(request.url).to.be.eq('https://id.crwdcntrl.net/id');
     });
   });
 });


### PR DESCRIPTION

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Lotame intends to do its best to honor TCF regardless of client configuration. Thus, if there is a TCF string to be found in the cookies, we would like to send that to our servers regardless of whether 1) Prebid has GDPR Consent Management Module enabled 2) The CMP responded in time to provide the consent string to the GDPR Consent Management Module.


- [x] contact email of the adapter’s maintainer: mike@lotame.com
- [ ] official adapter submission

