### PR TITLE
Inskin Bid Adapter: send screen size in the ad call

### DIFF
--- a/modules/inskinBidAdapter.js
+++ b/modules/inskinBidAdapter.js
@@ -108,8 +108,12 @@ export const spec = {
 
       placement.adTypes.push(5, 9, 163, 2163, 3006);
 
+      placement.properties = placement.properties || {};
+
+      placement.properties.screenWidth = screen.width;
+      placement.properties.screenHeight = screen.height;
+
       if (restrictions.length) {
-        placement.properties = placement.properties || {};
         placement.properties.restrictions = restrictions;
       }
 

--- a/test/spec/modules/inskinBidAdapter_spec.js
+++ b/test/spec/modules/inskinBidAdapter_spec.js
@@ -250,7 +250,7 @@ describe('InSkin BidAdapter', function () {
       const payload = JSON.parse(request.data);
 
       expect(payload.keywords).to.be.an('array').that.is.empty;
-      expect(payload.placements[0].properties).to.be.undefined;
+      expect(payload.placements[0].properties.restrictions).to.be.undefined;
     });
 
     it('should add keywords if TCF v2 purposes are not granted', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
We are now sending screen width/height information in the ad call.