### PR TITLE
Dev Devendencies: Update webpack to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "through2": "^2.0.3",
     "url-parse": "^1.0.5",
     "webdriverio": "^6.1.5",
-    "webpack": "^3.0.0",
+    "webpack": "^4.0.0",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-stream": "^3.2.0",
     "yargs": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/prebid.js",
   "scripts": {
     "test": "gulp test",
-    "lint": "gulp lint"
+    "lint": "gulp lint",
+    "build": "webpack"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "gulp test",
     "lint": "gulp lint",
-    "build": "webpack"
+    "build": "webpack --config webpack.conf.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "url-parse": "^1.0.5",
     "webdriverio": "^6.1.5",
     "webpack": "^4.0.0",
+    "webpack-cli": "^3.3.12",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-stream": "^3.2.0",
     "yargs": "^1.3.1"


### PR DESCRIPTION
Updating webpack to v4.0.0, add webpack-cli,  update build script, and fix whatever breaks. Appears the key issue is the SplitChunksPlugin we use is no longer supported in this verison. Docs to use optimization.splitChunks instead -> https://webpack.js.org/plugins/split-chunks-plugin/