### PR TITLE
AMX Bid Adapter: add or update general adapter support and code refactoring

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { parseUrl, deepAccess, _each, formatQS, getUniqueIdentifierStr, triggerPixel } from '../src/utils.js';
+import { parseUrl, deepAccess, _each, formatQS, getUniqueIdentifierStr, triggerPixel, isFn, logError } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 
@@ -9,7 +9,6 @@ const storage = getStorageManager(737, BIDDER_CODE);
 const SIMPLE_TLD_TEST = /\.com?\.\w{2,4}$/;
 const DEFAULT_ENDPOINT = 'https://prebid.a-mo.net/a/c';
 const VERSION = 'pba1.2.1';
-const xmlDTDRxp = /^\s*<\?xml[^\?]+\?>/;
 const VAST_RXP = /^\s*<\??(?:vast|xml)/i;
 const TRACKING_ENDPOINT = 'https://1x1.a-mo.net/hbx/';
 const AMUID_KEY = '__amuidpb';
@@ -45,11 +44,16 @@ function flatMap(input, mapFn) {
     .reduce((acc, item) => item != null && acc.concat(item), [])
 }
 
-const generateDTD = (xmlDocument) =>
-  `<?xml version="${xmlDocument.xmlVersion}" encoding="${xmlDocument.xmlEncoding}" ?>`;
-
 const isVideoADM = (html) => html != null && VAST_RXP.test(html);
-const getMediaType = (bid) => isVideoADM(bid.adm) ? VIDEO : BANNER;
+
+function getMediaType(bid) {
+  if (isVideoADM(bid.adm)) {
+    return VIDEO;
+  }
+
+  return BANNER;
+}
+
 const nullOrType = (value, type) =>
   value == null || (typeof value) === type // eslint-disable-line valid-typeof
 
@@ -103,6 +107,32 @@ const trackEvent = (eventName, data) =>
     eid: getUniqueIdentifierStr(),
   })}`);
 
+const DEFAULT_MIN_FLOOR = 0;
+
+function ensureFloor(floorValue) {
+  return typeof floorValue === 'number' && isFinite(floorValue) && floorValue > 0.0 ?
+    floorValue : DEFAULT_MIN_FLOOR;
+}
+
+function getFloor(bid) {
+  if (!isFn(bid.getFloor)) {
+    return deepAccess(bid, 'params.floor', DEFAULT_MIN_FLOOR);
+  }
+
+  try {
+    const floor = bid.getFloor({
+      currency: 'USD',
+      mediaType: '*',
+      size: '*',
+      bidRequest: bid
+    });
+    return floor.floor;
+  } catch (e) {
+    logError('call to getFloor failed: ', e);
+    return DEFAULT_MIN_FLOOR;
+  }
+}
+
 function convertRequest(bid) {
   const size = largestSize(bid.sizes, bid.mediaTypes) || [0, 0];
   const isVideoBid = bid.mediaType === VIDEO || VIDEO in bid.mediaTypes
@@ -116,16 +146,21 @@ function convertRequest(bid) {
     bid.sizes,
     deepAccess(bid, `mediaTypes.${BANNER}.sizes`, []) || [],
     deepAccess(bid, `mediaTypes.${VIDEO}.sizes`, []) || [],
-  ]
+  ];
+
+  const videoData = deepAccess(bid, `mediaTypes.${VIDEO}`, {}) || {};
 
   const params = {
     au,
     av,
+    vd: videoData,
     vr: isVideoBid,
     ms: multiSizes,
     aw: size[0],
     ah: size[1],
     tf: 0,
+    sc: bid.schain || {},
+    f: ensureFloor(getFloor(bid))
   };
 
   if (typeof tid === 'string' && tid.length > 0) {
@@ -141,52 +176,6 @@ function decorateADM(bid) {
     .map((src) => `<img src="${src}" width="0" height="0"/>`)
     .join('');
   return bid.adm + impressions;
-}
-
-function transformXmlSimple(bid) {
-  const pixels = []
-  _each([bid.nurl].concat(bid.ext != null && bid.ext.himp != null ? bid.ext.himp : []), (pixel) => {
-    if (pixel != null) {
-      pixels.push(`<Impression><![CDATA[${pixel}]]></Impression>`)
-    }
-  });
-  // find the current "Impression" here & slice ours in
-  const impressionIndex = bid.adm.indexOf('<Impression')
-  return bid.adm.slice(0, impressionIndex) + pixels.join('') + bid.adm.slice(impressionIndex)
-}
-
-function getOuterHTML(node) {
-  return 'outerHTML' in node && node.outerHTML != null
-    ? node.outerHTML : (new XMLSerializer()).serializeToString(node)
-}
-
-function decorateVideoADM(bid) {
-  if (typeof DOMParser === 'undefined' || DOMParser.prototype.parseFromString == null) {
-    return transformXmlSimple(bid)
-  }
-
-  const doc = new DOMParser().parseFromString(bid.adm, 'text/xml');
-  if (doc == null || doc.querySelector('parsererror') != null) {
-    return null;
-  }
-
-  const root = doc.querySelector('InLine,Wrapper')
-  if (root == null) {
-    return null;
-  }
-
-  const pixels = [bid.nurl].concat(bid.ext != null && bid.ext.himp != null ? bid.ext.himp : [])
-    .filter((url) => url != null);
-
-  _each(pixels, (pxl) => {
-    const imagePixel = doc.createElement('Impression');
-    const cdata = doc.createCDATASection(pxl);
-    imagePixel.appendChild(cdata);
-    root.appendChild(imagePixel);
-  });
-
-  const dtdMatch = xmlDTDRxp.exec(bid.adm);
-  return (dtdMatch != null ? dtdMatch[0] : generateDTD(doc)) + getOuterHTML(doc.documentElement);
 }
 
 function resolveSize(bid, request, bidId) {
@@ -212,14 +201,16 @@ function values(source) {
   });
 }
 
+const isTrue = (boolValue) =>
+  boolValue === true || boolValue === 1 || boolValue === 'true';
+
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO],
 
   isBidRequestValid(bid) {
     return nullOrType(deepAccess(bid, 'params.endpoint', null), 'string') &&
-      nullOrType(deepAccess(bid, 'params.tagId', null), 'string') &&
-      nullOrType(deepAccess(bid, 'params.testMode', null), 'boolean');
+      nullOrType(deepAccess(bid, 'params.tagId', null), 'string')
   },
 
   buildRequests(bidRequests, bidderRequest) {
@@ -239,8 +230,9 @@ export const spec = {
       brc: fbid.bidderRequestsCount || 0,
       bwc: fbid.bidderWinsCount || 0,
       trc: fbid.bidRequestsCount || 0,
-      tm: testMode,
+      tm: isTrue(testMode),
       V: '$prebid.version$',
+      vg: '$$PREBID_GLOBAL$$',
       i: (testMode && tagId != null) ? tagId : getID(loc),
       l: {},
       f: 0.01,
@@ -259,7 +251,8 @@ export const spec = {
       d: '',
       m: createBidMap(bidRequests),
       cpp: config.getConfig('coppa') ? 1 : 0,
-      fpd: config.getLegacyFpd(config.getConfig('ortb2')),
+      fpd2: config.getConfig('ortb2'),
+      tmax: config.getConfig('bidderTimeout'),
       eids: values(bidRequests.reduce((all, bid) => {
         // we only want unique ones in here
         if (bid == null || bid.userIdAsEids == null) {
@@ -306,7 +299,6 @@ export const spec = {
   },
 
   interpretResponse(serverResponse, request) {
-    // validate the body/response
     const response = serverResponse.body;
     if (response == null || typeof response === 'string') {
       return [];
@@ -320,13 +312,14 @@ export const spec = {
       return flatMap(response.r[bidID], (siteBid) =>
         siteBid.b.map((bid) => {
           const mediaType = getMediaType(bid);
-          // let ad = null;
-          let ad = mediaType === BANNER ? decorateADM(bid) : decorateVideoADM(bid);
+          const ad = mediaType === BANNER ? decorateADM(bid) : bid.adm;
+
           if (ad == null) {
             return null;
           }
 
           const size = resolveSize(bid, request.data, bidID);
+          const defaultExpiration = mediaType === BANNER ? 240 : 300;
 
           return ({
             requestId: bidID,
@@ -341,7 +334,7 @@ export const spec = {
               advertiserDomains: bid.adomain,
               mediaType,
             },
-            ttl: mediaType === VIDEO ? 90 : 70
+            ttl: typeof bid.exp === 'number' ? bid.exp : defaultExpiration,
           });
         })).filter((possibleBid) => possibleBid != null);
     });

--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -110,8 +110,8 @@ const trackEvent = (eventName, data) =>
 const DEFAULT_MIN_FLOOR = 0;
 
 function ensureFloor(floorValue) {
-  return typeof floorValue === 'number' && isFinite(floorValue) && floorValue > 0.0 ?
-    floorValue : DEFAULT_MIN_FLOOR;
+  return typeof floorValue === 'number' && isFinite(floorValue) && floorValue > 0.0
+    ? floorValue : DEFAULT_MIN_FLOOR;
 }
 
 function getFloor(bid) {

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -211,7 +211,7 @@ describe('AmxBidAdapter', () => {
     });
 
     it('will read the prebid version & global', () => {
-      const { data: { V: prebidVersion, vg: prebidGlobal }  } = spec.buildRequests([{
+      const { data: { V: prebidVersion, vg: prebidGlobal } } = spec.buildRequests([{
         ...sampleBidRequestBase,
         params: {
           testMode: true

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -31,20 +31,6 @@ const sampleFPD = {
   }
 };
 
-const legacySampleFPD = {
-  context: {
-    keywords: 'sample keywords',
-    data: {
-      pageType: 'article'
-
-    }
-  },
-  user: {
-    gender: 'O',
-    yob: 1982,
-  }
-};
-
 const stubConfig = (withStub) => {
   const stub = sinon.stub(config, 'getConfig').callsFake(
     (arg) => arg === 'ortb2' ? sampleFPD : null
@@ -74,6 +60,15 @@ const sampleBidRequestBase = {
     endpoint: 'https://httpbin.org/post',
   },
   sizes: [[320, 50]],
+  getFloor(params) {
+    if (params.size == null || params.currency == null || params.mediaType == null) {
+      throw new Error(`getFloor called with incomplete params: ${JSON.stringify(params)}`)
+    }
+    return {
+      floor: 0.5,
+      currency: 'USD'
+    }
+  },
   mediaTypes: {
     [BANNER]: {
       sizes: [[300, 250]]
@@ -85,13 +80,28 @@ const sampleBidRequestBase = {
   auctionId: utils.getUniqueIdentifierStr(),
 };
 
+const schainConfig = {
+  ver: '1.0',
+  nodes: [{
+    asi: 'greatnetwork.exchange',
+    sid: '000001',
+    hp: 1,
+    rid: 'bid_request_1',
+    domain: 'publisher.com'
+  }]
+};
+
 const sampleBidRequestVideo = {
   ...sampleBidRequestBase,
   bidId: sampleRequestId + '_video',
   sizes: [[300, 150]],
+  schain: schainConfig,
   mediaTypes: {
     [VIDEO]: {
-      sizes: [[360, 250]]
+      sizes: [[360, 250]],
+      context: 'adpod',
+      adPodDurationSec: 90,
+      contentMode: 'live'
     }
   }
 };
@@ -120,6 +130,7 @@ const sampleServerResponse = {
             'h': 600,
             'id': '2014691335735134254',
             'impid': '1',
+            'exp': 90,
             'price': 0.25,
             'w': 300
           },
@@ -139,6 +150,7 @@ const sampleServerResponse = {
             'h': 1,
             'id': '7735706981389902829',
             'impid': '1',
+            'exp': 90,
             'price': 0.25,
             'w': 1
           },
@@ -160,8 +172,11 @@ describe('AmxBidAdapter', () => {
       expect(spec.isBidRequestValid({params: { tagId: 'test' }})).to.equal(true)
     });
 
-    it('testMode is an optional boolean', () => {
-      expect(spec.isBidRequestValid({params: { testMode: 1 }})).to.equal(false)
+    it('testMode is an optional truthy value', () => {
+      expect(spec.isBidRequestValid({params: { testMode: 1 }})).to.equal(true)
+      expect(spec.isBidRequestValid({params: { testMode: 'true' }})).to.equal(true)
+      // ignore invalid values (falsy)
+      expect(spec.isBidRequestValid({params: { testMode: 'non-truthy-invalid-value' }})).to.equal(true)
       expect(spec.isBidRequestValid({params: { testMode: false }})).to.equal(true)
     });
 
@@ -193,6 +208,17 @@ describe('AmxBidAdapter', () => {
     it('will default to prebid.a-mo.net endpoint', () => {
       const { url } = spec.buildRequests([], sampleBidderRequest);
       expect(url).to.equal('https://prebid.a-mo.net/a/c')
+    });
+
+    it('will read the prebid version & global', () => {
+      const { data: { V: prebidVersion, vg: prebidGlobal }  } = spec.buildRequests([{
+        ...sampleBidRequestBase,
+        params: {
+          testMode: true
+        }
+      }], sampleBidderRequest);
+      expect(prebidVersion).to.equal('$prebid.version$')
+      expect(prebidGlobal).to.equal('$$PREBID_GLOBAL$$')
     });
 
     it('reads test mode from the first bid request', () => {
@@ -269,7 +295,7 @@ describe('AmxBidAdapter', () => {
     it('will forward first-party data', () => {
       stubConfig(() => {
         const { data } = spec.buildRequests([sampleBidRequestBase], sampleBidderRequest);
-        expect(data.fpd).to.deep.equal(legacySampleFPD)
+        expect(data.fpd2).to.deep.equal(sampleFPD)
       });
     });
 
@@ -315,20 +341,24 @@ describe('AmxBidAdapter', () => {
       expect(data.m[sampleRequestId]).to.deep.equal({
         av: true,
         au: 'div-gpt-ad-example',
+        vd: {},
         ms: [
           [[320, 50]],
           [[300, 250]],
           []
         ],
         aw: 300,
+        sc: {},
         ah: 250,
         tf: 0,
+        f: 0.5,
         vr: false
       });
       expect(data.m[sampleRequestId + '_2']).to.deep.equal({
         av: true,
         aw: 300,
         au: 'div-gpt-ad-example',
+        sc: {},
         ms: [
           [[320, 50]],
           [[300, 250]],
@@ -336,7 +366,9 @@ describe('AmxBidAdapter', () => {
         ],
         i: 'example',
         ah: 250,
+        vd: {},
         tf: 0,
+        f: 0.5,
         vr: false,
       });
     });
@@ -354,7 +386,15 @@ describe('AmxBidAdapter', () => {
         av: true,
         aw: 360,
         ah: 250,
+        sc: schainConfig,
+        vd: {
+          sizes: [[360, 250]],
+          context: 'adpod',
+          adPodDurationSec: 90,
+          contentMode: 'live'
+        },
         tf: 0,
+        f: 0.5,
         vr: true
       });
     });
@@ -401,7 +441,7 @@ describe('AmxBidAdapter', () => {
         },
         width: 300,
         height: 600, // from the bid itself
-        ttl: 70,
+        ttl: 90,
         ad: sampleDisplayAd(
           `<img src="${embeddedTrackingPixel}" width="0" height="0"/>` +
           `<img src="${sampleNurl}" width="0" height="0"/>`
@@ -412,20 +452,13 @@ describe('AmxBidAdapter', () => {
     it('can parse a video ad', () => {
       const parsed = spec.interpretResponse({ body: sampleServerResponse }, baseRequest)
       expect(parsed.length).to.equal(2)
-
-      // we should have display, video, display
-      const xml = parsed[1].vastXml
-      delete parsed[1].vastXml
-
-      expect(xml).to.have.string(`<Impression><![CDATA[${sampleNurl}]]></Impression>`)
-      expect(xml).to.have.string(`<Impression><![CDATA[${embeddedTrackingPixel}]]></Impression>`)
-
       expect(parsed[1]).to.deep.equal({
         ...baseBidResponse,
         meta: {
           ...baseBidResponse.meta,
           mediaType: VIDEO,
         },
+        vastXml: sampleVideoAd(''),
         width: 300,
         height: 250,
         ttl: 90,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature
- [X] Refactoring (no functional changes, no api changes)
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

- Added support for `schain`
- Added support for `getFloor` / floor module
- Updated use of legacy FPD to OpenRTB2
- Improved support for video requests
- Removed unnecessary VAST formatting code
 

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

contact email of the adapter’s maintainer: prebid@amxrtb.com
documentation repo PR: https://github.com/prebid/prebid.github.io/pull/2771