### PR TITLE
User id module: force calls to getId if there was previously no consent data stored

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -277,6 +277,7 @@ function makeStoredConsentDataHash(consentData) {
     storedConsentData.gdprApplies = consentData.gdprApplies;
     storedConsentData.apiVersion = consentData.apiVersion;
   }
+
   return utils.cyrb53Hash(JSON.stringify(storedConsentData));
 }
 
@@ -306,17 +307,17 @@ function getStoredConsentData() {
 }
 
 /**
- * test if the consent object stored locally matches the current consent data.
- * if there is nothing in storage, return true and we'll do an actual comparison next time.
- * this way, we don't force a refresh for every user when this code rolls out
+ * test if the consent object stored locally matches the current consent data. if they
+ * don't match or there is nothing stored locally, it means a refresh of the user id
+ * submodule is needed
  * @param storedConsentData
  * @param consentData
  * @returns {boolean}
  */
 function storedConsentDataMatchesConsentData(storedConsentData, consentData) {
   return (
-    typeof storedConsentData === 'undefined' ||
-    storedConsentData === null ||
+    typeof storedConsentData !== 'undefined' &&
+    storedConsentData !== null &&
     storedConsentData === makeStoredConsentDataHash(consentData)
   );
 }

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -234,9 +234,10 @@ describe('User ID', function () {
           });
         });
       });
-      // Because the cookie exists already, there should be no setCookie call by default; the only setCookie call is
-      // to store consent data
-      expect(coreStorage.setCookie.callCount).to.equal(1);
+      // Because the consent cookie doesn't exist yet, we'll have two setCookie calls:
+      // 1) for the consent cookie
+      // 2) from the getId() call that results in a new call to store the results
+      expect(coreStorage.setCookie.callCount).to.equal(2);
     });
 
     it('Extend cookie', function () {
@@ -2407,7 +2408,7 @@ describe('User ID', function () {
             });
             // check MockId data was copied to bid
             expect(bid).to.have.deep.nested.property('userId.mid');
-            expect(bid.userId.mid).to.equal('123456778');
+            expect(bid.userId.mid).to.equal('1234');
             // also check that intentIqId id data was copied to bid
             expect(bid).to.have.deep.nested.property('userId.intentIqId');
             expect(bid.userId.intentIqId).to.equal('testintentIqId');
@@ -2785,7 +2786,7 @@ describe('User ID', function () {
         sharedAfterFunction();
       });
 
-      it('does not call getId if no stored consent data and refresh is not needed', function () {
+      it('calls getId if no stored consent data and refresh is not needed', function () {
         coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
         coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
 
@@ -2796,9 +2797,9 @@ describe('User ID', function () {
           innerAdUnits = config.adUnits
         }, {adUnits});
 
-        sinon.assert.notCalled(mockGetId);
+        sinon.assert.calledOnce(mockGetId);
         sinon.assert.calledOnce(mockDecode);
-        sinon.assert.calledOnce(mockExtendId);
+        sinon.assert.notCalled(mockExtendId);
       });
 
       it('calls getId if no stored consent data but refresh is needed', function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The user id module currently [treats "empty" stored hashed consent data as matching the current consent data](https://github.com/prebid/Prebid.js/blob/master/modules/userId/index.js#L316) available in the auction, thus [not forcing](https://github.com/prebid/Prebid.js/blob/master/modules/userId/index.js#L652) a new call to `getId()` on its own. The intention is that if consent changes from one request to the next, that a `getId()` call will be made to the user id modules can update their ID (or remove it) based on the latest consent data.

After implementing https://github.com/prebid/Prebid.js/pull/6551, however, the hashed consent data was only stored AFTER gdpr checks and consent for local storage given. This means that if the user at first did not give consent (perhaps the CMP timed out and the auction proceeded with empty consent data), then nothing would be stored in the hashed consent data but the ID module could have been called and set a "no-consent" ID. A refresh would not be required on subsequent calls because the ID had already been set and the stored consent data was empty, thus not forcing a refresh.

This PR changes the behavior and treats empty stored consent data as a reason to force a `getId()` call to the ID module.

Note that even if there is no consent data (i.e. a user from outside of the EU), the stored consent data still stores a value due to the [way the hashed value is created](https://github.com/prebid/Prebid.js/blob/3f02a15968d16d1aa9cddc48ed73098cc5677006/modules/userId/index.js#L268). This means that on the first call where cookies are allowed to be written and the user id module executes, a value will be stored based on the current consent data. If consent is not given, then the user id module essentially doesn't execute the submodules, so this doesn't force `getId()` calls on every page view.


@idettman I don't know if this would help solve https://github.com/prebid/Prebid.js/issues/6738 at all, but would love you to take a look either way.