### PR TITLE
appneuxs Bid Adapter - add support for identitylink userId

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -240,34 +240,17 @@ export const spec = {
       });
     }
 
-    const criteoId = utils.deepAccess(bidRequests[0], `userId.criteoId`);
-    let eids = [];
-    if (criteoId) {
-      eids.push({
-        source: 'criteo.com',
-        id: criteoId
-      });
-    }
+    if (bidRequests[0].userId) {
+      let eids = [];
 
-    const netidId = utils.deepAccess(bidRequests[0], `userId.netId`);
-    if (netidId) {
-      eids.push({
-        source: 'netid.de',
-        id: netidId
-      });
-    }
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.criteoId`), 'criteo.com', null);
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.netId`), 'netid.de', null);
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.idl_env`), 'liveramp.com', null);
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.tdid`), 'adserver.org', 'TDID');
 
-    const tdid = utils.deepAccess(bidRequests[0], `userId.tdid`);
-    if (tdid) {
-      eids.push({
-        source: 'adserver.org',
-        id: tdid,
-        rti_partner: 'TDID'
-      });
-    }
-
-    if (eids.length) {
-      payload.eids = eids;
+      if (eids.length) {
+        payload.eids = eids;
+      }
     }
 
     if (tags[0].publisher_id) {
@@ -1040,6 +1023,17 @@ function parseMediaType(rtbBid) {
   } else {
     return BANNER;
   }
+}
+
+function addUserId(eids, id, source, rti) {
+  if (id) {
+    if (rti) {
+      eids.push({ source, id, rti_partner: rti });
+    } else {
+      eids.push({ source, id });
+    }
+  }
+  return eids;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -827,7 +827,8 @@ describe('AppNexusAdapter', function () {
         userId: {
           tdid: 'sample-userid',
           criteoId: 'sample-criteo-userid',
-          netId: 'sample-netId-userid'
+          netId: 'sample-netId-userid',
+          idl_env: 'sample-idl-userid'
         }
       });
 
@@ -848,6 +849,11 @@ describe('AppNexusAdapter', function () {
         source: 'netid.de',
         id: 'sample-netId-userid',
       });
+
+      expect(payload.eids).to.deep.include({
+        source: 'liveramp.com',
+        id: 'sample-idl-userid'
+      })
     });
 
     it('should populate iab_support object at the root level if omid support is detected', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR adds the identitylink (liveramp) userId to the appnexusBidAdapter.  

It also refactors the overall userId code to a functional approach.

## Docs PR
https://github.com/prebid/prebid.github.io/pull/2678