### PR TITLE
Adagio Bid Adapter: handle meta.advertiserDomains and update version

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -14,7 +14,7 @@ import { OUTSTREAM } from '../src/video.js';
 
 export const BIDDER_CODE = 'adagio';
 export const LOG_PREFIX = 'Adagio:';
-export const VERSION = '2.8.0';
+export const VERSION = '2.10.0';
 export const FEATURES_VERSION = '1';
 export const ENDPOINT = 'https://mp.4dex.io/prebid';
 export const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
@@ -1019,6 +1019,10 @@ export const spec = {
             const bidReq = (find(bidRequest.data.adUnits, bid => bid.bidId === bidObj.requestId));
 
             if (bidReq) {
+              bidObj.meta = utils.deepAccess(bidObj, 'meta', {});
+              bidObj.meta.mediaType = bidObj.mediaType;
+              bidObj.meta.advertiserDomains = (Array.isArray(bidObj.aDomain) && bidObj.aDomain.length) ? bidObj.aDomain : [];
+
               if (bidObj.mediaType === VIDEO) {
                 const mediaTypeContext = utils.deepAccess(bidReq, 'mediaTypes.video.context');
                 // Adagio SSP returns a `vastXml` only. No `vastUrl` nor `videoCacheKey`.

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -755,7 +755,14 @@ describe('Adagio bid adapter', () => {
           netRevenue: true,
           requestId: 'c180kg4267tyqz',
           ttl: 360,
-          width: 300
+          width: 300,
+          aDomain: ['advertiser.com'],
+          mediaType: 'banner',
+          meta: {
+            advertiserId: '80',
+            advertiserName: 'An Advertiser',
+            networkId: '110'
+          }
         }]
       }
     };
@@ -821,11 +828,51 @@ describe('Adagio bid adapter', () => {
         pagetype: 'ARTICLE',
         category: 'NEWS',
         subcategory: 'SPORT',
-        environment: 'desktop'
+        environment: 'desktop',
+        aDomain: ['advertiser.com'],
+        mediaType: 'banner',
+        meta: {
+          advertiserId: '80',
+          advertiserName: 'An Advertiser',
+          advertiserDomains: ['advertiser.com'],
+          networkId: '110',
+          mediaType: 'banner'
+        }
       }];
 
       expect(spec.interpretResponse(serverResponse, bidRequest)).to.be.an('array');
       expect(spec.interpretResponse(serverResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('Meta props should be limited if no bid.meta is provided', function() {
+      const altServerResponse = utils.deepClone(serverResponse);
+      delete altServerResponse.body.bids[0].meta;
+
+      let expectedResponse = [{
+        ad: '<div style="background-color:red; height:250px; width:300px"></div>',
+        cpm: 1,
+        creativeId: 'creativeId',
+        currency: 'EUR',
+        height: 250,
+        netRevenue: true,
+        requestId: 'c180kg4267tyqz',
+        ttl: 360,
+        width: 300,
+        placement: 'PAVE_ATF',
+        site: 'SITE-NAME',
+        pagetype: 'ARTICLE',
+        category: 'NEWS',
+        subcategory: 'SPORT',
+        environment: 'desktop',
+        aDomain: ['advertiser.com'],
+        mediaType: 'banner',
+        meta: {
+          advertiserDomains: ['advertiser.com'],
+          mediaType: 'banner'
+        }
+      }];
+
+      expect(spec.interpretResponse(altServerResponse, bidRequest)).to.deep.equal(expectedResponse);
     });
 
     it('should populate ADAGIO queue with ssp-data', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR is about to provide meta as described in https://prebid.org/blog/prebid-js-release-4-0/ and especially the `meta.advertiserDomains` which seems to be required for Prebid.js 5.0

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

## Other information
This PR is related to #6650