### PR TITLE
PBJS Core: clean side-effect when checking that local storage is enabled

### DIFF
--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -1,4 +1,4 @@
-import { hook } from './hook.js';
+import {hook} from './hook.js';
 import * as utils from './utils.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
@@ -110,7 +110,12 @@ export function newStorageManager({gvlid, moduleName, moduleType} = {}) {
         try {
           localStorage.setItem('prebid.cookieTest', '1');
           return localStorage.getItem('prebid.cookieTest') === '1';
-        } catch (error) {}
+        } catch (error) {
+        } finally {
+          try {
+            localStorage.removeItem('prebid.cookieTest');
+          } catch (error) {}
+        }
       }
       return false;
     }

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -46,16 +46,17 @@ describe('storage manager', function() {
 
   describe('localstorage forbidden access in 3rd-party context', function() {
     let errorLogSpy;
-    const originalLocalStorage = { get: () => window.localStorage };
+    let originalLocalStorage;
     const localStorageMock = { get: () => { throw Error } };
 
     beforeEach(function() {
+      originalLocalStorage = window.localStorage;
       Object.defineProperty(window, 'localStorage', localStorageMock);
       errorLogSpy = sinon.spy(utils, 'logError');
     });
 
     afterEach(function() {
-      Object.defineProperty(window, 'localStorage', originalLocalStorage);
+      Object.defineProperty(window, 'localStorage', { get: () => originalLocalStorage });
       errorLogSpy.restore();
     })
 
@@ -70,4 +71,28 @@ describe('storage manager', function() {
       sinon.assert.calledThrice(errorLogSpy);
     })
   })
+
+  describe('localstorage is enabled', function() {
+    let localStorage;
+
+    beforeEach(function() {
+      localStorage = window.localStorage;
+      localStorage.clear();
+    });
+
+    afterEach(function() {
+      localStorage.clear();
+    })
+
+    it('should remove side-effect after checking', function () {
+      const storage = getStorageManager();
+
+      localStorage.setItem('unrelated', 'dummy');
+      const val = storage.localStorageIsEnabled();
+
+      expect(val).to.be.true;
+      expect(localStorage.length).to.be.eq(1);
+      expect(localStorage.getItem('unrelated')).to.be.eq('dummy');
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

When calling `storageManager.localStorageInEnabled`, the function is doing a side effect by writing into the local storage and verifying that the write was effectively committed, and so indicating that the locale storage is effectively enabled.

Currently, the side effect remains and a `prebid.cookieTest` value remains in user's local storage.

This change aims to clean this side effect after determining if local storage is enabled.

## Other information

Linked to #6289 
