### PR TITLE
Sharethrough Bid Adapter: add support for COPPA

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,5 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
 
 const VERSION = '3.3.1';
 const BIDDER_CODE = 'sharethrough';
@@ -46,6 +47,10 @@ export const sharethroughAdapterSpec = {
 
       if (bidderRequest && bidderRequest.uspConsent) {
         query.us_privacy = bidderRequest.uspConsent
+      }
+
+      if (config.getConfig('coppa') === true) {
+        query.coppa = 1
       }
 
       if (bidRequest.schain) {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -50,7 +50,7 @@ export const sharethroughAdapterSpec = {
       }
 
       if (config.getConfig('coppa') === true) {
-        query.coppa = 1
+        query.coppa = true
       }
 
       if (bidRequest.schain) {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -2,7 +2,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
-const VERSION = '3.3.1';
+const VERSION = '3.3.2';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -448,7 +448,7 @@ describe('sharethrough adapter spec', function() {
         config.setConfig({coppa: true});
         const bidRequest = Object.assign({}, bidRequests[0]);
         const builtBidRequest = spec.buildRequests([bidRequest])[0];
-        expect(builtBidRequest.data.coppa).to.eq(1);
+        expect(builtBidRequest.data.coppa).to.eq(true);
       });
 
       it('should not add coppa to request if disabled', function() {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { sharethroughAdapterSpec, sharethroughInternal } from 'modules/sharethroughBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import * as utils from '../../../src/utils.js';
+import { config } from 'src/config';
 
 const spec = newBidder(sharethroughAdapterSpec).getSpec();
 const bidRequests = [
@@ -440,6 +441,29 @@ describe('sharethrough adapter spec', function() {
       const bidRequest = Object.assign({}, bidRequests[0]);
       const builtBidRequest = spec.buildRequests([bidRequest])[0];
       expect(builtBidRequest.data).to.not.include.any.keys('bidfloor');
+    });
+
+    describe('coppa', function() {
+      it('should add coppa to request if enabled', function() {
+        config.setConfig({coppa: true});
+        const bidRequest = Object.assign({}, bidRequests[0]);
+        const builtBidRequest = spec.buildRequests([bidRequest])[0];
+        expect(builtBidRequest.data.coppa).to.eq(1);
+      });
+
+      it('should not add coppa to request if disabled', function() {
+        config.setConfig({coppa: false});
+        const bidRequest = Object.assign({}, bidRequests[0]);
+        const builtBidRequest = spec.buildRequests([bidRequest])[0];
+        expect(builtBidRequest.data.coppa).to.be.undefined;
+      });
+
+      it('should not add coppa to request if unknown value', function() {
+        config.setConfig({coppa: 'something'});
+        const bidRequest = Object.assign({}, bidRequests[0]);
+        const builtBidRequest = spec.buildRequests([bidRequest])[0];
+        expect(builtBidRequest.data.coppa).to.be.undefined;
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
- Add support for COPPA
- Documentation PR: prebid/prebid.github.io#2872

pubgrowth.engineering@sharethrough.com