### PR TITLE
PBJS Core: use mediaType renderer when backupOnly and no bid.renderer

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -533,7 +533,7 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   var renderer = null;
 
   // the renderer for the mediaType takes precendence
-  if (mediaTypeRenderer && mediaTypeRenderer.url && !(mediaTypeRenderer.backupOnly === true && mediaTypeRenderer.render)) {
+  if (mediaTypeRenderer && mediaTypeRenderer.url && !(mediaTypeRenderer.backupOnly === true && bid.renderer)) {
     renderer = mediaTypeRenderer;
   } else if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly === true && bid.renderer)) {
     renderer = adUnitRenderer;

--- a/src/auction.js
+++ b/src/auction.js
@@ -533,9 +533,9 @@ function getPreparedBidForAuction({adUnitCode, bid, bidderRequest, auctionId}) {
   var renderer = null;
 
   // the renderer for the mediaType takes precendence
-  if (mediaTypeRenderer && mediaTypeRenderer.url && !(mediaTypeRenderer.backupOnly === true && bid.renderer)) {
+  if (mediaTypeRenderer && mediaTypeRenderer.url && mediaTypeRenderer.render && !(mediaTypeRenderer.backupOnly === true && bid.renderer)) {
     renderer = mediaTypeRenderer;
-  } else if (adUnitRenderer && adUnitRenderer.url && !(adUnitRenderer.backupOnly === true && bid.renderer)) {
+  } else if (adUnitRenderer && adUnitRenderer.url && adUnitRenderer.render && !(adUnitRenderer.backupOnly === true && bid.renderer)) {
     renderer = adUnitRenderer;
   }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
This change should match the behavior of mediaType renderer and adUnit renderer when `backupOnly` flag is set to `true`.
MediaType renderer was not used when backupOnly was set to true, and there was no renderer provided by bid adapter (like adUnit.renderer would be in this case).
So, for example, video bid would fail to render if it's from adapters that do not define renderer, even though there was a mediaType renderer defined, which should have been used as a backup here.
Video bid without renderer ends up in the second branch of this `if` (L398 of src/prebid.js), emitting adRender fail.

```
  if (isRendererRequired(renderer)) {
    executeRenderer(renderer, bid);
  } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
    const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
    emitAdRenderFail({ reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id });
  } else if (ad) {
  ...
```

The proposed fix makes mediaType renderer available to be used when there's no bid.renderer.
The issue was introduced with https://github.com/prebid/Prebid.js/pull/5972 which originally introduced backupOnly support for mediaType renderer.