### PR TITLE
Adnuntius Bid Adapter: Fix for request order.

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -49,9 +49,10 @@ export const spec = {
       const adUnit = serverBody.adUnits[k]
       if (adUnit.matchedAdCount > 0) {
         const bid = adUnit.ads[0];
+        const effectiveCpm = (bid.cpc && bid.cpm) ? bid.bid.amount + bid.cpm.amount : (bid.cpc) ? bid.bid.amount : (bid.cpm) ? bid.cpm.amount : 0;
         bidResponses.push({
           requestId: bidRequest.bid[k].bidId,
-          cpm: (bid.bid) ? bid.bid.amount : 0,
+          cpm: effectiveCpm,
           width: Number(bid.creativeWidth),
           height: Number(bid.creativeHeight),
           creativeId: bid.creativeId,

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,5 +1,6 @@
 
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import * as utils from '../src/utils.js';
 const BIDDER_CODE = 'adnuntius';
 const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
 
@@ -7,7 +8,7 @@ export const spec = {
   code: BIDDER_CODE,
 
   isBidRequestValid: function (bid) {
-    return !!(bid.params.auId || (bid.params.member && bid.params.invCode));
+    return !!(bid.bidId || (bid.params.member && bid.params.invCode));
   },
 
   buildRequests: function (validBidRequests) {
@@ -42,28 +43,36 @@ export const spec = {
   },
 
   interpretResponse: function (serverResponse, bidRequest) {
-    const bidResponses = [];
-    const serverBody = serverResponse.body;
-
-    for (var k = 0; k < serverBody.adUnits.length; k++) {
-      const adUnit = serverBody.adUnits[k]
-      if (adUnit.matchedAdCount > 0) {
+    const adUnits = serverResponse.body.adUnits;
+    const bidResponsesById = adUnits.reduce((response, adUnit) => {
+      if (adUnit.matchedAdCount >= 1) {
         const bid = adUnit.ads[0];
         const effectiveCpm = (bid.cpc && bid.cpm) ? bid.bid.amount + bid.cpm.amount : (bid.cpc) ? bid.bid.amount : (bid.cpm) ? bid.cpm.amount : 0;
-        bidResponses.push({
-          requestId: bidRequest.bid[k].bidId,
-          cpm: effectiveCpm,
-          width: Number(bid.creativeWidth),
-          height: Number(bid.creativeHeight),
-          creativeId: bid.creativeId,
-          currency: (bid.bid) ? bid.bid.currency : 'EUR',
-          netRevenue: false,
-          ttl: 360,
-          ad: adUnit.html
-        });
-      }
-    }
-    return bidResponses;
+        return {
+          ...response,
+          [adUnit.targetId]: {
+            requestId: adUnit.targetId,
+            cpm: effectiveCpm,
+            width: Number(bid.creativeWidth),
+            height: Number(bid.creativeHeight),
+            creativeId: bid.creativeId,
+            currency: (bid.bid) ? bid.bid.currency : 'EUR',
+            netRevenue: false,
+            ttl: 360,
+            ad: adUnit.html
+          }
+        }
+      } else return response
+    }, {});
+
+    const bidResponse = bidRequest.bid.map(bid => bid.bidId)
+      .reduce((request, adunitId) =>
+        request.concat(bidResponsesById[adunitId])
+        , []);
+
+    utils.logMessage('ADN: BIDREQ', bidRequest)
+    utils.logMessage('ADN: BIDRES', bidResponse)
+    return bidResponse
   },
 
 }

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,6 +1,5 @@
-
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import * as utils from '../src/utils.js';
+
 const BIDDER_CODE = 'adnuntius';
 const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
 
@@ -70,8 +69,6 @@ export const spec = {
         request.concat(bidResponsesById[adunitId])
         , []);
 
-    utils.logMessage('ADN: BIDREQ', bidRequest)
-    utils.logMessage('ADN: BIDRES', bidResponse)
     return bidResponse
   },
 

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -48,8 +48,8 @@ describe('adnuntiusBidAdapter', function () {
                 'destination': 'http://google.com'
               },
               'cpm': { 'amount': 5.0, 'currency': 'NOK' },
-              'bid': { 'amount': 5.0, 'currency': 'NOK' },
-              'cost': { 'amount': 5.0, 'currency': 'NOK' },
+              'bid': { 'amount': 0.005, 'currency': 'NOK' },
+              'cost': { 'amount': 0.005, 'currency': 'NOK' },
               'impressionTrackingUrls': [],
               'impressionTrackingUrlsEsc': [],
               'adId': 'adn-id-1347343135',
@@ -106,12 +106,14 @@ describe('adnuntiusBidAdapter', function () {
       const request = spec.buildRequests(bidRequests);
       const interpretedResponse = spec.interpretResponse(serverResponse, request[0]);
       const ad = serverResponse.body.adUnits[0].ads[0]
+      const cpm = (ad.cpc && ad.cpm) ? ad.bid.amount + ad.cpm.amount : (ad.cpm) ? ad.cpm.amount : 0;
+
       expect(interpretedResponse).to.have.lengthOf(1);
       expect(interpretedResponse[0].cpm).to.equal(ad.cpm.amount);
       expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
       expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
       expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
-      expect(interpretedResponse[0].currency).to.equal(ad.cpm.currency);
+      expect(interpretedResponse[0].currency).to.equal(ad.bid.currency);
       expect(interpretedResponse[0].netRevenue).to.equal(false);
       expect(interpretedResponse[0].ad).to.equal(serverResponse.body.adUnits[0].html);
       expect(interpretedResponse[0].ttl).to.equal(360);

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -7,23 +7,33 @@ describe('adnuntiusBidAdapter', function () {
   const tzo = new Date().getTimezoneOffset();
   const ENDPOINT_URL = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
   const adapter = newBidder(spec);
+
   const bidRequests = [
     {
+      bidId: '123',
       bidder: 'adnuntius',
       params: {
         auId: '8b6bc',
         network: 'adnuntius',
       },
-      bidId: '123'
+
     }
-  ];
+  ]
+
+  const singleBidRequest = {
+    bid: [
+      {
+        bidId: '123',
+      }
+    ]
+  }
 
   const serverResponse = {
     body: {
       'adUnits': [
         {
           'auId': '000000000008b6bc',
-          'targetId': '',
+          'targetId': '123',
           'html': '<h1>hi!</h1>',
           'matchedAdCount': 1,
           'responseId': 'adn-rsp-1460129238',
@@ -103,10 +113,8 @@ describe('adnuntiusBidAdapter', function () {
 
   describe('interpretResponse', function () {
     it('should return valid response when passed valid server response', function () {
-      const request = spec.buildRequests(bidRequests);
-      const interpretedResponse = spec.interpretResponse(serverResponse, request[0]);
+      const interpretedResponse = spec.interpretResponse(serverResponse, singleBidRequest);
       const ad = serverResponse.body.adUnits[0].ads[0]
-      const cpm = (ad.cpc && ad.cpm) ? ad.bid.amount + ad.cpm.amount : (ad.cpm) ? ad.cpm.amount : 0;
 
       expect(interpretedResponse).to.have.lengthOf(1);
       expect(interpretedResponse[0].cpm).to.equal(ad.cpm.amount);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This is a bugfix for Adnuntius bidder that only affect the adapter and not the client facing integration. The fix will make sure that the requested order is maintained. what heppens now is that the creatives might be placed on the wrong placement.


- contact email of the adapter’s maintainer
- [ ] official adapter submission
