### PR TITLE
Rubicon Analytics: Pass along source agnostic gam ids

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -482,8 +482,8 @@ function subscribeToGamSlots() {
             // these come in as `null` from Gpt, which when stringified does not get removed
             // so set explicitly to undefined when not a number
             'advertiserId', advertiserId => utils.isNumber(advertiserId) ? advertiserId : undefined,
-            'creativeId', creativeId => utils.isNumber(creativeId) ? creativeId : undefined,
-            'lineItemId', lineItemId => utils.isNumber(lineItemId) ? lineItemId : undefined,
+            'creativeId', creativeId => utils.isNumber(event.sourceAgnosticCreativeId) ? event.sourceAgnosticCreativeId : utils.isNumber(creativeId) ? creativeId : undefined,
+            'lineItemId', lineItemId => utils.isNumber(event.sourceAgnosticLineItemId) ? event.sourceAgnosticLineItemId : utils.isNumber(lineItemId) ? lineItemId : undefined,
             'adSlot', () => event.slot.getAdUnitPath(),
             'isSlotEmpty', () => event.isEmpty || undefined
           ]);

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -1436,8 +1436,8 @@ describe('rubicon analytics adapter', function () {
             slot: gptSlot0,
             isEmpty: false,
             advertiserId: 1111,
-            creativeId: 2222,
-            lineItemId: 3333
+            sourceAgnosticCreativeId: 2222,
+            sourceAgnosticLineItemId: 3333
           }
         };
 
@@ -1448,8 +1448,8 @@ describe('rubicon analytics adapter', function () {
             slot: gptSlot1,
             isEmpty: false,
             advertiserId: 4444,
-            creativeId: 5555,
-            lineItemId: 6666
+            sourceAgnosticCreativeId: 5555,
+            sourceAgnosticLineItemId: 6666
           }
         };
       });
@@ -1515,8 +1515,8 @@ describe('rubicon analytics adapter', function () {
             slot: gptSlot1,
             isEmpty: false,
             advertiserId: 0,
-            creativeId: 0,
-            lineItemId: 0
+            sourceAgnosticCreativeId: 0,
+            sourceAgnosticLineItemId: 0
           }
         }]);
         expect(server.requests.length).to.equal(1);
@@ -1535,6 +1535,38 @@ describe('rubicon analytics adapter', function () {
           advertiserId: 0,
           creativeId: 0,
           lineItemId: 0,
+          adSlot: '/19968336/header-bid-tag1'
+        };
+        expect(message).to.deep.equal(expectedMessage);
+      });
+
+      it('should pick backup Ids if no sourceAgnostic available first', function () {
+        performStandardAuction([gptSlotRenderEnded0, {
+          eventName: 'slotRenderEnded',
+          params: {
+            slot: gptSlot1,
+            isEmpty: false,
+            advertiserId: 0,
+            lineItemId: 1234,
+            creativeId: 5678
+          }
+        }]);
+        expect(server.requests.length).to.equal(1);
+        let request = server.requests[0];
+        let message = JSON.parse(request.requestBody);
+        validate(message);
+
+        let expectedMessage = utils.deepClone(ANALYTICS_MESSAGE);
+        expectedMessage.auctions[0].adUnits[0].gam = {
+          advertiserId: 1111,
+          creativeId: 2222,
+          lineItemId: 3333,
+          adSlot: '/19968336/header-bid-tag-0'
+        };
+        expectedMessage.auctions[0].adUnits[1].gam = {
+          advertiserId: 0,
+          creativeId: 5678,
+          lineItemId: 1234,
           adSlot: '/19968336/header-bid-tag1'
         };
         expect(message).to.deep.equal(expectedMessage);


### PR DESCRIPTION

## Type of change
- [X] Other

## Description of change
Google Ads respond with two forms of lineItem and creative ids

"Source Agnostic" and "Reservation"

Source Agnostic is Inclusive of Reservation, as well as containing ids for backfill, so we want to pass those along instead.

Because we do not know for sure that Source Agnostic will always populate, we will fallback to the main ids if not present.