### PR TITLE
ix bid adapter: send userIds in ixdiag

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -482,6 +482,31 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
 }
 
 /**
+ * Return an object of user IDs stored by Prebid User ID module
+ *
+ * @returns {Object} ID providers and whether they are present
+ */
+function _getUserIds(bidRequest) {
+  const userIds = bidRequest.userId || {};
+
+  return {
+    'britepoolid': utils.deepAccess(userIds, 'britepoolid') ? 1 : 0,
+    'id5id': utils.deepAccess(userIds, 'id5id') ? 1 : 0,
+    'lipbid': utils.deepAccess(userIds, 'lipb.lipbid') ? 1 : 0,
+    'haloId': utils.deepAccess(userIds, 'haloId') ? 1 : 0,
+    'criteoId': utils.deepAccess(userIds, 'criteoId') ? 1 : 0,
+    'lotamePanoramaId': utils.deepAccess(userIds, 'lotamePanoramaId') ? 1 : 0,
+    'merkleId': utils.deepAccess(userIds, 'merkleId') ? 1 : 0,
+    'parrableId': utils.deepAccess(userIds, 'parrableId') ? 1 : 0,
+    'connectid': utils.deepAccess(userIds, 'connectid') ? 1 : 0,
+    'sharedid': utils.deepAccess(userIds, 'sharedid') ? 1 : 0,
+    'tapadId': utils.deepAccess(userIds, 'tapadId') ? 1 : 0,
+    'quantcastId': utils.deepAccess(userIds, 'quantcastId') ? 1 : 0,
+    'pubcid': utils.deepAccess(userIds, 'pubcid') ? 1 : 0
+  }
+}
+
+/**
  * Calculates IX diagnostics values and packages them into an object
  *
  * @param {array} validBidRequests  The valid bid requests from prebid
@@ -500,7 +525,8 @@ function buildIXDiag(validBidRequests) {
     ou: 0,
     allU: 0,
     ren: false,
-    version: '$prebid.version$'
+    version: '$prebid.version$',
+    userIds: _getUserIds(validBidRequests[0])
   };
 
   // create ad unit map and collect the required diag properties

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -484,26 +484,28 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
 /**
  * Return an object of user IDs stored by Prebid User ID module
  *
- * @returns {Object} ID providers and whether they are present
+ * @returns {array} ID providers that are present in userIds
  */
 function _getUserIds(bidRequest) {
   const userIds = bidRequest.userId || {};
 
-  return {
-    'britepoolid': utils.deepAccess(userIds, 'britepoolid') ? 1 : 0,
-    'id5id': utils.deepAccess(userIds, 'id5id') ? 1 : 0,
-    'lipbid': utils.deepAccess(userIds, 'lipb.lipbid') ? 1 : 0,
-    'haloId': utils.deepAccess(userIds, 'haloId') ? 1 : 0,
-    'criteoId': utils.deepAccess(userIds, 'criteoId') ? 1 : 0,
-    'lotamePanoramaId': utils.deepAccess(userIds, 'lotamePanoramaId') ? 1 : 0,
-    'merkleId': utils.deepAccess(userIds, 'merkleId') ? 1 : 0,
-    'parrableId': utils.deepAccess(userIds, 'parrableId') ? 1 : 0,
-    'connectid': utils.deepAccess(userIds, 'connectid') ? 1 : 0,
-    'sharedid': utils.deepAccess(userIds, 'sharedid') ? 1 : 0,
-    'tapadId': utils.deepAccess(userIds, 'tapadId') ? 1 : 0,
-    'quantcastId': utils.deepAccess(userIds, 'quantcastId') ? 1 : 0,
-    'pubcid': utils.deepAccess(userIds, 'pubcid') ? 1 : 0
-  }
+  const PROVIDERS = [
+    'britepoolid',
+    'id5id',
+    'lipbid',
+    'haloId',
+    'criteoId',
+    'lotamePanoramaId',
+    'merkleId',
+    'parrableId',
+    'connectid',
+    'sharedid',
+    'tapadId',
+    'quantcastId',
+    'pubcid'
+  ]
+
+  return PROVIDERS.filter(provider => utils.deepAccess(userIds, provider))
 }
 
 /**

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1015,10 +1015,10 @@ describe('IndexexchangeAdapter', function () {
       const request = spec.buildRequests([bid], DEFAULT_OPTION)[0];
       const r = JSON.parse(request.data.r);
 
-      expect(r.ext.ixdiag.userIds).to.be.an('object');
-      expect(r.ext.ixdiag.userIds.lotamePanoramaId).to.equal(1);
-      expect(r.ext.ixdiag.userIds.merkleId).to.equal(0);
-      expect(r.ext.ixdiag.userIds.parrableId).to.equal(0);
+      expect(r.ext.ixdiag.userIds).to.be.an('array');
+      expect(r.ext.ixdiag.userIds.should.include('lotamePanoramaId'));
+      expect(r.ext.ixdiag.userIds.should.not.include('merkleId'));
+      expect(r.ext.ixdiag.userIds.should.not.include('parrableId'));
     });
   });
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -395,6 +395,10 @@ describe('IndexexchangeAdapter', function () {
     }
   ];
 
+  const DEFAULT_USERID_BID_DATA = {
+    lotamePanoramaId: 'bd738d136bdaa841117fe9b331bb4'
+  };
+
   describe('inherited functions', function () {
     it('should exists and is a function', function () {
       const adapter = newBidder(spec);
@@ -989,6 +993,32 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).to.deep.include(validUserIdPayload[2]);
       expect(payload.user.eids).to.deep.include(validUserIdPayload[3]);
       expect(payload.user.eids).to.deep.include(validUserIdPayload[4]);
+    });
+  });
+
+  describe('getUserIds', function () {
+    it('request should contain userId information if configured and within bid request', function () {
+      config.setConfig({
+        userSync: {
+          syncDelay: 0,
+          userIds: [
+            { name: 'lotamePanoramaId' },
+            { name: 'merkleId' },
+            { name: 'parrableId' },
+          ]
+        }
+      });
+
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.userId = DEFAULT_USERID_BID_DATA;
+
+      const request = spec.buildRequests([bid], DEFAULT_OPTION)[0];
+      const r = JSON.parse(request.data.r);
+
+      expect(r.ext.ixdiag.userIds).to.be.an('object');
+      expect(r.ext.ixdiag.userIds.lotamePanoramaId).to.equal(1);
+      expect(r.ext.ixdiag.userIds.merkleId).to.equal(0);
+      expect(r.ext.ixdiag.userIds.parrableId).to.equal(0);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

In this PR, we are collecting the `userIds` from the `bidRequest` and passing it on to your diagnostics object `ixdiag` that is part of our bid request URL (`cygnus`)
