### PR TITLE
Adnuntius Bid Adapter: added target ID to request for multiple ad requests.

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,7 +1,7 @@
 
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'adnuntius';
-const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=-60&format=json';
+const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -14,6 +14,7 @@ export const spec = {
     const networks = {};
     const bidRequests = {};
     const requests = [];
+    const tzo = new Date().getTimezoneOffset();
 
     for (var i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i]
@@ -23,7 +24,7 @@ export const spec = {
 
       networks[network] = networks[network] || {};
       networks[network].adUnits = networks[network].adUnits || [];
-      networks[network].adUnits.push({ ...bid.params.targeting, auId: bid.params.auId });
+      networks[network].adUnits.push({ ...bid.params.targeting, auId: bid.params.auId, targetId: bid.bidId });
     }
 
     const networkKeys = Object.keys(networks)
@@ -31,7 +32,7 @@ export const spec = {
       const network = networkKeys[j];
       requests.push({
         method: 'POST',
-        url: ENDPOINT_URL,
+        url: ENDPOINT_URL + tzo + '&format=json',
         data: JSON.stringify(networks[network]),
         bid: bidRequests[network]
       });
@@ -50,11 +51,11 @@ export const spec = {
         const bid = adUnit.ads[0];
         bidResponses.push({
           requestId: bidRequest.bid[k].bidId,
-          cpm: (bid.cpm) ? bid.cpm.amount : 0,
+          cpm: (bid.bid) ? bid.bid.amount : 0,
           width: Number(bid.creativeWidth),
           height: Number(bid.creativeHeight),
           creativeId: bid.creativeId,
-          currency: (bid.cpm) ? bid.cpm.currency : 'EUR',
+          currency: (bid.bid) ? bid.bid.currency : 'EUR',
           netRevenue: false,
           ttl: 360,
           ad: adUnit.html

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -4,7 +4,8 @@ import { spec } from 'modules/adnuntiusBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 
 describe('adnuntiusBidAdapter', function () {
-  const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=-60&format=json';
+  const tzo = new Date().getTimezoneOffset();
+  const ENDPOINT_URL = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
   const adapter = newBidder(spec);
   const bidRequests = [
     {
@@ -47,8 +48,8 @@ describe('adnuntiusBidAdapter', function () {
                 'destination': 'http://google.com'
               },
               'cpm': { 'amount': 5.0, 'currency': 'NOK' },
-              'bid': { 'amount': 0.005, 'currency': 'NOK' },
-              'cost': { 'amount': 0.005, 'currency': 'NOK' },
+              'bid': { 'amount': 5.0, 'currency': 'NOK' },
+              'cost': { 'amount': 5.0, 'currency': 'NOK' },
               'impressionTrackingUrls': [],
               'impressionTrackingUrlsEsc': [],
               'adId': 'adn-id-1347343135',
@@ -96,7 +97,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0]).to.have.property('url');
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\"}]}');
+      expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\",\"targetId\":\"123\"}]}');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
* Added automatic timezone recognition.
* Added `targetId` in adserver request to allow multiple requests for same ad unit id.
* Added use of bid parameter instead of cpm in response from adserver to allow CPC campaigns.

- contact email of the adapter’s maintainer
- [x] official adapter submission

my email: mikael@adnuntius.com
