### PR TITLE
ATS-identityLinkIdSystem - add use3P config property to control firing of 3P endpoint

### DIFF
--- a/integrationExamples/gpt/idImportLibrary_example.html
+++ b/integrationExamples/gpt/idImportLibrary_example.html
@@ -45,7 +45,8 @@
               },  {
                 name: 'identityLink',
                 params: {
-                  pid: '14' // Set your real identityLink placement ID here
+                  pid: '14', // Set your real identityLink placement ID here
+                  // use3P: false // true/false - If you want to use 3P endpoint to retrieve envelope. If you do not set this property to true, 3p endpoint will not be fired. By default this property is undefined and 3p request will not be fired.
                 },
                 storage: {
                   type: 'html5',

--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -229,7 +229,8 @@
                         },  {
                         name: 'identityLink',
                         params: {
-                            pid: '14' // Set your real identityLink placement ID here
+                            pid: '14', // Set your real identityLink placement ID here
+                            // use3P: false // true/false - If you want to use 3P endpoint to retrieve envelope. If you do not set this property to true, 3p endpoint will not be fired. By default this property is undefined and 3p request will not be fired.
                         },
                         storage: {
                             type: 'cookie',

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -67,11 +67,11 @@ export const identityLinkSubmodule = {
             setEnvelopeSource(true);
             callback(JSON.parse(envelope).envelope);
           } else {
-            getEnvelope(url, callback);
+            getEnvelope(url, callback, configParams);
           }
         });
       } else {
-        getEnvelope(url, callback);
+        getEnvelope(url, callback, configParams);
       }
     };
 
@@ -79,7 +79,7 @@ export const identityLinkSubmodule = {
   }
 };
 // return envelope from third party endpoint
-function getEnvelope(url, callback) {
+function getEnvelope(url, callback, configParams) {
   const callbacks = {
     success: response => {
       let responseObj;
@@ -98,7 +98,7 @@ function getEnvelope(url, callback) {
     }
   };
 
-  if (!storage.getCookie('_lr_retry_request')) {
+  if (configParams.use3P && !storage.getCookie('_lr_retry_request')) {
     setRetryCookie();
     utils.logInfo('identityLink: A 3P retrieval is attempted!');
     setEnvelopeSource(false);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -101,6 +101,7 @@
  * @property {(LiveIntentCollectConfig|undefined)} liCollectConfig - the config for LiveIntent's collect requests
  * @property {(string|undefined)} pd - publisher provided data for reconciling ID5 IDs
  * @property {(string|undefined)} emailHash - if provided, the hashed email address of a user
+ * @property {(string|undefined)} use3P - use to retrieve envelope from 3p endpoint
  */
 
 /**

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -43,7 +43,8 @@ pbjs.setConfig({
         }, {
             name: 'identityLink',
             params: {
-                pid: '999' // Set your real identityLink placement ID here
+                pid: '999', // Set your real identityLink placement ID here
+                // use3P: false // true/false - If you want to use 3P endpoint to retrieve envelope. If you do not set this property to true, 3p endpoint will not be fired. By default this propertt is undefined and 3p request will not be fired.
             },
             storage: {
                 type: 'cookie',
@@ -132,7 +133,8 @@ pbjs.setConfig({
         }, {
             name: 'identityLink',
             params: {
-                pid: '999' // Set your real identityLink placement ID here
+                pid: '999', // Set your real identityLink placement ID here
+                // use3P: false // true/false - If you want to use 3P endpoint to retrieve envelope. If you do not set this property to true, 3p endpoint will not be fired. By default this property is undefined and 3p request will not be fired.
             },
             storage: {
                 type: 'html5',

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -6,19 +6,21 @@ import {getStorageManager} from '../../../src/storageManager.js';
 export const storage = getStorageManager();
 
 const pid = '14';
-const defaultConfigParams = { params: {pid: pid} };
+let defaultConfigParams;
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('IdentityLinkId tests', function () {
   let logErrorStub;
 
   beforeEach(function () {
+    defaultConfigParams = { params: {pid: pid} };
     logErrorStub = sinon.stub(utils, 'logError');
     // remove _lr_retry_request cookie before test
     storage.setCookie('_lr_retry_request', 'true', 'Thu, 01 Jan 1970 00:00:01 GMT');
   });
 
   afterEach(function () {
+    defaultConfigParams = {};
     logErrorStub.restore();
   });
 
@@ -34,6 +36,7 @@ describe('IdentityLinkId tests', function () {
 
   it('should call the LiveRamp envelope endpoint', function () {
     let callBackSpy = sinon.spy();
+    defaultConfigParams.params.use3P = true;
     let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
@@ -62,6 +65,7 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should call the LiveRamp envelope endpoint with IAB consent string v1', function () {
+    defaultConfigParams.params.use3P = true;
     let callBackSpy = sinon.spy();
     let consentData = {
       gdprApplies: true,
@@ -80,6 +84,7 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should call the LiveRamp envelope endpoint with IAB consent string v2', function () {
+    defaultConfigParams.params.use3P = true;
     let callBackSpy = sinon.spy();
     let consentData = {
       gdprApplies: true,
@@ -101,6 +106,7 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should not throw Uncaught TypeError when envelope endpoint returns empty response', function () {
+    defaultConfigParams.params.use3P = true;
     let callBackSpy = sinon.spy();
     let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
@@ -117,6 +123,7 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should log an error and continue to callback if ajax request errors', function () {
+    defaultConfigParams.params.use3P = true;
     let callBackSpy = sinon.spy();
     let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
@@ -141,7 +148,8 @@ describe('IdentityLinkId tests', function () {
     expect(request).to.be.eq(undefined);
   });
 
-  it('should call the LiveRamp envelope endpoint if cookie _lr_retry_request does not exist', function () {
+  it('should call the LiveRamp envelope endpoint if cookie _lr_retry_request does not exist and use3P config property was set to true', function () {
+    defaultConfigParams.params.use3P = true;
     let callBackSpy = sinon.spy();
     let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
@@ -153,5 +161,22 @@ describe('IdentityLinkId tests', function () {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should not call the LiveRamp envelope endpoint if config property use3P is set to false', function () {
+    defaultConfigParams.params.use3P = false;
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request).to.be.eq(undefined);
+  });
+
+  it('should not call the LiveRamp envelope endpoint if config property use3P is undefined', function () {
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request).to.be.eq(undefined);
   });
 });


### PR DESCRIPTION
## Type of change

- [ ] Feature

## Description of change
Add 'use3P' configuration property to control firing of 3P endpoint in order to get identity envelope.


- Link to a PR on the docs repo: 
  https://github.com/prebid/prebid.github.io/pull/2853


