### PR TITLE
PBjs Core: override refererInfo.canonicalUrl if pageUrl is defined in config

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -9,6 +9,7 @@
  */
 
 import { logWarn } from './utils.js';
+import { config } from './config.js';
 
 /**
  * @param {Window} win Window
@@ -41,6 +42,10 @@ export function detectReferer(win) {
    * @returns {string|null}
    */
   function getCanonicalUrl(doc) {
+    let pageURL = config.getConfig('pageUrl');
+    
+    if (pageURL) return pageURL;
+
     try {
       const element = doc.querySelector("link[rel='canonical']");
 

--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -43,7 +43,7 @@ export function detectReferer(win) {
    */
   function getCanonicalUrl(doc) {
     let pageURL = config.getConfig('pageUrl');
-    
+
     if (pageURL) return pageURL;
 
     try {

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -1,4 +1,5 @@
 import { detectReferer } from 'src/refererDetection.js';
+import { config } from 'src/config.js';
 import { expect } from 'chai';
 
 /**
@@ -91,6 +92,10 @@ function buildWindowTree(urls, topReferrer = '', canonicalUrl = null, ancestorOr
 describe('Referer detection', () => {
   describe('Non cross-origin scenarios', () => {
     describe('No iframes', () => {
+      afterEach(function () {
+        config.resetConfig();
+      });
+
       it('Should return the current window location and no canonical URL', () => {
         const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/'),
           result = detectReferer(testWindow)();
@@ -154,6 +159,26 @@ describe('Referer detection', () => {
             'https://example.com/third/page'
           ],
           canonicalUrl: 'https://example.com/canonical/page'
+        });
+      });
+
+      it('Should override canonical URL with config pageUrl', () => {
+        config.setConfig({'pageUrl': 'testUrl.com'});
+
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
+          result = detectReferer(testWindow)();
+
+        expect(result).to.deep.equal({
+          referer: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 2,
+          stack: [
+            'https://example.com/some/page',
+            'https://example.com/other/page',
+            'https://example.com/third/page'
+          ],
+          canonicalUrl: 'testUrl.com'
         });
       });
     });


### PR DESCRIPTION

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Updated refererDetection logic for canonical url. 
1) Run getConfig('pageUrl')
2) - If value exists, return config set value
     - If undefined, run standard logic to retrieve canonical url from link tag

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
