### PR TITLE
GMOSSP BidAdapter: add adomain support

### DIFF
--- a/modules/gmosspBidAdapter.js
+++ b/modules/gmosspBidAdapter.js
@@ -94,6 +94,10 @@ export const spec = {
       ttl: res.ttl || 300
     };
 
+    if (res.adomains) {
+      utils.deepSetValue(bid, 'meta.advertiserDomains', Array.isArray(res.adomains) ? res.adomains : [res.adomains]);
+    }
+
     return [bid];
   },
 

--- a/test/spec/modules/gmosspBidAdapter_spec.js
+++ b/test/spec/modules/gmosspBidAdapter_spec.js
@@ -106,6 +106,9 @@ describe('GmosspAdapter', function () {
         price: 20,
         w: 300,
         h: 250,
+        adomains: [
+          'test.com'
+        ],
         ad: '<div class="gmossp"></div>',
         creativeId: '985ec572b32be309.76973017',
         cur: 'JPY',
@@ -126,6 +129,11 @@ describe('GmosspAdapter', function () {
           currency: 'JPY',
           width: 300,
           height: 250,
+          meta: {
+            advertiserDomains: [
+              'test.com'
+            ]
+          },
           ad: '<div class="gmossp"></div>',
           creativeId: '985ec572b32be309.76973017',
           netRevenue: true,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add meta.advertiserDomains to GMOSSP BidAdapter according to the issue mentioned #6650.

- contact email of the adapter’s maintainer
dev@ml.gmo-am.jp