### PR TITLE
[ParrableIdSystem] Accept list of partners as an array or string

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -999,9 +999,22 @@ function hidedfpContainer(elementId) {
   }
 }
 
+function hideSASIframe(elementId) {
+  try {
+    // find script tag with id 'sas_script'. This ensures it only works if you're using Smart Ad Server.
+    const el = document.getElementById(elementId).querySelectorAll("script[id^='sas_script']");
+    if (el[0].nextSibling && el[0].nextSibling.localName === 'iframe') {
+      el[0].nextSibling.style.setProperty('display', 'none');
+    }
+  } catch (e) {
+    // element not found!
+  }
+}
+
 function outstreamRender(bid) {
-  // push to render queue because ANOutstreamVideo may not be loaded yet
   hidedfpContainer(bid.adUnitCode);
+  hideSASIframe(bid.adUnitCode);
+  // push to render queue because ANOutstreamVideo may not be loaded yet
   bid.renderer.push(() => {
     window.ANOutstreamVideo.renderAd({
       tagId: bid.adResponse.tag_id,

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -74,20 +74,20 @@ function removeParrableCookie() {
   storage.setCookie(P_COOKIE_NAME, '', EXPIRED_COOKIE_DATE);
 }
 
+function decodeBase64UrlSafe(encBase64) {
+  const DEC = {
+    '-': '+',
+    '_': '/',
+    '.': '='
+  };
+  return encBase64.replace(/[-_.]/g, (m) => DEC[m]);
+}
+
 describe('Parrable ID System', function() {
   describe('parrableIdSystem.getId()', function() {
     describe('response callback function', function() {
       let logErrorStub;
       let callbackSpy = sinon.spy();
-
-      let decodeBase64UrlSafe = function (encBase64) {
-        const DEC = {
-          '-': '+',
-          '_': '/',
-          '.': '='
-        };
-        return encBase64.replace(/[-_.]/g, (m) => DEC[m]);
-      }
 
       beforeEach(function() {
         logErrorStub = sinon.stub(utils, 'logError');
@@ -503,7 +503,7 @@ describe('Parrable ID System', function() {
 
         let request = server.requests[0];
         let queryParams = utils.parseQS(request.url.split('?')[1]);
-        let data = JSON.parse(atob(queryParams.data));
+        let data = JSON.parse(atob(decodeBase64UrlSafe(queryParams.data)));
 
         expect(data.trackers).to.deep.equal(testCase.expected);
       });

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -247,7 +247,7 @@ describe('Parrable ID System', function() {
       writeParrableCookie({ eid: P_COOKIE_EID });
 
       expect(parrableIdSubmodule.getId({ params: {
-        partnerss: 'prebid-test',
+        partners: 'prebid-test',
         timezoneFilter: {
           blockedZones: [ blockedZone ]
         }

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -115,7 +115,7 @@ describe('Parrable ID System', function() {
         expect(queryParams).to.not.have.property('us_privacy');
         expect(data).to.deep.equal({
           eid: P_COOKIE_EID,
-          trackers: P_CONFIG_MOCK.params.partner.split(','),
+          trackers: P_CONFIG_MOCK.params.partners.split(','),
           url: getRefererInfo().referer,
           isIframe: true
         });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This changes introduces a new parameter (`partners`) to our module that supersedes the old `partner` string-list while still preserving the old behavior. While the old list accepted a comma-separated string of partner IDs we wanted to clean up the parameter name (make it plural) and have it accept a proper array for simplicity. Both `partner` and `partners` now operate the same way and can accept an array, or a comma-separated string.

Docs: https://github.com/prebid/prebid.github.io/pull/2688
