### PR TITLE
JW Player RTD Module - Limit scope to adUnits supporting instream video

### DIFF
--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -159,11 +159,21 @@ export function enrichAdUnits(adUnits) {
   });
 }
 
+function supportsInstreamVideo(mediaTypes) {
+  const video = mediaTypes && mediaTypes.video;
+  return video && video.context === 'instream';
+}
+
 export function extractPublisherParams(adUnit, fallback) {
   let adUnitTargeting;
   try {
     adUnitTargeting = adUnit.fpd.context.data.jwTargeting;
   } catch (e) {}
+
+  if (!adUnitTargeting && !supportsInstreamVideo(adUnit.mediaTypes)) {
+    return;
+  }
+
   return Object.assign({}, fallback, adUnitTargeting);
 }
 

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -146,6 +146,11 @@ function enrichBidRequest(bidReqConfig, onDone) {
 export function enrichAdUnits(adUnits) {
   const fpdFallback = config.getConfig('fpd.context.data.jwTargeting');
   adUnits.forEach(adUnit => {
+    const jwTargeting = extractPublisherParams(adUnit, fpdFallback);
+    if (!jwTargeting || !Object.keys(jwTargeting).length) {
+      return;
+    }
+
     const onVatResponse = function (vat) {
       if (!vat) {
         return;
@@ -153,8 +158,6 @@ export function enrichAdUnits(adUnits) {
       const targeting = formatTargetingResponse(vat);
       addTargetingToBids(adUnit.bids, targeting);
     };
-
-    const jwTargeting = extractPublisherParams(adUnit, fpdFallback);
     loadVat(jwTargeting, onVatResponse);
   });
 }
@@ -178,10 +181,6 @@ export function extractPublisherParams(adUnit, fallback) {
 }
 
 function loadVat(params, onCompletion) {
-  if (!params || !Object.keys(params).length) {
-    return;
-  }
-
   const { playerID, mediaID } = params;
   if (pendingRequests[mediaID] !== undefined) {
     loadVatForPendingRequest(playerID, mediaID, onCompletion);

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -415,12 +415,6 @@ describe('jwplayerRtdProvider', function() {
   describe(' Extract Publisher Params', function () {
     const config = { mediaID: 'test' };
 
-    it('should fallback to config when media type is video and is instream', function () {
-      const adUnit = { mediaTypes: { video: { context: 'instream' } } };
-      const targeting = extractPublisherParams(adUnit, config);
-      expect(targeting).to.deep.equal(config);
-    });
-
     it('should exclude adUnits that do not support instream video and do not specify jwTargeting', function () {
       const oustreamAdUnit = { mediaTypes: { video: { context: 'outstream' } } };
       const oustreamTargeting = extractPublisherParams(oustreamAdUnit, config);
@@ -434,7 +428,25 @@ describe('jwplayerRtdProvider', function() {
       expect(targeting).to.be.undefined;
     });
 
-    it('should fallback to config when jwTargeting is defined in ad unit', function () {
+    it('should include ad unit when media type is video and is instream', function () {
+      const adUnit = { mediaTypes: { video: { context: 'instream' } } };
+      const targeting = extractPublisherParams(adUnit, config);
+      expect(targeting).to.deep.equal(config);
+    });
+
+    it('should include banner ad units that specify jwTargeting', function() {
+      const adUnit = { mediaTypes: { banner: {} }, fpd: { context: { data: { jwTargeting: {} } } } };
+      const targeting = extractPublisherParams(adUnit, config);
+      expect(targeting).to.deep.equal(config);
+    });
+
+    it('should include outstream ad units that specify jwTargeting', function() {
+      const adUnit = { mediaTypes: { video: { context: 'outstream' } }, fpd: { context: { data: { jwTargeting: {} } } } };
+      const targeting = extractPublisherParams(adUnit, config);
+      expect(targeting).to.deep.equal(config);
+    });
+
+    it('should fallback to config when empty jwTargeting is defined in ad unit', function () {
       const adUnit = { fpd: { context: { data: { jwTargeting: {} } } } };
       const targeting = extractPublisherParams(adUnit, config);
       expect(targeting).to.deep.equal(config);

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -413,19 +413,31 @@ describe('jwplayerRtdProvider', function() {
   });
 
   describe(' Extract Publisher Params', function () {
-    it('should default to config', function () {
-      const config = { mediaID: 'test' };
+    const config = { mediaID: 'test' };
 
-      const adUnit1 = { fpd: { context: {} } };
-      const targeting1 = extractPublisherParams(adUnit1, config);
-      expect(targeting1).to.deep.equal(config);
+    it('should fallback to config when media type is video and is instream', function () {
+      const adUnit = { mediaTypes: { video: { context: 'instream' } } };
+      const targeting = extractPublisherParams(adUnit, config);
+      expect(targeting).to.deep.equal(config);
+    });
 
-      const adUnit2 = { fpd: { context: { data: { jwTargeting: {} } } } };
-      const targeting2 = extractPublisherParams(adUnit2, config);
-      expect(targeting2).to.deep.equal(config);
+    it('should exclude adUnits that do not support instream video and do not specify jwTargeting', function () {
+      const oustreamAdUnit = { mediaTypes: { video: { context: 'outstream' } } };
+      const oustreamTargeting = extractPublisherParams(oustreamAdUnit, config);
+      expect(oustreamTargeting).to.be.undefined;
 
-      const targeting3 = extractPublisherParams(null, config);
-      expect(targeting3).to.deep.equal(config);
+      const bannerAdUnit = { mediaTypes: { banner: {} } };
+      const bannerTargeting = extractPublisherParams(bannerAdUnit, config);
+      expect(bannerTargeting).to.be.undefined;
+
+      const targeting = extractPublisherParams({}, config);
+      expect(targeting).to.be.undefined;
+    });
+
+    it('should fallback to config when jwTargeting is defined in ad unit', function () {
+      const adUnit = { fpd: { context: { data: { jwTargeting: {} } } } };
+      const targeting = extractPublisherParams(adUnit, config);
+      expect(targeting).to.deep.equal(config);
     });
 
     it('should prioritize adUnit properties ', function () {
@@ -450,9 +462,9 @@ describe('jwplayerRtdProvider', function() {
       expect(targeting).to.have.property('playerID', expectedPlayerID);
     });
 
-    it('should return empty object when Publisher Params are absent', function () {
-      const targeting = extractPublisherParams(null, null);
-      expect(targeting).to.deep.equal({});
+    it('should return undefined when Publisher Params are absent', function () {
+      const targeting = extractPublisherParams({}, null);
+      expect(targeting).to.be.undefined;
     })
   });
 


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Prevents data retrieval if adUnit does not support video instream while preserving ability to obtain data if `jwTargeting` is defined on the ad unit


