### PR TITLE
Rubicon Analytics: Pick up wrapper family field

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -167,9 +167,10 @@ function sendMessage(auctionId, bidWonId) {
     referrerHostname: rubiconAdapter.referrerHostname || getHostNameFromReferer(referrer),
     channel: 'web',
   };
-  if (rubiConf.wrapperName || rubiConf.rule_name) {
+  if (rubiConf.wrapperName) {
     message.wrapper = {
       name: rubiConf.wrapperName,
+      family: rubiConf.wrapperFamily,
       rule: rubiConf.rule_name
     }
   }

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -1754,7 +1754,8 @@ describe('rubicon analytics adapter', function () {
   describe('wrapper details passed in', () => {
     it('should correctly pass in the wrapper details if provided', () => {
       config.setConfig({rubicon: {
-        wrapperName: '1001_wrapperName',
+        wrapperName: '1001_wrapperName_exp.4',
+        wrapperFamily: '1001_wrapperName',
         rule_name: 'na-mobile'
       }});
 
@@ -1771,7 +1772,8 @@ describe('rubicon analytics adapter', function () {
       const request = server.requests[0];
       const message = JSON.parse(request.requestBody);
       expect(message.wrapper).to.deep.equal({
-        name: '1001_wrapperName',
+        name: '1001_wrapperName_exp.4',
+        family: '1001_wrapperName',
         rule: 'na-mobile'
       });
 


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Prebid Wrappers using the Magnite Service will have a new field available called wrapperFamily which we will need to pass through to our analytics endpoint.