### PR TITLE
SynacorMedia Bid Adapter: Create bid.params.video object if it's not present

### DIFF
--- a/modules/synacormediaBidAdapter.js
+++ b/modules/synacormediaBidAdapter.js
@@ -157,6 +157,9 @@ export const spec = {
         pos
       };
       if (bid.mediaTypes.video) {
+        if (!bid.params.video) {
+          bid.params.video = {};
+        }
         this.setValidVideoParams(bid.mediaTypes.video, bid.params.video);
       }
       if (bid.params.video) {

--- a/test/spec/modules/synacormediaBidAdapter_spec.js
+++ b/test/spec/modules/synacormediaBidAdapter_spec.js
@@ -576,6 +576,50 @@ describe('synacormediaBidAdapter ', function () {
         }
       ]);
     });
+    it('should create params.video object if not present on bid request and move any video params in the mediaTypes object to it', function () {
+      let validBidRequestVideo = {
+        bidder: 'synacormedia',
+        params: {
+          seatId: 'prebid',
+          tagId: '1234'
+        },
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            playerSize: [[ 640, 480 ]],
+            startdelay: 1,
+            linearity: 1,
+            placement: 1,
+            mimes: ['video/mp4']
+          }
+        },
+        adUnitCode: 'video1',
+        transactionId: '93e5def8-29aa-4fe8-bd3a-0298c39f189a',
+        sizes: [[ 640, 480 ]],
+        bidId: '2624fabbb078e8',
+        bidderRequestId: '117954d20d7c9c',
+        auctionId: 'defd525f-4f1e-4416-a4cb-ae53be90e706',
+        src: 'client',
+        bidRequestsCount: 1
+      };
+
+      let req = spec.buildRequests([validBidRequestVideo], bidderRequest);
+      expect(req.data.imp).to.eql([
+        {
+          video: {
+            h: 480,
+            pos: 0,
+            w: 640,
+            startdelay: 1,
+            linearity: 1,
+            placement: 1,
+            mimes: ['video/mp4']
+          },
+          id: 'v2624fabbb078e8-640x480',
+          tagid: '1234',
+        }
+      ]);
+    });
     it('should contain the CCPA privacy string when UspConsent is in bidder request', function () {
       // banner test
       let req = spec.buildRequests([validBidRequest], bidderRequestWithCCPA);


### PR DESCRIPTION
…already present on the video request since it's an optional property

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Create bid.params.video object if it's not already present on the video request since it's an optional property. So, if a publisher doesn't define bid.params.video property,  this.setValidVideoParams(bid.mediaTypes.video, bid.params.video) call errors out since bid.params.video is the destination object where props get merged and it's undefined in this case.
