### PR TITLE
Smaato bid adapter: Rework multi imp support

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -5,75 +5,22 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'smaato';
 const SMAATO_ENDPOINT = 'https://prebid.ad.smaato.net/oapi/prebid';
-const CLIENT = 'prebid_js_$prebid.version$_1.1'
+const SMAATO_CLIENT = 'prebid_js_$prebid.version$_1.2'
 
-/**
-* Transform BidRequest to OpenRTB-formatted BidRequest Object
-* @param {Array<BidRequest>} validBidRequests
-* @param {any} bidderRequest
-* @returns {string}
-*/
-const buildOpenRtbBidRequestPayload = (validBidRequests, bidderRequest) => {
-  /**
-   * Turn incoming prebid sizes into openRtb format mapping.
-   * @param {*} sizes in format [[10, 10], [20, 20]]
-   * @returns array of openRtb format mappings [{w: 10, h: 10}, {w: 20, h: 20}]
-   */
-  const parseSizes = (sizes) => {
-    return sizes.map((size) => {
-      return {w: size[0], h: size[1]};
-    })
-  }
-
-  const imp = validBidRequests.map(br => {
-    const bannerMediaType = utils.deepAccess(br, 'mediaTypes.banner');
-    const videoMediaType = utils.deepAccess(br, 'mediaTypes.video');
-    let result = {
-      id: br.bidId,
-      tagid: utils.deepAccess(br, 'params.adspaceId')
-    }
-
-    if (bannerMediaType) {
-      const sizes = parseSizes(utils.getAdUnitSizes(br));
-      result.banner = {
-        w: sizes[0].w,
-        h: sizes[0].h,
-        format: sizes
-      }
-    }
-
-    if (videoMediaType) {
-      result.video = {
-        mimes: videoMediaType.mimes,
-        minduration: videoMediaType.minduration,
-        startdelay: videoMediaType.startdelay,
-        linearity: videoMediaType.linearity,
-        w: videoMediaType.playerSize[0][0],
-        h: videoMediaType.playerSize[0][1],
-        maxduration: videoMediaType.maxduration,
-        skip: videoMediaType.skip,
-        protocols: videoMediaType.protocols,
-        ext: {
-          rewarded: videoMediaType.ext && videoMediaType.ext.rewarded ? videoMediaType.ext.rewarded : 0
-        },
-        skipmin: videoMediaType.skipmin,
-        api: videoMediaType.api
-      }
-    }
-
-    return result;
-  });
-
+const buildOpenRtbBidRequest = (bidRequest, bidderRequest) => {
   const request = {
     id: bidderRequest.auctionId,
     at: 1,
-    imp,
+    imp: [{
+      id: bidRequest.bidId,
+      tagid: utils.deepAccess(bidRequest, 'params.adspaceId')
+    }],
     cur: ['USD'],
     tmax: bidderRequest.timeout,
     site: {
       id: window.location.hostname,
       publisher: {
-        id: utils.deepAccess(validBidRequests[0], 'params.publisherId')
+        id: utils.deepAccess(bidRequest, 'params.publisherId')
       },
       domain: window.location.hostname,
       page: window.location.href,
@@ -94,12 +41,40 @@ const buildOpenRtbBidRequestPayload = (validBidRequests, bidderRequest) => {
       ext: {}
     },
     ext: {
-      client: CLIENT
+      client: SMAATO_CLIENT
     }
   };
 
-  let ortb2 = config.getConfig('ortb2') || {};
+  if (utils.deepAccess(bidRequest, 'mediaTypes.banner')) {
+    const sizes = utils.getAdUnitSizes(bidRequest).map((size) => ({w: size[0], h: size[1]}));
+    request.imp[0].banner = {
+      w: sizes[0].w,
+      h: sizes[0].h,
+      format: sizes
+    }
+  }
 
+  const videoMediaType = utils.deepAccess(bidRequest, 'mediaTypes.video');
+  if (videoMediaType) {
+    request.imp[0].video = {
+      mimes: videoMediaType.mimes,
+      minduration: videoMediaType.minduration,
+      startdelay: videoMediaType.startdelay,
+      linearity: videoMediaType.linearity,
+      w: videoMediaType.playerSize[0][0],
+      h: videoMediaType.playerSize[0][1],
+      maxduration: videoMediaType.maxduration,
+      skip: videoMediaType.skip,
+      protocols: videoMediaType.protocols,
+      ext: {
+        rewarded: videoMediaType.ext && videoMediaType.ext.rewarded ? videoMediaType.ext.rewarded : 0
+      },
+      skipmin: videoMediaType.skipmin,
+      api: videoMediaType.api
+    }
+  }
+
+  let ortb2 = config.getConfig('ortb2') || {};
   Object.assign(request.user, ortb2.user);
   Object.assign(request.site, ortb2.site);
 
@@ -112,20 +87,19 @@ const buildOpenRtbBidRequestPayload = (validBidRequests, bidderRequest) => {
     utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
   }
 
-  if (utils.deepAccess(validBidRequests[0], 'params.app')) {
-    const geo = utils.deepAccess(validBidRequests[0], 'params.app.geo');
+  if (utils.deepAccess(bidRequest, 'params.app')) {
+    const geo = utils.deepAccess(bidRequest, 'params.app.geo');
     utils.deepSetValue(request, 'device.geo', geo);
-    const ifa = utils.deepAccess(validBidRequests[0], 'params.app.ifa')
+    const ifa = utils.deepAccess(bidRequest, 'params.app.ifa')
     utils.deepSetValue(request, 'device.ifa', ifa);
   }
 
-  const eids = utils.deepAccess(validBidRequests[0], 'userIdAsEids');
+  const eids = utils.deepAccess(bidRequest, 'userIdAsEids');
   if (eids && eids.length) {
     utils.deepSetValue(request, 'user.ext.eids', eids);
   }
 
-  utils.logInfo('[SMAATO] OpenRTB Request:', request);
-  return JSON.stringify(request);
+  return request
 }
 
 export const spec = {
@@ -133,41 +107,41 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO],
 
   /**
-      * Determines whether or not the given bid request is valid.
-      *
-      * @param {BidRequest} bid The bid params to validate.
-      * @return boolean True if this is a valid bid, and false otherwise.
-      */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: (bid) => {
     return typeof bid.params === 'object' &&
-           typeof bid.params.publisherId === 'string' &&
-           typeof bid.params.adspaceId === 'string';
+      typeof bid.params.publisherId === 'string' &&
+      typeof bid.params.adspaceId === 'string';
   },
 
-  /**
-      * Make a server request from the list of BidRequests.
-      *
-      * @param {validBidRequests[]} - an array of bids
-      * @return ServerRequest Info describing the request to the server.
-      */
   buildRequests: (validBidRequests, bidderRequest) => {
-    utils.logInfo('[SMAATO] Client version:', CLIENT);
-    return {
-      method: 'POST',
-      url: validBidRequests[0].params.endpoint || SMAATO_ENDPOINT,
-      data: buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest),
-      options: {
-        withCredentials: true,
-        crossOrigin: true,
-      }
-    };
+    utils.logInfo('[SMAATO] Client version:', SMAATO_CLIENT);
+
+    return validBidRequests.map((validBidRequest) => {
+      const openRtbBidRequest = buildOpenRtbBidRequest(validBidRequest, bidderRequest);
+      utils.logInfo('[SMAATO] OpenRTB Request:', openRtbBidRequest);
+
+      return {
+        method: 'POST',
+        url: validBidRequest.params.endpoint || SMAATO_ENDPOINT,
+        data: JSON.stringify(openRtbBidRequest),
+        options: {
+          withCredentials: true,
+          crossOrigin: true,
+        }
+      };
+    });
   },
   /**
-      * Unpack the response from the server into a list of bids.
-      *
-      * @param {ServerResponse} serverResponse A successful response from the server.
-      * @return {Bid[]} An array of bids which were nested inside the server.
-      */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: (serverResponse, bidRequest) => {
     // response is empty (HTTP 204)
     if (utils.isEmpty(serverResponse.body)) {
@@ -235,15 +209,14 @@ export const spec = {
   },
 
   /**
-      * Register the user sync pixels which should be dropped after the auction.
-      *
-      * @param {SyncOptions} syncOptions Which user syncs are allowed?
-      * @param {ServerResponse[]} serverResponses List of server's responses.
-      * @return {UserSync[]} The user syncs which should be dropped.
-      */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
-    const syncs = []
-    return syncs;
+    return [];
   }
 }
 registerBidder(spec);

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -1,115 +1,11 @@
-import { spec } from 'modules/smaatoBidAdapter.js';
+import {spec} from 'modules/smaatoBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {config} from 'src/config.js';
 import {createEidsArray} from 'modules/userId/eids.js';
 
-const imageAd = {
-  image: {
-    img: {
-      url: 'https://prebid/static/ad.jpg',
-      w: 320,
-      h: 50,
-      ctaurl: 'https://prebid/track/ctaurl'
-    },
-    impressiontrackers: [
-      'https://prebid/track/imp/1',
-      'https://prebid/track/imp/2'
-    ],
-    clicktrackers: [
-      'https://prebid/track/click/1'
-    ]
-  }
-};
-
-const richmediaAd = {
-  richmedia: {
-    mediadata: {
-      content: '<div><h3>RICHMEDIA CONTENT</h3></div>',
-      w: 800,
-      h: 600
-    },
-    impressiontrackers: [
-      'https://prebid/track/imp/1',
-      'https://prebid/track/imp/2'
-    ],
-    clicktrackers: [
-      'https://prebid/track/click/1'
-    ]
-  }
-};
-
 const ADTYPE_IMG = 'Img';
 const ADTYPE_RICHMEDIA = 'Richmedia';
 const ADTYPE_VIDEO = 'Video';
-
-const site = {
-  keywords: 'power tools,drills'
-};
-
-const user = {
-  keywords: 'a,b',
-  gender: 'M',
-  yob: 1984
-};
-
-const openRtbBidResponse = (adType) => {
-  let adm = '';
-
-  switch (adType) {
-    case ADTYPE_IMG:
-      adm = JSON.stringify(imageAd);
-      break;
-    case ADTYPE_RICHMEDIA:
-      adm = JSON.stringify(richmediaAd);
-      break;
-    case ADTYPE_VIDEO:
-      adm = '<VAST version="2.0"></VAST>';
-      break;
-    default:
-      throw Error('Invalid AdType');
-  }
-
-  let resp = {
-    body: {
-      bidid: '04db8629-179d-4bcd-acce-e54722969006',
-      cur: 'USD',
-      ext: {},
-      id: '5ebea288-f13a-4754-be6d-4ade66c68877',
-      seatbid: [
-        {
-          bid: [
-            {
-              'adm': adm,
-              'adomain': [
-                'smaato.com'
-              ],
-              'bidderName': 'smaato',
-              'cid': 'CM6523',
-              'crid': 'CR69381',
-              'dealid': '12345',
-              'id': '6906aae8-7f74-4edd-9a4f-f49379a3cadd',
-              'impid': '226416e6e6bf41',
-              'iurl': 'https://prebid/iurl',
-              'nurl': 'https://prebid/nurl',
-              'price': 0.01,
-              'w': 350,
-              'h': 50
-            }
-          ],
-          seat: 'CM6523'
-        }
-      ],
-    },
-    headers: {
-      get: function (header) {
-        if (header === 'X-SMT-ADTYPE') {
-          return adType;
-        }
-      }
-    }
-  };
-  return resp;
-};
 
 const request = {
   method: 'POST',
@@ -117,84 +13,24 @@ const request = {
   data: ''
 };
 
-const interpretedBidsImg = [
-  {
-    requestId: '226416e6e6bf41',
-    cpm: 0.01,
-    width: 350,
-    height: 50,
-    ad: '<div style=\"cursor:pointer\" onclick=\"fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});;window.open(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fctaurl\'));\"><img src=\"https://prebid/static/ad.jpg\" width=\"320\" height=\"50\"/><img src=\"https://prebid/track/imp/1\" alt=\"\" width=\"0\" height=\"0\"/><img src=\"https://prebid/track/imp/2\" alt=\"\" width=\"0\" height=\"0\"/></div>',
-    ttl: 300,
-    creativeId: 'CR69381',
-    dealId: '12345',
-    netRevenue: true,
-    currency: 'USD',
-    meta: {
-      advertiserDomains: ['smaato.com'],
-      agencyId: 'CM6523',
-      networkName: 'smaato',
-      mediaType: 'banner'
-    }
-  }
-];
-
-const interpretedBidsRichmedia = [
-  {
-    requestId: '226416e6e6bf41',
-    cpm: 0.01,
-    width: 350,
-    height: 50,
-    ad: '<div onclick=\"fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});\"><div><h3>RICHMEDIA CONTENT</h3></div><img src=\"https://prebid/track/imp/1\" alt=\"\" width=\"0\" height=\"0\"/><img src=\"https://prebid/track/imp/2\" alt=\"\" width=\"0\" height=\"0\"/></div>',
-    ttl: 300,
-    creativeId: 'CR69381',
-    dealId: '12345',
-    netRevenue: true,
-    currency: 'USD',
-    meta: {
-      advertiserDomains: ['smaato.com'],
-      agencyId: 'CM6523',
-      networkName: 'smaato',
-      mediaType: 'banner'
-    }
-  }
-];
-
-const interpretedBidsVideo = [
-  {
-    requestId: '226416e6e6bf41',
-    cpm: 0.01,
-    width: 350,
-    height: 50,
-    vastXml: '<VAST version="2.0"></VAST>',
-    ttl: 300,
-    creativeId: 'CR69381',
-    dealId: '12345',
-    netRevenue: true,
-    currency: 'USD',
-    meta: {
-      advertiserDomains: ['smaato.com'],
-      agencyId: 'CM6523',
-      networkName: 'smaato',
-      mediaType: 'video'
-    }
-  }
-];
+const REFERRER = 'http://example.com/page.html'
+const CONSENT_STRING = 'HFIDUYFIUYIUYWIPOI87392DSU'
 
 const defaultBidderRequest = {
   gdprConsent: {
-    consentString: 'HFIDUYFIUYIUYWIPOI87392DSU',
+    consentString: CONSENT_STRING,
     gdprApplies: true
   },
   uspConsent: 'uspConsentString',
   refererInfo: {
-    referer: 'http://example.com/page.html',
+    referer: REFERRER,
   },
   timeout: 1200
 };
 
 const minimalBidderRequest = {
   refererInfo: {
-    referer: 'http://example.com/page.html',
+    referer: REFERRER,
   }
 };
 
@@ -207,77 +43,6 @@ const singleBannerBidRequest = {
   mediaTypes: {
     banner: {
       sizes: [[300, 50]]
-    }
-  },
-  adUnitCode: '/19968336/header-bid-tag-0',
-  transactionId: 'transactionId',
-  sizes: [[300, 50]],
-  bidId: 'bidId',
-  bidderRequestId: 'bidderRequestId',
-  auctionId: 'auctionId',
-  src: 'client',
-  bidRequestsCount: 1,
-  bidderRequestsCount: 1,
-  bidderWinsCount: 0
-};
-
-const singleVideoBidRequest = {
-  bidder: 'smaato',
-  params: {
-    publisherId: 'publisherId',
-    adspaceId: 'adspaceId'
-  },
-  mediaTypes: {
-    video: {
-      context: 'outstream',
-      playerSize: [[768, 1024]],
-      mimes: ['video\/mp4', 'video\/quicktime', 'video\/3gpp', 'video\/x-m4v'],
-      minduration: 5,
-      maxduration: 30,
-      startdelay: 0,
-      linearity: 1,
-      protocols: [7],
-      skip: 1,
-      skipmin: 5,
-      api: [7],
-      ext: {rewarded: 0}
-    }
-  },
-  adUnitCode: '/19968336/header-bid-tag-0',
-  transactionId: 'transactionId',
-  sizes: [[300, 50]],
-  bidId: 'bidId',
-  bidderRequestId: 'bidderRequestId',
-  auctionId: 'auctionId',
-  src: 'client',
-  bidRequestsCount: 1,
-  bidderRequestsCount: 1,
-  bidderWinsCount: 0
-};
-
-const combinedBannerAndVideoBidRequest = {
-  bidder: 'smaato',
-  params: {
-    publisherId: 'publisherId',
-    adspaceId: 'adspaceId'
-  },
-  mediaTypes: {
-    banner: {
-      sizes: [[300, 50]]
-    },
-    video: {
-      context: 'outstream',
-      playerSize: [[768, 1024]],
-      mimes: ['video\/mp4', 'video\/quicktime', 'video\/3gpp', 'video\/x-m4v'],
-      minduration: 5,
-      maxduration: 30,
-      startdelay: 0,
-      linearity: 1,
-      protocols: [7],
-      skip: 1,
-      skipmin: 5,
-      api: [7],
-      ext: {rewarded: 0}
     }
   },
   adUnitCode: '/19968336/header-bid-tag-0',
@@ -322,37 +87,6 @@ const inAppBidRequest = {
   bidderWinsCount: 0
 };
 
-const userIdBidRequest = {
-  bidder: 'smaato',
-  params: {
-    publisherId: 'publisherId',
-    adspaceId: 'adspaceId'
-  },
-  mediaTypes: {
-    banner: {
-      sizes: [[300, 50]]
-    }
-  },
-  adUnitCode: '/19968336/header-bid-tag-0',
-  transactionId: 'transactionId',
-  sizes: [[300, 50]],
-  bidId: 'bidId',
-  bidderRequestId: 'bidderRequestId',
-  auctionId: 'auctionId',
-  src: 'client',
-  bidRequestsCount: 1,
-  bidderRequestsCount: 1,
-  bidderWinsCount: 0,
-  userId: {
-    criteoId: '123456',
-    tdid: '89145'
-  },
-  userIdAsEids: createEidsArray({
-    criteoId: '123456',
-    tdid: '89145'
-  })
-};
-
 describe('smaatoBidAdapterTest', () => {
   describe('isBidRequestValid', () => {
     it('has valid params', () => {
@@ -368,222 +102,529 @@ describe('smaatoBidAdapterTest', () => {
   });
 
   describe('buildRequests', () => {
-    beforeEach(() => {
-      this.req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
-      this.sandbox = sinon.sandbox.create();
-    });
+    describe('common', () => {
+      it('auction type is 1 (first price auction)', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
 
-    afterEach(() => {
-      this.sandbox.restore();
-    });
+        expect(req.at).to.be.equal(1)
+      })
 
-    it('can override endpoint', () => {
-      const overridenEndpoint = 'https://prebid/bidder';
-      let bidRequest = utils.deepClone(singleBannerBidRequest);
-      utils.deepSetValue(bidRequest, 'params.endpoint', overridenEndpoint);
-      const actualEndpoint = spec.buildRequests([bidRequest], defaultBidderRequest).url;
-      expect(actualEndpoint).to.equal(overridenEndpoint);
-    });
+      it('currency is US dollar', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
 
-    it('sends correct imps', () => {
-      expect(this.req.imp).to.deep.equal([
-        {
-          id: 'bidId',
-          banner: {
-            w: 300,
-            h: 50,
-            format: [
-              {
-                h: 50,
-                w: 300
-              }
-            ]
-          },
-          tagid: 'adspaceId'
-        }
-      ])
-    });
+        expect(req.cur).to.be.deep.equal(['USD'])
+      })
 
-    it('sends correct site', () => {
-      expect(this.req.site.id).to.exist.and.to.be.a('string');
-      expect(this.req.site.domain).to.exist.and.to.be.a('string');
-      expect(this.req.site.page).to.exist.and.to.be.a('string');
-      expect(this.req.site.ref).to.equal('http://example.com/page.html');
-      expect(this.req.site.publisher.id).to.equal('publisherId');
-    })
+      it('can override endpoint', () => {
+        const overridenEndpoint = 'https://prebid/bidder';
+        const updatedBidRequest = utils.deepClone(singleBannerBidRequest);
+        utils.deepSetValue(updatedBidRequest, 'params.endpoint', overridenEndpoint);
 
-    it('sends gdpr applies if exists', () => {
-      expect(this.req.regs.ext.gdpr).to.equal(1);
-      expect(this.req.user.ext.consent).to.equal('HFIDUYFIUYIUYWIPOI87392DSU');
-    });
+        const actualEndpoint = spec.buildRequests([updatedBidRequest], defaultBidderRequest).url;
 
-    it('sends no gdpr applies if no gdpr exists', () => {
-      let req_without_gdpr = JSON.parse(spec.buildRequests([singleBannerBidRequest], minimalBidderRequest).data);
-      expect(req_without_gdpr.regs.ext.gdpr).to.not.exist;
-      expect(req_without_gdpr.user.ext.consent).to.not.exist;
-    });
-
-    it('sends usp if exists', () => {
-      expect(this.req.regs.ext.us_privacy).to.equal('uspConsentString');
-    });
-
-    it('sends tmax', () => {
-      expect(this.req.tmax).to.equal(1200);
-    });
-
-    it('sends no usp if no usp exists', () => {
-      let req_without_usp = JSON.parse(spec.buildRequests([singleBannerBidRequest], minimalBidderRequest).data);
-      expect(req_without_usp.regs.ext.us_privacy).to.not.exist;
-    });
-
-    it('sends fp data', () => {
-      this.sandbox.stub(config, 'getConfig').callsFake(key => {
-        const config = {
-          ortb2: {
-            site,
-            user
-          }
-        };
-        return utils.deepAccess(config, key);
+        expect(actualEndpoint).to.equal(overridenEndpoint);
       });
-      let bidRequest = utils.deepClone(singleBannerBidRequest);
-      let req_fpd = JSON.parse(spec.buildRequests([bidRequest], defaultBidderRequest).data);
-      expect(req_fpd.user.gender).to.equal('M');
-      expect(req_fpd.user.yob).to.equal(1984);
-      expect(req_fpd.user.keywords).to.eql('a,b');
-      expect(req_fpd.user.ext.consent).to.equal('HFIDUYFIUYIUYWIPOI87392DSU');
-      expect(req_fpd.site.keywords).to.eql('power tools,drills');
-      expect(req_fpd.site.publisher.id).to.equal('publisherId');
-    });
 
-    it('has no user ids', () => {
-      expect(this.req.user.ext.eids).to.not.exist;
-    });
-  });
+      it('sends correct imps', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
 
-  describe('buildRequests for video imps', () => {
-    it('sends correct video imps', () => {
-      let req = JSON.parse(spec.buildRequests([singleVideoBidRequest], defaultBidderRequest).data);
-      expect(req.imp).to.deep.equal([
-        {
-          id: 'bidId',
-          video: {
-            mimes: ['video\/mp4', 'video\/quicktime', 'video\/3gpp', 'video\/x-m4v'],
-            minduration: 5,
-            startdelay: 0,
-            linearity: 1,
-            h: 1024,
-            maxduration: 30,
-            skip: 1,
-            protocols: [7],
-            ext: {
-              rewarded: 0
+        expect(req.imp).to.deep.equal([
+          {
+            id: 'bidId',
+            banner: {
+              w: 300,
+              h: 50,
+              format: [
+                {
+                  h: 50,
+                  w: 300
+                }
+              ]
             },
-            skipmin: 5,
-            api: [7],
-            w: 768
-          },
-          tagid: 'adspaceId'
-        }
-      ])
-    });
-    it('allows combines banner and video imp in single bid request', () => {
-      let req = JSON.parse(spec.buildRequests([combinedBannerAndVideoBidRequest], defaultBidderRequest).data);
-      expect(req.imp).to.deep.equal([
-        {
-          id: 'bidId',
-          banner: {
-            w: 300,
-            h: 50,
-            format: [
-              {
-                h: 50,
-                w: 300
+            tagid: 'adspaceId'
+          }
+        ])
+      });
+
+      it('sends correct site', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.site.id).to.exist.and.to.be.a('string');
+        expect(req.site.domain).to.exist.and.to.be.a('string');
+        expect(req.site.page).to.exist.and.to.be.a('string');
+        expect(req.site.ref).to.equal(REFERRER);
+        expect(req.site.publisher.id).to.equal('publisherId');
+      })
+
+      it('sends gdpr applies if exists', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.regs.ext.gdpr).to.equal(1);
+        expect(req.user.ext.consent).to.equal(CONSENT_STRING);
+      });
+
+      it('sends no gdpr applies if no gdpr exists', () => {
+        const req_without_gdpr = JSON.parse(spec.buildRequests([singleBannerBidRequest], minimalBidderRequest).data);
+
+        expect(req_without_gdpr.regs.ext.gdpr).to.not.exist;
+        expect(req_without_gdpr.user.ext.consent).to.not.exist;
+      });
+
+      it('sends us_privacy if exists', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.regs.ext.us_privacy).to.equal('uspConsentString');
+      });
+
+      it('sends tmax', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.tmax).to.equal(1200);
+      });
+
+      it('sends no us_privacy if no us_privacy exists', () => {
+        const req_without_usp = JSON.parse(spec.buildRequests([singleBannerBidRequest], minimalBidderRequest).data);
+
+        expect(req_without_usp.regs.ext.us_privacy).to.not.exist;
+      });
+
+      it('sends first party data', () => {
+        this.sandbox = sinon.sandbox.create()
+        this.sandbox.stub(config, 'getConfig').callsFake(key => {
+          const config = {
+            ortb2: {
+              site: {
+                keywords: 'power tools,drills'
+              },
+              user: {
+                keywords: 'a,b',
+                gender: 'M',
+                yob: 1984
               }
-            ]
+            }
+          };
+          return utils.deepAccess(config, key);
+        });
+        const bidRequest = utils.deepClone(singleBannerBidRequest);
+
+        const req_fpd = JSON.parse(spec.buildRequests([bidRequest], defaultBidderRequest).data);
+
+        const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+        expect(req.user.gender).to.equal('M');
+        expect(req.user.yob).to.equal(1984);
+        expect(req.user.keywords).to.eql('a,b');
+        expect(req.user.ext.consent).to.equal(CONSENT_STRING);
+        expect(req.site.keywords).to.eql('power tools,drills');
+        expect(req.site.publisher.id).to.equal('publisherId');
+        this.sandbox.restore();
+      });
+
+      it('has no user ids', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.user.ext.eids).to.not.exist;
+      });
+    });
+
+    describe('buildRequests for video imps', () => {
+      it('sends correct video imps', () => {
+        const singleVideoBidRequest = {
+          bidder: 'smaato',
+          params: {
+            publisherId: 'publisherId',
+            adspaceId: 'adspaceId'
           },
-          video: {
-            mimes: ['video\/mp4', 'video\/quicktime', 'video\/3gpp', 'video\/x-m4v'],
-            minduration: 5,
-            startdelay: 0,
-            linearity: 1,
-            h: 1024,
-            maxduration: 30,
-            skip: 1,
-            protocols: [7],
-            ext: {
-              rewarded: 0
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [[768, 1024]],
+              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+              minduration: 5,
+              maxduration: 30,
+              startdelay: 0,
+              linearity: 1,
+              protocols: [7],
+              skip: 1,
+              skipmin: 5,
+              api: [7],
+              ext: {rewarded: 0}
+            }
+          },
+          adUnitCode: '/19968336/header-bid-tag-0',
+          transactionId: 'transactionId',
+          sizes: [[300, 50]],
+          bidId: 'bidId',
+          bidderRequestId: 'bidderRequestId',
+          auctionId: 'auctionId',
+          src: 'client',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0
+        };
+
+        const req = JSON.parse(spec.buildRequests([singleVideoBidRequest], defaultBidderRequest).data);
+
+        expect(req.imp).to.deep.equal([
+          {
+            id: 'bidId',
+            video: {
+              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+              minduration: 5,
+              startdelay: 0,
+              linearity: 1,
+              h: 1024,
+              maxduration: 30,
+              skip: 1,
+              protocols: [7],
+              ext: {
+                rewarded: 0
+              },
+              skipmin: 5,
+              api: [7],
+              w: 768
             },
-            skipmin: 5,
-            api: [7],
-            w: 768
+            tagid: 'adspaceId'
+          }
+        ])
+      });
+
+      it('allows combines banner and video imp in single bid request', () => {
+        const combinedBannerAndVideoBidRequest = {
+          bidder: 'smaato',
+          params: {
+            publisherId: 'publisherId',
+            adspaceId: 'adspaceId'
           },
-          tagid: 'adspaceId'
-        }
-      ])
-    });
-    it('allows two imps in the same bid request', () => {
-      let req = JSON.parse(spec.buildRequests([singleBannerBidRequest, singleBannerBidRequest], defaultBidderRequest).data);
-      expect(req.imp).to.have.length(2);
-    });
-  });
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 50]]
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [[768, 1024]],
+              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+              minduration: 5,
+              maxduration: 30,
+              startdelay: 0,
+              linearity: 1,
+              protocols: [7],
+              skip: 1,
+              skipmin: 5,
+              api: [7],
+              ext: {rewarded: 0}
+            }
+          },
+          adUnitCode: '/19968336/header-bid-tag-0',
+          transactionId: 'transactionId',
+          sizes: [[300, 50]],
+          bidId: 'bidId',
+          bidderRequestId: 'bidderRequestId',
+          auctionId: 'auctionId',
+          src: 'client',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0
+        };
 
-  describe('in-app requests', () => {
-    it('add geo and ifa info to device object', () => {
-      let req = JSON.parse(spec.buildRequests([inAppBidRequest], defaultBidderRequest).data);
-      expect(req.device.geo).to.deep.equal({'lat': 33.3, 'lon': -88.8});
-      expect(req.device.ifa).to.equal('aDeviceId');
-    });
-    it('add only ifa to device object', () => {
-      let inAppBidRequestWithoutGeo = utils.deepClone(inAppBidRequest);
-      delete inAppBidRequestWithoutGeo.params.app.geo
-      let req = JSON.parse(spec.buildRequests([inAppBidRequestWithoutGeo], defaultBidderRequest).data);
+        const req = JSON.parse(spec.buildRequests([combinedBannerAndVideoBidRequest], defaultBidderRequest).data);
 
-      expect(req.device.geo).to.not.exist;
-      expect(req.device.ifa).to.equal('aDeviceId');
-    });
-    it('add no specific device info if param does not exist', () => {
-      let req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
-      expect(req.device.geo).to.not.exist;
-      expect(req.device.ifa).to.not.exist;
-    });
-  });
+        expect(req.imp).to.deep.equal([
+          {
+            id: 'bidId',
+            banner: {
+              w: 300,
+              h: 50,
+              format: [
+                {
+                  h: 50,
+                  w: 300
+                }
+              ]
+            },
+            video: {
+              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+              minduration: 5,
+              startdelay: 0,
+              linearity: 1,
+              h: 1024,
+              maxduration: 30,
+              skip: 1,
+              protocols: [7],
+              ext: {
+                rewarded: 0
+              },
+              skipmin: 5,
+              api: [7],
+              w: 768
+            },
+            tagid: 'adspaceId'
+          }
+        ])
+      });
 
-  describe('user ids in requests', () => {
-    it('user ids are added to user.ext.eids', () => {
-      let req = JSON.parse(spec.buildRequests([userIdBidRequest], defaultBidderRequest).data);
-      expect(req.user.ext.eids).to.exist;
-      expect(req.user.ext.eids).to.have.length(2);
+      it('allows two imps in the same bid request', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest, singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.imp).to.have.length(2);
+      });
+    });
+
+    describe('in-app requests', () => {
+      it('add geo and ifa info to device object', () => {
+        const req = JSON.parse(spec.buildRequests([inAppBidRequest], defaultBidderRequest).data);
+
+        expect(req.device.geo).to.deep.equal({'lat': 33.3, 'lon': -88.8});
+        expect(req.device.ifa).to.equal('aDeviceId');
+      });
+
+      it('when geo is missing, then add only ifa to device object', () => {
+        const inAppBidRequestWithoutGeo = utils.deepClone(inAppBidRequest);
+        delete inAppBidRequestWithoutGeo.params.app.geo
+        const req = JSON.parse(spec.buildRequests([inAppBidRequestWithoutGeo], defaultBidderRequest).data);
+
+        expect(req.device.geo).to.not.exist;
+        expect(req.device.ifa).to.equal('aDeviceId');
+      });
+
+      it('add no specific device info if param does not exist', () => {
+        const req = JSON.parse(spec.buildRequests([singleBannerBidRequest], defaultBidderRequest).data);
+
+        expect(req.device.geo).to.not.exist;
+        expect(req.device.ifa).to.not.exist;
+      });
+    });
+
+    describe('user ids in requests', () => {
+      it('user ids are added to user.ext.eids', () => {
+        const userIdBidRequest = {
+          bidder: 'smaato',
+          params: {
+            publisherId: 'publisherId',
+            adspaceId: 'adspaceId'
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 50]]
+            }
+          },
+          adUnitCode: '/19968336/header-bid-tag-0',
+          transactionId: 'transactionId',
+          sizes: [[300, 50]],
+          bidId: 'bidId',
+          bidderRequestId: 'bidderRequestId',
+          auctionId: 'auctionId',
+          src: 'client',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          userId: {
+            criteoId: '123456',
+            tdid: '89145'
+          },
+          userIdAsEids: createEidsArray({
+            criteoId: '123456',
+            tdid: '89145'
+          })
+        };
+
+        const req = JSON.parse(spec.buildRequests([userIdBidRequest], defaultBidderRequest).data);
+
+        expect(req.user.ext.eids).to.exist;
+        expect(req.user.ext.eids).to.have.length(2);
+      });
     });
   });
 
   describe('interpretResponse', () => {
+    const buildOpenRtbBidResponse = (adType) => {
+      let adm = '';
+
+      switch (adType) {
+        case ADTYPE_IMG:
+          adm = JSON.stringify({
+            image: {
+              img: {
+                url: 'https://prebid/static/ad.jpg',
+                w: 320,
+                h: 50,
+                ctaurl: 'https://prebid/track/ctaurl'
+              },
+              impressiontrackers: [
+                'https://prebid/track/imp/1',
+                'https://prebid/track/imp/2'
+              ],
+              clicktrackers: [
+                'https://prebid/track/click/1'
+              ]
+            }
+          });
+          break;
+        case ADTYPE_RICHMEDIA:
+          adm = JSON.stringify({
+            richmedia: {
+              mediadata: {
+                content: '<div><h3>RICHMEDIA CONTENT</h3></div>',
+                w: 800,
+                h: 600
+              },
+              impressiontrackers: [
+                'https://prebid/track/imp/1',
+                'https://prebid/track/imp/2'
+              ],
+              clicktrackers: [
+                'https://prebid/track/click/1'
+              ]
+            }
+          });
+          break;
+        case ADTYPE_VIDEO:
+          adm = '<VAST version="2.0"></VAST>';
+          break;
+        default:
+          throw Error('Invalid AdType');
+      }
+
+      return {
+        body: {
+          bidid: '04db8629-179d-4bcd-acce-e54722969006',
+          cur: 'USD',
+          ext: {},
+          id: '5ebea288-f13a-4754-be6d-4ade66c68877',
+          seatbid: [
+            {
+              bid: [
+                {
+                  'adm': adm,
+                  'adomain': [
+                    'smaato.com'
+                  ],
+                  'bidderName': 'smaato',
+                  'cid': 'CM6523',
+                  'crid': 'CR69381',
+                  'dealid': '12345',
+                  'id': '6906aae8-7f74-4edd-9a4f-f49379a3cadd',
+                  'impid': '226416e6e6bf41',
+                  'iurl': 'https://prebid/iurl',
+                  'nurl': 'https://prebid/nurl',
+                  'price': 0.01,
+                  'w': 350,
+                  'h': 50
+                }
+              ],
+              seat: 'CM6523'
+            }
+          ],
+        },
+        headers: {
+          get: function (header) {
+            if (header === 'X-SMT-ADTYPE') {
+              return adType;
+            }
+          }
+        }
+      };
+    };
+
+    it('returns empty array on no bid responses', () => {
+      const response_with_empty_body = { body: {} }
+
+      const bids = spec.interpretResponse(response_with_empty_body, request);
+
+      expect(bids).to.be.empty
+    });
+
     it('single image reponse', () => {
-      const bids = spec.interpretResponse(openRtbBidResponse(ADTYPE_IMG), request);
-      assert.deepStrictEqual(bids, interpretedBidsImg);
+      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_IMG), request);
+
+      expect(bids).to.deep.equal([
+        {
+          requestId: '226416e6e6bf41',
+          cpm: 0.01,
+          width: 350,
+          height: 50,
+          ad: '<div style="cursor:pointer" onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});;window.open(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fctaurl\'));"><img src="https://prebid/static/ad.jpg" width="320" height="50"/><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
+          ttl: 300,
+          creativeId: 'CR69381',
+          dealId: '12345',
+          netRevenue: true,
+          currency: 'USD',
+          meta: {
+            advertiserDomains: ['smaato.com'],
+            agencyId: 'CM6523',
+            networkName: 'smaato',
+            mediaType: 'banner'
+          }
+        }
+      ]);
     });
+
     it('single richmedia reponse', () => {
-      const bids = spec.interpretResponse(openRtbBidResponse(ADTYPE_RICHMEDIA), request);
-      assert.deepStrictEqual(bids, interpretedBidsRichmedia);
+      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_RICHMEDIA), request);
+
+      expect(bids).to.deep.equal([
+        {
+          requestId: '226416e6e6bf41',
+          cpm: 0.01,
+          width: 350,
+          height: 50,
+          ad: '<div onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});"><div><h3>RICHMEDIA CONTENT</h3></div><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
+          ttl: 300,
+          creativeId: 'CR69381',
+          dealId: '12345',
+          netRevenue: true,
+          currency: 'USD',
+          meta: {
+            advertiserDomains: ['smaato.com'],
+            agencyId: 'CM6523',
+            networkName: 'smaato',
+            mediaType: 'banner'
+          }
+        }
+      ]);
     });
+
     it('single video reponse', () => {
-      const bids = spec.interpretResponse(openRtbBidResponse(ADTYPE_VIDEO), request);
-      assert.deepStrictEqual(bids, interpretedBidsVideo);
+      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_VIDEO), request);
+
+      expect(bids).to.deep.equal([
+        {
+          requestId: '226416e6e6bf41',
+          cpm: 0.01,
+          width: 350,
+          height: 50,
+          vastXml: '<VAST version="2.0"></VAST>',
+          ttl: 300,
+          creativeId: 'CR69381',
+          dealId: '12345',
+          netRevenue: true,
+          currency: 'USD',
+          meta: {
+            advertiserDomains: ['smaato.com'],
+            agencyId: 'CM6523',
+            networkName: 'smaato',
+            mediaType: 'video'
+          }
+        }
+      ]);
     });
+
     it('ignores bid response with invalid ad type', () => {
-      let resp = openRtbBidResponse(ADTYPE_IMG);
+      const resp = buildOpenRtbBidResponse(ADTYPE_IMG);
       resp.headers.get = (header) => {
         if (header === 'X-SMT-ADTYPE') {
           return undefined;
         }
       }
+
       const bids = spec.interpretResponse(resp, request);
+
       expect(bids).to.be.empty
     });
+
     it('uses correct TTL when expire header exists', () => {
       const clock = sinon.useFakeTimers();
       clock.tick(2000);
-      let resp = openRtbBidResponse(ADTYPE_IMG);
+      const resp = buildOpenRtbBidResponse(ADTYPE_IMG);
       resp.headers.get = (header) => {
         if (header === 'X-SMT-ADTYPE') {
           return ADTYPE_IMG;
@@ -592,15 +633,27 @@ describe('smaatoBidAdapterTest', () => {
           return 2000 + (400 * 1000);
         }
       }
+
       const bids = spec.interpretResponse(resp, request);
+
       expect(bids[0].ttl).to.equal(400);
+
       clock.restore();
     });
+
     it('uses net revenue flag send from server', () => {
-      let resp = openRtbBidResponse(ADTYPE_IMG);
+      const resp = buildOpenRtbBidResponse(ADTYPE_IMG);
       resp.body.seatbid[0].bid[0].ext = {net: false};
+
       const bids = spec.interpretResponse(resp, request);
+
       expect(bids[0].netRevenue).to.equal(false);
     })
   });
+
+  describe('getUserSyncs', () => {
+    it('returns no pixels', () => {
+      expect(spec.getUserSyncs()).to.be.empty
+    })
+  })
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Code style update (formatting, local variables)

## Description of change
Smaatos Ad Server doesn't fully supports multiple impressions per request, creating an individual request per valid bid request is an alternative solution

- contact email of the adapter’s maintainer: prebid@smaato.com
- [x] official adapter submission