### PR TITLE
OpenX Bid Adapter: add support for mediaTypes.video and gpid

### DIFF
--- a/modules/openxBidAdapter.md
+++ b/modules/openxBidAdapter.md
@@ -98,7 +98,7 @@ pbjs.setConfig({
 ```
 
 # Additional Details
-[Banner Ads](https://docs.openx.com/Content/developers/containers/prebid-adapter.html)
+[Banner Ads](https://docs.openx.com/publishers/prebid-adapter-web/)
 
-[Video Ads](https://docs.openx.com/Content/developers/containers/prebid-video-adapter.html)
+[Video Ads](https://docs.openx.com/publishers/prebid-adapter-video/)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change

Add mediaTypes.video support for OpenX. Also add global placement support.