### PR TITLE
Fixing flaky adapter unit tests

### DIFF
--- a/modules/prebidmanagerAnalyticsAdapter.js
+++ b/modules/prebidmanagerAnalyticsAdapter.js
@@ -1,10 +1,12 @@
 import {ajaxBuilder} from '../src/ajax.js';
 import adapter from '../src/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 /**
  * prebidmanagerAnalyticsAdapter.js - analytics adapter for prebidmanager
  */
+export const storage = getStorageManager(undefined, 'prebidmanager');
 const DEFAULT_EVENT_URL = 'https://endpoint.prebidmanager.com/endpoint'
 const analyticsType = 'endpoint';
 const analyticsName = 'Prebid Manager Analytics: ';
@@ -82,14 +84,14 @@ function collectUtmTagData() {
     });
     if (newUtm === false) {
       utmTags.forEach(function (utmKey) {
-        let itemValue = localStorage.getItem(`pm_${utmKey}`);
+        let itemValue = storage.getDataFromLocalStorage(`pm_${utmKey}`);
         if (itemValue && itemValue.length !== 0) {
           pmUtmTags[utmKey] = itemValue;
         }
       });
     } else {
       utmTags.forEach(function (utmKey) {
-        localStorage.setItem(`pm_${utmKey}`, pmUtmTags[utmKey]);
+        storage.setDataInLocalStorage(`pm_${utmKey}`, pmUtmTags[utmKey]);
       });
     }
   } catch (e) {

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
+import strIncludes from 'core-js-pure/features/string/includes.js';
 
 const BIDDER_CODE = 'sspBC';
 const BIDDER_URL = 'https://ssp.wp.pl/bidder/';
@@ -339,7 +340,7 @@ const spec = {
             site.slot = slotid || site.slot;
           }
 
-          if (bidRequest && site.id && !site.id.includes('bidid')) {
+          if (bidRequest && site.id && !strIncludes(site.id, 'bidid')) {
             // found a matching request; add this bid
 
             // store site data for future notification

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -455,7 +455,7 @@ function getCombinedSubmoduleIdsForBidder(submodules, bidder) {
     return {};
   }
   return submodules
-    .filter(i => !i.config.bidders || !utils.isArray(i.config.bidders) || includes(i.config.bidders.includes, bidder))
+    .filter(i => !i.config.bidders || !utils.isArray(i.config.bidders) || includes(i.config.bidders, bidder))
     .filter(i => utils.isPlainObject(i.idObj) && Object.keys(i.idObj).length)
     .reduce((carry, i) => {
       Object.keys(i.idObj).forEach(key => {

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -141,6 +141,7 @@ import { module, hook } from '../../src/hook.js';
 import { createEidsArray, buildEidPermissions } from './eids.js';
 import { getCoreStorageManager } from '../../src/storageManager.js';
 import {getPrebidInternal} from '../../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const MODULE_NAME = 'User ID';
 const COOKIE = 'cookie';
@@ -454,7 +455,7 @@ function getCombinedSubmoduleIdsForBidder(submodules, bidder) {
     return {};
   }
   return submodules
-    .filter(i => !i.config.bidders || !utils.isArray(i.config.bidders) || i.config.bidders.includes(bidder))
+    .filter(i => !i.config.bidders || !utils.isArray(i.config.bidders) || includes(i.config.bidders.includes, bidder))
     .filter(i => utils.isPlainObject(i.idObj) && Object.keys(i.idObj).length)
     .reduce((carry, i) => {
       Object.keys(i.idObj).forEach(key => {

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -3,6 +3,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
 import includes from 'core-js-pure/features/array/includes';
+import find from 'core-js-pure/features/array/find.js';
 
 const BIDDER_CODE = 'yieldmo';
 const CURRENCY = 'USD';
@@ -223,7 +224,7 @@ function createNewBannerBid(response) {
  * @param bidRequest server request
  */
 function createNewVideoBid(response, bidRequest) {
-  const imp = (utils.deepAccess(bidRequest, 'data.imp') || []).find(imp => imp.id === response.impid);
+  const imp = find((utils.deepAccess(bidRequest, 'data.imp') || []), imp => imp.id === response.impid);
 
   let result = {
     requestId: imp.id,

--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -1,4 +1,6 @@
-import prebidmanagerAnalytics from 'modules/prebidmanagerAnalyticsAdapter.js';
+import prebidmanagerAnalytics, {
+  storage
+} from 'modules/prebidmanagerAnalyticsAdapter.js';
 import {expect} from 'chai';
 import {server} from 'test/mocks/xhr.js';
 import * as utils from 'src/utils.js';
@@ -105,19 +107,18 @@ describe('Prebid Manager Analytics Adapter', function () {
   });
 
   describe('build utm tag data', function () {
+    let getDataFromLocalStorageStub;
     beforeEach(function () {
-      localStorage.setItem('pm_utm_source', 'utm_source');
-      localStorage.setItem('pm_utm_medium', 'utm_medium');
-      localStorage.setItem('pm_utm_campaign', 'utm_camp');
-      localStorage.setItem('pm_utm_term', '');
-      localStorage.setItem('pm_utm_content', '');
+      getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+      getDataFromLocalStorageStub.withArgs('pm_utm_source').returns('utm_source');
+      getDataFromLocalStorageStub.withArgs('pm_utm_medium').returns('utm_medium');
+      getDataFromLocalStorageStub.withArgs('pm_utm_campaign').returns('utm_camp');
+      getDataFromLocalStorageStub.withArgs('pm_utm_term').returns('');
+      getDataFromLocalStorageStub.withArgs('pm_utm_content').returns('');
+      getDataFromLocalStorageStub.withArgs('pm_utm_source').returns('utm_source');
     });
     afterEach(function () {
-      localStorage.removeItem('pm_utm_source');
-      localStorage.removeItem('pm_utm_medium');
-      localStorage.removeItem('pm_utm_campaign');
-      localStorage.removeItem('pm_utm_term');
-      localStorage.removeItem('pm_utm_content');
+      getDataFromLocalStorageStub.restore();
       prebidmanagerAnalytics.disableAnalytics()
     });
     it('should build utm data from local storage', function () {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -169,16 +169,20 @@ const setUserAgent = (uaString) => {
 };
 
 describe('sharethrough internal spec', function() {
-  let windowSpy, windowTopSpy;
-
+  let windowStub, windowTopStub;
+  let stubbedReturn = [{
+    appendChild: () => undefined
+  }]
   beforeEach(function() {
-    windowSpy = sinon.spy(window.document, 'getElementsByTagName');
-    windowTopSpy = sinon.spy(window.top.document, 'getElementsByTagName');
+    windowStub = sinon.stub(window.document, 'getElementsByTagName');
+    windowTopStub = sinon.stub(window.top.document, 'getElementsByTagName');
+    windowStub.withArgs('body').returns(stubbedReturn);
+    windowTopStub.withArgs('body').returns(stubbedReturn);
   });
 
   afterEach(function() {
-    windowSpy.restore();
-    windowTopSpy.restore();
+    windowStub.restore();
+    windowTopStub.restore();
     window.STR = undefined;
     window.top.STR = undefined;
   });
@@ -194,29 +198,29 @@ describe('sharethrough internal spec', function() {
 
     it('appends sfp.js to the safeframe', function() {
       sharethroughInternal.handleIframe();
-      expect(windowSpy.calledOnce).to.be.true;
+      expect(windowStub.calledOnce).to.be.true;
     });
 
     it('does not append anything if sfp.js is already loaded in the safeframe', function() {
       window.STR = { Tag: true };
       sharethroughInternal.handleIframe();
-      expect(windowSpy.notCalled).to.be.true;
-      expect(windowTopSpy.notCalled).to.be.true;
+      expect(windowStub.notCalled).to.be.true;
+      expect(windowTopStub.notCalled).to.be.true;
     });
   });
 
   describe('we are able to bust out of the iframe', function() {
     it('appends sfp.js to window.top', function() {
       sharethroughInternal.handleIframe();
-      expect(windowSpy.calledOnce).to.be.true;
-      expect(windowTopSpy.calledOnce).to.be.true;
+      expect(windowStub.calledOnce).to.be.true;
+      expect(windowTopStub.calledOnce).to.be.true;
     });
 
     it('only appends sfp-set-targeting.js if sfp.js is already loaded on the page', function() {
       window.top.STR = { Tag: true };
       sharethroughInternal.handleIframe();
-      expect(windowSpy.calledOnce).to.be.true;
-      expect(windowTopSpy.notCalled).to.be.true;
+      expect(windowStub.calledOnce).to.be.true;
+      expect(windowTopStub.notCalled).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [X] Bugfix
Several Adapters were using Array Includes and Find which is not supported in IE. So tests were failing.

prebidManager adapter directly accessed localStorage, which is not allowed technically, and also is flaky.

Another adapter directly manipulates the DOM and appends child scripts. Which we certainly do not want to do for tests.

There are other adapters not in this PR which probably do this as well, but to keep this one relatively down, at least we have it somewhat passing. 

Still, there are fixes to be had, we get random jest timeouts at times.

## Description of change