### PR TITLE
Sharethrough Bid Adapter: Use getFloor module for Prebid 5.0 compliance

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -2,7 +2,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
-const VERSION = '3.3.2';
+const VERSION = '3.4.0';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -57,8 +57,9 @@ export const sharethroughAdapterSpec = {
         query.schain = JSON.stringify(bidRequest.schain);
       }
 
-      if (bidRequest.bidfloor) {
-        query.bidfloor = parseFloat(bidRequest.bidfloor);
+      const floor = getFloor(bidRequest);
+      if (floor) {
+        query.bidfloor = floor;
       }
 
       if (bidRequest.params.badv) {
@@ -290,6 +291,20 @@ function canAutoPlayHTML5Video() {
 
 function getProtocol() {
   return document.location.protocol;
+}
+
+function getFloor(bid) {
+  if (utils.isFn(bid.getFloor)) {
+    const floorInfo = bid.getFloor({
+      currency: 'USD',
+      mediaType: 'banner',
+      size: bid.sizes.map(size => ({ w: size[0], h: size[1] }))
+    });
+    if (utils.isPlainObject(floorInfo) && !isNaN(floorInfo.floor) && floorInfo.currency === 'USD') {
+      return parseFloat(floorInfo.floor);
+    }
+  }
+  return null;
 }
 
 registerBidder(sharethroughAdapterSpec);

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -436,7 +436,7 @@ describe('sharethrough adapter spec', function() {
 
     it('should include the bidfloor parameter if it is present in the bid request', function() {
       const bidRequest = Object.assign({}, bidRequests[0]);
-      bidRequest['bidfloor'] = 0.50;
+      bidRequest['getFloor'] = () => ({ currency: 'USD', floor: 0.5 });
       const builtBidRequest = spec.buildRequests([bidRequest])[0];
       expect(builtBidRequest.data.bidfloor).to.eq(0.5);
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Leverage `getFloor` from the floors module in order to be 5.0 compliant.

Related to: https://github.com/prebid/Prebid.js/issues/6465

pubgrowth.engineering@sharethrough.com
