### PR TITLE
Revert "ParrableIdSystem : Store third-party cookie support status in first-party cookie"

### DIFF
--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -21,7 +21,6 @@ const P_CONFIG_MOCK = {
     partners: 'parrable_test_partner_123,parrable_test_partner_456'
   }
 };
-const RESPONSE_HEADERS = { 'Content-Type': 'application/json' };
 
 function getConfigMock() {
   return {
@@ -57,11 +56,6 @@ function serializeParrableId(parrableId) {
   }
   if (parrableId.ccpaOptout) {
     str += ',ccpaOptout:1';
-  }
-  if (parrableId.tpc !== undefined) {
-    const tpcSupportComponent = parrableId.tpc === true ? 'tpc:1' : 'tpc:0';
-    str += `,${tpcSupportComponent}`;
-    str += `,tpcUntil:${parrableId.tpcUntil}`;
   }
   return str;
 }
@@ -131,6 +125,7 @@ describe('Parrable ID System', function() {
           { 'Content-Type': 'text/plain' },
           JSON.stringify({ eid: P_XHR_EID })
         );
+
         expect(callbackSpy.lastCall.lastArg).to.deep.equal({
           eid: P_XHR_EID
         });
@@ -245,143 +240,6 @@ describe('Parrable ID System', function() {
             expect(server.requests[0].url).to.not.contain('gdpr_consent');
           }
         })
-      });
-    });
-
-    describe('third party cookie support status', function () {
-      let logErrorStub;
-      let callbackSpy = sinon.spy();
-
-      beforeEach(function() {
-        logErrorStub = sinon.stub(utils, 'logError');
-      });
-
-      afterEach(function () {
-        callbackSpy.resetHistory();
-        removeParrableCookie();
-      });
-
-      afterEach(function() {
-        logErrorStub.restore();
-      });
-
-      describe('when getting tpcSupport from XHR response', function () {
-        let request;
-        let dateNowStub;
-        const dateNowMock = Date.now();
-        const tpcSupportTtl = 1;
-
-        before(() => {
-          dateNowStub = sinon.stub(Date, 'now').returns(dateNowMock);
-        });
-
-        after(() => {
-          dateNowStub.restore();
-        });
-
-        it('should set tpcSupport: true and tpcUntil in the cookie', function () {
-          let { callback } = parrableIdSubmodule.getId(P_CONFIG_MOCK);
-          callback(callbackSpy);
-          request = server.requests[0];
-
-          request.respond(
-            200,
-            RESPONSE_HEADERS,
-            JSON.stringify({ eid: P_XHR_EID, tpcSupport: true, tpcSupportTtl })
-          );
-
-          expect(storage.getCookie(P_COOKIE_NAME)).to.equal(
-            encodeURIComponent('eid:' + P_XHR_EID + ',tpc:1,tpcUntil:' + Math.floor((dateNowMock / 1000) + tpcSupportTtl))
-          );
-        });
-
-        it('should set tpcSupport: false and tpcUntil in the cookie', function () {
-          let { callback } = parrableIdSubmodule.getId(P_CONFIG_MOCK);
-          callback(callbackSpy);
-          request = server.requests[0];
-          request.respond(
-            200,
-            RESPONSE_HEADERS,
-            JSON.stringify({ eid: P_XHR_EID, tpcSupport: false, tpcSupportTtl })
-          );
-
-          expect(storage.getCookie(P_COOKIE_NAME)).to.equal(
-            encodeURIComponent('eid:' + P_XHR_EID + ',tpc:0,tpcUntil:' + Math.floor((dateNowMock / 1000) + tpcSupportTtl))
-          );
-        });
-
-        it('should not set tpcSupport in the cookie', function () {
-          let { callback } = parrableIdSubmodule.getId(P_CONFIG_MOCK);
-          callback(callbackSpy);
-          request = server.requests[0];
-
-          request.respond(
-            200,
-            RESPONSE_HEADERS,
-            JSON.stringify({ eid: P_XHR_EID })
-          );
-
-          expect(storage.getCookie(P_COOKIE_NAME)).to.equal(
-            encodeURIComponent('eid:' + P_XHR_EID)
-          );
-        });
-      });
-
-      describe('when getting tpcSupport from cookie', function () {
-        let request;
-        let dateNowStub;
-        const dateNowMock = Date.now();
-        const tpcSupportTtl = dateNowMock;
-        const tpcUntilExpired = 1;
-
-        before(() => {
-          dateNowStub = sinon.stub(Date, 'now').returns(dateNowMock);
-        });
-
-        after(() => {
-          dateNowStub.restore();
-        });
-
-        it('should send tpcSupport in the XHR', function () {
-          writeParrableCookie({
-            eid: P_COOKIE_EID,
-            tpc: true,
-            tpcUntil: (dateNowMock / 1000) + 1
-          });
-          let { callback } = parrableIdSubmodule.getId(P_CONFIG_MOCK);
-          callback(callbackSpy);
-          request = server.requests[0];
-
-          let queryParams = utils.parseQS(request.url.split('?')[1]);
-          let data = JSON.parse(atob(decodeBase64UrlSafe(queryParams.data)));
-
-          expect(data.tpcSupport).to.equal(true);
-        });
-
-        it('should unset tpcSupport from cookie when tpcUntil reached', function () {
-          writeParrableCookie({
-            eid: P_COOKIE_EID,
-            tpcSupport: true,
-            tpcUntil: tpcUntilExpired
-          });
-          let { callback } = parrableIdSubmodule.getId(P_CONFIG_MOCK);
-          callback(callbackSpy);
-          request = server.requests[0];
-
-          request.respond(
-            200,
-            RESPONSE_HEADERS,
-            JSON.stringify({ eid: P_XHR_EID, tpcSupport: false, tpcSupportTtl })
-          );
-
-          let queryParams = utils.parseQS(request.url.split('?')[1]);
-          let data = JSON.parse(atob(decodeBase64UrlSafe(queryParams.data)));
-
-          expect(data.tpcSupport).to.equal(undefined);
-          expect(storage.getCookie(P_COOKIE_NAME)).to.equal(
-            encodeURIComponent('eid:' + P_XHR_EID + ',tpc:0,tpcUntil:' + Math.floor((dateNowMock / 1000) + tpcSupportTtl))
-          );
-        });
       });
     });
   });
@@ -671,7 +529,7 @@ describe('Parrable ID System', function() {
     });
   });
 
-  describe('partners parsing', function () {
+  describe('partners parsing', () => {
     let callbackSpy = sinon.spy();
 
     const partnersTestCase = [


### PR DESCRIPTION
This pr #6689  shouldn't have been merged. It never passed the CircleCi tests. For some reason on the last commit the CircleCi tests didn't appear to have run.