### PR TITLE
Rubicon Analytics: Fire event once gptSlots render

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -564,6 +564,13 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         if (!cache.gpt.registered && utils.isGptPubadsDefined()) {
           subscribeToGamSlots();
           cache.gpt.registered = true;
+        } else if (!cache.gpt.registered) {
+          cache.gpt.registered = true;
+          let googletag = window.googletag || {};
+          googletag.cmd = googletag.cmd || [];
+          googletag.cmd.push(function() {
+            subscribeToGamSlots();
+          });
         }
         break;
       case BID_REQUESTED:

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -1361,22 +1361,11 @@ describe('rubicon analytics adapter', function () {
     describe('with googletag enabled', function () {
       let gptSlot0, gptSlot1;
       let gptSlotRenderEnded0, gptSlotRenderEnded1;
-      let gptslotOnload0, gptslotOnload1;
       beforeEach(function () {
         mockGpt.enable();
         gptSlot0 = mockGpt.makeSlot({code: '/19968336/header-bid-tag-0'});
         gptSlotRenderEnded0 = {
           eventName: 'slotRenderEnded',
-          params: {
-            slot: gptSlot0,
-            isEmpty: false,
-            advertiserId: 1111,
-            creativeId: 2222,
-            lineItemId: 3333
-          }
-        };
-        gptslotOnload0 = {
-          eventName: 'slotOnload',
           params: {
             slot: gptSlot0,
             isEmpty: false,
@@ -1395,16 +1384,6 @@ describe('rubicon analytics adapter', function () {
             advertiserId: 4444,
             creativeId: 5555,
             lineItemId: 6666
-          }
-        };
-        gptslotOnload1 = {
-          eventName: 'slotOnload',
-          params: {
-            slot: gptSlot1,
-            isEmpty: false,
-            advertiserId: 1111,
-            creativeId: 2222,
-            lineItemId: 3333
           }
         };
       });
@@ -1535,12 +1514,6 @@ describe('rubicon analytics adapter', function () {
         // should not send if just slotRenderEnded is emmitted for both
         mockGpt.emitEvent(gptSlotRenderEnded0.eventName, gptSlotRenderEnded0.params);
         mockGpt.emitEvent(gptSlotRenderEnded1.eventName, gptSlotRenderEnded1.params);
-
-        expect(server.requests.length).to.equal(0);
-
-        // now emit slotOnload and it should send
-        mockGpt.emitEvent(gptslotOnload0.eventName, gptslotOnload0.params);
-        mockGpt.emitEvent(gptslotOnload1.eventName, gptslotOnload1.params);
 
         expect(server.requests.length).to.equal(1);
         let request = server.requests[0];


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
After some testing we determined it was best to wait only for the gpt slotRenderEnded event instead of also slotOnLoad.

This change will mark adUnits as having gam rendered if the publisher has enabled the feature.

And once all adUnits in an auction have come back, the analytics event will fire.