### PR TITLE
Zemanta bid adapter: reinstate Outbrain as alias

### DIFF
--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -167,7 +167,11 @@ export const spec = {
     return syncs;
   },
   onBidWon: (bid) => {
-    ajax(utils.replaceAuctionPrice(bid.nurl, bid.originalCpm))
+    // for native requests we put the nurl as an imp tracker, otherwise if the auction takes place on prebid server
+    // the server JS adapter puts the nurl in the adm as a tracking pixel and removes the attribute
+    if (bid.nurl) {
+      ajax(utils.replaceAuctionPrice(bid.nurl, bid.originalCpm))
+    }
   }
 };
 

--- a/modules/zemantaBidAdapter.js
+++ b/modules/zemantaBidAdapter.js
@@ -25,6 +25,9 @@ const NATIVE_PARAMS = {
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
+  aliases: [
+    { code: 'outbrain', gvlid: GVLID }
+  ],
   supportedMediaTypes: [ NATIVE, BANNER ],
   isBidRequestValid: (bid) => {
     return (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Hey!

In https://github.com/prebid/Prebid.js/pull/6558 (released in v4.35.0) we copied the zemanta adapter as the outbrain and made outbrain a standalone non-aliased adapter. We left the zemanta adapter to be backwards compatible until prebid.js v5.

The issue we are now facing is that if anyone wants to download the outbrain adapter from https://docs.prebid.org/download.html using a version less than v4.35.0 there's an error since the library generation api is called with `modules[]: outbrainBidAdapter` that of course doesn't exist in previous versions.

This PR again makes the outbrain adapter an alias for zemanta and adds some changes that were already merged from outbrain adapter. The standalone outbrain adapter still exists and any future changes will be applied to both adapters. The zemanta adapter is already removed on the v5 branch (https://github.com/prebid/Prebid.js/pull/6560).

As far as I've tested, I see that with this setup bid requests for outbrain are handled by the zemanta adapter. I think this is because in https://github.com/prebid/Prebid.js/blob/master/src/adapters/bidderFactory.js#L154 zemanta alphabetically comes after outbrain and overrides the existing adapter. Since both adapters will be kept in sync I think this behaviour is ok.
Are there any potential issues here that I missed?

- PR on the docs repo https://github.com/prebid/prebid.github.io/pull/2880
