### PR TITLE
Prebid Server Bid Adapter: adding support for getFloor

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -639,6 +639,23 @@ const OPEN_RTB_PROTOCOL = {
         utils.deepSetValue(imp, 'ext.prebid.storedauctionresponse.id', storedAuctionResponseBid.storedAuctionResponse.toString());
       }
 
+      const getFloorBid = find(firstBidRequest.bids, bid => bid.adUnitCode === adUnit.code && typeof bid.getFloor === 'function');
+
+      if (getFloorBid) {
+        let floorInfo;
+        try {
+          floorInfo = getFloorBid.getFloor({
+            currency: config.getConfig('currency.adServerCurrency') || DEFAULT_S2S_CURRENCY,
+          });
+        } catch (e) {
+          utils.logError('PBS: getFloor threw an error: ', e);
+        }
+        if (floorInfo && floorInfo.currency && !isNaN(parseFloat(floorInfo.floor))) {
+          imp.bidfloor = parseFloat(floorInfo.floor);
+          imp.bidfloorcur = floorInfo.currency
+        }
+      }
+
       if (imp.banner || imp.video || imp.native) {
         imps.push(imp);
       }


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
This change will add in support to the pbsBidAdapter to call the price floors getFloor function.

When called, it will only pass currency as an attribute since having to add a bunch of logic to determine if the floor should be banner, or which size is overkill.

And the Price floors module will try to resolve these automatically by the context of the adUnit.
- If only one mediaType exists, it will use it, else *
- if only one size exists, it will use it, else *

For currency, it will send whatever the publisher has put their adServerCurrency to. Otherwise it will use the default 'USD'

Regardless of what is sent into the function, it will pass the returned currency from the getFloor function as to make sure it the `bidfloor` and `bidfloorcur` attributes are always in line.

*NOTE* One thing to point out is that if for some reason the price floors module is implemented with a bidder specific set of rules, we will obviously not be able to send a rule for all bidders in the request. each imp only gets one set of `bidfloor` and `bidfloorcur`.