### PR TITLE
Seedtag Bid Adapter: read video params from mediaTypes, and allow override from bidder params, support passing adomain

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -59,17 +59,11 @@ function hasMandatoryParams(params) {
 }
 
 function hasMandatoryVideoParams(bid) {
-  if (hasVideoMediaType(bid)) {
-    const videoParams = getVideoParams(bid)
-    const isVideoInStream =
-      (videoParams.context === 'instream');
-    const isPlayerSize =
-      !!videoParams.playerSize &&
-      utils.isArray(videoParams.playerSize);
-    return isVideoInStream && isPlayerSize;
-  } else {
-    return false
-  }
+  const videoParams = getVideoParams(bid)
+
+  return hasVideoMediaType(bid) && !!videoParams.playerSize &&
+    utils.isArray(videoParams.playerSize) &&
+    videoParams.playerSize.length > 0;
 }
 
 function buildBidRequests(validBidRequests) {

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -136,7 +136,7 @@ function buildBidResponse(seedtagBid) {
     ttl: seedtagBid.ttl,
     nurl: seedtagBid.nurl,
     meta: {
-      advertiserDomains: seedtagBid && seedtagBid.adomain ? seedtagBid.adomain : []
+      advertiserDomains: seedtagBid && seedtagBid.adomain && seedtagBid.adomain.length > 0 ? seedtagBid.adomain : []
     }
   };
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -122,7 +122,7 @@ function getVideoParams(validBidRequest) {
   return videoParams
 }
 
-function buildBid(seedtagBid) {
+function buildBidResponse(seedtagBid) {
   const mediaType = mapMediaType(seedtagBid.mediaType);
   const bid = {
     requestId: seedtagBid.bidId,
@@ -134,7 +134,10 @@ function buildBid(seedtagBid) {
     netRevenue: true,
     mediaType: mediaType,
     ttl: seedtagBid.ttl,
-    nurl: seedtagBid.nurl
+    nurl: seedtagBid.nurl,
+    meta: {
+      advertiserDomains: seedtagBid && seedtagBid.adomain ? seedtagBid.adomain : []
+    }
   };
 
   if (mediaType === VIDEO) {
@@ -217,7 +220,7 @@ export const spec = {
     const serverBody = serverResponse.body;
     if (serverBody && serverBody.bids && utils.isArray(serverBody.bids)) {
       return utils._map(serverBody.bids, function(bid) {
-        return buildBid(bid);
+        return buildBidResponse(bid);
       });
     } else {
       return [];

--- a/modules/seedtagBidAdapter.md
+++ b/modules/seedtagBidAdapter.md
@@ -46,7 +46,19 @@ var adUnits = [{
   mediaTypes: {
     video: {
       context: 'instream',   // required
-      playerSize: [600, 300] // required
+      playerSize: [600, 300], // required
+      mimes: ['video/mp4'], // recommended
+      minduration: 5,       // optional
+      maxduration: 60,      // optional
+      boxingallowed: 1,     // optional
+      skip: 1,              // optional
+      startdelay: 1,        // optional
+      linearity: 1,         // optional
+      battr: [1, 2],        // optional
+      maxbitrate: 10,       // optional
+      playbackmethod: [1],  // optional
+      delivery: [1],        // optional
+      placement: 1,         // optional
     }
   },
   bids: [
@@ -57,9 +69,10 @@ var adUnits = [{
         adUnitId: '0000',               // required
         placement: 'video',             // required
         adPosition: 0,                  // optional
-        // Video object as specified in OpenRTB 2.5
-        video: {
-          mimes: ['video/mp4'], // recommended
+        video: { // optional
+          context: 'instream',   // optional
+          playerSize: [600, 300], // optional
+          mimes: ['video/mp4'], // optional
           minduration: 5,       // optional
           maxduration: 60,      // optional
           boxingallowed: 1,     // optional

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -326,7 +326,8 @@ describe('Seedtag Adapter', function() {
                   height: 90,
                   mediaType: 'display',
                   ttl: 360,
-                  nurl: 'testurl.com/nurl'
+                  nurl: 'testurl.com/nurl',
+                  adomain: ['advertiserdomain.com']
                 }
               ],
               cookieSync: { url: '' }
@@ -342,6 +343,7 @@ describe('Seedtag Adapter', function() {
           expect(bids[0].netRevenue).to.equal(true)
           expect(bids[0].ad).to.equal('content')
           expect(bids[0].nurl).to.equal('testurl.com/nurl')
+          expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiserdomain.com'])
         })
       })
       describe('the bid is a video', function() {
@@ -374,6 +376,7 @@ describe('Seedtag Adapter', function() {
           expect(bids[0].currency).to.equal('USD')
           expect(bids[0].netRevenue).to.equal(true)
           expect(bids[0].vastXml).to.equal('content')
+          expect(bids[0].meta.advertiserDomains).to.deep.equal([])
         })
       })
     })

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -55,11 +55,29 @@ describe('Seedtag Adapter', function() {
         })
       })
       describe('when video slot has all mandatory params', function() {
-        it('should return true, when video mediatype object are correct.', function() {
+        it('should return true, when video context is instream', function () {
           const slotConfig = getSlotConfigs(
             {
               video: {
                 context: 'instream',
+                playerSize: [[600, 200]]
+              }
+            },
+            {
+              publisherId: PUBLISHER_ID,
+              adUnitId: ADUNIT_ID,
+              placement: 'video'
+            }
+          )
+          const isBidRequestValid = spec.isBidRequestValid(slotConfig)
+          expect(isBidRequestValid).to.equal(true)
+        })
+
+        it('should return true, when video context is outstream', function () {
+          const slotConfig = getSlotConfigs(
+            {
+              video: {
+                context: 'outstream',
                 playerSize: [[600, 200]]
               }
             },
@@ -137,7 +155,7 @@ describe('Seedtag Adapter', function() {
           )
           expect(isBidRequestValid).to.equal(false)
         })
-        it('is not instream ', function() {
+        it('is outstream ', function () {
           const isBidRequestValid = spec.isBidRequestValid(
             createVideoSlotConfig({
               video: {
@@ -146,7 +164,7 @@ describe('Seedtag Adapter', function() {
               }
             })
           )
-          expect(isBidRequestValid).to.equal(false)
+          expect(isBidRequestValid).to.equal(true)
         })
         describe('order does not matter', function() {
           it('when video is not the first slot', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Supports video params from adunit and bidder : https://github.com/prebid/Prebid.js/issues/6512
Support advertiserDomains : https://github.com/prebid/Prebid.js/issues/6650