### PR TITLE
AMX Bid Adapter: video bugfix to set mediaType on bid instead of meta object

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -8,7 +8,7 @@ const BIDDER_CODE = 'amx';
 const storage = getStorageManager(737, BIDDER_CODE);
 const SIMPLE_TLD_TEST = /\.com?\.\w{2,4}$/;
 const DEFAULT_ENDPOINT = 'https://prebid.a-mo.net/a/c';
-const VERSION = 'pba1.2.1';
+const VERSION = 'pba1.3.1';
 const VAST_RXP = /^\s*<\??(?:vast|xml)/i;
 const TRACKING_ENDPOINT = 'https://1x1.a-mo.net/hbx/';
 const AMUID_KEY = '__amuidpb';
@@ -334,6 +334,7 @@ export const spec = {
               advertiserDomains: bid.adomain,
               mediaType,
             },
+            mediaType,
             ttl: typeof bid.exp === 'number' ? bid.exp : defaultExpiration,
           });
         })).filter((possibleBid) => possibleBid != null);

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -439,6 +439,7 @@ describe('AmxBidAdapter', () => {
           ...baseBidResponse.meta,
           mediaType: BANNER,
         },
+        mediaType: BANNER,
         width: 300,
         height: 600, // from the bid itself
         ttl: 90,
@@ -458,6 +459,7 @@ describe('AmxBidAdapter', () => {
           ...baseBidResponse.meta,
           mediaType: VIDEO,
         },
+        mediaType: VIDEO,
         vastXml: sampleVideoAd(''),
         width: 300,
         height: 250,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X ] Bugfix


## Description of change

We were only setting mediaType in the `meta` object. It looks like the rest of the auction expects it to be set on the bid. Note the documentation [here](https://docs.prebid.org/dev-docs/bidder-adaptor.html) only mentions bid.meta.mediaType (we'll open a PR in the docs repo for that)


contact email of the adapter’s maintainer: prebid@amxrtb.com