### PR TITLE
Dspx Bid Adapter: new features and support of adomain in meta

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -120,7 +120,7 @@ export const spec = {
         type: response.type,
         ttl: config.getConfig('_bidderTimeout'),
         meta: {
-          advertiserDomains: response.adomain
+          advertiserDomains: response.adomain || []
         }
       };
       if (response.vastXml) {

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -118,7 +118,10 @@ export const spec = {
         currency: currency,
         netRevenue: netRevenue,
         type: response.type,
-        ttl: config.getConfig('_bidderTimeout')
+        ttl: config.getConfig('_bidderTimeout'),
+        meta: {
+          advertiserDomains: [response.adomain]
+        }
       };
       if (response.vastXml) {
         bidResponse.vastXml = response.vastXml;
@@ -126,6 +129,7 @@ export const spec = {
       } else {
         bidResponse.ad = response.adTag;
       }
+
       bidResponses.push(bidResponse);
     }
     return bidResponses;

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -120,7 +120,7 @@ export const spec = {
         type: response.type,
         ttl: config.getConfig('_bidderTimeout'),
         meta: {
-          advertiserDomains: [response.adomain]
+          advertiserDomains: response.adomain
         }
       };
       if (response.vastXml) {

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -32,10 +32,9 @@ export const spec = {
       let endpoint = isDev ? ENDPOINT_URL_DEV : ENDPOINT_URL;
       let payload = {};
 
-      if (isVideoRequest(bidRequest)) {
-        let vastFormat = params.vastFormat || DEFAULT_VAST_FORMAT;
+      if (isBannerRequest(bidRequest)) {
         payload = {
-          _f: vastFormat,
+          _f: 'html',
           alternative: 'prebid_js',
           inventory_item_id: placementId,
           srw: width,
@@ -46,8 +45,9 @@ export const spec = {
           bid_id: bidId,
         };
       } else {
+        let vastFormat = params.vastFormat || DEFAULT_VAST_FORMAT;
         payload = {
-          _f: 'html',
+          _f: vastFormat,
           alternative: 'prebid_js',
           inventory_item_id: placementId,
           srw: width,
@@ -76,6 +76,15 @@ export const spec = {
           };
         }
       }
+
+      if (bidRequest.userId.netId) {
+        payload.did_netid = bidRequest.userId.netId;
+      }
+      if (bidRequest.userId.uid2) {
+        payload.did_uid2 = bidRequest.userId.uid2;
+      }
+
+
 
       if (params.bcat !== undefined) {
         payload.bcat = params.bcat;
@@ -186,6 +195,16 @@ function objectToQueryString(obj, prefix) {
  */
 function isVideoRequest(bid) {
   return bid.mediaType === 'video' || !!utils.deepAccess(bid, 'mediaTypes.video');
+}
+
+/**
+ * Check if it's a banner bid request
+ *
+ * @param {BidRequest} bid - Bid request generated from ad slots
+ * @returns {boolean} True if it's a banner bid
+ */
+function isBannerRequest(bid) {
+  return bid.mediaType === 'banner' || !!utils.deepAccess(bid, 'mediaTypes.banner');
 }
 
 registerBidder(spec);

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -19,10 +19,6 @@ export const spec = {
     return validBidRequests.map(bidRequest => {
       const params = bidRequest.params;
 
-      const videoData = utils.deepAccess(bidRequest, 'mediaTypes.video') || {};
-      const sizes = utils.parseSizesInput(videoData.playerSize || bidRequest.sizes)[0];
-      const [width, height] = sizes.split('x');
-
       const placementId = params.placement;
       const rnd = Math.floor(Math.random() * 99999999999);
       const referrer = bidderRequest.refererInfo.referer;
@@ -33,25 +29,27 @@ export const spec = {
       let payload = {};
 
       if (isBannerRequest(bidRequest)) {
+        let size = getBannerSizes(bidRequest)[0];
         payload = {
           _f: 'html',
           alternative: 'prebid_js',
           inventory_item_id: placementId,
-          srw: width,
-          srh: height,
+          srw: size.width,
+          srh: size.height,
           idt: 100,
           rnd: rnd,
           ref: referrer,
           bid_id: bidId,
         };
       } else {
+        let size = getVideoSizes(bidRequest)[0];
         let vastFormat = params.vastFormat || DEFAULT_VAST_FORMAT;
         payload = {
           _f: vastFormat,
           alternative: 'prebid_js',
           inventory_item_id: placementId,
-          srw: width,
-          srh: height,
+          srw: size.width,
+          srh: size.height,
           idt: 100,
           rnd: rnd,
           ref: referrer,
@@ -77,15 +75,6 @@ export const spec = {
         }
       }
 
-      if (bidRequest.userId.netId) {
-        payload.did_netid = bidRequest.userId.netId;
-      }
-      if (bidRequest.userId.uid2) {
-        payload.did_uid2 = bidRequest.userId.uid2;
-      }
-
-
-
       if (params.bcat !== undefined) {
         payload.bcat = params.bcat;
       }
@@ -95,6 +84,14 @@ export const spec = {
       if (isDev) {
         payload.prebidDevMode = 1;
       }
+
+      if (bidRequest.userId && bidRequest.userId.netId) {
+        payload.did_netid = bidRequest.userId.netId;
+      }
+      if (bidRequest.userId && bidRequest.userId.uid2) {
+        payload.did_uid2 = bidRequest.userId.uid2;
+      }
+
       return {
         method: 'GET',
         url: endpoint,
@@ -188,6 +185,16 @@ function objectToQueryString(obj, prefix) {
 }
 
 /**
+ * Check if it's a banner bid request
+ *
+ * @param {BidRequest} bid - Bid request generated from ad slots
+ * @returns {boolean} True if it's a banner bid
+ */
+function isBannerRequest(bid) {
+  return bid.mediaType === 'banner' || !!utils.deepAccess(bid, 'mediaTypes.banner') || !isVideoRequest(bid);
+}
+
+/**
  * Check if it's a video bid request
  *
  * @param {BidRequest} bid - Bid request generated from ad slots
@@ -198,13 +205,47 @@ function isVideoRequest(bid) {
 }
 
 /**
- * Check if it's a banner bid request
+ * Get video sizes
  *
  * @param {BidRequest} bid - Bid request generated from ad slots
- * @returns {boolean} True if it's a banner bid
+ * @returns {object} True if it's a video bid
  */
-function isBannerRequest(bid) {
-  return bid.mediaType === 'banner' || !!utils.deepAccess(bid, 'mediaTypes.banner');
+function getVideoSizes(bid) {
+  return parseSizes(utils.deepAccess(bid, 'mediaTypes.video.playerSize') || bid.sizes);
+}
+
+/**
+ * Get banner sizes
+ *
+ * @param {BidRequest} bid - Bid request generated from ad slots
+ * @returns {object} True if it's a video bid
+ */
+function getBannerSizes(bid) {
+  return parseSizes(utils.deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes);
+}
+
+/**
+ * Parse size
+ * @param sizes
+ * @returns {width: number, h: height}
+ */
+function parseSize(size) {
+  let sizeObj = {}
+  sizeObj.width = parseInt(size[0], 10);
+  sizeObj.height = parseInt(size[1], 10);
+  return sizeObj;
+}
+
+/**
+ * Parse sizes
+ * @param sizes
+ * @returns {{width: number , height: number }[]}
+ */
+function parseSizes(sizes) {
+  if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])
+    return sizes.map(size => parseSize(size));
+  }
+  return [parseSize(sizes)]; // or a single one ? (ie. [728,90])
 }
 
 registerBidder(spec);

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -228,7 +228,7 @@ describe('dspxAdapter', function () {
         'currency': 'EUR',
         'ttl': 60,
         'netRevenue': true,
-        'zone': '6682',
+        'zone': '6682'
       }
     };
 

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -212,7 +212,8 @@ describe('dspxAdapter', function () {
         'currency': 'EUR',
         'ttl': 60,
         'netRevenue': true,
-        'zone': '6682'
+        'zone': '6682',
+        'admomain': 'bdomain'
       }
     };
     let serverVideoResponse = {
@@ -227,7 +228,8 @@ describe('dspxAdapter', function () {
         'currency': 'EUR',
         'ttl': 60,
         'netRevenue': true,
-        'zone': '6682'
+        'zone': '6682',
+        'admomain': 'vdomain'
       }
     };
 
@@ -242,7 +244,8 @@ describe('dspxAdapter', function () {
       netRevenue: true,
       ttl: 300,
       type: 'sspHTML',
-      ad: '<!-- test creative -->'
+      ad: '<!-- test creative -->',
+      meta: {advertiserDomains: 'bdomain'}
     }, {
       requestId: '23beaa6af6cdde',
       cpm: 0.5,
@@ -255,7 +258,8 @@ describe('dspxAdapter', function () {
       ttl: 300,
       type: 'vast2',
       vastXml: '{"reason":7001,"status":"accepted"}',
-      mediaType: 'video'
+      mediaType: 'video',
+      meta: {advertiserDomains: 'vdomain'}
     }];
 
     it('should get the correct bid response by display ad', function () {

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -213,7 +213,7 @@ describe('dspxAdapter', function () {
         'ttl': 60,
         'netRevenue': true,
         'zone': '6682',
-        'admomain': ['bdomain']
+        'adomain': ['bdomain']
       }
     };
     let serverVideoResponse = {
@@ -229,7 +229,6 @@ describe('dspxAdapter', function () {
         'ttl': 60,
         'netRevenue': true,
         'zone': '6682',
-        'admomain': ['vdomain']
       }
     };
 
@@ -259,7 +258,7 @@ describe('dspxAdapter', function () {
       type: 'vast2',
       vastXml: '{"reason":7001,"status":"accepted"}',
       mediaType: 'video',
-      meta: {advertiserDomains: ['vdomain']}
+      meta: {advertiserDomains: []}
     }];
 
     it('should get the correct bid response by display ad', function () {
@@ -272,6 +271,8 @@ describe('dspxAdapter', function () {
       }];
       let result = spec.interpretResponse(serverResponse, bidRequest[0]);
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0].meta.advertiserDomains.length).to.equal(1);
+      expect(result[0].meta.advertiserDomains[0]).to.equal(expectedResponse[0].meta.advertiserDomains[0]);
     });
 
     it('should get the correct dspx video bid response by display ad', function () {
@@ -290,6 +291,7 @@ describe('dspxAdapter', function () {
       }];
       let result = spec.interpretResponse(serverVideoResponse, bidRequest[0]);
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[1]));
+      expect(result[0].meta.advertiserDomains.length).to.equal(0);
     });
 
     it('handles empty bid response', function () {

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -213,7 +213,7 @@ describe('dspxAdapter', function () {
         'ttl': 60,
         'netRevenue': true,
         'zone': '6682',
-        'admomain': 'bdomain'
+        'admomain': ['bdomain']
       }
     };
     let serverVideoResponse = {
@@ -229,7 +229,7 @@ describe('dspxAdapter', function () {
         'ttl': 60,
         'netRevenue': true,
         'zone': '6682',
-        'admomain': 'vdomain'
+        'admomain': ['vdomain']
       }
     };
 
@@ -245,7 +245,7 @@ describe('dspxAdapter', function () {
       ttl: 300,
       type: 'sspHTML',
       ad: '<!-- test creative -->',
-      meta: {advertiserDomains: 'bdomain'}
+      meta: {advertiserDomains: ['bdomain']}
     }, {
       requestId: '23beaa6af6cdde',
       cpm: 0.5,
@@ -259,7 +259,7 @@ describe('dspxAdapter', function () {
       type: 'vast2',
       vastXml: '{"reason":7001,"status":"accepted"}',
       mediaType: 'video',
-      meta: {advertiserDomains: 'vdomain'}
+      meta: {advertiserDomains: ['vdomain']}
     }];
 
     it('should get the correct bid response by display ad', function () {

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -61,7 +61,11 @@ describe('dspxAdapter', function () {
       ],
       'bidId': '30b31c1838de1e1',
       'bidderRequestId': '22edbae2733bf61',
-      'auctionId': '1d1a030790a475'
+      'auctionId': '1d1a030790a475',
+      'userId': {
+        'netId': '123',
+        'uid2': '456'
+      }
     },
     {
       'bidder': 'dspx',
@@ -102,9 +106,18 @@ describe('dspxAdapter', function () {
         'placement': '101',
         'devMode': true
       },
-      'sizes': [
-        [300, 250]
-      ],
+      'mediaTypes': {
+        'video': {
+          'playerSize': [640, 480],
+          'context': 'instream'
+        },
+        'banner': {
+          'sizes': [
+            [300, 250]
+          ]
+        }
+      },
+
       'bidId': '30b31c1838de1e4',
       'bidderRequestId': '22edbae2733bf67',
       'auctionId': '1d1a030790a478'
@@ -145,7 +158,7 @@ describe('dspxAdapter', function () {
       expect(request1.method).to.equal('GET');
       expect(request1.url).to.equal(ENDPOINT_URL);
       let data = request1.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bprivate_auction%5D=0&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop');
+      expect(data).to.equal('_f=html&alternative=prebid_js&inventory_item_id=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bprivate_auction%5D=0&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop&did_netid=123&did_uid2=456');
     });
 
     var request2 = spec.buildRequests([bidRequests[1]], bidderRequest)[0];


### PR DESCRIPTION
## Type of change
- [ x ] Others

## Description of change
 - Added support of  adomain in meta for Prebid v5
 - Added support alternative external userIds (UID 2.0, netID)
 - Changed priority for banner ad type instead video ad type
 - Changed code for parse of sizes

- [ x ] official adapter submission
