### PR TITLE
LockerDome Bid Adapter: support for meta.advertiserDomains 

### DIFF
--- a/modules/lockerdomeBidAdapter.js
+++ b/modules/lockerdomeBidAdapter.js
@@ -66,7 +66,10 @@ export const spec = {
         currency: bid.currency,
         netRevenue: bid.netRevenue,
         ad: bid.ad,
-        ttl: bid.ttl
+        ttl: bid.ttl,
+        meta: {
+          advertiserDomains: bid.adomain && Array.isArray(bid.adomain) ? bid.adomain : []
+        }
       };
     });
   },

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -236,6 +236,5 @@ describe('LockerDomeAdapter', function () {
       expect(interpretedResponse[1].meta).to.have.property('advertiserDomains');
       expect(interpretedResponse[1].meta.advertiserDomains).to.deep.equal(serverResponse.body.bids[1].adomain);
     });
-
   });
 });

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -180,7 +180,10 @@ describe('LockerDomeAdapter', function () {
             currency: 'USD',
             netRevenue: true,
             ad: '<!-- AD 1 CREATIVE -->',
-            ttl: 300
+            ttl: 300,
+            meta: {
+              advertiserDomains: ['example.com']
+            }
           },
           {
             requestId: '4510f2834773ce',
@@ -191,7 +194,10 @@ describe('LockerDomeAdapter', function () {
             currency: 'USD',
             netRevenue: true,
             ad: '<!-- AD 2 CREATIVE -->',
-            ttl: 300
+            ttl: 300,
+            meta: {
+              advertiserDomains: ['example.com']
+            }
           }]
         }
       };
@@ -217,6 +223,9 @@ describe('LockerDomeAdapter', function () {
       expect(interpretedResponse[0].netRevenue).to.equal(serverResponse.body.bids[0].netRevenue);
       expect(interpretedResponse[0].ad).to.equal(serverResponse.body.bids[0].ad);
       expect(interpretedResponse[0].ttl).to.equal(serverResponse.body.bids[0].ttl);
+      expect(interpretedResponse[0]).to.have.property('meta');
+      expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[0].meta.advertiserDomains).to.deep.equal(serverResponse.body.bids[0].adomain);
 
       expect(interpretedResponse[1].requestId).to.equal(serverResponse.body.bids[1].requestId);
       expect(interpretedResponse[1].cpm).to.equal(serverResponse.body.bids[1].cpm);
@@ -227,6 +236,10 @@ describe('LockerDomeAdapter', function () {
       expect(interpretedResponse[1].netRevenue).to.equal(serverResponse.body.bids[1].netRevenue);
       expect(interpretedResponse[1].ad).to.equal(serverResponse.body.bids[1].ad);
       expect(interpretedResponse[1].ttl).to.equal(serverResponse.body.bids[1].ttl);
+      expect(interpretedResponse[1]).to.have.property('meta');
+      expect(interpretedResponse[1].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[1].meta.advertiserDomains).to.deep.equal(serverResponse.body.bids[1].adomain);
     });
+
   });
 });

--- a/test/spec/modules/lockerdomeBidAdapter_spec.js
+++ b/test/spec/modules/lockerdomeBidAdapter_spec.js
@@ -181,9 +181,7 @@ describe('LockerDomeAdapter', function () {
             netRevenue: true,
             ad: '<!-- AD 1 CREATIVE -->',
             ttl: 300,
-            meta: {
-              advertiserDomains: ['example.com']
-            }
+            adomain: ['example.com']
           },
           {
             requestId: '4510f2834773ce',
@@ -195,9 +193,7 @@ describe('LockerDomeAdapter', function () {
             netRevenue: true,
             ad: '<!-- AD 2 CREATIVE -->',
             ttl: 300,
-            meta: {
-              advertiserDomains: ['example.com']
-            }
+            adomain: ['example.com']
           }]
         }
       };


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Update LockerDome Adapter to address the issue described in:
Adapter does not seem capable of supporting advertiserDomains https://github.com/prebid/Prebid.js/issues/6650

## Contact
margaret.liu@lockerdome.com

