### PR TITLE
Rubicon adapter: ortb2 data update to use segtax

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -974,11 +974,12 @@ function applyFPD(bidRequest, mediaType, data) {
 
   let fpd = utils.mergeDeep({}, config.getConfig('ortb2') || {}, BID_FPD);
   let impData = utils.deepAccess(bidRequest.ortb2Imp, 'ext.data') || {};
+  const SEGTAX = {user: [3], site: [1, 2]};
   const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
-  const validate = function(prop, key) {
+  const validate = function(prop, key, parentName) {
     if (key === 'data' && Array.isArray(prop)) {
-      return prop.filter(name => name.segment && utils.deepAccess(name, 'ext.taxonomyname') &&
-        utils.deepAccess(name, 'ext.taxonomyname').match(/iab/i)).map(value => {
+      return prop.filter(name => name.segment && utils.deepAccess(name, 'ext.segtax') && SEGTAX[parentName] &&
+        SEGTAX[parentName].indexOf(utils.deepAccess(name, 'ext.segtax')) !== -1).map(value => {
         let segments = value.segment.filter(obj => obj.id).reduce((result, obj) => {
           result.push(obj.id);
           return result;
@@ -996,7 +997,7 @@ function applyFPD(bidRequest, mediaType, data) {
     }
   };
   const addBannerData = function(obj, name, key, isParent = true) {
-    let val = validate(obj, key);
+    let val = validate(obj, key, name);
     let loc = (MAP[key] && isParent) ? `${MAP[key]}` : (key === 'data') ? `${MAP[name]}iab` : `${MAP[name]}${key}`;
     data[loc] = (data[loc]) ? data[loc].concat(',', val) : val;
   }
@@ -1014,7 +1015,9 @@ function applyFPD(bidRequest, mediaType, data) {
   if (mediaType === BANNER) {
     ['site', 'user'].forEach(name => {
       Object.keys(fpd[name]).forEach((key) => {
-        if (key !== 'ext') {
+        if (name === 'site' && key === 'content' && fpd[name][key].data) {
+          addBannerData(fpd[name][key].data, name, 'data');
+        } else if (key !== 'ext') {
           addBannerData(fpd[name][key], name, key);
         } else if (fpd[name][key].data) {
           Object.keys(fpd[name].ext.data).forEach((key) => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -846,12 +846,27 @@ describe('the rubicon adapter', function () {
                 data: {
                   page: 'home'
                 }
+              },
+              content: {
+                data: [{
+                  'name': 'www.dataprovider1.com',
+                  'ext': { 'segtax': 1 },
+                  'segment': [
+                    { 'id': '987' }
+                  ]
+                }, {
+                  'name': 'www.dataprovider1.com',
+                  'ext': { 'segtax': 2 },
+                  'segment': [
+                    { 'id': '432' }
+                  ]
+                }]
               }
             };
             const user = {
               data: [{
                 'name': 'www.dataprovider1.com',
-                'ext': { 'taxonomyname': 'IAB Audience Taxonomy' },
+                'ext': { 'segtax': 3 },
                 'segment': [
                   { 'id': '687' },
                   { 'id': '123' }
@@ -886,6 +901,7 @@ describe('the rubicon adapter', function () {
               'tg_v.gender': 'M',
               'tg_v.age': '40',
               'tg_v.iab': '687,123',
+              'tg_i.iab': '987,432',
               'tg_v.yob': '1984',
               'tg_i.rating': '4-star,5-star',
               'tg_i.page': 'home',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Update to move fpd data matching from taxonomyname to segtax values. Add iab value to banner requests as follows:
- user.data. if segtax=3, send the values as tg_v.iab=A,B,C
- site.content.data. If segtax in (1,2) then send the values as tg_i.iab=X,Y,Z

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
