### PR TITLE
Core PBjs : add check for empty mediaquery declaration in sizeConfig object

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -121,22 +121,17 @@ function evaluateSizeConfig(configs) {
   return configs.reduce((results, config) => {
     if (
       typeof config === 'object' &&
-      typeof config.mediaQuery === 'string'
+      typeof config.mediaQuery === 'string' &&
+      config.mediaQuery.length > 0
     ) {
       let ruleMatch = false;
 
-      // TODO: (Prebid - 4.0) Remove empty mediaQuery string check. Disallow empty mediaQuery in sizeConfig.
-      // Refer: https://github.com/prebid/Prebid.js/pull/4691, https://github.com/prebid/Prebid.js/issues/4810 for more details.
-      if (config.mediaQuery === '') {
-        ruleMatch = true;
-      } else {
-        try {
-          ruleMatch = getWindowTop().matchMedia(config.mediaQuery).matches;
-        } catch (e) {
-          logWarn('Unfriendly iFrame blocks sizeConfig from being correctly evaluated');
+      try {
+        ruleMatch = getWindowTop().matchMedia(config.mediaQuery).matches;
+      } catch (e) {
+        logWarn('Unfriendly iFrame blocks sizeConfig from being correctly evaluated');
 
-          ruleMatch = matchMedia(config.mediaQuery).matches;
-        }
+        ruleMatch = matchMedia(config.mediaQuery).matches;
       }
 
       if (ruleMatch) {

--- a/test/spec/sizeMapping_spec.js
+++ b/test/spec/sizeMapping_spec.js
@@ -93,6 +93,15 @@ describe('sizeMapping', function () {
       expect(utils.logWarn.firstCall.args[0]).to.match(/missing.+?mediaQuery/);
     });
 
+    it('should log a warning message when mediaQuery property is declared as an empty string', function() {
+      const errorConfig = deepClone(sizeConfig);
+      errorConfig[0].mediaQuery = '';
+
+      sandbox.stub(utils, 'logWarn');
+      resolveStatus(undefined, testSizes, undefined, errorConfig);
+      expect(utils.logWarn.firstCall.args[0]).to.match(/missing.+?mediaQuery/);
+    });
+
     it('should allow deprecated adUnit.sizes', function() {
       matchMediaOverride = (str) => str === '(min-width: 1200px)' ? {matches: true} : {matches: false};
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change

We have allowed `mediaQuery` property in **sizeConfig** to be declared as an empty string. This can lead to some inconsistencies as described [here](https://github.com/prebid/Prebid.js/pull/4691#issuecomment-571538911)

This can be a breaking change for some publishers who maybe using empty mediaQuery declarations in their sizeConfigs. This PR should go out in a major release of Prebid.js

Fixes https://github.com/prebid/Prebid.js/issues/4810

Please refer to https://github.com/prebid/Prebid.js/pull/4691 for a detailed context.