### PR TITLE
Prebid Core: Display bidder in utils.logs and disable bidder config on auction end

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -411,8 +411,10 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
     bidRequest.start = timestamp();
     // TODO : Do we check for bid in pool from here and skip calling adapter again ?
     const adapter = _bidderRegistry[bidRequest.bidderCode];
-    utils.logMessage(`CALLING BIDDER ======= ${bidRequest.bidderCode}`);
-    events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
+    config.runWithBidder(bidRequest.bidderCode, () => {
+      utils.logMessage(`CALLING BIDDER`);
+      events.emit(CONSTANTS.EVENTS.BID_REQUESTED, bidRequest);
+    });
     let ajax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
       request: requestCallbacks.request.bind(null, bidRequest.bidderCode),
       done: requestCallbacks.done

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -197,8 +197,10 @@ export function newBidder(spec) {
       const responses = [];
       function afterAllResponses() {
         done();
-        events.emit(CONSTANTS.EVENTS.BIDDER_DONE, bidderRequest);
-        registerSyncs(responses, bidderRequest.gdprConsent, bidderRequest.uspConsent);
+        config.runWithBidder(spec.code, () => {
+          events.emit(CONSTANTS.EVENTS.BIDDER_DONE, bidderRequest);
+          registerSyncs(responses, bidderRequest.gdprConsent, bidderRequest.uspConsent);
+        });
       }
 
       const validBidRequests = bidderRequest.bids.filter(filterAndWarn);

--- a/src/auction.js
+++ b/src/auction.js
@@ -197,6 +197,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   }
 
   function auctionDone() {
+    config.resetBidder();
     // when all bidders have called done callback atleast once it means auction is complete
     utils.logInfo(`Bids Received for Auction with id: ${_auctionId}`, _bidsReceived);
     _auctionStatus = AUCTION_COMPLETED;

--- a/src/config.js
+++ b/src/config.js
@@ -595,7 +595,7 @@ export function newConfig() {
     try {
       return fn();
     } finally {
-      currBidder = null;
+      resetBidder();
     }
   }
   function callbackWithBidder(bidder) {
@@ -614,10 +614,15 @@ export function newConfig() {
     return currBidder;
   }
 
+  function resetBidder() {
+    currBidder = null;
+  }
+
   resetConfig();
 
   return {
     getCurrentBidder,
+    resetBidder,
     getConfig,
     setConfig,
     setDefaults,

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,10 +276,19 @@ export function logError() {
 
 function decorateLog(args, prefix) {
   args = [].slice.call(args);
+  let bidder = config.getCurrentBidder();
+
   prefix && args.unshift(prefix);
-  args.unshift('display: inline-block; color: #fff; background: #3b88c3; padding: 1px 4px; border-radius: 3px;');
-  args.unshift('%cPrebid');
+  if (bidder) {
+    args.unshift(label('#aaa'));
+  }
+  args.unshift(label('#3b88c3'));
+  args.unshift('%cPrebid' + (bidder ? `%c${bidder}` : ''));
   return args;
+
+  function label(color) {
+    return `display: inline-block; color: #fff; background: ${color}; padding: 1px 4px; border-radius: 3px;`
+  }
 }
 
 export function hasConsoleLogger() {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature

## Description of change
As discussed in Prebid.js PMC meeting, this adds bidder logging to `utils.logMessage`, `utils.logWarn`, `utils.logError`, `utils.logInfo` when a bidder has been set using `config.runWithBidder` (which includes all the functions that run as part of a bidder spec).  This adds bidder labels to various relevant areas as shown below:

![Capture](https://user-images.githubusercontent.com/551085/116759802-779cf980-a9d0-11eb-8447-5f13021dfa07.PNG)

Also fixed a small potential surface area for bugs by clearing the bidder once bidders are done bidding. Currently the last bidder would still be set as the active bidder while prebid core was running code to finish the auction. This is due to the last bidder triggering the auction end code in the same call stack as its ajax response handler (which I think we want to keep for performance reasons).
