### PR TITLE
appnexus bid adapter 5.0 - video params updates

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -13,6 +13,7 @@ const BIDDER_CODE = 'appnexus';
 const URL = 'https://ib.adnxs.com/ut/v3/prebid';
 const VIDEO_TARGETING = ['id', 'minduration', 'maxduration',
   'skippable', 'playback_method', 'frameworks', 'context', 'skipoffset'];
+const VIDEO_RTB_TARGETING = ['minduration', 'maxduration', 'skip', 'skipafter', 'playbackmethod', 'api'];
 const USER_PARAMS = ['age', 'externalUid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
 const DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout'];
@@ -792,6 +793,51 @@ function bidToTag(bid) {
     if (bid.params.video.frameworks && utils.isArray(bid.params.video.frameworks)) {
       tag['video_frameworks'] = bid.params.video.frameworks;
     }
+  }
+
+  // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
+  if (videoMediaType) {
+    tag.video = tag.video || {};
+    Object.keys(videoMediaType)
+      .filter(param => includes(VIDEO_RTB_TARGETING, param))
+      .forEach(param => {
+        switch (param) {
+          case 'minduration':
+          case 'maxduration':
+            if (typeof tag.video[param] !== 'number') tag.video[param] = videoMediaType[param];
+            break;
+          case 'skip':
+            if (typeof tag.video['skippable'] !== 'boolean') tag.video['skippable'] = (videoMediaType[param] === 1);
+            break;
+          case 'skipafter':
+            if (typeof tag.video['skipoffset'] !== 'number') tag.video['skippoffset'] = videoMediaType[param];
+            break;
+          case 'playbackmethod':
+            if (typeof tag.video['playback_method'] !== 'number') {
+              let type = videoMediaType[param];
+              type = (utils.isArray(type)) ? type[0] : type;
+
+              // we only support iab's options 1-4 at this time.
+              if (type >= 1 && type <= 4) {
+                tag.video['playback_method'] = type;
+              }
+            }
+            break;
+          case 'api':
+            if (!tag['video_frameworks'] && utils.isArray(videoMediaType[param])) {
+              // need to read thru array; remove 6 (we don't support it), swap 4 <> 5 if found (to match our adserver mapping for these specific values)
+              let apiTmp = videoMediaType[param].map(val => {
+                let v = (val === 4) ? 5 : (val === 5) ? 4 : val;
+
+                if (v >= 1 && v <= 5) {
+                  return v;
+                }
+              }).filter(v => v);
+              tag['video_frameworks'] = apiTmp;
+            }
+            break;
+        }
+      });
   }
 
   if (bid.renderer) {

--- a/modules/appnexusBidAdapter.md
+++ b/modules/appnexusBidAdapter.md
@@ -90,12 +90,14 @@ var adUnits = [
        video: {
          playerSize: [[300, 250]],
          context: 'outstream',
-         // certain ORTB 2.5 video values can be read from the mediatypes object; below are examples of supported params
-         // to note - appnexus supports additional values for our system that are not part of the ORTB spec.  If you want
+         // Certain ORTB 2.5 video values can be read from the mediatypes object; below are examples of supported params.
+         // To note - appnexus supports additional values for our system that are not part of the ORTB spec.  If you want
          // to use these values, they will have to be declared in the bids[].params.video object instead using the appnexus syntax.
+         // Between the corresponding values of the mediaTypes.video and params.video objects, the properties in params.video will 
+         // take precedence if declared; eg in the example below, the `skippable: true` setting will be used instead of the `skip: 0`.
          minduration: 1,
          maxduration: 60,
-         skip: 1,   // 1 - true, 0 - false
+         skip: 0,   // 1 - true, 0 - false
          skipafter: 5,
          playbackmethod: [2], // note - we only support options 1-4 at this time
          api: [1,2,3]   // note - option 6 is not supported at this time

--- a/modules/appnexusBidAdapter.md
+++ b/modules/appnexusBidAdapter.md
@@ -89,7 +89,16 @@ var adUnits = [
      mediaTypes: {
        video: {
          playerSize: [[300, 250]],
-         context: 'outstream'
+         context: 'outstream',
+         // certain ORTB 2.5 video values can be read from the mediatypes object; below are examples of supported params
+         // to note - appnexus supports additional values for our system that are not part of the ORTB spec.  If you want
+         // to use these values, they will have to be declared in the bids[].params.video object instead using the appnexus syntax.
+         minduration: 1,
+         maxduration: 60,
+         skip: 1,   // 1 - true, 0 - false
+         skipafter: 5,
+         playbackmethod: [2], // note - we only support options 1-4 at this time
+         api: [1,2,3]   // note - option 6 is not supported at this time
        }
      },
      bids: [

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -215,6 +215,40 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].hb_source).to.deep.equal(1);
     });
 
+    it('should include ORTB video values when video params were not set', function() {
+      let bidRequest = deepClone(bidRequests[0]);
+      bidRequest.params = {
+        placementId: '1234235',
+        video: {
+          skippable: true,
+          playback_method: ['auto_play_sound_off', 'auto_play_sound_unknown'],
+          context: 'outstream'
+        }
+      };
+      bidRequest.mediaTypes = {
+        video: {
+          playerSize: [640, 480],
+          context: 'outstream',
+          mimes: ['video/mp4'],
+          skip: 0,
+          minduration: 5,
+          api: [1, 5, 6],
+          playbackmethod: [2, 4]
+        }
+      };
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].video).to.deep.equal({
+        minduration: 5,
+        playback_method: 2,
+        skippable: true,
+        context: 4
+      });
+      expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
+    });
+
     it('should add video property when adUnit includes a renderer', function () {
       const videoData = {
         mediaTypes: {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
Related to https://github.com/prebid/Prebid.js/issues/6512

This change updates the appnexus bidder to read more from the `mediaTypes.video` params.  

It supports specific ORTB 2.5 video params that are closely aligned to video properties we currently support.  As discussed in the linked ticket, due to a number of unique values that are available/used by our ad-server but that are not supported by the ORTB spec - the `bids.params.video` are still read and would be preferred (if present) over the mediaType values.