### PR TITLE
UserId Module: trim stored value prior to checking if the first character indicates it's json

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -247,7 +247,7 @@ function getStoredValue(storage, key = undefined) {
       }
     }
     // support storing a string or a stringified object
-    if (typeof storedValue === 'string' && storedValue.charAt(0) === '{') {
+    if (typeof storedValue === 'string' && storedValue.trim().charAt(0) === '{') {
       storedValue = JSON.parse(storedValue);
     }
   } catch (e) {


### PR DESCRIPTION
if the stored value was an object, then it could end up with a space before the `{`, causing the stored value not to be json parsed simply because of a space in the first character


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Bugfix
