### PR TITLE
a4g Bid Adapter: delete adid and use crid if it exists

### DIFF
--- a/modules/a4gBidAdapter.js
+++ b/modules/a4gBidAdapter.js
@@ -71,7 +71,6 @@ export const spec = {
         const bidResponse = {
           requestId: response.id,
           creativeId: response.id,
-          adId: response.id,
           cpm: response.cpm,
           width: response.width,
           height: response.height,

--- a/modules/a4gBidAdapter.js
+++ b/modules/a4gBidAdapter.js
@@ -70,7 +70,7 @@ export const spec = {
       if (response.cpm > 0) {
         const bidResponse = {
           requestId: response.id,
-          creativeId: response.id,
+          creativeId: response.crid || response.id,
           cpm: response.cpm,
           width: response.width,
           height: response.height,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Removed adid from interpretResponse #6381 
- use crid if it's exist

- contact email of the adapter’s maintainer
devops@ad4game.com