### PR TITLE
spotx Bid Adapter: renderer url to ensure onLoad is always called

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -365,7 +365,7 @@ export const spec = {
             const playersize = utils.deepAccess(currentBidRequest, 'mediaTypes.video.playerSize');
             const renderer = Renderer.install({
               id: 0,
-              url: '//',
+              url: '/',
               config: {
                 adText: 'SpotX Outstream Video Ad via Prebid.js',
                 player_width: playersize[0][0],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Change https://github.com/prebid/Prebid.js/pull/6422 caused an issue in the spotxBidAdapter renderer where the provided URL "//" would never load meaning the renderer would never get called. I update the renderer URL to "/" and now onLoad gets called as expected. 
