### PR TITLE
Eplanning Bid Adapter: Adjust endpoint parameter formatting

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -85,7 +85,7 @@ export const spec = {
       }
       const userIds = (getGlobal()).getUserIds();
       for (var id in userIds) {
-        params[id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
+        params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
       }
     }
 

--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -58,7 +58,6 @@ export const spec = {
         rnd: rnd,
         e: spaces.str,
         ur: pageUrl || FILE,
-        r: 'pbjs',
         pbv: '$prebid.version$',
         ncb: '1',
         vs: spaces.vs

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -922,9 +922,9 @@ describe('E-Planning Adapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const dataRequest = request.data;
 
-      expect('D6885E90-2A7A-4E0F-87CB-7734ED1B99A3').to.equal(dataRequest.tdid);
-      expect('c29cb2ae-769d-42f6-891a-f53cadee823d').to.equal(dataRequest.pubcid);
-      expect(expected_id5id).to.equal(dataRequest.id5id);
+      expect('D6885E90-2A7A-4E0F-87CB-7734ED1B99A3').to.equal(dataRequest.e_tdid);
+      expect('c29cb2ae-769d-42f6-891a-f53cadee823d').to.equal(dataRequest.e_pubcid);
+      expect(expected_id5id).to.equal(dataRequest.e_id5id);
     });
   });
 });

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -324,11 +324,6 @@ describe('E-Planning Adapter', function () {
       expect(method).to.equal('GET');
     });
 
-    it('should return r parameter with value pbjs', function () {
-      const r = spec.buildRequests(bidRequests, bidderRequest).data.r;
-      expect(r).to.equal('pbjs');
-    });
-
     it('should return pbv parameter with value prebid version', function () {
       const pbv = spec.buildRequests(bidRequests, bidderRequest).data.pbv;
       expect(pbv).to.equal('$prebid.version$');


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
I'm updating the eplanning adapter code to add a prefix on some parameters related to eids we send internally to our servers

- contact email of the adapter’s maintainer: ndigrazia@e-planning.net
- [x] official adapter submission