### PR TITLE
Conversant adapter - picks up additional params from mediaTypes.video

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -33,10 +33,11 @@ export const spec = {
     }
 
     if (isVideoRequest(bid)) {
-      if (!bid.params.mimes) {
+      const mimes = bid.params.mimes || utils.deepAccess(bid, 'mediaTypes.video.mimes');
+      if (!mimes) {
         // Give a warning but let it pass
         utils.logWarn(BIDDER_CODE + ': mimes should be specified for videos');
-      } else if (!utils.isArray(bid.params.mimes) || !bid.params.mimes.every(s => utils.isStr(s))) {
+      } else if (!utils.isArray(mimes) || !mimes.every(s => utils.isStr(s))) {
         utils.logWarn(BIDDER_CODE + ': mimes must be an array of strings');
         return false;
       }
@@ -90,7 +91,7 @@ export const spec = {
 
         copyOptProperty(bid.params.position, video, 'pos');
         copyOptProperty(bid.params.mimes || videoData.mimes, video, 'mimes');
-        copyOptProperty(bid.params.maxduration, video, 'maxduration');
+        copyOptProperty(bid.params.maxduration || videoData.maxduration, video, 'maxduration');
         copyOptProperty(bid.params.protocols || videoData.protocols, video, 'protocols');
         copyOptProperty(bid.params.api || videoData.api, video, 'api');
 

--- a/modules/conversantBidAdapter.md
+++ b/modules/conversantBidAdapter.md
@@ -29,17 +29,17 @@ var adUnits = [
         mediaTypes: {
             video: {
                 context: 'instream',
-                playerSize: [640, 480]
+                playerSize: [640, 480],
+                api: [2],
+                protocols: [1, 2],
+                mimes: ['video/mp4']
             }
         },
         bids: [{
             bidder: "conversant",
             params: {
                 site_id: '108060',
-                api: [2],
-                protocols: [1, 2],
-                white_label_url: 'https://web.hb.ad.cpe.dotomi.com/s2s/header/24',
-                mimes: ['video/mp4']
+                white_label_url: 'https://web.hb.ad.cpe.dotomi.com/s2s/header/24'
             }
         }]
     }];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
While Conversant adapter already reads from mediaTypes.video for most fields, the following are added:

* Pick up maxduration from mediaTypes.video
* In isBidRequestValid, also check mediaTypes.video.mimes before logging a warning

Relates to #6512

- contact email of the adapter’s maintainer: pyang@conversantmedia.com