### PR TITLE
Inject creativeComment after render so it actually persists

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -449,8 +449,8 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
 
           if (isRendererRequired(renderer)) {
             executeRenderer(renderer, bid);
-            emitAdRenderSucceeded({ doc, bid, id });
             utils.insertElement(creativeComment, doc, 'html');
+            emitAdRenderSucceeded({ doc, bid, id });
           } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
             const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
             emitAdRenderFail({reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id});

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -446,11 +446,11 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
           const {height, width, ad, mediaType, adUrl, renderer} = bid;
 
           const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
-          utils.insertElement(creativeComment, doc, 'body');
 
           if (isRendererRequired(renderer)) {
             executeRenderer(renderer, bid);
             emitAdRenderSucceeded({ doc, bid, id });
+            utils.insertElement(creativeComment, doc, 'html');
           } else if ((doc === document && !utils.inIframe()) || mediaType === 'video') {
             const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
             emitAdRenderFail({reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id});
@@ -468,6 +468,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
             doc.write(ad);
             doc.close();
             setRenderSize(doc, width, height);
+            utils.insertElement(creativeComment, doc, 'html');
             utils.callBurl(bid);
             emitAdRenderSucceeded({ doc, bid, id });
           } else if (adUrl) {
@@ -480,6 +481,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
 
             utils.insertElement(iframe, doc, 'body');
             setRenderSize(doc, width, height);
+            utils.insertElement(creativeComment, doc, 'html');
             utils.callBurl(bid);
             emitAdRenderSucceeded({ doc, bid, id });
           } else {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

pbjs.renderAd currently injects an HTML comment into the body tag of the document passed in. This comment seems to get eaten up in any case where an ad is actually rendered successfully.  Some bid adapters insert a comment similar to this in their renderers, but some don't.  This change moves the actual injection of the comment to the HTML tag of the document, as well as changing it to run after the ad has been rendered.  In my testing this actually results in a comment that you can see in the DOM for the adapters I happened to get demand from during manual testing.

I suppose there could/should be some tests for this, but i haven't written any since there aren't any renderAd tests that care about this comment.  I'd be happy to look into getting some working if desired.


