### PR TITLE
Relevant Yield analytics adapter

### DIFF
--- a/modules/relevantAnalyticsAdapter.js
+++ b/modules/relevantAnalyticsAdapter.js
@@ -1,0 +1,33 @@
+import adapter from '../src/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+
+const relevantAnalytics = adapter({ analyticsType: 'bundle', handler: 'on' });
+
+const { enableAnalytics: orgEnableAnalytics } = relevantAnalytics;
+
+Object.assign(relevantAnalytics, {
+  /**
+   * Save event in the global array that will be consumed later by the Relevant Yield library
+   */
+  track: ({ eventType: ev, args }) => {
+    window.relevantDigital.pbEventLog.push({ ev, args, ts: new Date() });
+  },
+
+  /**
+   * Before forwarding the call to the original enableAnalytics function -
+   * create (if needed) the global array that is used to pass events to the Relevant Yield library
+   * by the 'track' function above.
+   */
+  enableAnalytics: function(...args) {
+    window.relevantDigital = window.relevantDigital || {};
+    window.relevantDigital.pbEventLog = window.relevantDigital.pbEventLog || [];
+    return orgEnableAnalytics.call(this, ...args);
+  },
+});
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: relevantAnalytics,
+  code: 'relevant',
+});
+
+export default relevantAnalytics;

--- a/modules/relevantAnalyticsAdapter.md
+++ b/modules/relevantAnalyticsAdapter.md
@@ -1,0 +1,13 @@
+# Overview
+
+Module Name: Relevant Yield Analytics Adapter
+
+Module Type: Analytics Adapter
+
+Maintainer: [support@relevant-digital.com](mailto:support@relevant-digital.com)
+
+# Description
+
+Analytics adapter to be used with [Relevant Yield](https://www.relevant-digital.com/relevantyield)
+
+Contact [sales@relevant-digital.com](mailto:sales@relevant-digital.com) for information.

--- a/test/spec/modules/relevantAnalyticsAdapter_spec.js
+++ b/test/spec/modules/relevantAnalyticsAdapter_spec.js
@@ -1,0 +1,43 @@
+import relevantAnalytics from '../../../modules/relevantAnalyticsAdapter.js';
+import adapterManager from 'src/adapterManager';
+import events from 'src/events';
+import constants from 'src/constants.json'
+import { expect } from 'chai';
+
+describe('Relevant Analytics Adapter', () => {
+  beforeEach(() => {
+    adapterManager.enableAnalytics({
+      provider: 'relevant'
+    });
+  });
+
+  afterEach(() => {
+    relevantAnalytics.disableAnalytics();
+  });
+
+  it('should pass all events to the global array', () => {
+    // Given
+    const testEvents = [
+      { ev: constants.EVENTS.AUCTION_INIT, args: { test: 1 } },
+      { ev: constants.EVENTS.BID_REQUESTED, args: { test: 2 } },
+    ];
+
+    // When
+    testEvents.forEach(({ ev, args }) => (
+      events.emit(ev, args)
+    ));
+
+    // Then
+    const eventQueue = (window.relevantDigital || {}).pbEventLog;
+    expect(eventQueue).to.be.an('array');
+    expect(eventQueue.length).to.be.at.least(testEvents.length);
+
+    // The last events should be our test events
+    const myEvents = eventQueue.slice(-testEvents.length);
+    testEvents.forEach(({ ev, args }, idx) => {
+      const actualEvent = myEvents[idx];
+      expect(actualEvent.ev).to.eql(ev);
+      expect(actualEvent.args).to.eql(args);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] Analytics adapter

## Description of change
This is an analytics adapter for the "HB Analytics" module in [Relevant Yield](https://www.relevant-digital.com/relevantyield)

The code is simply logging events in a global array that is later consumed by our library script - which in turn needs to be loaded separately on the page.

- contact email of the adapter’s maintainer: samuel.palmer@relevant-digital.com
 
- [x] official adapter submission

## Other information
The purpose of this adapter is to simplify the integration of our product on clients' websites as it will no longer be necessary to place our "tag" in such way that no events are triggered before we listen to them.

