### PR TITLE
Adkernel Bid Adapter: support for denakop alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -68,7 +68,8 @@ export const spec = {
     {code: 'bcm'},
     {code: 'engageadx'},
     {code: 'converge_digital', gvlid: 248},
-    {code: 'adomega'}
+    {code: 'adomega'},
+    {code: 'denakop'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Alias for network denakop  https://github.com/prebid/prebid.github.io/pull/3001

- prebid-dev@adkernel.com
- [x] official adapter submission