### PR TITLE
ID5 User Id Module: move id5's user id extension to the uids array

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -516,7 +516,7 @@ export const spec = {
           } else if (eid.source === 'sharedid.org') {
             data['eid_sharedid.org'] = `${eid.uids[0].id}^${eid.uids[0].atype}^${(eid.uids[0].ext && eid.uids[0].ext.third) || ''}`;
           } else if (eid.source === 'id5-sync.com') {
-            data['eid_id5-sync.com'] = `${eid.uids[0].id}^${eid.uids[0].atype}^${(eid.ext && eid.ext.linkType) || ''}`;
+            data['eid_id5-sync.com'] = `${eid.uids[0].id}^${eid.uids[0].atype}^${(eid.uids[0].ext && eid.uids[0].ext.linkType) || ''}`;
           } else {
             // add anything else with this generic format
             data[`eid_${eid.source}`] = `${eid.uids[0].id}^${eid.uids[0].atype || ''}`;

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -245,9 +245,9 @@ export const spec = {
           {
             source: 'id5-sync.com',
             uids: [{
-              id: bid.userId.id5id.uid
-            }],
-            ext: bid.userId.id5id.ext || {}
+              id: bid.userId.id5id.uid,
+              ext: bid.userId.id5id.ext || {}
+            }]
           }
         )
       }

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -35,7 +35,7 @@ const USER_IDS_CONFIG = {
     },
     source: 'id5-sync.com',
     atype: 1,
-    getEidExt: function(data) {
+    getUidExt: function(data) {
       if (data.ext) {
         return data.ext;
       }

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -33,11 +33,11 @@ userIdAsEids = [
         source: 'id5-sync.com',
         uids: [{
             id: 'some-random-id-value',
-            atype: 1
-        },
-        ext: {
-            linkType: 2,
-            abTestingControlGroup: false
+            atype: 1,
+            ext: {
+                linkType: 2,
+                abTestingControlGroup: false
+            }
         }]
     },
 

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -57,10 +57,13 @@ describe('eids array generation for known sub-modules', function() {
       expect(newEids.length).to.equal(1);
       expect(newEids[0]).to.deep.equal({
         source: 'id5-sync.com',
-        uids: [{ id: 'some-random-id-value', atype: 1 }],
-        ext: {
-          linkType: 0
-        }
+        uids: [{
+          id: 'some-random-id-value',
+          atype: 1,
+          ext: {
+            linkType: 0
+          }
+        }]
       });
     });
   });

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -297,10 +297,13 @@ describe('ID5 ID System', function() {
             expect(bid.userId.id5id.uid).to.equal(ID5_STORED_ID);
             expect(bid.userIdAsEids[0]).to.deep.equal({
               source: ID5_SOURCE,
-              uids: [{ id: ID5_STORED_ID, atype: 1 }],
-              ext: {
-                linkType: ID5_STORED_LINK_TYPE
-              }
+              uids: [{
+                id: ID5_STORED_ID,
+                atype: 1,
+                ext: {
+                  linkType: ID5_STORED_LINK_TYPE
+                }
+              }]
             });
           });
         });

--- a/test/spec/modules/nobidBidAdapter_spec.js
+++ b/test/spec/modules/nobidBidAdapter_spec.js
@@ -257,12 +257,12 @@ describe('Nobid Adapter', function () {
             'uids': [
               {
                 'id': 'ID5_ID',
-                'atype': 1
+                'atype': 1,
+                'ext': {
+                  'linkType': 0
+                }
               }
-            ],
-            'ext': {
-              'linkType': 0
-            }
+            ]
           },
           {
             'source': 'adserver.org',
@@ -284,7 +284,7 @@ describe('Nobid Adapter', function () {
       refererInfo: {referer: REFERER}
     }
 
-    it('should criteo eid', function () {
+    it('should get user ids from eids', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = JSON.parse(request.data);
       expect(payload.sid).to.exist.and.to.equal(2);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1207,7 +1207,7 @@ describe('S2S Adapter', function () {
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveintent.com')[0].ext.segments[1]).is.equal('segB');
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')).is.not.empty;
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')[0].uids[0].id).is.equal('11111');
-      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')[0].ext.linkType).is.equal('some-link-type');
+      expect(requestBid.user.ext.eids.filter(eid => eid.source === 'id5-sync.com')[0].uids[0].ext.linkType).is.equal('some-link-type');
       // LiveRamp should exist
       expect(requestBid.user.ext.eids.filter(eid => eid.source === 'liveramp.com')[0].uids[0].id).is.equal('0000-1111-2222-3333');
     });

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -204,9 +204,9 @@ describe('the spotx adapter', function () {
         eids: [{
           source: 'id5-sync.com',
           uids: [{
-            id: 'id5id_1'
-          }],
-          ext: {}
+            id: 'id5id_1',
+            ext: {}
+          }]
         },
         {
           source: 'adserver.org',


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Moving the user id extension we provide into the uids array to better conform to conventions being established by other id providers.

There were only a few places using this field specifically, so this PR also includes the necessary changes to that code to read it properly.