### PR TITLE
disable webdriver tests in trionBidAdapter spec

### DIFF
--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -146,47 +146,47 @@ describe('Trion adapter tests', function () {
       expect(bidUrlParams).to.include(getPublisherUrl());
     });
 
-    describe('webdriver', function () {
-      let originalWD;
+    // describe('webdriver', function () {
+    //   let originalWD;
 
-      beforeEach(function () {
-        originalWD = window.navigator.webdriver;
-      });
+    //   beforeEach(function () {
+    //     originalWD = window.navigator.webdriver;
+    //   });
 
-      afterEach(function () {
-        window.navigator['__defineGetter__']('webdriver', function () {
-          return originalWD;
-        });
-      });
+    //   afterEach(function () {
+    //     window.navigator['__defineGetter__']('webdriver', function () {
+    //       return originalWD;
+    //     });
+    //   });
 
-      describe('is present', function () {
-        beforeEach(function () {
-          window.navigator['__defineGetter__']('webdriver', function () {
-            return 1;
-          });
-        });
+    //   describe('is present', function () {
+    //     beforeEach(function () {
+    //       window.navigator['__defineGetter__']('webdriver', function () {
+    //         return 1;
+    //       });
+    //     });
 
-        it('when there is non human traffic', function () {
-          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
-          let bidUrlParams = bidRequests[0].data;
-          expect(bidUrlParams).to.include('tr_wd=1');
-        });
-      });
+    //     it('when there is non human traffic', function () {
+    //       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+    //       let bidUrlParams = bidRequests[0].data;
+    //       expect(bidUrlParams).to.include('tr_wd=1');
+    //     });
+    //   });
 
-      describe('is not present', function () {
-        beforeEach(function () {
-          window.navigator['__defineGetter__']('webdriver', function () {
-            return 0;
-          });
-        });
+    //   describe('is not present', function () {
+    //     beforeEach(function () {
+    //       window.navigator['__defineGetter__']('webdriver', function () {
+    //         return 0;
+    //       });
+    //     });
 
-        it('when there is not non human traffic', function () {
-          let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
-          let bidUrlParams = bidRequests[0].data;
-          expect(bidUrlParams).to.include('tr_wd=0');
-        });
-      });
-    });
+    //     it('when there is not non human traffic', function () {
+    //       let bidRequests = spec.buildRequests(TRION_BID_REQUEST);
+    //       let bidUrlParams = bidRequests[0].data;
+    //       expect(bidUrlParams).to.include('tr_wd=0');
+    //     });
+    //   });
+    // });
 
     describe('document', function () {
       let originalHD;


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
A number of Prebid.js reviewers were seeing the following type of errors coming from the `trionBidAdapter_spec` file:
```
  Trion adapter tests
    buildRequests
      webdriver
        is present
          ✖ "before each" hook for "when there is non human traffic"
            HeadlessChrome 88.0.4324 (Mac OS X 10.14.6)
          TypeError: Cannot redefine property: webdriver
              at Navigator.__defineGetter__ (<anonymous>)
              at Context.<anonymous> (webpack:///test/spec/modules/trionBidAdapter_spec.js:164:11 <- test/test_index.js:378575:47)

        ✖ "after each" hook for "when there is non human traffic"
          HeadlessChrome 88.0.4324 (Mac OS X 10.14.6)
        TypeError: Cannot redefine property: webdriver
            at Navigator.__defineGetter__ (<anonymous>)
            at Context.<anonymous> (webpack:///test/spec/modules/trionBidAdapter_spec.js:157:9 <- test/test_index.js:378569:45)
```

These errors only appeared when running the unit tests locally; they were not observed in the circleci unit test jobs for some reason.

The tests in question modify the primary `webdriver` object and try to restore it after the tests are done.  Given the inconsistent nature of these tests, it was decided to disable these tests for now.

An issue will be created to ask the trion team to review these tests again.