### PR TITLE
Verizon Media ID System: Changed EU consent string parameter name to gdpr_consent

### DIFF
--- a/modules/verizonMediaIdSystem.js
+++ b/modules/verizonMediaIdSystem.js
@@ -59,7 +59,7 @@ export const verizonMediaIdSubmodule = {
       '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
       he: params.he,
       gdpr: isEUConsentRequired(consentData) ? '1' : '0',
-      euconsent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',
+      gdpr_consent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',
       us_privacy: consentData && consentData.uspConsent ? consentData.uspConsent : ''
     };
 

--- a/test/spec/modules/verizonMediaIdSystem_spec.js
+++ b/test/spec/modules/verizonMediaIdSystem_spec.js
@@ -87,7 +87,7 @@ describe('Verizon Media ID Submodule', () => {
         pixelId: PIXEL_ID,
         '1p': '0',
         gdpr: '1',
-        euconsent: consentData.gdpr.consentString,
+        gdpr_consent: consentData.gdpr.consentString,
         us_privacy: consentData.uspConsent
       };
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
@@ -107,7 +107,7 @@ describe('Verizon Media ID Submodule', () => {
         he: HASHED_EMAIL,
         '1p': '0',
         gdpr: '1',
-        euconsent: consentData.gdpr.consentString,
+        gdpr_consent: consentData.gdpr.consentString,
         us_privacy: consentData.uspConsent
       };
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
@@ -134,7 +134,7 @@ describe('Verizon Media ID Submodule', () => {
 
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
       expect(requestQueryParams.gdpr).to.equal('1');
-      expect(requestQueryParams.euconsent).to.equal(consentData.gdpr.consentString);
+      expect(requestQueryParams.gdpr_consent).to.equal(consentData.gdpr.consentString);
     });
 
     it('sets GDPR consent data flag correctly when call is NOT under GDPR jurisdiction.', () => {
@@ -147,7 +147,7 @@ describe('Verizon Media ID Submodule', () => {
 
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
       expect(requestQueryParams.gdpr).to.equal('0');
-      expect(requestQueryParams.euconsent).to.equal('');
+      expect(requestQueryParams.gdpr_consent).to.equal('');
     });
 
     [1, '1', true].forEach(firstPartyParamValue => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Was using a non-standard parameter name for passing the TCF consent string.

- contact email of the adapter’s maintainer: hb-fe-tech@verizonmedia.com
- [x] official adapter submission