### PR TITLE
PR_REVIEW: added check for bidder name validity

### DIFF
--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -38,7 +38,7 @@ General gulp commands include separate commands for serving the codebase on a bu
 Documentation they're supposed to be following is https://docs.prebid.org/dev-docs/bidder-adaptor.html
 
 Follow steps above for general review process. In addition, please verify the following:
-- Verify the biddercode is valid:
+- Verify the biddercode and aliases are valid:
     - Lower case alphanumeric with the only special character allowed is underscore.
     - The bidder code should be unique for the first 6 characters
     - Reserved words that cannot be used as bidder names: all, context, data, general, prebid, and skadn

--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -38,6 +38,10 @@ General gulp commands include separate commands for serving the codebase on a bu
 Documentation they're supposed to be following is https://docs.prebid.org/dev-docs/bidder-adaptor.html
 
 Follow steps above for general review process. In addition, please verify the following:
+- Verify the biddercode is valid:
+    - Lower case alphanumeric with the only special character allowed is underscore.
+    - The bidder code should be unique for the first 6 characters
+    - Reserved words that cannot be used as bidder names: all, context, data, general, prebid, and skadn
 - Verify that bidder has submitted valid bid params and that bids are being received.
 - Verify that bidder is not manipulating the prebid.js auction in any way or doing things that go against the principles of the project. If unsure check with the Tech Lead.
 - Verify that code re-use is being done properly and that changes introduced by a bidder don't impact other bidders.


### PR DESCRIPTION
## Type of change
Documentation

## Description of change
Updating the reviewer reference to check the validity of the proposed bidder code:

- The bidder code must be lower case alphanumeric. The only special character allowed is underscore.
- The bidder code must be unique - make sure none of the other bid adapters is using the same code.
- The bidder code should be unique for the first 6 characters - this consideration helps with generating unique targeting keys for use by some ad exchanges, such as Google Ad Manager.
- There are several reserved words that cannot be used as bidder names: all, context, data, general, prebid, and skadn.