### PR TITLE
Adloox RTD Module: add new RTD module

### DIFF
--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -64,9 +64,11 @@
                         playerSize: [ 640, 480 ]
                     }
                 },
-                fpd: {
-                    context: {
-                        pbAdSlot: '/19968336/prebid_cache_video_adunit'
+                ortb2Imp: {
+                    ext: {
+                        data: {
+                            pbadslot: '/19968336/prebid_cache_video_adunit'
+                        }
                     }
                 },
                 bids: [
@@ -106,7 +108,8 @@
                 pbjs.initAdserverSet = true;
 
                 googletag.cmd.push(function() {
-                    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync(adUnits);
+                    const adUnitCodes = adUnits.map(adUnit => adUnit.code);
+                    pbjs.setTargetingForGPTAsync(adUnitCodes);
                     googletag.pubads().refresh();
                 });
 
@@ -135,12 +138,24 @@
             }
 
             // optionally wrap with googletag to have gpt-pre-auction
-            // automatically populate Prebid Ad Slot (pbAdSlot)
+            // automatically populate Prebid Ad Slot (pbadslot)
             // https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html
-            // alternatively remove wrapping and set AdUnit.fpd.context.pbAdSlot
+            // alternatively remove wrapping and set AdUnit.ortb2Imp.ext.data.pbadslot
             googletag.cmd.push(function() {
                 pbjs.que.push(function() {
                     pbjs.setConfig({
+                        realTimeData: {
+                            auctionDelay: AUCTION_DELAY,
+                            dataProviders: [
+                                {
+                                    name: 'adloox',
+                                    params: {             // optional, defaults shown
+                                        thresholds: [ 50, 60, 70, 80, 90 ],
+                                        slotinpath: false
+                                    }
+                                }
+                            ]
+                        },
                         instreamTracking: {
                             enabled: true
                         },

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -43,14 +43,15 @@ MACRO['targetelt'] = function(b, c) {
 MACRO['creatype'] = function(b, c) {
   return b.mediaType == 'video' ? ADLOOX_MEDIATYPE.VIDEO : ADLOOX_MEDIATYPE.DISPLAY;
 };
-MACRO['pbAdSlot'] = function(b, c) {
+MACRO['pbadslot'] = function(b, c) {
   const adUnit = find(auctionManager.getAdUnits(), a => b.adUnitCode === a.code);
-  return utils.deepAccess(adUnit, 'fpd.context.pbAdSlot') || utils.getGptSlotInfoForAdUnitCode(b.adUnitCode).gptSlot || b.adUnitCode;
+  return utils.deepAccess(adUnit, 'ortb2Imp.ext.data.pbadslot') || utils.getGptSlotInfoForAdUnitCode(b.adUnitCode).gptSlot || b.adUnitCode;
 };
+MACRO['pbAdSlot'] = MACRO['pbadslot']; // legacy
 
 const PARAMS_DEFAULT = {
   'id1': function(b) { return b.adUnitCode },
-  'id2': '%%pbAdSlot%%',
+  'id2': '%%pbadslot%%',
   'id3': function(b) { return b.bidder },
   'id4': function(b) { return b.adId },
   'id5': function(b) { return b.dealId },
@@ -251,6 +252,7 @@ export default analyticsAdapter;
 const COMMAND_QUEUE = {};
 export const COMMAND = {
   CONFIG: 'config',
+  TOSELECTOR: 'toselector',
   URL: 'url',
   TRACK: 'track'
 };
@@ -277,6 +279,9 @@ function commandProcess(cid) {
         platformid: analyticsAdapter.context.platformid
       };
       callback(response);
+      break;
+    case COMMAND.TOSELECTOR:
+      callback(analyticsAdapter.context.toselector(data.bid));
       break;
     case COMMAND.URL:
       if (data.ids) data.args = data.args.concat(analyticsAdapter.context.params.filter(p => /^id([1-9]|10)$/.test(p[0]))); // not >10

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -2,11 +2,11 @@
 
     Module Name: Adloox Analytics Adapter
     Module Type: Analytics Adapter
-    Maintainer: technique@adloox.com
+    Maintainer: contact@adloox.com
 
 # Description
 
-Analytics adapter for adloox.com. Contact adops@adloox.com for information.
+Analytics adapter for adloox.com. Contact contact@adloox.com for information.
 
 This module can be used to track:
 
@@ -34,7 +34,7 @@ When tracking video you have two options:
 
 To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
 
-    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,rtdModule,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo,adlooxRtdProvider
 
 **N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
 
@@ -43,6 +43,8 @@ Now point your browser at: http://localhost:9999/integrationExamples/gpt/adloox.
 ### Public Example
 
 The example is published publically at: https://storage.googleapis.com/adloox-ads-js-test/prebid.html?pbjs_debug=true
+
+**N.B.** this will show a [CORS error](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors) for the request `https://p.adlooxtracking.com/q?...` that is safe to ignore on the public example page; it is related to the [RTD integration](./adlooxRtdProvider.md) which requires pre-registration of your sites
 
 It is recommended you use [Google Chrome's 'Local Overrides' located in the Developer Tools panel](https://www.trysmudford.com/blog/chrome-local-overrides/) to explore the example without the inconvience of having to run your own web server.
 
@@ -61,7 +63,7 @@ You should be able to use this during the QA process of your own internal testin
 The main Prebid.js documentation is a bit opaque on this but you can use the following to test only Adloox's modules:
 
     gulp lint
-    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo}_spec.js'
+    gulp test-coverage --file 'test/spec/modules/adloox{AnalyticsAdapter,AdServerVideo,RtdProvider}_spec.js'
     gulp view-coverage
 
 # Integration
@@ -103,8 +105,8 @@ For example, you have a number of reporting breakdown slots available in the for
         platformid: 0,
         tagid: 0,
         params: {
-          id1: function(b) { return b.adUnitCode },
-          id2: '%%pbAdSlot%%',
+          id1: function(b) { return b.adUnitCode },  // do not change when using the Adloox RTD Provider
+          id2: '%%pbadslot%%',                       // do not change when using the Adloox RTD Provider
           id3: function(b) { return b.bidder },
           id4: function(b) { return b.adId },
           id5: function(b) { return b.dealId },
@@ -123,7 +125,8 @@ For example, you have a number of reporting breakdown slots available in the for
 
 The following macros are available
 
- * `%%pbAdSlot%%`: [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html) returns [`AdUnit.code`](https://docs.prebid.org/features/pbAdSlot.html) if set otherwise returns [`AdUnit.code`](https://docs.prebid.org/dev-docs/adunit-reference.html#adunit)
+ * `%%pbadslot%%`: [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html) returns [`AdUnit.code`](https://docs.prebid.org/features/pbAdSlot.html) if set otherwise returns [`AdUnit.code`](https://docs.prebid.org/dev-docs/adunit-reference.html#adunit)
+     * it is recommended you read the [Prebid Ad Slot section in the Adloox RTD Provider documentation](./adlooxRtdProvider.md#prebid-ad-slot)
 
 ### Functions
 

--- a/modules/adlooxRtdProvider.js
+++ b/modules/adlooxRtdProvider.js
@@ -1,0 +1,390 @@
+/**
+ * This module adds the Adloox provider to the real time data module
+ * This module adds the [Adloox]{@link https://www.adloox.com/} provider to the real time data module
+ * The {@link module:modules/realTimeData} module is required
+ * The module will fetch segments from Adloox's server
+ * @module modules/adlooxRtdProvider
+ * @requires module:modules/realTimeData
+ * @requires module:modules/adlooxAnalyticsAdapter
+ */
+
+/* eslint standard/no-callback-literal: "off" */
+/* eslint prebid/validate-imports: "off" */
+
+import { command as analyticsCommand, COMMAND } from './adlooxAnalyticsAdapter.js';
+import { config as _config } from '../src/config.js';
+import { submodule } from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
+
+const MODULE_NAME = 'adloox';
+const MODULE = `${MODULE_NAME}RtdProvider`;
+
+const API_ORIGIN = 'https://p.adlooxtracking.com';
+const SEGMENT_HISTORIC = { 'a': 'aud', 'd': 'dis', 'v': 'vid' };
+const SEGMENT_HISTORIC_VALUES = Object.keys(SEGMENT_HISTORIC).map(k => SEGMENT_HISTORIC[k]);
+
+const ADSERVER_TARGETING_PREFIX = 'adl_';
+
+const CREATIVE_WIDTH_MIN = 20;
+const CREATIVE_HEIGHT_MIN = 20;
+const CREATIVE_AREA_MIN = CREATIVE_WIDTH_MIN * CREATIVE_HEIGHT_MIN;
+// try to avoid using IntersectionObserver as it has unbounded (observed multi-second) latency
+let intersectionObserver = window == top ? false : undefined;
+const intersectionObserverElements = [];
+// .map/.findIndex are safe here as they are only used for intersectionObserver
+function atf(adUnit, cb) {
+  analyticsCommand(COMMAND.TOSELECTOR, { bid: { adUnitCode: adUnit.code } }, function(selector) {
+    const element = document.querySelector(selector);
+    if (!element) return cb(null);
+
+    if (window.getComputedStyle(element)['display'] == 'none') return cb(NaN);
+
+    try {
+      // short circuit for cross-origin
+      if (intersectionObserver) throw false;
+
+      // Google's advice is to collapse slots on no fill but
+      // we have to cater to clients that grow slots on fill
+      const rect = (function(rect) {
+        const sizes = utils.getAdUnitSizes(adUnit);
+
+        if (sizes.length == 0) return false;
+        // interstitial (0x0, 1x1)
+        if (sizes.length == 1 && (sizes[0][0] * sizes[0][1]) <= 1) return true;
+        // try to catch premium slots (coord=0,0) as they will likely bounce into view
+        if (rect.top <= -window.pageYOffset && rect.left <= -window.pageXOffset && rect.top == rect.bottom) return true;
+
+        // pick the smallest creative size as many publishers will just leave the element unbounded in the vertical
+        let width = Infinity;
+        let height = Infinity;
+        for (let i = 0; i < sizes.length; i++) {
+          const area = sizes[i][0] * sizes[i][1];
+          if (area < CREATIVE_AREA_MIN) continue;
+          if (area < (width * height)) {
+            width = sizes[i][0];
+            height = sizes[i][1];
+          }
+        }
+        // we also scale the smallest size to the size of the slot as publishers resize units depending on viewport
+        const scale = Math.min(1, (rect.right - rect.left) / width);
+
+        return {
+          left: rect.left,
+          right: rect.left + Math.max(CREATIVE_WIDTH_MIN, scale * width),
+          top: rect.top,
+          bottom: rect.top + Math.max(CREATIVE_HEIGHT_MIN, scale * height)
+        };
+      })(element.getBoundingClientRect());
+
+      if (rect === false) return cb(NaN);
+      if (rect === true) return cb(1);
+
+      const W = rect.right - rect.left;
+      const H = rect.bottom - rect.top;
+
+      if (W * H < CREATIVE_AREA_MIN) return cb(NaN);
+
+      let el;
+      let win = window;
+      while (1) {
+        // https://stackoverflow.com/a/8876069
+        const vw = Math.max(win.document.documentElement.clientWidth || 0, win.innerWidth || 0);
+        const vh = Math.max(win.document.documentElement.clientHeight || 0, win.innerHeight || 0);
+
+        // cut to viewport
+        rect.left = Math.min(Math.max(rect.left, 0), vw);
+        rect.right = Math.min(Math.max(rect.right, 0), vw);
+        rect.top = Math.min(Math.max(rect.top, 0), vh);
+        rect.bottom = Math.min(Math.max(rect.bottom, 0), vh);
+
+        if (win == top) return cb(((rect.right - rect.left) * (rect.bottom - rect.top)) / (W * H));
+        el = win.frameElement;
+        if (!el) throw false; // cross-origin
+        win = win.parent;
+
+        // transpose to frame element
+        const frameElementRect = el.getBoundingClientRect();
+        rect.left += frameElementRect.left;
+        rect.right = Math.min(rect.right + frameElementRect.left, frameElementRect.right);
+        rect.top += frameElementRect.top;
+        rect.bottom = Math.min(rect.bottom + frameElementRect.top, frameElementRect.bottom);
+      }
+    } catch (_) {
+      if (intersectionObserver === undefined) {
+        try {
+          intersectionObserver = new IntersectionObserver(function(entries) {
+            entries.forEach(entry => {
+              const ratio = entry.intersectionRect.width * entry.intersectionRect.height < CREATIVE_AREA_MIN ? NaN : entry.intersectionRatio;
+              const idx = intersectionObserverElements.findIndex(x => x.element == entry.target);
+              intersectionObserverElements[idx].cb.forEach(cb => cb(ratio));
+              intersectionObserverElements.splice(idx, 1);
+              intersectionObserver.unobserve(entry.target);
+            });
+          });
+        } catch (_) {
+          intersectionObserver = false;
+        }
+      }
+      if (!intersectionObserver) return cb(null);
+      const idx = intersectionObserverElements.findIndex(x => x.element == element);
+      if (idx == -1) {
+        intersectionObserverElements.push({ element, cb: [ cb ] });
+        intersectionObserver.observe(element);
+      } else {
+        intersectionObserverElements[idx].cb.push(cb);
+      }
+    }
+  });
+}
+
+function init(config, userConsent) {
+  utils.logInfo(MODULE, 'init', config, userConsent);
+
+  if (!utils.isPlainObject(config)) {
+    utils.logError(MODULE, 'missing config');
+    return false;
+  }
+  if (config.params === undefined) config.params = {};
+  if (!(utils.isPlainObject(config.params))) {
+    utils.logError(MODULE, 'invalid params');
+    return false;
+  }
+  if (!(config.params.api_origin === undefined || utils.isStr(config.params.api_origin))) {
+    utils.logError(MODULE, 'invalid api_origin params value');
+    return false;
+  }
+  if (!(config.params.imps === undefined || (utils.isInteger(config.params.imps) && config.params.imps > 0))) {
+    utils.logError(MODULE, 'invalid imps params value');
+    return false;
+  }
+  if (!(config.params.freqcap_ip === undefined || (utils.isInteger(config.params.freqcap_ip) && config.params.freqcap_ip >= 0))) {
+    utils.logError(MODULE, 'invalid freqcap_ip params value');
+    return false;
+  }
+  if (!(config.params.freqcap_ipua === undefined || (utils.isInteger(config.params.freqcap_ipua) && config.params.freqcap_ipua >= 0))) {
+    utils.logError(MODULE, 'invalid freqcap_ipua params value');
+    return false;
+  }
+  if (!(config.params.thresholds === undefined || (utils.isArray(config.params.thresholds) && config.params.thresholds.every(x => utils.isInteger(x) && x > 0 && x <= 100)))) {
+    utils.logError(MODULE, 'invalid thresholds params value');
+    return false;
+  }
+  if (!(config.params.slotinpath === undefined || utils.isBoolean(config.params.slotinpath))) {
+    utils.logError(MODULE, 'invalid slotinpath params value');
+    return false;
+  }
+  // legacy/deprecated configuration code path
+  if (!(config.params.params === undefined || (utils.isPlainObject(config.params.params) && utils.isInteger(config.params.params.clientid) && utils.isInteger(config.params.params.tagid) && utils.isInteger(config.params.params.platformid)))) {
+    utils.logError(MODULE, 'invalid subsection params block');
+    return false;
+  }
+
+  config.params.thresholds = config.params.thresholds || [ 50, 60, 70, 80, 90 ];
+
+  function analyticsConfigCallback(data) {
+    config = utils.mergeDeep(config.params, data);
+  }
+  if (config.params.params) {
+    utils.logWarn(MODULE, `legacy/deprecated configuration (please migrate to ${MODULE_NAME}AnalyticsAdapter)`);
+    analyticsConfigCallback(config.params.params);
+  } else {
+    analyticsCommand(COMMAND.CONFIG, null, analyticsConfigCallback);
+  }
+
+  return true;
+}
+
+function getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
+  // gptPreAuction runs *after* RTD so pbadslot may not be populated... (╯°□°)╯ ┻━┻
+  const adUnits = (reqBidsConfigObj.adUnits || getGlobal().adUnits).map(adUnit => {
+    let path = utils.deepAccess(adUnit, 'ortb2Imp.ext.data.pbadslot');
+    if (!path) path = utils.getGptSlotInfoForAdUnitCode(adUnit.code).gptSlot;
+    return {
+      path: path,
+      unit: adUnit
+    };
+  }).filter(adUnit => !!adUnit.path);
+
+  let response = {};
+  function setSegments() {
+    function val(v, k) {
+      if (!((SEGMENT_HISTORIC[k] || k == 'atf') && v >= 0)) return v;
+      return config.params.thresholds.filter(t => t <= v);
+    }
+
+    const ortb2 = _config.getConfig('ortb2') || {};
+    const dataSite = _config.getConfig('ortb2.site.ext.data') || {};
+    const dataUser = _config.getConfig('ortb2.user.ext.data') || {};
+
+    utils._each(response, (v0, k0) => {
+      if (k0 == '_') return;
+      const k = SEGMENT_HISTORIC[k0] || k0;
+      const v = val(v0, k0);
+      utils.deepSetValue(k == k0 ? dataUser : dataSite, `${MODULE_NAME}_rtd.${k}`, v);
+    });
+    utils.deepSetValue(dataSite, `${MODULE_NAME}_rtd.ok`, true);
+
+    utils.deepSetValue(ortb2, 'site.ext.data', dataSite);
+    utils.deepSetValue(ortb2, 'user.ext.data', dataUser);
+    _config.setConfig({ ortb2 });
+
+    adUnits.forEach((adUnit, i) => {
+      utils._each(response['_'][i], (v0, k0) => {
+        const k = SEGMENT_HISTORIC[k0] || k0;
+        const v = val(v0, k0);
+        utils.deepSetValue(adUnit.unit, `ortb2Imp.ext.data.${MODULE_NAME}_rtd.${k}`, v);
+      });
+    });
+  };
+
+  // utils.mergeDeep does not handle merging deep arrays... (╯°□°)╯ ┻━┻
+  function mergeDeep(target, ...sources) {
+    function emptyValue(v) {
+      if (utils.isPlainObject(v)) {
+        return {};
+      } else if (utils.isArray(v)) {
+        return [];
+      } else {
+        return undefined;
+      }
+    }
+
+    if (!sources.length) return target;
+    const source = sources.shift();
+
+    if (utils.isPlainObject(target) && utils.isPlainObject(source)) {
+      Object.keys(source).forEach(key => {
+        if (!(key in target)) target[key] = emptyValue(source[key]);
+        target[key] = target[key] !== undefined ? mergeDeep(target[key], source[key]) : source[key];
+      });
+    } else if (utils.isArray(target) && utils.isArray(source)) {
+      source.forEach((v, i) => {
+        if (!(i in target)) target[i] = emptyValue(v);
+        target[i] = target[i] !== undefined ? mergeDeep(target[i], v) : v;
+      });
+    } else {
+      target = source;
+    }
+
+    return mergeDeep(target, ...sources);
+  }
+
+  let semaphore = 1;
+  function semaphoreInc(inc) {
+    if (semaphore == 0) return;
+    semaphore += inc;
+    if (semaphore == 0) {
+      setSegments()
+      callback();
+    }
+  }
+
+  const args = [
+    [ 'v', `pbjs-${getGlobal().version}` ],
+    [ 'c', config.params.clientid ],
+    [ 'p', config.params.platformid ],
+    [ 't', config.params.tagid ],
+    [ 'imp', config.params.imps ],
+    [ 'fc_ip', config.params.freqcap_ip ],
+    [ 'fc_ipua', config.params.freqcap_ipua ],
+    [ 'pn', document.location.pathname ]
+  ];
+
+  if (!adUnits.length) {
+    utils.logWarn(MODULE, 'no suitable adUnits (missing pbadslot?)');
+  }
+  const atfQueue = [];
+  adUnits.map((adUnit, i) => {
+    const ref = [ adUnit.path ];
+    if (!config.params.slotinpath) ref.push(adUnit.unit.code);
+    args.push(['s', ref.join('\t')]);
+
+    semaphoreInc(1);
+    atfQueue.push(function() {
+      atf(adUnit.unit, function(x) {
+        let viewable = document.visibilityState === undefined || document.visibilityState == 'visible';
+        try { viewable = viewable && top.document.hasFocus() } catch (_) {}
+        utils.logInfo(MODULE, `atf code=${adUnit.unit.code} has area=${x}, viewable=${viewable}`);
+        const atfList = []; atfList[i] = { atf: parseInt(x * 100) };
+        response = mergeDeep(response, { _: atfList });
+        semaphoreInc(-1);
+      });
+    });
+  });
+  function atfCb() {
+    atfQueue.forEach(x => x());
+  }
+  if (document.readyState == 'loading') {
+    document.addEventListener('DOMContentLoaded', atfCb, false);
+  } else {
+    atfCb();
+  }
+
+  analyticsCommand(COMMAND.URL, {
+    url: (config.params.api_origin || API_ORIGIN) + '/q?',
+    args: args
+  }, function(url) {
+    ajax(url, {
+      success: function(responseText, q) {
+        try {
+          if (q.getResponseHeader('content-type') == 'application/json') {
+            response = mergeDeep(response, JSON.parse(responseText));
+          } else {
+            throw false;
+          }
+        } catch (_) {
+          utils.logError(MODULE, 'unexpected response');
+        }
+        semaphoreInc(-1);
+      },
+      error: function(statusText, q) {
+        utils.logError(MODULE, 'request failed');
+        semaphoreInc(-1);
+      }
+    });
+  });
+}
+
+function getTargetingData(adUnitArray, config, userConsent) {
+  function targetingNormalise(v) {
+    if (utils.isArray(v) && v.length == 0) return undefined;
+    if (utils.isBoolean(v)) v = ~~v;
+    if (!v) return undefined; // empty string and zero
+    return v;
+  }
+
+  const dataSite = _config.getConfig(`ortb2.site.ext.data.${MODULE_NAME}_rtd`) || {};
+  if (!dataSite.ok) return {};
+
+  const dataUser = _config.getConfig(`ortb2.user.ext.data.${MODULE_NAME}_rtd`) || {};
+  return getGlobal().adUnits.filter(adUnit => includes(adUnitArray, adUnit.code)).reduce((a, adUnit) => {
+    a[adUnit.code] = {};
+
+    utils._each(dataSite, (v0, k) => {
+      if (includes(SEGMENT_HISTORIC_VALUES, k)) return; // ignore site average viewability
+      const v = targetingNormalise(v0);
+      if (v) a[adUnit.code][ADSERVER_TARGETING_PREFIX + k] = v;
+    });
+
+    const adUnitSegments = utils.deepAccess(adUnit, `ortb2Imp.ext.data.${MODULE_NAME}_rtd`, {});
+    utils._each(Object.assign({}, dataUser, adUnitSegments), (v0, k) => {
+      const v = targetingNormalise(v0);
+      if (v) a[adUnit.code][ADSERVER_TARGETING_PREFIX + k] = v;
+    });
+
+    return a;
+  }, {});
+}
+
+export const subModuleObj = {
+  name: MODULE_NAME,
+  init,
+  getBidRequestData,
+  getTargetingData,
+  atf // used by adlooxRtdProvider_spec.js
+};
+
+submodule('realTimeData', subModuleObj);

--- a/modules/adlooxRtdProvider.md
+++ b/modules/adlooxRtdProvider.md
@@ -1,0 +1,105 @@
+# Overview
+
+    Module Name: Adloox RTD Provider
+    Module Type: RTD Provider
+    Maintainer: contact@adloox.com
+
+# Description
+
+RTD provider for adloox.com. Contact contact@adloox.com for information.
+
+This provider fetches segments and populates the [First Party Data](https://docs.prebid.org/features/firstPartyData.html) attributes, some examples of the segments as described by the Adloox 'Google Publisher Tag Targeting Guidelines' and where they are placed are:
+
+ * Page segments are placed into `ortb2.site.ext.data.adloox_rtd`:
+     * **`ok`:** boolean (use to capture if our module successfully ran)
+ * Device segments are placed into `ortb2.user.ext.data.adloox_rtd`:
+     * **`ivt`:** boolean
+     * **`ua_old`:** boolean
+     * **`ip`:** list of strings describing classification of IP (eg. `rfc-special`, `iab-dc`, ...)
+ * AdUnit segments are placed into `AdUnit.ortb2Imp.ext.data.adloox_rtd`:
+     * **`{dis,vid,aud}`:** an list of integers describing the likelihood the AdUnit will be visible
+     * **`atf`:** an list of integers describing the percentage of pixels visible at auction
+         * measured only once at pre-auction
+         * usable when the publisher uses the strategy of collapsing ad slots on no-fill
+             * using the reverse strategy, growing ad slots on fill, invalidates the measurement the position of all content (including the slots) changes post-auction
+             * works best when your page loads your ad slots have their actual size rendered (ie. not zero height)
+         * uses the smallest ad unit (above a threshold area of 20x20) supplied by the [publisher to Prebid.js](https://docs.prebid.org/dev-docs/examples/basic-example.html) and measures viewability as if that size to be used
+         * when used in cross-origin (unfriendly) IFRAME environments the ad slot is directly measured as is (ignoring publisher provided sizes) due to limitations in using [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
+
+**N.B.** this provider does not offer or utilise any user orientated data
+
+These segments are also sent to your ad server but are translated using the following rules:
+
+ * prepended the segment name with `adl_`
+ * segments are filtered out when their value is either:
+     * empty string ("")
+     * zero (`0`)
+     * boolean `false`
+     * empty list/array
+
+For example:
+
+ * `ortb2.site.ext.data.adloox_rtd.ok` is translated to `adl_ok`
+ * `ortb2.user.ext.data.adloox_rtd.ivt` is translated to `adl_ivt`
+ * `AdUnit.ortb2Imp.ext.data.adloox_rtd.dis` is translated to `adl_dis`
+
+## Example
+
+To view an example of an Adloox integration look at the example provided in the [Adloox Analytics Adapter documentation](./adlooxAnalyticsAdapter.md#example).
+
+# Integration
+
+To use this, you *must* also integrate the [Adloox Analytics Adapter](./adlooxAnalyticsAdapter.md) as shown below:
+
+    pbjs.setConfig({
+      ...
+
+      realTimeData: {
+        auctionDelay: 100,             // see below for guidance
+        dataProviders: [
+          {
+            name: 'adloox',
+            params: {                  // optional, defaults shown
+              thresholds: [ 50, 60, 70, 80, 90 ],
+              slotinpath: false
+            }
+          }
+        ]
+      },
+
+      ...
+    });
+    pbjs.enableAnalytics({
+      provider: 'adloox',
+      options: {
+        client: 'adlooxtest',
+        clientid: 127,
+        platformid: 0,
+        tagid: 0
+      }
+    });
+
+You may optionally pass a subsection `params` in the `params` block to the Adloox RTD Provider, these will be passed through to the segment handler as is and as described by the integration guidelines.
+
+**N.B.** If you pass `params` to the Adloox Analytics Adapter, `id1` (`AdUnit.code`) and `id2` (`%%pbadslot%%`) *must* describe a stable identifier otherwise no usable segments will be served and so they *must not* be changed; if `id1` for your inventory could contain a non-stable random number please consult with us before continuing
+
+Though our segment technology is fast (less than 10ms) the time it takes for the users device to connect to our service and fetch the segments may not be. For this reason we recommend setting `auctionDelay` no lower than 100ms and if possible you should explore using user-agent sourced information such as [NetworkInformation.{rtt,downlink,...}](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation) to dynamically tune this for each user.
+
+## Prebid Ad Slot
+
+To create reliable segments, a stable description for slots on your inventory needs to be supplied which is typically solved by using the [Prebid Ad Slot](https://docs.prebid.org/features/pbAdSlot.html).
+
+You may use one of two ways to do achieve this:
+
+ * for display inventory [using GPT](https://developers.google.com/publisher-tag/guides/get-started) you may configure Prebid.js to automatically use the [full ad unit path](https://developers.google.com/publisher-tag/reference#googletag.Slot_getAdUnitPath)
+     1. include the [`gptPreAuction` module](https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html)
+     1. wrap both `pbjs.setConfig({...})` and `pbjs.enableAnalytics({...})` with `googletag.cmd.push(function() { ... })`
+ * set `pbadslot` in the [first party data](https://docs.prebid.org/dev-docs/adunit-reference.html#first-party-data) variable `AdUnit.ortb2Imp.ext.data.pbadslot` for all your ad units
+
+## Timeouts
+
+It is strongly recommended you increase any [failsafe timeout](https://docs.prebid.org/dev-docs/faq.html#when-starting-out-what-should-my-timeouts-be) you use by at least the value you supply to `auctionDelay` above.
+
+Adloox recommends you use the following (based on [examples provided on the Prebid.js website](https://docs.prebid.org/dev-docs/examples/basic-example.html))
+
+    FAILSAFE_TIMEOUT = AUCTION_DELAY + (3 * PREBID_TIMEOUT)

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -35,7 +35,7 @@ describe('Adloox Analytics Adapter', function () {
     tagid: 0,
     params: {
       dummy1: '%%client%%',
-      dummy2: '%%pbAdSlot%%',
+      dummy2: '%%pbadslot%%',
       dummy3: function(bid) { throw new Error(esplode) }
     }
   };

--- a/test/spec/modules/adlooxRtdProvider_spec.js
+++ b/test/spec/modules/adlooxRtdProvider_spec.js
@@ -1,0 +1,313 @@
+import adapterManager from 'src/adapterManager.js';
+import analyticsAdapter from 'modules/adlooxAnalyticsAdapter.js';
+import { config as _config } from 'src/config.js';
+import { expect } from 'chai';
+import events from 'src/events.js';
+import * as prebidGlobal from 'src/prebidGlobal.js';
+import { subModuleObj as rtdProvider } from 'modules/adlooxRtdProvider.js';
+import * as utils from 'src/utils.js';
+
+const analyticsAdapterName = 'adloox';
+
+describe('Adloox RTD Provider', function () {
+  let sandbox;
+
+  const adUnit = {
+    code: 'ad-slot-1',
+    ortb2Imp: {
+      ext: {
+        data: {
+          pbadslot: '/123456/home/ad-slot-1'
+        }
+      }
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [ [300, 250] ]
+      }
+    },
+    bids: [
+      {
+        bidder: 'dummy'
+      }
+    ]
+  };
+
+  const analyticsOptions = {
+    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
+    client: 'adlooxtest',
+    clientid: 127,
+    platformid: 0,
+    tagid: 0
+  };
+
+  const config = {};
+
+  adapterManager.registerAnalyticsAdapter({
+    code: analyticsAdapterName,
+    adapter: analyticsAdapter
+  });
+
+  before(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(events, 'getEvents').returns([]);
+  });
+
+  after(function () {
+    sandbox.restore();
+    sandbox = undefined;
+  });
+
+  describe('invalid config', function () {
+    it('should require config', function (done) {
+      const ret = rtdProvider.init();
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject non-object config.params', function (done) {
+      const ret = rtdProvider.init({ params: null });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject non-string config.params.api_origin', function (done) {
+      const ret = rtdProvider.init({ params: { api_origin: null } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject less than one config.params.imps', function (done) {
+      const ret = rtdProvider.init({ params: { imps: 0 } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject negative config.params.freqcap_ip', function (done) {
+      const ret = rtdProvider.init({ params: { freqcap_ip: -1 } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject negative integer config.params.freqcap_ipua', function (done) {
+      const ret = rtdProvider.init({ params: { freqcap_ipua: -1 } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject non-array of integers with value greater than zero config.params.thresholds', function (done) {
+      const ret = rtdProvider.init({ params: { thresholds: [ 70, null ] } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject non-boolean config.params.slotinpath', function (done) {
+      const ret = rtdProvider.init({ params: { slotinpath: null } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+
+    it('should reject invalid config.params.params (legacy/deprecated)', function (done) {
+      const ret = rtdProvider.init({ params: { params: { clientid: 0, tagid: 0 } } });
+
+      expect(ret).is.false;
+
+      done();
+    });
+  });
+
+  describe('process segments', function () {
+    before(function () {
+      adapterManager.enableAnalytics({
+        provider: analyticsAdapterName,
+        options: analyticsOptions
+      });
+      expect(analyticsAdapter.context).is.not.null;
+    });
+
+    after(function () {
+      analyticsAdapter.disableAnalytics();
+      expect(analyticsAdapter.context).is.null;
+    });
+
+    let server = null;
+    let __config = null, CONFIG = null;
+    let getConfigStub, setConfigStub;
+    beforeEach(function () {
+      server = sinon.createFakeServer();
+      __config = {};
+      CONFIG = utils.deepClone(config);
+      getConfigStub = sinon.stub(_config, 'getConfig').callsFake(function (path) {
+        return utils.deepAccess(__config, path);
+      });
+      setConfigStub = sinon.stub(_config, 'setConfig').callsFake(function (obj) {
+        utils.mergeDeep(__config, obj);
+      });
+    });
+    afterEach(function () {
+      setConfigStub.restore();
+      getConfigStub.restore();
+      getConfigStub = setConfigStub = undefined;
+      CONFIG = null;
+      __config = null;
+      server.restore();
+      server = null;
+    });
+
+    it('should fetch segments', function (done) {
+      const adUnitWithSegments = utils.deepClone(adUnit);
+      const getGlobalStub = sinon.stub(prebidGlobal, 'getGlobal').returns({
+        adUnits: [ adUnitWithSegments ]
+      });
+
+      const ret = rtdProvider.init(CONFIG);
+      expect(ret).is.true;
+
+      const callback = function () {
+        expect(__config.ortb2.site.ext.data.adloox_rtd.ok).is.true;
+        expect(__config.ortb2.site.ext.data.adloox_rtd.nope).is.undefined;
+        expect(__config.ortb2.user.ext.data.adloox_rtd.unused).is.false;
+        expect(__config.ortb2.user.ext.data.adloox_rtd.nope).is.undefined;
+        expect(adUnitWithSegments.ortb2Imp.ext.data.adloox_rtd.dis.length).is.equal(3);
+        expect(adUnitWithSegments.ortb2Imp.ext.data.adloox_rtd.nope).is.undefined;
+
+        getGlobalStub.restore();
+
+        done();
+      };
+      rtdProvider.getBidRequestData({}, callback, CONFIG, null);
+
+      const request = server.requests[0];
+      const response = { unused: false, _: [ { d: 77 } ] };
+      request.respond(200, { 'content-type': 'application/json' }, JSON.stringify(response));
+    });
+
+    it('should set ad server targeting', function (done) {
+      utils.deepSetValue(__config, 'ortb2.site.ext.data.adloox_rtd.ok', true);
+
+      const adUnitWithSegments = utils.deepClone(adUnit);
+      utils.deepSetValue(adUnitWithSegments, 'ortb2Imp.ext.data.adloox_rtd.dis', [ 50, 60 ]);
+      const getGlobalStub = sinon.stub(prebidGlobal, 'getGlobal').returns({
+        adUnits: [ adUnitWithSegments ]
+      });
+
+      const targetingData = rtdProvider.getTargetingData([ adUnitWithSegments.code ], CONFIG);
+      expect(Object.keys(targetingData).length).is.equal(1);
+      expect(Object.keys(targetingData[adUnit.code]).length).is.equal(2);
+      expect(targetingData[adUnit.code].adl_ok).is.equal(1);
+      expect(targetingData[adUnit.code].adl_dis.length).is.equal(2);
+
+      getGlobalStub.restore();
+
+      done();
+    });
+  });
+
+  describe('measure atf', function () {
+    const adUnitCopy = utils.deepClone(adUnit);
+
+    const ratio = 0.38;
+    const [ [width, height] ] = utils.getAdUnitSizes(adUnitCopy);
+
+    before(function () {
+      adapterManager.enableAnalytics({
+        provider: analyticsAdapterName,
+        options: analyticsOptions
+      });
+      expect(analyticsAdapter.context).is.not.null;
+    });
+
+    after(function () {
+      analyticsAdapter.disableAnalytics();
+      expect(analyticsAdapter.context).is.null;
+    });
+
+    it(`should return ${ratio} for same-origin`, function (done) {
+      const el = document.createElement('div');
+      el.setAttribute('id', adUnitCopy.code);
+
+      const offset = height * ratio;
+      const elStub = sinon.stub(el, 'getBoundingClientRect').returns({
+        top: 0 - (height - offset),
+        bottom: height - offset,
+        left: 0,
+        right: width
+      });
+
+      const querySelectorStub = sinon.stub(document, 'querySelector');
+      querySelectorStub.withArgs(`#${adUnitCopy.code}`).returns(el);
+
+      rtdProvider.atf(adUnitCopy, function(x) {
+        expect(x).is.equal(ratio);
+
+        querySelectorStub.restore();
+        elStub.restore();
+
+        done();
+      });
+    });
+
+    ('IntersectionObserver' in window ? it : it.skip)(`should return ${ratio} for cross-origin`, function (done) {
+      const frameElementStub = sinon.stub(window, 'frameElement').value(null);
+
+      const el = document.createElement('div');
+      el.setAttribute('id', adUnitCopy.code);
+
+      const elStub = sinon.stub(el, 'getBoundingClientRect').returns({
+        top: 0,
+        bottom: height,
+        left: 0,
+        right: width
+      });
+
+      const querySelectorStub = sinon.stub(document, 'querySelector');
+      querySelectorStub.withArgs(`#${adUnitCopy.code}`).returns(el);
+
+      let intersectionObserverStubFn = null;
+      const intersectionObserverStub = sinon.stub(window, 'IntersectionObserver').callsFake((fn) => {
+        intersectionObserverStubFn = fn;
+        return {
+          observe: (element) => {
+            expect(element).is.equal(el);
+
+            intersectionObserverStubFn([{
+              target: element,
+              intersectionRect: { width, height },
+              intersectionRatio: ratio
+            }]);
+          },
+          unobserve: (element) => {
+            expect(element).is.equal(el);
+          }
+        }
+      });
+
+      rtdProvider.atf(adUnitCopy, function(x) {
+        expect(x).is.equal(ratio);
+
+        intersectionObserverStub.restore();
+        querySelectorStub.restore();
+        elStub.restore();
+        frameElementStub.restore();
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change

- [X] New [RTD provider](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxRtdProvider.js) ([documentation](https://github.com/corememltd/Prebid.js/blob/feature/adloox/modules/adlooxRtdProvider.md))

## Description of change

Introduction of Adloox's RTD provider module.

* contact email of the adapter’s maintainer: contact@adloox.com and alex+adloox@coremem.com
* this is an official submission

Disclosures:

 * loads the generic segmentation script (~3kB gzipped from `p.adlooxtracking.com`) and provides no user orientated segments (only page, slot quality and IVT/fraud related); used to provide a consistent experience with our [GPT](https://developers.google.com/publisher-tag/guides/get-started) clients as it also includes observability/tracing for our monitoring purposes which would not be appropriate to be included here.

This module automate the complex tasks an AdOps teams must perform when integrating with Adloox, including the script loading listed in the disclosure above. If the any of the scripts fail to load, it impacts only Adloox's measurement and does not affect the operation of Prebid.js or inventory fill for the publisher.

## Other information

 * Looking for feedback on what to do about `getGlobal().adUnits` in the RTD module; I looked to use `auctionManager.getAdUnits()` but it does not seem to be initialised early on enough to have any adunits in there and though [supposedly a no-no](https://docs.prebid.org/dev-docs/module-rules.html#global-module-rules) I see the other RTD modules are using `getGlobal()` so I just copied them on this one. Is there something better I could be doing here?
 * requires and communicates with the Adloox analytics module over a command processing queue
   * this module will not function without it and must not be merged before https://github.com/prebid/Prebid.js/pull/6308 has been merged
 * [raised but not elaborated on was the setting of the ad server key-value targetting](https://github.com/prebid/Prebid.js/pull/6174#discussion_r557606362) so left as is until someone chirps up

This PR was created on request in https://github.com/prebid/Prebid.js/pull/6174#issuecomment-763964406

Changes since that version:
 * word smithing
 * removal of `waitForIt` check
 * reduce 700ms auction delay recommendation to 100ms
 * [change eslint "warn" to "off"](https://github.com/prebid/Prebid.js/pull/6174#issuecomment-758582001) to neuter 'prebid/validate-imports' grumblings over the analytics command queue