### PR TITLE
Documentation: Prebid Server and Postbid integration example ( ad server-less )

### DIFF
--- a/integrationExamples/postbid/postbid_prebidServer_example.html
+++ b/integrationExamples/postbid/postbid_prebidServer_example.html
@@ -1,0 +1,86 @@
+<html>
+<head>
+<script>
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+    (function() {
+        var pbjsEl = document.createElement("script");
+        pbjsEl.type = "text/javascript";
+        pbjsEl.async = true;
+        pbjsEl.src = '../../build/dev/prebid.js';
+        var pbjsTargetEl = document.getElementsByTagName("head")[0];
+        pbjsTargetEl.insertBefore(pbjsEl, pbjsTargetEl.firstChild);
+      })();
+
+    pbjs.que.push(function() {
+        var adUnits = [{
+            code: 'postbid_iframe',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]]
+              }
+            },
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                   placementId: 13144370
+                }
+              }
+            ]
+          }];
+
+        pbjs.setConfig({
+          bidderTimeout: 1000,
+          s2sConfig : {
+            accountId : '1',
+            enabled : true, //default value set to false
+            bidders : ['appnexus'],
+            timeout : 1000, //default value is 1000
+            adapter : 'prebidServer', //if we have any other s2s adapter, default value is s2s
+            endpoint : 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
+          }
+        });
+
+        pbjs.addAdUnits(adUnits);
+
+        pbjs.requestBids({
+            bidsBackHandler: function(bidResponses) {
+                var iframe = document.getElementById('postbid_iframe');
+                var iframeDoc = iframe.contentWindow.document;
+                var adServerTargeting = pbjs.getAdserverTargetingForAdUnitCode('postbid_iframe');
+
+                // If any bidders return any creatives
+                if (adServerTargeting && adServerTargeting['hb_adid']) {
+                    pbjs.renderAd(iframeDoc, adServerTargeting['hb_adid']);
+                } else {
+                    iframe.width = sizes[0][0];
+                    iframe.height = sizes[0][1];
+                    iframeDoc.write('<head></head><body>' + passbackTagHtml + '</body>');
+                    iframeDoc.close();
+                }
+            }
+        })
+    });
+
+    var passbackTagHtml = 'TO ADD';
+</script>
+
+</head>
+
+<body>
+    <iframe id='postbid_iframe'
+            FRAMEBORDER="0"
+            SCROLLING="no"
+            MARGINHEIGHT="0"
+            MARGINWIDTH="0"
+            TOPMARGIN="0"
+            LEFTMARGIN="0"
+            ALLOWTRANSPARENCY="true"
+            WIDTH="0"
+            HEIGHT="0">
+    </iframe>
+
+</body>
+</html>

--- a/integrationExamples/postbid/postbid_prebidServer_example.html
+++ b/integrationExamples/postbid/postbid_prebidServer_example.html
@@ -32,7 +32,7 @@
           }];
 
         pbjs.setConfig({
-          bidderTimeout: 2000,
+          bidderTimeout: 1000,
           s2sConfig : {
             accountId : '1',
             enabled : true, //default value set to false

--- a/integrationExamples/postbid/postbid_prebidServer_example.html
+++ b/integrationExamples/postbid/postbid_prebidServer_example.html
@@ -32,7 +32,7 @@
           }];
 
         pbjs.setConfig({
-          bidderTimeout: 1000,
+          bidderTimeout: 2000,
           s2sConfig : {
             accountId : '1',
             enabled : true, //default value set to false


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other ( Documentation )

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding a test page that uses Prebid Server without an ad server. In this example, the Postpid integration is used to bypass the ad server call, and to render the winning bid directly on the web page.

![pbjs-server-flow](https://user-images.githubusercontent.com/9834101/108860146-382be880-75ee-11eb-93e7-9ec7a8acb749.png)


