### PR TITLE
Prebid Analytics Manager Analytics Adapter: Remove utm from local storage test from _spec file

### DIFF
--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -104,40 +104,6 @@ describe('Prebid Manager Analytics Adapter', function () {
     });
   });
 
-  describe('build utm tag data', function () {
-    beforeEach(function () {
-      localStorage.setItem('pm_utm_source', 'utm_source');
-      localStorage.setItem('pm_utm_medium', 'utm_medium');
-      localStorage.setItem('pm_utm_campaign', 'utm_camp');
-      localStorage.setItem('pm_utm_term', '');
-      localStorage.setItem('pm_utm_content', '');
-    });
-    afterEach(function () {
-      localStorage.removeItem('pm_utm_source');
-      localStorage.removeItem('pm_utm_medium');
-      localStorage.removeItem('pm_utm_campaign');
-      localStorage.removeItem('pm_utm_term');
-      localStorage.removeItem('pm_utm_content');
-      prebidmanagerAnalytics.disableAnalytics()
-    });
-    it('should build utm data from local storage', function () {
-      prebidmanagerAnalytics.enableAnalytics({
-        provider: 'prebidmanager',
-        options: {
-          bundleId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-        }
-      });
-
-      const pmEvents = JSON.parse(server.requests[0].requestBody.substring(2));
-
-      expect(pmEvents.utmTags.utm_source).to.equal('utm_source');
-      expect(pmEvents.utmTags.utm_medium).to.equal('utm_medium');
-      expect(pmEvents.utmTags.utm_campaign).to.equal('utm_camp');
-      expect(pmEvents.utmTags.utm_term).to.equal('');
-      expect(pmEvents.utmTags.utm_content).to.equal('');
-    });
-  });
-
   describe('build page info', function () {
     afterEach(function () {
       prebidmanagerAnalytics.disableAnalytics()


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
Removal of nondeterministic test

## Other information
This test is far and away the most likely to fail at random in circleci for IE11. I propose adapter maintainer reconsider the test. 