### PR TITLE
Novatiq ID System: add snowflake userId submodule

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -20,7 +20,8 @@
     "fabrickIdSystem",
     "verizonMediaIdSystem",
     "pubProvidedIdSystem",
-    "tapadIdSystem"
+    "tapadIdSystem",
+    "novatiqIdSystem"
   ],
   "adpod": [
     "freeWheelAdserverVideo",

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -58,7 +58,7 @@ export const novatiqIdSubmodule = {
     ajax(url, undefined, undefined, { method: 'GET', withCredentials: false });
 
     utils.logInfo('NOVATIQ snowflake: ' + novatiqId);
-    return { 'id': novatiqId, 'srcid': srcId }
+    return { 'id': novatiqId }
   },
 
   getSrcId(configParams) {

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -1,0 +1,88 @@
+/**
+ * This module adds novatiqId to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/novatiqIdSystem
+ * @requires module:modules/userId
+ */
+
+import * as utils from '../src/utils.js';
+import { ajax } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
+
+/** @type {Submodule} */
+export const novatiqIdSubmodule = {
+
+/**
+* used to link submodule with config
+* @type {string}
+*/
+  name: 'novatiq',
+
+  /**
+* decode the stored id value for passing to bid requests
+* @function
+* @returns {novatiq: {snowflake: string}}
+*/
+  decode(novatiqId, config) {
+    let responseObj = {
+      novatiq: {
+        snowflake: novatiqId
+      }
+    };
+    return responseObj;
+  },
+
+  /**
+* performs action to obtain id and return a value in the callback's response argument
+* @function
+* @param {SubmoduleConfig} config
+* @returns {id: string}
+*/
+  getId(config) {
+    function snowflakeId(placeholder) {
+      return placeholder
+        ? (placeholder ^ Math.random() * 16 >> placeholder / 4).toString(16)
+        : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11 + 1e3).replace(/[018]/g, snowflakeId);
+    }
+
+    const configParams = config.params || {};
+    const srcId = this.getSrcId(configParams);
+    utils.logInfo('NOVATIQ Sync request used sourceid param: ' + srcId);
+
+    let partnerhost;
+    partnerhost = window.location.hostname;
+    utils.logInfo('NOVATIQ partner hostname: ' + partnerhost);
+
+    const novatiqId = snowflakeId();
+    const url = 'https://spadsync.com/sync?sptoken=' + novatiqId + '&sspid=' + srcId + '&ssphost=' + partnerhost;
+    ajax(url, undefined, undefined, { method: 'GET', withCredentials: false });
+
+    utils.logInfo('NOVATIQ snowflake: ' + novatiqId);
+    return { 'id': novatiqId, 'srcid': srcId }
+  },
+
+  getSrcId(configParams) {
+    utils.logInfo('NOVATIQ Configured sourceid param: ' + configParams.sourceid);
+
+    function isHex(str) {
+      var a = parseInt(str, 16);
+      return (a.toString(16) === str)
+    }
+
+    let srcId;
+    if (typeof configParams.sourceid === 'undefined' || configParams.sourceid === null || configParams.sourceid === '') {
+      srcId = '000';
+      utils.logInfo('NOVATIQ sourceid param set to value 000 due to undefined parameter or missing value in config section');
+    } else if (configParams.sourceid.length < 3 || configParams.sourceid.length > 3) {
+      srcId = '001';
+      utils.logInfo('NOVATIQ sourceid param set to value 001 due to wrong size in config section 3 chars max e.g. 1ab');
+    } else if (isHex(configParams.sourceid) == false) {
+      srcId = '002';
+      utils.logInfo('NOVATIQ sourceid param set to value 002 due to wrong format in config section expecting hex value only');
+    } else {
+      srcId = configParams.sourceid;
+    }
+    return srcId
+  }
+};
+submodule('userId', novatiqIdSubmodule);

--- a/modules/novatiqIdSystem.md
+++ b/modules/novatiqIdSystem.md
@@ -1,0 +1,36 @@
+# Novatiq Snowflake ID
+
+Novatiq proprietary dynamic snowflake ID is a unique, non sequential and single use identifier for marketing activation. Only the snowflake ID moves beyond the firewall, keeping all customer data (publisher / brand and telco) private, secure and under control. Our in network solution matches verification requests to the telco network ID, safely and securely behind the telco firewall .
+
+## Novatiq Snowflake ID Configuration
+
+Enable by adding the Novatiq submodule to your Prebid.js package with:
+
+```
+gulp build --modules=novatiqIdSystem,userId
+```
+
+Module activation and configuration:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'novatiq',
+      params: {
+        sourceid '1a3',            // change to the Partner Number you received from Novatiq
+        }
+      }
+    }],
+    auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
+  }
+});
+```
+
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | Module identification: `"novatiq"` | `"novatiq"` |
+| params | Required | Object | Configuration specifications for the Novatiq module. | |
+| params.sourceid | Required | String | This is the Novatiq Partner Number obtained via Novatiq registration. | `1a3` |
+
+If you have any questions, please reach out to us at prebid@novatiq.com.

--- a/modules/novatiqIdSystem.md
+++ b/modules/novatiqIdSystem.md
@@ -1,6 +1,6 @@
 # Novatiq Snowflake ID
 
-Novatiq proprietary dynamic snowflake ID is a unique, non sequential and single use identifier for marketing activation. Only the snowflake ID moves beyond the firewall, keeping all customer data (publisher / brand and telco) private, secure and under control. Our in network solution matches verification requests to the telco network ID, safely and securely behind the telco firewall .
+Novatiq proprietary dynamic snowflake ID is a unique, non sequential and single use identifier for marketing activation. Our in network solution matches verification requests to telco network IDs, safely and securely inside telecom infrastructure. Novatiq snowflake ID can be used for identity validation and as a secured 1st party data delivery mechanism.
 
 ## Novatiq Snowflake ID Configuration
 

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -172,6 +172,15 @@ const USER_IDS_CONFIG = {
   'tapadId': {
     source: 'tapad.com',
     atype: 1
+  },
+
+  // Novatiq Snowflake
+  'novatiq': {
+    getValue: function(data) {
+      return data.snowflake
+    },
+    source: 'novatiq.com',
+    atype: 1
   }
 };
 

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -148,6 +148,13 @@ userIdAsEids = [
             id: 'some-random-id-value',
             atype: 1
         }]
+    },
+    {
+        source: 'novatiq.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
+        }]
     }
 ]
 ```

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -182,6 +182,10 @@ pbjs.setConfig({
         {
             name: "criteo",
             value: { "criteoId": "wK-fkF8zaEIlMkZMbHl3eFo4NEtoNmZaeXJtYkFjZlVuWjBhcjJMaTRYd3pZNSUyQnlKRHNGRXlpdzdjd3pjVzhjcSUyQmY4eTFzN3VSZjV1ZyUyRlA0U2ZiR0UwN2I4bDZRJTNEJTNE" }
+        },
+        {
+            name: "novatiq",
+            value: { "snowflake": "81b001ec-8914-488c-a96e-8c220d4ee08895ef" }
         }],
         syncDelay: 5000
     }

--- a/test/spec/modules/novatiqIdSystem_spec.js
+++ b/test/spec/modules/novatiqIdSystem_spec.js
@@ -6,32 +6,37 @@ describe('novatiqIdSystem', function () {
   describe('getSrcId', function() {
     it('getSrcId should set srcId value to 000 due to undefined parameter in config section', function() {
       const config = { params: { } };
-      const response = novatiqIdSubmodule.getSrcId(config);
-      expect('000').to.eq(response);
+      const configParams = config.params || {};
+      const response = novatiqIdSubmodule.getSrcId(configParams);
+      expect(response).to.eq('000');
     });
 
     it('getSrcId should set srcId value to 000 due to missing value in config section', function() {
       const config = { params: { sourceid: '' } };
-      const response = novatiqIdSubmodule.getId(config);
-      expect('000').to.eq(response.srcid);
+      const configParams = config.params || {};
+      const response = novatiqIdSubmodule.getSrcId(configParams);
+      expect(response).to.eq('000');
     });
 
     it('getSrcId should set value to 000 due to null value in config section', function() {
       const config = { params: { sourceid: null } };
-      const response = novatiqIdSubmodule.getId(config);
-      expect('000').to.eq(response.srcid);
+      const configParams = config.params || {};
+      const response = novatiqIdSubmodule.getSrcId(configParams);
+      expect(response).to.eq('000');
     });
 
-    it('getSrcId should set value to 001 due to due to wrong length in config section max 3 chars', function() {
+    it('getSrcId should set value to 001 due to wrong length in config section max 3 chars', function() {
       const config = { params: { sourceid: '1234' } };
-      const response = novatiqIdSubmodule.getId(config);
-      expect('001').to.eq(response.srcid);
+      const configParams = config.params || {};
+      const response = novatiqIdSubmodule.getSrcId(configParams);
+      expect(response).to.eq('001');
     });
 
-    it('getSrcId should set value to 002 due to due to wrong format in config section', function() {
+    it('getSrcId should set value to 002 due to wrong format in config section', function() {
       const config = { params: { sourceid: '1xc' } };
-      const response = novatiqIdSubmodule.getId(config);
-      expect('002').to.eq(response.srcid);
+      const configParams = config.params || {};
+      const response = novatiqIdSubmodule.getSrcId(configParams);
+      expect(response).to.eq('002');
     });
   });
 

--- a/test/spec/modules/novatiqIdSystem_spec.js
+++ b/test/spec/modules/novatiqIdSystem_spec.js
@@ -1,0 +1,65 @@
+import { novatiqIdSubmodule } from 'modules/novatiqIdSystem.js';
+import * as utils from 'src/utils.js';
+import { server } from 'test/mocks/xhr.js';
+
+describe('novatiqIdSystem', function () {
+  describe('getSrcId', function() {
+    it('getSrcId should set srcId value to 000 due to undefined parameter in config section', function() {
+      const config = { params: { } };
+      const response = novatiqIdSubmodule.getSrcId(config);
+      expect('000').to.eq(response);
+    });
+
+    it('getSrcId should set srcId value to 000 due to missing value in config section', function() {
+      const config = { params: { sourceid: '' } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect('000').to.eq(response.srcid);
+    });
+
+    it('getSrcId should set value to 000 due to null value in config section', function() {
+      const config = { params: { sourceid: null } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect('000').to.eq(response.srcid);
+    });
+
+    it('getSrcId should set value to 001 due to due to wrong length in config section max 3 chars', function() {
+      const config = { params: { sourceid: '1234' } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect('001').to.eq(response.srcid);
+    });
+
+    it('getSrcId should set value to 002 due to due to wrong format in config section', function() {
+      const config = { params: { sourceid: '1xc' } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect('002').to.eq(response.srcid);
+    });
+  });
+
+  describe('getId', function() {
+    it('should log message if novatiqId has wrong format', function() {
+      const config = { params: { sourceid: '123' } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect(response.id).to.have.length(40);
+    });
+
+    it('should log message if novatiqId not provided', function() {
+      const config = { params: { sourceid: '123' } };
+      const response = novatiqIdSubmodule.getId(config);
+      expect(response.id).should.be.not.empty;
+    });
+  });
+
+  describe('decode', function() {
+    it('should log message if novatiqId has wrong format', function() {
+      const novatiqId = '81b001ec-8914-488c-a96e-8c220d4ee08895ef';
+      const response = novatiqIdSubmodule.decode(novatiqId);
+      expect(response.novatiq.snowflake).to.have.length(40);
+    });
+
+    it('should log message if novatiqId has wrong format', function() {
+      const novatiqId = '81b001ec-8914-488c-a96e-8c220d4ee08895ef';
+      const response = novatiqIdSubmodule.decode(novatiqId);
+      expect(response.novatiq.snowflake).should.be.not.empty;
+    });
+  });
+})


### PR DESCRIPTION
Novatiq snowflake userId submodule initial release

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
