### PR TITLE
Revert "Extended ID permissions supported by bidder"

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -236,7 +236,6 @@
                         },
                         {
                         name: "sharedId",
-                        // bidders: ["rubicon", "sampleBidders"], // to allow this ID for specific bidders
                         params: {
                             syncTime: 60 // in seconds, default is 24 hours
                         },

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -12,7 +12,6 @@ import includes from 'core-js-pure/features/array/includes.js';
 import { S2S_VENDORS } from './config.js';
 import { ajax } from '../../src/ajax.js';
 import find from 'core-js-pure/features/array/find.js';
-import { getEidPermissions } from '../userId/index.js';
 
 const getConfig = config.getConfig;
 
@@ -460,7 +459,7 @@ export function resetWurlMap() {
 }
 
 const OPEN_RTB_PROTOCOL = {
-  buildRequest(s2sBidRequest, bidRequests, adUnits, s2sConfig, requestedBidders) {
+  buildRequest(s2sBidRequest, bidRequests, adUnits, s2sConfig) {
     let imps = [];
     let aliases = {};
     const firstBidRequest = bidRequests[0];
@@ -703,18 +702,6 @@ const OPEN_RTB_PROTOCOL = {
     const bidUserIdAsEids = utils.deepAccess(bidRequests, '0.bids.0.userIdAsEids');
     if (utils.isArray(bidUserIdAsEids) && bidUserIdAsEids.length > 0) {
       utils.deepSetValue(request, 'user.ext.eids', bidUserIdAsEids);
-    }
-
-    const eidPermissions = getEidPermissions();
-    if (utils.isArray(eidPermissions) && eidPermissions.length > 0) {
-      if (requestedBidders && utils.isArray(requestedBidders)) {
-        eidPermissions.forEach(i => {
-          if (i.bidders) {
-            i.bidders = i.bidders.filter(bidder => requestedBidders.includes(bidder))
-          }
-        });
-      }
-      utils.deepSetValue(request, 'ext.prebid.data.eidpermissions', eidPermissions);
     }
 
     if (bidRequests) {
@@ -975,7 +962,7 @@ export function PrebidServer() {
         queueSync(syncBidders, gdprConsent, uspConsent, s2sBidRequest.s2sConfig);
       }
 
-      const request = OPEN_RTB_PROTOCOL.buildRequest(s2sBidRequest, bidRequests, validAdUnits, s2sBidRequest.s2sConfig, requestedBidders);
+      const request = OPEN_RTB_PROTOCOL.buildRequest(s2sBidRequest, bidRequests, validAdUnits, s2sBidRequest.s2sConfig);
       const requestJson = request && JSON.stringify(request);
       if (request && requestJson) {
         ajax(

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -224,25 +224,3 @@ export function createEidsArray(bidRequestUserId) {
   }
   return eids;
 }
-
-/**
- * @param {SubmoduleContainer[]} submodules
- */
-export function buildEidPermissions(submodules) {
-  let eidPermissions = [];
-  submodules.filter(i => utils.isPlainObject(i.idObj) && Object.keys(i.idObj).length)
-    .forEach(i => {
-      Object.keys(i.idObj).forEach(key => {
-        if (utils.deepAccess(i, 'config.bidders') && Array.isArray(i.config.bidders) &&
-          utils.deepAccess(USER_IDS_CONFIG, key + '.source')) {
-          eidPermissions.push(
-            {
-              source: USER_IDS_CONFIG[key].source,
-              bidders: i.config.bidders
-            }
-          );
-        }
-      });
-    });
-  return eidPermissions;
-}

--- a/plugins/eslint/validateImports.js
+++ b/plugins/eslint/validateImports.js
@@ -26,8 +26,7 @@ function flagErrors(context, node, importPath) {
     if (
       path.dirname(absImportPath) === absModulePath || (
         absImportPath.startsWith(absModulePath) &&
-        path.basename(absImportPath) === 'index.js' &&
-        path.basename(absFileDir) !== 'prebidServerBidAdapter'
+        path.basename(absImportPath) === 'index.js'
       )
     ) {
       context.report(node, `import "${importPath}" cannot require module entry point`);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -953,15 +953,17 @@ describe('S2S Adapter', function () {
       adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
 
       const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.ext).to.haveOwnProperty('prebid');
-      expect(requestBid.ext.prebid).to.deep.include({
-        aliases: {
-          brealtime: 'appnexus'
-        },
-        auctiontimestamp: 1510852447530,
-        targeting: {
-          includebidderkeys: false,
-          includewinners: true
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          aliases: {
+            brealtime: 'appnexus'
+          },
+          auctiontimestamp: 1510852447530,
+          targeting: {
+            includebidderkeys: false,
+            includewinners: true
+          }
         }
       });
     });
@@ -983,15 +985,17 @@ describe('S2S Adapter', function () {
       adapter.callBids(request, BID_REQUESTS, addBidResponse, done, ajax);
 
       const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.ext).to.haveOwnProperty('prebid');
-      expect(requestBid.ext.prebid).to.deep.include({
-        aliases: {
-          [alias]: 'appnexus'
-        },
-        auctiontimestamp: 1510852447530,
-        targeting: {
-          includebidderkeys: false,
-          includewinners: true
+
+      expect(requestBid.ext).to.deep.equal({
+        prebid: {
+          aliases: {
+            [alias]: 'appnexus'
+          },
+          auctiontimestamp: 1510852447530,
+          targeting: {
+            includebidderkeys: false,
+            includewinners: true
+          }
         }
       });
     });
@@ -1372,7 +1376,7 @@ describe('S2S Adapter', function () {
 
       expect(requestBid).to.haveOwnProperty('ext');
       expect(requestBid.ext).to.haveOwnProperty('prebid');
-      expect(requestBid.ext.prebid).to.deep.include({
+      expect(requestBid.ext.prebid).to.deep.equal({
         auctiontimestamp: 1510852447530,
         foo: 'bar',
         targeting: {
@@ -1406,7 +1410,7 @@ describe('S2S Adapter', function () {
 
       expect(requestBid).to.haveOwnProperty('ext');
       expect(requestBid.ext).to.haveOwnProperty('prebid');
-      expect(requestBid.ext.prebid).to.deep.include({
+      expect(requestBid.ext.prebid).to.deep.equal({
         auctiontimestamp: 1510852447530,
         targeting: {
           includewinners: false,
@@ -1442,7 +1446,7 @@ describe('S2S Adapter', function () {
 
       expect(requestBid).to.haveOwnProperty('ext');
       expect(requestBid.ext).to.haveOwnProperty('prebid');
-      expect(requestBid.ext.prebid).to.deep.include({
+      expect(requestBid.ext.prebid).to.deep.equal({
         auctiontimestamp: 1510852447530,
         cache: {
           vastxml: 'vastxml-set-though-extPrebid.cache.vastXml'

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2,7 +2,6 @@ import {
   attachIdSystem,
   auctionDelay,
   coreStorage,
-  getEidPermissions,
   init,
   requestBidsHook,
   setStoredConsentData,
@@ -71,7 +70,7 @@ describe('User ID', function () {
       code,
       mediaTypes: {banner: {}, native: {}},
       sizes: [[300, 200], [300, 600]],
-      bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}, {bidder: 'anotherSampleBidder', params: {placementId: 'banner-only-bidder'}}]
+      bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}]
     };
   }
 
@@ -1189,120 +1188,6 @@ describe('User ID', function () {
                 id: 'test_sharedId',
                 atype: 1
               }]
-            });
-          });
-        });
-        coreStorage.setCookie('sharedid', '', EXPIRED_COOKIE_DATE);
-        done();
-      }, {adUnits});
-    });
-
-    it('eidPermissions fun with bidders', function (done) {
-      coreStorage.setCookie('sharedid', JSON.stringify({
-        'id': 'test222',
-        'ts': 1590525289611
-      }), (new Date(Date.now() + 5000).toUTCString()));
-
-      setSubmoduleRegistry([sharedIdSubmodule]);
-      init(config);
-      config.setConfig({
-        userSync: {
-          syncDelay: 0,
-          userIds: [
-            {
-              name: 'sharedId',
-              bidders: [
-                'sampleBidder'
-              ],
-              storage: {
-                type: 'cookie',
-                name: 'sharedid',
-                expires: 28
-              }
-            }
-          ]
-        }
-      });
-
-      requestBidsHook(function () {
-        const eidPermissions = getEidPermissions();
-        expect(eidPermissions).to.deep.equal(
-          [
-            {source: 'sharedid.org', bidders: ['sampleBidder']}
-          ]
-        );
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            if (bid.bidder === 'sampleBidder') {
-              expect(bid).to.have.deep.nested.property('userId.sharedid');
-              expect(bid.userId.sharedid.id).to.equal('test222');
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'sharedid.org',
-                uids: [
-                  {
-                    id: 'test222',
-                    atype: 1,
-                    ext: {
-                      third: 'test222'
-                    }
-                  }
-                ]
-              });
-            }
-            if (bid.bidder === 'anotherSampleBidder') {
-              expect(bid).to.not.have.deep.nested.property('userId.sharedid');
-              expect(bid).to.not.have.property('userIdAsEids');
-            }
-          });
-        });
-        coreStorage.setCookie('sharedid', '', EXPIRED_COOKIE_DATE);
-        done();
-      }, {adUnits});
-    });
-
-    it('eidPermissions fun without bidders', function (done) {
-      coreStorage.setCookie('sharedid', JSON.stringify({
-        'id': 'test222',
-        'ts': 1590525289611
-      }), (new Date(Date.now() + 5000).toUTCString()));
-
-      setSubmoduleRegistry([sharedIdSubmodule]);
-      init(config);
-      config.setConfig({
-        userSync: {
-          syncDelay: 0,
-          userIds: [
-            {
-              name: 'sharedId',
-              storage: {
-                type: 'cookie',
-                name: 'sharedid',
-                expires: 28
-              }
-            }
-          ]
-        }
-      });
-
-      requestBidsHook(function () {
-        const eidPermissions = getEidPermissions();
-        expect(eidPermissions).to.deep.equal(
-          []
-        );
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.sharedid');
-            expect(bid.userId.sharedid.id).to.equal('test222');
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'sharedid.org',
-              uids: [
-                {
-                  id: 'test222',
-                  atype: 1,
-                  ext: {
-                    third: 'test222'
-                  }
-                }]
             });
           });
         });


### PR DESCRIPTION
Reverts prebid/Prebid.js#6112

Observed that calling the PBS adapter without any defined userId modules causes an exception error to be thrown, interrupting the request.  

Additionally, we should not be directly importing functions from module files.  This creates an implicit setup for the other module to always be included - which is not what the publisher would expect.

We are reverting this PR, for now, to allow time for the below issue to be addressed.

```
ERROR: Error processing command : prebid.js TypeError: Cannot read property 'filter' of undefined
    at buildEidPermissions (eids.js:233)
    at getEidPermissions (index.js:218)
    at Object.buildRequest (index.js:708)
    at PrebidServer.baseAdapter.callBids (index.js:978)
    at adapterManager.js:389
    at Array.forEach (<anonymous>)
    at Object.8.adapterManager.callBids (adapterManager.js:355)
    at Object.run (auction.js:248)
    at runIfOriginHasCapacity (auction.js:311)
    at Object.addBidderRequestsCallback (auction.js:280)
```