### PR TITLE
Fix dfp module translation hook

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -111,7 +111,7 @@ export function notifyTranslationModule(fn) {
   fn.call(this, 'dfp');
 }
 
-getHook('registerAdserver').before(notifyTranslationModule);
+if (config.getConfig('brandCategoryTranslation.translationFile')) { getHook('registerAdserver').before(notifyTranslationModule); }
 
 /**
  * @typedef {Object} DfpAdpodOptions

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -708,40 +708,6 @@ describe('S2S Adapter', function () {
       });
     });
 
-    it('adds digitrust id is present and user is not optout', function () {
-      let ortb2Config = utils.deepClone(CONFIG);
-      ortb2Config.endpoint = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
-
-      let consentConfig = { s2sConfig: ortb2Config };
-      config.setConfig(consentConfig);
-
-      let digiTrustObj = {
-        privacy: {
-          optout: false
-        },
-        id: 'testId',
-        keyv: 'testKeyV'
-      };
-
-      let digiTrustBidRequest = utils.deepClone(BID_REQUESTS);
-      digiTrustBidRequest[0].bids[0].userId = { digitrustid: { data: digiTrustObj } };
-
-      adapter.callBids(REQUEST, digiTrustBidRequest, addBidResponse, done, ajax);
-      let requestBid = JSON.parse(server.requests[0].requestBody);
-
-      expect(requestBid.user.ext.digitrust).to.deep.equal({
-        id: digiTrustObj.id,
-        keyv: digiTrustObj.keyv
-      });
-
-      digiTrustObj.privacy.optout = true;
-
-      adapter.callBids(REQUEST, digiTrustBidRequest, addBidResponse, done, ajax);
-      requestBid = JSON.parse(server.requests[1].requestBody);
-
-      expect(requestBid.user && request.user.ext && requestBid.user.ext.digitrust).to.not.exist;
-    });
-
     it('adds device and app objects to request', function () {
       const _config = {
         s2sConfig: CONFIG,

--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -98,7 +98,7 @@ describe('Prebid Manager Analytics Adapter', function () {
       events.emit(constants.EVENTS.AUCTION_END, {});
       events.emit(constants.EVENTS.BID_TIMEOUT, {});
 
-      sinon.assert.callCount(prebidmanagerAnalytics.track, 6);
+      sinon.assert.callCount(prebidmanagerAnalytics.track, 7);
     });
   });
 });


### PR DESCRIPTION
This would add a requirement that getConfig('brandCategoryTranslation.translationFile') exists for the hook to the translation module to occur, solving https://github.com/prebid/Prebid.js/issues/4048

This is technically a breaking change, as publishers that want this hook to occur from dfp would have to define this config, however I think there are zero affected pubs, because the default translation file is for freewheel, so the it wouldn't make any sense not to have the config.