### PR TITLE
PBS Bid Adapter: Fix duplicate imp.id

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -501,7 +501,7 @@ const OPEN_RTB_PROTOCOL = {
       let i = 1;
       while (impIds.has(impressionId)) {
         i++;
-        impressionId = `${impressionId}-${i}`;
+        impressionId = `${adUnit.code}-${i}`;
       }
       impIds.add(impressionId);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR suggests deduplication of `imp.id` by adding suffix `-2` to the `imp.id`, if duplication is detected.  
Change `bidIdMap` so that the keys are in format `imp.id-bidder` instead of `adUnit.code-bidder`.
## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Fixes #6910 