### PR TITLE
gjirafa Bid Adapter : added meta.advertiserDomains to bidResponse

### DIFF
--- a/modules/gjirafaBidAdapter.js
+++ b/modules/gjirafaBidAdapter.js
@@ -95,7 +95,10 @@ export const spec = {
         referrer: responses[i].Referrer,
         ad: responses[i].Ad,
         vastUrl: responses[i].VastUrl,
-        mediaType: responses[i].MediaType
+        mediaType: responses[i].MediaType,
+        meta: {
+          advertiserDomains: Array.isArray(responses[i].ADomain) ? responses[i].ADomain : []
+        }
       };
       bidResponses.push(bidResponse);
     }

--- a/test/spec/modules/gjirafaBidAdapter_spec.js
+++ b/test/spec/modules/gjirafaBidAdapter_spec.js
@@ -136,7 +136,8 @@ describe('gjirafaAdapterTest', () => {
         'CreativeId': '123abc',
         'NetRevenue': false,
         'Currency': 'EUR',
-        'TTL': 360
+        'TTL': 360,
+        'ADomain': ['somedomain.com']
       }],
       headers: {}
     };
@@ -156,13 +157,29 @@ describe('gjirafaAdapterTest', () => {
         'referrer',
         'ad',
         'vastUrl',
-        'mediaType'
+        'mediaType',
+        'meta'
       ];
 
       let resultKeys = Object.keys(result[0]);
       resultKeys.forEach(function (key) {
         expect(keys.indexOf(key) !== -1).to.equal(true);
       });
+    })
+
+    it('all values correct', () => {
+      const result = spec.interpretResponse(bidResponse, bidRequest);
+
+      expect(result[0].cpm).to.equal(1);
+      expect(result[0].width).to.equal(728);
+      expect(result[0].height).to.equal(90);
+      expect(result[0].creativeId).to.equal('123abc');
+      expect(result[0].currency).to.equal('EUR');
+      expect(result[0].netRevenue).to.equal(false);
+      expect(result[0].ttl).to.equal(360);
+      expect(result[0].referrer).to.equal('http://localhost:9999/integrationExamples/gpt/hello_world.html?pbjs_debug=true');
+      expect(result[0].ad).to.equal('<div>Test ad</div>');
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['somedomain.com']);
     })
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Added advertiserDomains support to gjirafa adapter
