### PR TITLE
GumGum Bid Adapter: adds meta field to bidresponse

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -390,7 +390,8 @@ function interpretResponse (serverResponse, bidRequest) {
       pvid: 0
     },
     meta: {
-      adomain: []
+      adomain: [],
+      mediaType: ''
     }
   }
   const {
@@ -406,7 +407,8 @@ function interpretResponse (serverResponse, bidRequest) {
     },
     jcsi,
     meta: {
-      adomain: advertiserDomains
+      adomain: advertiserDomains,
+      mediaType: type
     }
   } = Object.assign(defaultResponse, serverResponseBody)
   let data = bidRequest.data || {}
@@ -416,7 +418,8 @@ function interpretResponse (serverResponse, bidRequest) {
   let sizes = utils.parseSizesInput(bidRequest.sizes)
   let [width, height] = sizes[0].split('x')
   let metaData = {
-    advertiserDomains: advertiserDomains
+    advertiserDomains: advertiserDomains || [],
+    mediaType: type || mediaType
   }
 
   // return 1x1 when breakout expected

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -388,6 +388,9 @@ function interpretResponse (serverResponse, bidRequest) {
     },
     pag: {
       pvid: 0
+    },
+    meta: {
+      adomain: []
     }
   }
   const {
@@ -401,7 +404,10 @@ function interpretResponse (serverResponse, bidRequest) {
     pag: {
       pvid
     },
-    jcsi
+    jcsi,
+    meta: {
+      adomain: advertiserDomains
+    }
   } = Object.assign(defaultResponse, serverResponseBody)
   let data = bidRequest.data || {}
   let product = data.pi
@@ -409,6 +415,9 @@ function interpretResponse (serverResponse, bidRequest) {
   let isTestUnit = (product === 3 && data.si === 9)
   let sizes = utils.parseSizesInput(bidRequest.sizes)
   let [width, height] = sizes[0].split('x')
+  let metaData = {
+    advertiserDomains: advertiserDomains
+  }
 
   // return 1x1 when breakout expected
   if ((product === 2 || product === 5) && includes(sizes, '1x1')) {
@@ -437,7 +446,8 @@ function interpretResponse (serverResponse, bidRequest) {
       netRevenue: true,
       requestId: bidRequest.id,
       ttl: TIME_TO_LIVE,
-      width
+      width,
+      meta: metaData
     })
   }
   return bidResponses

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -462,27 +462,30 @@ describe('gumgumAdapter', function () {
 
   describe('interpretResponse', function () {
     let serverResponse = {
-      'ad': {
-        'id': 29593,
-        'width': 300,
-        'height': 250,
-        'ipd': 2000,
-        'markup': '<html><h3>I am an ad</h3></html>',
-        'ii': true,
-        'du': null,
-        'price': 0,
-        'zi': 0,
-        'impurl': 'http://g2.gumgum.com/ad/view',
-        'clsurl': 'http://g2.gumgum.com/ad/close'
+      ad: {
+        id: 29593,
+        width: 300,
+        height: 250,
+        ipd: 2000,
+        markup: '<html><h3>I am an ad</h3></html>',
+        ii: true,
+        du: null,
+        price: 0,
+        zi: 0,
+        impurl: 'http://g2.gumgum.com/ad/view',
+        clsurl: 'http://g2.gumgum.com/ad/close'
       },
-      'pag': {
-        't': 'ggumtest',
-        'pvid': 'aa8bbb65-427f-4689-8cee-e3eed0b89eec',
-        'css': 'html { overflow-y: auto }',
-        'js': 'console.log("environment", env);'
+      pag: {
+        t: 'ggumtest',
+        pvid: 'aa8bbb65-427f-4689-8cee-e3eed0b89eec',
+        css: 'html { overflow-y: auto }',
+        js: 'console.log("environment", env);'
       },
-      'jcsi': { t: 0, rq: 8 },
-      'thms': 10000
+      jcsi: { t: 0, rq: 8 },
+      thms: 10000,
+      meta: {
+        adomain: ['advertiser.com']
+      }
     }
     let bidRequest = {
       id: 12345,
@@ -501,19 +504,35 @@ describe('gumgumAdapter', function () {
       requestId: 12345,
       width: '300',
       mediaType: BANNER,
-      ttl: 60
+      ttl: 60,
+      meta: {
+        advertiserDomains: ['advertiser.com']
+      }
     };
 
     it('should get correct bid response', function () {
       expect(spec.interpretResponse({ body: serverResponse }, bidRequest)).to.deep.equal([expectedResponse]);
     });
 
+    it('should set a default value for advertiserDomains if adomain is not found', function () {
+      const response = { ...serverResponse };
+      delete response.meta;
+
+      const expected = { ...expectedResponse };
+      const meta = { advertiserDomains: [] };
+      expected.meta = meta;
+
+      expect(spec.interpretResponse({ body: response }, bidRequest)).to.deep.equal([expected]);
+    });
+
     it('should pass correct currency if found in bid response', function () {
       const cur = 'EURO';
-      let response = Object.assign({}, serverResponse);
-      let expected = Object.assign({}, expectedResponse);
+      const response = { ...serverResponse };
       response.ad.cur = cur;
+
+      const expected = { ...expectedResponse };
       expected.currency = cur;
+
       expect(spec.interpretResponse({ body: response }, bidRequest)).to.deep.equal([expected]);
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
adds the meta field to bidresponse as meta.advertiserDomains field is proposed as required in 5.0+ and meta.mediaType