### PR TITLE
pubGENIUS bid adapter: support floor module

### DIFF
--- a/modules/pubgeniusBidAdapter.js
+++ b/modules/pubgeniusBidAdapter.js
@@ -7,8 +7,8 @@ import {
   deepSetValue,
   inIframe,
   isArrayOfNums,
+  isFn,
   isInteger,
-  isNumber,
   isStr,
   logError,
   parseQueryStringParameters,
@@ -185,9 +185,16 @@ function buildImp(bid) {
     imp.video = buildVideoParams(bid.mediaTypes.video, bid.params.video);
   }
 
-  const bidFloor = bid.params.bidFloor;
-  if (isNumber(bidFloor)) {
-    imp.bidfloor = bidFloor;
+  if (isFn(bid.getFloor)) {
+    const { floor } = bid.getFloor({
+      mediaType: bid.mediaTypes.banner ? 'banner' : 'video',
+      size: '*',
+      currency: 'USD',
+    });
+
+    if (floor) {
+      imp.bidfloor = floor;
+    }
   }
 
   const pos = bid.params.position;

--- a/modules/pubgeniusBidAdapter.md
+++ b/modules/pubgeniusBidAdapter.md
@@ -12,8 +12,6 @@ Module that connects to pubGENIUS's demand sources
 
 # Test Parameters
 
-Test bids have $0.01 CPM by default. Use `bidFloor` in bidder params to control CPM for testing purposes.
-
 ```
 var adUnits = [
   {
@@ -45,7 +43,6 @@ var adUnits = [
         bidder: 'pubgenius',
         params: {
           adUnitId: '1000',
-          bidFloor: 0.5,
           test: true
         }
       }
@@ -66,7 +63,6 @@ var adUnits = [
         bidder: 'pubgenius',
         params: {
           adUnitId: '1001',
-          bidFloor: 1,
           test: true,
 
           // other video parameters as in OpenRTB v2.5 spec

--- a/test/spec/modules/pubgeniusBidAdapter_spec.js
+++ b/test/spec/modules/pubgeniusBidAdapter_spec.js
@@ -225,8 +225,8 @@ describe('pubGENIUS adapter', () => {
       expect(buildRequests([bidRequest, bidRequest1], bidderRequest)).to.deep.equal(expectedRequest);
     });
 
-    it('should take bid floor in bidder params', () => {
-      bidRequest.params.bidFloor = 0.5;
+    it('should take bid floor from getFloor interface', () => {
+      bidRequest.getFloor = () => ({ floor: 0.5, currency: 'USD' });
       expectedRequest.data.imp[0].bidfloor = 0.5;
 
       expect(buildRequests([bidRequest], bidderRequest)).to.deep.equal(expectedRequest);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Make pubGENIUS bid adapter support getFloor.
Flagged by https://github.com/prebid/Prebid.js/issues/6465

- contact email of the adapter’s maintainer: meng@pubgenius.io
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
  https://github.com/prebid/prebid.github.io/pull/2842
