### PR TITLE
AdkernelAdn Bid Adapter: meta fields support

### DIFF
--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -103,13 +103,17 @@ function buildBid(tag) {
     requestId: tag.impid,
     bidderCode: spec.code,
     cpm: tag.bid,
-    width: tag.w,
-    height: tag.h,
     creativeId: tag.crid,
     currency: 'USD',
     ttl: 720,
     netRevenue: true
   };
+  if (tag.w) {
+    bid.width = tag.w;
+  }
+  if (tag.h) {
+    bid.height = tag.h;
+  }
   if (tag.tag) {
     bid.ad = tag.tag;
     bid.mediaType = BANNER;
@@ -117,7 +121,29 @@ function buildBid(tag) {
     bid.vastUrl = tag.vast_url;
     bid.mediaType = VIDEO;
   }
+  fillBidMeta(bid, tag);
   return bid;
+}
+
+function fillBidMeta(bid, tag) {
+  if (utils.isStr(tag.agencyName)) {
+    utils.deepSetValue(bid, 'meta.agencyName', tag.agencyName);
+  }
+  if (utils.isNumber(tag.advertiserId)) {
+    utils.deepSetValue(bid, 'meta.advertiserId', tag.advertiserId);
+  }
+  if (utils.isStr(tag.advertiserName)) {
+    utils.deepSetValue(bid, 'meta.advertiserName', tag.advertiserName);
+  }
+  if (utils.isArray(tag.advertiserDomains)) {
+    utils.deepSetValue(bid, 'meta.advertiserDomains', tag.advertiserDomains);
+  }
+  if (utils.isStr(tag.primaryCatId)) {
+    utils.deepSetValue(bid, 'meta.primaryCatId', tag.primaryCatId);
+  }
+  if (utils.isArray(tag.secondaryCatIds)) {
+    utils.deepSetValue(bid, 'meta.secondaryCatIds', tag.secondaryCatIds);
+  }
 }
 
 function getBidFloor(bid, mediaType, sizes) {

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -107,7 +107,12 @@ describe('AdkernelAdn adapter', function () {
         bid: 5.0,
         tag: '<!-- tag goes here -->',
         w: 300,
-        h: 250
+        h: 250,
+        advertiserId: 777,
+        advertiserName: 'advertiser',
+        agencyName: 'agency',
+        advertiserDomains: ['example.com'],
+        primaryCatId: 'IAB1-1',
       }, {
         id: 'ad-unit-2',
         impid: '31d798477126c4',
@@ -115,7 +120,12 @@ describe('AdkernelAdn adapter', function () {
         bid: 2.5,
         tag: '<!-- tag goes here -->',
         w: 300,
-        h: 250
+        h: 250,
+        advertiserId: 777,
+        advertiserName: 'advertiser',
+        agencyName: 'agency',
+        advertiserDomains: ['example.com'],
+        secondaryCatIds: ['IAB1-4', 'IAB8-16', 'IAB25-5']
       }, {
         id: 'video_wrapper',
         impid: '57d602ad1c9545',
@@ -375,6 +385,11 @@ describe('AdkernelAdn adapter', function () {
       expect(resp).to.have.property('mediaType', 'banner');
       expect(resp).to.have.property('ad');
       expect(resp.ad).to.have.string('<!-- tag goes here -->');
+      expect(resp.meta.advertiserId).to.be.eql(777);
+      expect(resp.meta.advertiserName).to.be.eql('advertiser');
+      expect(resp.meta.agencyName).to.be.eql('agency');
+      expect(resp.meta.advertiserDomains).to.be.eql(['example.com']);
+      expect(resp.meta.primaryCatId).to.be.eql('IAB1-1');
     });
 
     it('should return fully-initialized video bid-response', function () {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Implemented bid.meta.* fields population



- prebid-dev@adkernel.com
- [x] official adapter submission

## Other information
https://github.com/prebid/Prebid.js/issues/6650
