### PR TITLE
add warning for non-string adSlots

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -204,6 +204,9 @@ function _cleanSlot(slotName) {
   if (utils.isStr(slotName)) {
     return slotName.replace(/^\s+/g, '').replace(/\s+$/g, '');
   }
+  if (slotName) {
+    utils.logWarn(BIDDER_CODE + ': adSlot must be a string. Ignoring adSlot');
+  }
   return '';
 }
 

--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -24,9 +24,9 @@ var adUnits = [
     bids: [{
       bidder: 'pubmatic',
       params: {
-        publisherId: '156209',               // required, must be wrapped in quotes
+        publisherId: '156209',               // required, must be a string, not an integer or other js type.
         oustreamAU: 'renderer_test_pubmatic',   // required if mediaTypes-> video-> context is 'outstream' and optional if renderer is defined in adUnits or in mediaType video. This value can be get by BlueBillyWig Team.
-        adSlot: 'pubmatic_test2',            // optional, must be wrapped in quotes
+        adSlot: 'pubmatic_test2',            // optional, must be a string, not an integer or other js type.
         pmzoneid: 'zone1, zone11',           // optional
         lat: '40.712775',                    // optional
         lon: '-74.005973',                   // optional

--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -26,7 +26,7 @@ var adUnits = [
       params: {
         publisherId: '156209',               // required, must be wrapped in quotes
         oustreamAU: 'renderer_test_pubmatic',   // required if mediaTypes-> video-> context is 'outstream' and optional if renderer is defined in adUnits or in mediaType video. This value can be get by BlueBillyWig Team.
-        adSlot: 'pubmatic_test2',            // optional
+        adSlot: 'pubmatic_test2',            // optional, must be wrapped in quotes
         pmzoneid: 'zone1, zone11',           // optional
         lat: '40.712775',                    // optional
         lon: '-74.005973',                   // optional


### PR DESCRIPTION

## Type of change

- [x] Other

## Description of change
output a warning if adSlot is not a string. Update markdown to indicate they should be strings.  It might be better to just support non-strings, since the recommended usage of the field is actually a number these days, but that's a bit more work, and would probably want tests.
