### PR TITLE
[ParrableIdSystem] Add GVLID and handle TC Consent data

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -999,9 +999,22 @@ function hidedfpContainer(elementId) {
   }
 }
 
+function hideSASIframe(elementId) {
+  try {
+    // find script tag with id 'sas_script'. This ensures it only works if you're using Smart Ad Server.
+    const el = document.getElementById(elementId).querySelectorAll("script[id^='sas_script']");
+    if (el[0].nextSibling && el[0].nextSibling.localName === 'iframe') {
+      el[0].nextSibling.style.setProperty('display', 'none');
+    }
+  } catch (e) {
+    // element not found!
+  }
+}
+
 function outstreamRender(bid) {
-  // push to render queue because ANOutstreamVideo may not be loaded yet
   hidedfpContainer(bid.adUnitCode);
+  hideSASIframe(bid.adUnitCode);
+  // push to render queue because ANOutstreamVideo may not be loaded yet
   bid.renderer.push(() => {
     window.ANOutstreamVideo.renderAd({
       tagId: bid.adResponse.tag_id,

--- a/modules/idLibrary.js
+++ b/modules/idLibrary.js
@@ -200,10 +200,10 @@ function postData() {
     logInfo('No user ids');
     return;
   }
-  logInfo('Users' + JSON.stringify(userIds));
+  logInfo('Users' + userIds);
   const syncPayload = {};
   syncPayload.hid = MD5(email).toString();
-  syncPayload.uids = JSON.stringify(userIds);
+  syncPayload.uids = userIds;
   const payloadString = JSON.stringify(syncPayload);
   logInfo(payloadString);
   ajax(conf.url, syncCallback(), payloadString, {method: 'POST', withCredentials: true});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This change allows our User ID module to support GDPR via the TCF2 consent string. Since we interact with cookie storage inside of our ID system we pass the GVLID to Prebid's storage manager so that device access consent can be checked for our GVLID. We then forward gdpr applicability and the consent string to our backend systems.

Docs: https://github.com/prebid/prebid.github.io/pull/2693