### PR TITLE
pubGENIUS bid adapter: read more video params from mediaTypes.video

### DIFF
--- a/modules/pubgeniusBidAdapter.js
+++ b/modules/pubgeniusBidAdapter.js
@@ -149,7 +149,22 @@ export const spec = {
 
 function buildVideoParams(videoMediaType, videoParams) {
   videoMediaType = videoMediaType || {};
-  const params = pick(videoMediaType, ['api', 'mimes', 'protocols', 'playbackmethod']);
+  const params = pick(videoMediaType, [
+    'mimes',
+    'minduration',
+    'maxduration',
+    'protocols',
+    'startdelay',
+    'placement',
+    'skip',
+    'skipafter',
+    'minbitrate',
+    'maxbitrate',
+    'delivery',
+    'playbackmethod',
+    'api',
+    'linearity',
+  ]);
 
   switch (videoMediaType.context) {
     case 'instream':

--- a/modules/pubgeniusBidAdapter.md
+++ b/modules/pubgeniusBidAdapter.md
@@ -65,16 +65,16 @@ var adUnits = [
           adUnitId: '1001',
           test: true,
 
-          // other video parameters as in OpenRTB v2.5 spec
+          // Other video parameters can be put here as in OpenRTB v2.5 spec.
+          // This overrides the same parameters in mediaTypes.video.
           video: {
-            skip: 1
-
-            // the following overrides mediaTypes.video of the ad unit
             placement: 1,
+
+            // w and h overrides mediaTypes.video.playerSize.
             w: 640,
             h: 360,
-            mimes: ['video/mp4'],
-            protocols: [3],
+
+            skip: 1
           }
         }
       }

--- a/test/spec/modules/pubgeniusBidAdapter_spec.js
+++ b/test/spec/modules/pubgeniusBidAdapter_spec.js
@@ -370,6 +370,8 @@ describe('pubGENIUS adapter', () => {
           protocols: [2, 3],
           api: [1, 2],
           playbackmethod: [3, 4],
+          maxduration: 10,
+          linearity: 1,
         },
       };
       bidRequest.params.video = {
@@ -394,6 +396,7 @@ describe('pubGENIUS adapter', () => {
         skipafter: 1,
         playbackmethod: [3, 4],
         api: [1, 2],
+        linearity: 1,
       };
 
       expect(buildRequests([bidRequest], bidderRequest)).to.deep.equal(expectedRequest);


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
As flagged in https://github.com/prebid/Prebid.js/issues/6512


- contact email of the adapter’s maintainer: meng@pubgenius.io
- [x] official adapter submission

- A link to a PR on the docs repo https://github.com/prebid/prebid.github.io/pull/2974
