### PR TITLE
PBJS Core: Add allowSendAllBidsTargetingKeys to targetingControls

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -597,13 +597,19 @@ export function newTargeting(auctionManager) {
     const standardKeys = TARGETING_KEYS.concat(NATIVE_TARGETING_KEYS);
     const adUnitBidLimit = config.getConfig('sendBidsControl.bidLimit');
     const bids = getHighestCpmBidsFromBidPool(bidsReceived, getHighestCpm, adUnitBidLimit);
+    const allowSendAllBidsTargetingKeys = config.getConfig('targetingControls.allowSendAllBidsTargetingKeys');
+
+    const allowedSendAllBidTargeting = allowSendAllBidsTargetingKeys
+      ? allowSendAllBidsTargetingKeys.map((key) => CONSTANTS.TARGETING_KEYS[key])
+      : standardKeys;
 
     // populate targeting keys for the remaining bids
     return bids.map(bid => {
       if (bidShouldBeAddedToTargeting(bid, adUnitCodes)) {
         return {
           [bid.adUnitCode]: getTargetingMap(bid, standardKeys.filter(
-            key => typeof bid.adserverTargeting[key] !== 'undefined')
+            key => typeof bid.adserverTargeting[key] !== 'undefined' &&
+            allowedSendAllBidTargeting.includes(key))
           )
         };
       }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -609,7 +609,7 @@ export function newTargeting(auctionManager) {
         return {
           [bid.adUnitCode]: getTargetingMap(bid, standardKeys.filter(
             key => typeof bid.adserverTargeting[key] !== 'undefined' &&
-            allowedSendAllBidTargeting.includes(key))
+            allowedSendAllBidTargeting.indexOf(key) !== -1)
           )
         };
       }

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -456,6 +456,49 @@ describe('targeting tests', function () {
       });
     });
 
+    describe('targetingControls.allowSendAllBidsTargetingKeys', function () {
+      let bid4;
+
+      beforeEach(function() {
+        bid4 = utils.deepClone(bid1);
+        bid4.adserverTargeting = {
+          hb_deal: '4321',
+          hb_pb: '0.1',
+          hb_adid: '567891011',
+          hb_bidder: 'appnexus',
+        };
+        bid4.bidder = bid4.bidderCode = 'appnexus';
+        bid4.cpm = 0.1; // losing bid so not included if enableSendAllBids === false
+        bid4.dealId = '4321';
+        enableSendAllBids = true;
+        config.setConfig({
+          targetingControls: {
+            allowTargetingKeys: ['BIDDER', 'AD_ID', 'PRICE_BUCKET'],
+            allowSendAllBidsTargetingKeys: ['PRICE_BUCKET', 'AD_ID']
+          }
+        });
+        bidsReceived.push(bid4);
+      });
+
+      it('targeting should include custom keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('foobar');
+      });
+
+      it('targeting should only include keys prefixed by allowed default send all bids targeting keys and standard keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder', 'hb_adid', 'hb_pb');
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_adid_rubicon', 'hb_pb_rubicon');
+        expect(targeting['/123456/header-bid-tag-0']).to.include.all.keys('hb_bidder', 'hb_adid', 'hb_pb', 'hb_adid_appnexus', 'hb_pb_appnexus');
+      });
+
+      it('targeting should not include keys prefixed by disallowed default targeting keys and disallowed send all bid targeting keys', function () {
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+        expect(targeting['/123456/header-bid-tag-0']).to.not.have.all.keys(['hb_deal', 'hb_bidder_rubicon', 'hb_bidder_appnexus', 'hb_deal_appnexus', 'hb_deal_rubicon']);
+      });
+    });
+
     describe('targetingControls.alwaysIncludeDeals', function () {
       let bid4;
 


### PR DESCRIPTION
## Type of change
Feature

## Description of change
Allows a publisher to limit the number 'sendAllBids' keys sent to the adServer. For example hb_bidder_rubicon is one of the more redudant keys we would like to stop sending but we still need hb_bidder key sent. This would similar to the targetingControl option, allowTargetingKeys.

Sample Config:
Example will not send hb_bidder_rubicon
```  enableSendAllBids: true,
    targetingControls: {
        allowTargetingKeys: ['BIDDER', 'AD_ID', 'PRICE_BUCKET'],
        allowSendAllBidsTargetingKeys: ['PRICE_BUCKET', 'AD_ID']
    }
```


- Docs PR -- https://github.com/prebid/prebid.github.io/pull/2985