### PR TITLE
Yieldmo adapter: cut banner bid request parameters in case the url for banner request is too long

### DIFF
--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -281,6 +281,53 @@ describe('YieldmoAdapter', function () {
         const placementsData = JSON.parse(buildAndGetPlacementInfo([mockBannerBid()]));
         expect(placementsData[0].bidfloor).to.undefined;
       });
+
+      it('should not exceed max url length', () => {
+        const longString = new Array(8000).join('a');
+        const localWindow = utils.getWindowTop();
+
+        const originalTitle = localWindow.document.title;
+        localWindow.document.title = longString;
+
+        const request = spec.buildRequests(
+          [mockBannerBid()],
+          mockBidderRequest({
+            refererInfo: {
+              numIframes: 1,
+              reachedTop: true,
+              referer: longString,
+            },
+          })
+        )[0];
+        const url = `${request.url}?${utils.parseQueryStringParameters(request.data)}`;
+
+        expect(url.length).equal(8000);
+
+        localWindow.document.title = originalTitle;
+      });
+
+      it('should only shortcut properties rather then completely remove it', () => {
+        const longString = new Array(7516).join('a');
+        const localWindow = utils.getWindowTop();
+
+        const originalTitle = localWindow.document.title;
+        localWindow.document.title = `testtitle${longString}`;
+
+        const request = spec.buildRequests(
+          [mockBannerBid()],
+          mockBidderRequest({
+            refererInfo: {
+              numIframes: 1,
+              reachedTop: true,
+              referer: longString,
+            },
+          })
+        )[0];
+
+        expect(request.data.title.length).greaterThan(0);
+
+        localWindow.document.title = originalTitle;
+      });
     });
 
     describe('Instream video:', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Cut banner bid request parameters in case the url for banner request is too long

contact email of the adapter’s maintainer: opensource@yieldmo.com
- [x] official adapter submission
