### PR TITLE
ID5: differentiate the IDs provided when the user is opted out vs in the control group of A/B testing

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -67,7 +67,8 @@ export const id5IdSubmodule = {
     } else if (abConfig.enabled === true && controlGroup === true) {
       // A/B Testing is enabled and user is in the Control Group, so do not share the ID5 ID
       utils.logInfo('User ID - ID5 submodule: A/B Testing Enabled - user is in the Control Group, so the ID5 ID is NOT exposed');
-      universalUid = linkType = 0;
+      universalUid = '';
+      linkType = 0;
     } else if (abConfig.enabled === true) {
       // A/B Testing is enabled but user is not in the Control Group, so ID5 ID is shared
       utils.logInfo('User ID - ID5 submodule: A/B Testing Enabled - user is NOT in the Control Group, so the ID5 ID is exposed');

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -449,7 +449,7 @@ describe('ID5 ID System', function() {
   describe('A/B Testing', function() {
     const expectedDecodedObjectWithIdAbOff = { id5id: { uid: ID5_STORED_ID, ext: { linkType: ID5_STORED_LINK_TYPE } } };
     const expectedDecodedObjectWithIdAbOn = { id5id: { uid: ID5_STORED_ID, ext: { linkType: ID5_STORED_LINK_TYPE, abTestingControlGroup: false } } };
-    const expectedDecodedObjectWithoutIdAbOn = { id5id: { uid: 0, ext: { linkType: 0, abTestingControlGroup: true } } };
+    const expectedDecodedObjectWithoutIdAbOn = { id5id: { uid: '', ext: { linkType: 0, abTestingControlGroup: true } } };
     let testConfig;
 
     beforeEach(function() {


### PR DESCRIPTION
## Type of change
- [ x ] Feature

## Description of change
When a user is opted out of ID5, the `universal_id` value will be `"0"`, so we want to differentiate that from the value we expose for users in the control group of A/B testing to avoid confusion.