### PR TITLE
pbsBidAdapter: change order of client syncs

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -227,10 +227,13 @@ function doAllSyncs(bidders, s2sConfig) {
     return;
   }
 
-  const thisSync = bidders.pop();
+  // pull the syncs off the list in the order that prebid server sends them
+  const thisSync = bidders.shift();
+  
+  // if PBS reports this bidder doesn't have an ID, then call the sync and recurse to the next sync entry
   if (thisSync.no_cookie) {
     doPreBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, utils.bind.call(doAllSyncs, null, bidders, s2sConfig), s2sConfig);
-  } else {
+  } else {  // bidder already has an ID, so just recurse to the next sync entry
     doAllSyncs(bidders, s2sConfig);
   }
 }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -229,11 +229,12 @@ function doAllSyncs(bidders, s2sConfig) {
 
   // pull the syncs off the list in the order that prebid server sends them
   const thisSync = bidders.shift();
-  
+
   // if PBS reports this bidder doesn't have an ID, then call the sync and recurse to the next sync entry
   if (thisSync.no_cookie) {
     doPreBidderSync(thisSync.usersync.type, thisSync.usersync.url, thisSync.bidder, utils.bind.call(doAllSyncs, null, bidders, s2sConfig), s2sConfig);
-  } else {  // bidder already has an ID, so just recurse to the next sync entry
+  } else {
+    // bidder already has an ID, so just recurse to the next sync entry
     doAllSyncs(bidders, s2sConfig);
   }
 }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -201,10 +201,6 @@ function queueSync(bidderCodes, gdprConsent, uspConsent, s2sConfig) {
     payload.us_privacy = uspConsent;
   }
 
-  if (typeof _s2sConfig.coopSync === 'boolean') {
-    payload.coopSync = _s2sConfig.coopSync;
-  }
-
   const jsonPayload = JSON.stringify(payload);
   ajax(s2sConfig.syncEndpoint,
     (response) => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2434,36 +2434,5 @@ describe('S2S Adapter', function () {
       const requestBid = JSON.parse(server.requests[0].requestBody);
       expect(requestBid.bidders).to.deep.equal(['appnexus', 'rubicon']);
     });
-
-    it('should add cooperative sync flag to cookie_sync request if property is present', function () {
-      let cookieSyncConfig = utils.deepClone(CONFIG);
-      cookieSyncConfig.coopSync = false;
-      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
-
-      let consentConfig = { s2sConfig: cookieSyncConfig };
-      config.setConfig(consentConfig);
-
-      let bidRequest = utils.deepClone(BID_REQUESTS);
-
-      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(server.requests[0].requestBody);
-
-      expect(requestBid.coopSync).to.equal(false);
-    });
-
-    it('should not add cooperative sync flag to cookie_sync request if property is not present', function () {
-      let cookieSyncConfig = utils.deepClone(CONFIG);
-      cookieSyncConfig.syncEndpoint = 'https://prebid.adnxs.com/pbs/v1/cookie_sync';
-
-      let consentConfig = { s2sConfig: cookieSyncConfig };
-      config.setConfig(consentConfig);
-
-      let bidRequest = utils.deepClone(BID_REQUESTS);
-
-      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(server.requests[0].requestBody);
-
-      expect(requestBid.coopSync).to.be.undefined;
-    });
   });
 });


### PR DESCRIPTION
## Type of change
- [ X ] Enhancement

## Description of change

Prebid Server places cookie-sync URLs in a specific order. PBJS was pulling them off in reverse order.
