### PR TITLE
Prebid Core: Check for stale rendering

### DIFF
--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -15,6 +15,8 @@
  * @property {function(): Object} createAuction - creates auction instance and stores it for future reference
  * @property {function(): Object} findBidByAdId - find bid received by adId. This function will be called by $$PREBID_GLOBAL$$.renderAd
  * @property {function(): Object} getStandardBidderAdServerTargeting - returns standard bidder targeting for all the adapters. Refer http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings for more details
+ * @property {function(Object): void} addWinningBid - add a winning bid to an auction based on auctionId
+ * @property {function(): void} clearAllAuctions - clear all auctions for testing
  */
 
 import { uniques, flatten, logWarn } from './utils.js';
@@ -112,6 +114,10 @@ export function newAuctionManager() {
   auctionManager.getLastAuctionId = function() {
     return _auctions.length && _auctions[_auctions.length - 1].getAuctionId()
   };
+
+  auctionManager.clearAllAuctions = function() {
+    _auctions.length = 0;
+  }
 
   function _addAuction(auction) {
     _auctions.push(auction);

--- a/src/config.js
+++ b/src/config.js
@@ -278,7 +278,7 @@ export function newConfig() {
             return false
           }
         } else if (k === 'suppressStaleRender') {
-          if (typeof val[k] !== 'boolean') {
+          if (!utils.isBoolean(val[k])) {
             utils.logWarn(`Auction Options ${k} must be of type boolean`);
             return false;
           }

--- a/src/config.js
+++ b/src/config.js
@@ -265,7 +265,7 @@ export function newConfig() {
       }
 
       for (let k of Object.keys(val)) {
-        if (k !== 'secondaryBidders') {
+        if (k !== 'secondaryBidders' && k !== 'suppressStaleRender') {
           utils.logWarn(`Auction Options given an incorrect param: ${k}`)
           return false
         }
@@ -276,6 +276,11 @@ export function newConfig() {
           } else if (!val[k].every(utils.isStr)) {
             utils.logWarn(`Auction Options ${k} must be only string`);
             return false
+          }
+        } else if (k === 'suppressStaleRender') {
+          if (typeof val[k] !== 'boolean') {
+            utils.logWarn(`Auction Options ${k} must be of type boolean`);
+            return false;
           }
         }
       }

--- a/src/constants.json
+++ b/src/constants.json
@@ -39,7 +39,8 @@
     "AD_RENDER_FAILED": "adRenderFailed",
     "TCF2_ENFORCEMENT": "tcf2Enforcement",
     "AUCTION_DEBUG": "auctionDebug",
-    "BID_VIEWABLE": "bidViewable"
+    "BID_VIEWABLE": "bidViewable",
+    "STALE_RENDER": "staleRender"
   },
   "AD_RENDER_FAILED_REASON" : {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocument",

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -23,7 +23,7 @@ const events = require('./events.js');
 const { triggerUserSyncs } = userSync;
 
 /* private variables */
-const { ADD_AD_UNITS, BID_WON, REQUEST_BIDS, SET_TARGETING, AD_RENDER_FAILED } = CONSTANTS.EVENTS;
+const { ADD_AD_UNITS, BID_WON, REQUEST_BIDS, SET_TARGETING, AD_RENDER_FAILED, STALE_RENDER } = CONSTANTS.EVENTS;
 const { PREVENT_WRITING_ON_MAIN_DOCUMENT, NO_AD, EXCEPTION, CANNOT_FIND_AD, MISSING_DOC_OR_ADID } = CONSTANTS.AD_RENDER_FAILED_REASON;
 
 const eventValidators = {
@@ -390,63 +390,75 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id, options) {
     try {
       // lookup ad by ad Id
       const bid = auctionManager.findBidByAdId(id);
-      if (bid) {
-        // replace macros according to openRTB with price paid = bid.cpm
-        bid.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);
-        bid.adUrl = utils.replaceAuctionPrice(bid.adUrl, bid.cpm);
 
-        // replacing clickthrough if submitted
-        if (options && options.clickThrough) {
-          const { clickThrough } = options;
-          bid.ad = utils.replaceClickThrough(bid.ad, clickThrough);
-          bid.adUrl = utils.replaceClickThrough(bid.adUrl, clickThrough);
+      if (bid) {
+        let shouldRender = true;
+        if (bid && bid.status === CONSTANTS.BID_STATUS.RENDERED) {
+          utils.logWarn(`Ad id ${bid.adId} has been rendered before`);
+          events.emit(STALE_RENDER, bid);
+          if (utils.deepAccess(config.getConfig('auctionOptions'), 'suppressStaleRender')) {
+            shouldRender = false;
+          }
         }
 
-        // save winning bids
-        auctionManager.addWinningBid(bid);
+        if (shouldRender) {
+          // replace macros according to openRTB with price paid = bid.cpm
+          bid.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);
+          bid.adUrl = utils.replaceAuctionPrice(bid.adUrl, bid.cpm);
 
-        // emit 'bid won' event here
-        events.emit(BID_WON, bid);
-
-        const { height, width, ad, mediaType, adUrl, renderer } = bid;
-
-        const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
-        utils.insertElement(creativeComment, doc, 'body');
-
-        if (isRendererRequired(renderer)) {
-          executeRenderer(renderer, bid);
-        } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
-          const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
-          emitAdRenderFail({ reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id });
-        } else if (ad) {
-          // will check if browser is firefox and below version 67, if so execute special doc.open()
-          // for details see: https://github.com/prebid/Prebid.js/pull/3524
-          // TODO remove this browser specific code at later date (when Firefox < 67 usage is mostly gone)
-          if (navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox/') > -1) {
-            const firefoxVerRegx = /firefox\/([\d\.]+)/;
-            let firefoxVer = navigator.userAgent.toLowerCase().match(firefoxVerRegx)[1]; // grabs the text in the 1st matching group
-            if (firefoxVer && parseInt(firefoxVer, 10) < 67) {
-              doc.open('text/html', 'replace');
-            }
+          // replacing clickthrough if submitted
+          if (options && options.clickThrough) {
+            const {clickThrough} = options;
+            bid.ad = utils.replaceClickThrough(bid.ad, clickThrough);
+            bid.adUrl = utils.replaceClickThrough(bid.adUrl, clickThrough);
           }
-          doc.write(ad);
-          doc.close();
-          setRenderSize(doc, width, height);
-          utils.callBurl(bid);
-        } else if (adUrl) {
-          const iframe = utils.createInvisibleIframe();
-          iframe.height = height;
-          iframe.width = width;
-          iframe.style.display = 'inline';
-          iframe.style.overflow = 'hidden';
-          iframe.src = adUrl;
 
-          utils.insertElement(iframe, doc, 'body');
-          setRenderSize(doc, width, height);
-          utils.callBurl(bid);
-        } else {
-          const message = `Error trying to write ad. No ad for bid response id: ${id}`;
-          emitAdRenderFail({ reason: NO_AD, message, bid, id });
+          // save winning bids
+          auctionManager.addWinningBid(bid);
+
+          // emit 'bid won' event here
+          events.emit(BID_WON, bid);
+
+          const {height, width, ad, mediaType, adUrl, renderer} = bid;
+
+          const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
+          utils.insertElement(creativeComment, doc, 'body');
+
+          if (isRendererRequired(renderer)) {
+            executeRenderer(renderer, bid);
+          } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
+            const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
+            emitAdRenderFail({reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id});
+          } else if (ad) {
+            // will check if browser is firefox and below version 67, if so execute special doc.open()
+            // for details see: https://github.com/prebid/Prebid.js/pull/3524
+            // TODO remove this browser specific code at later date (when Firefox < 67 usage is mostly gone)
+            if (navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox/') > -1) {
+              const firefoxVerRegx = /firefox\/([\d\.]+)/;
+              let firefoxVer = navigator.userAgent.toLowerCase().match(firefoxVerRegx)[1]; // grabs the text in the 1st matching group
+              if (firefoxVer && parseInt(firefoxVer, 10) < 67) {
+                doc.open('text/html', 'replace');
+              }
+            }
+            doc.write(ad);
+            doc.close();
+            setRenderSize(doc, width, height);
+            utils.callBurl(bid);
+          } else if (adUrl) {
+            const iframe = utils.createInvisibleIframe();
+            iframe.height = height;
+            iframe.width = width;
+            iframe.style.display = 'inline';
+            iframe.style.overflow = 'hidden';
+            iframe.src = adUrl;
+
+            utils.insertElement(iframe, doc, 'body');
+            setRenderSize(doc, width, height);
+            utils.callBurl(bid);
+          } else {
+            const message = `Error trying to write ad. No ad for bid response id: ${id}`;
+            emitAdRenderFail({reason: NO_AD, message, bid, id});
+          }
         }
       } else {
         const message = `Error trying to write ad. Cannot find ad by given id : ${id}`;

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -233,9 +233,17 @@ describe('config API', function () {
     expect(logWarnSpy.called).to.equal(false);
   });
 
-  it('sets auctionOptions', function () {
+  it('sets auctionOptions secondaryBidders', function () {
     const auctionOptionsConfig = {
       'secondaryBidders': ['rubicon', 'appnexus']
+    }
+    setConfig({ auctionOptions: auctionOptionsConfig });
+    expect(getConfig('auctionOptions')).to.eql(auctionOptionsConfig);
+  });
+
+  it('sets auctionOptions suppressStaleRender', function () {
+    const auctionOptionsConfig = {
+      'suppressStaleRender': true
     }
     setConfig({ auctionOptions: auctionOptionsConfig });
     expect(getConfig('auctionOptions')).to.eql(auctionOptionsConfig);
@@ -254,6 +262,15 @@ describe('config API', function () {
     }});
     expect(logWarnSpy.calledOnce).to.equal(true);
     const warning = 'Auction Options secondaryBidders must be of type Array';
+    assert.ok(logWarnSpy.calledWith(warning), 'expected warning was logged');
+  });
+
+  it('should log warning for invalid auctionOptions suppress stale render', function () {
+    setConfig({ auctionOptions: {
+      'suppressStaleRender': 'test',
+    }});
+    expect(logWarnSpy.calledOnce).to.equal(true);
+    const warning = 'Auction Options suppressStaleRender must be of type boolean';
     assert.ok(logWarnSpy.calledWith(warning), 'expected warning was logged');
   });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -199,6 +199,10 @@ describe('Unit: Prebid Module', function () {
     configObj.setConfig({ useBidCache: false });
   });
 
+  after(function() {
+    auctionManager.clearAllAuctions();
+  });
+
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     beforeEach(function () {
       resetAuction();
@@ -1062,6 +1066,8 @@ describe('Unit: Prebid Module', function () {
     var adResponse = {};
     var spyLogError = null;
     var spyLogMessage = null;
+    var spyLogWarn = null;
+    var spyAddWinningBid;
     var inIframe = true;
     var triggerPixelStub;
 
@@ -1100,6 +1106,8 @@ describe('Unit: Prebid Module', function () {
 
       spyLogError = sinon.spy(utils, 'logError');
       spyLogMessage = sinon.spy(utils, 'logMessage');
+      spyLogWarn = sinon.spy(utils, 'logWarn');
+      spyAddWinningBid = sinon.spy(auctionManager, 'addWinningBid');
 
       inIframe = true;
       sinon.stub(utils, 'inIframe').callsFake(() => inIframe);
@@ -1110,8 +1118,10 @@ describe('Unit: Prebid Module', function () {
       auction.getBidsReceived = getBidResponses;
       utils.logError.restore();
       utils.logMessage.restore();
+      utils.logWarn.restore();
       utils.inIframe.restore();
       triggerPixelStub.restore();
+      spyAddWinningBid.restore();
     });
 
     it('should require doc and id params', function () {
@@ -1217,6 +1227,117 @@ describe('Unit: Prebid Module', function () {
 
       sinon.assert.calledOnce(triggerPixelStub);
       sinon.assert.calledWith(triggerPixelStub, burl);
+    });
+
+    it('should call addWinningBid', function () {
+      pushBidResponseToAuction({
+        ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>"
+      });
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      var message = 'Calling renderAd with adId :' + bidId;
+      sinon.assert.calledWith(spyLogMessage, message);
+
+      sinon.assert.calledOnce(spyAddWinningBid);
+      sinon.assert.calledWith(spyAddWinningBid, adResponse);
+    });
+
+    it.only('should warn stale rendering', function () {
+      var message = 'Calling renderAd with adId :' + bidId;
+      var warning = `Ad id ${bidId} has been rendered before`;
+      var onWonEvent = sinon.stub();
+      var onStaleEvent = sinon.stub();
+
+      $$PREBID_GLOBAL$$.onEvent(CONSTANTS.EVENTS.BID_WON, onWonEvent);
+      $$PREBID_GLOBAL$$.onEvent(CONSTANTS.EVENTS.STALE_RENDER, onStaleEvent);
+
+      pushBidResponseToAuction({
+        ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>"
+      });
+
+      // First render should pass with no warning and added to winning bids
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      sinon.assert.calledWith(spyLogMessage, message);
+      sinon.assert.neverCalledWith(spyLogWarn, warning);
+
+      sinon.assert.calledOnce(spyAddWinningBid);
+      sinon.assert.calledWith(spyAddWinningBid, adResponse);
+
+      sinon.assert.calledWith(onWonEvent, adResponse);
+      sinon.assert.notCalled(onStaleEvent);
+      expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+      // Reset call history for spies and stubs
+      spyLogMessage.resetHistory();
+      spyLogWarn.resetHistory();
+      spyAddWinningBid.resetHistory();
+      onWonEvent.resetHistory();
+      onStaleEvent.resetHistory();
+
+      // Second render should have a warning but still added to winning bids
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      sinon.assert.calledWith(spyLogMessage, message);
+      sinon.assert.calledWith(spyLogWarn, warning);
+
+      sinon.assert.calledOnce(spyAddWinningBid);
+      sinon.assert.calledWith(spyAddWinningBid, adResponse);
+
+      sinon.assert.calledWith(onWonEvent, adResponse);
+      sinon.assert.calledWith(onStaleEvent, adResponse);
+
+      // Clean up
+      $$PREBID_GLOBAL$$.offEvent(CONSTANTS.EVENTS.BID_WON, onWonEvent);
+      $$PREBID_GLOBAL$$.offEvent(CONSTANTS.EVENTS.STALE_RENDER, onStaleEvent);
+    });
+
+    it('should stop stale rendering', function () {
+      var message = 'Calling renderAd with adId :' + bidId;
+      var warning = `Ad id ${bidId} has been rendered before`;
+      var onWonEvent = sinon.stub();
+      var onStaleEvent = sinon.stub();
+
+      // Setting suppressStaleRender to true explicitly
+      configObj.setConfig({'auctionOptions': {'suppressStaleRender': true}});
+
+      $$PREBID_GLOBAL$$.onEvent(CONSTANTS.EVENTS.BID_WON, onWonEvent);
+      $$PREBID_GLOBAL$$.onEvent(CONSTANTS.EVENTS.STALE_RENDER, onStaleEvent);
+
+      pushBidResponseToAuction({
+        ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>"
+      });
+
+      // First render should pass with no warning and added to winning bids
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      sinon.assert.calledWith(spyLogMessage, message);
+      sinon.assert.neverCalledWith(spyLogWarn, warning);
+
+      sinon.assert.calledOnce(spyAddWinningBid);
+      sinon.assert.calledWith(spyAddWinningBid, adResponse);
+      expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+      sinon.assert.calledWith(onWonEvent, adResponse);
+      sinon.assert.notCalled(onStaleEvent);
+
+      // Reset call history for spies and stubs
+      spyLogMessage.resetHistory();
+      spyLogWarn.resetHistory();
+      spyAddWinningBid.resetHistory();
+      onWonEvent.resetHistory();
+      onStaleEvent.resetHistory();
+
+      // Second render should have a warning and do not proceed further
+      $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      sinon.assert.calledWith(spyLogMessage, message);
+      sinon.assert.calledWith(spyLogWarn, warning);
+
+      sinon.assert.notCalled(spyAddWinningBid);
+
+      sinon.assert.notCalled(onWonEvent);
+      sinon.assert.calledWith(onStaleEvent, adResponse);
+
+      // Clean up
+      $$PREBID_GLOBAL$$.offEvent(CONSTANTS.EVENTS.BID_WON, onWonEvent);
+      $$PREBID_GLOBAL$$.offEvent(CONSTANTS.EVENTS.STALE_RENDER, onStaleEvent);
+      configObj.setConfig({'auctionOptions': {}});
     });
   });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1241,7 +1241,7 @@ describe('Unit: Prebid Module', function () {
       sinon.assert.calledWith(spyAddWinningBid, adResponse);
     });
 
-    it.only('should warn stale rendering', function () {
+    it('should warn stale rendering', function () {
       var message = 'Calling renderAd with adId :' + bidId;
       var warning = `Ad id ${bidId} has been rendered before`;
       var onWonEvent = sinon.stub();

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -1,8 +1,18 @@
 import {
-  _sendAdToCreative
-} from '../../../src/secureCreatives.js';
-import { expect } from 'chai';
+  _sendAdToCreative, receiveMessage
+} from 'src/secureCreatives.js';
 import * as utils from 'src/utils.js';
+import {getAdUnits, getBidRequests, getBidResponses} from 'test/fixtures/fixtures.js';
+import {auctionManager} from 'src/auctionManager.js';
+import * as auctionModule from 'src/auction.js';
+import * as native from 'src/native.js';
+import {fireNativeTrackers, getAllAssetsMessage} from 'src/native.js';
+import events from 'src/events.js';
+import { config as configObj } from 'src/config.js';
+
+import { expect } from 'chai';
+
+var CONSTANTS = require('src/constants.json');
 
 describe('secureCreatives', () => {
   describe('_sendAdToCreative', () => {
@@ -40,6 +50,321 @@ describe('secureCreatives', () => {
       expect(JSON.parse(event.source.postMessage.args[0][0]).adUrl).to.equal('http://creative.prebid.org/1.00');
       window.googletag = oldVal;
       window.apntag = oldapntag;
+    });
+  });
+
+  describe('receiveMessage', function() {
+    const bidId = 1;
+    const warning = `Ad id ${bidId} has been rendered before`;
+    let auction;
+    let adResponse = {};
+    let spyAddWinningBid;
+    let spyLogWarn;
+    let stubFireNativeTrackers;
+    let stubGetAllAssetsMessage;
+    let stubEmit;
+
+    function pushBidResponseToAuction(obj) {
+      adResponse = Object.assign({
+        auctionId: 1,
+        adId: bidId,
+        width: 300,
+        height: 250,
+        renderer: null
+      }, obj);
+      auction.getBidsReceived = function() {
+        let bidsReceived = getBidResponses();
+        bidsReceived.push(adResponse);
+        return bidsReceived;
+      }
+      auction.getAuctionId = () => 1;
+    }
+
+    function resetAuction() {
+      $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: false });
+      auction.getBidRequests = getBidRequests;
+      auction.getBidsReceived = getBidResponses;
+      auction.getAdUnits = getAdUnits;
+      auction.getAuctionStatus = function() { return auctionModule.AUCTION_COMPLETED }
+    }
+
+    function resetHistories(...others) {
+      [
+        spyAddWinningBid,
+        spyLogWarn,
+        stubFireNativeTrackers,
+        stubGetAllAssetsMessage,
+        stubEmit
+      ].forEach(s => s.resetHistory());
+
+      if (others && others.length > 0) { others.forEach(s => s.resetHistory()); }
+    }
+
+    before(function() {
+      const adUnits = getAdUnits();
+      const adUnitCodes = getAdUnits().map(unit => unit.code);
+      const bidsBackHandler = function() {};
+      const timeout = 2000;
+      auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout: timeout});
+      resetAuction();
+    });
+
+    after(function() {
+      auctionManager.clearAllAuctions();
+    });
+
+    beforeEach(function() {
+      spyAddWinningBid = sinon.spy(auctionManager, 'addWinningBid');
+      spyLogWarn = sinon.spy(utils, 'logWarn');
+      stubFireNativeTrackers = sinon.stub(native, 'fireNativeTrackers');
+      stubGetAllAssetsMessage = sinon.stub(native, 'getAllAssetsMessage');
+      stubEmit = sinon.stub(events, 'emit');
+    });
+
+    afterEach(function() {
+      spyAddWinningBid.restore();
+      spyLogWarn.restore();
+      stubFireNativeTrackers.restore();
+      stubGetAllAssetsMessage.restore();
+      stubEmit.restore();
+      resetAuction();
+    });
+
+    describe('Prebid Request', function() {
+      it('should render', function () {
+        pushBidResponseToAuction({
+          renderer: {render: sinon.stub(), url: 'some url'}
+        });
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Request'
+        };
+
+        const ev = {
+          data: JSON.stringify(data)
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(spyAddWinningBid, adResponse);
+        sinon.assert.calledOnce(adResponse.renderer.render);
+        sinon.assert.calledWith(adResponse.renderer.render, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+      });
+
+      it('should allow stale rendering without config', function () {
+        pushBidResponseToAuction({
+          renderer: {render: sinon.stub(), url: 'some url'}
+        });
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Request'
+        };
+
+        const ev = {
+          data: JSON.stringify(data)
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(spyAddWinningBid, adResponse);
+        sinon.assert.calledOnce(adResponse.renderer.render);
+        sinon.assert.calledWith(adResponse.renderer.render, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+        resetHistories(adResponse.renderer.render);
+
+        receiveMessage(ev);
+
+        sinon.assert.calledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(spyAddWinningBid, adResponse);
+        sinon.assert.calledOnce(adResponse.renderer.render);
+        sinon.assert.calledWith(adResponse.renderer.render, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER, adResponse);
+      });
+
+      it('should stop stale rendering with config', function () {
+        configObj.setConfig({'auctionOptions': {'suppressStaleRender': true}});
+
+        pushBidResponseToAuction({
+          renderer: {render: sinon.stub(), url: 'some url'}
+        });
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Request'
+        };
+
+        const ev = {
+          data: JSON.stringify(data)
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(spyAddWinningBid, adResponse);
+        sinon.assert.calledOnce(adResponse.renderer.render);
+        sinon.assert.calledWith(adResponse.renderer.render, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+        resetHistories(adResponse.renderer.render);
+
+        receiveMessage(ev);
+
+        sinon.assert.calledWith(spyLogWarn, warning);
+        sinon.assert.notCalled(spyAddWinningBid);
+        sinon.assert.notCalled(adResponse.renderer.render);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER, adResponse);
+
+        configObj.setConfig({'auctionOptions': {}});
+      });
+    });
+
+    describe('Prebid Native', function() {
+      it('Prebid native should render', function () {
+        pushBidResponseToAuction({});
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Native',
+          action: 'allAssetRequest'
+        };
+
+        const ev = {
+          data: JSON.stringify(data),
+          source: {
+            postMessage: sinon.stub()
+          },
+          origin: 'any origin'
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(stubGetAllAssetsMessage);
+        sinon.assert.calledWith(stubGetAllAssetsMessage, data, adResponse);
+        sinon.assert.calledOnce(ev.source.postMessage);
+        sinon.assert.calledOnce(stubFireNativeTrackers);
+        sinon.assert.calledWith(stubFireNativeTrackers, data, adResponse);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+      });
+
+      it('Prebid native should allow stale rendering without config', function () {
+        pushBidResponseToAuction({});
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Native',
+          action: 'allAssetRequest'
+        };
+
+        const ev = {
+          data: JSON.stringify(data),
+          source: {
+            postMessage: sinon.stub()
+          },
+          origin: 'any origin'
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(stubGetAllAssetsMessage);
+        sinon.assert.calledWith(stubGetAllAssetsMessage, data, adResponse);
+        sinon.assert.calledOnce(ev.source.postMessage);
+        sinon.assert.calledOnce(stubFireNativeTrackers);
+        sinon.assert.calledWith(stubFireNativeTrackers, data, adResponse);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+        resetHistories(ev.source.postMessage);
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(stubGetAllAssetsMessage);
+        sinon.assert.calledWith(stubGetAllAssetsMessage, data, adResponse);
+        sinon.assert.calledOnce(ev.source.postMessage);
+        sinon.assert.calledOnce(stubFireNativeTrackers);
+        sinon.assert.calledWith(stubFireNativeTrackers, data, adResponse);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+      });
+
+      it('Prebid native should allow stale rendering with config', function () {
+        configObj.setConfig({'auctionOptions': {'suppressStaleRender': true}});
+
+        pushBidResponseToAuction({});
+
+        const data = {
+          adId: bidId,
+          message: 'Prebid Native',
+          action: 'allAssetRequest'
+        };
+
+        const ev = {
+          data: JSON.stringify(data),
+          source: {
+            postMessage: sinon.stub()
+          },
+          origin: 'any origin'
+        };
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(stubGetAllAssetsMessage);
+        sinon.assert.calledWith(stubGetAllAssetsMessage, data, adResponse);
+        sinon.assert.calledOnce(ev.source.postMessage);
+        sinon.assert.calledOnce(stubFireNativeTrackers);
+        sinon.assert.calledWith(stubFireNativeTrackers, data, adResponse);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        expect(adResponse).to.have.property('status', CONSTANTS.BID_STATUS.RENDERED);
+
+        resetHistories(ev.source.postMessage);
+
+        receiveMessage(ev);
+
+        sinon.assert.neverCalledWith(spyLogWarn, warning);
+        sinon.assert.calledOnce(stubGetAllAssetsMessage);
+        sinon.assert.calledWith(stubGetAllAssetsMessage, data, adResponse);
+        sinon.assert.calledOnce(ev.source.postMessage);
+        sinon.assert.calledOnce(stubFireNativeTrackers);
+        sinon.assert.calledWith(stubFireNativeTrackers, data, adResponse);
+        sinon.assert.calledOnce(spyAddWinningBid);
+        sinon.assert.calledWith(stubEmit, CONSTANTS.EVENTS.BID_WON, adResponse);
+        sinon.assert.neverCalledWith(stubEmit, CONSTANTS.EVENTS.STALE_RENDER);
+
+        configObj.setConfig({'auctionOptions': {}});
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Closes #6020 

Stale rendering means displaying an ad that's been shown before without getting new bids.  This change leverage auctionManager.addWinningBid, which is called for direct rendering by prebid.js, or by universal creatives in safeframes via postMessage.  This function sets the bid's status to RENDERED.  So if a bid's status is already RENDERED, then it's treated as stale.

When a stale rendering is detected, by default the following two behaviors are added:
* Add a warning message 
* Emit a new event called STALE_RENDER with the bid as the argument.

No other changes should occur.  So the ad is still rendered, and BID_WON event is emitted etc.

A new auctionOption is added to prevent stale ads from shown.  This is false by default.
```javascript
pbjs.setConfig({auctionOptions: {suppressStaleRender: true}})
````
When true, stale ads will skip the main rendering code, which generally means they are not rendered.

Note that natives and video ads are not affected by this change.

- email: pyang@conversantmedia.com
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- doc PR prebid/prebid.github.io#2939

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
