### PR TITLE
Replace uglify with terser to support ES6 output

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -29,6 +29,7 @@ module.exports = {
   ],
   "plugins": [
     path.resolve(__dirname, './plugins/pbjsGlobals.js'),
-    useLocal('babel-plugin-transform-object-assign')
+    useLocal('babel-plugin-transform-object-assign'),
+    useLocal('@babel/plugin-proposal-object-rest-spread')
   ]
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var gutil = require('gulp-util');
 var connect = require('gulp-connect');
 var webpack = require('webpack');
 var webpackStream = require('webpack-stream');
-var uglify = require('gulp-uglify');
+var terser = require('gulp-terser');
 var gulpClean = require('gulp-clean');
 var KarmaServer = require('karma').Server;
 var karmaConfMaker = require('./karma.conf.maker');
@@ -168,7 +168,7 @@ function makeWebpackPkg() {
   return gulp.src([].concat(moduleSources, analyticsSources, 'src/prebid.js'))
     .pipe(helpers.nameModules(externalModules))
     .pipe(webpackStream(cloned, webpack))
-    .pipe(uglify())
+    .pipe(terser())
     .pipe(replace(/('|")v\$prebid\.modulesList\$('|")/g, makeModuleList(externalModules)))
     .pipe(gulpif(file => file.basename === 'prebid-core.js', header(banner, { prebid: prebid })))
     .pipe(gulp.dest('build/dist'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "4.39.0-pre",
+  "version": "4.42.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10910,22 +10910,27 @@
         }
       }
     },
-    "gulp-uglify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
-      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
+    "gulp-terser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-terser/-/gulp-terser-2.0.1.tgz",
+      "integrity": "sha512-XCrnCXP8ovNpgLK9McJIXlgm0j3W2TsiWu7K9y3m+Sn5XZgUzi6U8MPHtS3NdLMic9poCj695N0ARJ2B6atypw==",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "extend-shallow": "^3.0.2",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "isobject": "^3.0.1",
-        "make-error-cause": "^1.1.1",
-        "safe-buffer": "^5.1.2",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "plugin-error": "^1.0.1",
+        "terser": "5.4.0",
+        "through2": "^4.0.2",
+        "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "3"
+          }
+        }
       }
     },
     "gulp-util": {
@@ -16211,21 +16216,6 @@
         }
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "make-error-cause": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-      "dev": true,
-      "requires": {
-        "make-error": "^1.2.0"
-      }
-    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -21075,6 +21065,49 @@
         }
       }
     },
+    "terser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.4.0.tgz",
+      "integrity": "sha512-3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -21615,7 +21648,8 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
       "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gulp-replace": "^1.0.0",
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^2.6.0",
-    "gulp-uglify": "^3.0.0",
+    "gulp-terser": "^2.0.1",
     "gulp-util": "^3.0.0",
     "is-docker": "^1.1.0",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
## Type of change
- [X] Build related changes

## Description of change

Changing the babel [presets-env browser target](https://github.com/spanishdict/Prebid.js/blob/master/.babelrc.js#L18) to just Chrome in the master branch will fail with an error.

````
[19:03:38] 'makeWebpackPkg' errored after 8.06 s
[19:03:38] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: Unexpected token: keyword «const»
File: /Users/kenan/scm/sd/Prebid.js/criteoBidAdapter.js
Line: 38
[19:03:38] 'build-bundle-prod' errored after 8.07 s
[19:03:38] 'build' errored after 8.13 s
````

uglify-js does not support ES6+. By switching to terser, builds of prebid can target es6 if desired.

## Other information

https://github.com/terser/terser#why-choose-terser