### PR TITLE
Index Exchange Bid Adapter: BidFloor decimal precision should be 3 or less

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -125,7 +125,7 @@ function _applyFloor(bid, imp, mediaType) {
   let moduleFloor = null;
 
   if (bid.params.bidFloor && bid.params.bidFloorCur) {
-    adapterFloor = { floor: roundUp(bid.params.bidFloor, 2), currency: bid.params.bidFloorCur };
+    adapterFloor = { floor: bid.params.bidFloor, currency: bid.params.bidFloorCur };
   }
 
   if (utils.isFn(bid.getFloor)) {
@@ -148,11 +148,6 @@ function _applyFloor(bid, imp, mediaType) {
     }
   }
 
-  // fixing floor precision to 2
-  if (moduleFloor && moduleFloor.floor) {
-    moduleFloor.floor = roundUp(moduleFloor.floor, 2);
-  }
-
   if (adapterFloor && moduleFloor) {
     if (adapterFloor.currency !== moduleFloor.currency) {
       utils.logWarn('The bid floor currency mismatch between IX params and priceFloors module config');
@@ -160,11 +155,11 @@ function _applyFloor(bid, imp, mediaType) {
     }
 
     if (adapterFloor.floor > moduleFloor.floor) {
-      imp.bidfloor = adapterFloor.floor;
+      imp.bidfloor = roundUp(adapterFloor.floor, 2);
       imp.bidfloorcur = adapterFloor.currency;
       imp.ext.fl = FLOOR_SOURCE.IX;
     } else {
-      imp.bidfloor = moduleFloor.floor;
+      imp.bidfloor = roundUp(moduleFloor.floor, 2);
       imp.bidfloorcur = moduleFloor.currency;
       imp.ext.fl = FLOOR_SOURCE.PBJS;
     }
@@ -172,11 +167,11 @@ function _applyFloor(bid, imp, mediaType) {
   }
 
   if (moduleFloor) {
-    imp.bidfloor = moduleFloor.floor;
+    imp.bidfloor = roundUp(moduleFloor.floor, 2);
     imp.bidfloorcur = moduleFloor.currency;
     imp.ext.fl = FLOOR_SOURCE.PBJS;
   } else if (adapterFloor) {
-    imp.bidfloor = adapterFloor.floor;
+    imp.bidfloor = roundUp(adapterFloor.floor, 2);
     imp.bidfloorcur = adapterFloor.currency;
     imp.ext.fl = FLOOR_SOURCE.IX;
   } else {

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -104,10 +104,10 @@ function bidToImp(bid) {
   return imp;
 }
 /**
- * 
- * @param {*} number 
- * @param {*} precision 
- * @returns 
+ *
+ * @param {*} number
+ * @param {*} precision
+ * @returns
  */
 function roundUp(number, precision) {
   return Math.ceil((parseFloat(number) * Math.pow(10, precision)).toFixed(1)) / Math.pow(10, precision);

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -16,13 +16,13 @@ const CENT_TO_DOLLAR_FACTOR = 100;
 const BANNER_TIME_TO_LIVE = 300;
 const VIDEO_TIME_TO_LIVE = 3600; // 1hr
 const NET_REVENUE = true;
-
 const PRICE_TO_DOLLAR_FACTOR = {
   JPY: 1
 };
 const USER_SYNC_URL = 'https://js-sec.indexww.com/um/ixmatch.html';
 
 const FLOOR_SOURCE = { PBJS: 'p', IX: 'x' };
+const FLOOR_PRECISION = 3;
 
 /**
  * Transform valid bid request config object to banner impression object that will be sent to ad server.
@@ -155,11 +155,11 @@ function _applyFloor(bid, imp, mediaType) {
     }
 
     if (adapterFloor.floor > moduleFloor.floor) {
-      imp.bidfloor = roundUp(adapterFloor.floor, 2);
+      imp.bidfloor = roundUp(adapterFloor.floor, FLOOR_PRECISION);
       imp.bidfloorcur = adapterFloor.currency;
       imp.ext.fl = FLOOR_SOURCE.IX;
     } else {
-      imp.bidfloor = roundUp(moduleFloor.floor, 2);
+      imp.bidfloor = roundUp(moduleFloor.floor, FLOOR_PRECISION);
       imp.bidfloorcur = moduleFloor.currency;
       imp.ext.fl = FLOOR_SOURCE.PBJS;
     }
@@ -167,11 +167,11 @@ function _applyFloor(bid, imp, mediaType) {
   }
 
   if (moduleFloor) {
-    imp.bidfloor = roundUp(moduleFloor.floor, 2);
+    imp.bidfloor = roundUp(moduleFloor.floor, FLOOR_PRECISION);
     imp.bidfloorcur = moduleFloor.currency;
     imp.ext.fl = FLOOR_SOURCE.PBJS;
   } else if (adapterFloor) {
-    imp.bidfloor = roundUp(adapterFloor.floor, 2);
+    imp.bidfloor = roundUp(adapterFloor.floor, FLOOR_PRECISION);
     imp.bidfloorcur = adapterFloor.currency;
     imp.ext.fl = FLOOR_SOURCE.IX;
   } else {

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -4,7 +4,6 @@ import { config } from '../src/config.js';
 import find from 'core-js-pure/features/array/find.js';
 import isInteger from 'core-js-pure/features/number/is-integer.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { module } from '../webpack.conf.js';
 
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
@@ -148,7 +147,7 @@ function _applyFloor(bid, imp, mediaType) {
       utils.logWarn('priceFloors module call getFloor failed, error : ', err);
     }
   }
-  
+
   // fixing floor precision to 2
   if (moduleFloor && moduleFloor.floor) {
     moduleFloor.floor = roundUp(moduleFloor.floor, 2);

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -4,6 +4,7 @@ import { config } from '../src/config.js';
 import find from 'core-js-pure/features/array/find.js';
 import isInteger from 'core-js-pure/features/number/is-integer.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { module } from '../webpack.conf.js';
 
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
@@ -103,6 +104,15 @@ function bidToImp(bid) {
 
   return imp;
 }
+/**
+ * 
+ * @param {*} number 
+ * @param {*} precision 
+ * @returns 
+ */
+function roundUp(number, precision) {
+  return Math.ceil((parseFloat(number) * Math.pow(10, precision)).toFixed(1)) / Math.pow(10, precision);
+}
 
 /**
  * Gets priceFloors floors and IX adapter floors,
@@ -116,7 +126,7 @@ function _applyFloor(bid, imp, mediaType) {
   let moduleFloor = null;
 
   if (bid.params.bidFloor && bid.params.bidFloorCur) {
-    adapterFloor = { floor: bid.params.bidFloor, currency: bid.params.bidFloorCur };
+    adapterFloor = { floor: roundUp(bid.params.bidFloor, 2), currency: bid.params.bidFloorCur };
   }
 
   if (utils.isFn(bid.getFloor)) {
@@ -137,6 +147,11 @@ function _applyFloor(bid, imp, mediaType) {
       // continue with no module floors
       utils.logWarn('priceFloors module call getFloor failed, error : ', err);
     }
+  }
+  
+  // fixing floor precision to 2
+  if (moduleFloor && moduleFloor.floor) {
+    moduleFloor.floor = roundUp(moduleFloor.floor, 2);
   }
 
   if (adapterFloor && moduleFloor) {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1181,7 +1181,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal(sidValue);
     });
 
-    it('video impression has #priceFloors floors', function () {
+    it('video impression has priceFloors floors', function () {
       const bid = utils.deepClone(ONE_VIDEO[0]);
       const flr = 5.5
       const floorInfo = {floor: flr, currency: 'USD'};
@@ -1197,7 +1197,7 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.ext.fl).to.equal('p');
     });
 
-    it('banner imp has floors from #priceFloors module', function () {
+    it('banner imp has floors from priceFloors module', function () {
       const floor300x250 = 3.25
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0])
 
@@ -1215,7 +1215,7 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.ext.fl).to.equal('p');
     });
 
-    it('ix adapter floors chosen over #priceFloors ', function () {
+    it('ix adapter floors chosen over PBJS priceFloors ', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 
       const floorhi = 4.5
@@ -1235,6 +1235,26 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.bidfloor).to.equal(floorhi);
       expect(imp1.bidfloorcur).to.equal(bid.params.bidFloorCur);
       expect(imp1.ext.fl).to.equal('x');
+    });
+
+    it('Floors not sent in case of currency mismatch ', function () {
+      const bid = utils.deepClone(ONE_BANNER[0]);
+
+      const ixcur = 'CAD';
+      const pbjscur = 'JPY';
+
+      bid.params.bidFloor = 4.4347;
+      bid.params.bidFloorCur = ixcur;
+
+      const floorInfo = { floor: 5.34567, currency: pbjscur };
+      bid.getFloor = function () {
+        return floorInfo;
+      };
+      // check if floors are in imp
+      const requestBidFloor = spec.buildRequests([bid])[0];
+      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
+      expect(imp1.bidfloor).to.be.undefined;
+      expect(imp1.bidfloorcur).to.be.undefined;
     });
 
     it('IX Floors precision less than 3 ', function () {
@@ -1279,24 +1299,7 @@ describe('IndexexchangeAdapter', function () {
       expect(prec).to.have.lengthOf.at.most(3);
     });
 
-    it('PBJS Floors precision less than 3, ', function () {
-      const bid = utils.deepClone(ONE_BANNER[0]);
-
-      const floorpbjs = 5.3
-
-      const floorInfo = { floor: floorpbjs, currency: 'USD' };
-      bid.getFloor = function () {
-        return floorInfo;
-      };
-
-      // check if floors are in imp
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      const prec = (imp1.bidfloor).toString().split('.')[1];
-      expect(prec).to.have.lengthOf.at.most(3);
-    });
-
-    it(' #priceFloors floors chosen over ix adapter floors', function () {
+    it(' PBJS priceFloors floors chosen over ix adapter floors', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 
       const floorhi = 4.5
@@ -1330,7 +1333,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.fl).to.equal('x');
     });
 
-    it('missing sizes #priceFloors ', function () {
+    it('missing sizes priceFloors ', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
       bid.mediaTypes.banner.sizes.push([500, 400])
 
@@ -1362,7 +1365,7 @@ describe('IndexexchangeAdapter', function () {
       expect(imp2.bidfloorcur).to.equal('USD');
     });
 
-    it('#pricefloors inAdUnit, banner impressions should have floors', function () {
+    it('pricefloors inAdUnit, banner impressions should have floors', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 
       const flr = 4.3

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1237,6 +1237,65 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.ext.fl).to.equal('x');
     });
 
+    it('IX Floors precision less than 3 ', function () {
+      const bid = utils.deepClone(ONE_BANNER[0]);
+
+      const floorix = 4.5783546
+      const floorpbjs = 3.565476484
+
+      bid.params.bidFloor = floorix
+      bid.params.bidFloorCur = 'USD'
+
+      const floorInfo = { floor: floorpbjs, currency: 'USD' };
+      bid.getFloor = function () {
+        return floorInfo;
+      };
+
+      // check if floors are in imp
+      const requestBidFloor = spec.buildRequests([bid])[0];
+      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
+      const prec = (imp1.bidfloor).toString().split('.')[1];
+      expect(prec).to.have.lengthOf.at.most(3);
+    });
+
+    it('PBJS Floors precision less than 3 ', function () {
+      const bid = utils.deepClone(ONE_BANNER[0]);
+
+      const floorpbjs = 5.654356
+      const floorix = 3.574634
+
+      bid.params.bidFloor = floorix
+      bid.params.bidFloorCur = 'USD'
+
+      const floorInfo = { floor: floorpbjs, currency: 'USD' };
+      bid.getFloor = function () {
+        return floorInfo;
+      };
+
+      // check if floors are in imp
+      const requestBidFloor = spec.buildRequests([bid])[0];
+      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
+      const prec = (imp1.bidfloor).toString().split('.')[1];
+      expect(prec).to.have.lengthOf.at.most(3);
+    });
+
+    it('PBJS Floors precision less than 3, ', function () {
+      const bid = utils.deepClone(ONE_BANNER[0]);
+
+      const floorpbjs = 5.3
+
+      const floorInfo = { floor: floorpbjs, currency: 'USD' };
+      bid.getFloor = function () {
+        return floorInfo;
+      };
+
+      // check if floors are in imp
+      const requestBidFloor = spec.buildRequests([bid])[0];
+      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
+      const prec = (imp1.bidfloor).toString().split('.')[1];
+      expect(prec).to.have.lengthOf.at.most(3);
+    });
+
     it(' #priceFloors floors chosen over ix adapter floors', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
The ixBidAdapter should not send bidfloor values with more than 3 decimal precision 

<!-- For new bidder adapters, please provide the following -->

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
