### PR TITLE
Zemanta adapter: add meta.advertiserDomains

### DIFF
--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -139,6 +139,10 @@ export const spec = {
           bidObject.width = bidResponse.w;
           bidObject.height = bidResponse.h;
         }
+        bidObject.meta = {};
+        if (bidResponse.adomain && bidResponse.adomain.length > 0) {
+          bidObject.meta.advertiserDomains = bidResponse.adomain;
+        }
         return bidObject;
       }
     }).filter(Boolean);

--- a/test/spec/modules/zemantaBidAdapter_spec.js
+++ b/test/spec/modules/zemantaBidAdapter_spec.js
@@ -352,7 +352,7 @@ describe('Zemanta Adapter', function () {
                     nurl: 'http://example.com/win/${AUCTION_PRICE}',
                     adm: '{"ver":"1.2","assets":[{"id":3,"required":1,"img":{"url":"http://example.com/img/url","w":120,"h":100}},{"id":0,"required":1,"title":{"text":"Test title"}},{"id":5,"data":{"value":"Test sponsor"}}],"link":{"url":"http://example.com/click/url"},"eventtrackers":[{"event":1,"method":1,"url":"http://example.com/impression"}]}',
                     adomain: [
-                      'example.co'
+                      'example.com'
                     ],
                     cid: '3487171',
                     crid: '28023739',
@@ -386,6 +386,11 @@ describe('Zemanta Adapter', function () {
             currency: 'USD',
             mediaType: 'native',
             nurl: 'http://example.com/win/${AUCTION_PRICE}',
+            meta: {
+              'advertiserDomains': [
+                'example.com'
+              ]
+            },
             native: {
               clickTrackers: undefined,
               clickUrl: 'http://example.com/click/url',
@@ -459,7 +464,12 @@ describe('Zemanta Adapter', function () {
             nurl: 'http://example.com/win/${AUCTION_PRICE}',
             ad: '<div>ad</div>',
             width: 300,
-            height: 250
+            height: 250,
+            meta: {
+              'advertiserDomains': [
+                'example.com'
+              ]
+            },
           }
         ]
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Adds meta.advertiserDomains to the Zemanta adapter. Addresses https://github.com/prebid/Prebid.js/issues/6466.