### PR TITLE
Update britepoolIdSystem.md

### DIFF
--- a/modules/britepoolIdSystem.md
+++ b/modules/britepoolIdSystem.md
@@ -4,7 +4,7 @@ BritePool User ID Module. For assistance setting up your module please contact u
 
 ### Prebid Params
 
-Individual params may be set for the BritePool User ID Submodule. At least one identifier must be set in the params.
+Individual params may be set for the BritePool User ID Submodule. 
 ```
 pbjs.setConfig({
     userSync: {


### PR DESCRIPTION
Eliot from Britepool says you can set just the api key without any params (eg ssid or hash)

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- 
- [X] Refactoring (no functional changes, no api changes)

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Docs change
