### PR TITLE
Beachfront Bid Adapter: add support for advertiser domains

### DIFF
--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -71,13 +71,15 @@ export const spec = {
       let firstSize = getFirstSize(sizes);
       let context = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
       let responseType = getVideoBidParam(bidRequest, 'responseType') || 'both';
+      let responseMeta = Object.assign({ mediaType: VIDEO, advertiserDomains: [] }, response.meta);
       let bidResponse = {
         requestId: bidRequest.bidId,
         bidderCode: spec.code,
         cpm: response.bidPrice,
         width: firstSize.w,
         height: firstSize.h,
-        creativeId: response.crid || response.cmpId,
+        creativeId: response.crid,
+        meta: responseMeta,
         renderer: context === OUTSTREAM ? createRenderer(bidRequest) : null,
         mediaType: VIDEO,
         currency: CURRENCY,
@@ -103,6 +105,7 @@ export const spec = {
         .filter(bid => bid.adm)
         .map((bid) => {
           let request = find(bidRequest, req => req.adUnitCode === bid.slot);
+          let responseMeta = Object.assign({ mediaType: BANNER, advertiserDomains: [] }, bid.meta);
           return {
             requestId: request.bidId,
             bidderCode: spec.code,
@@ -111,6 +114,7 @@ export const spec = {
             cpm: bid.price,
             width: bid.w,
             height: bid.h,
+            meta: responseMeta,
             mediaType: BANNER,
             currency: CURRENCY,
             netRevenue: true,

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -673,30 +673,11 @@ describe('BeachfrontAdapter', function () {
           width: width,
           height: height,
           renderer: null,
+          meta: { mediaType: 'video', advertiserDomains: [] },
           mediaType: 'video',
           currency: 'USD',
           netRevenue: true,
           ttl: 300
-        });
-      });
-
-      it('should default to the legacy "cmpId" value for the creative ID', () => {
-        const width = 640;
-        const height = 480;
-        const bidRequest = bidRequests[0];
-        bidRequest.mediaTypes = {
-          video: {
-            playerSize: [ width, height ]
-          }
-        };
-        const serverResponse = {
-          bidPrice: 5.00,
-          url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
-          cmpId: '123abc'
-        };
-        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
-        expect(bidResponse).to.deep.contain({
-          creativeId: serverResponse.cmpId
         });
       });
 
@@ -761,6 +742,31 @@ describe('BeachfrontAdapter', function () {
         });
         expect(bidResponse.renderer.render).to.be.a('function');
       });
+
+      it('should return meta data for the bid response', () => {
+        const width = 640;
+        const height = 480;
+        const bidRequest = bidRequests[0];
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [ width, height ]
+          }
+        };
+        const serverResponse = {
+          bidPrice: 5.00,
+          url: 'http://reachms.bfmio.com/getmu?aid=bid:19c4a196-fb21-4c81-9a1a-ecc5437a39da',
+          meta: {
+            advertiserDomains: ['example.com'],
+            advertiserId: '123'
+          }
+        };
+        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+        expect(bidResponse.meta).to.deep.equal({
+          mediaType: 'video',
+          advertiserDomains: ['example.com'],
+          advertiserId: '123'
+        });
+      });
     });
 
     describe('for banner bids', function () {
@@ -815,12 +821,39 @@ describe('BeachfrontAdapter', function () {
             cpm: serverResponse[ i ].price,
             width: serverResponse[ i ].w,
             height: serverResponse[ i ].h,
+            meta: { mediaType: 'banner', advertiserDomains: [] },
             mediaType: 'banner',
             currency: 'USD',
             netRevenue: true,
             ttl: 300
           });
         }
+      });
+
+      it('should return meta data for the bid response', () => {
+        bidRequests[0].mediaTypes = {
+          banner: {
+            sizes: [[ 300, 250 ], [ 728, 90 ]]
+          }
+        };
+        const serverResponse = [{
+          slot: bidRequests[0].adUnitCode,
+          adm: '<div id="44851937"></div>',
+          crid: 'crid_1',
+          price: 3.02,
+          w: 728,
+          h: 90,
+          meta: {
+            advertiserDomains: ['example.com'],
+            advertiserId: '123'
+          }
+        }];
+        const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest: bidRequests });
+        expect(bidResponse[0].meta).to.deep.equal({
+          mediaType: 'banner',
+          advertiserDomains: ['example.com'],
+          advertiserId: '123'
+        });
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds support for passing advertiser domains and other meta data in the bid response.
Also removes support for legacy `cmpId` value from the bid response.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#6650 