### PR TITLE
adnuntias Bid Adapter: Added GDPR support and segment passing

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -7,12 +7,19 @@ const BIDDER_CODE = 'adnuntius';
 const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
 const GVLID = 855;
 
+const checkSegment = function (segment) {
+  if (utils.isStr(segment)) return segment;
+  if (segment.id) return segment.id
+}
+
 const getSegmentsFromOrtb = function (ortb2) {
   const userData = utils.deepAccess(ortb2, 'user.data');
-  let segments;
+  let segments = [];
   if (userData) {
     userData.forEach(userdat => {
-      segments = (userdat.segment) ? userdat.segment.map(segment => segment.id) : undefined
+      if (userdat.segment) {
+        segments.push(...userdat.segment.filter(checkSegment).map(checkSegment));
+      }
     });
   }
   return segments

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -43,7 +43,7 @@ export const spec = {
     const gdprApplies = utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
     const reqConsent = (gdprApplies !== undefined) ? '&consentString=' + consentString : '';
-    const reqSegments = (segments !== undefined && utils.isArray(segments) && segments.length > 0) ? '&segments=' + segments.join(',') : '';
+    const reqSegments = (segments.length > 0) ? '&segments=' + segments.join(',') : '';
 
     for (var i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i]

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,30 +1,42 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'adnuntius';
 const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
+const GVLID = 855;
 
 export const spec = {
   code: BIDDER_CODE,
-
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER],
   isBidRequestValid: function (bid) {
     return !!(bid.bidId || (bid.params.member && bid.params.invCode));
   },
 
-  buildRequests: function (validBidRequests) {
+  buildRequests: function (validBidRequests, bidderRequest) {
     const networks = {};
     const bidRequests = {};
     const requests = [];
+    const segments = config.getConfig('segments');
+    utils.logMessage('CONF', segments)
     const tzo = new Date().getTimezoneOffset();
-
+    const gdprApplies = utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
+    const consentString = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
+    const reqConsent = (gdprApplies !== undefined) ? '&consentString=' + consentString : '';
+    const reqSegments = (segments !== undefined && utils.isArray(segments)) ? '&segments=' + segments.join(',') : '';
     for (var i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i]
       const network = bid.params.network || 'network';
+      const targeting = bid.params.targeting || {};
+
       bidRequests[network] = bidRequests[network] || [];
       bidRequests[network].push(bid);
 
       networks[network] = networks[network] || {};
       networks[network].adUnits = networks[network].adUnits || [];
-      networks[network].adUnits.push({ ...bid.params.targeting, auId: bid.params.auId, targetId: bid.bidId });
+      networks[network].adUnits.push({ ...targeting, auId: bid.params.auId, targetId: bid.bidId });
     }
 
     const networkKeys = Object.keys(networks)
@@ -32,7 +44,7 @@ export const spec = {
       const network = networkKeys[j];
       requests.push({
         method: 'POST',
-        url: ENDPOINT_URL + tzo + '&format=json',
+        url: ENDPOINT_URL + tzo + '&format=json' + reqSegments + reqConsent,
         data: JSON.stringify(networks[network]),
         bid: bidRequests[network]
       });

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -25,7 +25,7 @@ export const spec = {
     const gdprApplies = utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
     const reqConsent = (gdprApplies !== undefined) ? '&consentString=' + consentString : '';
-    const reqSegments = (segments !== undefined && utils.isArray(segments)) ? '&segments=' + segments.join(',') : '';
+    const reqSegments = (segments !== undefined && utils.isArray(segments) && segments.length > 0) ? '&segments=' + segments.join(',') : '';
     for (var i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i]
       const network = bid.params.network || 'network';

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -7,6 +7,17 @@ const BIDDER_CODE = 'adnuntius';
 const ENDPOINT_URL = 'https://delivery.adnuntius.com/i?tzo=';
 const GVLID = 855;
 
+const getSegmentsFromOrtb = function (ortb2) {
+  const userData = utils.deepAccess(ortb2, 'user.data');
+  let segments;
+  if (userData) {
+    userData.forEach(userdat => {
+      segments = (userdat.segment) ? userdat.segment.map(segment => segment.id) : undefined
+    });
+  }
+  return segments
+}
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
@@ -19,13 +30,14 @@ export const spec = {
     const networks = {};
     const bidRequests = {};
     const requests = [];
-    const segments = config.getConfig('segments');
-    utils.logMessage('CONF', segments)
+    const ortb2 = config.getConfig('ortb2');
+    const segments = getSegmentsFromOrtb(ortb2);
     const tzo = new Date().getTimezoneOffset();
     const gdprApplies = utils.deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = utils.deepAccess(bidderRequest, 'gdprConsent.consentString');
     const reqConsent = (gdprApplies !== undefined) ? '&consentString=' + consentString : '';
     const reqSegments = (segments !== undefined && utils.isArray(segments) && segments.length > 0) ? '&segments=' + segments.join(',') : '';
+
     for (var i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i]
       const network = bid.params.network || 'network';

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -5,13 +5,13 @@ import { newBidder } from 'src/adapters/bidderFactory.js';
 import { config } from 'src/config.js';
 
 describe('adnuntiusBidAdapter', function () {
-  beforeEach(function () {
-    config.setConfig({ segments: [] });
+  afterEach(function () {
+    config.resetConfig();
   });
   const tzo = new Date().getTimezoneOffset();
   const ENDPOINT_URL = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
-  // const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&segments=segment1,segment2`;
-  const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
+  // const ENDPOINT_URL_SEGMENTS_ = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
+  const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&segments=segment1,segment2,segment3`;
   const ENDPOINT_URL_CONSENT = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&consentString=consentString`;
   const adapter = newBidder(spec);
 
@@ -125,10 +125,52 @@ describe('adnuntiusBidAdapter', function () {
     });
 
     it('should pass segments if available in config', function () {
-      config.setConfig({
-        segments: ['segment1', 'segment2']
+      config.setBidderConfig({
+        bidders: ['adnuntius', 'other'],
+        config: {
+          ortb2: {
+            user: {
+              data: [{
+                name: 'adnuntius',
+                segment: [{ id: 'segment1' }, { id: 'segment2' }]
+              },
+              {
+                name: 'other',
+                segment: ['segment3']
+              }],
+            }
+          }
+        }
       });
-      const request = spec.buildRequests(bidRequests);
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidRequests));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
+    });
+
+    it('should skip segments in config if not either id or array of strings', function () {
+      config.setBidderConfig({
+        bidders: ['adnuntius', 'other'],
+        config: {
+          ortb2: {
+            user: {
+              data: [{
+                name: 'adnuntius',
+                segment: [{ id: 'segment1' }, { id: 'segment2' }, { id: 'segment3' }]
+              },
+              {
+                name: 'other',
+                segment: [{
+                  notright: 'segment4'
+                }]
+              }],
+            }
+          }
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidRequests));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -2,10 +2,16 @@
 import { expect } from 'chai'; // may prefer 'assert' in place of 'expect'
 import { spec } from 'modules/adnuntiusBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
 
 describe('adnuntiusBidAdapter', function () {
+  beforeEach(function () {
+    config.setConfig({ segments: [] });
+  });
   const tzo = new Date().getTimezoneOffset();
   const ENDPOINT_URL = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
+  const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&segments=segment1,segment2`;
+  const ENDPOINT_URL_CONSENT = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&consentString=consentString`;
   const adapter = newBidder(spec);
 
   const bidRequests = [
@@ -115,6 +121,32 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
       expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\",\"targetId\":\"123\"}]}');
+    });
+
+    it('should pass segments if available in config', function () {
+      config.setConfig({
+        segments: ['segment1', 'segment2']
+      });
+      const request = spec.buildRequests(bidRequests);
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
+    });
+  });
+
+  describe('user privacy', function () {
+    it('should send GDPR Consent data if gdprApplies', function () {
+      let request = spec.buildRequests(bidRequests, { gdprConsent: { gdprApplies: true, consentString: 'consentString' } });
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_CONSENT);
+    });
+
+    it('should not send GDPR Consent data if gdprApplies equals undefined', function () {
+      let request = spec.buildRequests(bidRequests, { gdprConsent: { gdprApplies: undefined, consentString: 'consentString' } });
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
     });
   });
 

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -10,7 +10,8 @@ describe('adnuntiusBidAdapter', function () {
   });
   const tzo = new Date().getTimezoneOffset();
   const ENDPOINT_URL = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
-  const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&segments=segment1,segment2`;
+  // const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&segments=segment1,segment2`;
+  const ENDPOINT_URL_SEGMENTS = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json`;
   const ENDPOINT_URL_CONSENT = `https://delivery.adnuntius.com/i?tzo=${tzo}&format=json&consentString=consentString`;
   const adapter = newBidder(spec);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding GDPR support for the bid adapter and allowing customers to pass segments through the bidder config. If a user has accepted our GLV ID we will use the segments passed on to the adserver. If not, they will not be matched against targeted line items by the adserver.


- contact email of the adapter’s maintainer: mikael@adnuntius.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/2975

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->