### PR TITLE
AOL Bid Adapter: Remove validation of bidder specific video params for Nexage endpoint call formation

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -86,8 +86,7 @@ function _isOneMobileBidder(bidderCode) {
 function _isNexageRequestPost(bid) {
   if (_isOneMobileBidder(bid.bidder) && bid.params.id && bid.params.imp && bid.params.imp[0]) {
     let imp = bid.params.imp[0];
-    return imp.id && imp.tagid &&
-      ((imp.banner && imp.banner.w && imp.banner.h);
+    return imp.id && imp.tagid && imp.banner && imp.banner.w && imp.banner.h;
   }
 }
 

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -87,8 +87,7 @@ function _isNexageRequestPost(bid) {
   if (_isOneMobileBidder(bid.bidder) && bid.params.id && bid.params.imp && bid.params.imp[0]) {
     let imp = bid.params.imp[0];
     return imp.id && imp.tagid &&
-      ((imp.banner && imp.banner.w && imp.banner.h) ||
-        (imp.video && imp.video.mimes && imp.video.minduration && imp.video.maxduration));
+      ((imp.banner && imp.banner.w && imp.banner.h);
   }
 }
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change

This brings the AOL adapter into compliance with 5.0 requirement outlined at https://github.com/prebid/Prebid.js/issues/6512

AOL is welcome to recommit these validations to function from either mediatypes.video or their own parameters; however they have said they are planning to deprecate this adapter altogether in other threads and also the onevideo adapter is where they concentrate their video demand. It isn't actually clear if this adapter still functions for video demand, but it seems unlikely to for long if it does now. 

Additionally, their documentation makes no mention of Video support at https://github.com/prebid/prebid.github.io/blob/master/dev-docs/bidders/aol.md or any other place. 