### PR TITLE
appnexus bid adapter - add price floor module support

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -703,8 +703,9 @@ function bidToTag(bid) {
   tag.use_pmt_rule = bid.params.usePaymentRule || false
   tag.prebid = true;
   tag.disable_psa = true;
-  if (bid.params.reserve) {
-    tag.reserve = bid.params.reserve;
+  let bidFloor = getBidFloor(bid);
+  if (bidFloor) {
+    tag.reserve = bidFloor;
   }
   if (bid.params.position) {
     tag.position = { 'above': 1, 'below': 2 }[bid.params.position] || 0;
@@ -1034,6 +1035,23 @@ function addUserId(eids, id, source, rti) {
     }
   }
   return eids;
+}
+
+function getBidFloor(bid) {
+  if (!utils.isFn(bid.getFloor)) {
+    return (bid.params.reserve) ? bid.params.reserve : null;
+  }
+
+  let floor = bid.getFloor({
+    currency: 'USD',
+    mediaType: '*',
+    size: '*',
+    bidRequest: bid
+  });
+  if (utils.isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'USD') {
+    return floor.floor;
+  }
+  return null;
 }
 
 registerBidder(spec);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1045,8 +1045,7 @@ function getBidFloor(bid) {
   let floor = bid.getFloor({
     currency: 'USD',
     mediaType: '*',
-    size: '*',
-    bidRequest: bid
+    size: '*'
   });
   if (utils.isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'USD') {
     return floor.floor;

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -282,6 +282,36 @@ describe('AppNexusAdapter', function () {
       });
     });
 
+    it('should attach reserve param when either bid param or getFloor function exists', function () {
+      let getFloorResponse = { currency: 'USD', floor: 3 };
+      let request, payload = null;
+      let bidRequest = deepClone(bidRequests[0]);
+
+      // 1 -> reserve not defined, getFloor not defined > empty
+      request = spec.buildRequests([bidRequest]);
+      payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].reserve).to.not.exist;
+
+      // 2 -> reserve is defined, getFloor not defined > reserve is used
+      bidRequest.params = {
+        'placementId': '10433394',
+        'reserve': 0.5
+      };
+      request = spec.buildRequests([bidRequest]);
+      payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].reserve).to.exist.and.to.equal(0.5);
+
+      // 3 -> reserve is defined, getFloor is defined > getFloor is used
+      bidRequest.getFloor = () => getFloorResponse;
+
+      request = spec.buildRequests([bidRequest]);
+      payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].reserve).to.exist.and.to.equal(3);
+    });
+
     it('should duplicate adpod placements into batches and set correct maxduration', function() {
       let bidRequest = Object.assign({},
         bidRequests[0],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Related to #6465

This PR updates the appnexus bid adapter to use the priceFloors module.  

Specifically the logic between the module and the existing `reserve` param will wok as follows:
- if priceFloors module is defined and `reserve` is not, read the values and pass the matching floor price to ad server
- if priceFloors module is defined and `reserve` is defined, prefer the priceFloors module's value(s)
- if priceFloors module is not defined and `reserve` is defined, pass `reserve` value (as normal).