### PR TITLE
Vox Bid Adapter: Add placeholder to pass advertiser domains

### DIFF
--- a/modules/voxBidAdapter.js
+++ b/modules/voxBidAdapter.js
@@ -70,7 +70,10 @@ function buildBid(bidData) {
     netRevenue: true,
     mediaType: BANNER,
     ttl: TTL,
-    content: bidData.content
+    content: bidData.content,
+    meta: {
+      advertiserDomains: bidData.advertiserDomains || [],
+    }
   };
 
   if (bidData.placement === 'video') {

--- a/test/spec/modules/voxBidAdapter_spec.js
+++ b/test/spec/modules/voxBidAdapter_spec.js
@@ -243,7 +243,8 @@ describe('VOX Adapter', function() {
                     content: 'html',
                     width: 100,
                     height: 100
-                  }
+                  },
+                  advertiserDomains: ['voxexchange.io']
                 }
               ]
             }
@@ -257,6 +258,7 @@ describe('VOX Adapter', function() {
           expect(bids[0].height).to.equal(100)
           expect(bids[0].currency).to.equal('USD')
           expect(bids[0].netRevenue).to.equal(true)
+          expect(bids[0].meta.advertiserDomains).to.deep.equal(['voxexchange.io'])
           expect(typeof bids[0].ad).to.equal('string')
         })
         it('should return a In-Image bid', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
