### PR TITLE
Adloox Video Adserver Module: add new adserver module

### DIFF
--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -112,6 +112,7 @@
 
                 var videoBids = bids[videoAdUnit.code];
                 if (videoBids) {
+// DEMO NOTES: your environment likely will use the commented section ////
                     var videoUrl = videoBids.bids[0].vastUrl;
 //                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
 //                        adUnit: videoAdUnit,
@@ -124,7 +125,12 @@
 //                            output: 'vast'
 //                        }
 //                    });
-                    invokeVideoPlayer(videoUrl);
+//////////////////////////////////////////////////////////////////////////
+                    var ret = pbjs.adServers.adloox.buildVideoUrl({
+                        adUnit: videoAdUnit,
+                        url: videoUrl
+                    }, invokeVideoPlayer);
+                    if (!ret) console.log('Error building Adloox video URL');
                 }
             }
 

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -1,0 +1,223 @@
+/**
+ * This module adds [Adloox]{@link https://www.adloox.com/} Ad Server support for Video to Prebid
+ * @module modules/adlooxAdServerVideo
+ * @requires module:modules/adlooxAnalyticsAdapter
+ */
+
+/* eslint prebid/validate-imports: "off" */
+
+import { registerVideoSupport } from '../src/adServerManager.js';
+import { command as analyticsCommand, COMMAND } from './adlooxAnalyticsAdapter.js';
+import { ajax } from '../src/ajax.js';
+import { EVENTS } from '../src/constants.json';
+import { targeting } from '../src/targeting.js';
+import * as utils from '../src/utils.js';
+
+const MODULE = 'adlooxAdserverVideo';
+
+const URL_VAST = 'https://j.adlooxtracking.com/ads/vast/tag.php';
+
+export function buildVideoUrl(options, callback) {
+  utils.logInfo(MODULE, 'buildVideoUrl', options);
+
+  if (!utils.isFn(callback)) {
+    utils.logError(MODULE, 'invalid callback');
+    return false;
+  }
+  if (!utils.isPlainObject(options)) {
+    utils.logError(MODULE, 'missing options');
+    return false;
+  }
+  if (!(options.url_vast === undefined || utils.isStr(options.url_vast))) {
+    utils.logError(MODULE, 'invalid url_vast options value');
+    return false;
+  }
+  if (!(utils.isPlainObject(options.adUnit) || utils.isPlainObject(options.bid))) {
+    utils.logError(MODULE, "requires either 'adUnit' or 'bid' options value");
+    return false;
+  }
+  if (!utils.isStr(options.url)) {
+    utils.logError(MODULE, 'invalid url options value');
+    return false;
+  }
+  if (!(options.wrap === undefined || utils.isBoolean(options.wrap))) {
+    utils.logError(MODULE, 'invalid wrap options value');
+    return false;
+  }
+  if (!(options.blob === undefined || utils.isBoolean(options.blob))) {
+    utils.logError(MODULE, 'invalid blob options value');
+    return false;
+  }
+
+  // same logic used in modules/dfpAdServerVideo.js
+  options.bid = options.bid || targeting.getWinningBids(options.adUnit.code)[0];
+
+  utils.deepSetValue(options.bid, 'ext.adloox.video.adserver', true);
+
+  if (options.wrap !== false) {
+    VASTWrapper(options, callback);
+  } else {
+    track(options, callback);
+  }
+
+  return true;
+}
+
+registerVideoSupport('adloox', {
+  buildVideoUrl: buildVideoUrl
+});
+
+function track(options, callback) {
+  callback(options.url);
+
+  const bid = utils.deepClone(options.bid);
+  bid.ext.adloox.video.adserver = false;
+
+  analyticsCommand(COMMAND.TRACK, {
+    eventType: EVENTS.BID_WON,
+    args: bid
+  });
+}
+
+function VASTWrapper(options, callback) {
+  const chain = [];
+
+  function process(result) {
+    function getAd(xml) {
+      if (!xml || xml.documentElement.tagName != 'VAST') {
+        utils.logError(MODULE, 'not a VAST tag, using non-wrapped tracking');
+        return;
+      }
+
+      const ads = xml.querySelectorAll('Ad');
+      if (!ads.length) {
+        utils.logError(MODULE, 'no VAST ads, using non-wrapped tracking');
+        return;
+      }
+
+      // get first Ad (VAST may be an Ad Pod so sort on sequence and pick lowest sequence number)
+      const ad = Array.prototype.slice.call(ads).sort(function(a, b) {
+        return parseInt(a.getAttribute('sequence'), 10) - parseInt(b.getAttribute('sequence'), 10);
+      }).shift();
+
+      return ad;
+    }
+
+    function getWrapper(ad) {
+      return ad.querySelector('VASTAdTagURI');
+    }
+
+    function durationToSeconds(duration) {
+      return Date.parse('1970-01-01 ' + duration + 'Z') / 1000;
+    }
+
+    function blobify() {
+      if (!(chain.length > 0 && options.blob !== false)) return;
+
+      const urls = [];
+
+      function toBlob(r) {
+        const text = new XMLSerializer().serializeToString(r.xml);
+        const url = URL.createObjectURL(new Blob([text], { type: r.type }));
+        urls.push(url);
+        return url;
+      }
+
+      let n = chain.length - 1; // do not process the linear
+      while (n-- > 0) {
+        const ad = getAd(chain[n].xml);
+        const wrapper = getWrapper(ad);
+        wrapper.textContent = toBlob(chain[n + 1]);
+      }
+
+      options.url = toBlob(chain[0]);
+
+      const epoch = utils.timestamp() - new Date().getTimezoneOffset() * 60 * 1000;
+      const expires0 = options.bid.ttl * 1000 - (epoch - options.bid.responseTimestamp);
+      const expires = Math.max(30 * 1000, expires0);
+      setTimeout(function() { urls.forEach(u => URL.revokeObjectURL(u)) }, expires);
+    }
+
+    if (!result) {
+      blobify();
+      return track(options, callback);
+    }
+
+    const ad = getAd(result.xml);
+    if (!ad) {
+      blobify();
+      return track(options, callback);
+    }
+
+    chain.push(result);
+
+    const wrapper = getWrapper(ad);
+    if (wrapper) {
+      if (chain.length > 5) {
+        utils.logWarn(MODULE, `got wrapped tag at depth ${chain.length}, not continuing`);
+        blobify();
+        return track(options, callback);
+      }
+      return fetch(wrapper.textContent.trim());
+    }
+
+    blobify();
+
+    const version = chain[0].xml.documentElement.getAttribute('version');
+
+    const vpaid = ad.querySelector("MediaFiles > MediaFile[apiFramework='VPAID'][type='application/javascript']");
+
+    const duration = durationToSeconds(ad.querySelector('Duration').textContent.trim());
+
+    let skip;
+    const skipd = ad.querySelector('Linear').getAttribute('skipoffset');
+    if (skipd) skip = durationToSeconds(skipd.trim());
+
+    const args = [
+      [ 'client', '%%client%%' ],
+      [ 'platform_id', '%%platformid%%' ],
+      [ 'scriptname', 'adl_%%clientid%%' ],
+      [ 'tag_id', '%%tagid%%' ],
+      [ 'fwtype', 4 ],
+      [ 'vast', options.url ],
+      [ 'id11', 'video' ],
+      [ 'id12', '$ADLOOX_WEBSITE' ],
+      [ 'id18', (!skip || skip >= duration) ? 'fd' : 'od' ],
+      [ 'id19', 'na' ],
+      [ 'id20', 'na' ]
+    ];
+    if (version && version != 3) args.push([ 'version', version ]);
+    if (vpaid) args.push([ 'vpaid', 1 ]);
+    if (duration != 15) args.push([ 'duration', duration ]);
+    if (skip) args.push([ 'skip', skip ]);
+
+    utils.logInfo(MODULE, `processed VAST tag chain of depth ${chain.depth}, running callback`);
+
+    analyticsCommand(COMMAND.URL, {
+      url: (options.url_vast || URL_VAST) + '?',
+      args: args,
+      bid: options.bid,
+      ids: true
+    }, callback);
+  }
+
+  function fetch(url, withoutcredentials) {
+    utils.logInfo(MODULE, `fetching VAST ${url}`);
+
+    ajax(url, {
+      success: function(responseText, q) {
+        process({ type: q.getResponseHeader('content-type'), xml: q.responseXML });
+      },
+      error: function(statusText, q) {
+        if (!withoutcredentials) {
+          utils.logWarn(MODULE, `unable to download (${statusText}), suspected CORS withCredentials problem, retrying without`);
+          return fetch(url, true);
+        }
+        utils.logError(MODULE, `failed to fetch (${statusText}), using non-wrapped tracking`);
+        process();
+      }
+    }, undefined, { withCredentials: !withoutcredentials });
+  }
+
+  fetch(options.url);
+}

--- a/modules/adlooxAdServerVideo.md
+++ b/modules/adlooxAdServerVideo.md
@@ -1,0 +1,92 @@
+# Overview
+
+    Module Name: Adloox Ad Server Video
+    Module Type: Ad Server Video
+    Maintainer: contact@adloox.com
+
+# Description
+
+Ad Server Video for adloox.com. Contact contact@adloox.com for information.
+
+This module pairs with the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) to provide video tracking and measurement.
+
+Prebid.js does not support [`bidWon` events for video](https://github.com/prebid/prebid.github.io/issues/1320) without the [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html) module that has the limitations:
+
+ * works only with instream video
+ * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+
+This module has two modes of operation configurable with the `wrap` parameter below:
+
+ * **`true` [default]:**
+     * provides MRC accredited viewability measurement of your [IAB](https://www.iab.com/) [VPAID](https://iabtechlab.com/standards/video-player-ad-interface-definition-vpaid/) and [OM SDK](https://iabtechlab.com/standards/open-measurement-sdk/) enabled inventory
+     * VAST tracking is collected by Adloox
+     * wraps the winning bid VAST URL with the Adloox VAST/VPAID wrapper (`https://j.adlooxtracking.com/ads/vast/tag.php?...`)
+ * **`false`:**
+     * sends a `bidWon` event *only* to the Adloox Analytics Adapter
+     * inventory is measured
+     * viewability metrics are *not* MRC accredited.
+     * VAST tracking is *not* collected by Adloox
+
+**N.B.** this module is compatible for use alongside the Instream Video Ads Tracking module though not required in order to function
+
+## Example
+
+To view an example of an Adloox integration look at the example provided in the [Adloox Analytics Adapter documentation](./adlooxAnalyticsAdapter.md#example).
+
+# Integration
+
+To use this, you *must* also integrate the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) (and optionally the Instream Video Ads Tracking module) as shown below:
+
+    function sendAdserverRequest(bids, timedOut, auctionId) {
+      if (pbjs.initAdserverSet) return;
+      pbjs.initAdserverSet = true;
+
+      // handle display tags as usual
+      googletag.cmd.push(function() {
+        pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync(adUnits);
+        googletag.pubads().refresh();
+      });
+
+      // handle the bids on the video adUnit
+      var videoBids = bids[videoAdUnit.code];
+      if (videoBids) {
+        var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+          adUnit: videoAdUnit,
+          params: {
+            iu: '/19968336/prebid_cache_video_adunit',
+            cust_params: {
+              section: 'blog',
+              anotherKey: 'anotherValue'
+            },
+            output: 'vast'
+          }
+        });
+        pbjs.adServers.adloox.buildVideoUrl({
+          adUnit: videoAdUnit,
+          url: videoUrl
+        }, invokeVideoPlayer);
+      }
+    }
+
+The helper function takes the form:
+
+    pbjs.adServers.adloox.buildVideoUrl(options, callback)
+
+Where:
+
+ * **`options`:** configuration object:
+     * **`adUnit`:** ad unit that is being filled
+     * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.dfp.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
+     * **`url`:** VAST tag URL, typically the value returned by `pbjs.adServers.dfp.buildVideoUrl(...)`
+     * **`wrap`:**
+         * **`true` [default]:** VAST tag is be converted to an Adloox VAST wrapped tag
+         * **`false`:** VAST tag URL is returned as is
+     * **`blob`:**
+         * **`true` [default]:** [Blob URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) is returned so that the VAST tag is only fetched once
+             * only has an affect when `wrap` is set to `true`
+         * **`false`:** VAST tag may be fetched twice depending on your Ad Server and video player configuration
+             * use when the ad is served into a cross-origin (non-friendly) IFRAME
+             * use if during QAing you discover your video player does not supports Blob URLs; widely supported (including JW Player) so contact your player vendor to resolve this where possible for the best user and device experience
+ * **`callback`:** function you use to pass the VAST tag URL to your video player
+
+**N.B.** call `pbjs.adServers.adloox.buildVideoUrl(...)` as close as possible to starting the ad to reduce impression discrepancies

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -211,6 +211,11 @@ analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
 }
 
 analyticsAdapter[`handle_${EVENTS.BID_WON}`] = function(bid) {
+  if (utils.deepAccess(bid, 'ext.adloox.video.adserver')) {
+    utils.logMessage(MODULE, `measuring '${bid.mediaType}' ad unit code '${bid.adUnitCode}' via Ad Server module`);
+    return;
+  }
+
   const sl = analyticsAdapter.context.toselector(bid);
   let el;
   try {

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -18,17 +18,23 @@ The adapter adds an HTML `<script>` tag to load Adloox's post-buy verification J
 
 ## Video
 
-When tracking video you will need to enable the [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html) module but be aware that it is:
+When tracking video you have two options:
 
- * only suitable for instream video bids
- * VAST events are not collected by Adloox
- * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+ * [Instream Video Ads Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html)
+     * only suitable for instream video bids
+     * VAST events are not collected by Adloox
+     * viewability metrics are *not* [MRC accredited](http://mediaratingcouncil.org/)
+ * [Adloox Ad Server Video](./adlooxAdServerVideo.md)
+     * works by by wrapping the Ad Server VAST URL
+     * viewability metrics are MRC accredited for [IAB](https://www.iab.com/) [VPAID](https://iabtechlab.com/standards/video-player-ad-interface-definition-vpaid/) and [OM SDK](https://iabtechlab.com/standards/open-measurement-sdk/) enable inventory
+     * compatible for use alongside the Instream Video Ads Tracking module though not required in order to function
+     * slightly more complicated though straight forward to implement
 
 ## Example
 
 To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
 
-    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo
 
 **N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
 
@@ -55,7 +61,7 @@ You should be able to use this during the QA process of your own internal testin
 The main Prebid.js documentation is a bit opaque on this but you can use the following to test only Adloox's modules:
 
     gulp lint
-    gulp test-coverage --file test/spec/modules/adlooxAnalyticsAdapter_spec.js
+    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo}_spec.js'
     gulp view-coverage
 
 # Integration

--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -1,0 +1,339 @@
+import adapterManager from 'src/adapterManager.js';
+import analyticsAdapter from 'modules/adlooxAnalyticsAdapter.js';
+import { ajax } from 'src/ajax.js';
+import { buildVideoUrl } from 'modules/adlooxAdServerVideo.js';
+import { expect } from 'chai';
+import events from 'src/events.js';
+import { targeting } from 'src/targeting.js';
+import * as utils from 'src/utils.js';
+
+const analyticsAdapterName = 'adloox';
+
+describe('Adloox Ad Server Video', function () {
+  let sandbox;
+
+  const adUnit = {
+    code: 'ad-slot-1',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [ 640, 480 ]
+      }
+    },
+    bids: [
+      {
+        bidder: 'dummy'
+      }
+    ]
+  };
+
+  const bid = {
+    bidder: adUnit.bids[0].bidder,
+    adUnitCode: adUnit.code,
+    mediaType: 'video'
+  };
+
+  const analyticsOptions = {
+    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
+    client: 'adlooxtest',
+    clientid: 127,
+    platformid: 0,
+    tagid: 0
+  };
+
+  const urlVAST = 'https://j.adlooxtracking.com/ads/vast/tag.php';
+
+  const creativeUrl = 'http://example.invalid/c';
+  const vastHeaders = {
+    'content-type': 'application/xml;charset=utf-8'
+  };
+
+  const vastUrl = 'http://example.invalid/w';
+  const vastContent =
+`<?xml version="1.0" encoding="UTF-8" ?>
+<VAST version="3.0">
+  <Ad id="main" sequence="1">
+    <InLine>
+      <Creatives>
+        <Creative>
+          <Linear skipoffset="00:00:05">
+            <Duration>00:00:30</Duration>
+            <MediaFiles>
+              <MediaFile apiFramework="VPAID" type="application/javascript">http://example.invalid/v.js</MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+  <Ad id="fallback">
+    <InLine>
+      <Creatives>
+        <Creative>
+          <Linear skipoffset="00:00:05">
+            <Duration>00:00:30</Duration>
+            <MediaFiles>
+              <MediaFile width="640" height="480" bitrate="1000" scalable="true" maintainAspectRatio="true" type="video/mp4" delivery="progressive">${creativeUrl}</MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>`
+
+  const wrapperUrl = 'http://example.invalid/w';
+  const wrapperContent =
+`<?xml version="1.0" encoding="UTF-8" ?>
+<VAST version="2.0">
+  <Ad id="Test">
+    <Wrapper>
+      <VASTAdTagURI><![CDATA[${vastUrl}]]></VASTAdTagURI>
+    </Wrapper>
+  </Ad>
+</VAST>`;
+
+  adapterManager.registerAnalyticsAdapter({
+    code: analyticsAdapterName,
+    adapter: analyticsAdapter
+  });
+
+  before(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(events, 'getEvents').returns([]);
+
+    adapterManager.enableAnalytics({
+      provider: analyticsAdapterName,
+      options: analyticsOptions
+    });
+    expect(analyticsAdapter.context).is.not.null;
+  });
+
+  after(function () {
+    analyticsAdapter.disableAnalytics();
+    expect(analyticsAdapter.context).is.null;
+
+    sandbox.restore();
+    sandbox = undefined;
+  });
+
+  describe('buildVideoUrl', function () {
+    describe('invalid arguments', function () {
+      it('should require callback', function (done) {
+        const ret = buildVideoUrl();
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should require options', function (done) {
+        const ret = buildVideoUrl(undefined, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-string options.url_vast', function (done) {
+        const ret = buildVideoUrl({ url_vast: null }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should require options.adUnit or options.bid', function (done) {
+        let BID = utils.deepClone(bid);
+
+        let getWinningBidsStub = sinon.stub(targeting, 'getWinningBids')
+        getWinningBidsStub.withArgs(adUnit.code).returns([ BID ]);
+
+        const ret = buildVideoUrl({ url: vastUrl }, function () {});
+        expect(ret).is.false;
+
+        const retAdUnit = buildVideoUrl({ url: vastUrl, adUnit: utils.deepClone(adUnit) }, function () {})
+        expect(retAdUnit).is.true;
+
+        const retBid = buildVideoUrl({ url: vastUrl, bid: BID }, function () {});
+        expect(retBid).is.true;
+
+        getWinningBidsStub.restore();
+
+        done();
+      });
+
+      it('should reject non-string options.url', function (done) {
+        const ret = buildVideoUrl({ url: null, bid: utils.deepClone(bid) }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-boolean options.wrap', function (done) {
+        const ret = buildVideoUrl({ wrap: null, url: vastUrl, bid: utils.deepClone(bid) }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+
+      it('should reject non-boolean options.blob', function (done) {
+        const ret = buildVideoUrl({ blob: null, url: vastUrl, bid: utils.deepClone(bid) }, function () {});
+
+        expect(ret).is.false;
+
+        done();
+      });
+    });
+
+    describe('process VAST', function () {
+      let server = null;
+      let BID = null;
+      let getWinningBidsStub;
+      beforeEach(function () {
+        server = sinon.createFakeServer();
+        BID = utils.deepClone(bid);
+        getWinningBidsStub = sinon.stub(targeting, 'getWinningBids')
+        getWinningBidsStub.withArgs(adUnit.code).returns([ BID ]);
+      });
+      afterEach(function () {
+        getWinningBidsStub.restore();
+        getWinningBidsStub = undefined;
+        BID = null;
+        server.restore();
+        server = null;
+      });
+
+      it('should return URL unchanged for non-VAST', function (done) {
+        const ret = buildVideoUrl({ url: vastUrl, bid: BID }, function (url) {
+          expect(url).is.equal(vastUrl);
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const request = server.requests[0];
+        expect(request.url).is.equal(vastUrl);
+        request.respond(200, { 'content-type': 'application/octet-stream' }, 'notvast');
+      });
+
+      it('should return URL unchanged for empty VAST', function (done) {
+        const ret = buildVideoUrl({ url: vastUrl, bid: BID }, function (url) {
+          expect(url).is.equal(vastUrl);
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const request = server.requests[0];
+        expect(request.url).is.equal(vastUrl);
+        request.respond(200, vastHeaders, '<?xml version="1.0" encoding="UTF-8" ?>\n<VAST version="3.0"/>');
+      });
+
+      it('should fetch, retry on withoutCredentials, follow and return a wrapped blob that expires', function (done) {
+        BID.responseTimestamp = utils.timestamp();
+        BID.ttl = 30;
+
+        const clock = sandbox.useFakeTimers(BID.responseTimestamp);
+
+        const options = {
+          url_vast: urlVAST,
+          url: wrapperUrl,
+          bid: BID
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url.substr(0, options.url_vast.length)).is.equal(options.url_vast);
+
+          const match = url.match(/[?&]vast=(blob%3A[^&]+)/);
+          expect(match).is.not.null;
+
+          const blob = decodeURIComponent(match[1]);
+
+          const xfr = sandbox.useFakeXMLHttpRequest();
+          xfr.useFilters = true;
+          xfr.addFilter(x => true);	// there is no network traffic for Blob URLs here
+
+          ajax(blob, {
+            success: (responseText, q) => {
+              expect(q.status).is.equal(200);
+              expect(q.getResponseHeader('content-type')).is.equal(vastHeaders['content-type']);
+
+              clock.runAll();
+
+              ajax(blob, {
+                success: (responseText, q) => {
+                  xfr.useFilters = false;		// .restore() does not really work
+                  if (q.status == 0) return done();
+                  done(new Error('Blob should have expired'));
+                },
+                error: (statusText, q) => {
+                  xfr.useFilters = false;
+                  done();
+                }
+              });
+            },
+            error: (statusText, q) => {
+              xfr.useFilters = false;
+              done(new Error(statusText));
+            }
+          });
+        });
+        expect(ret).is.true;
+
+        const wrapperRequestCORS = server.requests[0];
+        expect(wrapperRequestCORS.url).is.equal(wrapperUrl);
+        expect(wrapperRequestCORS.withCredentials).is.true;
+        wrapperRequestCORS.respond(0);
+
+        const wrapperRequest = server.requests[1];
+        expect(wrapperRequest.url).is.equal(wrapperUrl);
+        expect(wrapperRequest.withCredentials).is.false;
+        wrapperRequest.respond(200, vastHeaders, wrapperContent);
+
+        const vastRequest = server.requests[2];
+        expect(vastRequest.url).is.equal(vastUrl);
+        vastRequest.respond(200, vastHeaders, vastContent);
+      });
+
+      it('should fetch, follow and return a wrapped non-blob', function (done) {
+        const options = {
+          url_vast: urlVAST,
+          url: wrapperUrl,
+          bid: BID,
+          blob: false
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url.substr(0, options.url_vast.length)).is.equal(options.url_vast);
+          expect(/[?&]vast=blob%3/.test(url)).is.false;
+
+          done();
+        });
+        expect(ret).is.true;
+
+        const wrapperRequest = server.requests[0];
+        expect(wrapperRequest.url).is.equal(wrapperUrl);
+        wrapperRequest.respond(200, vastHeaders, wrapperContent);
+
+        const vastRequest = server.requests[1];
+        expect(vastRequest.url).is.equal(vastUrl);
+        vastRequest.respond(200, vastHeaders, vastContent);
+      });
+
+      it('should not follow and return URL unchanged for non-wrap', function (done) {
+        const options = {
+          url: wrapperUrl,
+          bid: BID,
+          wrap: false
+        };
+        const ret = buildVideoUrl(options, function (url) {
+          expect(url).is.equal(options.url);
+
+          done();
+        });
+        expect(ret).is.true;
+      });
+    });
+  });
+});

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -178,6 +178,30 @@ describe('Adloox Analytics Adapter', function () {
 
         done();
       });
+
+      it('should not inject verification JS on BID_WON when handled via Ad Server module', function (done) {
+        const bidIgnore = utils.deepClone(bid);
+        utils.deepSetValue(bidIgnore, 'ext.adloox.video.adserver', true);
+
+        const parent = document.createElement('div');
+
+        const slot = document.createElement('div');
+        slot.id = bidIgnore.adUnitCode;
+        parent.appendChild(slot);
+
+        const script = document.createElement('script');
+        const createElementStub = sandbox.stub(document, 'createElement');
+        createElementStub.withArgs('script').returns(script);
+
+        const querySelectorStub = sandbox.stub(document, 'querySelector');
+        querySelectorStub.withArgs(`#${bid.adUnitCode}`).returns(slot);
+
+        events.emit(EVENTS.BID_WON, bidIgnore);
+
+        expect(parent.querySelector('script')).is.null;
+
+        done();
+      });
     });
 
     describe('command', function () {


### PR DESCRIPTION
## Type of change

- [X] New [Ad Server for Video](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAdServerVideo.js) ([documentation](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxAdServerVideo.md))

## Description of change

Introduction of Adloox's (video) Ad Server module.

* contact email of the adapter’s maintainer: contact@adloox.com and alex+adloox@coremem.com
* this is an official submission

Disclosures:

 * optionally (enabled by default) processes the VAST tag into a Adloox VPAID JS wrapper which uses the Adloox post-buy verification script (~25kB gzipped from `j.adlooxtracking.com`)

This module automates the complex tasks an AdOps teams must perform when integrating with Adloox.

## Other information

 * module is required to bring [MRC accredited](http://www.mediaratingcouncil.org/) viewability metrics to video inventory
   * converts the VAST URL into an Adloox wrapped VAST/VPAID tag (`j.adlooxtracking.com/ads/vast/tag.php`)
   * optionally (enabled by default) walks the VAST chain and rewrites the fetched VAST tags in the chain to use [Blob URLs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) to avoid duplicate requests; solves the no-fill [`correlator`](https://support.google.com/admanager/table/9749596) related problems you get with [GAM](https://admanager.google.com/home/) tags
 * requires and communicates with the Adloox analytics module over a command processing queue
   * this module will not function without it and must not be merged before https://github.com/prebid/Prebid.js/pull/6308 has been merged
 * 'KLUDGE' commit (4ddcffaaa528c6f9e65018e173b79f351c0085ee) will be removed once I figure out (advice welcomed!) a better integration example and for us internally to merge the changes in `tag-dev.php` into `tag.php` in on Adloox's production infrastructure

This PR was created on request in https://github.com/prebid/Prebid.js/pull/6174#issuecomment-763964406

Changes since that version:
 * word smithing
 * [change eslint "warn" to "off"](https://github.com/prebid/Prebid.js/pull/6174#issuecomment-758582001) to neuter 'prebid/validate-imports' grumblings over the analytics command queue