### PR TITLE
Beachfront Bid Adapter: add floors module support

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -6,9 +6,10 @@ import { VIDEO, BANNER } from '../src/mediaTypes.js';
 import find from 'core-js-pure/features/array/find.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
-const ADAPTER_VERSION = '1.15';
+const ADAPTER_VERSION = '1.16';
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
+const CURRENCY = 'USD';
 
 export const VIDEO_ENDPOINT = 'https://reachms.bfmio.com/bid.json?exchange_id=';
 export const BANNER_ENDPOINT = 'https://display.bfmio.com/prebid_display';
@@ -78,7 +79,7 @@ export const spec = {
         creativeId: response.crid || response.cmpId,
         renderer: context === OUTSTREAM ? createRenderer(bidRequest) : null,
         mediaType: VIDEO,
-        currency: 'USD',
+        currency: CURRENCY,
         netRevenue: true,
         ttl: 300
       };
@@ -110,7 +111,7 @@ export const spec = {
             width: bid.w,
             height: bid.h,
             mediaType: BANNER,
-            currency: 'USD',
+            currency: CURRENCY,
             netRevenue: true,
             ttl: 300
           };
@@ -250,6 +251,16 @@ function getPlayerBidParam(bid, key, defaultValue) {
   return param === undefined ? defaultValue : param;
 }
 
+function getBannerBidFloor(bid) {
+  let floorInfo = utils.isFn(bid.getFloor) ? bid.getFloor({ currency: CURRENCY, mediaType: 'banner', size: '*' }) : {};
+  return floorInfo.floor || getBannerBidParam(bid, 'bidfloor');
+}
+
+function getVideoBidFloor(bid) {
+  let floorInfo = utils.isFn(bid.getFloor) ? bid.getFloor({ currency: CURRENCY, mediaType: 'video', size: '*' }) : {};
+  return floorInfo.floor || getVideoBidParam(bid, 'bidfloor');
+}
+
 function isVideoBidValid(bid) {
   return isVideoBid(bid) && getVideoBidParam(bid, 'appId') && getVideoBidParam(bid, 'bidfloor');
 }
@@ -315,7 +326,7 @@ function createVideoRequestData(bid, bidderRequest) {
   let firstSize = getFirstSize(sizes);
   let video = getVideoTargetingParams(bid);
   let appId = getVideoBidParam(bid, 'appId');
-  let bidfloor = getVideoBidParam(bid, 'bidfloor');
+  let bidfloor = getVideoBidFloor(bid);
   let tagid = getVideoBidParam(bid, 'tagid');
   let topLocation = getTopWindowLocation(bidderRequest);
   let eids = getEids(bid);
@@ -354,7 +365,7 @@ function createVideoRequestData(bid, bidderRequest) {
     user: {
       ext: {}
     },
-    cur: ['USD']
+    cur: [CURRENCY]
   };
 
   if (bidderRequest && bidderRequest.uspConsent) {
@@ -386,7 +397,7 @@ function createBannerRequestData(bids, bidderRequest) {
     return {
       slot: bid.adUnitCode,
       id: getBannerBidParam(bid, 'appId'),
-      bidfloor: getBannerBidParam(bid, 'bidfloor'),
+      bidfloor: getBannerBidFloor(bid),
       tagid: getBannerBidParam(bid, 'tagid'),
       sizes: getBannerSizes(bid)
     };

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -18,8 +18,7 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'instream',
-                    playerSize: [640, 360],
-                    mimes: ['video/mp4', 'application/javascript']
+                    playerSize: [ 640, 360 ]
                 }
             },
             bids: [
@@ -27,7 +26,10 @@ Module that connects to Beachfront's demand sources
                     bidder: 'beachfront',
                     params: {
                         bidfloor: 0.01,
-                        appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+                        appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+                        video: {
+                            mimes: [ 'video/mp4', 'application/javascript' ]
+                        }
                     }
                 }
             ]
@@ -35,7 +37,7 @@ Module that connects to Beachfront's demand sources
             code: 'test-banner',
             mediaTypes: {
                 banner: {
-                    sizes: [300, 250]
+                    sizes: [ 300, 250 ]
                 }
             },
             bids: [
@@ -59,11 +61,10 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'outstream',
-                    playerSize: [640, 360],
-                    mimes: ['video/mp4', 'application/javascript']
+                    playerSize: [ 640, 360 ]
                 },
                 banner: {
-                    sizes: [300, 250]
+                    sizes: [ 300, 250 ]
                 }
             },
             bids: [
@@ -72,7 +73,8 @@ Module that connects to Beachfront's demand sources
                     params: {
                         video: {
                             bidfloor: 0.01,
-                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+                            mimes: [ 'video/mp4', 'application/javascript' ]
                         },
                         banner: {
                             bidfloor: 0.01,
@@ -93,8 +95,7 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'outstream',
-                    playerSize: [640, 360],
-                    mimes: ['video/mp4', 'application/javascript']
+                    playerSize: [ 640, 360 ]
                 }
             },
             bids: [
@@ -103,7 +104,8 @@ Module that connects to Beachfront's demand sources
                     params: {
                         video: {
                             bidfloor: 0.01,
-                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
+                            mimes: [ 'video/mp4', 'application/javascript' ]
                         },
                         player: {
                             progressColor: '#50A8FA',

--- a/modules/beachfrontBidAdapter.md
+++ b/modules/beachfrontBidAdapter.md
@@ -18,7 +18,8 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'instream',
-                    playerSize: [ 640, 360 ]
+                    playerSize: [640, 360],
+                    mimes: ['video/mp4', 'application/javascript']
                 }
             },
             bids: [
@@ -26,10 +27,7 @@ Module that connects to Beachfront's demand sources
                     bidder: 'beachfront',
                     params: {
                         bidfloor: 0.01,
-                        appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
-                        video: {
-                            mimes: [ 'video/mp4', 'application/javascript' ]
-                        }
+                        appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
                     }
                 }
             ]
@@ -37,7 +35,7 @@ Module that connects to Beachfront's demand sources
             code: 'test-banner',
             mediaTypes: {
                 banner: {
-                    sizes: [ 300, 250 ]
+                    sizes: [300, 250]
                 }
             },
             bids: [
@@ -61,10 +59,11 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'outstream',
-                    playerSize: [ 640, 360 ]
+                    playerSize: [640, 360],
+                    mimes: ['video/mp4', 'application/javascript']
                 },
                 banner: {
-                    sizes: [ 300, 250 ]
+                    sizes: [300, 250]
                 }
             },
             bids: [
@@ -73,8 +72,7 @@ Module that connects to Beachfront's demand sources
                     params: {
                         video: {
                             bidfloor: 0.01,
-                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
-                            mimes: [ 'video/mp4', 'application/javascript' ]
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
                         },
                         banner: {
                             bidfloor: 0.01,
@@ -95,7 +93,8 @@ Module that connects to Beachfront's demand sources
             mediaTypes: {
                 video: {
                     context: 'outstream',
-                    playerSize: [ 640, 360 ]
+                    playerSize: [640, 360],
+                    mimes: ['video/mp4', 'application/javascript']
                 }
             },
             bids: [
@@ -104,8 +103,7 @@ Module that connects to Beachfront's demand sources
                     params: {
                         video: {
                             bidfloor: 0.01,
-                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76',
-                            mimes: [ 'video/mp4', 'application/javascript' ]
+                            appId: '11bc5dd5-7421-4dd8-c926-40fa653bec76'
                         },
                         player: {
                             progressColor: '#50A8FA',

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -172,6 +172,24 @@ describe('BeachfrontAdapter', function () {
         expect(data.cur).to.deep.equal(['USD']);
       });
 
+      it('must read from the floors module if available', function () {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { video: {} };
+        bidRequest.getFloor = () => ({ currency: 'USD', floor: 1.16 });
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.imp[0].bidfloor).to.equal(1.16);
+      });
+
+      it('must use the bid floor param if no value is returned from the floors module', function () {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { video: {} };
+        bidRequest.getFloor = () => ({});
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
+      });
+
       it('must parse bid size from a nested array', function () {
         const width = 640;
         const height = 480;
@@ -363,6 +381,24 @@ describe('BeachfrontAdapter', function () {
         expect(data.domain).to.equal(topLocation.hostname);
         expect(data.search).to.equal(topLocation.search);
         expect(data.ua).to.equal(navigator.userAgent);
+      });
+
+      it('must read from the floors module if available', function () {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.getFloor = () => ({ currency: 'USD', floor: 1.16 });
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.slots[0].bidfloor).to.equal(1.16);
+      });
+
+      it('must use the bid floor param if no value is returned from the floors module', function () {
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.getFloor = () => ({});
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.slots[0].bidfloor).to.equal(bidRequest.params.bidfloor);
       });
 
       it('must parse bid size from a nested array', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Modifies the Beachfront adapter to read from the floors module.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
PR for docs: prebid/prebid.github.io#2956
Relates to: prebid/Prebid.js#6465