### PR TITLE
s2s Alias Bug

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -539,16 +539,6 @@ const OPEN_RTB_PROTOCOL = {
         // OpenRTB response contains the adunit code and bidder name. These are
         // combined to create a unique key for each bid since an id isn't returned
         bidIdMap[`${adUnit.code}${bid.bidder}`] = bid.bid_id;
-
-        // check for and store valid aliases to add to the request
-        if (adapterManager.aliasRegistry[bid.bidder]) {
-          const bidder = adapterManager.bidderRegistry[bid.bidder];
-          // adding alias only if alias source bidder exists and alias isn't configured to be standalone
-          // pbs adapter
-          if (bidder && !bidder.getSpec().skipPbsAliasing) {
-            aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
-          }
-        }
       });
 
       let mediaTypes = {};
@@ -695,8 +685,17 @@ const OPEN_RTB_PROTOCOL = {
       };
     }
 
+    // check for and store valid aliases to add to the requests
+    _s2sConfigs.forEach(s2sConfig => {
+      s2sConfig.bidders.forEach(bidder => {
+        if (adapterManager.aliasRegistry[bidder]) {
+          aliases[bidder] = adapterManager.aliasRegistry[bidder];
+        }
+      })
+    })
+
     if (!utils.isEmpty(aliases)) {
-      request.ext.prebid.aliases = aliases;
+      request.ext.prebid.aliases = { ...request.ext.prebid.aliases, ...aliases };
     }
 
     const bidUserIdAsEids = utils.deepAccess(bidRequests, '0.bids.0.userIdAsEids');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
There is a bug when adding s2s aliases when you are also making a call for a bidder with an alias built into the prebid code. The code overwrites any aliases you add. For example when I have districtM in my set up which is aliased in the appnexus adapter and I want to add a new alias (eg. tripleliftvideo) in the s2sConfig it will only list the alias for districtM in the request.

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
