### PR TITLE
ETARGET Bid adapter: add get meta data functionality

### DIFF
--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -24,33 +24,6 @@ export const spec = {
   isBidRequestValid: function (bid) {
     return !!(bid.params.refid && bid.params.country);
   },
-  getMetaData: function(){
-    var mts = {};
-    var hmetas = document.getElementsByTagName('meta');
-    var wnames = ['title','og:title','description','og:description','og:url','base','keywords'];
-    try{
-      for(var k in hmetas){
-          if(typeof(hmetas[k])=='object'){
-              var mname = hmetas[k].name || hmetas[k].getAttribute('property');
-              var mcont = hmetas[k].content;
-              if(!!mname && mname!="null" && !!mcont){
-                  if(wnames.indexOf(mname)>=0){
-                      if(!mts[mname]){
-                          mts[mname] = [];
-                      }    
-                      mts[mname].push(mcont);
-                  }
-              }
-          }
-      }
-      mts['title'] = [(document.getElementsByTagName('title')[0] || []).innerHTML];
-      mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
-      mts['referer'] = [document.location.href];
-    }catch(e){
-      // error
-    }
-    return mts;
-  },
   buildRequests: function (validBidRequests, bidderRequest) {
     var i, l, bid, reqParams, netRevenue, gdprObject;
     var request = [];
@@ -88,15 +61,41 @@ export const spec = {
       bidder: 'etarget',
       gdpr: gdprObject
     };
+    
+    function getMetaData() {
+      var mts = {};
+      var hmetas = document.getElementsByTagName('meta');
+      var wnames = ['title', 'og:title', 'description', 'og:description', 'og:url', 'base', 'keywords'];
+      try {
+        for (var k in hmetas) {
+          if (typeof hmetas[k] == 'object') {
+            var mname = hmetas[k].name || hmetas[k].getAttribute('property');
+            var mcont = hmetas[k].content;
+            if (!!mname && mname != "null" && !!mcont) {
+              if (wnames.indexOf(mname) >= 0) {
+                if (!mts[mname]) {
+                    mts[mname] = [];
+                }
+                mts[mname].push(mcont);
+              }
+            }
+          }
+        }
+        mts['title'] = [(document.getElementsByTagName('title')[0] || []).innerHTML];
+        mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
+        mts['referer'] = [document.location.href];
+      } catch(e) {
+        // error
+      }
+      return mts;
+    }
 
     function formRequestUrl(reqData) {
       var key;
       var url = [];
-
       for (key in reqData) {
         if (reqData.hasOwnProperty(key) && reqData[key]) { url.push(key, '=', reqData[key], '&'); }
       }
-
       return encodeURIComponent(btoa(url.join('').slice(0, -1)));
     }
   },

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -58,11 +58,11 @@ export const spec = {
       data: bidderRequest,
       bids: validBidRequests,
       netRevenue: netRevenue,
-      //  metaData: getMetaData(),
+      metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
     };
-    /**
+    
     function getMetaData() {
       var mts = {};
       var hmetas = document.getElementsByTagName('meta');
@@ -90,7 +90,7 @@ export const spec = {
       }
       return mts;
     }
-    **/
+    
     function formRequestUrl(reqData) {
       var key;
       var url = [];
@@ -124,7 +124,7 @@ export const spec = {
           currency: data.win_cur,
           netRevenue: true,
           ttl: 360,
-          // reason: data.reason ? data.reason : 'none',
+          reason: data.reason ? data.reason : 'none',
           ad: data.banner,
           vastXml: data.vast_content,
           vastUrl: data.vast_link,

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -61,7 +61,7 @@ export const spec = {
       bidder: 'etarget',
       gdpr: gdprObject
     };
-    
+
     function getMetaData() {
       var mts = {};
       var hmetas = document.getElementsByTagName('meta');
@@ -71,10 +71,10 @@ export const spec = {
           if (typeof hmetas[k] == 'object') {
             var mname = hmetas[k].name || hmetas[k].getAttribute('property');
             var mcont = hmetas[k].content;
-            if (!!mname && mname != "null" && !!mcont) {
+            if (!!mname && mname != 'null' && !!mcont) {
               if (wnames.indexOf(mname) >= 0) {
                 if (!mts[mname]) {
-                    mts[mname] = [];
+                  mts[mname] = [];
                 }
                 mts[mname].push(mcont);
               }
@@ -85,7 +85,7 @@ export const spec = {
         mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
         mts['referer'] = [document.location.href];
       } catch(e) {
-        // error
+        mts.error = e;
       }
       return mts;
     }

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -61,7 +61,7 @@ export const spec = {
       //  metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
-    }; 
+    };
     /**
     function getMetaData() {
       var mts = {};

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -84,7 +84,7 @@ export const spec = {
         mts['title'] = [(document.getElementsByTagName('title')[0] || []).innerHTML];
         mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
         mts['referer'] = [document.location.href];
-      } catch(e) {
+      } catch (e) {
         mts.error = e;
       }
       return mts;

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -96,6 +96,7 @@ export const spec = {
           currency: data.win_cur,
           netRevenue: true,
           ttl: 360,
+          reason: data.reason,
           ad: data.banner,
           vastXml: data.vast_content,
           vastUrl: data.vast_link,

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
       bidder: 'etarget',
       gdpr: gdprObject
     };
-    
+
     function getMetaData() {
       var mts = {};
       var hmetas = document.getElementsByTagName('meta');
@@ -90,7 +90,7 @@ export const spec = {
       }
       return mts;
     }
-    
+
     function formRequestUrl(reqData) {
       var key;
       var url = [];

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -61,8 +61,7 @@ export const spec = {
       //  metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
-    };
-    
+    }; 
     /**
     function getMetaData() {
       var mts = {};
@@ -92,7 +91,6 @@ export const spec = {
       return mts;
     }
     **/
-    
     function formRequestUrl(reqData) {
       var key;
       var url = [];

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -24,6 +24,33 @@ export const spec = {
   isBidRequestValid: function (bid) {
     return !!(bid.params.refid && bid.params.country);
   },
+  getMetaData: function(){
+    var mts = {};
+    var hmetas = document.getElementsByTagName('meta');
+    var wnames = ['title','og:title','description','og:description','og:url','base','keywords'];
+    try{
+      for(var k in hmetas){
+          if(typeof(hmetas[k])=='object'){
+              var mname = hmetas[k].name || hmetas[k].getAttribute('property');
+              var mcont = hmetas[k].content;
+              if(!!mname && mname!="null" && !!mcont){
+                  if(wnames.indexOf(mname)>=0){
+                      if(!mts[mname]){
+                          mts[mname] = [];
+                      }    
+                      mts[mname].push(mcont);
+                  }
+              }
+          }
+      }
+      mts['title'] = [(document.getElementsByTagName('title')[0] || []).innerHTML];
+      mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
+      mts['referer'] = [document.location.href];
+    }catch(e){
+      // error
+    }
+    return mts;
+  },
   buildRequests: function (validBidRequests, bidderRequest) {
     var i, l, bid, reqParams, netRevenue, gdprObject;
     var request = [];
@@ -57,6 +84,7 @@ export const spec = {
       data: bidderRequest,
       bids: validBidRequests,
       netRevenue: netRevenue,
+      metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
     };

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -62,7 +62,8 @@ export const spec = {
       bidder: 'etarget',
       gdpr: gdprObject
     };
-/**
+    
+    /**
     function getMetaData() {
       var mts = {};
       var hmetas = document.getElementsByTagName('meta');
@@ -90,7 +91,8 @@ export const spec = {
       }
       return mts;
     }
-**/
+    **/
+    
     function formRequestUrl(reqData) {
       var key;
       var url = [];

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -58,7 +58,7 @@ export const spec = {
       data: bidderRequest,
       bids: validBidRequests,
       netRevenue: netRevenue,
-      metaData: getMetaData(),
+      //metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
     };

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -124,7 +124,7 @@ export const spec = {
           currency: data.win_cur,
           netRevenue: true,
           ttl: 360,
-          reason: data.reason ? data.reason : 'none',
+          // reason: data.reason ? data.reason : 'none',
           ad: data.banner,
           vastXml: data.vast_content,
           vastUrl: data.vast_link,

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -96,7 +96,7 @@ export const spec = {
           currency: data.win_cur,
           netRevenue: true,
           ttl: 360,
-          reason: data.reason,
+          reason: data.reason ? data.reason : 'none',
           ad: data.banner,
           vastXml: data.vast_content,
           vastUrl: data.vast_link,

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -18,6 +18,7 @@ const countryMap = {
   11: 'de',
   255: 'en'
 }
+
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [ BANNER, VIDEO ],

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -58,11 +58,11 @@ export const spec = {
       data: bidderRequest,
       bids: validBidRequests,
       netRevenue: netRevenue,
-      //metaData: getMetaData(),
+      //  metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
     };
-
+/**
     function getMetaData() {
       var mts = {};
       var hmetas = document.getElementsByTagName('meta');
@@ -90,7 +90,7 @@ export const spec = {
       }
       return mts;
     }
-
+**/
     function formRequestUrl(reqData) {
       var key;
       var url = [];

--- a/modules/etargetBidAdapter.md
+++ b/modules/etargetBidAdapter.md
@@ -21,6 +21,7 @@ Banner and video formats are supported.
                        params: {
                            country: 1, //require // specific to your country {1:'sk',2:'cz',3:'hu',4:'ro',5:'rs',6:'bg',7:'pl',8:'hr',9:'at',11:'de',255:'en'}
                            refid: '12345' // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
+                           options: {}  // optional // you can insert optional data if needed
                        }
                    }
                ]

--- a/modules/etargetBidAdapter.md
+++ b/modules/etargetBidAdapter.md
@@ -20,8 +20,7 @@ Banner and video formats are supported.
                        bidder: "etarget",
                        params: {
                            country: 1, //require // specific to your country {1:'sk',2:'cz',3:'hu',4:'ro',5:'rs',6:'bg',7:'pl',8:'hr',9:'at',11:'de',255:'en'}
-                           refid: '12345', // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
-                           options: {}  // optional // you can insert optional data if needed
+                           refid: '12345' // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
                        }
                    }
                ]

--- a/modules/etargetBidAdapter.md
+++ b/modules/etargetBidAdapter.md
@@ -20,7 +20,7 @@ Banner and video formats are supported.
                        bidder: "etarget",
                        params: {
                            country: 1, //require // specific to your country {1:'sk',2:'cz',3:'hu',4:'ro',5:'rs',6:'bg',7:'pl',8:'hr',9:'at',11:'de',255:'en'}
-                           refid: '12345' // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
+                           refid: '12345', // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
                            options: {}  // optional // you can insert optional data if needed
                        }
                    }

--- a/modules/etargetBidAdapter.md
+++ b/modules/etargetBidAdapter.md
@@ -19,8 +19,11 @@ Banner and video formats are supported.
                    {
                        bidder: "etarget",
                        params: {
-                           country: 1, //require // specific to your country {1:'sk',2:'cz',3:'hu',4:'ro',5:'rs',6:'bg',7:'pl',8:'hr',9:'at',11:'de',255:'en'}
-                           refid: '12345' // require // you can create/find this ID in Our portal administration on https://sk.etarget-media.com/partner/
+                           country: 1,
+                           refid: 12345,
+                           options: {
+                              site: 'example.com'
+                           }
                        }
                    }
                ]

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -154,6 +154,7 @@ describe('etarget adapter', function () {
       assert.equal(result.height, 250);
       assert.equal(result.currency, 'EUR');
       assert.equal(result.netRevenue, true);
+      assert.isNotNull(result.reason);
       assert.equal(result.ttl, 360);
       assert.equal(result.ad, '<tag1>');
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -19,13 +19,6 @@ describe('etarget adapter', function () {
     });
   });
 
-  describe('getMetaData', function () {
-    it('should return object with page info or empty object', function () {
-      let metaData = spec.getMetaData();
-      assert.ok(metaData);
-    });
-  });
-
   describe('buildRequests', function () {
     it('should pass multiple bids via single request', function () {
       let request = spec.buildRequests(bids);

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -154,7 +154,7 @@ describe('etarget adapter', function () {
       assert.equal(result.height, 250);
       assert.equal(result.currency, 'EUR');
       assert.equal(result.netRevenue, true);
-      // assert.isNotNull(result.reason);
+      assert.isNotNull(result.reason);
       assert.equal(result.ttl, 360);
       assert.equal(result.ad, '<tag1>');
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -18,6 +18,13 @@ describe('etarget adapter', function () {
       assert(spec.isBidRequestValid(bid));
     });
   });
+  
+  describe('getMetaData', function () {
+    it('should return object with page info or empty object', function () {
+      let metaData = spec.getMetaData();
+      assert.ok(metaData);
+    });
+  });
 
   describe('buildRequests', function () {
     it('should pass multiple bids via single request', function () {

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -18,7 +18,7 @@ describe('etarget adapter', function () {
       assert(spec.isBidRequestValid(bid));
     });
   });
-  
+
   describe('getMetaData', function () {
     it('should return object with page info or empty object', function () {
       let metaData = spec.getMetaData();

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -154,7 +154,7 @@ describe('etarget adapter', function () {
       assert.equal(result.height, 250);
       assert.equal(result.currency, 'EUR');
       assert.equal(result.netRevenue, true);
-      assert.isNotNull(result.reason);
+      //assert.isNotNull(result.reason);
       assert.equal(result.ttl, 360);
       assert.equal(result.ad, '<tag1>');
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');

--- a/test/spec/modules/etargetBidAdapter_spec.js
+++ b/test/spec/modules/etargetBidAdapter_spec.js
@@ -154,7 +154,7 @@ describe('etarget adapter', function () {
       assert.equal(result.height, 250);
       assert.equal(result.currency, 'EUR');
       assert.equal(result.netRevenue, true);
-      //assert.isNotNull(result.reason);
+      // assert.isNotNull(result.reason);
       assert.equal(result.ttl, 360);
       assert.equal(result.ad, '<tag1>');
       assert.equal(result.transactionId, '5f33781f-9552-4ca1');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
