### PR TITLE
PBS Bid Adapter: allow pbs stored impression configuration

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -604,6 +604,7 @@ const OPEN_RTB_PROTOCOL = {
       }
 
       // get bidder params in form { <bidder code>: {...params} }
+      // initialize reduce function with the user defined `ext` properties on the ad unit
       const ext = adUnit.bids.reduce((acc, bid) => {
         const adapter = adapterManager.bidderRegistry[bid.bidder];
         if (adapter && adapter.getSpec().transformBidParams) {
@@ -611,7 +612,7 @@ const OPEN_RTB_PROTOCOL = {
         }
         acc[bid.bidder] = (s2sConfig.adapterOptions && s2sConfig.adapterOptions[bid.bidder]) ? Object.assign({}, bid.params, s2sConfig.adapterOptions[bid.bidder]) : bid.params;
         return acc;
-      }, {});
+      }, {...utils.deepAccess(adUnit, 'ortb2Imp.ext')});
 
       const imp = { id: adUnit.code, ext, secure: s2sConfig.secure };
 
@@ -622,7 +623,12 @@ const OPEN_RTB_PROTOCOL = {
           * @type {(string|undefined)}
         */
         if (prop === 'pbadslot') {
-          if (typeof ortb2[prop] === 'string' && ortb2[prop]) utils.deepSetValue(imp, 'ext.data.pbadslot', ortb2[prop]);
+          if (typeof ortb2[prop] === 'string' && ortb2[prop]) {
+            utils.deepSetValue(imp, 'ext.data.pbadslot', ortb2[prop]);
+          } else {
+            // remove pbadslot property if it doesn't meet the spec
+            delete imp.ext.data.pbadslot;
+          }
         } else if (prop === 'adserver') {
           /**
            * Copy GAM AdUnit and Name to imp

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1814,6 +1814,32 @@ describe('S2S Adapter', function () {
     });
   });
 
+  describe('ext.prebid config', function () {
+    it('should send \"imp.ext.prebid.storedrequest.id\" if \"ortb2Imp.ext.prebid.storedrequest.id\" is set', function () {
+      const consentConfig = { s2sConfig: CONFIG };
+      config.setConfig(consentConfig);
+      const bidRequest = utils.deepClone(REQUEST);
+      const storedRequestId = 'my-id';
+      bidRequest.ad_units[0].ortb2Imp = {
+        ext: {
+          prebid: {
+            storedrequest: {
+              id: storedRequestId
+            }
+          }
+        }
+      };
+
+      adapter.callBids(bidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+      const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
+
+      expect(parsedRequestBody.imp).to.be.a('array');
+      expect(parsedRequestBody.imp[0]).to.be.a('object');
+      expect(parsedRequestBody.imp[0]).to.have.deep.nested.property('ext.prebid.storedrequest.id');
+      expect(parsedRequestBody.imp[0].ext.prebid.storedrequest.id).to.equal(storedRequestId);
+    });
+  });
+
   describe('response handler', function () {
     beforeEach(function () {
       sinon.stub(utils, 'triggerPixel');


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

The prebid server java implementation allows [stored impressions|https://github.com/prebid/prebid-server-java/blob/master/docs/developers/stored-requests.md] to be configured. This change allows publishers to
enable stored impressions per ad unit.

On your prebid server you have a stored impression with id `content_pos1`

```json
{
  "id": "content_pos1",
  "banner": {
    "format": [
      { "w": 300, "h": 250  },
      { "w": 300, "h": 600 }
    ]
  },
  "ext": {
    "prebid": {
      "bidder": {
        "appnexus": {
          "placement_id": 10433394
        }
      }
    }
  }
}
```

Then you could configure your ad unit like this

```javascript
const adUnit = {
    adUnit: {
      code: 'content_pos1',
      pbs: {
         // 'true' will use the adUnit.code . You could also supply a string to set a different id 
         storedImp: true
      },
      mediaTypes: {
        banner: { sizes: [ [300, 250], [300,600] ] }
      },
      bids: [   ]
    }
}
```


For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- [ ] A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Open questions

- will this work with no `bids` configured?
- which sizes will be used - server side or the ones sent by the client?
- is there any test for the prebidServerAdapter?
- will floor prices work?

Relates to #6361

