### PR TITLE
Add eids to eplanning adapter

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -1,4 +1,5 @@
 import * as utils from '../src/utils.js';
+import { getGlobal } from '../src/prebidGlobal.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 
@@ -46,7 +47,7 @@ export const spec = {
       url = 'https://' + urlConfig.isv + '/layers/t_pbjs_2.json';
       params = {};
     } else {
-      url = 'https://' + (urlConfig.sv || DEFAULT_SV) + '/hb/1/' + urlConfig.ci + '/' + dfpClientId + '/' + getDomain(pageUrl) + '/' + sec;
+      url = 'https://' + (urlConfig.sv || DEFAULT_SV) + '/pbjs/1/' + urlConfig.ci + '/' + dfpClientId + '/' + getDomain(pageUrl) + '/' + sec;
       const referrerUrl = bidderRequest.refererInfo.referer.reachedTop ? window.top.document.referrer : bidderRequest.refererInfo.referer;
 
       if (storage.hasLocalStorage()) {
@@ -81,6 +82,10 @@ export const spec = {
 
       if (bidderRequest && bidderRequest.uspConsent) {
         params.ccpa = bidderRequest.uspConsent;
+      }
+      const userIds = (getGlobal()).getUserIds();
+      for (var id in userIds) {
+        params[id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : userIds[id];
       }
     }
 

--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -85,7 +85,7 @@ export const spec = {
       }
       const userIds = (getGlobal()).getUserIds();
       for (var id in userIds) {
-        params[id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : userIds[id];
+        params[id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
       }
     }
 

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -904,8 +904,8 @@ describe('E-Planning Adapter', function () {
         expect('aaa').to.equal(respuesta.data.vs);
       });
     });
-  describe('Send ids customs', function() {
-    it('should add to request ids customs', function() {
+  describe('Send eids', function() {
+    it('should add eids to the request', function() {
       init(config);
       config.setConfig({
         userSync: {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { spec, storage } from 'modules/eplanningBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
+import { init } from 'modules/userId/index.js';
 import * as utils from 'src/utils.js';
 
 describe('E-Planning Adapter', function () {
@@ -314,7 +316,7 @@ describe('E-Planning Adapter', function () {
 
     it('should create the url correctly', function () {
       const url = spec.buildRequests(bidRequests, bidderRequest).url;
-      expect(url).to.equal('https://ads.us.e-planning.net/hb/1/' + CI + '/1/localhost/ROS');
+      expect(url).to.equal('https://ads.us.e-planning.net/pbjs/1/' + CI + '/1/localhost/ROS');
     });
 
     it('should return GET method', function () {
@@ -690,7 +692,7 @@ describe('E-Planning Adapter', function () {
       hasLocalStorageStub.returns(false);
       const response = spec.buildRequests(bidRequests, bidderRequest);
 
-      expect(response.url).to.equal('https://ads.us.e-planning.net/hb/1/' + CI + '/1/localhost/ROS');
+      expect(response.url).to.equal('https://ads.us.e-planning.net/pbjs/1/' + CI + '/1/localhost/ROS');
       expect(response.data.vs).to.equal('F');
 
       sinon.assert.notCalled(getLocalStorageSpy);
@@ -700,7 +702,7 @@ describe('E-Planning Adapter', function () {
     it('should create the url correctly with LocalStorage', function() {
       createElementVisible();
       const response = spec.buildRequests(bidRequests, bidderRequest);
-      expect(response.url).to.equal('https://ads.us.e-planning.net/hb/1/' + CI + '/1/localhost/ROS');
+      expect(response.url).to.equal('https://ads.us.e-planning.net/pbjs/1/' + CI + '/1/localhost/ROS');
 
       expect(response.data.vs).to.equal('F');
 
@@ -902,5 +904,27 @@ describe('E-Planning Adapter', function () {
         expect('aaa').to.equal(respuesta.data.vs);
       });
     });
+  describe('Send ids customs', function() {
+    it('should add to request ids customs', function() {
+      init(config);
+      config.setConfig({
+        userSync: {
+          userIds: [
+            { name: 'id5Id', value: { 'id5id': { uid: 'ID5-ZHMOL_IfFSt7_lVYX8rBZc6GH3XMWyPQOBUfr4bm0g!', ext: { linkType: 1 } } } },
+            { name: 'pubCommonId', value: {'pubcid': 'c29cb2ae-769d-42f6-891a-f53cadee823d'} },
+            { name: 'unifiedId', value: {'tdid': 'D6885E90-2A7A-4E0F-87CB-7734ED1B99A3'} }
+          ]
+        }
+      });
+      let bidRequests = [validBidView];
+      const expected_id5id = encodeURIComponent(JSON.stringify({ uid: 'ID5-ZHMOL_IfFSt7_lVYX8rBZc6GH3XMWyPQOBUfr4bm0g!', ext: { linkType: 1 } }));
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const dataRequest = request.data;
+
+      expect('D6885E90-2A7A-4E0F-87CB-7734ED1B99A3').to.equal(dataRequest.tdid);
+      expect('c29cb2ae-769d-42f6-891a-f53cadee823d').to.equal(dataRequest.pubcid);
+      expect(expected_id5id).to.equal(dataRequest.id5id);
+    });
+  });
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
I'm adding a call to getUserIds() function on eplanning adapter in order to send the user ID values in the request

- contact email of the adapter’s maintainer: ndigrazia@e-planning.net
- [x] official adapter submission