### PR TITLE
Adbookpsp Bid Adapter: add new bid adapter

### DIFF
--- a/modules/adbookpspBidAdapter.js
+++ b/modules/adbookpspBidAdapter.js
@@ -19,8 +19,7 @@ const USER_ID_COOKIE_EXP = 2592000000; // lasts 30 days
 const BID_TTL = 300;
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
 const DEFAULT_CURRENCY = 'USD';
-const VIDEO_PARAMS = ['api', 'mimes', 'playbackmethod', 'protocols'];
-const BIDDER_VIDEO_PARAMS = [
+const VIDEO_PARAMS = [
   'mimes',
   'minduration',
   'maxduration',
@@ -262,32 +261,15 @@ function buildVideoObject(bidRequest) {
   };
 
   for (const param of VIDEO_PARAMS) {
-    const value = utils.deepAccess(bidRequest, `mediaTypes.video.${param}`);
-    if (validateParamValue(param, value)) {
-      videoObj[param] = value;
-    }
-  }
+    const paramsValue = utils.deepAccess(bidRequest, `params.video.${param}`);
+    const mediaTypeValue = utils.deepAccess(bidRequest, `mediaTypes.video.${param}`);
 
-  for (const param of BIDDER_VIDEO_PARAMS) {
-    const value = utils.deepAccess(bidRequest, `params.video.${param}`);
-    if (value) {
-      videoObj[param] = value;
+    if (paramsValue || mediaTypeValue) {
+      videoObj[param] = paramsValue || mediaTypeValue;
     }
   }
 
   return videoObj;
-}
-
-function validateParamValue(param, value) {
-  const result = utils.isArray(value);
-
-  if (!result) {
-    utils.logWarn(
-      `${BIDDER_CODE}: Ignoring param: ${param} expects an array, got ${typeof value}`
-    );
-  }
-
-  return result;
 }
 
 function buildImpExt(validBidRequest) {

--- a/modules/adbookpspBidAdapter.js
+++ b/modules/adbookpspBidAdapter.js
@@ -1,0 +1,786 @@
+import includes from 'core-js-pure/features/array/includes.js';
+import find from 'core-js-pure/features/array/find';
+import { config } from '../src/config.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { getStorageManager } from '../src/storageManager.js';
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+
+/**
+ * CONSTANTS
+ */
+
+export const VERSION = '1.0.0';
+const EXCHANGE_URL = 'https://ex.fattail.com/openrtb2';
+const WIN_TRACKING_URL = 'https://ev.fattail.com/wins';
+const BIDDER_CODE = 'adbookpsp';
+const USER_ID_KEY = 'hb_adbookpsp_uid';
+const USER_ID_COOKIE_EXP = 2592000000; // lasts 30 days
+const BID_TTL = 300;
+const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
+const DEFAULT_CURRENCY = 'USD';
+const VIDEO_PARAMS = ['api', 'mimes', 'playbackmethod', 'protocols'];
+const BIDDER_VIDEO_PARAMS = [
+  'mimes',
+  'minduration',
+  'maxduration',
+  'protocols',
+  'w',
+  'h',
+  'startdelay',
+  'placement',
+  'linearity',
+  'skip',
+  'skipmin',
+  'skipafter',
+  'sequence',
+  'battr',
+  'maxextended',
+  'minbitrate',
+  'maxbitrate',
+  'boxingallowed',
+  'playbackmethod',
+  'playbackend',
+  'delivery',
+  'pos',
+  'companionad',
+  'api',
+  'companiontype',
+  'ext',
+];
+const TARGETING_VALUE_SEPARATOR = ',';
+
+export const DEFAULT_BIDDER_CONFIG = {
+  bidTTL: BID_TTL,
+  defaultCurrency: DEFAULT_CURRENCY,
+  exchangeUrl: EXCHANGE_URL,
+  winTrackingEnabled: true,
+  winTrackingUrl: WIN_TRACKING_URL,
+  orgId: null,
+};
+
+config.setDefaults({
+  adbookpsp: DEFAULT_BIDDER_CONFIG,
+});
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: SUPPORTED_MEDIA_TYPES,
+
+  buildRequests,
+  getUserSyncs,
+  interpretResponse,
+  isBidRequestValid,
+  onBidWon,
+};
+
+registerBidder(spec);
+
+/**
+ * BID REQUEST
+ */
+
+function isBidRequestValid(bidRequest) {
+  return (
+    hasRequiredParams(bidRequest) &&
+    (isValidBannerRequest(bidRequest) || isValidVideoRequest(bidRequest))
+  );
+}
+
+function buildRequests(validBidRequests, bidderRequest) {
+  const requests = [];
+
+  if (validBidRequests.length > 0) {
+    requests.push({
+      method: 'POST',
+      url: getBidderConfig('exchangeUrl'),
+      options: {
+        contentType: 'application/json',
+        withCredentials: true,
+      },
+      data: buildRequest(validBidRequests, bidderRequest),
+    });
+  }
+
+  return requests;
+}
+
+function buildRequest(validBidRequests, bidderRequest) {
+  const request = {
+    id: bidderRequest.bidderRequestId,
+    tmax: bidderRequest.timeout,
+    site: {
+      domain: window.location.hostname,
+      page: window.location.href,
+      ref: bidderRequest.refererInfo.referer,
+    },
+    source: buildSource(validBidRequests, bidderRequest),
+    device: buildDevice(),
+    regs: buildRegs(bidderRequest),
+    user: buildUser(bidderRequest),
+    imp: validBidRequests.map(buildImp),
+    ext: {
+      adbook: {
+        config: getBidderConfig(),
+        version: {
+          prebid: '$prebid.version$',
+          adapter: VERSION,
+        },
+      },
+    },
+  };
+
+  return JSON.stringify(request);
+}
+
+function buildDevice() {
+  const { innerWidth, innerHeight } = common.getWindowDimensions();
+
+  const device = {
+    w: innerWidth,
+    h: innerHeight,
+    js: true,
+    ua: navigator.userAgent,
+    dnt:
+      navigator.doNotTrack === 'yes' ||
+      navigator.doNotTrack == '1' ||
+      navigator.msDoNotTrack == '1'
+        ? 1
+        : 0,
+  };
+
+  const deviceConfig = common.getConfig('device');
+
+  if (utils.isPlainObject(deviceConfig)) {
+    return { ...device, ...deviceConfig };
+  }
+
+  return device;
+}
+
+function buildRegs(bidderRequest) {
+  const regs = {
+    coppa: common.getConfig('coppa') === true ? 1 : 0,
+  };
+
+  if (bidderRequest.gdprConsent) {
+    utils.deepSetValue(
+      regs,
+      'ext.gdpr',
+      bidderRequest.gdprConsent.gdprApplies ? 1 : 0
+    );
+    utils.deepSetValue(
+      regs,
+      'ext.gdprConsentString',
+      bidderRequest.gdprConsent.consentString || ''
+    );
+  }
+
+  if (bidderRequest.uspConsent) {
+    utils.deepSetValue(regs, 'ext.us_privacy', bidderRequest.uspConsent);
+  }
+
+  return regs;
+}
+
+function buildSource(bidRequests, bidderRequest) {
+  const source = {
+    fd: 1,
+    tid: bidderRequest.auctionId,
+  };
+  const schain = utils.deepAccess(bidRequests, '0.schain');
+
+  if (schain) {
+    utils.deepSetValue(source, 'ext.schain', schain);
+  }
+
+  return source;
+}
+
+function buildUser(bidderRequest) {
+  const user = {
+    id: getUserId(),
+  };
+
+  if (bidderRequest.gdprConsent) {
+    user.gdprConsentString = bidderRequest.gdprConsent.consentString || '';
+  }
+
+  return user;
+}
+
+function buildImp(bidRequest) {
+  let impBase = {
+    id: bidRequest.bidId,
+    tagid: bidRequest.adUnitCode,
+    ext: buildImpExt(bidRequest),
+  };
+
+  return Object.keys(bidRequest.mediaTypes)
+    .filter((mediaType) => includes(SUPPORTED_MEDIA_TYPES, mediaType))
+    .reduce((imp, mediaType) => {
+      return {
+        ...imp,
+        [mediaType]: buildMediaTypeObject(mediaType, bidRequest),
+      };
+    }, impBase);
+}
+
+function buildMediaTypeObject(mediaType, bidRequest) {
+  switch (mediaType) {
+    case BANNER:
+      return buildBannerObject(bidRequest);
+    case VIDEO:
+      return buildVideoObject(bidRequest);
+    default:
+      utils.logWarn(`Unsupported media type ${mediaType}!`);
+  }
+}
+
+function buildBannerObject(bidRequest) {
+  const format = bidRequest.mediaTypes.banner.sizes.map((size) => {
+    const [w, h] = size;
+
+    return { w, h };
+  });
+  const { w, h } = format[0];
+
+  return {
+    pos: 0,
+    topframe: utils.inIframe() ? 0 : 1,
+    format,
+    w,
+    h,
+  };
+}
+
+function buildVideoObject(bidRequest) {
+  const [w, h] = bidRequest.mediaTypes.video.playerSize[0];
+  let videoObj = {
+    w,
+    h,
+  };
+
+  for (const param of VIDEO_PARAMS) {
+    const value = utils.deepAccess(bidRequest, `mediaTypes.video.${param}`);
+    if (validateParamValue(param, value)) {
+      videoObj[param] = value;
+    }
+  }
+
+  for (const param of BIDDER_VIDEO_PARAMS) {
+    const value = utils.deepAccess(bidRequest, `params.video.${param}`);
+    if (value) {
+      videoObj[param] = value;
+    }
+  }
+
+  return videoObj;
+}
+
+function validateParamValue(param, value) {
+  const result = utils.isArray(value);
+
+  if (!result) {
+    utils.logWarn(
+      `${BIDDER_CODE}: Ignoring param: ${param} expects an array, got ${typeof value}`
+    );
+  }
+
+  return result;
+}
+
+function buildImpExt(validBidRequest) {
+  const defaultOrgId = getBidderConfig('orgId');
+  const { orgId, placementId } = validBidRequest.params || {};
+  const effectiverOrgId = orgId || defaultOrgId;
+  const ext = {};
+
+  if (placementId) {
+    utils.deepSetValue(ext, 'adbook.placementId', placementId);
+  }
+
+  if (effectiverOrgId) {
+    utils.deepSetValue(ext, 'adbook.orgId', effectiverOrgId);
+  }
+
+  return ext;
+}
+
+/**
+ * BID RESPONSE
+ */
+
+function interpretResponse(bidResponse, bidderRequest) {
+  const bidderRequestBody = safeJSONparse(bidderRequest.data);
+
+  if (
+    utils.deepAccess(bidderRequestBody, 'id') !=
+    utils.deepAccess(bidResponse, 'body.id')
+  ) {
+    utils.logError(
+      `${BIDDER_CODE}: Bid response id does not match bidder request id`
+    );
+
+    return [];
+  }
+
+  const referrer = utils.deepAccess(bidderRequestBody, 'site.ref', '');
+  const incomingBids = utils
+    .deepAccess(bidResponse, 'body.seatbid', [])
+    .filter((seat) => utils.isArray(seat.bid))
+    .reduce((bids, seat) => bids.concat(seat.bid), [])
+    .filter(validateBid(bidderRequestBody));
+  const targetingMap = buildTargetingMap(incomingBids);
+
+  return impBidsToPrebidBids(
+    incomingBids,
+    bidderRequestBody,
+    bidResponse.body.cur,
+    referrer,
+    targetingMap
+  );
+}
+
+function impBidsToPrebidBids(
+  incomingBids,
+  bidderRequestBody,
+  bidResponseCurrency,
+  referrer,
+  targetingMap
+) {
+  return incomingBids
+    .map(
+      impToPrebidBid(
+        bidderRequestBody,
+        bidResponseCurrency,
+        referrer,
+        targetingMap
+      )
+    )
+    .filter((i) => i !== null);
+}
+
+const impToPrebidBid =
+  (bidderRequestBody, bidResponseCurrency, referrer, targetingMap) => (bid) => {
+    try {
+      const bidRequest = findBidRequest(bidderRequestBody, bid);
+
+      if (!bidRequest) {
+        utils.logError(`${BIDDER_CODE}: Could not match bid to bid request`);
+
+        return null;
+      }
+      const categories = utils.deepAccess(bid, 'cat', []);
+      const mediaType = getMediaType(bid.adm);
+      let prebidBid = {
+        ad: bid.adm,
+        adId: bid.adid,
+        adserverTargeting: targetingMap[bid.impid],
+        adUnitCode: bidRequest.tagid,
+        bidderRequestId: bidderRequestBody.id,
+        bidId: bid.id,
+        cpm: bid.price,
+        creativeId: bid.crid || bid.id,
+        currency: bidResponseCurrency || getBidderConfig('defaultCurrency'),
+        height: bid.h,
+        lineItemId: utils.deepAccess(bid, 'ext.liid'),
+        mediaType,
+        meta: {
+          advertiserDomains: bid.adomain,
+          mediaType: mediaType,
+          primaryCatId: categories[0],
+          secondaryCatIds: categories.slice(1),
+        },
+        netRevenue: true,
+        nurl: bid.nurl,
+        referrer: referrer,
+        requestId: bid.impid,
+        ttl: getBidderConfig('bidTTL'),
+        width: bid.w,
+      };
+
+      if (mediaType === VIDEO) {
+        prebidBid = {
+          ...prebidBid,
+          ...getVideoSpecificParams(bidRequest, bid),
+        };
+      }
+
+      return prebidBid;
+    } catch (error) {
+      utils.logError(error);
+
+      return null;
+    }
+  };
+
+function getVideoSpecificParams(bidRequest, bid) {
+  return {
+    height: bid.h || bidRequest.video.h,
+    vastXml: bid.adm,
+    width: bid.w || bidRequest.video.w,
+  };
+}
+
+function buildTargetingMap(bids) {
+  const impIds = bids.map(({ impid }) => impid).filter(utils.uniques);
+  const values = impIds.reduce((result, id) => {
+    result[id] = {
+      lineItemIds: [],
+      dealIds: [],
+      adIds: [],
+    };
+
+    return result;
+  }, {});
+
+  bids.forEach((bid) => {
+    values[bid.impid].lineItemIds.push(bid.ext.liid);
+    values[bid.impid].dealIds.push(bid.dealid);
+    values[bid.impid].adIds.push(bid.adid);
+  });
+
+  const targetingMap = {};
+
+  for (const id of impIds) {
+    targetingMap[id] = {
+      hb_liid_adbookpsp: values[id].lineItemIds.join(TARGETING_VALUE_SEPARATOR),
+      hb_deal_adbookpsp: values[id].dealIds.join(TARGETING_VALUE_SEPARATOR),
+      hb_adid_c_adbookpsp: values[id].adIds.join(TARGETING_VALUE_SEPARATOR),
+    };
+  }
+
+  return targetingMap;
+}
+
+/**
+ * VALIDATION
+ */
+
+function hasRequiredParams(bidRequest) {
+  const value =
+    utils.deepAccess(bidRequest, 'params.placementId') != null ||
+    utils.deepAccess(bidRequest, 'params.orgId') != null ||
+    getBidderConfig('orgId') != null;
+
+  if (!value) {
+    utils.logError(`${BIDDER_CODE}: missing orgId and placementId parameter`);
+  }
+
+  return value;
+}
+
+function isValidBannerRequest(bidRequest) {
+  const value = validateSizes(
+    utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes', [])
+  );
+
+  return value;
+}
+
+function isValidVideoRequest(bidRequest) {
+  const value =
+    utils.isArray(utils.deepAccess(bidRequest, 'mediaTypes.video.mimes')) &&
+    validateSizes(utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize'));
+
+  return value;
+}
+
+function validateSize(size) {
+  return utils.isArray(size) && size.length === 2 && size.every(utils.isNumber);
+}
+
+function validateSizes(sizes) {
+  return utils.isArray(sizes) && sizes.length > 0 && sizes.every(validateSize);
+}
+
+function validateBid(bidderRequestBody) {
+  return function (bid) {
+    const mediaType = getMediaType(bid.adm);
+    const bidRequest = findBidRequest(bidderRequestBody, bid);
+    let validators = commonBidValidators;
+
+    if (mediaType === BANNER) {
+      validators = [...commonBidValidators, ...bannerBidValidators];
+    }
+
+    const value = validators.every((validator) => validator(bid, bidRequest));
+
+    if (!value) {
+      utils.logWarn(`${BIDDER_CODE}: Invalid bid`, bid);
+    }
+
+    return value;
+  };
+}
+
+const commonBidValidators = [
+  (bid) => utils.isPlainObject(bid),
+  (bid) => isNonEmptyStr(bid.adid),
+  (bid) => isNonEmptyStr(bid.adm),
+  (bid) => isNonEmptyStr(bid.id),
+  (bid) => isNonEmptyStr(bid.impid),
+  (bid) => isNonEmptyStr(utils.deepAccess(bid, 'ext.liid')),
+  (bid) => utils.isNumber(bid.price),
+];
+
+const bannerBidValidators = [
+  validateBannerDimension('w'),
+  validateBannerDimension('h'),
+];
+
+function validateBannerDimension(dimension) {
+  return function (bid, bidRequest) {
+    if (bid[dimension] == null) {
+      return bannerHasSingleSize(bidRequest);
+    }
+
+    return utils.isNumber(bid[dimension]);
+  };
+}
+
+function bannerHasSingleSize(bidRequest) {
+  return utils.deepAccess(bidRequest, 'banner.format', []).length === 1;
+}
+
+/**
+ * USER SYNC
+ */
+
+export const storage = getStorageManager();
+
+function getUserSyncs(syncOptions, responses, gdprConsent, uspConsent) {
+  return responses
+    .map((response) => utils.deepAccess(response, 'body.ext.sync'))
+    .filter(utils.isArray)
+    .reduce(utils.flatten, [])
+    .filter(validateSync(syncOptions))
+    .map(applyConsents(gdprConsent, uspConsent));
+}
+
+const validateSync = (syncOptions) => (sync) => {
+  return (
+    ((sync.type === 'image' && syncOptions.pixelEnabled) ||
+      (sync.type === 'iframe' && syncOptions.iframeEnabled)) &&
+    sync.url
+  );
+};
+
+const applyConsents = (gdprConsent, uspConsent) => (sync) => {
+  const url = getUrlBuilder(sync.url);
+
+  if (gdprConsent) {
+    url.set('gdpr', gdprConsent.gdprApplies ? 1 : 0);
+    url.set('consentString', gdprConsent.consentString || '');
+  }
+  if (uspConsent) {
+    url.set('us_privacy', encodeURIComponent(uspConsent));
+  }
+  if (common.getConfig('coppa') === true) {
+    url.set('coppa', 1);
+  }
+
+  return { ...sync, url: url.toString() };
+};
+
+function getUserId() {
+  const id = getUserIdFromStorage() || common.generateUUID();
+
+  setUserId(id);
+
+  return id;
+}
+
+function getUserIdFromStorage() {
+  const id = storage.localStorageIsEnabled()
+    ? storage.getDataFromLocalStorage(USER_ID_KEY)
+    : storage.getCookie(USER_ID_KEY);
+
+  if (!validateUUID(id)) {
+    return;
+  }
+
+  return id;
+}
+
+function setUserId(userId) {
+  if (storage.localStorageIsEnabled()) {
+    storage.setDataInLocalStorage(USER_ID_KEY, userId);
+  }
+
+  if (storage.cookiesAreEnabled()) {
+    const expires = new Date(Date.now() + USER_ID_COOKIE_EXP).toISOString();
+
+    storage.setCookie(USER_ID_KEY, userId, expires);
+  }
+}
+
+function validateUUID(uuid) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    uuid
+  );
+}
+
+/**
+ * EVENT TRACKING
+ */
+
+function onBidWon(bid) {
+  if (!getBidderConfig('winTrackingEnabled')) {
+    return;
+  }
+
+  const wurl = buildWinUrl(bid);
+
+  if (wurl !== null) {
+    utils.triggerPixel(wurl);
+  }
+
+  if (utils.isStr(bid.nurl)) {
+    utils.triggerPixel(bid.nurl);
+  }
+}
+
+function buildWinUrl(bid) {
+  try {
+    const url = getUrlBuilder(getBidderConfig('winTrackingUrl'));
+
+    url.set('impId', bid.requestId);
+    url.set('reqId', bid.bidderRequestId);
+    url.set('bidId', bid.bidId);
+
+    return url.toString();
+  } catch (_) {
+    utils.logError(
+      `${BIDDER_CODE}: Could not build win tracking URL with %s`,
+      getBidderConfig('winTrackingUrl')
+    );
+
+    return null;
+  }
+}
+
+/**
+ * COMMON
+ */
+
+const VAST_REGEXP = /VAST\s+version/;
+
+function getMediaType(adm) {
+  const videoRegex = new RegExp(VAST_REGEXP);
+
+  if (videoRegex.test(adm)) {
+    return VIDEO;
+  }
+
+  const markup = safeJSONparse(adm.replace(/\\/g, ''));
+
+  if (markup && utils.isPlainObject(markup.native)) {
+    return NATIVE;
+  }
+
+  return BANNER;
+}
+
+function safeJSONparse(...args) {
+  try {
+    return JSON.parse(...args);
+  } catch (_) {
+    return undefined;
+  }
+}
+
+function isNonEmptyStr(value) {
+  return utils.isStr(value) && !utils.isEmptyStr(value);
+}
+
+function findBidRequest(bidderRequest, bid) {
+  return find(bidderRequest.imp, (imp) => imp.id === bid.impid);
+}
+
+function getBidderConfig(property) {
+  if (!property) {
+    return common.getConfig(`${BIDDER_CODE}`);
+  }
+
+  return common.getConfig(`${BIDDER_CODE}.${property}`);
+}
+
+const getUrlBase = function (url) {
+  return url.split('?')[0];
+};
+
+const getUrlQuery = function (url) {
+  const query = url.split('?')[1];
+
+  if (!query) {
+    return;
+  }
+
+  return '?' + query.split('#')[0];
+};
+
+const getUrlHash = function (url) {
+  const hash = url.split('#')[1];
+
+  if (!hash) {
+    return;
+  }
+
+  return '#' + hash;
+};
+
+const getUrlBuilder = function (url) {
+  const hash = getUrlHash(url);
+  const base = getUrlBase(url);
+  const query = getUrlQuery(url);
+  const pairs = [];
+
+  function set(key, value) {
+    pairs.push([key, value]);
+
+    return {
+      set,
+      toString,
+    };
+  }
+
+  function toString() {
+    if (!pairs.length) {
+      return url;
+    }
+
+    const queryString = pairs
+      .map(function (pair) {
+        return pair.join('=');
+      })
+      .join('&');
+
+    if (!query) {
+      return base + '?' + queryString + (hash || '');
+    }
+
+    return base + query + '&' + queryString + (hash || '');
+  }
+
+  return {
+    set,
+    toString,
+  };
+};
+
+export const common = {
+  generateUUID: function () {
+    return utils.generateUUID();
+  },
+  getConfig: function (property) {
+    return config.getConfig(property);
+  },
+  getWindowDimensions: function () {
+    return {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+    };
+  },
+};

--- a/modules/adbookpspBidAdapter.md
+++ b/modules/adbookpspBidAdapter.md
@@ -10,6 +10,8 @@ Maintainer: hbsupport@fattail.com
 
 Prebid.JS adapter that connects to the AdbookPSP demand sources.
 
+*NOTE*: The AdBookPSP Bidder Adapter requires setup and approval before use. The adapter uses custom targeting keys that require a dedicated Google Ad Manager setup to work. Please reach out to your AdbookPSP representative for more details. 
+
 ### Bidder parameters
 
 Each adUnit with `adbookpsp` adapter has to have either `placementId` or `orgId` set.

--- a/modules/adbookpspBidAdapter.md
+++ b/modules/adbookpspBidAdapter.md
@@ -1,0 +1,189 @@
+### Overview
+
+```
+Module Name: AdbookPSP Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: hbsupport@fattail.com
+```
+
+### Description
+
+Prebid.JS adapter that connects to the AdbookPSP demand sources.
+
+### Bidder parameters
+
+Each adUnit with `adbookpsp` adapter has to have either `placementId` or `orgId` set.
+
+```js
+var adUnits = [
+  {
+    bids: [
+      {
+        bidder: 'adbookpsp',
+        params: {
+          placementId: 'example-placement-id',
+          orgId: 'example-org-id',
+        },
+      },
+    ],
+  },
+];
+```
+
+Alternatively, `orgId` can be set globally while configuring prebid.js:
+
+```js
+pbjs.setConfig({
+  adbookpsp: {
+    orgId: 'example-org-id',
+  },
+});
+```
+
+*NOTE*: adUnit orgId will take precedence over the globally set orgId.
+
+#### Banner parameters
+
+Required:
+
+- sizes
+
+Example configuration:
+
+```js
+var adUnits = [
+  {
+    code: 'div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+      },
+    }
+  },
+];
+```
+
+#### Video parameters
+
+Required:
+
+- context
+- mimes
+- playerSize
+
+Additionaly, all `Video` object parameters described in chapter `3.2.7` of the [OpenRTB 2.5 specification](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) can be passed as bidder params.
+
+Example configuration:
+
+```js
+var adUnits = [
+  {
+    code: 'div-1',
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        mimes: ['video/mp4', 'video/x-flv'],
+        playerSize: [400, 300],
+      },
+    },
+    bids: [
+      {
+        bidder: 'adbookpsp',
+        params: {
+          placementId: 'example-placement-id',
+          video: {
+            protocols: [2, 3],
+            placement: 2,
+          },
+        },
+      },
+    ],
+  },
+];
+```
+
+*NOTE*: Supporting outstream video requires the publisher to set up a renderer as described here: https://docs.prebid.org/dev-docs/show-outstream-video-ads.html
+
+#### Testing params
+
+To test the adapter, either `placementId: 'example-placement-id'` or `orgId: 'example-org-id'` can be used. 
+
+*NOTE*: If any adUnit uses the testing params, all adUnits will receive testing responses.
+
+Example adUnit configuration:
+
+```js
+var adUnits = [
+  {
+    code: 'div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+      },
+    },
+    bids: [
+      {
+        bidder: 'adbookpsp',
+        params: {
+          placementId: 'example-placement-id',
+        },
+      },
+    ],
+  },
+];
+```
+
+Example google publisher tag configuration:
+
+```js
+googletag
+  .defineSlot('/22094606581/example-adbookPSP', sizes, 'div-1')
+  .addService(googletag.pubads());
+```
+
+### Configuration
+
+Setting of the `orgId` can be done in the `pbjs.setConfig()` call. If this is the case, both `orgId` and `placementId` become optional. Remember to only call `pbjs.setConfig()` once as each call overwrites anything set in previous calls.
+
+Enabling iframe based user syncs is also encouraged.
+
+```javascript
+pbjs.setConfig({
+  adbookpsp: {
+    orgId: 'example-org-id',
+    winTrackingEnabled: true,
+  },
+  userSync: {
+    filterSettings: {
+      iframe: {
+        bidders: '*',
+        filter: 'include',
+      },
+    },
+  },
+});
+```
+
+### Privacy
+
+GDPR and US Privacy are both supported by default.
+
+#### Event tracking
+
+This adapter tracks win events for it’s bids. This functionality can be disabled by adding `winTrackingEnabled: false` to the adapter configuration:
+
+```js
+pbjs.setConfig({
+  adbookpsp: {
+    winTrackingEnabled: false,
+  },
+});
+```
+
+#### COPPA support
+
+COPPA support can be enabled for all the visitors by changing the config value:
+
+```js
+config.setConfig({ coppa: true });
+```

--- a/modules/adbookpspBidAdapter.md
+++ b/modules/adbookpspBidAdapter.md
@@ -102,7 +102,7 @@ var adUnits = [
 ];
 ```
 
-*NOTE*: Supporting outstream video requires the publisher to set up a renderer as described here: https://docs.prebid.org/dev-docs/show-outstream-video-ads.html
+*NOTE*: Supporting outstream video requires the publisher to set up a renderer as described [in the Prebid docs](https://docs.prebid.org/dev-docs/show-outstream-video-ads.html).
 
 #### Testing params
 

--- a/modules/adbookpspBidAdapter.md
+++ b/modules/adbookpspBidAdapter.md
@@ -84,6 +84,7 @@ var adUnits = [
         context: 'outstream',
         mimes: ['video/mp4', 'video/x-flv'],
         playerSize: [400, 300],
+        protocols: [2, 3],
       },
     },
     bids: [
@@ -92,7 +93,6 @@ var adUnits = [
         params: {
           placementId: 'example-placement-id',
           video: {
-            protocols: [2, 3],
             placement: 2,
           },
         },

--- a/test/spec/modules/adbookpspBidAdapter_spec.js
+++ b/test/spec/modules/adbookpspBidAdapter_spec.js
@@ -78,6 +78,27 @@ describe('adbookpsp bid adapter', () => {
 
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
+
+    it('should return true if player size is set via playerSize', () => {
+      expect(spec.isBidRequestValid(videoBid)).to.equal(true);
+    });
+
+    it('should return true if player size is set via w and h', () => {
+      const bid = utils.deepClone(videoBid);
+      delete bid.mediaTypes.video.playerSize;
+
+      bid.mediaTypes.video.w = 400;
+      bid.mediaTypes.video.h = 300;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should reutrn false if player size is not set', () => {
+      const bid = utils.deepClone(videoBid);
+      delete bid.mediaTypes.video.playerSize;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
   });
 
   describe('buildRequests()', () => {
@@ -136,6 +157,34 @@ describe('adbookpsp bid adapter', () => {
           },
         },
       });
+    });
+
+    it('should build correct request for video bid with w and h', () => {
+      const bid = utils.deepClone(videoBid);
+
+      delete bid.mediaTypes.video.playerSize;
+
+      bid.mediaTypes.video.w = 400;
+      bid.mediaTypes.video.h = 300;
+
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      const requestData = JSON.parse(request.data);
+
+      expect(requestData.imp[0].video.w).to.equal(400);
+      expect(requestData.imp[0].video.h).to.equal(300);
+    });
+
+    it('should build correct request for video bid with both w, h and playerSize', () => {
+      const bid = utils.deepClone(videoBid);
+
+      bid.mediaTypes.video.w = 640;
+      bid.mediaTypes.video.h = 480;
+
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      const requestData = JSON.parse(request.data);
+
+      expect(requestData.imp[0].video.w).to.equal(640);
+      expect(requestData.imp[0].video.h).to.equal(480);
     });
 
     it('should build correct request for mixed bid', () => {

--- a/test/spec/modules/adbookpspBidAdapter_spec.js
+++ b/test/spec/modules/adbookpspBidAdapter_spec.js
@@ -1,0 +1,1274 @@
+import { expect } from 'chai';
+import * as utils from '../../../src/utils.js';
+import {
+  spec,
+  storage,
+  DEFAULT_BIDDER_CONFIG,
+  VERSION,
+  common,
+} from '../../../modules/adbookpspBidAdapter.js';
+
+describe('adbookpsp bid adapter', () => {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+
+    sandbox
+      .stub(common, 'generateUUID')
+      .returns('54444444-5444-4444-9444-544444444444');
+    sandbox.stub(common, 'getWindowDimensions').returns({
+      innerWidth: 100,
+      innerHeight: 100,
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('isBidRequestValid()', () => {
+    it('should return false when there is no banner in mediaTypes', () => {
+      const bid = utils.deepClone(bannerBid);
+      delete bid.mediaTypes.banner;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when orgId and placementId is not defined', () => {
+      const bid = utils.deepClone(bannerBid);
+      delete bid.params.placementId;
+      delete bid.params.orgId;
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('should return true when orgId is set in config', () => {
+      const bid = utils.deepClone(bannerBid);
+
+      delete bid.params.placementId;
+      delete bid.params.orgId;
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.orgId')
+        .returns('129576');
+
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
+      expect(spec.isBidRequestValid(videoBid)).to.equal(true);
+      expect(spec.isBidRequestValid(mixedBid)).to.equal(true);
+    });
+
+    it('should return false when sizes for banner are not specified', () => {
+      const bid = utils.deepClone(bannerBid);
+      delete bid.mediaTypes.banner.sizes;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when sizes for banner are invalid', () => {
+      const bid = utils.deepClone(bannerBid);
+      delete bid.mediaTypes.banner.sizes;
+
+      bid.mediaTypes.banner.sizes = [['123', 'foo']];
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests()', () => {
+    it('should build correct request for banner bid', () => {
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.orgId')
+        .returns(undefined)
+        .withArgs('adbookpsp.exchangeUrl')
+        .returns('https://ex.fattail.com/openrtb2');
+
+      const requests = spec.buildRequests([bannerBid], bidderRequest);
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0]).to.deep.include({
+        method: 'POST',
+        url: 'https://ex.fattail.com/openrtb2',
+        options: {
+          contentType: 'application/json',
+          withCredentials: true,
+        },
+      });
+      expect(JSON.parse(requests[0].data)).to.deep.equal(bannerExchangeRequest);
+    });
+
+    it('should build correct request for video bid', () => {
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp')
+        .returns(DEFAULT_BIDDER_CONFIG)
+        .withArgs('adbookpsp.exchangeUrl')
+        .returns(DEFAULT_BIDDER_CONFIG.exchangeUrl)
+        .withArgs('adbookpsp.orgId')
+        .returns(undefined);
+
+      const requests = spec.buildRequests([videoBid], bidderRequest);
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0]).to.deep.include({
+        method: 'POST',
+        url: 'https://ex.fattail.com/openrtb2',
+        options: {
+          contentType: 'application/json',
+          withCredentials: true,
+        },
+      });
+      expect(JSON.parse(requests[0].data)).to.deep.include({
+        ...videoExchangeRequest,
+        ext: {
+          adbook: {
+            config: DEFAULT_BIDDER_CONFIG,
+            version: {
+              adapter: VERSION,
+              prebid: '$prebid.version$',
+            },
+          },
+        },
+      });
+    });
+
+    it('should build correct request for mixed bid', () => {
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.orgId')
+        .returns(undefined)
+        .withArgs('adbookpsp.exchangeUrl')
+        .returns('https://ex.fattail.com/openrtb2');
+
+      const requests = spec.buildRequests([mixedBid], bidderRequest);
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0]).to.deep.include({
+        method: 'POST',
+        url: 'https://ex.fattail.com/openrtb2',
+        options: {
+          contentType: 'application/json',
+          withCredentials: true,
+        },
+      });
+      expect(JSON.parse(requests[0].data)).to.deep.include(
+        mixedExchangeRequest
+      );
+    });
+
+    it('should use orgId from config', () => {
+      const bid = utils.deepClone(bannerBid);
+
+      delete bid.params;
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.orgId')
+        .returns('129576');
+
+      const requests = spec.buildRequests([bid], bidderRequest);
+      const request = JSON.parse(requests[0].data);
+
+      expect(request.imp[0].ext).to.deep.include({
+        adbook: {
+          orgId: '129576',
+        },
+      });
+    });
+
+    it('should use orgId from adUnit when orgId is also set in config', () => {
+      const bid = utils.deepClone(bannerBid);
+
+      delete bid.params.placementId;
+
+      bid.params.orgId = 'adUnitOrgId';
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.orgId')
+        .returns('configOrgId');
+
+      const requests = spec.buildRequests([bid], bidderRequest);
+      const request = JSON.parse(requests[0].data);
+
+      expect(request.imp[0].ext).to.deep.include({
+        adbook: {
+          orgId: 'adUnitOrgId',
+        },
+      });
+    });
+
+    it('should include in request GDPR options if available', () => {
+      const request = utils.deepClone(bidderRequest);
+
+      delete request.uspConsent;
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], request);
+
+      expect(JSON.parse(requests[0].data)).to.deep.include({
+        regs: {
+          coppa: 0,
+          ext: {
+            gdpr: 1,
+            gdprConsentString: 'gdprConsentString',
+          },
+        },
+      });
+    });
+
+    it('should include in request USP (CPPA) options if available', () => {
+      const request = utils.deepClone(bidderRequest);
+
+      delete request.gdprConsent;
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], request);
+
+      expect(JSON.parse(requests[0].data)).to.deep.include({
+        regs: {
+          coppa: 0,
+          ext: {
+            us_privacy: 'uspConsentString',
+          },
+        },
+      });
+    });
+
+    it('should pass valid coppa flag based on config', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(true);
+
+      const request = utils.deepClone(bidderRequest);
+
+      delete request.gdprConsent;
+      delete request.uspConsent;
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], request);
+
+      expect(JSON.parse(requests[0].data)).to.deep.include({
+        regs: {
+          coppa: 1,
+        },
+      });
+    });
+
+    it('should pass GDPR, USP (CCPA) and COPPA options', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(true);
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], bidderRequest);
+
+      expect(JSON.parse(requests[0].data)).to.deep.include({
+        regs: {
+          coppa: 1,
+          ext: {
+            gdpr: 1,
+            gdprConsentString: 'gdprConsentString',
+            us_privacy: 'uspConsentString',
+          },
+        },
+      });
+    });
+
+    it('should generate and pass user id when is not present in cookie and local storage is not enabled', () => {
+      sandbox.stub(storage, 'localStorageIsEnabled').returns(false);
+      const requests = spec.buildRequests([bannerBid, mixedBid], bidderRequest);
+      const rtbRequest = JSON.parse(requests[0].data);
+
+      expect(rtbRequest.user.id).to.have.lengthOf(36);
+    });
+
+    it('should pass user id when is present in cookie', () => {
+      sandbox.stub(storage, 'localStorageIsEnabled').returns(false);
+      sandbox
+        .stub(storage, 'getCookie')
+        .returns('e35da6bb-f2f8-443b-aeff-3375bef45c9d');
+      const requests = spec.buildRequests([bannerBid, mixedBid], bidderRequest);
+      const rtbRequest = JSON.parse(requests[0].data);
+
+      expect(rtbRequest.user.id).to.equal(
+        'e35da6bb-f2f8-443b-aeff-3375bef45c9d'
+      );
+    });
+
+    it('should pass user id if is present in local storage', () => {
+      sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
+      sandbox
+        .stub(storage, 'getDataFromLocalStorage')
+        .returns('e35da6bb-f2f8-443b-aeff-3375bef45c9d');
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], bidderRequest);
+      const rtbRequest = JSON.parse(requests[0].data);
+      expect(rtbRequest.user.id).to.equal(
+        'e35da6bb-f2f8-443b-aeff-3375bef45c9d'
+      );
+    });
+
+    it('should regenerate user id if it is invalid', () => {
+      sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
+      sandbox.stub(storage, 'getDataFromLocalStorage').returns('foo');
+
+      const requests = spec.buildRequests([bannerBid, mixedBid], bidderRequest);
+      const rtbRequest = JSON.parse(requests[0].data);
+      expect(rtbRequest.user.id).to.have.lengthOf(36);
+    });
+
+    it('should pass schain if available', () => {
+      const bid = utils.deepClone(bannerBid);
+      const schain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'exchange1.com',
+            sid: '1234',
+            hp: 1,
+            rid: 'bid-request-1',
+            name: 'publisher',
+            domain: 'publisher.com',
+          },
+        ],
+      };
+
+      bid.schain = schain;
+
+      const requests = spec.buildRequests([bid], bidderRequest);
+
+      expect(JSON.parse(requests[0].data).source).to.deep.include({
+        ext: {
+          schain,
+        },
+      });
+    });
+
+    it('return empty array if there are no valid bid requests', () => {
+      const requests = spec.buildRequests([], bidderRequest);
+
+      expect(requests).to.deep.equal([]);
+    });
+
+    it('should prioritize device information set in config', () => {
+      const ua =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1';
+
+      sandbox.stub(common, 'getConfig').withArgs('device').returns({
+        ua,
+      });
+
+      const requests = spec.buildRequests([bannerBid], bidderRequest);
+
+      expect(JSON.parse(requests[0].data).device.ua).to.equal(ua);
+    });
+
+    it('should include bidder config', () => {
+      const bidderConfig = {
+        bidTTL: 500,
+        defaultCurrency: 'USD',
+        exchangeUrl: 'https://exsb.fattail.com/openrtb2',
+        winTrackingEnabled: true,
+        winTrackingUrl: 'https://evsb.fattail.com/wins',
+        orgId: '129576',
+      };
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp')
+        .returns(bidderConfig);
+
+      const requests = spec.buildRequests([bannerBid], bidderRequest);
+      const request = JSON.parse(requests[0].data);
+
+      expect(request.ext).to.deep.include({
+        adbook: {
+          config: bidderConfig,
+          version: {
+            adapter: VERSION,
+            prebid: '$prebid.version$',
+          },
+        },
+      });
+    });
+
+    it('should use bidder video params if they are set', () => {
+      const videoBidWithParams = utils.deepClone(videoBid);
+      const bidderVideoParams = {
+        api: [1, 2],
+        mimes: ['video/mp4', 'video/x-flv'],
+        playbackmethod: [3, 4],
+        protocols: [5, 6],
+        minduration: 10,
+        maxduration: 30,
+      };
+      videoBidWithParams.params.video = bidderVideoParams;
+
+      const requests = spec.buildRequests([videoBidWithParams], bidderRequest);
+      const request = JSON.parse(requests[0].data);
+
+      expect(request.imp[0]).to.deep.include({
+        video: {
+          ...bidderVideoParams,
+          w: videoBidWithParams.mediaTypes.video.playerSize[0][0],
+          h: videoBidWithParams.mediaTypes.video.playerSize[0][1],
+        },
+      });
+    });
+  });
+
+  describe('interpretResponse()', () => {
+    it('should correctly interpret valid response', () => {
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.defaultCurrency')
+        .returns(DEFAULT_BIDDER_CONFIG.defaultCurrency)
+        .withArgs('adbookpsp.bidTTL')
+        .returns(DEFAULT_BIDDER_CONFIG.bidTTL);
+
+      const response = utils.deepClone(exchangeResponse);
+      const bids = spec.interpretResponse(
+        { body: response },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.deep.equal([
+        {
+          bidderRequestId: '999ccceeee11',
+          requestId: '9873kfse',
+          bidId: 'bid123456',
+          width: 300,
+          height: 250,
+          ttl: 300,
+          cpm: 0.5,
+          currency: 'USD',
+          creativeId: '123456789',
+          mediaType: 'banner',
+          meta: {
+            advertiserDomains: ['advertiser.com'],
+            mediaType: 'banner',
+            primaryCatId: 'IAB2-1',
+            secondaryCatIds: ['IAB2-2', 'IAB2-3'],
+          },
+          netRevenue: true,
+          nurl: 'http://win.example.url',
+          adUnitCode: 'div-gpt-ad-837465923534-0',
+          ad: '<div>ad</div>',
+          adId: '5',
+          adserverTargeting: {
+            hb_adid_c_adbookpsp: '5',
+            hb_deal_adbookpsp: 'werwetwerw',
+            hb_liid_adbookpsp: '2342345',
+          },
+          referrer: 'http://prebid-test-page.io:8080/banner.html',
+          lineItemId: '2342345',
+        },
+        {
+          ad: '<VAST version="4.2" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST"></VAST>',
+          adId: '10',
+          adUnitCode: 'div-gpt-ad-837465923534-0',
+          adserverTargeting: {
+            hb_adid_c_adbookpsp: '10',
+            hb_deal_adbookpsp: 'dsfxcxcvxc',
+            hb_liid_adbookpsp: '2121221',
+          },
+          bidId: 'bid4321',
+          bidderRequestId: '999ccceeee11',
+          cpm: 0.45,
+          creativeId: '543123',
+          currency: 'USD',
+          height: 250,
+          lineItemId: '2121221',
+          mediaType: 'video',
+          meta: {
+            advertiserDomains: ['advertiser.com', 'campaign.advertiser.com'],
+            mediaType: 'video',
+            primaryCatId: 'IAB2-3',
+            secondaryCatIds: [],
+          },
+          netRevenue: true,
+          nurl: 'http://win.example.url',
+          referrer: 'http://prebid-test-page.io:8080/banner.html',
+          requestId: '120kfeske',
+          ttl: 300,
+          vastXml:
+            '<VAST version="4.2" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST"></VAST>',
+          width: 300,
+        },
+      ]);
+    });
+
+    it('should place valid GAM targeting for all bids when multiple bids are present for multiple impressions', () => {
+      const response = utils.deepClone(exchangeResponse);
+
+      const bids = spec.interpretResponse(
+        { body: response },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.have.length(2);
+      expect(bids[0].adserverTargeting).to.deep.equal({
+        hb_deal_adbookpsp: 'werwetwerw',
+        hb_liid_adbookpsp: '2342345',
+        hb_adid_c_adbookpsp: '5',
+      });
+      expect(bids[1].adserverTargeting).to.deep.equal({
+        hb_deal_adbookpsp: 'dsfxcxcvxc',
+        hb_liid_adbookpsp: '2121221',
+        hb_adid_c_adbookpsp: '10',
+      });
+    });
+
+    it('should place valid GAM targeting for all bids when multiple bids are present for single impression', () => {
+      const response = utils.deepClone(exchangeResponse);
+
+      response.seatbid[1].bid[0].impid = '9873kfse';
+
+      const bids = spec.interpretResponse(
+        { body: response },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.have.length(2);
+      for (const bid of bids) {
+        expect(bid.adserverTargeting).to.deep.equal({
+          hb_deal_adbookpsp: 'werwetwerw,dsfxcxcvxc',
+          hb_liid_adbookpsp: '2342345,2121221',
+          hb_adid_c_adbookpsp: '5,10',
+        });
+      }
+    });
+
+    it('should return no bids if response id does not match bidderRequestId', () => {
+      const body = utils.deepClone(exchangeResponse);
+      body.id = '999';
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('should return no bids if response does not include seatbid', () => {
+      const body = utils.deepClone(exchangeResponse);
+      delete body.seatbid;
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('should return no bids if response does not include any bids', () => {
+      const body = utils.deepClone(exchangeResponse);
+      body.seatbid = [];
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('should exclude invalid video bids', () => {
+      const body = utils.deepClone(exchangeResponse);
+
+      body.seatbid.shift();
+      body.seatbid[0].bid[0].adid = 34;
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('should exclude invalid banner bids', () => {
+      const body = utils.deepClone(exchangeResponse);
+      const request = utils.deepClone(exchangeBidRequest);
+
+      body.seatbid.pop();
+
+      delete body.seatbid[0].bid[0].w;
+      delete body.seatbid[0].bid[0].h;
+
+      request.imp[0].banner.format.push({ w: 300, h: 600 });
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(request) }
+      );
+
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('should not include invalid banner bids in targeting map', () => {
+      const body = utils.deepClone(exchangeResponse);
+      const request = utils.deepClone(exchangeBidRequest);
+
+      body.seatbid[0].bid[0].h = '600';
+
+      request.imp[0].banner.format.push({ w: 300, h: 600 });
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(exchangeBidRequest) }
+      );
+
+      expect(bids[0].adserverTargeting).to.deep.equal({
+        hb_adid_c_adbookpsp: '10',
+        hb_deal_adbookpsp: 'dsfxcxcvxc',
+        hb_liid_adbookpsp: '2121221',
+      });
+    });
+
+    it('should not validate banner bid dimensions if bid request has single size', () => {
+      const body = utils.deepClone(exchangeResponse);
+      const request = utils.deepClone(exchangeBidRequest);
+
+      delete body.seatbid[1];
+      delete body.seatbid[0].bid[0].h;
+      delete body.seatbid[0].bid[0].w;
+
+      const bids = spec.interpretResponse(
+        { body },
+        { data: JSON.stringify(request) }
+      );
+
+      expect(bids.length).to.equal(1);
+    });
+  });
+
+  describe('getUserSyncs()', () => {
+    it('should return user syncs if there are included in the response and syncs are enabled', () => {
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: true,
+          iframeEnabled: true,
+        },
+        [{ body: exchangeResponse }]
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'http://sometest.com/sync/1234567',
+        },
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567',
+        },
+      ]);
+    });
+
+    it('should not return user syncs if syncs are disabled', () => {
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: false,
+          iframeEnabled: false,
+        },
+        [{ body: exchangeResponse }]
+      );
+
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('should return image syncs if they are enabled', () => {
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: true,
+          iframeEnabled: false,
+        },
+        [{ body: exchangeResponse }]
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'http://sometest.com/sync/1234567',
+        },
+      ]);
+    });
+
+    it('should return iframe syncs if they are enabled', () => {
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: false,
+          iframeEnabled: true,
+        },
+        [{ body: exchangeResponse }]
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567',
+        },
+      ]);
+    });
+
+    it('should append COPPA status to sync url', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(true);
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: false,
+          iframeEnabled: true,
+        },
+        [{ body: utils.deepClone(exchangeResponse) }]
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567?coppa=1',
+        },
+      ]);
+    });
+
+    it('should append GDPR consent data to url', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(false);
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: false,
+          iframeEnabled: true,
+        },
+        [{ body: utils.deepClone(exchangeResponse) }],
+        { gdprApplies: true, consentString: 'gdprConsentString' }
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567?gdpr=1&consentString=gdprConsentString',
+        },
+      ]);
+    });
+
+    it('should append USP (CCPA) consent string to url', () => {
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: false,
+          iframeEnabled: true,
+        },
+        [{ body: utils.deepClone(exchangeResponse) }],
+        undefined,
+        'uspConsentString'
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567?us_privacy=uspConsentString',
+        },
+      ]);
+    });
+
+    it('should append COPPA, GDPR and USP (CCPA) url params', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(true);
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: true,
+          iframeEnabled: true,
+        },
+        [{ body: utils.deepClone(exchangeResponse) }],
+        { gdprApplies: true, consentString: 'gdprConsentString' },
+        'uspConsentString'
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'http://sometest.com/sync/1234567?gdpr=1&consentString=gdprConsentString&us_privacy=uspConsentString&coppa=1',
+        },
+        {
+          type: 'iframe',
+          url: 'http://sometest.com/sync/1234567?gdpr=1&consentString=gdprConsentString&us_privacy=uspConsentString&coppa=1',
+        },
+      ]);
+    });
+
+    it('should respect url param syntax when appending params', () => {
+      sandbox.stub(common, 'getConfig').withArgs('coppa').returns(true);
+
+      const response = utils.deepClone(exchangeResponse);
+
+      response.ext.sync[0] = {
+        type: 'image',
+        url: 'http://sometest.com/sync/1234567?horseCount=4',
+      };
+
+      const syncs = spec.getUserSyncs(
+        {
+          pixelEnabled: true,
+          iframeEnabled: false,
+        },
+        [{ body: response }],
+        { gdprApplies: true, consentString: 'gdprConsentString' },
+        'uspConsentString'
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'http://sometest.com/sync/1234567?horseCount=4&gdpr=1&consentString=gdprConsentString&us_privacy=uspConsentString&coppa=1',
+        },
+      ]);
+    });
+  });
+
+  describe('onBidWon()', () => {
+    it('should track win if win tracking is enabled', () => {
+      const spy = sandbox.spy(utils, 'triggerPixel');
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.winTrackingEnabled')
+        .returns(true)
+        .withArgs('adbookpsp.winTrackingUrl')
+        .returns('https://ev.fattail.com/wins');
+
+      spec.onBidWon({
+        requestId: 'requestId',
+        bidderRequestId: 'bidderRequestId',
+        bidId: 'bidId',
+      });
+
+      expect(
+        spy.calledWith(
+          'https://ev.fattail.com/wins?impId=requestId&reqId=bidderRequestId&bidId=bidId'
+        )
+      ).to.equal(true);
+    });
+    it('should call bid.nurl if win tracking is enabled', () => {
+      const spy = sandbox.spy(utils, 'triggerPixel');
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.winTrackingEnabled')
+        .returns(true)
+        .withArgs('adbookpsp.winTrackingUrl')
+        .returns('https://ev.fattail.com/wins');
+
+      spec.onBidWon({
+        requestId: 'requestId',
+        bidderRequestId: 'bidderRequestId',
+        bidId: 'bidId',
+        nurl: 'http://win.example.url',
+      });
+
+      expect(spy.calledWith('http://win.example.url')).to.equal(true);
+    });
+    it('should not track win nor call bid.nurl if win tracking is disabled', () => {
+      const spy = sandbox.spy(utils, 'triggerPixel');
+
+      sandbox
+        .stub(common, 'getConfig')
+        .withArgs('adbookpsp.winTrackingEnabled')
+        .returns(false)
+        .withArgs('adbookpsp.winTrackingUrl')
+        .returns('https://ev.fattail.com/wins');
+
+      spec.onBidWon({
+        requestId: 'requestId',
+        bidderRequestId: 'bidderRequestId',
+        bidId: 'bidId',
+        nurl: 'http://win.example.url',
+      });
+
+      expect(spy.notCalled).to.equal(true);
+    });
+  });
+});
+
+const bidderRequest = {
+  auctionId: 'aaccee333311',
+  bidderRequestId: '999ccceeee11',
+  timeout: 200,
+  refererInfo: {
+    referer: 'http://example-domain.com/foo',
+  },
+  gdprConsent: {
+    gdprApplies: 1,
+    consentString: 'gdprConsentString',
+  },
+  uspConsent: 'uspConsentString',
+};
+
+const bannerBid = {
+  bidder: 'adbookpsp',
+  params: {
+    placementId: '12390123',
+  },
+  mediaTypes: {
+    banner: {
+      sizes: [
+        [300, 250],
+        [300, 600],
+      ],
+    },
+  },
+  adUnitCode: 'div-gpt-ad-837465923534-0',
+  transactionId: 'sfsf89e-mck3-asf3-fe45-feksjfi123mfs',
+  bidId: '9873kfse',
+  bidderRequestId: '999ccceeee11',
+  auctionId: 'aaccee333311',
+  lineItemId: 123123123,
+};
+
+const bannerExchangeRequest = {
+  id: '999ccceeee11',
+  device: {
+    h: 100,
+    w: 100,
+    js: true,
+    ua: navigator.userAgent,
+    dnt: 0,
+  },
+  regs: {
+    coppa: 0,
+    ext: {
+      gdpr: 1,
+      gdprConsentString: 'gdprConsentString',
+      us_privacy: 'uspConsentString',
+    },
+  },
+  site: {
+    domain: location.hostname,
+    page: location.href,
+    ref: 'http://example-domain.com/foo',
+  },
+  source: {
+    fd: 1,
+    tid: 'aaccee333311',
+  },
+  tmax: 200,
+  user: {
+    gdprConsentString: 'gdprConsentString',
+    id: '54444444-5444-4444-9444-544444444444',
+  },
+  imp: [
+    {
+      banner: {
+        format: [
+          {
+            w: 300,
+            h: 250,
+          },
+          {
+            w: 300,
+            h: 600,
+          },
+        ],
+        w: 300,
+        h: 250,
+        topframe: 0,
+        pos: 0,
+      },
+      ext: {
+        adbook: {
+          placementId: '12390123',
+        },
+      },
+      id: '9873kfse',
+      tagid: 'div-gpt-ad-837465923534-0',
+    },
+  ],
+  ext: {
+    adbook: {
+      version: {
+        adapter: VERSION,
+        prebid: '$prebid.version$',
+      },
+    },
+  },
+};
+
+const videoBid = {
+  bidder: 'adbookpsp',
+  params: {
+    placementId: '129576',
+  },
+  mediaTypes: {
+    video: {
+      api: [1, 2, 4, 6],
+      mimes: ['video/mp4'],
+      playbackmethod: [2, 4, 6],
+      playerSize: [[400, 300]],
+      protocols: [3, 4, 7, 8, 10],
+    },
+  },
+  adUnitCode: 'div-gpt-ad-9383743831-6',
+  transactionId: 'aacc3fasf-fere-1335-8m1s-785393mc3fj',
+  bidId: '120kfeske',
+  bidderRequestId: '999ccceeee11',
+  auctionId: 'aaccee333311',
+  lineItemId: 321321321,
+};
+
+const videoExchangeRequest = {
+  id: '999ccceeee11',
+  device: {
+    h: 100,
+    w: 100,
+    js: true,
+    ua: navigator.userAgent,
+    dnt: 0,
+  },
+  regs: {
+    coppa: 0,
+    ext: {
+      gdpr: 1,
+      gdprConsentString: 'gdprConsentString',
+      us_privacy: 'uspConsentString',
+    },
+  },
+  site: {
+    domain: location.hostname,
+    page: location.href,
+    ref: 'http://example-domain.com/foo',
+  },
+  source: {
+    fd: 1,
+    tid: 'aaccee333311',
+  },
+  tmax: 200,
+  user: {
+    gdprConsentString: 'gdprConsentString',
+    id: '54444444-5444-4444-9444-544444444444',
+  },
+  imp: [
+    {
+      video: {
+        api: [1, 2, 4, 6],
+        h: 300,
+        mimes: ['video/mp4'],
+        playbackmethod: [2, 4, 6],
+        protocols: [3, 4, 7, 8, 10],
+        w: 400,
+      },
+      ext: {
+        adbook: {
+          placementId: '129576',
+        },
+      },
+      id: '120kfeske',
+      tagid: 'div-gpt-ad-9383743831-6',
+    },
+  ],
+  ext: {
+    adbook: {
+      version: {
+        adapter: VERSION,
+        prebid: '$prebid.version$',
+      },
+    },
+  },
+};
+
+const mixedBid = {
+  bidder: 'adbookpsp',
+  params: {
+    orgId: '129576',
+  },
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 600]],
+    },
+    video: {
+      mimes: ['video/mp4'],
+      playerSize: [[300, 600]],
+    },
+  },
+  adUnitCode: 'div-gpt-ad-9383743831-5',
+  transactionId: 'aacc3fasf-fere-1335-8m1s-785393mc3fj',
+  bidId: '120kfeske',
+  bidderRequestId: '999ccceeee11',
+  auctionId: 'aaccee333311',
+  lineItemId: 12341234,
+};
+
+const mixedExchangeRequest = {
+  id: '999ccceeee11',
+  device: {
+    h: 100,
+    w: 100,
+    js: true,
+    ua: navigator.userAgent,
+    dnt: 0,
+  },
+  regs: {
+    coppa: 0,
+    ext: {
+      gdpr: 1,
+      gdprConsentString: 'gdprConsentString',
+      us_privacy: 'uspConsentString',
+    },
+  },
+  site: {
+    domain: location.hostname,
+    page: location.href,
+    ref: 'http://example-domain.com/foo',
+  },
+  source: {
+    fd: 1,
+    tid: 'aaccee333311',
+  },
+  tmax: 200,
+  user: {
+    gdprConsentString: 'gdprConsentString',
+    id: '54444444-5444-4444-9444-544444444444',
+  },
+  imp: [
+    {
+      banner: {
+        format: [
+          {
+            w: 300,
+            h: 600,
+          },
+        ],
+        w: 300,
+        h: 600,
+        topframe: 0,
+        pos: 0,
+      },
+      video: {
+        h: 600,
+        mimes: ['video/mp4'],
+        w: 300,
+      },
+      ext: {
+        adbook: {
+          orgId: '129576',
+        },
+      },
+      id: '120kfeske',
+      tagid: 'div-gpt-ad-9383743831-5',
+    },
+  ],
+  ext: {
+    adbook: {
+      version: {
+        adapter: VERSION,
+        prebid: '$prebid.version$',
+      },
+    },
+  },
+};
+
+const exchangeBidRequest = {
+  id: '999ccceeee11',
+  tmax: 200,
+  imp: [
+    {
+      id: '9873kfse',
+      banner: {
+        format: [
+          {
+            w: 300,
+            h: 250,
+          },
+        ],
+      },
+      video: {
+        w: 300,
+        h: 250,
+      },
+      tagid: 'div-gpt-ad-837465923534-0',
+    },
+    {
+      id: '120kfeske',
+      banner: {
+        format: [
+          {
+            w: 300,
+            h: 250,
+          },
+        ],
+      },
+      video: {
+        w: 300,
+        h: 250,
+      },
+      tagid: 'div-gpt-ad-837465923534-0',
+    },
+  ],
+  source: {
+    fd: 1,
+    tid: 'aaccee333311',
+  },
+  site: {
+    domain: location.hostname,
+    page: location.href,
+    ref: 'http://prebid-test-page.io:8080/banner.html',
+  },
+};
+
+const exchangeResponse = {
+  id: '999ccceeee11',
+  seatbid: [
+    {
+      seat: 'adbookpsp',
+      group: 0,
+      bid: [
+        {
+          id: 'bid123456',
+          w: 300,
+          h: 250,
+          impid: '9873kfse',
+          price: 0.5,
+          exp: 300,
+          crid: '123456789',
+          adm: '<div>ad</div>',
+          adid: '5',
+          dealid: 'werwetwerw',
+          nurl: 'http://win.example.url',
+          ext: {
+            liid: '2342345',
+          },
+          cat: ['IAB2-1', 'IAB2-2', 'IAB2-3'],
+          adomain: ['advertiser.com'],
+        },
+      ],
+    },
+    {
+      seat: 'adbookpsp',
+      group: 0,
+      bid: [
+        {
+          id: 'bid4321',
+          impid: '120kfeske',
+          price: 0.45,
+          exp: 300,
+          crid: '543123',
+          adm: '<VAST version="4.2" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST"></VAST>',
+          adid: '10',
+          dealid: 'dsfxcxcvxc',
+          nurl: 'http://win.example.url',
+          ext: {
+            liid: '2121221',
+          },
+          cat: ['IAB2-3'],
+          adomain: ['advertiser.com', 'campaign.advertiser.com'],
+        },
+      ],
+    },
+  ],
+  ext: {
+    sync: [
+      {
+        type: 'image',
+        url: 'http://sometest.com/sync/1234567',
+      },
+      {
+        type: 'iframe',
+        url: 'http://sometest.com/sync/1234567',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Type of change
- New bidder adapter 

## Description of change
Added adapter that connects to the AdbookPSP demand sources

- test parameters for validating bids
```
{
  bidder: 'adbookpsp',
  params: {
    placementId: 'example-placement-id',
  },
}
```
- hbsupport@fattail.com
- [x] official adapter submission
- https://github.com/prebid/prebid.github.io/pull/2933