### PR TITLE
Adagio Bid Adapter: decrease adapter weight

### DIFF
--- a/allowedModules.js
+++ b/allowedModules.js
@@ -12,7 +12,6 @@ module.exports = {
   'modules': [
     ...sharedWhiteList,
     'criteo-direct-rsa-validate',
-    'jsencrypt',
     'crypto-js',
     'live-connect' // Maintained by LiveIntent : https://github.com/liveintent-berlin/live-connect/
   ],

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -3,33 +3,27 @@ import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { loadExternalScript } from '../src/adloader.js';
-import JSEncrypt from 'jsencrypt/bin/jsencrypt.js';
-import sha256 from 'crypto-js/sha256.js';
+import { verify } from 'criteo-direct-rsa-validate/build/verify.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { createEidsArray } from './userId/eids.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import { OUTSTREAM } from '../src/video.js';
-
-export const BIDDER_CODE = 'adagio';
-export const LOG_PREFIX = 'Adagio:';
-export const VERSION = '2.10.0';
-export const FEATURES_VERSION = '1';
+const BIDDER_CODE = 'adagio';
+const LOG_PREFIX = 'Adagio:';
+export const VERSION = '2.11.0';
+const FEATURES_VERSION = '1';
 export const ENDPOINT = 'https://mp.4dex.io/prebid';
-export const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
-export const ADAGIO_TAG_URL = 'https://script.4dex.io/localstore.js';
-export const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
-export const GVLID = 617;
+const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
+const ADAGIO_TAG_URL = 'https://script.4dex.io/localstore.js';
+const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
+const GVLID = 617;
 export const storage = getStorageManager(GVLID, 'adagio');
 export const RENDERER_URL = 'https://script.4dex.io/outstream-player.js';
-export const MAX_SESS_DURATION = 30 * 60 * 1000;
-export const ADAGIO_PUBKEY = `-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC9el0+OEn6fvEh1RdVHQu4cnT0
-jFSzIbGJJyg3cKqvtE6A0iaz9PkIdJIvSSSNrmJv+lRGKPEyRA/VnzJIieL39Ngl
-t0b0lsHN+W4n9kitS/DZ/xnxWK/9vxhv0ZtL1LL/rwR5Mup7rmJbNtDoNBw4TIGj
-pV6EP3MTLosuUEpLaQIDAQAB
------END PUBLIC KEY-----`;
+const MAX_SESS_DURATION = 30 * 60 * 1000;
+const ADAGIO_PUBKEY = 'AL16XT44Sfp+8SHVF1UdC7hydPSMVLMhsYknKDdwqq+0ToDSJrP0+Qh0ki9JJI2uYm/6VEYo8TJED9WfMkiJ4vf02CW3RvSWwc35bif2SK1L8Nn/GfFYr/2/GG/Rm0vUsv+vBHky6nuuYls20Og0HDhMgaOlXoQ/cxMuiy5QSktp';
+const ADAGIO_PUBKEY_E = 65537;
 
 // This provide a whitelist and a basic validation
 // of OpenRTB 2.5 options used by the Adagio SSP.
@@ -81,10 +75,7 @@ export function adagioScriptFromLocalStorageCb(ls) {
       const hash = r[2];
       const content = r[3];
 
-      var jsEncrypt = new JSEncrypt();
-      jsEncrypt.setPublicKey(ADAGIO_PUBKEY);
-
-      if (jsEncrypt.verify(content, hash, sha256)) {
+      if (verify(content, hash, ADAGIO_PUBKEY, ADAGIO_PUBKEY_E)) {
         utils.logInfo(`${LOG_PREFIX} start script.`);
         Function(ls)(); // eslint-disable-line no-new-func
       } else {
@@ -524,19 +515,8 @@ function autoDetectAdUnitElementId(adUnitCode) {
 
 function autoDetectEnvironment() {
   const device = _features.getDevice();
-  let environment;
-  switch (device) {
-    case 2:
-      environment = 'desktop';
-      break;
-    case 4:
-      environment = 'mobile';
-      break;
-    case 5:
-      environment = 'tablet';
-      break;
-  };
-  return environment;
+  const map = { 2: 'desktop', 4: 'mobile', 5: 'tablet' };
+  return map[device] || 'unknown';
 };
 
 function supportIObs() {
@@ -653,25 +633,12 @@ function _getGdprConsent(bidderRequest) {
     allowAuctionWithoutConsent
   } = bidderRequest.gdprConsent;
 
-  const consent = {};
-
-  if (apiVersion !== undefined) {
-    consent.apiVersion = apiVersion;
-  }
-
-  if (consentString !== undefined) {
-    consent.consentString = consentString;
-  }
-
-  if (gdprApplies !== undefined) {
-    consent.consentRequired = (gdprApplies) ? 1 : 0;
-  }
-
-  if (allowAuctionWithoutConsent !== undefined) {
-    consent.allowAuctionWithoutConsent = allowAuctionWithoutConsent ? 1 : 0;
-  }
-
-  return consent;
+  return utils.cleanObj({
+    apiVersion,
+    consentString,
+    consentRequired: gdprApplies ? 1 : 0,
+    allowAuctionWithoutConsent: allowAuctionWithoutConsent ? 1 : 0
+  });
 }
 
 function _getCoppa() {
@@ -685,9 +652,7 @@ function _getUspConsent(bidderRequest) {
 }
 
 function _getSchain(bidRequest) {
-  if (utils.deepAccess(bidRequest, 'schain')) {
-    return bidRequest.schain;
-  }
+  return utils.deepAccess(bidRequest, 'schain');
 }
 
 function _getEids(bidRequest) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15084,11 +15084,6 @@
         }
       }
     },
-    "jsencrypt": {
-      "version": "3.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/jsencrypt/-/jsencrypt-3.0.0-rc.1.tgz",
-      "integrity": "sha512-gcvGaqerlUJy1Kq6tNgPYteVEoWNemu+9hBe2CdsCIz4rVcwjoTQ72iD1W76/PRMlnkzG0yVh7nwOOMOOUfKmg=="
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "dset": "2.0.1",
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
-    "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2",
     "live-connect-js": "2.0.0"
   }

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -579,6 +579,7 @@ describe('Adagio bid adapter', () => {
 
           const expected = {
             consentString,
+            allowAuctionWithoutConsent: 0,
             consentRequired: 1,
             apiVersion: 2
           };
@@ -615,6 +616,7 @@ describe('Adagio bid adapter', () => {
           const expected = {
             consentString,
             consentRequired: 0,
+            allowAuctionWithoutConsent: 0,
             apiVersion: 2
           };
 


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This PR is about to switch the library used for RSA decryption in the adagioBidAdapter to the Criteo authored one (criteo-direct-rsa-validate). This change decreased by 62% the weight of the bidder. Thanks to them!

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

## Other information
Note for Prebid Core members:
The jsencrypt library (registred in [package.json](https://github.com/prebid/Prebid.js/blob/master/package.json) and [allowedModules.js](https://github.com/prebid/Prebid.js/blob/master/allowedModules.js)) is no more used by any adapters or core modules and can be removed. Please let me know if you want to remove it.
