### PR TITLE
Smartyads Bid Adapter: add coppa field from config

### DIFF
--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -1,5 +1,6 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
 import * as utils from '../src/utils.js';
 
 const BIDDER_CODE = 'smartyads';
@@ -49,6 +50,7 @@ export const spec = {
       'secure': 1,
       'host': location.host,
       'page': location.pathname,
+      'coppa': config.getConfig('coppa') === true ? 1 : 0,
       'placements': placements
     };
     request.language.indexOf('-') != -1 && (request.language = request.language.split('-')[0])

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -61,14 +61,18 @@ describe('SmartyadsAdapter', function () {
   });
 
   describe('with COPPA', function() {
-    it('should send the Coppa "required" flag set to "1" in the request', function () {
+    beforeEach(function() {
       sinon.stub(config, 'getConfig')
         .withArgs('coppa')
         .returns(true);
+    });
+    afterEach(function() {
+      config.getConfig.restore();
+    });
+
+    it('should send the Coppa "required" flag set to "1" in the request', function () {
       let serverRequest = spec.buildRequests([bid]);
       expect(serverRequest.data.coppa).to.equal(1);
-
-      config.getConfig.restore();
     });
   });
 

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/smartyadsBidAdapter.js';
+import { config } from '../../../src/config.js';
 
 describe('SmartyadsAdapter', function () {
   let bid = {
@@ -38,9 +39,10 @@ describe('SmartyadsAdapter', function () {
     it('Returns valid data if array of bids is valid', function () {
       let data = serverRequest.data;
       expect(data).to.be.an('object');
-      expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'language', 'secure', 'host', 'page', 'placements');
+      expect(data).to.have.all.keys('deviceWidth', 'deviceHeight', 'language', 'secure', 'host', 'page', 'placements', 'coppa');
       expect(data.deviceWidth).to.be.a('number');
       expect(data.deviceHeight).to.be.a('number');
+      expect(data.coppa).to.be.a('number');
       expect(data.language).to.be.a('string');
       expect(data.secure).to.be.within(0, 1);
       expect(data.host).to.be.a('string');
@@ -57,6 +59,19 @@ describe('SmartyadsAdapter', function () {
       expect(data.placements).to.be.an('array').that.is.empty;
     });
   });
+
+  describe('with COPPA', function() {
+    it('should send the Coppa "required" flag set to "1" in the request', function () {
+      sinon.stub(config, 'getConfig')
+        .withArgs('coppa')
+        .returns(true);
+      let serverRequest = spec.buildRequests([bid]);
+      expect(serverRequest.data.coppa).to.equal(1);
+
+      config.getConfig.restore();
+    });
+  });
+
   describe('interpretResponse', function () {
     it('Should interpret banner response', function () {
       const banner = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [ x] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->
Add coppa field from config
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
var adUnits = [
                // Will return static native ad. Assets are stored through user UI for each placement separetly
                {
                    code: 'placementId_0',
                    mediaTypes: {
                        native: {}
                    },
                    bids: [
                        {
                            bidder: 'smartyads',
                            params: {
                                placementId: 0,
                                traffic: 'native'
                            }
                        }
                    ]
                },
                // Will return static test banner
                {
                    code: 'placementId_0',
                    mediaTypes: {
                        video: {
                            sizes: [[300, 250]],
                        }
                    },
                    bids: [
                        {
                            bidder: 'smartyads',
                            params: {
                                placementId: 0,
                                traffic: 'video'
                            }
                        }
                    ]
                },
                // Will return test vast xml. All video params are stored under placement in publishers UI
                {
                    code: 'placementId_0',
                    mediaTypes: {
                        banner: {
                            sizes: [[300, 250]],
                        }
                    },
                    bids: [
                        {
                            bidder: 'smartyads',
                            params: {
                                placementId: 0,
                                traffic: 'banner'
                            }
                        }
                    ]
                }
            ];
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- support@smartyads.com
- [x ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
