### PR TITLE
Fabrick ID System : updates to _setReferrer and appending urls

### DIFF
--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -81,7 +81,7 @@ export const fabrickIdSubmodule = {
         setReferrer(refs, window.location.href);
 
         for (let value of refs.values()) {
-          url = appendURL(url, 'r', value, configParams);
+          url = _appendUrl(url, 'r', value, configParams);
         }
 
         const resp = function (callback) {
@@ -117,6 +117,9 @@ export const fabrickIdSubmodule = {
     } catch (e) {
       utils.logError(`fabrickIdSystem encountered an error`, e);
     }
+  },
+  appendUrl: (url, paramName, s, configParams) => {
+    return _appendUrl(url, paramName, s, configParams);
   }
 };
 
@@ -153,8 +156,7 @@ function setReferrer(refs, s) {
   }
 }
 
-// function appendURL(url, paramName, s, configParams) {
-export function appendURL(url, paramName, s, configParams) {
+function _appendUrl(url, paramName, s, configParams) {
   const maxUrlLen = (configParams && configParams.maxUrlLen) || 2000;
   const maxRefLen = (configParams && configParams.maxRefLen) || 1000;
   const maxSpaceAvailable = (configParams && configParams.maxSpaceAvailable) || 50;

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -80,9 +80,9 @@ export const fabrickIdSubmodule = {
         _setReferrer(refs, referer.canonicalUrl);
         _setReferrer(refs, window.location.href);
 
-        for (const key in refs) {
-          url = appendUrl(url, 'r', refs.get(key), configParams);
-        }
+        refs.forEach(v => {
+          url = appendUrl(url, 'r', v, configParams);
+        });
 
         const resp = function (callback) {
           const callbacks = {

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -73,15 +73,15 @@ export const fabrickIdSubmodule = {
         url = url.slice(0, -1)
         const referer = _getRefererInfo(configParams);
         const refs = new Map();
-        setReferrer(refs, referer.referer);
+        _setReferrer(refs, referer.referer);
         if (referer.stack && referer.stack[0]) {
-          setReferrer(refs, referer.stack[0]);
+          _setReferrer(refs, referer.stack[0]);
         }
-        setReferrer(refs, referer.canonicalUrl);
-        setReferrer(refs, window.location.href);
+        _setReferrer(refs, referer.canonicalUrl);
+        _setReferrer(refs, window.location.href);
 
         for (let value of refs.values()) {
-          url = _appendUrl(url, 'r', value, configParams);
+          url = appendUrl(url, 'r', value, configParams);
         }
 
         const resp = function (callback) {
@@ -117,9 +117,6 @@ export const fabrickIdSubmodule = {
     } catch (e) {
       utils.logError(`fabrickIdSystem encountered an error`, e);
     }
-  },
-  appendUrl: (url, paramName, s, configParams) => {
-    return _appendUrl(url, paramName, s, configParams);
   }
 };
 
@@ -139,7 +136,7 @@ function _getBaseUrl(configParams) {
   }
 }
 
-function setReferrer(refs, s) {
+function _setReferrer(refs, s) {
   if (s) {
     // store the longest one for the same URI
     const url = s.split('?')[0];
@@ -156,7 +153,7 @@ function setReferrer(refs, s) {
   }
 }
 
-function _appendUrl(url, paramName, s, configParams) {
+export function appendUrl(url, paramName, s, configParams) {
   const maxUrlLen = (configParams && configParams.maxUrlLen) || 2000;
   const maxRefLen = (configParams && configParams.maxRefLen) || 1000;
   const maxSpaceAvailable = (configParams && configParams.maxSpaceAvailable) || 50;

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -55,7 +55,7 @@ export const fabrickIdSubmodule = {
         let keysArr = Object.keys(configParams);
         for (let i in keysArr) {
           let k = keysArr[i];
-          if (k === 'url' || k === 'refererInfo' || k.startsWith('max')) {
+          if (k === 'url' || k === 'refererInfo' || (k.length > 3 && k.substring(0, 3) === 'max')) {
             continue;
           }
           let v = configParams[k];

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -46,7 +46,7 @@ export const fabrickIdSubmodule = {
       if (window.fabrickMod1) {
         window.fabrickMod1(configParams, consentData, cacheIdObj);
       }
-      if (!configParams || typeof configParams.apiKey !== 'string') {
+      if (!configParams || !configParams.apiKey || typeof configParams.apiKey !== 'string') {
         utils.logError('fabrick submodule requires an apiKey.');
         return;
       }
@@ -80,8 +80,8 @@ export const fabrickIdSubmodule = {
         _setReferrer(refs, referer.canonicalUrl);
         _setReferrer(refs, window.location.href);
 
-        for (let value of refs.values()) {
-          url = appendUrl(url, 'r', value, configParams);
+        for (const key in refs) {
+          url = appendUrl(url, 'r', refs.get(key), configParams);
         }
 
         const resp = function (callback) {

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -7,7 +7,8 @@ const defaultConfigParams = {
   apiKey: '123',
   e: 'abc',
   p: ['def', 'hij'],
-  url: 'http://localhost:9999/test/mocks/fabrickId.json?'
+  url: 'http://localhost:9999/test/mocks/fabrickId.json?',
+  f: () => 'ignore this'
 };
 const responseHeader = {'Content-Type': 'application/json'}
 const fabrickIdSubmodule = fabrickIdSystem.fabrickIdSubmodule;
@@ -48,7 +49,7 @@ describe('Fabrick ID System', function() {
 
   it('should truncate the params', function() {
     let r = '';
-    for (let i = 0; i < 300; i++) {
+    for (let i = 0; i < 1500; i++) {
       r += 'r';
     }
     let configParams = Object.assign({}, defaultConfigParams, {
@@ -66,7 +67,7 @@ describe('Fabrick ID System', function() {
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     r = '';
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < 1000 - 3; i++) {
       r += 'r';
     }
     expect(request.url).to.match(new RegExp(`r=${r}&r=`));
@@ -102,5 +103,35 @@ describe('Fabrick ID System', function() {
     );
     expect(callBackSpy.calledOnce).to.be.true;
     expect(logErrorStub.calledOnce).to.be.false;
+  });
+
+  it('should truncate 2', function() {
+    let configParams = {
+      maxUrlLen: 10,
+      maxRefLen: 5,
+      maxSpaceAvailable: 2
+    };
+
+    let url = fabrickIdSystem.appendURL('', 'r', '123', configParams);
+    expect(url).to.equal('&r=12');
+
+    url = fabrickIdSystem.appendURL('12345', 'r', '678', configParams);
+    expect(url).to.equal('12345&r=67');
+
+    url = fabrickIdSystem.appendURL('12345678', 'r', '9', configParams);
+    expect(url).to.equal('12345678');
+
+    configParams.maxRefLen = 8;
+    url = fabrickIdSystem.appendURL('', 'r', '1234&', configParams);
+    expect(url).to.equal('&r=1234');
+
+    url = fabrickIdSystem.appendURL('', 'r', '123&', configParams);
+    expect(url).to.equal('&r=123');
+
+    url = fabrickIdSystem.appendURL('', 'r', '12&', configParams);
+    expect(url).to.equal('&r=12%26');
+
+    url = fabrickIdSystem.appendURL('', 'r', '1&&', configParams);
+    expect(url).to.equal('&r=1%26');
   });
 });

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -7,7 +7,8 @@ const defaultConfigParams = {
   apiKey: '123',
   e: 'abc',
   p: ['def', 'hij'],
-  url: 'http://localhost:9999/test/mocks/fabrickId.json?'
+  url: 'http://localhost:9999/test/mocks/fabrickId.json?',
+  f: () => 'ignore this'
 };
 const responseHeader = {'Content-Type': 'application/json'}
 const fabrickIdSubmodule = fabrickIdSystem.fabrickIdSubmodule;
@@ -111,26 +112,26 @@ describe('Fabrick ID System', function() {
       maxSpaceAvailable: 2
     };
 
-    let url = fabrickIdSystem.appendURL('', 'r', '123', configParams);
+    let url = fabrickIdSubmodule.appendUrl('', 'r', '123', configParams);
     expect(url).to.equal('&r=12');
 
-    url = fabrickIdSystem.appendURL('12345', 'r', '678', configParams);
+    url = fabrickIdSubmodule.appendUrl('12345', 'r', '678', configParams);
     expect(url).to.equal('12345&r=67');
 
-    url = fabrickIdSystem.appendURL('12345678', 'r', '9', configParams);
+    url = fabrickIdSubmodule.appendUrl('12345678', 'r', '9', configParams);
     expect(url).to.equal('12345678');
 
     configParams.maxRefLen = 8;
-    url = fabrickIdSystem.appendURL('', 'r', '1234&', configParams);
+    url = fabrickIdSubmodule.appendUrl('', 'r', '1234&', configParams);
     expect(url).to.equal('&r=1234');
 
-    url = fabrickIdSystem.appendURL('', 'r', '123&', configParams);
+    url = fabrickIdSubmodule.appendUrl('', 'r', '123&', configParams);
     expect(url).to.equal('&r=123');
 
-    url = fabrickIdSystem.appendURL('', 'r', '12&', configParams);
+    url = fabrickIdSubmodule.appendUrl('', 'r', '12&', configParams);
     expect(url).to.equal('&r=12%26');
 
-    url = fabrickIdSystem.appendURL('', 'r', '1&&', configParams);
+    url = fabrickIdSubmodule.appendUrl('', 'r', '1&&', configParams);
     expect(url).to.equal('&r=1%26');
   });
 });

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -7,8 +7,7 @@ const defaultConfigParams = {
   apiKey: '123',
   e: 'abc',
   p: ['def', 'hij'],
-  url: 'http://localhost:9999/test/mocks/fabrickId.json?',
-  f: () => 'ignore this'
+  url: 'http://localhost:9999/test/mocks/fabrickId.json?'
 };
 const responseHeader = {'Content-Type': 'application/json'}
 const fabrickIdSubmodule = fabrickIdSystem.fabrickIdSubmodule;

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -1,5 +1,6 @@
 import * as utils from '../../../src/utils.js';
 import {server} from '../../mocks/xhr.js';
+import {config} from '../../../src/config.js';
 
 import {fabrickIdSubmodule, appendUrl} from 'modules/fabrickIdSystem.js';
 
@@ -10,6 +11,7 @@ const defaultConfigParams = {
   url: 'http://localhost:9999/test/mocks/fabrickId.json?'
 };
 const responseHeader = {'Content-Type': 'application/json'}
+config.setConfig({debug: true});
 
 describe('Fabrick ID System', function() {
   let logErrorStub;

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -1,7 +1,7 @@
 import * as utils from '../../../src/utils.js';
 import {server} from '../../mocks/xhr.js';
 
-import * as fabrickIdSystem from 'modules/fabrickIdSystem.js';
+import {fabrickIdSubmodule, appendUrl} from 'modules/fabrickIdSystem.js';
 
 const defaultConfigParams = {
   apiKey: '123',
@@ -10,7 +10,6 @@ const defaultConfigParams = {
   url: 'http://localhost:9999/test/mocks/fabrickId.json?'
 };
 const responseHeader = {'Content-Type': 'application/json'}
-const fabrickIdSubmodule = fabrickIdSystem.fabrickIdSubmodule;
 
 describe('Fabrick ID System', function() {
   let logErrorStub;
@@ -111,26 +110,26 @@ describe('Fabrick ID System', function() {
       maxSpaceAvailable: 2
     };
 
-    let url = fabrickIdSubmodule.appendUrl('', 'r', '123', configParams);
+    let url = appendUrl('', 'r', '123', configParams);
     expect(url).to.equal('&r=12');
 
-    url = fabrickIdSubmodule.appendUrl('12345', 'r', '678', configParams);
+    url = appendUrl('12345', 'r', '678', configParams);
     expect(url).to.equal('12345&r=67');
 
-    url = fabrickIdSubmodule.appendUrl('12345678', 'r', '9', configParams);
+    url = appendUrl('12345678', 'r', '9', configParams);
     expect(url).to.equal('12345678');
 
     configParams.maxRefLen = 8;
-    url = fabrickIdSubmodule.appendUrl('', 'r', '1234&', configParams);
+    url = appendUrl('', 'r', '1234&', configParams);
     expect(url).to.equal('&r=1234');
 
-    url = fabrickIdSubmodule.appendUrl('', 'r', '123&', configParams);
+    url = appendUrl('', 'r', '123&', configParams);
     expect(url).to.equal('&r=123');
 
-    url = fabrickIdSubmodule.appendUrl('', 'r', '12&', configParams);
+    url = appendUrl('', 'r', '12&', configParams);
     expect(url).to.equal('&r=12%26');
 
-    url = fabrickIdSubmodule.appendUrl('', 'r', '1&&', configParams);
+    url = appendUrl('', 'r', '1&&', configParams);
     expect(url).to.equal('&r=1%26');
   });
 });

--- a/test/spec/modules/fabrickIdSystem_spec.js
+++ b/test/spec/modules/fabrickIdSystem_spec.js
@@ -1,6 +1,5 @@
 import * as utils from '../../../src/utils.js';
 import {server} from '../../mocks/xhr.js';
-import {config} from '../../../src/config.js';
 
 import {fabrickIdSubmodule, appendUrl} from 'modules/fabrickIdSystem.js';
 
@@ -11,26 +10,25 @@ const defaultConfigParams = {
   url: 'http://localhost:9999/test/mocks/fabrickId.json?'
 };
 const responseHeader = {'Content-Type': 'application/json'}
-config.setConfig({debug: true});
 
 describe('Fabrick ID System', function() {
   let logErrorStub;
 
   beforeEach(function () {
-    logErrorStub = sinon.stub(utils, 'logError');
   });
 
   afterEach(function () {
-    logErrorStub.restore();
-    fabrickIdSubmodule.getRefererInfoOverride = null;
   });
 
   it('should log an error if no configParams were passed into getId', function () {
+    logErrorStub = sinon.stub(utils, 'logError');
     fabrickIdSubmodule.getId();
     expect(logErrorStub.calledOnce).to.be.true;
+    logErrorStub.restore();
   });
 
   it('should error on json parsing', function() {
+    logErrorStub = sinon.stub(utils, 'logError');
     let submoduleCallback = fabrickIdSubmodule.getId({
       name: 'fabrickId',
       params: defaultConfigParams
@@ -45,6 +43,7 @@ describe('Fabrick ID System', function() {
     );
     expect(callBackSpy.calledOnce).to.be.true;
     expect(logErrorStub.calledOnce).to.be.true;
+    logErrorStub.restore();
   });
 
   it('should truncate the params', function() {
@@ -77,7 +76,6 @@ describe('Fabrick ID System', function() {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
-    expect(logErrorStub.calledOnce).to.be.false;
   });
 
   it('should complete successfully', function() {
@@ -102,7 +100,6 @@ describe('Fabrick ID System', function() {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
-    expect(logErrorStub.calledOnce).to.be.false;
   });
 
   it('should truncate 2', function() {


### PR DESCRIPTION
## Type of change
- [X ] Bugfix

## Description of change
The only change is with the url sent to the fabrick endpoint for getting a fabrickId.
 - encode all url params
 - dedupe w/out queryString and keep the longest
 - additionally truncate from % if that ends up being the last (or next to last) char after truncation
 - truncate 1k instead of 200
 - don't send functions along in query (only send strings and numbers)