### PR TITLE
Apacdex Bid Adapter: userId module support, show demo ads in debug mode & other maintenance

### DIFF
--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -1,4 +1,5 @@
 import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'apacdex';
 const CONFIG = {
@@ -49,11 +50,34 @@ export const spec = {
   },
 
   buildRequests: function (validBidRequests, bidderRequest) {
+    let siteId;
+    let schain;
+    let eids;
+    let geo;
+    let test;
+
     var bids = JSON.parse(JSON.stringify(validBidRequests))
     bidderConfig = CONFIG[bids[0].bidder];
-    const payload = {};
+
+    test = config.getConfig('debug');
 
     bids.forEach(bidReq => {
+      siteId = siteId || bidReq.params.siteId;
+
+      if (bidReq.schain) {
+        schain = schain || bidReq.schain
+      }
+
+      if (bidReq.userIdAsEids) {
+        eids = eids || bidReq.userIdAsEids
+      }
+
+      if (bidReq.params && bidReq.params.geo) {
+        if (validateGeoObject(bidReq.params.geo)) {
+          geo = bidReq.params.geo;
+        }
+      }
+
       var targetKey = 0;
       if (bySlotTargetKey[bidReq.adUnitCode] != undefined) {
         targetKey = bySlotTargetKey[bidReq.adUnitCode];
@@ -73,34 +97,53 @@ export const spec = {
       bidReq.targetKey = targetKey;
     });
 
+    const payload = {};
+    payload.tmax = bidderRequest.timeout;
+    if (test) {
+      payload.test = 1;
+    }
+
     payload.device = {};
     payload.device.ua = navigator.userAgent;
-    payload.device.height = window.top.innerHeight;
-    payload.device.width = window.top.innerWidth;
+    payload.device.height = window.screen.width;
+    payload.device.width = window.screen.height;
     payload.device.dnt = _getDoNotTrack();
     payload.device.language = navigator.language;
 
+    var pageUrl = _extractTopWindowUrlFromBidderRequest(bidderRequest);
     payload.site = {};
-    payload.site.id = bids[0].params.siteId;
-    payload.site.page = _extractTopWindowUrlFromBidderRequest(bidderRequest);
+    payload.site.id = siteId;
+    payload.site.page = pageUrl
     payload.site.referrer = _extractTopWindowReferrerFromBidderRequest(bidderRequest);
-    payload.site.hostname = window.top.location.hostname;
+    payload.site.hostname = getDomain(pageUrl);
 
     // Apply GDPR parameters to request.
-    payload.gdpr = {};
     if (bidderRequest && bidderRequest.gdprConsent) {
+      payload.gdpr = {};
       payload.gdpr.gdprApplies = !!bidderRequest.gdprConsent.gdprApplies;
       if (bidderRequest.gdprConsent.consentString) {
         payload.gdpr.consentString = bidderRequest.gdprConsent.consentString;
       }
     }
-    // Apply schain.
-    if (bids[0].schain) {
-      payload.schain = bids[0].schain
-    }
+
     // Apply us_privacy.
     if (bidderRequest && bidderRequest.uspConsent) {
       payload.us_privacy = bidderRequest.uspConsent;
+    }
+
+    // Apply schain.
+    if (schain) {
+      payload.schain = schain
+    }
+
+    // Apply eids.
+    if (eids) {
+      payload.eids = eids
+    }
+
+    // Apply geo
+    if (geo) {
+      payload.geo = geo;
     }
 
     payload.bids = bids;
@@ -115,12 +158,12 @@ export const spec = {
   },
   interpretResponse: function (serverResponse, bidRequest) {
     const serverBody = serverResponse.body;
-    const serverBids = serverBody.bids;
-    // check overall response
-    if (!serverBody || typeof serverBody !== 'object') {
+    if (!serverBody || !utils.isPlainObject(serverBody)) {
       return [];
     }
-    if (!serverBids || typeof serverBids !== 'object') {
+
+    const serverBids = serverBody.bids;
+    if (!serverBids || !utils.isArray(serverBids)) {
       return [];
     }
 
@@ -192,15 +235,25 @@ function _getBiggestSize(sizes) {
 }
 
 function _getDoNotTrack() {
-  if (window.top.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack) {
-    if (window.top.doNotTrack == '1' || navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') {
+  try {
+    if (window.top.doNotTrack && window.top.doNotTrack == '1') {
       return 1;
-    } else {
-      return 0;
     }
-  } else {
-    return 0;
-  }
+  } catch (e) { }
+
+  try {
+    if (navigator.doNotTrack && (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1')) {
+      return 1;
+    }
+  } catch (e) { }
+
+  try {
+    if (navigator.msDoNotTrack && navigator.msDoNotTrack == '1') {
+      return 1;
+    }
+  } catch (e) { }
+
+  return 0
 }
 
 /**
@@ -210,8 +263,11 @@ function _getDoNotTrack() {
  * @returns {string}
  */
 function _extractTopWindowUrlFromBidderRequest(bidderRequest) {
-  if (bidderRequest && utils.deepAccess(bidderRequest, 'refererInfo.canonicalUrl')) {
-    return bidderRequest.refererInfo.canonicalUrl;
+  if (config.getConfig('pageUrl')) {
+    return config.getConfig('pageUrl');
+  }
+  if (utils.deepAccess(bidderRequest, 'refererInfo.referer')) {
+    return bidderRequest.refererInfo.referer;
   }
 
   try {
@@ -237,6 +293,47 @@ function _extractTopWindowReferrerFromBidderRequest(bidderRequest) {
   } catch (e) {
     return window.document.referrer;
   }
+}
+
+/**
+ * Extracts the domain from given page url
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+function getDomain(pageUrl) {
+  if (config.getConfig('publisherDomain')) {
+    var publisherDomain = config.getConfig('publisherDomain');
+    return publisherDomain.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)[0];
+  }
+
+  if (!pageUrl) {
+    return pageUrl;
+  }
+
+  return pageUrl.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)[0];
+}
+
+/**
+ * Validate geo object
+ *
+ * @param {Object} geo
+ * @returns {boolean}
+ */
+function validateGeoObject(geo) {
+  if (!utils.isPlainObject(geo)) {
+    return false;
+  }
+  if (!geo.lat) {
+    return false;
+  }
+  if (!geo.lon) {
+    return false;
+  }
+  if (!geo.accuracy) {
+    return false;
+  }
+  return true;
 }
 
 registerBidder(spec);

--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -301,17 +301,17 @@ function _extractTopWindowReferrerFromBidderRequest(bidderRequest) {
  * @param {string} url
  * @returns {string}
  */
-function getDomain(pageUrl) {
+export function getDomain(pageUrl) {
   if (config.getConfig('publisherDomain')) {
     var publisherDomain = config.getConfig('publisherDomain');
-    return publisherDomain.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)[0];
+    return publisherDomain.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#:]/)[0];
   }
 
   if (!pageUrl) {
     return pageUrl;
   }
 
-  return pageUrl.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)[0];
+  return pageUrl.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#:]/)[0];
 }
 
 /**
@@ -320,7 +320,7 @@ function getDomain(pageUrl) {
  * @param {Object} geo
  * @returns {boolean}
  */
-function validateGeoObject(geo) {
+export function validateGeoObject(geo) {
   if (!utils.isPlainObject(geo)) {
     return false;
   }

--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai'
-import { spec } from 'modules/apacdexBidAdapter.js'
+import { spec, validateGeoObject, getDomain } from '../../../modules/apacdexBidAdapter.js'
 import { newBidder } from 'src/adapters/bidderFactory.js'
 import { userSync } from '../../../src/userSync.js';
+import { config } from 'src/config.js';
 
 describe('ApacdexBidAdapter', function () {
   const adapter = newBidder(spec)
@@ -199,11 +200,34 @@ describe('ApacdexBidAdapter', function () {
       'bidder': 'apacdex',
       'params': {
         'siteId': '1a2b3c4d5e6f1a2b3c4d',
+        'geo': {'lat': 123.13123456, 'lon': 54.23467311, 'accuracy': 60}
       },
       'adUnitCode': 'adunit-code-1',
       'sizes': [[300, 250], [300, 600]],
       'targetKey': 0,
       'bidId': '30b31c1838de1f',
+      'userIdAsEids': [{
+        'source': 'criteo.com',
+        'uids': [{
+          'id': 'p0cCLF9JazY1ZUFjazJRb3NKbEprVTcwZ0IwRUlGalBjOG9laUZNbFJ0ZGpOSnVFbE9VMjBNMzNBTzladGt4cUVGQzBybDY2Y1FqT1dkUkFsMmJIWDRHNjlvNXJjbiUyQlZDd1dOTmt6VlV2TDhRd0F0RTlBcmpyZU5WRHBPU25GQXpyMnlT',
+          'atype': 1
+        }]
+      }, {
+        'source': 'pubcid.org',
+        'uids': [{
+          'id': '2ae366c2-2576-45e5-bd21-72ed10598f17',
+          'atype': 1
+        }]
+      }, {
+        'source': 'sharedid.org',
+        'uids': [{
+          'id': '01EZXQDVAPER4KE1VBS29XKV4Z',
+          'atype': 1,
+          'ext': {
+            'third': '01EZXQDVAPER4KE1VBS29XKV4Z'
+          }
+        }]
+      }],
     },
     {
       'bidder': 'apacdex',
@@ -300,9 +324,22 @@ describe('ApacdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.schain).to.deep.equal(bidRequest[0].schain)
     });
+    it('should return a properly formatted request with eids defined', function () {
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.data.eids).to.deep.equal(bidRequest[0].userIdAsEids)
+    });
+    it('should return a properly formatted request with geo defined', function () {
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.data.geo).to.deep.equal(bidRequest[0].params.geo)
+    });
     it('should return a properly formatted request with us_privacy included', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.us_privacy).to.equal('someCCPAString');
+    });
+    it('should return a properly formatted request with pbjs_debug is true', function () {
+      config.setConfig({debug: true});
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+      expect(bidRequests.data.test).to.equal(1)
     });
   });
 
@@ -599,6 +636,68 @@ describe('ApacdexBidAdapter', function () {
     it('should return an empty array', function () {
       expect(spec.getUserSyncs({ pixelEnabled: false }, bidResponse)).to.have.length(0);
       expect(spec.getUserSyncs({ pixelEnabled: true }, [])).to.have.length(0);
+    });
+  });
+
+  describe('validateGeoObject', function () {
+    it('should return true if the geo object is valid', () => {
+      let geoObject = {
+        lat: 123.5624234,
+        lon: 23.6712341,
+        accuracy: 20
+      };
+      expect(validateGeoObject(geoObject)).to.equal(true);
+    });
+
+    it('should return false if the geo object is not plain object', () => {
+      let geoObject = [{
+        lat: 123.5624234,
+        lon: 23.6712341,
+        accuracy: 20
+      }];
+      expect(validateGeoObject(geoObject)).to.equal(false);
+    });
+
+    it('should return false if the geo object is missing lat attribute', () => {
+      let geoObject = {
+        lon: 23.6712341,
+        accuracy: 20
+      };
+      expect(validateGeoObject(geoObject)).to.equal(false);
+    });
+
+    it('should return false if the geo object is missing lon attribute', () => {
+      let geoObject = {
+        lat: 123.5624234,
+        accuracy: 20
+      };
+      expect(validateGeoObject(geoObject)).to.equal(false);
+    });
+
+    it('should return false if the geo object is missing accuracy attribute', () => {
+      let geoObject = {
+        lat: 123.5624234,
+        lon: 23.6712341
+      };
+      expect(validateGeoObject(geoObject)).to.equal(false);
+    });
+  });
+
+  describe('getDomain', function () {
+    it('should return valid domain from publisherDomain config', () => {
+      let pageUrl = 'https://www.example.com/page/prebid/exam.html';
+      config.setConfig({publisherDomain: pageUrl});
+      expect(getDomain(pageUrl)).to.equal('example.com');
+    });
+    it('should return valid domain from pageUrl argument', () => {
+      let pageUrl = 'https://www.example.com/page/prebid/exam.html';
+      config.setConfig({publisherDomain: ''});
+      expect(getDomain(pageUrl)).to.equal('example.com');
+    });
+    it('should return undefined if pageUrl and publisherDomain not config', () => {
+      let pageUrl;
+      config.setConfig({publisherDomain: ''});
+      expect(getDomain(pageUrl)).to.equal(pageUrl);
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
- Support Prebid UserId Module.
- Show demo ads when debug mode is enabled.
- Handles bidderRequest.timeout on the endpoint side.
- Fix error getting wrong device size if prebid.js is loaded in iframe.
- Add function to get domain from prebid config publisherDomain, pageUrl
