### PR TITLE
VIS.X Bid Adapter: implement onSetTargeting, onBidWon & onTimeout handlers

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -2,10 +2,14 @@ import * as utils from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 const BIDDER_CODE = 'visx';
-const ENDPOINT_URL = 'https://t.visx.net/hb';
+const BASE_URL = 'https://t.visx.net';
+const ENDPOINT_URL = BASE_URL + '/hb';
 const TIME_TO_LIVE = 360;
 const DEFAULT_CUR = 'EUR';
-const ADAPTER_SYNC_URL = 'https://t.visx.net/push_sync';
+const ADAPTER_SYNC_URL = BASE_URL + '/push_sync';
+const TRACK_WIN_URL = BASE_URL + '/track/win';
+const TRACK_PENDING_URL = BASE_URL + '/track/pending';
+const TRACK_TIMEOUT_URL = BASE_URL + '/track/bid_timeout';
 const LOG_ERROR_MESS = {
   noAuid: 'Bid from response has no auid parameter - ',
   noAdm: 'Bid from response has no adm parameter - ',
@@ -170,6 +174,18 @@ export const spec = {
         url: ADAPTER_SYNC_URL + (query.length ? '?' + query.join('&') : '')
       }];
     }
+  },
+  onSetTargeting: function(bid) {
+    // Call '/track/pending' with the corresponding bid.requestId
+    utils.triggerPixel(TRACK_PENDING_URL + '?requestId=' + bid.requestId);
+  },
+  onBidWon: function(bid) {
+    // Call '/track/win' with the corresponding bid.requestId
+    utils.triggerPixel(TRACK_WIN_URL + '?requestId=' + bid.requestId);
+  },
+  onTimeout: function(timeoutData) {
+    // Call '/track/bid_timeout' with timeout data
+    utils.triggerPixel(TRACK_TIMEOUT_URL + '?data=' + JSON.stringify(timeoutData));
   }
 };
 

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/visxBidAdapter.js';
 import { config } from 'src/config.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import * as utils from 'src/utils.js';
 
 describe('VisxAdapter', function () {
   const adapter = newBidder(spec);
@@ -654,6 +655,33 @@ describe('VisxAdapter', function () {
 
       const result = spec.interpretResponse({'body': {'seatbid': fullResponse}}, request);
       expect(result).to.deep.equal(expectedResponse);
+    });
+  });
+  describe('check trackers', function () {
+    beforeEach(function () {
+      sinon.stub(utils, 'triggerPixel');
+    });
+
+    afterEach(function () {
+      utils.triggerPixel.restore();
+    });
+
+    it('onSetTargeting', function () {
+      const requestId = '111';
+      spec.onSetTargeting({ requestId });
+      expect(utils.triggerPixel.calledOnceWith('https://t.visx.net/track/pending?requestId=' + requestId)).to.equal(true);
+    });
+
+    it('onBidWon', function () {
+      const requestId = '111';
+      spec.onBidWon({ requestId });
+      expect(utils.triggerPixel.calledOnceWith('https://t.visx.net/track/win?requestId=' + requestId)).to.equal(true);
+    });
+
+    it('onTimeout', function () {
+      const data = { timeout: 3000, bidId: '23423', params: { uid: 1 } };
+      spec.onTimeout(data);
+      expect(utils.triggerPixel.calledOnceWith('https://t.visx.net/track/bid_timeout?data=' + JSON.stringify(data))).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Added tracking to `onSetTargeting`, `onBidWon` and `onTimeout` handlers in the VIS.X adapter.