### PR TITLE
Rubicon Bid Adapter: removing maxduration as a required bidder parameter

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1108,7 +1108,6 @@ export function hasValidVideoParams(bid) {
   var requiredParams = {
     mimes: arrayType,
     protocols: arrayType,
-    maxduration: numberType,
     linearity: numberType,
     api: arrayType
   }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1821,16 +1821,6 @@ describe('the rubicon adapter', function () {
           delete bidderRequest.bids[0].mediaTypes.video.protocols;
           expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
 
-          // change maxduration to an string, no good
-          createVideoBidderRequest();
-          bidderRequest.bids[0].mediaTypes.video.maxduration = 'string';
-          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
-          // delete maxduration, no good
-          createVideoBidderRequest();
-          delete bidderRequest.bids[0].mediaTypes.video.maxduration;
-          expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
           // change linearity to an string, no good
           createVideoBidderRequest();
           bidderRequest.bids[0].mediaTypes.video.linearity = 'string';


### PR DESCRIPTION
## Type of change
minor update

## Description of change
The Rubicon adapter no longer requires the maxduration parameter for video.

As requested in https://github.com/prebid/Prebid.js/issues/6502