### PR TITLE
GAM Video Module: make hook to category translation dependent on config

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -123,7 +123,7 @@ export function notifyTranslationModule(fn) {
   fn.call(this, 'dfp');
 }
 
-getHook('registerAdserver').before(notifyTranslationModule);
+if (config.getConfig('brandCategoryTranslation.translationFile')) { getHook('registerAdserver').before(notifyTranslationModule); }
 
 /**
  * @typedef {Object} DfpAdpodOptions


### PR DESCRIPTION
This would add a requirement that getConfig('brandCategoryTranslation.translationFile') exists for the hook to the translation module to occur, solving https://github.com/prebid/Prebid.js/issues/4048

This is technically a breaking change, as publishers that want this hook to occur from dfp video module would have to define this config, however I think there are zero affected pubs, because the default translation file is for freewheel, so it wouldn't make any sense not to have the config if you are using dfp video module. As such, I don't think it actually requires a doc change on prebid.org, but I added one just in case.
