### PR TITLE
SmileWanted Bid Adapter : Add GDPR and consent string to cookie sync call

### DIFF
--- a/modules/smilewantedBidAdapter.js
+++ b/modules/smilewantedBidAdapter.js
@@ -108,16 +108,31 @@ export const spec = {
    * @param {*} serverResponses A successful response from the server.
    * @return {Syncs[]} An array of syncs that should be executed.
    */
-  getUserSyncs: function(syncOptions, serverResponses) {
-    const syncs = []
-    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
-      if (serverResponses[0].body.cSyncUrl === 'https://csync.smilewanted.com') {
-        syncs.push({
-          type: 'iframe',
-          url: serverResponses[0].body.cSyncUrl
-        });
+  getUserSyncs: function(syncOptions, responses, gdprConsent, uspConsent) {
+    let params = '';
+
+    if (gdprConsent && typeof gdprConsent.consentString === 'string') {
+      // add 'gdpr' only if 'gdprApplies' is defined
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        params += `?gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        params += `?gdpr_consent=${gdprConsent.consentString}`;
       }
     }
+
+    if (uspConsent) {
+      params += `${params ? '&' : '?'}us_privacy=${encodeURIComponent(uspConsent)}`;
+    }
+
+    const syncs = []
+
+    if (syncOptions.iframeEnabled) {
+      syncs.push({
+        type: 'iframe',
+        url: 'https://csync.smilewanted.com' + params
+      });
+    }
+
     return syncs;
   }
 }

--- a/test/spec/modules/smilewantedBidAdapter_spec.js
+++ b/test/spec/modules/smilewantedBidAdapter_spec.js
@@ -305,12 +305,12 @@ describe('smilewantedBidAdapterTests', function () {
   });
 
   it('SmileWanted - Verify user sync', function () {
-    var syncs = spec.getUserSyncs({
-      iframeEnabled: true
-    }, [BID_RESPONSE_DISPLAY]);
+    var syncs = spec.getUserSyncs({iframeEnabled: true}, {}, {
+      consentString: 'foo'
+    }, '1NYN');
     expect(syncs).to.have.lengthOf(1);
     expect(syncs[0].type).to.equal('iframe');
-    expect(syncs[0].url).to.equal('https://csync.smilewanted.com');
+    expect(syncs[0].url).to.equal('https://csync.smilewanted.com?gdpr_consent=foo&us_privacy=1NYN');
 
     syncs = spec.getUserSyncs({
       iframeEnabled: false
@@ -320,6 +320,6 @@ describe('smilewantedBidAdapterTests', function () {
     syncs = spec.getUserSyncs({
       iframeEnabled: true
     }, []);
-    expect(syncs).to.have.lengthOf(0);
+    expect(syncs).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
- Calling the cookie sync url even without ad responses.
- Add GDPR and consent string to cookie sync call

Updated doc : https://github.com/prebid/prebid.github.io/pull/2852
