### PR TITLE
Bucksense Bid Adapter: add adomain to adapter

### DIFF
--- a/modules/bucksenseBidAdapter.js
+++ b/modules/bucksenseBidAdapter.js
@@ -90,6 +90,7 @@ export const spec = {
       var sCurrency = oResponse.currency || 'USD';
       var bNetRevenue = oResponse.netRevenue || true;
       var sAd = oResponse.ad || '';
+      var sAdomains = oResponse.adomains || [];
 
       if (request && sRequestID.length == 0) {
         utils.logInfo(WHO + ' interpretResponse() - use RequestID from Placments');
@@ -110,7 +111,10 @@ export const spec = {
         creativeId: sCreativeID,
         currency: sCurrency,
         netRevenue: bNetRevenue,
-        ad: sAd
+        ad: sAd,
+        meta: {
+          advertiserDomains: sAdomains
+        }
       };
       bidResponses.push(bidResponse);
     } else {

--- a/test/spec/modules/bucksenseBidAdapter_spec.js
+++ b/test/spec/modules/bucksenseBidAdapter_spec.js
@@ -128,7 +128,10 @@ describe('Bucksense Adapter', function() {
           'creativeId': 'creative002',
           'currency': 'USD',
           'netRevenue': false,
-          'ad': '<div id=\"bks-banner\"><a href=\"https://www.bucksense.com\" target=\"_blank\"><img src=\"https://i.bksn.se/s/1334/c5acdc75ba096bk.jpg\" width=\"300\" height=\"250\"/></a></div>'
+          'ad': '<div id=\"bks-banner\"><a href=\"https://www.bucksense.com\" target=\"_blank\"><img src=\"https://i.bksn.se/s/1334/c5acdc75ba096bk.jpg\" width=\"300\" height=\"250\"/></a></div>',
+          'meta': {
+            'advertiserDomains': ['http://www.bucksense.com/']
+          }
         }
       };
     });


### PR DESCRIPTION
Added support for advertiserDomains

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
