### PR TITLE
PBjs Core: remove cache_id and source as default targeting keys

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -271,7 +271,7 @@ function getCustParams(bid, options) {
   const prebidTargetingSet = Object.assign({},
     // Why are we adding standard keys here ? Refer https://github.com/prebid/Prebid.js/issues/3664
     { hb_uuid: bid && bid.videoCacheKey },
-    // hb_uuid will be deprecated and replaced by hb_cache_id
+    // hb_cache_id became optional in prebid 5.0 after 4.x enabled the concept of optional keys. Discussion led to reversing the prior expectation of deprecating hb_uuid
     { hb_cache_id: bid && bid.videoCacheKey },
     allTargetingData,
     adserverTargeting,

--- a/src/constants.json
+++ b/src/constants.json
@@ -79,7 +79,7 @@
     "SIZE": "hb_size",
     "DEAL": "hb_deal",
     "FORMAT": "hb_format",
-    "CACHE_ID": "hb_cache_id",
+    "UUID": "hb_uuid",
     "CACHE_HOST": "hb_cache_host"
   },
   "NATIVE_KEYS": {

--- a/src/constants.json
+++ b/src/constants.json
@@ -78,9 +78,7 @@
     "PRICE_BUCKET": "hb_pb",
     "SIZE": "hb_size",
     "DEAL": "hb_deal",
-    "SOURCE": "hb_source",
     "FORMAT": "hb_format",
-    "UUID": "hb_uuid",
     "CACHE_ID": "hb_cache_id",
     "CACHE_HOST": "hb_cache_host"
   },

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -489,8 +489,8 @@ describe('targeting tests', function () {
 
       it('targeting should not include keys not in default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid_appnexus', 'hb_uuid_rubicon', 'hb_source_appnexus', 'hb_source_rubicon']);
-        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid', 'hb_source']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_cache_id_appnexus', 'hb_cache_id_rubicon', 'hb_source_appnexus', 'hb_source_rubicon']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_cache_id', 'hb_source']);
       });
     });
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -456,7 +456,7 @@ describe('targeting tests', function () {
       });
     });
 
-    describe('targetingControls:default_targeting_keys', function () {
+    describe('targetingControls:only allow default_targeting_keys', function () {
       let bid4;
 
       beforeEach(function() {
@@ -487,7 +487,7 @@ describe('targeting tests', function () {
         expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_appnexus', 'hb_adid_appnexus', 'hb_pb_appnexus', 'hb_deal_appnexus');
       });
 
-      it('targeting should not include keys prefixed by disallowed default targeting keys', function () {
+      it('targeting should not include keys not in default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
         expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid_appnexus', 'hb_uuid_rubicon','hb_source_appnexus', 'hb_source_rubicon']);
         expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid', 'hb_source']);

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -456,6 +456,44 @@ describe('targeting tests', function () {
       });
     });
 
+    describe('targetingControls:default_targeting_keys', function () {
+      let bid4;
+
+      beforeEach(function() {
+        bid4 = utils.deepClone(bid1);
+        bid4.adserverTargeting = {
+          hb_deal: '4321',
+          hb_pb: '0.1',
+          hb_uuid: 'myuuid',
+          hb_source: 's2s',
+          hb_adid: '567891011',
+          hb_bidder: 'appnexus',
+        };
+        bid4.bidder = bid4.bidderCode = 'appnexus';
+        bid4.cpm = 0.1; // losing bid so not included if enableSendAllBids === false
+        bid4.dealId = '4321';
+        enableSendAllBids = true;
+        bidsReceived.push(bid4);
+      });
+
+      it('targeting should include custom keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('foobar');
+      });
+
+      it('targeting should include keys in default targeting keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_rubicon', 'hb_adid_rubicon', 'hb_pb_rubicon','hb_deal_rubicon');
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_appnexus', 'hb_adid_appnexus', 'hb_pb_appnexus', 'hb_deal_appnexus');
+      });
+
+      it('targeting should not include keys prefixed by disallowed default targeting keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid_appnexus', 'hb_uuid_rubicon','hb_source_appnexus', 'hb_source_rubicon']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid', 'hb_source']);
+      });
+    });
+
     describe('targetingControls.alwaysIncludeDeals', function () {
       let bid4;
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -483,13 +483,13 @@ describe('targeting tests', function () {
 
       it('targeting should include keys in default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_rubicon', 'hb_adid_rubicon', 'hb_pb_rubicon','hb_deal_rubicon');
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_rubicon', 'hb_adid_rubicon', 'hb_pb_rubicon', 'hb_deal_rubicon');
         expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder_appnexus', 'hb_adid_appnexus', 'hb_pb_appnexus', 'hb_deal_appnexus');
       });
 
       it('targeting should not include keys not in default targeting keys', function () {
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid_appnexus', 'hb_uuid_rubicon','hb_source_appnexus', 'hb_source_rubicon']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid_appnexus', 'hb_uuid_rubicon', 'hb_source_appnexus', 'hb_source_rubicon']);
         expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_uuid', 'hb_source']);
       });
     });


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Removes uuid and source as default keys

## Other information
Solves #6485 