### PR TITLE
Permutive RTD module docs: depends on `rtdModule`

### DIFF
--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -4,8 +4,11 @@ This submodule reads segments from Permutive and attaches them as targeting keys
 ## Usage
 Compile the Permutive RTD module into your Prebid build:
 ```
-gulp build --modules=permutiveRtdProvider
+gulp build --modules=rtdModule,permutiveRtdProvider
 ```
+
+> Note that the global RTD module, `rtdModule`, is a prerequisite of the Permutive RTD module.
+
 You then need to enable the Permutive RTD in your Prebid configuration, using the below format:
 
 ```javascript


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change

Clarify the Permutive RTD module's dependency on global `rtdModule`, as discussed with David from Permutive.

## Other information

cc. for info @dreischer
