### PR TITLE
Inskin adapter: Support bidder aliasing

### DIFF
--- a/modules/inskinBidAdapter.js
+++ b/modules/inskinBidAdapter.js
@@ -4,9 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'inskin';
 
 const CONFIG = {
-  'inskin': {
-    'BASE_URI': 'https://mfad.inskinad.com/api/v2'
-  }
+  BASE_URI: 'https://mfad.inskinad.com/api/v2'
 };
 
 export const spec = {
@@ -97,8 +95,7 @@ export const spec = {
     }
 
     validBidRequests.map(bid => {
-      let config = CONFIG[bid.bidder];
-      ENDPOINT_URL = config.BASE_URI;
+      ENDPOINT_URL = CONFIG.BASE_URI;
 
       const placement = Object.assign({
         divName: bid.bidId,


### PR DESCRIPTION
Support bidder aliasing by not using bid.bidder to retrieve configs (which are static anyway).

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
We simplified our code and how (static) configuration data is accessed. This in turn enabled our adapter to support aliasing.