### PR TITLE
Sonobi bid adapter: add support for gpid and set advertiserDomains 

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess, logWarn, logMessage, deepClone } from '../src/utils.js';
+import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess, logWarn, logMessage, deepClone, getGptSlotInfoForAdUnitCode } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
@@ -60,11 +60,11 @@ export const spec = {
       if (/^[\/]?[\d]+[[\/].+[\/]?]?$/.test(slotIdentifier)) {
         slotIdentifier = slotIdentifier.charAt(0) === '/' ? slotIdentifier : '/' + slotIdentifier;
         return {
-          [`${slotIdentifier}|${bid.bidId}`]: `${_validateSize(bid)}${_validateFloor(bid)}`
+          [`${slotIdentifier}|${bid.bidId}`]: `${_validateSize(bid)}${_validateFloor(bid)}${_validateGPID(bid)}`
         }
       } else if (/^[0-9a-fA-F]{20}$/.test(slotIdentifier) && slotIdentifier.length === 20) {
         return {
-          [bid.bidId]: `${slotIdentifier}|${_validateSize(bid)}${_validateFloor(bid)}`
+          [bid.bidId]: `${slotIdentifier}|${_validateSize(bid)}${_validateFloor(bid)}${_validateGPID(bid)}`
         }
       } else {
         logError(`The ad unit code or Sonobi Placement id for slot ${bid.bidId} is invalid`);
@@ -300,6 +300,15 @@ function _validateFloor (bid) {
     return `|f=${bid.params.floor}`;
   }
   return '';
+}
+
+function _validateGPID(bid) {
+  const gpid = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot') || deepAccess(getGptSlotInfoForAdUnitCode(bid.adUnitCode), 'gptSlot') || bid.params.ad_unit;
+
+  if (gpid) {
+    return `|gpid=${gpid}`
+  }
+  return ''
 }
 
 const _creative = (mediaType, referer) => (sbiDc, sbiAid) => {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -199,6 +199,10 @@ export const spec = {
           width = 1,
           height = 1
         ] = bid.sbi_size.split('x');
+        let aDomains = [];
+        if (bid.sbi_adomain) {
+          aDomains = [bid.sbi_adomain]
+        }
         const bids = {
           requestId: bidId,
           cpm: Number(bid.sbi_mouse),
@@ -209,7 +213,10 @@ export const spec = {
           creativeId: bid.sbi_crid || bid.sbi_aid,
           aid: bid.sbi_aid,
           netRevenue: true,
-          currency: 'USD'
+          currency: 'USD',
+          meta: {
+            advertiserDomains: aDomains
+          }
         };
 
         if (bid.sbi_dozer) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -652,6 +652,7 @@ describe('SonobiBidAdapter', function () {
             'sbi_crid': '1234abcd',
             'sbi_aid': '30292e432662bd5f86d90774b944b039',
             'sbi_mouse': 1.07,
+            'sbi_adomain': 'sonobi.com'
           },
           '30b31c1838de1e': {
             'sbi_size': '300x250',
@@ -659,7 +660,9 @@ describe('SonobiBidAdapter', function () {
             'sbi_aid': '30292e432662bd5f86d90774b944b038',
             'sbi_mouse': 1.25,
             'sbi_dozer': 'dozerkey',
-            'sbi_ct': 'video'
+            'sbi_ct': 'video',
+            'sbi_adomain': 'sonobi.com'
+
           },
           '/7780971/sparks_prebid_LB_OUTSTREAM|30b31c1838de1g': {
             'sbi_size': '300x600',
@@ -667,6 +670,8 @@ describe('SonobiBidAdapter', function () {
             'sbi_crid': '1234abcd',
             'sbi_aid': '30292e432662bd5f86d90774b944b038',
             'sbi_mouse': 1.07,
+            'sbi_adomain': 'sonobi.com'
+
           },
           '/7780971/sparks_prebid_LB|30b31c1838de1g': {},
           '30b31c1838de1zzzz': {
@@ -677,6 +682,7 @@ describe('SonobiBidAdapter', function () {
             sbi_mouse: 1.25,
             sbi_size: 'preroll',
             'sbi_crid': 'somecrid',
+            'sbi_adomain': 'sonobi.com'
 
           }
 
@@ -703,7 +709,10 @@ describe('SonobiBidAdapter', function () {
         'creativeId': '1234abcd',
         'netRevenue': true,
         'currency': 'USD',
-        'aid': '30292e432662bd5f86d90774b944b039'
+        'aid': '30292e432662bd5f86d90774b944b039',
+        meta: {
+          advertiserDomains: ['sonobi.com']
+        }
       },
       {
         'requestId': '30b31c1838de1e',
@@ -717,7 +726,10 @@ describe('SonobiBidAdapter', function () {
         'currency': 'USD',
         'dealId': 'dozerkey',
         'aid': '30292e432662bd5f86d90774b944b038',
-        'mediaType': 'video'
+        'mediaType': 'video',
+        meta: {
+          advertiserDomains: ['sonobi.com']
+        }
       },
       {
         'requestId': '30b31c1838de1g',
@@ -729,7 +741,10 @@ describe('SonobiBidAdapter', function () {
         'creativeId': '1234abcd',
         'netRevenue': true,
         'currency': 'USD',
-        'aid': '30292e432662bd5f86d90774b944b038'
+        'aid': '30292e432662bd5f86d90774b944b038',
+        meta: {
+          advertiserDomains: ['sonobi.com']
+        }
       },
       {
         'requestId': '30b31c1838de1zzzz',
@@ -744,7 +759,10 @@ describe('SonobiBidAdapter', function () {
         'dealId': 'dozerkey',
         'aid': 'force_1550072228_da1c5d030cb49150c5db8a2136175755',
         'mediaType': 'video',
-        renderer: () => {}
+        renderer: () => {},
+        meta: {
+          advertiserDomains: ['sonobi.com']
+        }
       },
     ];
 

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -3,6 +3,7 @@ import { spec, _getPlatform } from 'modules/sonobiBidAdapter.js'
 import { newBidder } from 'src/adapters/bidderFactory.js'
 import {userSync} from '../../../src/userSync.js';
 import { config } from 'src/config.js';
+import * as utils from '../../../src/utils.js';
 
 describe('SonobiBidAdapter', function () {
   const adapter = newBidder(spec)
@@ -239,9 +240,12 @@ describe('SonobiBidAdapter', function () {
   describe('.buildRequests', function () {
     beforeEach(function() {
       sinon.stub(userSync, 'canBidderRegisterSync');
+      sinon.stub(utils, 'getGptSlotInfoForAdUnitCode')
+        .onFirstCall().returns({gptSlot: '/123123/gpt_publisher/adunit-code-3', divId: 'adunit-code-3-div-id'})
     });
     afterEach(function() {
       userSync.canBidderRegisterSync.restore();
+      utils.getGptSlotInfoForAdUnitCode.restore();
     });
     let bidRequest = [{
       'schain': {
@@ -271,6 +275,24 @@ describe('SonobiBidAdapter', function () {
       'adUnitCode': 'adunit-code-1',
       'sizes': [[300, 250], [300, 600]],
       'bidId': '30b31c1838de1f',
+      ortb2Imp: {
+        ext: {
+          data: {
+            pbadslot: '/123123/gpt_publisher/adunit-code-1'
+          }
+        }
+      }
+    },
+    {
+      'bidder': 'sonobi',
+      'params': {
+        'placement_id': '1a2b3c4d5e6f1a2b3c4e',
+        'sizes': [[300, 250], [300, 600]],
+        'referrer': 'overrides_top_window_location'
+      },
+      'adUnitCode': 'adunit-code-3',
+      'sizes': [[120, 600], [300, 600], [160, 600]],
+      'bidId': '30b31c1838de1d',
     },
     {
       'bidder': 'sonobi',
@@ -285,8 +307,9 @@ describe('SonobiBidAdapter', function () {
     }];
 
     let keyMakerData = {
-      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25',
-      '/7780971/sparks_prebid_LB|30b31c1838de1e': '300x250,300x600',
+      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25|gpid=/123123/gpt_publisher/adunit-code-1',
+      '30b31c1838de1d': '1a2b3c4d5e6f1a2b3c4e|300x250,300x600|gpid=/123123/gpt_publisher/adunit-code-3',
+      '/7780971/sparks_prebid_LB|30b31c1838de1e': '300x250,300x600|gpid=/7780971/sparks_prebid_LB',
     };
 
     let bidderRequests = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change
Try to send the gpid as the gpt ad unit code in the Sonobi bid request if it is available.

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- apex.prebid@sonobi.com
- [x] official adapter submission