### PR TITLE
appnexus bid adapter: add support for flocid

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -244,6 +244,7 @@ export const spec = {
     if (bidRequests[0].userId) {
       let eids = [];
 
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.flocId.id`), 'chrome.com', null);
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.criteoId`), 'criteo.com', null);
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.netId`), 'netid.de', null);
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.idl_env`), 'liveramp.com', null);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -875,7 +875,11 @@ describe('AppNexusAdapter', function () {
           tdid: 'sample-userid',
           criteoId: 'sample-criteo-userid',
           netId: 'sample-netId-userid',
-          idl_env: 'sample-idl-userid'
+          idl_env: 'sample-idl-userid',
+          flocId: {
+            id: 'sample-flocid-value',
+            version: 'chrome.1.0'
+          }
         }
       });
 
@@ -890,6 +894,11 @@ describe('AppNexusAdapter', function () {
       expect(payload.eids).to.deep.include({
         source: 'criteo.com',
         id: 'sample-criteo-userid',
+      });
+
+      expect(payload.eids).to.deep.include({
+        source: 'chrome.com',
+        id: 'sample-flocid-value'
       });
 
       expect(payload.eids).to.deep.include({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Updates the appnexus bid adapter to support the `flocId` userId module.


Docs PR: https://github.com/prebid/prebid.github.io/pull/2979