### PR TITLE
Zeotap id plus gvlid

### DIFF
--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -9,14 +9,15 @@ import {submodule} from '../src/hook.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const ZEOTAP_COOKIE_NAME = 'IDP';
+const ZEOTAP_VENDOR_ID = 301;
 export const storage = getStorageManager();
 
 function readCookie() {
-  return storage.cookiesAreEnabled ? storage.getCookie(ZEOTAP_COOKIE_NAME) : null;
+  return storage.cookiesAreEnabled() ? storage.getCookie(ZEOTAP_COOKIE_NAME) : null;
 }
 
 function readFromLocalStorage() {
-  return storage.localStorageIsEnabled ? storage.getDataFromLocalStorage(ZEOTAP_COOKIE_NAME) : null;
+  return storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(ZEOTAP_COOKIE_NAME) : null;
 }
 
 /** @type {Submodule} */
@@ -26,6 +27,11 @@ export const zeotapIdPlusSubmodule = {
    * @type {string}
    */
   name: 'zeotapIdPlus',
+  /**
+   * Vendor ID of Zeotap
+   * @type {Number}
+   */
+  gvlid: ZEOTAP_VENDOR_ID,
   /**
    * decode the stored id value for passing to bid requests
    * @function

--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -10,7 +10,8 @@ import { getStorageManager } from '../src/storageManager.js';
 
 const ZEOTAP_COOKIE_NAME = 'IDP';
 const ZEOTAP_VENDOR_ID = 301;
-export const storage = getStorageManager();
+const ZEOTAP_MODULE_NAME = 'zeotapIdPlus';
+export const storage = getStorageManager(ZEOTAP_VENDOR_ID, ZEOTAP_MODULE_NAME);
 
 function readCookie() {
   return storage.cookiesAreEnabled() ? storage.getCookie(ZEOTAP_COOKIE_NAME) : null;
@@ -26,7 +27,7 @@ export const zeotapIdPlusSubmodule = {
    * used to link submodule with config
    * @type {string}
    */
-  name: 'zeotapIdPlus',
+  name: ZEOTAP_MODULE_NAME,
   /**
    * Vendor ID of Zeotap
    * @type {Number}

--- a/modules/zeotapIdPlusIdSystem.js
+++ b/modules/zeotapIdPlusIdSystem.js
@@ -11,7 +11,6 @@ import { getStorageManager } from '../src/storageManager.js';
 const ZEOTAP_COOKIE_NAME = 'IDP';
 const ZEOTAP_VENDOR_ID = 301;
 const ZEOTAP_MODULE_NAME = 'zeotapIdPlus';
-export const storage = getStorageManager(ZEOTAP_VENDOR_ID, ZEOTAP_MODULE_NAME);
 
 function readCookie() {
   return storage.cookiesAreEnabled() ? storage.getCookie(ZEOTAP_COOKIE_NAME) : null;
@@ -20,6 +19,12 @@ function readCookie() {
 function readFromLocalStorage() {
   return storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(ZEOTAP_COOKIE_NAME) : null;
 }
+
+export function getStorage() {
+  return getStorageManager(ZEOTAP_VENDOR_ID, ZEOTAP_MODULE_NAME);
+}
+
+export const storage = getStorage();
 
 /** @type {Submodule} */
 export const zeotapIdPlusSubmodule = {

--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import find from 'core-js-pure/features/array/find.js';
 import { config } from 'src/config.js';
 import { init, requestBidsHook, setSubmoduleRegistry } from 'modules/userId/index.js';
-import { storage, zeotapIdPlusSubmodule } from 'modules/zeotapIdPlusIdSystem.js';
+import { storage, getStorage, zeotapIdPlusSubmodule } from 'modules/zeotapIdPlusIdSystem.js';
+import * as storageManager from 'src/storageManager.js';
 
 const ZEOTAP_COOKIE_NAME = 'IDP';
 const ZEOTAP_COOKIE = 'THIS-IS-A-DUMMY-COOKIE';
@@ -42,8 +43,72 @@ function unsetLocalStorage() {
   storage.setDataInLocalStorage(ZEOTAP_COOKIE_NAME, '');
 }
 
-describe('Zeotap ID System', function() {
+describe.only('Zeotap ID System', function() {
+  describe('Zeotap Module invokes StorageManager with appropriate arguments', function() {
+    let getStorageManagerSpy;
+
+    beforeEach(function() {
+      getStorageManagerSpy = sinon.spy(storageManager, 'getStorageManager');
+    });
+
+
+    it('when a stored Zeotap ID exists it is added to bids', function() {
+      let store = getStorage();
+      expect(getStorageManagerSpy.calledOnce).to.be.true;
+      sinon.assert.calledWith(getStorageManagerSpy, 301, 'zeotapIdPlus');
+    });
+  });
+
+  describe('test method: getId calls storage methods to fetch ID', function() {
+
+    let cookiesAreEnabledStub;
+    let getCookieStub;
+    let localStorageIsEnabledStub;
+    let getDataFromLocalStorageStub;
+
+    beforeEach(() => {
+      cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
+      getCookieStub = sinon.stub(storage, 'getCookie');
+      localStorageIsEnabledStub = sinon.stub(storage, 'localStorageIsEnabled');
+      getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+    });
+
+    afterEach(() => {
+      storage.cookiesAreEnabled.restore();
+      storage.getCookie.restore();
+      storage.localStorageIsEnabled.restore();
+      storage.getDataFromLocalStorage.restore();
+      unsetCookie();
+      unsetLocalStorage();
+    });
+
+    it('should check if cookies are enabled', function() {
+      let id = zeotapIdPlusSubmodule.getId();
+      expect(cookiesAreEnabledStub.calledOnce).to.be.true;
+    });
+
+    it('should call getCookie if cookies are enabled', function() {
+      cookiesAreEnabledStub.returns(true);
+      let id = zeotapIdPlusSubmodule.getId();
+      expect(cookiesAreEnabledStub.calledOnce).to.be.true;
+      expect(getCookieStub.calledOnce).to.be.true;
+      sinon.assert.calledWith(getCookieStub, 'IDP');
+    });
+
+    it('should check for localStorage if cookies are disabled', function() {
+      cookiesAreEnabledStub.returns(false);
+      localStorageIsEnabledStub.returns(true)
+      let id = zeotapIdPlusSubmodule.getId();
+      expect(cookiesAreEnabledStub.calledOnce).to.be.true;
+      expect(getCookieStub.called).to.be.false;
+      expect(localStorageIsEnabledStub.calledOnce).to.be.true;
+      expect(getDataFromLocalStorageStub.calledOnce).to.be.true;
+      sinon.assert.calledWith(getDataFromLocalStorageStub, 'IDP');
+    });
+  });
+
   describe('test method: getId', function() {
+
     afterEach(() => {
       unsetCookie();
       unsetLocalStorage();

--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -43,14 +43,13 @@ function unsetLocalStorage() {
   storage.setDataInLocalStorage(ZEOTAP_COOKIE_NAME, '');
 }
 
-describe.only('Zeotap ID System', function() {
+describe('Zeotap ID System', function() {
   describe('Zeotap Module invokes StorageManager with appropriate arguments', function() {
     let getStorageManagerSpy;
 
     beforeEach(function() {
       getStorageManagerSpy = sinon.spy(storageManager, 'getStorageManager');
     });
-
 
     it('when a stored Zeotap ID exists it is added to bids', function() {
       let store = getStorage();
@@ -60,7 +59,6 @@ describe.only('Zeotap ID System', function() {
   });
 
   describe('test method: getId calls storage methods to fetch ID', function() {
-
     let cookiesAreEnabledStub;
     let getCookieStub;
     let localStorageIsEnabledStub;
@@ -108,7 +106,6 @@ describe.only('Zeotap ID System', function() {
   });
 
   describe('test method: getId', function() {
-
     afterEach(() => {
       unsetCookie();
       unsetLocalStorage();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Added **gvlid** as Zeotap's vendor id to avoid issues in case **gdprEnforcement** module is enabled. 
Also pass appropriate arguments to StorageManager (gvlid, module name).

## Desired Output
Prebid is able to fetch Zeotap cookie (IDP) from the storage and `pbjs.getUserIds()` gives appropriate results.

## Actual Result
Currently since the gvlid was not set, so warning of _'User denied Permission .. '_ was seen on dev console if gdprEnforcement is enabled. Also since storageManager was not invoked with correct arguments, cookie was not read from storage even after adding _'zeotapIdPlus'_ to _vendorExceptions_ in `prebid.setConfig()` on publisher page.
