### PR TITLE
Consent Management Module: TCFApi in Iframe callId fix

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -200,7 +200,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     let apiName = (cmpVersion === 2) ? '__tcfapi' : '__cmp';
 
     let callName = `${apiName}Call`;
-    
+
     /* Setup up a __cmp function to do the postMessage and stash the callback.
     This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
     if (cmpVersion === 2) {

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -199,12 +199,12 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
   function callCmpWhileInIframe(commandName, cmpFrame, moduleCallback) {
     let apiName = (cmpVersion === 2) ? '__tcfapi' : '__cmp';
 
-    let callId = Math.random() + '';
     let callName = `${apiName}Call`;
-
+    
     /* Setup up a __cmp function to do the postMessage and stash the callback.
-      This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
+    This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
     if (cmpVersion === 2) {
+      let callId = Math.random() + '';
       window[apiName] = function (cmd, cmpVersion, callback, arg) {
         let msg = {
           [callName]: {
@@ -225,6 +225,7 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
       // call CMP
       window[apiName](commandName, cmpVersion, moduleCallback);
     } else {
+      let callId = Math.random() + '';
       window[apiName] = function (cmd, arg, callback) {
         let msg = {
           [callName]: {

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -204,8 +204,8 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
     /* Setup up a __cmp function to do the postMessage and stash the callback.
     This function behaves (from the caller's perspective identicially to the in-frame __cmp call */
     if (cmpVersion === 2) {
-      let callId = Math.random() + '';
       window[apiName] = function (cmd, cmpVersion, callback, arg) {
+        let callId = Math.random() + '';
         let msg = {
           [callName]: {
             command: cmd,
@@ -225,8 +225,8 @@ function lookupIabConsent(cmpSuccess, cmpError, hookConfig) {
       // call CMP
       window[apiName](commandName, cmpVersion, moduleCallback);
     } else {
-      let callId = Math.random() + '';
       window[apiName] = function (cmd, arg, callback) {
+        let callId = Math.random() + '';
         let msg = {
           [callName]: {
             command: cmd,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Prebid installs a tcfapi function in case the CMP is only accessible through the message API. This setup works through an object mapping callIds to callback functions. The callId should be random, but was only generated once. As a result, having calls running in parallel resulted in overriding the callback.

For example: running prebid and amazon in parallel resulted in amazon asking for consent through the tcfapi function installed by prebid, and has a race condition where prebid's callback never fired as it got overridden by amazon's consent request.

## Other information
@jsnellbaker I think you're the owner / original author of the module, so tagging you. Sorry if that's not the case.