### PR TITLE
adformOpenRTB Bid Adapter: change name to adf to avoid collision

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -10,8 +10,9 @@ import {
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
-const BIDDER_CODE = 'adformOpenRTB';
+const BIDDER_CODE = 'adf';
 const GVLID = 50;
+const BIDDER_ALIAS = [ { code: 'adformOpenRTB', gvlid: GVLID } ];
 const NATIVE_ASSET_IDS = { 0: 'title', 2: 'icon', 3: 'image', 5: 'sponsoredBy', 4: 'body', 1: 'cta' };
 const NATIVE_PARAMS = {
   title: {
@@ -47,6 +48,7 @@ const NATIVE_PARAMS = {
 
 export const spec = {
   code: BIDDER_CODE,
+  aliases: BIDDER_ALIAS,
   gvlid: GVLID,
   supportedMediaTypes: [ NATIVE ],
   isBidRequestValid: bid => !!bid.params.mid,
@@ -170,7 +172,6 @@ export const spec = {
           netRevenue: bid.netRevenue === 'net',
           currency: cur,
           mediaType: NATIVE,
-          bidderCode: BIDDER_CODE,
           native: parseNative(bidResponse)
         };
       }

--- a/modules/adfBidAdapter.md
+++ b/modules/adfBidAdapter.md
@@ -1,13 +1,13 @@
 # Overview
 
-Module Name: Adform OpenRTB Adapter
+Module Name: Adf Adapter
 Module Type: Bidder Adapter
 Maintainer: Scope.FL.Scripts@adform.com
 
 # Description
 
 Module that connects to Adform demand sources to fetch bids.
-Only native format is supported. Using OpenRTB standard.
+Only native format is supported. Using OpenRTB standard. Previous adapter name - adformOpenRTB.
 
 # Test Parameters
 ```
@@ -42,7 +42,7 @@ Only native format is supported. Using OpenRTB standard.
             }
         },
         bids: [{
-            bidder: 'adformOpenRTB',
+            bidder: 'adf',
             params: {
                 mid: 606169,                  // required
                 adxDomain: 'adx.adform.net',  // optional

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -1,13 +1,20 @@
 // jshint esversion: 6, es3: false, node: true
 import {assert, expect} from 'chai';
-import {spec} from 'modules/adformOpenRTBBidAdapter.js';
+import {spec} from 'modules/adfBidAdapter.js';
 import { NATIVE } from 'src/mediaTypes.js';
 import { config } from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
 
-describe('AdformOpenRTB adapter', function () {
+describe('Adf adapter', function () {
   let serverResponse, bidRequest, bidResponses;
   let bids = [];
+
+  describe('backwards-compatibility', function () {
+    it('should have adformOpenRTB alias defined', function () {
+      assert.equal(spec.aliases[0].code, 'adformOpenRTB');
+      assert.equal(spec.aliases[0].gvlid, 50);
+    });
+  });
 
   describe('isBidRequestValid', function () {
     let bid = {
@@ -567,7 +574,6 @@ describe('AdformOpenRTB adapter', function () {
       assert.deepEqual(bids[0].netRevenue, false);
       assert.deepEqual(bids[0].currency, serverResponse.body.cur);
       assert.deepEqual(bids[0].mediaType, 'native');
-      assert.deepEqual(bids[0].bidderCode, 'adformOpenRTB');
     });
     it('should set correct native params', function () {
       const bid = [


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Added prebid-server adapter https://github.com/prebid/prebid-server/pull/1815 . Changing the name to avoid targeting key collision.

- Team.FLS@adform.com
- [x] official adapter submission

- Docs: https://github.com/prebid/prebid.github.io/pull/2887

