### PR TITLE
oneVideo Adapter - content object mapping bug fix (VDEFECT-5405)

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -312,7 +312,7 @@ function getRequestData(bid, consentData, bidRequest) {
     }
   }
   if (bid.params.video.content && utils.isPlainObject(bid.params.video.content)) {
-    bidData.imp[0].content = {};
+    bidData.site.content = {};
     const contentStringKeys = ['id', 'title', 'series', 'season', 'genre', 'contentrating', 'language'];
     const contentNumberkeys = ['episode', 'prodq', 'context', 'livestream', 'len'];
     const contentArrayKeys = ['cat'];
@@ -324,7 +324,7 @@ function getRequestData(bid, consentData, bidRequest) {
         (contentObjectKeys.indexOf(contentKey) > -1 && utils.isPlainObject(bid.params.video.content[contentKey])) ||
         (contentArrayKeys.indexOf(contentKey) > -1 && utils.isArray(bid.params.video.content[contentKey]) &&
         bid.params.video.content[contentKey].every(catStr => utils.isStr(catStr)))) {
-        bidData.imp[0].content[contentKey] = bid.params.video.content[contentKey];
+        bidData.site.content[contentKey] = bid.params.video.content[contentKey];
       } else {
         utils.logMessage('oneVideo bid adapter validation error: ', contentKey, ' is either not supported is OpenRTB V2.5 or value is undefined');
       }

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -4,7 +4,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'oneVideo';
 export const spec = {
   code: 'oneVideo',
-  VERSION: '3.0.6',
+  VERSION: '3.0.7',
   ENDPOINT: 'https://ads.adaptv.advertising.com/rtb/openrtb?ext_id=',
   E2ETESTENDPOINT: 'https://ads-wc.v.ssp.yahoo.com/rtb/openrtb?ext_id=',
   SYNC_ENDPOINT1: 'https://pixel.advertising.com/ups/57304/sync?gdpr=&gdpr_consent=&_origin=0&redir=true',

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -221,7 +221,7 @@ describe('OneVideoBidAdapter', function () {
       const placement = bidRequest.params.video.placement;
       const rewarded = bidRequest.params.video.rewarded;
       const inventoryid = bidRequest.params.video.inventoryid;
-      const VERSION = '3.0.6';
+      const VERSION = '3.0.7';
       expect(data.imp[0].video.w).to.equal(width);
       expect(data.imp[0].video.h).to.equal(height);
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -387,37 +387,37 @@ describe('OneVideoBidAdapter', function () {
         bidRequest.params.video.content = null;
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.undefined;
+        expect(data.site.content).to.be.undefined;
       });
       it('should not accept content object if value is is Array ', function () {
         bidRequest.params.video.content = [];
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.undefined;
+        expect(data.site.content).to.be.undefined;
       });
       it('should not accept content object if value is Number ', function () {
         bidRequest.params.video.content = 123456;
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.undefined;
+        expect(data.site.content).to.be.undefined;
       });
       it('should not accept content object if value is String ', function () {
         bidRequest.params.video.content = 'keyValuePairs';
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.undefined;
+        expect(data.site.content).to.be.undefined;
       });
       it('should not accept content object if value is Boolean ', function () {
         bidRequest.params.video.content = true;
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.undefined;
+        expect(data.site.content).to.be.undefined;
       });
       it('should accept content object if value is Object ', function () {
         bidRequest.params.video.content = {};
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.a('object');
+        expect(data.site.content).to.be.a('object');
       });
 
       it('should not append unsupported content object keys', function () {
@@ -428,7 +428,7 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.empty;
+        expect(data.site.content).to.be.empty;
       });
 
       it('should not append content string parameters if value is not string ', function () {
@@ -443,8 +443,8 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.a('object');
-        expect(data.imp[0].content).to.be.empty
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
       });
       it('should not append content Number parameters if value is not Number ', function () {
         bidRequest.params.video.content = {
@@ -456,8 +456,8 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.a('object');
-        expect(data.imp[0].content).to.be.empty
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
       });
       it('should not append content Array parameters if value is not Array ', function () {
         bidRequest.params.video.content = {
@@ -465,8 +465,8 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.a('object');
-        expect(data.imp[0].content).to.be.empty
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
       });
       it('should not append content ext if value is not Object ', function () {
         bidRequest.params.video.content = {
@@ -474,8 +474,8 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.be.a('object');
-        expect(data.imp[0].content).to.be.empty
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
       });
       it('should append supported parameters if value match validations ', function () {
         bidRequest.params.video.content = {
@@ -498,7 +498,7 @@ describe('OneVideoBidAdapter', function () {
         };
         const requests = spec.buildRequests([bidRequest], bidderRequest);
         const data = requests[0].data;
-        expect(data.imp[0].content).to.deep.equal(bidRequest.params.video.content);
+        expect(data.site.content).to.deep.equal(bidRequest.params.video.content);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Fix moving content object into bid.site for the outgoing bid-request to Video SSP.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
const adUnits = [{
            code: 'video1',
            mediaTypes: {
                video: {
                    context: 'outstream',
                    playerSize: [640, 480]
                }
            },
            bids: [{
                bidder: 'oneVideo',
                params: {
                    video: {
                        playerWidth: 640,
                        playerHeight: 480,
                        mimes: ['video/mp4', 'application/javascript'],
                        protocols: [2, 5],
                        api: [1, 2],
                        e2etest: true,
                            content: {
                            id: "1234",
                            title: "Title",
                            series: "Series",
                            season: "Season",
                            episode: "Episode",
                            cat: [
                                "IAB1",
                                "IAB1-1",
                                "IAB1-2",
                                "IAB2",
                                "IAB2-1"
                            ],
                            genre: "Fantase",
                            contentrating: "C-Rating",
                            language: "EN",
                            prodq: 1,
                            context: 1,
                            livestream: 0,
                            len: 200,
                            ext: {
                                    network: "ext-network",
                                    channel: "ext-channel"
                                }
                            }
                        },
                        pubId: 'whatever'
                    }
            }]
        }]
```


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Hi @DeepthiNeeladri & @kprasadpvv
I would appreciate it if you could review this bug fix PR please.
basically mapping the content object into bid.site.content from where it was.
Thanks in advance,
Adam