### PR TITLE
PBJS Core - Validate adunit page position / PBS and RP adapters updates to pass pos in banner and video requests

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -571,6 +571,8 @@ const OPEN_RTB_PROTOCOL = {
         });
 
         mediaTypes['banner'] = {format};
+
+        if (bannerParams.pos) mediaTypes['banner'].pos = bannerParams.pos;
       }
 
       if (!utils.isEmpty(videoParams)) {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -453,7 +453,9 @@ export const spec = {
 
     // add p_pos only if specified and valid
     // For SRA we need to explicitly put empty semi colons so AE treats it as empty, instead of copying the latter value
-    data['p_pos'] = (params.position === 'atf' || params.position === 'btf') ? params.position : '';
+    let posMapping = {1: 'atf', 3: 'btf'};
+    let pos = posMapping[utils.deepAccess(bidRequest, 'mediaTypes.banner.pos')] || '';
+    data['p_pos'] = (params.position === 'atf' || params.position === 'btf') ? params.position : pos;
 
     // pass publisher provided userId if configured
     const configUserId = config.getConfig('user.id');

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -137,6 +137,20 @@ function validateNativeMediaType(adUnit) {
   return validatedAdUnit;
 }
 
+function validateAdUnitPos(adUnit, mediaType) {
+  let pos =  utils.deepAccess(adUnit, `mediaTypes.${mediaType}.pos`);
+
+  if (!pos || !utils.isNumber(pos) || !isFinite(pos)) {
+    let warning = `Value of property 'pos' on ad unit ${adUnit.code} should be of type: Number`;
+
+    utils.logWarn(warning);
+    events.emit(CONSTANTS.EVENTS.AUCTION_DEBUG, {type: 'WARNING', arguments: warning});
+    delete adUnit.mediaTypes[mediaType].pos;
+  }
+
+  return adUnit
+}
+
 export const adUnitSetupChecks = {
   validateBannerMediaType,
   validateVideoMediaType,
@@ -164,10 +178,12 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
 
     if (mediaTypes.banner) {
       validatedBanner = validateBannerMediaType(adUnit);
+      if (mediaTypes.banner.hasOwnProperty('pos')) validatedBanner = validateAdUnitPos(validatedBanner, 'banner');
     }
 
     if (mediaTypes.video) {
       validatedVideo = validatedBanner ? validateVideoMediaType(validatedBanner) : validateVideoMediaType(adUnit);
+      if (mediaTypes.video.hasOwnProperty('pos')) validatedVideo = validateAdUnitPos(validatedVideo, 'video');
     }
 
     if (mediaTypes.native) {
@@ -500,7 +516,7 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
     s2sBidders.push(...s2sConfig.bidders);
   });
 
-  adUnits = checkAdUnitSetup(adUnits);
+  adUnits = checkAdUnitSetup(adUnits);console.log(adUnits);
 
   if (adUnitCodes && adUnitCodes.length) {
     // if specific adUnitCodes supplied filter adUnits for those codes

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -138,7 +138,7 @@ function validateNativeMediaType(adUnit) {
 }
 
 function validateAdUnitPos(adUnit, mediaType) {
-  let pos =  utils.deepAccess(adUnit, `mediaTypes.${mediaType}.pos`);
+  let pos = utils.deepAccess(adUnit, `mediaTypes.${mediaType}.pos`);
 
   if (!pos || !utils.isNumber(pos) || !isFinite(pos)) {
     let warning = `Value of property 'pos' on ad unit ${adUnit.code} should be of type: Number`;
@@ -516,7 +516,7 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
     s2sBidders.push(...s2sConfig.bidders);
   });
 
-  adUnits = checkAdUnitSetup(adUnits);console.log(adUnits);
+  adUnits = checkAdUnitSetup(adUnits);
 
   if (adUnitCodes && adUnitCodes.length) {
     // if specific adUnitCodes supplied filter adUnits for those codes

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -499,6 +499,38 @@ describe('the rubicon adapter', function () {
           expect(data['p_pos']).to.equal(undefined);
         });
 
+        it('should not send p_pos to AE if not mediaTypes.banner.pos is invalid', function () {
+          var bidRequest = utils.deepClone(bidderRequest);
+          bidRequest.bids[0].mediaTypes = {
+            banner: {
+              pos: 5
+            }
+          };
+          delete bidRequest.bids[0].params.position;
+
+          let [request] = spec.buildRequests(bidRequest.bids, bidRequest);
+          let data = parseQuery(request.data);
+
+          expect(data['site_id']).to.equal('70608');
+          expect(data['p_pos']).to.equal(undefined);
+        });
+
+        it('should send p_pos to AE if mediaTypes.banner.pos is valid', function () {
+          var bidRequest = utils.deepClone(bidderRequest);
+          bidRequest.bids[0].mediaTypes = {
+            banner: {
+              pos: 1
+            }
+          };
+          delete bidRequest.bids[0].params.position;
+
+          let [request] = spec.buildRequests(bidRequest.bids, bidRequest);
+          let data = parseQuery(request.data);
+
+          expect(data['site_id']).to.equal('70608');
+          expect(data['p_pos']).to.equal('atf');
+        });
+
         it('should not send p_pos to AE if not params.position is invalid', function () {
           var badposRequest = utils.deepClone(bidderRequest);
           badposRequest.bids[0].params.position = 'bad';

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1662,6 +1662,42 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
             expect(auctionArgs.adUnits[0].mediaTypes.banner.sizes).to.deep.equal([[300, 250]]);
           });
+
+          it('should filter mediaType pos value if not integer', function () {
+            let adUnit = [{
+              code: 'test5',
+              bids: [],
+              sizes: [300, 250],
+              mediaTypes: {
+                banner: {
+                  sizes: [300, 250],
+                  pos: 'foo'
+                }
+              }
+            }];
+            $$PREBID_GLOBAL$$.requestBids({
+              adUnits: adUnit
+            });
+            expect(auctionArgs.adUnits[0].mediaTypes.banner.pos).to.be.undefined;
+          });
+
+          it('should pass mediaType pos value if integer', function () {
+            let adUnit = [{
+              code: 'test5',
+              bids: [],
+              sizes: [300, 250],
+              mediaTypes: {
+                banner: {
+                  sizes: [300, 250],
+                  pos: 2
+                }
+              }
+            }];
+            $$PREBID_GLOBAL$$.requestBids({
+              adUnits: adUnit
+            });
+            expect(auctionArgs.adUnits[0].mediaTypes.banner.pos).to.equal(2);
+          });
         });
 
         describe('negative tests for validating adUnits', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- PBJS Core update to include validation of pos value on adunit
- PBS adapter update to include pos value on banner requests (video already included)
- RP adapter update to use pos bidder params.pos or mediaType.banner.pos value in banner request (video already passed properly)

Issue: https://github.com/prebid/Prebid.js/issues/5578

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
