### PR TITLE
Rubicon Bid Adapter: Added new size - Id 558 (640x640)

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -105,7 +105,8 @@ var sizeMap = {
   288: '640x380',
   548: '500x1000',
   550: '980x480',
-  552: '300x200'
+  552: '300x200',
+  558: '640x640'
 };
 utils._each(sizeMap, (item, key) => sizeMap[item] = key);
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add new size 640x640 (ID: 558) in Rubicon Adapter