### PR TITLE
userID Module: move reading and writing of the consent string hash

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -590,15 +590,16 @@ function refreshUserIds(options, callback) {
   initializeSubmodulesAndExecuteCallbacks(function() {
     let consentData = gdprDataHandler.getConsentData()
 
-    const storedConsentData = getStoredConsentData();
-    setStoredConsentData(consentData);
-
     // gdpr consent with purpose one is required, otherwise exit immediately
     let {userIdModules, hasValidated} = validateGdprEnforcement(submodules, consentData);
     if (!hasValidated && !hasGDPRConsent(consentData)) {
       utils.logWarn(`${MODULE_NAME} - gdpr permission not valid for local storage or cookies, exit module`);
       return;
     }
+
+    // we always want the latest consentData stored, even if we don't execute any submodules
+    const storedConsentData = getStoredConsentData();
+    setStoredConsentData(consentData);
 
     let callbackSubmodules = [];
     for (let submodule of userIdModules) {
@@ -689,16 +690,16 @@ function populateSubmoduleId(submodule, consentData, storedConsentData, forceRef
  * @returns {SubmoduleContainer[]} initialized submodules
  */
 function initSubmodules(submodules, consentData) {
-  // we always want the latest consentData stored, even if we don't execute any submodules
-  const storedConsentData = getStoredConsentData();
-  setStoredConsentData(consentData);
-
   // gdpr consent with purpose one is required, otherwise exit immediately
   let { userIdModules, hasValidated } = validateGdprEnforcement(submodules, consentData);
   if (!hasValidated && !hasGDPRConsent(consentData)) {
     utils.logWarn(`${MODULE_NAME} - gdpr permission not valid for local storage or cookies, exit module`);
     return [];
   }
+
+  // we always want the latest consentData stored, even if we don't execute any submodules
+  const storedConsentData = getStoredConsentData();
+  setStoredConsentData(consentData);
 
   return userIdModules.reduce((carry, submodule) => {
     populateSubmoduleId(submodule, consentData, storedConsentData, false);


### PR DESCRIPTION
move reading and writing of hte consent string hash for the user id module to after the gdpr checks. if no user id modules will be executed, this value isn't really necessary anyways.

this should alleviate the issue brought up in https://github.com/prebid/Prebid.js/issues/6386

somewhat related docs PR: https://github.com/prebid/prebid.github.io/pull/2839

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other
