### PR TITLE
Apacdex Bid Adapter: add support for meta.advertiserDomains, add and update sample adunit, validate dealId field from server response, add support Price Floors Module

### DIFF
--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -169,22 +169,29 @@ export const spec = {
 
     const bidResponses = [];
     serverBids.forEach(bid => {
+      const dealId = bid.dealId || '';
       const bidResponse = {
         requestId: bid.requestId,
         cpm: bid.cpm,
         width: bid.width,
         height: bid.height,
         creativeId: bid.creativeId,
-        dealId: bid.dealId,
         currency: bid.currency,
         netRevenue: bid.netRevenue,
         ttl: bid.ttl,
         mediaType: bid.mediaType
       };
+      if (dealId.length > 0) {
+        bidResponse.dealId = dealId;
+      }
       if (bid.vastXml) {
         bidResponse.vastXml = utils.replaceAuctionPrice(bid.vastXml, bid.cpm);
       } else {
         bidResponse.ad = utils.replaceAuctionPrice(bid.ad, bid.cpm);
+      }
+      bidResponse.meta = {};
+      if (bid.meta && bid.meta.advertiserDomains && utils.isArray(bid.meta.advertiserDomains)) {
+        bidResponse.meta.advertiserDomains = bid.meta.advertiserDomains;
       }
       bidResponses.push(bidResponse);
     });

--- a/modules/apacdexBidAdapter.md
+++ b/modules/apacdexBidAdapter.md
@@ -53,8 +53,6 @@ var videoAdUnit = {
       playbackmethod: [6],
       startdelay: 0,
       protocols: [1, 2, 3, 4, 5, 6]
-      ... // Aditional ORTB video params
-      // you must review all video parameters to ensure validity for your player and DSPs
     },
   },
   bids: [
@@ -68,6 +66,8 @@ var videoAdUnit = {
   ]
 };
 ```
+mediaTypes.video object reference to section 3.2.7 Object: Video in the OpenRTB 2.5 document
+You must review all video parameters to ensure validity for your player and DSPs
 
 # Sample Video Ad Unit: Outstream
 ```
@@ -87,8 +87,6 @@ var videoAdUnit = {
       playbackmethod: [6],
       startdelay: 0,
       protocols: [1, 2, 3, 4, 5, 6]
-      ... // Aditional ORTB video params
-      // you must review all video parameters to ensure validity for your player and DSPs
     },
   },
   bids: [
@@ -102,3 +100,5 @@ var videoAdUnit = {
   ]
 };
 ```
+mediaTypes.video object reference to section 3.2.7 Object: Video in the OpenRTB 2.5 document
+You must review all video parameters to ensure validity for your player and DSPs

--- a/modules/apacdexBidAdapter.md
+++ b/modules/apacdexBidAdapter.md
@@ -73,10 +73,10 @@ var videoAdUnit = {
 ```
 var videoAdUnit = {
   code: 'test-div',
-  sizes: [[640, 480]],
+  sizes: [[410, 231]],
   mediaTypes: {
     video: {
-      playerSize: [[640, 480]],
+      playerSize: [[410, 231]],
       context: "outstream"
       api: [2],
       placement: 6,

--- a/modules/apacdexBidAdapter.md
+++ b/modules/apacdexBidAdapter.md
@@ -79,7 +79,7 @@ var videoAdUnit = {
       playerSize: [[410, 231]],
       context: "outstream"
       api: [2],
-      placement: 6,
+      placement: 5,
       linearity: 1,
       minduration: 1,
       maxduration: 120,

--- a/modules/apacdexBidAdapter.md
+++ b/modules/apacdexBidAdapter.md
@@ -11,7 +11,7 @@ Maintainer: ken@apacdex.com
 Connects to APAC Digital Exchange for bids.
 Apacdex bid adapter supports Banner and Video (Instream and Outstream) ads.
 
-# Test Parameters
+# Sample Banner Ad Unit
 ```
 var adUnits = [
   {
@@ -26,6 +26,7 @@ var adUnits = [
           bidder: 'apacdex',
           params: {
               siteId: 'apacdex1234', // siteId provided by Apacdex
+              floorPrice: 0.01, // default is 0.01 if not declared
           }
       }
     ]
@@ -33,7 +34,7 @@ var adUnits = [
 ];
 ```
 
-# Video Test Parameters
+# Sample Video Ad Unit: Instream
 ```
 var videoAdUnit = {
   code: 'test-div',
@@ -41,7 +42,19 @@ var videoAdUnit = {
   mediaTypes: {
     video: {
       playerSize: [[640, 480]],
-      context: 'instream'
+      context: "instream"
+      api: [2],
+      placement: 1,
+      skip: 1,
+      linearity: 1,
+      minduration: 1,
+      maxduration: 120,
+      mimes: ["video/mp4", "video/x-flv", "video/x-ms-wmv", "application/vnd.apple.mpegurl", "application/x-mpegurl", "video/3gpp", "video/mpeg", "video/ogg", "video/quicktime", "video/webm", "video/x-m4v", "video/ms-asf", video/x-msvideo"],
+      playbackmethod: [6],
+      startdelay: 0,
+      protocols: [1, 2, 3, 4, 5, 6]
+      ... // Aditional ORTB video params
+      // you must review all video parameters to ensure validity for your player and DSPs
     },
   },
   bids: [
@@ -49,6 +62,41 @@ var videoAdUnit = {
       bidder: 'apacdex',
       params: {
         siteId: 'apacdex1234', // siteId provided by Apacdex
+        floorPrice: 0.01, // default is 0.01 if not declared
+      }
+    }
+  ]
+};
+```
+
+# Sample Video Ad Unit: Outstream
+```
+var videoAdUnit = {
+  code: 'test-div',
+  sizes: [[640, 480]],
+  mediaTypes: {
+    video: {
+      playerSize: [[640, 480]],
+      context: "outstream"
+      api: [2],
+      placement: 6,
+      linearity: 1,
+      minduration: 1,
+      maxduration: 120,
+      mimes: ["video/mp4", "video/x-flv", "video/x-ms-wmv", "application/vnd.apple.mpegurl", "application/x-mpegurl", "video/3gpp", "video/mpeg", "video/ogg", "video/quicktime", "video/webm", "video/x-m4v", "video/ms-asf", video/x-msvideo"],
+      playbackmethod: [6],
+      startdelay: 0,
+      protocols: [1, 2, 3, 4, 5, 6]
+      ... // Aditional ORTB video params
+      // you must review all video parameters to ensure validity for your player and DSPs
+    },
+  },
+  bids: [
+    {
+      bidder: 'apacdex',
+      params: {
+        siteId: 'apacdex1234', // siteId provided by Apacdex
+        floorPrice: 0.01, // default is 0.01 if not declared
       }
     }
   ]

--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -200,7 +200,7 @@ describe('ApacdexBidAdapter', function () {
       'bidder': 'apacdex',
       'params': {
         'siteId': '1a2b3c4d5e6f1a2b3c4d',
-        'geo': {'lat': 123.13123456, 'lon': 54.23467311, 'accuracy': 60}
+        'geo': { 'lat': 123.13123456, 'lon': 54.23467311, 'accuracy': 60 }
       },
       'adUnitCode': 'adunit-code-1',
       'sizes': [[300, 250], [300, 600]],
@@ -336,12 +336,12 @@ describe('ApacdexBidAdapter', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.data.us_privacy).to.equal('someCCPAString');
     });
-    describe('debug test', function() {
-      beforeEach(function() {
-        config.setConfig({debug: true});
+    describe('debug test', function () {
+      beforeEach(function () {
+        config.setConfig({ debug: true });
       });
-      afterEach(function() {
-        config.setConfig({debug: false});
+      afterEach(function () {
+        config.setConfig({ debug: false });
       });
       it('should return a properly formatted request with pbjs_debug is true', function () {
         const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
@@ -514,7 +514,10 @@ describe('ApacdexBidAdapter', function () {
             'netRevenue': true,
             'currency': 'USD',
             'dealId': 'apacdex',
-            'mediaType': 'banner'
+            'mediaType': 'banner',
+            'meta': {
+              'advertiserDomains': ['https://example.com']
+            }
           },
           {
             'requestId': '30024615be22ef66a',
@@ -527,7 +530,10 @@ describe('ApacdexBidAdapter', function () {
             'netRevenue': true,
             'currency': 'USD',
             'dealId': 'apacdex',
-            'mediaType': 'banner'
+            'mediaType': 'banner',
+            'meta': {
+              'advertiserDomains': ['https://example.com']
+            }
           },
           {
             'requestId': '1854b40107d6745c',
@@ -540,7 +546,10 @@ describe('ApacdexBidAdapter', function () {
             'netRevenue': true,
             'currency': 'USD',
             'dealId': 'apacdex',
-            'mediaType': 'video'
+            'mediaType': 'video',
+            'meta': {
+              'advertiserDomains': ['https://example.com']
+            }
           }
         ],
         'pixel': [{
@@ -610,6 +619,7 @@ describe('ApacdexBidAdapter', function () {
         if (resp.mediaType === 'banner') {
           expect(resp.ad.indexOf('Apacdex AD')).to.be.greaterThan(0);
         }
+        expect(resp.meta.advertiserDomains).to.deep.equal(['https://example.com']);
       });
     });
   });
@@ -693,17 +703,17 @@ describe('ApacdexBidAdapter', function () {
   describe('getDomain', function () {
     it('should return valid domain from publisherDomain config', () => {
       let pageUrl = 'https://www.example.com/page/prebid/exam.html';
-      config.setConfig({publisherDomain: pageUrl});
+      config.setConfig({ publisherDomain: pageUrl });
       expect(getDomain(pageUrl)).to.equal('example.com');
     });
     it('should return valid domain from pageUrl argument', () => {
       let pageUrl = 'https://www.example.com/page/prebid/exam.html';
-      config.setConfig({publisherDomain: ''});
+      config.setConfig({ publisherDomain: '' });
       expect(getDomain(pageUrl)).to.equal('example.com');
     });
     it('should return undefined if pageUrl and publisherDomain not config', () => {
       let pageUrl;
-      config.setConfig({publisherDomain: ''});
+      config.setConfig({ publisherDomain: '' });
       expect(getDomain(pageUrl)).to.equal(pageUrl);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
- Add meta.advertiserDomains to Apacdex bid adapter according to the issue mentioned https://github.com/prebid/Prebid.js/issues/6650
- Add and update sample ad units
- Validate dealId from server response
- Lint code
- Add support Price Floors Module according to the issue mentioned https://github.com/prebid/Prebid.js/issues/6465