### PR TITLE
update apacdex unit test to disable debug mode

### DIFF
--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -336,10 +336,17 @@ describe('ApacdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.us_privacy).to.equal('someCCPAString');
     });
-    it('should return a properly formatted request with pbjs_debug is true', function () {
-      config.setConfig({debug: true});
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
-      expect(bidRequests.data.test).to.equal(1)
+    describe('debug test', function() {
+      beforeEach(function() {
+        config.setConfig({debug: true});
+      });
+      afterEach(function() {
+        config.setConfig({debug: false});
+      });
+      it('should return a properly formatted request with pbjs_debug is true', function () {
+        const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+        expect(bidRequests.data.test).to.equal(1);
+      });
     });
   });
 


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
This change disables the debug mode after a unit test for the apacdexbidadapter has finished.  This change prevents some spam-like console messages from appearing in the terminal window when running build commands.