### PR TITLE
Rubicon Analytics: Handle PBS Sending Bid ID 0

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -363,8 +363,8 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
       const height = bid.height || bid.playerHeight;
       return (width && height) ? {width, height} : undefined;
     },
-    'pbsBidId',
-    'seatBidId',
+    'pbsBidId', pbsBidId => pbsBidId == 0 ? utils.generateUUID() : pbsBidId,
+    'seatBidId', seatBidId => seatBidId == 0 ? utils.generateUUID() : seatBidId,
     'floorValue', () => utils.deepAccess(bid, 'floorData.floorValue'),
     'floorRuleValue', () => utils.deepAccess(bid, 'floorData.floorRuleValue'),
     'floorRule', () => utils.debugTurnedOn() ? utils.deepAccess(bid, 'floorData.floorRule') : undefined,

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -363,6 +363,7 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
       const height = bid.height || bid.playerHeight;
       return (width && height) ? {width, height} : undefined;
     },
+    // Handling use case where pbs sends back 0 or '0' bidIds
     'pbsBidId', pbsBidId => pbsBidId == 0 ? utils.generateUUID() : pbsBidId,
     'seatBidId', seatBidId => seatBidId == 0 ? utils.generateUUID() : seatBidId,
     'floorValue', () => utils.deepAccess(bid, 'floorData.floorValue'),


### PR DESCRIPTION

## Type of change
- [X] Bugfix
- 
## Description of change
Prebid Server sometimes sends a bidId of 0. Which causes downstream analytics joins to fail.

This small change will overwrite these bidIds in this case.