### PR TITLE
A4G Bid Adapter: add meta adomain

### DIFF
--- a/modules/a4gBidAdapter.js
+++ b/modules/a4gBidAdapter.js
@@ -77,7 +77,10 @@ export const spec = {
           currency: A4G_CURRENCY,
           netRevenue: true,
           ttl: A4G_TTL,
-          ad: response.ad
+          ad: response.ad,
+          meta: {
+            advertiserDomains: response.adomain && response.adomain.length > 0 ? response.adomain : []
+          }
         };
         bidResponses.push(bidResponse);
       }

--- a/test/spec/modules/a4gBidAdapter_spec.js
+++ b/test/spec/modules/a4gBidAdapter_spec.js
@@ -161,7 +161,11 @@ describe('a4gAdapterTests', function () {
           ad: 'test ad',
           currency: 'USD',
           ttl: 120,
-          netRevenue: true
+          netRevenue: true,
+          meta: {
+            advertiserDomains: []
+          }
+
         }
       ];
       const result = spec.interpretResponse(bidResponse, bidRequest);
@@ -181,7 +185,10 @@ describe('a4gAdapterTests', function () {
           ad: 'test ad',
           currency: 'USD',
           ttl: 120,
-          netRevenue: true
+          netRevenue: true,
+          meta: {
+            advertiserDomains: []
+          }
         }
       ];
       const result = spec.interpretResponse(bidResponseWithoutCrid, bidRequest);
@@ -201,7 +208,8 @@ describe('a4gAdapterTests', function () {
         'currency',
         'netRevenue',
         'ttl',
-        'ad'
+        'ad',
+        'meta'
       ];
 
       let resultKeys = Object.keys(result[0]);

--- a/test/spec/modules/a4gBidAdapter_spec.js
+++ b/test/spec/modules/a4gBidAdapter_spec.js
@@ -223,5 +223,13 @@ describe('a4gAdapterTests', function () {
 
       expect(result[0].requestId).to.not.equal(result[0].adId);
     })
+
+    it('advertiserDomains is included when sent by server', function () {
+      bidResponse.body[0].adomain = ['test_adomain'];
+      let response = spec.interpretResponse(bidResponse, bidRequest);
+      expect(Object.keys(response[0].meta)).to.include.members(['advertiserDomains']);
+      expect(response[0].meta.advertiserDomains).to.deep.equal(['test_adomain']);
+      delete bidResponse.body[0].adomain;
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding A4G adapter support for meta advertiserDomains  according to the issue mentioned #6650

- contact email of the adapter’s maintainer
devops@ad4game.com