### PR TITLE
Prebid Core: Fix linting in Gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,12 +170,12 @@ function makeWebpackPkg() {
     .pipe(webpackStream(cloned, webpack))
     .pipe(uglify())
     .pipe(replace(/('|")v\$prebid\.modulesList\$('|")/g, makeModuleList(externalModules)))
-    .pipe(gulpif(file => file.basename === 'prebid-core.js', header(banner, { prebid: prebid})))
+    .pipe(gulpif(file => file.basename === 'prebid-core.js', header(banner, { prebid: prebid })))
     .pipe(gulp.dest('build/dist'));
 }
 
-function getModulesListToAddInBanner(modules){
-  return (modules.length > 0) ? modules.join(', ') :  'All available modules in current version.';
+function getModulesListToAddInBanner(modules) {
+  return (modules.length > 0) ? modules.join(', ') : 'All available modules in current version.';
 }
 
 function gulpBundle(dev) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Fix linting in Gulpfile:
* eslint(standard/object-curly-even-spacing)
* eslint(space-before-blocks)
* eslint(no-multi-spaces)
