### PR TITLE
CointrafficBidAdapter: add meta.advertiserDomains and meta.mediaType to bid response

### DIFF
--- a/modules/cointrafficBidAdapter.js
+++ b/modules/cointrafficBidAdapter.js
@@ -85,7 +85,11 @@ export const spec = {
       height: response.height,
       creativeId: response.creativeId,
       ttl: response.ttl,
-      ad: response.ad
+      ad: response.ad,
+      meta: {
+        advertiserDomains: response.adomain && response.adomain.length ? response.adomain : [],
+        mediaType: response.mediaType
+      }
     };
 
     bidResponses.push(bidResponse);

--- a/test/spec/modules/cointrafficBidAdapter_spec.js
+++ b/test/spec/modules/cointrafficBidAdapter_spec.js
@@ -142,7 +142,9 @@ describe('cointrafficBidAdapter', function () {
           height: 250,
           creativeId: 'creativeId12345',
           ttl: 90,
-          ad: '<html><h3>I am an ad</h3></html> '
+          ad: '<html><h3>I am an ad</h3></html> ',
+          mediaType: 'banner',
+          adomain: ['test.com']
         }
       };
 
@@ -155,7 +157,13 @@ describe('cointrafficBidAdapter', function () {
         height: 250,
         creativeId: 'creativeId12345',
         ttl: 90,
-        ad: '<html><h3>I am an ad</h3></html>'
+        ad: '<html><h3>I am an ad</h3></html>',
+        meta: {
+          mediaType: 'banner',
+          advertiserDomains: [
+            'test.com',
+          ]
+        }
       }];
 
       let result = spec.interpretResponse(serverResponse, bidRequest[0]);
@@ -186,7 +194,9 @@ describe('cointrafficBidAdapter', function () {
           height: 250,
           creativeId: 'creativeId12345',
           ttl: 90,
-          ad: '<html><h3>I am an ad</h3></html> '
+          ad: '<html><h3>I am an ad</h3></html> ',
+          mediaType: 'banner',
+          adomain: ['test.com']
         }
       };
 
@@ -199,7 +209,13 @@ describe('cointrafficBidAdapter', function () {
         height: 250,
         creativeId: 'creativeId12345',
         ttl: 90,
-        ad: '<html><h3>I am an ad</h3></html>'
+        ad: '<html><h3>I am an ad</h3></html>',
+        meta: {
+          mediaType: 'banner',
+          advertiserDomains: [
+            'test.com',
+          ]
+        }
       }];
 
       const getConfigStub = sinon.stub(config, 'getConfig').returns('USD');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add meta.advertiserDomains as requested in #6650.
