### PR TITLE
Axonix bid adapter: set both connectiontype & effectivetype in the request

### DIFF
--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -5,7 +5,7 @@ import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 
 const BIDDER_CODE = 'axonix';
-const BIDDER_VERSION = '1.0.0';
+const BIDDER_VERSION = '1.0.1';
 
 const CURRENCY = 'USD';
 const DEFAULT_REGION = 'us-east-1';

--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -81,11 +81,13 @@ export const spec = {
 
   buildRequests: function(validBidRequests, bidderRequest) {
     // device.connectiontype
-    let connection = navigator.connection || navigator.webkitConnection;
-    let connectiontype = 'unknown';
+    let connection = window.navigator && (window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection)
+    let connectionType = 'unknown';
+    let effectiveType = '';
 
-    if (connection && connection.effectiveType) {
-      connectiontype = connection.effectiveType;
+    if (connection) {
+      connectionType = connection.type;
+      effectiveType = connection.effectiveType;
     }
 
     const requests = validBidRequests.map(validBidRequest => {
@@ -105,7 +107,8 @@ export const spec = {
         app,
         site,
         validBidRequest,
-        connectiontype,
+        connectionType,
+        effectiveType,
         devicetype: isMobile() ? 1 : isConnectedTV() ? 3 : 2,
         bidfloor: getBidFloor(validBidRequest),
         dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0,

--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -86,8 +86,13 @@ export const spec = {
     let effectiveType = '';
 
     if (connection) {
-      connectionType = connection.type;
-      effectiveType = connection.effectiveType;
+      if (connection.type) {
+        connectionType = connection.type;
+      }
+
+      if (connection.effectiveType) {
+        effectiveType = connection.effectiveType;
+      }
     }
 
     const requests = validBidRequests.map(validBidRequest => {

--- a/test/spec/modules/axonixBidAdapter_spec.js
+++ b/test/spec/modules/axonixBidAdapter_spec.js
@@ -179,7 +179,8 @@ describe('AxonixBidAdapter', function () {
       expect(data.site).to.have.property('page', 'https://www.prebid.org');
 
       expect(data).to.have.property('validBidRequest', BANNER_REQUEST);
-      expect(data).to.have.property('connectiontype').to.exist;
+      expect(data).to.have.property('connectionType').to.exist;
+      expect(data).to.have.property('effectiveType').to.exist;
       expect(data).to.have.property('devicetype', 2);
       expect(data).to.have.property('bidfloor', 0);
       expect(data).to.have.property('dnt', 0);
@@ -237,7 +238,8 @@ describe('AxonixBidAdapter', function () {
       expect(data.site).to.have.property('page', 'https://www.prebid.org');
 
       expect(data).to.have.property('validBidRequest', VIDEO_REQUEST);
-      expect(data).to.have.property('connectiontype').to.exist;
+      expect(data).to.have.property('connectionType').to.exist;
+      expect(data).to.have.property('effectiveType').to.exist;
       expect(data).to.have.property('devicetype', 2);
       expect(data).to.have.property('bidfloor', 0);
       expect(data).to.have.property('dnt', 0);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fixed connection type handling, we need both "type" and "effective type" values.

- Adapter’s maintainer: support+prebid@axonix.com