### PR TITLE
Beachfront Bid Adapter: add Unified ID 2.0 support

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -19,7 +19,8 @@ export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 
 export const SUPPORTED_USER_IDS = [
   { key: 'tdid', source: 'adserver.org', rtiPartner: 'TDID', queryParam: 'tdid' },
-  { key: 'idl_env', source: 'liveramp.com', rtiPartner: 'idl', queryParam: 'idl' }
+  { key: 'idl_env', source: 'liveramp.com', rtiPartner: 'idl', queryParam: 'idl' },
+  { key: 'uid2.id', source: 'uidapi.com', rtiPartner: 'UID2', queryParam: 'uid2' }
 ];
 
 let appId = '';
@@ -279,7 +280,7 @@ function getEids(bid) {
 
 function getUserId(bid) {
   return ({ key, source, rtiPartner }) => {
-    let id = bid.userId && bid.userId[key];
+    let id = utils.deepAccess(bid, `userId.${key}`);
     return id ? formatEid(id, source, rtiPartner) : null;
   };
 }
@@ -417,7 +418,7 @@ function createBannerRequestData(bids, bidderRequest) {
   }
 
   SUPPORTED_USER_IDS.forEach(({ key, queryParam }) => {
-    let id = bids[0] && bids[0].userId && bids[0].userId[key];
+    let id = utils.deepAccess(bids, `0.userId.${key}`)
     if (id) {
       payload[queryParam] = id;
     }

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -313,6 +313,24 @@ describe('BeachfrontAdapter', function () {
           }]
         });
       });
+
+      it('must add the Unified ID 2.0 to the request', () => {
+        const uid2 = { id: '4321' };
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { video: {} };
+        bidRequest.userId = { uid2 };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.user.ext.eids[0]).to.deep.equal({
+          source: 'uidapi.com',
+          uids: [{
+            id: uid2.id,
+            ext: {
+              rtiPartner: 'UID2'
+            }
+          }]
+        });
+      });
     });
 
     describe('for banner bids', function () {
@@ -464,6 +482,16 @@ describe('BeachfrontAdapter', function () {
         const requests = spec.buildRequests([ bidRequest ]);
         const data = requests[0].data;
         expect(data.idl).to.equal(idl_env);
+      });
+
+      it('must add the Unified ID 2.0 to the request', () => {
+        const uid2 = { id: '4321' };
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = { banner: {} };
+        bidRequest.userId = { uid2 };
+        const requests = spec.buildRequests([ bidRequest ]);
+        const data = requests[0].data;
+        expect(data.uid2).to.equal(uid2.id);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds Unified ID 2.0 data to the bid request.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
PR for docs:
prebid/prebid.github.io#2963