### PR TITLE
Zemanta Bid Adapter: add support for new params & consent strings to usersync URL

### DIFF
--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -41,6 +41,8 @@ export const spec = {
     const ua = navigator.userAgent;
     const test = setOnAny(validBidRequests, 'params.test');
     const publisher = setOnAny(validBidRequests, 'params.publisher');
+    const bcat = setOnAny(validBidRequests, 'params.bcat');
+    const badv = setOnAny(validBidRequests, 'params.badv');
     const cur = CURRENCY;
     const endpointUrl = config.getConfig('zemanta.bidderUrl') || config.getConfig('outbrain.bidderUrl');
     const timeout = bidderRequest.timeout;
@@ -77,7 +79,9 @@ export const spec = {
       source: { fd: 1 },
       cur: [cur],
       tmax: timeout,
-      imp: imps
+      imp: imps,
+      bcat: bcat,
+      badv: badv,
     };
 
     if (test) {

--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -143,10 +143,18 @@ export const spec = {
       }
     }).filter(Boolean);
   },
-  getUserSyncs: (syncOptions) => {
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent) => {
     const syncs = [];
-    const syncUrl = config.getConfig('zemanta.usersyncUrl') || config.getConfig('outbrain.usersyncUrl');
+    let syncUrl = config.getConfig('zemanta.usersyncUrl') || config.getConfig('outbrain.usersyncUrl');
     if (syncOptions.pixelEnabled && syncUrl) {
+      if (gdprConsent) {
+        syncUrl += '&gdpr=' + (gdprConsent.gdprApplies & 1);
+        syncUrl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+      }
+      if (uspConsent) {
+        syncUrl += '&us_privacy=' + encodeURIComponent(uspConsent);
+      }
+
       syncs.push({
         type: 'image',
         url: syncUrl

--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -10,6 +10,7 @@ import { ajax } from '../src/ajax.js';
 import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'zemanta';
+const GVLID = 164;
 const CURRENCY = 'USD';
 const NATIVE_ASSET_IDS = { 0: 'title', 2: 'icon', 3: 'image', 5: 'sponsoredBy', 4: 'body', 1: 'cta' };
 const NATIVE_PARAMS = {
@@ -23,7 +24,10 @@ const NATIVE_PARAMS = {
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['outbrain'],
+  gvlid: GVLID,
+  aliases: [
+    { code: 'outbrain', gvlid: GVLID }
+  ],
   supportedMediaTypes: [ NATIVE, BANNER ],
   isBidRequestValid: (bid) => {
     return (

--- a/modules/zemantaBidAdapter.md
+++ b/modules/zemantaBidAdapter.md
@@ -65,7 +65,9 @@ pbjs.setConfig({
                   name: 'Publishers Name',
                   domain: 'publisher.com'
                 },
-                tagid: 'tag-id'
+                tagid: 'tag-id',
+                bcat: ['IAB1-1'],
+                badv: ['example.com']
             }
         }]
     ];
@@ -94,7 +96,9 @@ pbjs.setConfig({
                   name: 'Publishers Name',
                   domain: 'publisher.com'
                 },
-                tagid: 'tag-id'
+                tagid: 'tag-id',
+                bcat: ['IAB1-1'],
+                badv: ['example.com']
             },
         }]
     ];

--- a/test/spec/modules/zemantaBidAdapter_spec.js
+++ b/test/spec/modules/zemantaBidAdapter_spec.js
@@ -470,10 +470,11 @@ describe('Zemanta Adapter', function () {
   })
 
   describe('getUserSyncs', function () {
-    before(() => {
+    const usersyncUrl = 'https://usersync-url.com';
+    beforeEach(() => {
       config.setConfig({
         zemanta: {
-          usersyncUrl: 'https://usersync-url.com',
+          usersyncUrl: usersyncUrl,
         }
       }
       )
@@ -507,6 +508,30 @@ describe('Zemanta Adapter', function () {
       const ret = spec.getUserSyncs({pixelEnabled: true})
       expect(ret).to.be.an('array').that.is.empty
     })
+
+    it('should pass GDPR consent', function() {
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, {gdprApplies: true, consentString: 'foo'}, undefined)).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}&gdpr=1&gdpr_consent=foo`
+      }]);
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, {gdprApplies: false, consentString: 'foo'}, undefined)).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}&gdpr=0&gdpr_consent=foo`
+      }]);
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, {gdprApplies: true, consentString: undefined}, undefined)).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}&gdpr=1&gdpr_consent=`
+      }]);
+    });
+
+    it('should pass US consent', function() {
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, undefined, '1NYN')).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}&us_privacy=1NYN`
+      }]);
+    });
+
+    it('should pass GDPR and US consent', function() {
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, {gdprApplies: true, consentString: 'foo'}, '1NYN')).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}&gdpr=1&gdpr_consent=foo&us_privacy=1NYN`
+      }]);
+    });
   })
 
   describe('onBidWon', function () {

--- a/test/spec/modules/zemantaBidAdapter_spec.js
+++ b/test/spec/modules/zemantaBidAdapter_spec.js
@@ -251,16 +251,24 @@ describe('Zemanta Adapter', function () {
         expect(res.data).to.deep.equal(JSON.stringify(expectedData))
       })
 
-      it('should pass optional tagid in request', function () {
+      it('should pass optional parameters in request', function () {
         const bidRequest = {
           ...commonBidRequest,
           ...nativeBidRequestParams,
         }
         bidRequest.params.tagid = 'test-tag'
+        bidRequest.params.publisher.name = 'test-publisher'
+        bidRequest.params.publisher.domain = 'test-publisher.com'
+        bidRequest.params.bcat = ['bad-category']
+        bidRequest.params.badv = ['bad-advertiser']
 
         const res = spec.buildRequests([bidRequest], commonBidderRequest)
         const resData = JSON.parse(res.data)
         expect(resData.imp[0].tagid).to.equal('test-tag')
+        expect(resData.site.publisher.name).to.equal('test-publisher')
+        expect(resData.site.publisher.domain).to.equal('test-publisher.com')
+        expect(resData.bcat).to.deep.equal(['bad-category'])
+        expect(resData.badv).to.deep.equal(['bad-advertiser'])
       });
 
       it('should pass bidder timeout', function () {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Hey!
This PR adds support for two new params: `bcat` and `badv`.
It also adds consent strings to usersync URL and the GVL id to the spec.

- contact email of the adapter’s maintainer: prog-ops-team@outbrain.com

- docs repo PR https://github.com/prebid/prebid.github.io/pull/2796