### PR TITLE
Adhese Bid Adapter: replace id5 with eid

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -158,12 +158,6 @@ function getAccount(validBidRequests) {
   return validBidRequests[0].params.account;
 }
 
-function getId5Id(validBidRequests) {
-  if (validBidRequests[0] && validBidRequests[0].userId && validBidRequests[0].userId.id5id && validBidRequests[0].userId.id5id.uid) {
-    return validBidRequests[0].userId.id5id.uid;
-  }
-}
-
 function getEids(validBidRequests) {
   if (validBidRequests[0] && validBidRequests[0].userIdAsEids) {
     return validBidRequests[0].userIdAsEids;

--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -24,8 +24,7 @@ export const spec = {
 
     const gdprParams = (gdprConsent && gdprConsent.consentString) ? { xt: [gdprConsent.consentString] } : {};
     const refererParams = (refererInfo && refererInfo.referer) ? { xf: [base64urlEncode(refererInfo.referer)] } : {};
-    const id5Params = (getId5Id(validBidRequests)) ? { x5: [getId5Id(validBidRequests)] } : {};
-    const commonParams = { ...gdprParams, ...refererParams, ...id5Params };
+    const commonParams = { ...gdprParams, ...refererParams };
 
     const slots = validBidRequests.map(bid => ({
       slotname: bidToSlotName(bid),
@@ -34,8 +33,13 @@ export const spec = {
 
     const payload = {
       slots: slots,
-      parameters: commonParams
-    }
+      parameters: commonParams,
+      user: {
+        ext: {
+          eids: getEids(validBidRequests),
+        }
+      }
+    };
 
     const account = getAccount(validBidRequests);
     const uri = 'https://ads-' + account + '.adhese.com/json';
@@ -157,6 +161,12 @@ function getAccount(validBidRequests) {
 function getId5Id(validBidRequests) {
   if (validBidRequests[0] && validBidRequests[0].userId && validBidRequests[0].userId.id5id && validBidRequests[0].userId.id5id.uid) {
     return validBidRequests[0].userId.id5id.uid;
+  }
+}
+
+function getEids(validBidRequests) {
+  if (validBidRequests[0] && validBidRequests[0].userIdAsEids) {
+    return validBidRequests[0].userIdAsEids;
   }
 }
 

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -17,10 +17,9 @@ let minimalBid = function() {
   }
 };
 
-let bidWithParams = function(data, userId) {
+let bidWithParams = function(data) {
   let bid = minimalBid();
   bid.params.data = data;
-  bid.userId = userId;
   return bid;
 };
 
@@ -117,10 +116,19 @@ describe('AdheseAdapter', function () {
       expect(JSON.parse(req.data).parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
     });
 
-    it('should include id5 id as /x5 param', function () {
-      let req = spec.buildRequests([ bidWithParams({}, { 'id5id': { 'uid': 'ID5-1234567890' } }) ], bidderRequest);
+    it('should include eids', function () {
+      let bid = minimalBid();
+      bid.userIdAsEids = [{ source: 'id5-sync.com', uids: [{ id: 'ID5@59sigaS-...' }] }];
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
+      let req = spec.buildRequests([ bid ], bidderRequest);
+
+      expect(JSON.parse(req.data).user.ext.eids).to.deep.equal(bid.userIdAsEids);
+    });
+
+    it('should not include eids field when userid module disabled', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data)).to.not.have.key('eids');
     });
 
     it('should include bids', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Pass eids (when userid module enabled) down to Adhese.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
