### PR TITLE
Adagio bid adapter: support priceFloors module

### DIFF
--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -740,6 +740,77 @@ describe('Adagio bid adapter', () => {
         expect(requests[0].data.user.eids).to.be.empty;
       });
     });
+
+    describe('with priceFloors module', function() {
+      it('should get and set floor by mediatype and sizes', function() {
+        const bid01 = new BidRequestBuilder({
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]]
+            },
+            video: {
+              playerSize: [600, 480]
+            }
+          }
+        }).withParams().build();
+        const bidderRequest = new BidderRequestBuilder().build();
+
+        // delete the computed `sizes` prop as we are based on mediaTypes only.
+        delete bid01.sizes
+
+        bid01.getFloor = () => {
+          return { floor: 1, currency: 'USD' }
+        }
+        const requests = spec.buildRequests([bid01], bidderRequest);
+
+        expect(requests[0].data.adUnits[0].floors.length).to.equal(3);
+        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'banner', s: '300x250'});
+        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'banner', s: '300x600'});
+        expect(requests[0].data.adUnits[0].floors[2]).to.deep.equal({f: 1, mt: 'video', s: '600x480'});
+      });
+
+      it('should get and set floor by mediatype if no size provided (ex native, video)', function() {
+        const bid01 = new BidRequestBuilder({
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              mimes: ['video/mp4']
+            },
+            native: {
+              body: { required: true }
+            }
+          }
+        }).withParams().build();
+        const bidderRequest = new BidderRequestBuilder().build();
+        bid01.getFloor = () => {
+          return { floor: 1, currency: 'USD' }
+        }
+        const requests = spec.buildRequests([bid01], bidderRequest);
+
+        expect(requests[0].data.adUnits[0].floors.length).to.equal(2);
+        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'video'});
+        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'native'});
+      });
+
+      it('should get and set floor with default value if no floors found', function() {
+        const bid01 = new BidRequestBuilder({
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              mimes: ['video/mp4']
+            }
+          }
+        }).withParams().build();
+        const bidderRequest = new BidderRequestBuilder().build();
+        bid01.getFloor = () => {
+          return { floor: NaN, currency: 'USD' }
+        }
+        const requests = spec.buildRequests([bid01], bidderRequest);
+
+        expect(requests[0].data.adUnits[0].floors.length).to.equal(1);
+        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 0.1, mt: 'video'});
+      });
+    });
   });
 
   describe('interpretResponse()', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Prebid 5.0 requires adapters to be compatible with priceFloors module. This PR implements the support of this module.

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
- https://github.com/prebid/prebid.github.io/pull/2995

## Other information
Related to https://github.com/prebid/Prebid.js/issues/6465
