### PR TITLE
Adyoulike Bid Adapter: added conditional statement to native events 

### DIFF
--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -276,10 +276,15 @@ function getNativeAssets(response, nativeConfig) {
     native.clickUrl = adJson.TrackingPrefix + '/ar?event_kind=CLICK&attempt=' + adJson.Attempt +
       '&campaign=' + adJson.Campaign + '&url=' + encodeURIComponent(adJson.Content.Landing.Url);
 
-    native.clickTrackers = getTrackers(adJson.OnEvents['CLICK']);
-    native.impressionTrackers = getTrackers(adJson.OnEvents['IMPRESSION']);
+    if (adJson.OnEvents) {
+      native.clickTrackers = getTrackers(adJson.OnEvents['CLICK']);
+      native.impressionTrackers = getTrackers(adJson.OnEvents['IMPRESSION']);
+      native.javascriptTrackers = getTrackers(adJson.OnEvents['IMPRESSION'], true);
+    } else {
+      native.impressionTrackers = [];
+    }
+
     native.impressionTrackers.push(impressionUrl);
-    native.javascriptTrackers = getTrackers(adJson.OnEvents['IMPRESSION'], true);
   }
 
   Object.keys(nativeConfig).map(function(key, index) {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
-  Bugfix
- 
## Description of change
Improve robustness on native mediatype for adyoulike bidder adapte.


- contact email of the adapter’s maintainer
guillaume.andouard@adyoulike.com
- [*] official adapter submission
