### PR TITLE
IronSource Bid Adapter: add session_id & is_wrapper params to adapter

### DIFF
--- a/modules/ironsourceBidAdapter.js
+++ b/modules/ironsourceBidAdapter.js
@@ -211,7 +211,8 @@ function generateParameters(bid, bidderRequest) {
     bid_id: utils.getBidIdParameter('bidId', bid),
     bidder_request_id: utils.getBidIdParameter('bidderRequestId', bid),
     transaction_id: utils.getBidIdParameter('transactionId', bid),
-    session_id: utils.getBidIdParameter('auctionId', bid),
+    session_id: params.sessionId || utils.getBidIdParameter('auctionId', bid),
+    is_wrapper: !!params.isWrapper,
     publisher_name: domain,
     site_domain: domain,
     bidder_version: BIDDER_VERSION

--- a/test/spec/modules/ironsourceBidAdapter_spec.js
+++ b/test/spec/modules/ironsourceBidAdapter_spec.js
@@ -75,6 +75,8 @@ describe('ironsourceAdapter', function () {
       bidderCode: 'ironsource',
     }
 
+    const customSessionId = '12345678';
+
     it('sends bid request to ENDPOINT via GET', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       for (const request of requests) {
@@ -95,6 +97,22 @@ describe('ironsourceAdapter', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       for (const request of requests) {
         expect(request.data.bid_id).to.equal('299ffc8cca0b87');
+      }
+    });
+
+    it('sends the is_wrapper query param', function () {
+      bidRequests[0].params.isWrapper = true;
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data.is_wrapper).to.equal(true);
+      }
+    });
+
+    it('sends the custom session id as a query param', function () {
+      bidRequests[0].params.sessionId = customSessionId;
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data.session_id).to.equal(customSessionId);
       }
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add isWrapper and sessionId as adapter parameters.