### PR TITLE
LiveRamp userId: updated atype parameter

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -71,7 +71,7 @@ const USER_IDS_CONFIG = {
   // identityLink
   'idl_env': {
     source: 'liveramp.com',
-    atype: 1
+    atype: 3
   },
 
   // liveIntentId

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -52,8 +52,8 @@ userIdAsEids = [
     {
         source: 'liveramp.com',
         uids: [{
-            id: 'some-random-id-value',
-            atype: 1
+            id: 'Ah4zcGxA1xuMNVMo9dkaASexpS3TjjzEOE_jOPgbDGhSgX2yoY9bch3nxninV1fXowpJFk7-rLf5Yu1uxLLO5r-STmTnjtD56wxNvSF93j3b',
+            atype: 3
         }]
     },
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Other

## Description of change
Some small changes related to the `atype` associated with the LiveRamp UserId module. Per [AdCOM](https://github.com/InteractiveAdvertisingBureau/AdCOM), `3` is the correct int for our identifier. Both the .js and .md files have been updated. 