### PR TITLE
Add the trade desk gvlid

### DIFF
--- a/modules/unifiedIdSystem.js
+++ b/modules/unifiedIdSystem.js
@@ -19,6 +19,10 @@ export const unifiedIdSubmodule = {
    */
   name: MODULE_NAME,
   /**
+   * required for the gdpr enforcement module
+   */
+  gvlid: 21,
+  /**
    * decode the stored id value for passing to bid requests
    * @function
    * @param {{TDID:string}} value


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

UnifiedId only works with a vendor exception in the gdpr enforcement module.
However this is not okay as the unifiedId matching endpoint doesn't take the consent into account and
cookies are being dropped even without consent.



## Other information

- #5615
- #5615
