### PR TITLE
PBJS Core: call custom render func after loadscript if provided

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -39,17 +39,22 @@ export function Renderer(options) {
 
   // use a function, not an arrow, in order to be able to pass "arguments" through
   this.render = function () {
+    const renderArgs = arguments
+    const runRender = () => {
+      if (this._render) {
+        this._render.apply(this, renderArgs)
+      } else {
+        utils.logWarn(`No render function was provided, please use .setRender on the renderer`);
+      }
+    }
+
     if (!isRendererPreferredFromAdUnit(adUnitCode)) {
       // we expect to load a renderer url once only so cache the request to load script
+      this.cmd.unshift(runRender) // should render run first ?
       loadExternalScript(url, moduleCode, this.callback);
     } else {
       utils.logWarn(`External Js not loaded by Renderer since renderer url and callback is already defined on adUnit ${adUnitCode}`);
-    }
-
-    if (this._render) {
-      this._render.apply(this, arguments) // _render is expected to use push as appropriate
-    } else {
-      utils.logWarn(`No render function was provided, please use .setRender on the renderer`);
+      runRender()
     }
   }.bind(this) // bind the function to this object to avoid 'this' errors
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other: Small behavior change

## Description of change
As per comments on #5235 some users expected the renderer render function to be called once the script url is loaded.
It was written as a comment that `// _render is expected to use push as appropriate` however that would not be really developer friendly. This change allows the render function to be called once the script url is loaded or right now if no script url is available.

## Other information
@ACannuniRP will be interested by this PR
