### PR TITLE
PBjs Core Testing: update Windows 10 testing on Chrome to v 89.0

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -23,11 +23,11 @@
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_80_windows_10": {
+  "bs_chrome_89_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "chrome",
-    "browser_version": "80.0",
+    "browser_version": "89.0",
     "device": null,
     "os": "Windows"
   },


### PR DESCRIPTION
Update windows 10 testing on chrome from version 80.0 to 89.0. There also still remains testing in this environment for chrome 79.0 however functional testing will only run on this new version since chrome 79.0 is dropped for functional testing in https://github.com/prebid/Prebid.js/blob/master/wdio.conf.js
