### PR TITLE
Proxistore Bid Adapter: use another uri for cookieless

### DIFF
--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -57,7 +57,7 @@ function _createServerRequest(bidRequests, bidderRequest) {
 
   const endPointUri = payload.gdpr.consentGiven || !payload.gdpr.applies
     ? `https://abs.proxistore.com/${payload.language}/v3/rtb/prebid/multi`
-    : `https://abs.proxistore.com/${payload.language}/v3/rtb/prebid/multi/cookieless`;
+    : `https://abs.cookieless-proxistore.com/${payload.language}/v3/rtb/prebid/multi`;
 
   return {
     method: 'POST',

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -54,7 +54,7 @@ describe('ProxistoreBidAdapter', function () {
     const url = {
       cookieBase: 'https://abs.proxistore.com/fr/v3/rtb/prebid/multi',
       cookieLess:
-        'https://abs.proxistore.com/fr/v3/rtb/prebid/multi/cookieless',
+        'https://abs.cookieless-proxistore.com/fr/v3/rtb/prebid/multi',
     };
     let request = spec.buildRequests([bid], bidderRequest);
     it('should return a valid object', function () {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
Point to another URI when we the user refuses the consent

