### PR TITLE
PBjs Core: bugfix for renderer not called when loading an external script

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -54,8 +54,8 @@ export function Renderer(options) {
       loadExternalScript(url, moduleCode, this.callback);
     } else {
       utils.logWarn(`External Js not loaded by Renderer since renderer url and callback is already defined on adUnit ${adUnitCode}`);
-      runRender()
     }
+    runRender()
   }.bind(this) // bind the function to this object to avoid 'this' errors
 }
 


### PR DESCRIPTION
	- The renderer should be called reguardless of whether or not
          an external script was loaded.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change

- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
In Renderer.js the this.render function would only call the renderer if an external script was not loaded. 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

Issue seems to have been introduced in https://github.com/prebid/Prebid.js/pull/6422
@jeremiegirault Can you confirm that the runRender function should be called reguardless of whether an external script was loaded or not. 
