### PR TITLE
Appnexus bid adapter: ensure withCredentials is always passed

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -483,7 +483,10 @@ function hasPurpose1Consent(bidderRequest) {
 
 function formatRequest(payload, bidderRequest) {
   let request = [];
-  let options = {};
+  let options = {
+    withCredentials: true
+  };
+
   let endpointUrl = URL;
 
   if (!hasPurpose1Consent(bidderRequest)) {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -644,7 +644,7 @@ describe('AppNexusAdapter', function () {
       bidderRequest.bids = bidRequests;
 
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.options).to.be.empty;
+      expect(request.options).to.deep.equal({withCredentials: true});
       const payload = JSON.parse(request.data);
 
       expect(payload.gdpr_consent).to.exist;
@@ -794,6 +794,12 @@ describe('AppNexusAdapter', function () {
       expect(request.options.customHeaders).to.deep.equal({'X-Is-Test': 1});
 
       config.getConfig.restore();
+    });
+
+    it('should always set withCredentials: true on the request.options', function () {
+      let bidRequest = Object.assign({}, bidRequests[0]);
+      const request = spec.buildRequests([bidRequest]);
+      expect(request.options.withCredentials).to.equal(true);
     });
 
     it('should set simple domain variant if purpose 1 consent is not given', function () {


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
A minor update to ensure we always pass the `withCredentials: true` flag in the options param for our request object.

