### PR TITLE
Optimized AdUp Technology bid adapter: add support for native, adomain, and multibid

### DIFF
--- a/modules/aduptechBidAdapter.js
+++ b/modules/aduptechBidAdapter.js
@@ -1,20 +1,169 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER } from '../src/mediaTypes.js'
+import { config } from '../src/config.js';
+import { BANNER, NATIVE } from '../src/mediaTypes.js'
 import * as utils from '../src/utils.js';
 
 export const BIDDER_CODE = 'aduptech';
-export const PUBLISHER_PLACEHOLDER = '{PUBLISHER}';
-export const ENDPOINT_URL = 'https://rtb.d.adup-tech.com/prebid/' + PUBLISHER_PLACEHOLDER + '_bid';
+export const ENDPOINT_URL_PUBLISHER_PLACEHOLDER = '{PUBLISHER}';
+export const ENDPOINT_URL = 'https://rtb.d.adup-tech.com/prebid/' + ENDPOINT_URL_PUBLISHER_PLACEHOLDER + '_bid';
 export const ENDPOINT_METHOD = 'POST';
 
+/**
+ * Internal utitlity functions
+ */
+export const internal = {
+
+  /**
+   * Extracts the GDPR information from given bidderRequest
+   *
+   * @param {BidderRequest} bidderRequest
+   * @returns {null|Object.<string, string|boolean>}
+   */
+  extractGdpr: (bidderRequest) => {
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      return {
+        consentString: bidderRequest.gdprConsent.consentString,
+        consentRequired: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+      };
+    }
+
+    return null;
+  },
+
+  /**
+   * Extracts the pageUrl from given bidderRequest.refererInfo or gobal "pageUrl" config or from (top) window location
+   *
+   * @param {BidderRequest} bidderRequest
+   * @returns {string}
+   */
+  extractPageUrl: (bidderRequest) => {
+    if (bidderRequest && utils.deepAccess(bidderRequest, 'refererInfo.canonicalUrl')) {
+      return bidderRequest.refererInfo.canonicalUrl;
+    }
+
+    if (config && config.getConfig('pageUrl')) {
+      return config.getConfig('pageUrl');
+    }
+
+    try {
+      return utils.getWindowTop().location.href;
+    } catch (e) {
+      return utils.getWindowSelf().location.href;
+    }
+  },
+
+  /**
+   * Extracts the referrer based on given bidderRequest.refererInfo or from (top) document referrer
+   *
+   * @param {BidderRequest} bidderRequest
+   * @returns {string}
+   */
+  extractReferrer: (bidderRequest) => {
+    if (bidderRequest && utils.deepAccess(bidderRequest, 'refererInfo.referer')) {
+      return bidderRequest.refererInfo.referer;
+    }
+
+    try {
+      return utils.getWindowTop().document.referrer;
+    } catch (e) {
+      return utils.getWindowSelf().document.referrer;
+    }
+  },
+
+  /**
+   * Extracts banner config from given bidRequest
+   *
+   * @param {BidRequest} bidRequest
+   * @returns {null|Object.<string, *>}
+   */
+  extractBannerConfig: (bidRequest) => {
+    const sizes = utils.getAdUnitSizes(bidRequest);
+    if (Array.isArray(sizes) && sizes.length > 0) {
+      return { sizes: sizes };
+    }
+
+    return null;
+  },
+
+  /**
+   * Extracts native config from given bidRequest
+   *
+   * @param {BidRequest} bidRequest
+   * @returns {null|Object.<string, *>}
+   */
+  extractNativeConfig: (bidRequest) => {
+    if (bidRequest && utils.deepAccess(bidRequest, 'mediaTypes.native')) {
+      return bidRequest.mediaTypes.native;
+    }
+
+    return null;
+  },
+
+  /**
+   * Extracts the bidder params from given bidRequest
+   *
+   * @param {BidRequest} bidRequest
+   * @returns {null|Object.<string, *>}
+   */
+  extractParams: (bidRequest) => {
+    if (bidRequest && bidRequest.params) {
+      return bidRequest.params
+    }
+
+    return null;
+  },
+
+  /**
+   * Group given array of bidRequests by params.publisher
+   *
+   * @param {BidRequest[]} bidRequests
+   * @returns {Object.<string, BidRequest>}
+   */
+  groupBidRequestsByPublisher: (bidRequests) => {
+    const groupedBidRequests = {};
+
+    if (!bidRequests || bidRequests.length === 0) {
+      return groupedBidRequests;
+    }
+
+    bidRequests.forEach((bidRequest) => {
+      const publisher = internal.extractParams(bidRequest).publisher;
+      if (!publisher) {
+        return;
+      }
+
+      if (!groupedBidRequests[publisher]) {
+        groupedBidRequests[publisher] = [];
+      }
+
+      groupedBidRequests[publisher].push(bidRequest);
+    });
+
+    return groupedBidRequests;
+  },
+
+  /**
+   * Build ednpoint url based on given publisher code
+   *
+   * @param {string} publisher
+   * @returns {string}
+   */
+  buildEndpointUrl: (publisher) => {
+    return ENDPOINT_URL.replace(ENDPOINT_URL_PUBLISHER_PLACEHOLDER, encodeURIComponent(publisher));
+  },
+}
+
+/**
+ * The bid adapter definition
+ */
 export const spec = {
   code: BIDDER_CODE,
-  supportedMediaTypes: [BANNER],
+  supportedMediaTypes: [BANNER, NATIVE],
 
   /**
    * Validate given bid request
    *
-   * @param {*} bidRequest
+   * @param {BidRequest[]} bidRequest
    * @returns {boolean}
    */
   isBidRequestValid: (bidRequest) => {
@@ -22,12 +171,13 @@ export const spec = {
       return false;
     }
 
-    const sizes = extractSizesFromBidRequest(bidRequest);
-    if (!sizes || sizes.length === 0) {
+    // banner or native config has to be set
+    if (!internal.extractBannerConfig(bidRequest) && !internal.extractNativeConfig(bidRequest)) {
       return false;
     }
 
-    const params = extractParamsFromBidRequest(bidRequest);
+    // publisher and placement param has to be set
+    const params = internal.extractParams(bidRequest);
     if (!params || !params.publisher || !params.placement) {
       return false;
     }
@@ -38,152 +188,124 @@ export const spec = {
   /**
    * Build real bid requests
    *
-   * @param {*} validBidRequests
-   * @param {*} bidderRequest
-   * @returns {*[]}
+   * @param {BidRequest[]} validBidRequests
+   * @param {BidderRequest} bidderRequest
+   * @returns {Object[]}
    */
   buildRequests: (validBidRequests, bidderRequest) => {
-    const bidRequests = [];
-    const gdpr = extractGdprFromBidderRequest(bidderRequest);
+    const requests = [];
 
-    validBidRequests.forEach((bidRequest) => {
-      bidRequests.push({
-        url: ENDPOINT_URL.replace(PUBLISHER_PLACEHOLDER, encodeURIComponent(bidRequest.params.publisher)),
+    // stop here on invalid or empty data
+    if (!bidderRequest || !validBidRequests || validBidRequests.length === 0) {
+      return requests;
+    }
+
+    // collect required data
+    const auctionId = bidderRequest.auctionId;
+    const pageUrl = internal.extractPageUrl(bidderRequest);
+    const referrer = internal.extractReferrer(bidderRequest);
+    const gdpr = internal.extractGdpr(bidderRequest);
+
+    // group bid requests by publisher
+    const groupedBidRequests = internal.groupBidRequestsByPublisher(validBidRequests);
+
+    // build requests
+    for (const publisher in groupedBidRequests) {
+      const request = {
+        url: internal.buildEndpointUrl(publisher),
         method: ENDPOINT_METHOD,
         data: {
+          auctionId: auctionId,
+          pageUrl: pageUrl,
+          referrer: referrer,
+          imp: []
+        }
+      };
+
+      // add gdpr data
+      if (gdpr) {
+        request.data.gdpr = gdpr;
+      }
+
+      // handle multiple bids per request
+      groupedBidRequests[publisher].forEach((bidRequest) => {
+        const bid = {
           bidId: bidRequest.bidId,
-          auctionId: bidRequest.auctionId,
           transactionId: bidRequest.transactionId,
           adUnitCode: bidRequest.adUnitCode,
-          pageUrl: extractTopWindowUrlFromBidRequest(bidRequest),
-          referrer: extractTopWindowReferrerFromBidRequest(bidRequest),
-          sizes: extractSizesFromBidRequest(bidRequest),
-          params: extractParamsFromBidRequest(bidRequest),
-          gdpr: gdpr
-        }
-      });
-    });
+          params: internal.extractParams(bidRequest)
+        };
 
-    return bidRequests;
+        // add banner config
+        const bannerConfig = internal.extractBannerConfig(bidRequest);
+        if (bannerConfig) {
+          bid.banner = bannerConfig;
+        }
+
+        // add native config
+        const nativeConfig = internal.extractNativeConfig(bidRequest);
+        if (nativeConfig) {
+          bid.native = nativeConfig;
+        }
+
+        request.data.imp.push(bid);
+      });
+
+      requests.push(request);
+    }
+
+    return requests;
   },
 
   /**
    * Handle bid response
    *
-   * @param {*} response
-   * @returns {*[]}
+   * @param {Object} response
+   * @returns {Object[]}
    */
   interpretResponse: (response) => {
     const bidResponses = [];
 
-    if (!response.body || !response.body.bid || !response.body.creative) {
+    // stop here on invalid or empty data
+    if (!response || !utils.deepAccess(response, 'body.bids') || response.body.bids.length === 0) {
       return bidResponses;
     }
 
-    bidResponses.push({
-      requestId: response.body.bid.bidId,
-      cpm: response.body.bid.price,
-      netRevenue: response.body.bid.net,
-      currency: response.body.bid.currency,
-      ttl: response.body.bid.ttl,
-      creativeId: response.body.creative.id,
-      width: response.body.creative.width,
-      height: response.body.creative.height,
-      ad: response.body.creative.html
+    // parse multiple bids per response
+    response.body.bids.forEach((bid) => {
+      if (!bid || !bid.bid || !bid.creative) {
+        return;
+      }
+
+      const bidResponse = {
+        requestId: bid.bid.bidId,
+        cpm: bid.bid.price,
+        netRevenue: bid.bid.net,
+        currency: bid.bid.currency,
+        ttl: bid.bid.ttl,
+        creativeId: bid.creative.id,
+        meta: {
+          advertiserDomains: bid.creative.advertiserDomains
+        }
+      }
+
+      if (bid.creative.html) {
+        bidResponse.mediaType = BANNER;
+        bidResponse.ad = bid.creative.html;
+        bidResponse.width = bid.creative.width;
+        bidResponse.height = bid.creative.height;
+      }
+
+      if (bid.creative.native) {
+        bidResponse.mediaType = NATIVE;
+        bidResponse.native = bid.creative.native;
+      }
+
+      bidResponses.push(bidResponse);
     });
 
     return bidResponses;
   }
 };
-
-/**
- * Extracts the possible ad unit sizes from given bid request
- *
- * @param {*} bidRequest
- * @returns {number[]}
- */
-export function extractSizesFromBidRequest(bidRequest) {
-  // since pbjs 3.0
-  if (bidRequest && utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes')) {
-    return bidRequest.mediaTypes.banner.sizes;
-
-  // for backward compatibility
-  } else if (bidRequest && bidRequest.sizes) {
-    return bidRequest.sizes;
-
-  // fallback
-  } else {
-    return [];
-  }
-}
-
-/**
- * Extracts the custom params from given bid request
- *
- * @param {*} bidRequest
- * @returns {*}
- */
-export function extractParamsFromBidRequest(bidRequest) {
-  if (bidRequest && bidRequest.params) {
-    return bidRequest.params
-  } else {
-    return null;
-  }
-}
-
-/**
- * Extracts the GDPR information from given bidder request
- *
- * @param {*} bidderRequest
- * @returns {*}
- */
-export function extractGdprFromBidderRequest(bidderRequest) {
-  let gdpr = null;
-
-  if (bidderRequest && bidderRequest.gdprConsent) {
-    gdpr = {
-      consentString: bidderRequest.gdprConsent.consentString,
-      consentRequired: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
-    };
-  }
-
-  return gdpr;
-}
-
-/**
- * Extracts the page url from given bid request or use the (top) window location as fallback
- *
- * @param {*} bidRequest
- * @returns {string}
- */
-export function extractTopWindowUrlFromBidRequest(bidRequest) {
-  if (bidRequest && utils.deepAccess(bidRequest, 'refererInfo.canonicalUrl')) {
-    return bidRequest.refererInfo.canonicalUrl;
-  }
-
-  try {
-    return window.top.location.href;
-  } catch (e) {
-    return window.location.href;
-  }
-}
-
-/**
- * Extracts the referrer from given bid request or use the (top) document referrer as fallback
- *
- * @param {*} bidRequest
- * @returns {string}
- */
-export function extractTopWindowReferrerFromBidRequest(bidRequest) {
-  if (bidRequest && utils.deepAccess(bidRequest, 'refererInfo.referer')) {
-    return bidRequest.refererInfo.referer;
-  }
-
-  try {
-    return window.top.document.referrer;
-  } catch (e) {
-    return window.document.referrer;
-  }
-}
 
 registerBidder(spec);

--- a/modules/aduptechBidAdapter.md
+++ b/modules/aduptechBidAdapter.md
@@ -1,35 +1,86 @@
-# Overview
-```
-Module Name: AdUp Technology Bid Adapter
-Module Type: Bidder Adapter
-Maintainers:
-  - steffen.anders@adup-tech.com
-  - sebastian.briesemeister@adup-tech.com
-  - marten.lietz@adup-tech.com
-```
+# AdUp Technology Bid Adapter
 
-# Description
+## Description
 Connects to AdUp Technology demand sources to fetch bids.
-Please use ```aduptech``` as  bidder code. Only banner formats are supported.
 
-The AdUp Technology bidding adapter requires setup and approval before beginning.
-For more information visit [www.adup-tech.com](https://www.adup-tech.com/en) or contact [info@adup-tech.com](mailto:info@adup-tech.com).
+**Note:** The bid adapter requires correct setup and approval, including an existing publisher account. For more information visit [www.adup-tech.com](https://www.adup-tech.com/en) or contact [info@adup-tech.com](mailto:info@adup-tech.com).
 
-# Test Parameters
+
+## Overview
+- Module Name: AdUp Technology Bid Adapter
+- Module Type: Bidder Adapter
+- Maintainers:
+  - [steffen.anders@adup-tech.com](mailto:steffen.anders@adup-tech.com)
+  - [sebastian.briesemeister@adup-tech.com](mailto:sebastian.briesemeister@adup-tech.com)
+  - [marten.lietz@adup-tech.com](mailto:marten.lietz@adup-tech.com)
+- Bidder code: `aduptech`
+- Supported media types: `banner`, `native`
+
+## Paramters
+| Name | Scope | Description | Example |
+| :--- | :---- | :---------- | :------ |
+| `publisher` | required | Unique publisher identifier | `'prebid'` |
+| `placement` | required | Unique placement identifier per publisher | `'1234'` |
+| `query` | optional | Semicolon separated list of keywords | `'urlaub;ibiza;mallorca'` |
+| `adtest` | optional | Deactivates tracking of impressions and clicks. **Should only be used for testing purposes!** | `true` |
+
+
+## Examples
+
+### Banner
 ```js
 var adUnits = [
    {
-        code: 'banner',
+        code: "example1",
         mediaTypes: {
             banner: {
                 sizes: [[300, 250], [300, 600]],
             }
         },
         bids: [{
-            bidder: 'aduptech',
+            bidder: "aduptech",
             params: {
-                publisher: 'prebid',
-                placement: '12345'
+                publisher: "prebid",
+                placement: "12345"
+            }
+        }]
+   }
+];
+```
+
+### Native
+```js
+var adUnits = [
+   {
+        code: "example2",
+        mediaTypes: {
+            native: {
+                image: {
+                    required: true,
+                    sizes: [150, 150]
+                },
+                title: {
+                    required: true
+                },
+                body: {
+                    required: true
+                },
+                clickUrl: {
+                    required: true
+                },
+                displayUrl: {
+                    required: true
+                },
+                sponsoredBy: {
+                    required: true
+                }
+            }
+        },
+        bids: [{
+            bidder: "aduptech",
+            params: {
+                publisher: "prebid",
+                placement: "12345"
             }
         }]
    }


### PR DESCRIPTION
## Type of change
- [X] Feature
- [X] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [X] Other

## Description of change
* Add Support for `native` mediaType
* Add Support for `meta.advertiserDomains` (https://github.com/prebid/Prebid.js/issues/6650)
* Add "multibidding" Support (adapter is now sending/receiving one request with all bids per auction)
* Code cleanup & refactoring
* Added/fixed tests

#### Example banner implementation
```js
var adUnits = [
   {
        code: "example1",
        mediaTypes: {
            banner: {
                sizes: [[300, 250], [300, 600]],
            }
        },
        bids: [{
            bidder: "aduptech",
            params: {
                publisher: "prebid",
                placement: "12345"
            }
        }]
   }
];
```

#### Example native implementation
```js
var adUnits = [
   {
        code: "example2",
        mediaTypes: {
            native: {
                image: {
                    required: true,
                    sizes: [150, 150]
                },
                title: {
                    required: true
                },
                body: {
                    required: true
                },
                clickUrl: {
                    required: true
                },
                displayUrl: {
                    required: true
                },
                sponsoredBy: {
                    required: true
                }
            }
        },
        bids: [{
            bidder: "aduptech",
            params: {
                publisher: "prebid",
                placement: "12345"
            }
        }]
   }
];
```

- [x] official adapter submission
- Related prebid.github.io PR:  https://github.com/prebid/prebid.github.io/pull/2978

