### PR TITLE
PBJS videoCache: Update to add auction Id in vasttrack payload

### DIFF
--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -71,6 +71,7 @@ function toStorageRequest(bid) {
   if (config.getConfig('cache.vasttrack')) {
     payload.bidder = bid.bidder;
     payload.bidid = bid.requestId;
+    payload.aid = bid.auctionId;
     // function has a thisArg set to bidderRequest for accessing the auctionStart
     if (utils.isPlainObject(this) && this.hasOwnProperty('auctionStart')) {
       payload.timestamp = this.auctionStart;

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -201,13 +201,15 @@ describe('The video cache', function () {
         ttl: 25,
         customCacheKey: customKey1,
         requestId: '12345abc',
-        bidder: 'appnexus'
+        bidder: 'appnexus',
+        auctionId: '1234-56789-abcde'
       }, {
         vastXml: vastXml2,
         ttl: 25,
         customCacheKey: customKey2,
         requestId: 'cba54321',
-        bidder: 'rubicon'
+        bidder: 'rubicon',
+        auctionId: '1234-56789-abcde'
       }];
 
       store(bids, function () { });
@@ -222,6 +224,7 @@ describe('The video cache', function () {
           ttlseconds: 25,
           key: customKey1,
           bidid: '12345abc',
+          aid: '1234-56789-abcde',
           bidder: 'appnexus'
         }, {
           type: 'xml',
@@ -229,6 +232,7 @@ describe('The video cache', function () {
           ttlseconds: 25,
           key: customKey2,
           bidid: 'cba54321',
+          aid: '1234-56789-abcde',
           bidder: 'rubicon'
         }]
       };
@@ -254,13 +258,15 @@ describe('The video cache', function () {
         ttl: 25,
         customCacheKey: customKey1,
         requestId: '12345abc',
-        bidder: 'appnexus'
+        bidder: 'appnexus',
+        auctionId: '1234-56789-abcde'
       }, {
         vastXml: vastXml2,
         ttl: 25,
         customCacheKey: customKey2,
         requestId: 'cba54321',
-        bidder: 'rubicon'
+        bidder: 'rubicon',
+        auctionId: '1234-56789-abcde'
       }];
 
       store(bids, function () { }, getMockBidRequest());
@@ -276,6 +282,7 @@ describe('The video cache', function () {
           key: customKey1,
           bidid: '12345abc',
           bidder: 'appnexus',
+          aid: '1234-56789-abcde',
           timestamp: 1510852447530
         }, {
           type: 'xml',
@@ -284,6 +291,7 @@ describe('The video cache', function () {
           key: customKey2,
           bidid: 'cba54321',
           bidder: 'rubicon',
+          aid: '1234-56789-abcde',
           timestamp: 1510852447530
         }]
       };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This update adds 'aid' property to the vasttrack payload which is set to bid auctionId

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
