### PR TITLE
appnexus bid adapter: add support for uid2

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -248,6 +248,7 @@ export const spec = {
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.netId`), 'netid.de', null);
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.idl_env`), 'liveramp.com', null);
       addUserId(eids, utils.deepAccess(bidRequests[0], `userId.tdid`), 'adserver.org', 'TDID');
+      addUserId(eids, utils.deepAccess(bidRequests[0], `userId.uid2.id`), 'uidapi.com', 'UID2');
 
       if (eids.length) {
         payload.eids = eids;

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -873,6 +873,7 @@ describe('AppNexusAdapter', function () {
       const bidRequest = Object.assign({}, bidRequests[0], {
         userId: {
           tdid: 'sample-userid',
+          uid2: { id: 'sample-uid2-value' },
           criteoId: 'sample-criteo-userid',
           netId: 'sample-netId-userid',
           idl_env: 'sample-idl-userid'
@@ -900,7 +901,13 @@ describe('AppNexusAdapter', function () {
       expect(payload.eids).to.deep.include({
         source: 'liveramp.com',
         id: 'sample-idl-userid'
-      })
+      });
+
+      expect(payload.eids).to.deep.include({
+        source: 'uidapi.com',
+        id: 'sample-uid2-value',
+        rti_partner: 'UID2'
+      });
     });
 
     it('should populate iab_support object at the root level if omid support is detected', function () {


### PR DESCRIPTION

## Type of change
- [x] Feature


## Description of change
Updates the appnexus bid adapter to support the `uid2` userId module.