### PR TITLE
Eplanning Bid Adapter: verify getUserIds exists and is a function; add adomain support

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -117,6 +117,11 @@ export const spec = {
               netRevenue: NET_REVENUE,
               currency: DOLLARS,
             };
+            if (ad.adom) {
+              bidResponse.meta = {
+                advertiserDomains: ad.adom
+              };
+            }
             bidResponses.push(bidResponse);
           });
         }

--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -83,13 +83,12 @@ export const spec = {
         params.ccpa = bidderRequest.uspConsent;
       }
 
-      if ((getGlobal()).getUserIds && typeof (getGlobal()).getUserIds === "function") {
+      if ((getGlobal()).getUserIds && typeof (getGlobal()).getUserIds === 'function') {
         const userIds = (getGlobal()).getUserIds();
         for (var id in userIds) {
           params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
         }
       }
-
     }
 
     return {

--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -476,4 +476,3 @@ function registerAuction(storageID) {
   return true;
 }
 registerBidder(spec);
-

--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -82,10 +82,14 @@ export const spec = {
       if (bidderRequest && bidderRequest.uspConsent) {
         params.ccpa = bidderRequest.uspConsent;
       }
-      const userIds = (getGlobal()).getUserIds();
-      for (var id in userIds) {
-        params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
+
+      if ((getGlobal()).getUserIds && typeof (getGlobal()).getUserIds === "function") {
+        const userIds = (getGlobal()).getUserIds();
+        for (var id in userIds) {
+          params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
+        }
       }
+
     }
 
     return {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -26,6 +26,7 @@ describe('E-Planning Adapter', function () {
   const I_ID = '7854abc56248f873';
   const CRID = '1234567890';
   const TEST_ISV = 'leles.e-planning.net';
+  const ADOMAIN = 'adomain.com';
   const validBid = {
     'bidder': 'eplanning',
     'bidId': BID_ID,
@@ -237,6 +238,39 @@ describe('E-Planning Adapter', function () {
       ]
     }
   };
+  const responseWithAdomain = {
+    body: {
+      'sI': {
+        'k': '12345'
+      },
+      'sec': {
+        'k': 'ROS'
+      },
+      'sp': [{
+        'k': CLEAN_ADUNIT_CODE,
+        'a': [{
+          'adm': ADM,
+          'id': '7854abc56248f874',
+          'i': I_ID,
+          'fi': '7854abc56248f872',
+          'ip': '45621afd87462104',
+          'w': W,
+          'h': H,
+          'crid': CRID,
+          'pr': CPM,
+          'adom': ADOMAIN
+        }],
+      }],
+      'cs': [
+        'http://a-sync-url.com/',
+        {
+          'u': 'http://another-sync-url.com/test.php?&partner=123456&endpoint=us-east',
+          'ifr': true
+        }
+      ]
+    }
+  };
+
   const responseWithNoSpace = {
     body: {
       'sI': {
@@ -517,6 +551,25 @@ describe('E-Planning Adapter', function () {
         creativeId: CRID,
         netRevenue: true,
         currency: 'USD',
+      };
+      expect(bidResponse).to.deep.equal(expectedResponse);
+    });
+
+    it('should pass advertiserDomains when present', function () {
+      const bidResponse = spec.interpretResponse(responseWithAdomain, { adUnitToBidId: { [CLEAN_ADUNIT_CODE]: BID_ID } })[0];
+      const expectedResponse = {
+        requestId: BID_ID,
+        cpm: CPM,
+        width: W,
+        height: H,
+        ad: ADM,
+        ttl: 120,
+        creativeId: CRID,
+        netRevenue: true,
+        currency: 'USD',
+        meta: {
+          advertiserDomains: ADOMAIN
+        }
       };
       expect(bidResponse).to.deep.equal(expectedResponse);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
We are calling getUserIds() before checking if this is defined and is a function. When the publisher does not include the userId module it throws the following JS error: Object(...)().getUserIds is not a function

This change check this first and fix this error

- contact email of the adapter’s maintainer: sperez@e-planning.net
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
