### PR TITLE
eTarget Bid Adapter: add "getMetaData" function to adapter

### DIFF
--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -57,10 +57,37 @@ export const spec = {
       data: bidderRequest,
       bids: validBidRequests,
       netRevenue: netRevenue,
+      metaData: getMetaData(),
       bidder: 'etarget',
       gdpr: gdprObject
     };
-
+    function getMetaData() {
+      var mts = {};
+      var hmetas = document.getElementsByTagName('meta');
+      var wnames = ['title', 'og:title', 'description', 'og:description', 'og:url', 'base', 'keywords'];
+      try {
+        for (var k in hmetas) {
+          if (typeof hmetas[k] == 'object') {
+            var mname = hmetas[k].name || hmetas[k].getAttribute('property');
+            var mcont = hmetas[k].content;
+            if (!!mname && mname != 'null' && !!mcont) {
+              if (wnames.indexOf(mname) >= 0) {
+                if (!mts[mname]) {
+                  mts[mname] = [];
+                }
+                mts[mname].push(mcont);
+              }
+            }
+          }
+        }
+        mts['title'] = [(document.getElementsByTagName('title')[0] || []).innerHTML];
+        mts['base'] = [(document.getElementsByTagName('base')[0] || {}).href];
+        mts['referer'] = [document.location.href];
+      } catch (e) {
+        mts.error = e;
+      }
+      return mts;
+    }
     function formRequestUrl(reqData) {
       var key;
       var url = [];
@@ -68,7 +95,6 @@ export const spec = {
       for (key in reqData) {
         if (reqData.hasOwnProperty(key) && reqData[key]) { url.push(key, '=', reqData[key], '&'); }
       }
-
       return encodeURIComponent(btoa(url.join('').slice(0, -1)));
     }
   },
@@ -111,7 +137,6 @@ export const spec = {
       }
     }
     return bidRespones;
-
     function verifySize(adItem, validSizes) {
       for (var j = 0, k = validSizes.length; j < k; j++) {
         if (adItem.width == validSizes[j][0] &&


### PR DESCRIPTION
getMetaData used to gether useful information from publisher site

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
