### PR TITLE
Seedtag adapter: Fixing bug preventing to receive the right params onTimeout.

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -226,8 +226,8 @@ export const spec = {
    * @param {data} Containing timeout specific data
    */
   onTimeout(data) {
-    getTimeoutUrl(data);
-    utils.triggerPixel(SEEDTAG_SSP_ONTIMEOUT_ENDPOINT);
+    const url = getTimeoutUrl(data);
+    utils.triggerPixel(url);
   },
 
   /**

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -409,6 +409,14 @@ describe('Seedtag Adapter', function() {
   })
 
   describe('onTimeout', function () {
+    beforeEach(function() {
+      sinon.stub(utils, 'triggerPixel')
+    })
+
+    afterEach(function() {
+      utils.triggerPixel.restore()
+    })
+
     it('should return the correct endpoint', function () {
       const params = { publisherId: '0000', adUnitId: '11111' }
       const timeoutData = [{ params: [ params ] }];
@@ -419,6 +427,16 @@ describe('Seedtag Adapter', function() {
         '&adUnitId=' +
         params.adUnitId
       )
+    })
+
+    it('shoud set the timeout pixel', function() {
+      const params = { publisherId: '0000', adUnitId: '11111' }
+      const timeoutData = [{ params: [ params ] }];
+      spec.onTimeout(timeoutData)
+      expect(utils.triggerPixel.calledWith('https://s.seedtag.com/se/hb/timeout?publisherToken=' +
+      params.publisherId +
+      '&adUnitId=' +
+      params.adUnitId)).to.equal(true);
     })
   })
 

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -429,7 +429,7 @@ describe('Seedtag Adapter', function() {
       )
     })
 
-    it('shoud set the timeout pixel', function() {
+    it('should set the timeout pixel', function() {
       const params = { publisherId: '0000', adUnitId: '11111' }
       const timeoutData = [{ params: [ params ] }];
       spec.onTimeout(timeoutData)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Using the right url to report timeout information onTimeout, before we were generating the url but we were using always a fixed one when triggering the pixel.



- laura@seedtag.com

