### PR TITLE
LiveIntent Id System: fix for parsing response twice 

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -166,15 +166,7 @@ export const liveIntentIdSubmodule = {
     const result = function(callback) {
       liveConnect.resolve(
         response => {
-          let responseObj = {};
-          if (response) {
-            try {
-              responseObj = JSON.parse(response);
-            } catch (error) {
-              utils.logError(error);
-            }
-          }
-          callback(responseObj);
+          callback(response);
         },
         error => {
           utils.logError(`${MODULE_NAME}: ID fetch encountered an error: `, error);

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -36,7 +36,7 @@ describe('LiveIntentId', function() {
     resetLiveIntentIdSubmodule();
   });
 
-  it('should initialize LiveConnect with a privacy string when getId, and include it in the resolution request', function() {
+  it('should initialize LiveConnect with a privacy string when getId, and include it in the resolution request', function () {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
       gdprApplies: true,
@@ -47,12 +47,16 @@ describe('LiveIntentId', function() {
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
     expect(request.url).to.match(/.*us_privacy=1YNY.*&gdpr=1&gdpr_consent=consentDataString.*/);
+    const response = {
+      unifiedId: 'a_unified_id',
+      segments: [123, 234]
+    }
     request.respond(
       200,
       responseHeader,
-      JSON.stringify({})
+      JSON.stringify(response)
     );
-    expect(callBackSpy.calledOnce).to.be.true;
+    expect(callBackSpy.calledOnceWith(response)).to.be.true;
   });
 
   it('should fire an event when getId', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -135,11 +135,10 @@ describe('LiveIntentId', function() {
     let request = server.requests[1];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899');
     request.respond(
-      200,
-      responseHeader,
-      JSON.stringify({})
+      204,
+      responseHeader
     );
-    expect(callBackSpy.calledOnce).to.be.true;
+    expect(callBackSpy.calledOnceWith({})).to.be.true;
   });
 
   it('should call the default url of the LiveIntent Identity Exchange endpoint, with a partner', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [X] Bugfix

## Description of change
The LiveConnect npm library parses the string into the js object before calling the success callback https://github.com/LiveIntent/live-connect/blob/master/src/idex/identity-resolver.js#L11-L18.
The prebid module is trying to parse the js object once more even though the values are not a string.
This pr fixes this issue by avoiding the duplicate json parsing.