### PR TITLE
Adform Bid Adapter: add global targeting to the request query as parameter

### DIFF
--- a/modules/adformBidAdapter.js
+++ b/modules/adformBidAdapter.js
@@ -5,6 +5,7 @@ import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const OUTSTREAM_RENDERER_URL = 'https://s2.adform.net/banners/scripts/video/outstream/render.js';
 
@@ -24,13 +25,32 @@ export const spec = {
 
     var request = [];
     var globalParams = [ [ 'adxDomain', 'adx.adform.net' ], [ 'fd', 1 ], [ 'url', null ], [ 'tid', null ], [ 'eids', eids ] ];
+    const targetingParams = { mkv: [], mkw: [], msw: [] };
+
     var bids = JSON.parse(JSON.stringify(validBidRequests));
     var bidder = (bids[0] && bids[0].bidder) || BIDDER_CODE;
+
+    // set common targeting options as query params
+    if (bids.length > 1) {
+      for (let key in targetingParams) {
+        if (targetingParams.hasOwnProperty(key)) {
+          const collection = bids.map(bid => ((bid.params[key] && bid.params[key].split(',')) || []));
+          targetingParams[key] = collection.reduce(intersects);
+          if (targetingParams[key].length) {
+            bids.forEach((bid, index) => {
+              bid.params[key] = collection[index].filter(item => !includes(targetingParams[key], item));
+            });
+          }
+        }
+      }
+    }
+
     for (i = 0, l = bids.length; i < l; i++) {
       bid = bids[i];
       if ((bid.params.priceType === 'net') || (bid.params.pt === 'net')) {
         netRevenue = 'net';
       }
+
       for (j = 0, k = globalParams.length; j < k; j++) {
         _key = globalParams[j][0];
         _value = bid[_key] || bid.params[_key];
@@ -63,6 +83,12 @@ export const spec = {
 
     if (bidderRequest && bidderRequest.uspConsent) {
       request.push('us_privacy=' + bidderRequest.uspConsent);
+    }
+
+    for (let key in targetingParams) {
+      if (targetingParams.hasOwnProperty(key)) {
+        globalParams.push([ key, targetingParams[key].join(',') ]);
+      }
     }
 
     for (i = 1, l = globalParams.length; i < l; i++) {
@@ -113,6 +139,10 @@ export const spec = {
 
         return result;
       }, {});
+    }
+
+    function intersects(col1, col2) {
+      return col1.filter(item => includes(col2, item));
     }
   },
   interpretResponse: function (serverResponse, bidRequest) {

--- a/test/spec/modules/adformBidAdapter_spec.js
+++ b/test/spec/modules/adformBidAdapter_spec.js
@@ -157,6 +157,37 @@ describe('Adform adapter', function () {
       assert.equal(eids, 'some_id_value');
     });
 
+    it('should add parameter to global parameters if it exists in all bids', function () {
+      const _bids = [];
+      _bids.push(bids[0]);
+      _bids.push(bids[1]);
+      _bids.push(bids[2]);
+      _bids[0].params.mkv = 'key:value,key1:value1';
+      _bids[1].params.mkv = 'key:value,key1:value1,keyR:removed';
+      _bids[2].params.mkv = 'key:value,key1:value1,keyR:removed,key8:value1';
+      _bids[0].params.mkw = 'targeting';
+      _bids[1].params.mkw = 'targeting';
+      _bids[2].params.mkw = 'targeting,targeting2';
+      _bids[0].params.msw = 'search:word,search:word2';
+      _bids[1].params.msw = 'search:word';
+      _bids[2].params.msw = 'search:word,search:word5';
+      let bidList = _bids;
+      let request = spec.buildRequests(bidList);
+      let parsedUrl = parseUrl(request.url);
+      assert.equal(parsedUrl.query.mkv, encodeURIComponent('key:value,key1:value1'));
+      assert.equal(parsedUrl.query.mkw, 'targeting');
+      assert.equal(parsedUrl.query.msw, encodeURIComponent('search:word'));
+      assert.ok(!parsedUrl.items[0].mkv);
+      assert.ok(!parsedUrl.items[0].mkw);
+      assert.equal(parsedUrl.items[0].msw, 'search:word2');
+      assert.equal(parsedUrl.items[1].mkv, 'keyR:removed');
+      assert.ok(!parsedUrl.items[1].mkw);
+      assert.ok(!parsedUrl.items[1].msw);
+      assert.equal(parsedUrl.items[2].mkv, 'keyR:removed,key8:value1');
+      assert.equal(parsedUrl.items[2].mkw, 'targeting2');
+      assert.equal(parsedUrl.items[2].msw, 'search:word5');
+    });
+
     describe('user privacy', function () {
       it('should send GDPR Consent data to adform if gdprApplies', function () {
         let request = spec.buildRequests([bids[0]], {gdprConsent: {gdprApplies: true, consentString: 'concentDataString'}});


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
When clients use the same targeting parameters for all bids, it expands the bid requests URL. This change adds global targeting parameters that repeat in all bids to the request query string as global parameters and saves query string length.

- contact email of the adapter’s maintainer
 Scope.FL.Scripts@adform.com
- [x] official adapter submission
