### PR TITLE
Mediasquare Bid Adapter: support advertiserDomains

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -102,6 +102,9 @@ export const spec = {
             'bidder': value['bidder'],
             'code': value['code']
           }
+          meta: {
+            'advertiserDomains': value['adomain']
+          }
         };
         if ('native' in value) {
           bidResponse['native'] = value['native'];

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -101,7 +101,7 @@ export const spec = {
           mediasquare: {
             'bidder': value['bidder'],
             'code': value['code']
-          }
+          },
           meta: {
             'advertiserDomains': value['adomain']
           }

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -76,6 +76,7 @@ describe('MediaSquare bid adapter tests', function () {
       'bidder': 'msqClassic',
       'code': 'test/publishername_atf_desktop_rg_pave',
       'bid_id': 'aaaa1234',
+      'adomain': ["test.com"],
     }],
   }};
 
@@ -135,6 +136,8 @@ describe('MediaSquare bid adapter tests', function () {
     expect(bid.mediasquare).to.exist;
     expect(bid.mediasquare.bidder).to.equal('msqClassic');
     expect(bid.mediasquare.code).to.equal([DEFAULT_PARAMS[0].params.owner, DEFAULT_PARAMS[0].params.code].join('/'));
+    expect(bid.adomain).to.exist;
+    expect(bid.adomain).to.have.lengthOf(1);
   });
 
   it('Verifies bidder code', function () {

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -136,8 +136,9 @@ describe('MediaSquare bid adapter tests', function () {
     expect(bid.mediasquare).to.exist;
     expect(bid.mediasquare.bidder).to.equal('msqClassic');
     expect(bid.mediasquare.code).to.equal([DEFAULT_PARAMS[0].params.owner, DEFAULT_PARAMS[0].params.code].join('/'));
-    expect(bid.adomain).to.exist;
-    expect(bid.adomain).to.have.lengthOf(1);
+    expect(bid.meta).to.exist;
+    expect(bid.meta.advertiserDomains).to.exist;
+    expect(bid.meta.advertiserDomains).to.have.lengthOf(1);
   });
 
   it('Verifies bidder code', function () {

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -76,7 +76,7 @@ describe('MediaSquare bid adapter tests', function () {
       'bidder': 'msqClassic',
       'code': 'test/publishername_atf_desktop_rg_pave',
       'bid_id': 'aaaa1234',
-      'adomain': ["test.com"],
+      'adomain': ['test.com'],
     }],
   }};
 


### PR DESCRIPTION
## Type of change
- [ ] Feature

## Description of change
Add support for advertiserDomains as per https://github.com/prebid/Prebid.js/issues/6650
