### PR TITLE
Increase cookie expire time to 1 day

### DIFF
--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -12,7 +12,7 @@ import { server } from 'test/mocks/xhr.js';
 const storage = newStorageManager();
 
 const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
-const EXPIRE_COOKIE_TIME = 20000;
+const EXPIRE_COOKIE_TIME = 864000000;
 const P_COOKIE_NAME = '_parrable_id';
 const P_COOKIE_EID = '01.1563917337.test-eid';
 const P_XHR_EID = '01.1588030911.test-new-eid'

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -15,7 +15,7 @@ const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
 const EXPIRE_COOKIE_TIME = 864000000;
 const P_COOKIE_NAME = '_parrable_id';
 const P_COOKIE_EID = '01.1563917337.test-eid';
-const P_XHR_EID = '01.1588030911.test-new-eid'
+const P_XHR_EID = '01.1588030911.test-new-eid';
 const P_CONFIG_MOCK = {
   name: 'parrableId',
   params: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Previous PR caused some test to fail occasionally due to a low cookie expire time. Now the expire time is increased to one day to avoid those failures.
This is the PR that introduced the problem: https://github.com/prebid/Prebid.js/pull/6741

Other information
Author @victorigualada
