### PR TITLE
adot Bid Adapter: add publisher path from bidder config

### DIFF
--- a/modules/adotBidAdapter.js
+++ b/modules/adotBidAdapter.js
@@ -7,7 +7,7 @@ import { config } from '../src/config.js';
 
 const ADAPTER_VERSION = 'v1.0.0';
 const BID_METHOD = 'POST';
-const BIDDER_URL = 'https://dsp.adotmob.com/headerbidding/bidrequest';
+const BIDDER_URL = 'https://dsp.adotmob.com/headerbidding{PUBLISHER_PATH}/bidrequest';
 const FIRST_PRICE = 1;
 const NET_REVENUE = true;
 // eslint-disable-next-line no-template-curly-in-string
@@ -141,9 +141,10 @@ function validateServerRequest(serverRequest) {
 }
 
 function createServerRequestFromAdUnits(adUnits, bidRequestId, adUnitContext) {
+  const publisherPath = config.getConfig('adot.publisherPath') === undefined ? '' : '/' + config.getConfig('adot.publisherPath');
   return {
     method: BID_METHOD,
-    url: BIDDER_URL,
+    url: BIDDER_URL.replace('{PUBLISHER_PATH}', publisherPath),
     data: generateBidRequestsFromAdUnits(adUnits, bidRequestId, adUnitContext),
     _adot_internal: generateAdotInternal(adUnits)
   }

--- a/modules/adotBidAdapter.md
+++ b/modules/adotBidAdapter.md
@@ -6,7 +6,7 @@ Adot Bidder Adapter is a module that enables the communication between the Prebi
 
 - Module name: Adot Bidder Adapter
 - Module type: Bidder Adapter
-- Maintainer: `maxime.lequain@we-are-adot.com`
+- Maintainer: `aurelien.giudici@adotmob.com`
 - Supported media types: `banner`, `video`, `native`
 
 ## Example ad units
@@ -227,6 +227,24 @@ pbjs.setBidderConfig({
     config: {
         adot: {
             publisherId: '__MY_PUBLISHER_ID__'
+        }
+    }
+});
+```
+
+### Specific publisher path
+
+You can set a specific publisher path using `pbjs.setBidderConfig` for the bidder `adot`
+The bidrequest will add this path to the bidder endpoint
+
+#### Example
+
+```javascript
+pbjs.setBidderConfig({
+    bidders: ['adot'],
+    config: {
+        adot: {
+            publisherPath: '__MY_PUBLISHER_PATH__'
         }
     }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Partners can now set a publisherPath for adot using pbjs.setBidderConfig so it can be use by the adapter and call a specific endpoint path
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
pbjs.setBidderConfig({
    bidders: ['adot'],
    config: {
        adot: {
            publisherPath: '__MY_PUBLISHER_PATH__'
        }
    }
});
```

