### PR TITLE
Criteo Bid Adapter: update adapter to use mediaTypes.video instead of custom parameters

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -311,14 +311,13 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
           mimes: bidRequest.mediaTypes.video.mimes,
           protocols: bidRequest.mediaTypes.video.protocols,
           maxduration: bidRequest.mediaTypes.video.maxduration,
-          api: bidRequest.mediaTypes.video.api
+          api: bidRequest.mediaTypes.video.api,
+          skip: bidRequest.mediaTypes.video.skip || bidRequest.params.video.skip,
+          placement: bidRequest.mediaTypes.video.placement || bidRequest.params.video.placement,
+          minduration: bidRequest.mediaTypes.video.minduration || bidRequest.params.video.minduration,
+          playbackmethod: bidRequest.mediaTypes.video.playbackmethod || bidRequest.params.video.playbackmethod,
+          startdelay: bidRequest.mediaTypes.video.startdelay || bidRequest.params.video.startdelay
         };
-
-        video.skip = bidRequest.params.video.skip;
-        video.placement = bidRequest.params.video.placement;
-        video.minduration = bidRequest.params.video.minduration;
-        video.playbackmethod = bidRequest.params.video.playbackmethod;
-        video.startdelay = bidRequest.params.video.startdelay;
 
         slot.video = video;
       }
@@ -373,38 +372,27 @@ function parseNativeSize(size) {
 }
 
 function hasVideoMediaType(bidRequest) {
-  if (utils.deepAccess(bidRequest, 'params.video') === undefined) {
-    return false;
-  }
   return utils.deepAccess(bidRequest, 'mediaTypes.video') !== undefined;
 }
 
 function hasValidVideoMediaType(bidRequest) {
   let isValid = true;
 
-  var requiredMediaTypesParams = ['mimes', 'playerSize', 'maxduration', 'protocols', 'api'];
+  var requiredMediaTypesParams = ['mimes', 'playerSize', 'maxduration', 'protocols', 'api', 'skip', 'placement', 'playbackmethod'];
 
   requiredMediaTypesParams.forEach(function(param) {
-    if (utils.deepAccess(bidRequest, 'mediaTypes.video.' + param) === undefined) {
+    if (utils.deepAccess(bidRequest, 'mediaTypes.video.' + param) === undefined && utils.deepAccess(bidRequest, 'params.video.' + param) === undefined) {
       isValid = false;
       utils.logError('Criteo Bid Adapter: mediaTypes.video.' + param + ' is required');
     }
   });
 
-  var requiredParams = ['skip', 'placement', 'playbackmethod'];
-
-  requiredParams.forEach(function(param) {
-    if (utils.deepAccess(bidRequest, 'params.video.' + param) === undefined) {
-      isValid = false;
-      utils.logError('Criteo Bid Adapter: params.video.' + param + ' is required');
-    }
-  });
-
   if (isValid) {
+    const videoPlacement = bidRequest.mediaTypes.video.placement || bidRequest.params.video.placement;
     // We do not support long form for now, also we have to check that context & placement are consistent
-    if (bidRequest.mediaTypes.video.context == 'instream' && bidRequest.params.video.placement === 1) {
+    if (bidRequest.mediaTypes.video.context == 'instream' && videoPlacement === 1) {
       return true;
-    } else if (bidRequest.mediaTypes.video.context == 'outstream' && bidRequest.params.video.placement !== 1) {
+    } else if (bidRequest.mediaTypes.video.context == 'outstream' && videoPlacement !== 1) {
       return true;
     }
   }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -72,7 +72,7 @@ describe('The Criteo bidding adapter', function () {
       expect(isValid).to.equal(true);
     });
 
-    it('should return true when given a valid video bid request', function () {
+    it('should return true when given a valid video bid request using mix custom bidder video parameters', function () {
       expect(spec.isBidRequestValid({
         bidder: 'criteo',
         mediaTypes: {
@@ -114,6 +114,30 @@ describe('The Criteo bidding adapter', function () {
             placement: 2,
             playbackmethod: 1
           }
+        },
+      })).to.equal(true);
+    });
+
+    it('should return true when given a valid video bid request using only mediaTypes.video parameters', function () {
+      expect(spec.isBidRequestValid({
+        bidder: 'criteo',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2],
+            skip: 1,
+            placement: 1,
+            minduration: 0,
+            playbackmethod: 1,
+            startdelay: 0
+          }
+        },
+        params: {
+          networkId: 456
         },
       })).to.equal(true);
     });


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Updated adapter to use mediaTypes.video instead of custom parameters.
Reading from custom parameters is kep for now to ensure backward compatibility. Documentation will be updated once PBJS 5.0 will be released.
