### PR TITLE
PBS Bid Adapter: Allow request when renderer is defined for the ad unit or for the video mediatype setting of the ad unit

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -594,7 +594,7 @@ const OPEN_RTB_PROTOCOL = {
       }
 
       if (!utils.isEmpty(videoParams)) {
-        if (videoParams.context === 'outstream' && !adUnit.renderer) {
+        if (videoParams.context === 'outstream' && (!videoParams.renderer || !adUnit.renderer)) {
           // Don't push oustream w/o renderer to request object.
           utils.logError('Outstream bid without renderer cannot be sent to Prebid Server.');
         } else {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
Prebid Server renderer validation only checks adUnit.renderer

Expected results
If only adUnit.mediaTypes.video.renderer is defined the request should be sent to prebid server

## Other information
https://github.com/prebid/Prebid.js/issues/6792
