### PR TITLE
Prebid Server Bid Adapter: Bugfix for not taking defaultVendor enabled

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -103,9 +103,9 @@ function updateConfigDefaultVendor(option) {
       utils.logError('Incorrect or unavailable prebid server default vendor option: ' + vendor);
       return false;
     }
-    // this is how we can know if user / defaultVendor has set it, or if we should default to false
-    return option.enabled = typeof option.enabled === 'boolean' ? option.enabled : false;
   }
+  // this is how we can know if user / defaultVendor has set it, or if we should default to false
+  return option.enabled = typeof option.enabled === 'boolean' ? option.enabled : false;
 }
 
 /**

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -72,7 +72,6 @@ let eidPermissions;
  * @type {S2SDefaultConfig}
  */
 const s2sDefaultConfig = {
-  enabled: false,
   timeout: 1000,
   maxBids: 1,
   adapter: 'prebidServer',
@@ -89,7 +88,7 @@ config.setDefaults({
  * @return {boolean}
  */
 function updateConfigDefaultVendor(option) {
-  if (option.defaultVendor && option.enabled !== false) {
+  if (option.defaultVendor) {
     let vendor = option.defaultVendor;
     let optionKeys = Object.keys(option);
     if (S2S_VENDORS[vendor]) {
@@ -104,6 +103,8 @@ function updateConfigDefaultVendor(option) {
       utils.logError('Incorrect or unavailable prebid server default vendor option: ' + vendor);
       return false;
     }
+    // this is how we can know if user / defaultVendor has set it, or if we should default to false
+    return option.enabled = typeof option.enabled === 'boolean' ? option.enabled : false;
   }
 }
 
@@ -163,6 +164,7 @@ function setS2sConfig(options) {
         return true;
       }
     }
+    utils.logWarn('prebidServer: s2s config is disabled');
     return false;
   });
 


### PR DESCRIPTION


## Type of change
- [X] Bugfix

## Description of change
Bug description described in https://github.com/prebid/Prebid.js/releases/tag/4.37.0

Honestly, this whole s2sConfig thing needs to be rewritten a bit. I started to do so, but then it became a bit too large for a quick bugfix.

When a module subscribes to getConfig, if they make any assumptions or defaults, there is no easy way to let downstream subscribers (or people who just run config.getConfig) those updates without calling setConfig again. Which has some extra complexities to think of.

This example is that when a user sets the s2sConfig, several new or updates params are added. And it is possible other modules or prebid core spots need to know of these updates.

For now though, this should solve all the problems with this `enabled` flag.

```js
{
   accountId: 1001,
   defaultVendor: 'rubicon',
   bidders: ['rubicon'],
}
```
=> fires s2s

```js
{
   accountId: 1001,
   defaultVendor: 'rubicon',
   bidders: ['rubicon'],
   enabled: true
}
```
=> fires s2s

```js
{
   accountId: 1001,
   defaultVendor: 'rubicon',
   bidders: ['rubicon'],
   enabled: false
}
```
=> DOES NOT fire s2s

```js
{
   accountId: 1001,
   endpoint: 'https://prebid-server.rubiconproject.com/openrtb2/auction',
   syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
   bidders: ['rubicon'],
}
```
=> DOES NOT fire s2s

```js
{
   accountId: 1001,
   endpoint: 'https://prebid-server.rubiconproject.com/openrtb2/auction',
   syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
   bidders: ['rubicon'],
   enabled: true
}
```
=> fires s2s