### PR TITLE
ConnectAd Bid-Adapter: Add adomain support

### DIFF
--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -124,7 +124,7 @@ export const spec = {
           bid.width = decision.width;
           bid.height = decision.height;
           bid.dealid = decision.dealid || null;
-          meta: { advertiserDomains: decision && decision.adomain ? decision.adomain : [] },
+          bid.meta: { advertiserDomains: decision && decision.adomain ? decision.adomain : [] },
           bid.ad = retrieveAd(decision);
           bid.currency = 'USD';
           bid.creativeId = decision.adId;

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -124,7 +124,7 @@ export const spec = {
           bid.width = decision.width;
           bid.height = decision.height;
           bid.dealid = decision.dealid || null;
-          bid.meta: { advertiserDomains: decision && decision.adomain ? decision.adomain : [] },
+          bid.meta = { advertiserDomains: decision && decision.adomain ? decision.adomain : [] };
           bid.ad = retrieveAd(decision);
           bid.currency = 'USD';
           bid.creativeId = decision.adId;

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -124,6 +124,7 @@ export const spec = {
           bid.width = decision.width;
           bid.height = decision.height;
           bid.dealid = decision.dealid || null;
+          meta: { advertiserDomains: decision && decision.adomain ? decision.adomain : [] },
           bid.ad = retrieveAd(decision);
           bid.currency = 'USD';
           bid.creativeId = decision.adId;

--- a/test/spec/modules/connectadBidAdapter_spec.js
+++ b/test/spec/modules/connectadBidAdapter_spec.js
@@ -303,7 +303,43 @@ describe('ConnectAd Adapter', function () {
     });
 
     describe('bid responses', function () {
-      it('should return complete bid response', function () {
+      it('should return complete bid response with adomain', function () {
+        const ADOMAINS = ['connectad.io'];
+
+        let serverResponse = {
+          body: {
+            decisions: {
+              '2f95c00074b931': {
+                adId: '0',
+                adomain: ['connectad.io'],
+                contents: [
+                  {
+                    body: '<<<---- Creative --->>>'
+                  }
+                ],
+                height: '250',
+                width: '300',
+                pricing: {
+                  clearPrice: 11.899999999999999
+                }
+              }
+            }
+          }
+        };
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        const bids = spec.interpretResponse(serverResponse, request);
+
+        expect(bids).to.be.lengthOf(1);
+        expect(bids[0].cpm).to.equal(11.899999999999999);
+        expect(bids[0].width).to.equal('300');
+        expect(bids[0].height).to.equal('250');
+        expect(bids[0].ad).to.have.length.above(1);
+        expect(bids[0].meta.advertiserDomains).to.deep.equal(ADOMAINS);
+      });
+
+      it('should return complete bid response with empty adomain', function () {
+        const ADOMAINS = [];
+
         let serverResponse = {
           body: {
             decisions: {
@@ -331,6 +367,7 @@ describe('ConnectAd Adapter', function () {
         expect(bids[0].width).to.equal('300');
         expect(bids[0].height).to.equal('250');
         expect(bids[0].ad).to.have.length.above(1);
+        expect(bids[0].meta.advertiserDomains).to.deep.equal(ADOMAINS);
       });
 
       it('should return empty bid response', function () {


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
Add meta.advertiserDomains to ConnectAd Bid-Adapter

- contact email of the adapter’s maintainer
support@connectad.io