### PR TITLE
Invibes Bid Adapter - support for meta taxonomy

### DIFF
--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -11,7 +11,8 @@ const CONSTANTS = {
   PREBID_VERSION: 6,
   METHOD: 'GET',
   INVIBES_VENDOR_ID: 436,
-  USERID_PROVIDERS: ['pubcid', 'pubProvidedId', 'uid2', 'zeotapIdPlus', 'id5id']
+  USERID_PROVIDERS: ['pubcid', 'pubProvidedId', 'uid2', 'zeotapIdPlus', 'id5id'],
+  META_TAXONOMY: ['networkId', 'networkName', 'agencyId', 'agencyName', 'advertiserId', 'advertiserName', 'advertiserDomains', 'brandId', 'brandName', 'primaryCatId', 'secondaryCatIds', 'mediaType']
 };
 
 const storage = getStorageManager(CONSTANTS.INVIBES_VENDOR_ID);
@@ -236,8 +237,22 @@ function createBid(bidRequest, requestPlacement) {
     currency: bidModel.Currency || CONSTANTS.DEFAULT_CURRENCY,
     netRevenue: true,
     ttl: CONSTANTS.TIME_TO_LIVE,
-    ad: renderCreative(bidModel)
+    ad: renderCreative(bidModel),
+    meta: addMeta(bidModel.Meta)
   };
+}
+
+function addMeta(bidModelMeta) {
+  var meta = {};
+  if (bidModelMeta != null) {
+    for (let i = 0; i < CONSTANTS.META_TAXONOMY.length; i++) {
+      if (bidModelMeta.hasOwnProperty(CONSTANTS.META_TAXONOMY[i])) {
+        meta[CONSTANTS.META_TAXONOMY[i]] = bidModelMeta[CONSTANTS.META_TAXONOMY[i]];
+      }
+    }
+  }
+
+  return meta;
 }
 
 function generateRandomId() {

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -733,7 +733,8 @@ describe('invibesBidAdapter:', function () {
           <body style='margin : 0; padding: 0;'>
           <!-- Creative -->
           </body>
-        </html>`
+        </html>`,
+      meta: {}
     }];
 
     let multiResponse = {
@@ -758,6 +759,23 @@ describe('invibesBidAdapter:', function () {
           VideoExposedId: 123
         }]
       }]
+    };
+
+    let responseWithMeta = {
+      Ads: [{
+        BidPrice: 0.5,
+        VideoExposedId: 123
+      }],
+      BidModel: {
+        BidVersion: 1,
+        PlacementId: '12345',
+        AuctionStartTime: Date.now(),
+        CreativeHtml: '<!-- Creative -->',
+        Meta: {
+          advertiserDomains: ['theadvertiser.com', 'theadvertiser_2.com'],
+          advertiserName: 'theadvertiser'
+        }
+      }
     };
 
     context('when the response is not valid', function () {
@@ -827,6 +845,15 @@ describe('invibesBidAdapter:', function () {
         let result = spec.interpretResponse({body: response}, {bidRequests});
         let secondResult = spec.interpretResponse({body: response}, {bidRequests});
         expect(secondResult).to.be.empty;
+      });
+    });
+
+    context('when the response has meta', function () {
+      it('responds with a valid bid, with the meta info', function () {
+        let result = spec.interpretResponse({body: responseWithMeta}, {bidRequests});
+        expect(result[0].meta.advertiserName).to.equal('theadvertiser');
+        expect(result[0].meta.advertiserDomains).to.contain('theadvertiser.com');
+        expect(result[0].meta.advertiserDomains).to.contain('theadvertiser_2.com');
       });
     });
   });


### PR DESCRIPTION

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added support for meta taxonomy:   
'networkId', 'networkName', 'agencyId', 'agencyName', 'advertiserId', 'advertiserName', 'advertiserDomains', 'brandId', 'brandName', 'primaryCatId', 'secondaryCatIds', 'mediaType'

- contact email of the adapter’s maintainer:
system_operations@invibes.com

- [x] official adapter submission
