### PR TITLE
VIS.X adapter: fix for multiformat ad units & added fields to bidResponse.meta

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -246,6 +246,10 @@ function _addBidResponse(serverBid, bidsMap, currency, bidResponses, bidsWithout
             netRevenue: true,
             ttl: TIME_TO_LIVE,
             dealId: serverBid.dealid,
+            meta: {
+              advertiserDomains: serverBid.advertiserDomains ? serverBid.advertiserDomains : [],
+              mediaType: serverBid.mediaType
+            },
           };
 
           if (serverBid.ext && serverBid.ext.prebid) {

--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -24,8 +24,7 @@ const LOG_ERROR_MESS = {
   notAllowedCurrency: 'Currency is not supported - ',
   currencyMismatch: 'Currency from the request is not match currency from the response - ',
   onlyVideoInstream: `Only video ${VIDEO_INSTREAM} supported`,
-  videoMissing: 'Bid request videoType property is missing - ',
-  bannerMissing: 'Bid request bannerType property is missing - '
+  videoMissing: 'Bid request videoType property is missing - '
 };
 const currencyWhiteList = ['EUR', 'USD', 'GBP', 'PLN'];
 const RE_EMPTY_OR_ONLY_COMMAS = /^,*$/;

--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -24,7 +24,8 @@ const LOG_ERROR_MESS = {
   notAllowedCurrency: 'Currency is not supported - ',
   currencyMismatch: 'Currency from the request is not match currency from the response - ',
   onlyVideoInstream: `Only video ${VIDEO_INSTREAM} supported`,
-  videoMissing: 'Bid request videoType property is missing - '
+  videoMissing: 'Bid request videoType property is missing - ',
+  bannerMissing: 'Bid request bannerType property is missing - '
 };
 const currencyWhiteList = ['EUR', 'USD', 'GBP', 'PLN'];
 const RE_EMPTY_OR_ONLY_COMMAS = /^,*$/;
@@ -33,8 +34,11 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {
     if (_isVideoBid(bid)) {
-      if (!_isValidVideoBid(bid)) {
-        return false;
+      if (!_isValidVideoBid(bid, true)) {
+        // in case if video bid configuration invalid will try to send bid request for banner
+        if (!_isBannerBid(bid)) {
+          return false;
+        }
       }
     }
     return !!bid.params.uid;
@@ -289,23 +293,35 @@ function _isVideoBid(bid) {
   return bid.mediaType === VIDEO || deepAccess(bid, 'mediaTypes.video');
 }
 
-function _isValidVideoBid(bid) {
+function _isBannerBid(bid) {
+  return bid.mediaType === BANNER || deepAccess(bid, 'mediaTypes.banner');
+}
+
+function _isValidVideoBid(bid, logErrors = false) {
   let result = true;
   const videoMediaType = deepAccess(bid, 'mediaTypes.video');
   if (videoMediaType.context !== VIDEO_INSTREAM) {
-    logError(LOG_ERROR_MESS.onlyVideoInstream)
+    if (logErrors) {
+      logError(LOG_ERROR_MESS.onlyVideoInstream);
+    }
     result = false;
   }
   if (!(videoMediaType.playerSize && parseSizesInput(deepAccess(videoMediaType, 'playerSize', [])))) {
-    logError(LOG_ERROR_MESS.videoMissing + 'playerSize');
+    if (logErrors) {
+      logError(LOG_ERROR_MESS.videoMissing + 'playerSize');
+    }
     result = false;
   }
   if (!videoMediaType.mimes) {
-    logError(LOG_ERROR_MESS.videoMissing + 'mimes');
+    if (logErrors) {
+      logError(LOG_ERROR_MESS.videoMissing + 'mimes');
+    }
     result = false;
   }
   if (!videoMediaType.protocols) {
-    logError(LOG_ERROR_MESS.videoMissing + 'protocols');
+    if (logErrors) {
+      logError(LOG_ERROR_MESS.videoMissing + 'protocols');
+    }
     result = false;
   }
   return result;
@@ -323,13 +339,29 @@ function _initVideoTypes(bids) {
   if (bids && bids.length) {
     bids.forEach(function (bid) {
       const mediaTypes = deepAccess(bid, 'mediaTypes.video', {});
-      _playerSize.push(parseSizesInput(deepAccess(mediaTypes, 'playerSize', [])).join('|'));
-      _protocols.push(deepAccess(mediaTypes, 'protocols', []).join('|'));
-      _api.push(deepAccess(mediaTypes, 'api', []).join('|'));
-      _mimes.push(deepAccess(mediaTypes, 'mimes', []).join('|'));
-      _minduration.push(deepAccess(mediaTypes, 'minduration', null));
-      _maxduration.push(deepAccess(mediaTypes, 'maxduration', null));
-      _skip.push(deepAccess(mediaTypes, 'skip', null));
+      let bidPlayerSize = '';
+      let bidProtocols = '';
+      let bidApi = '';
+      let bidMimes = '';
+      let bidMinduration = null;
+      let bidMaxduration = null;
+      let bidSkip = null;
+      if (_isVideoBid(bid) && _isValidVideoBid(bid)) {
+        bidPlayerSize = parseSizesInput(deepAccess(mediaTypes, 'playerSize', [])).join('|');
+        bidProtocols = deepAccess(mediaTypes, 'protocols', []).join('|');
+        bidApi = deepAccess(mediaTypes, 'api', []).join('|');
+        bidMimes = deepAccess(mediaTypes, 'mimes', []).join('|');
+        bidMinduration = deepAccess(mediaTypes, 'minduration', null);
+        bidMaxduration = deepAccess(mediaTypes, 'maxduration', null);
+        bidSkip = deepAccess(mediaTypes, 'skip', null);
+      }
+      _playerSize.push(bidPlayerSize);
+      _protocols.push(bidProtocols);
+      _api.push(bidApi);
+      _mimes.push(bidMimes);
+      _minduration.push(bidMinduration);
+      _maxduration.push(bidMaxduration);
+      _skip.push(bidSkip);
     });
   }
   _playerSize = _playerSize.join(',');

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -302,6 +302,45 @@ describe('VisxAdapter', function () {
     });
   });
 
+  describe('buildRequests (multiple media types w/ unsupported video+outstream)', function () {
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'https://example.com'
+      }
+    };
+    const referrer = bidderRequest.refererInfo.referer;
+    const bidRequests = [
+      {
+        'bidder': 'visx',
+        'params': {
+          'uid': '903538'
+        },
+        'adUnitCode': 'misconfigured-video',
+        'sizes': [[300, 250], [300, 600]],
+        'mediaTypes': {
+          'video': {
+            'context': 'outstream',
+            'playerSize': [400, 300]
+          }
+        },
+        'bidId': '39aff3a7169a6a',
+        'bidderRequestId': '22edffe2733bf6',
+        'auctionId': '1d1a030790a476',
+      }
+    ];
+
+    it('should send requst for banner bid', function () {
+      const request = spec.buildRequests([bidRequests[0]], bidderRequest);
+      const payload = request.data;
+      expect(payload).to.be.an('object');
+      expect(payload).to.have.property('u', referrer);
+      expect(payload).to.have.property('pt', 'net');
+      expect(payload).to.have.property('auids', '903538');
+      expect(payload).to.have.property('sizes', '300x250,300x600');
+      expect(payload).to.not.have.property('playerSize');
+    });
+  });
+
   describe('interpretResponse', function () {
     const responses = [
       {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -343,9 +343,9 @@ describe('VisxAdapter', function () {
 
   describe('interpretResponse', function () {
     const responses = [
-      {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-      {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-      {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728, 'cur': 'EUR'}], 'seat': '1'},
+      {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner', 'advertiserDomains': ['some_domain.com']}], 'seat': '1'},
+      {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
+      {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
       {'bid': [{'price': 0, 'auid': 903537, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
       {'bid': [{'price': 0, 'adm': '<div>test content 5</div>', 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
       undefined,
@@ -380,6 +380,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': ['some_domain.com'],
+            'mediaType': 'banner',
+          },
         }
       ];
 
@@ -436,6 +440,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': ['some_domain.com'],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '4dff80cc4ee346',
@@ -448,6 +456,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '5703af74d0472a',
@@ -460,6 +472,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         }
       ];
 
@@ -495,6 +511,10 @@ describe('VisxAdapter', function () {
           'currency': 'PLN',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': ['some_domain.com'],
+            'mediaType': 'banner',
+          },
         }
       ];
 
@@ -548,11 +568,11 @@ describe('VisxAdapter', function () {
 
     it('complicated case', function () {
       const fullResponse = [
-        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-        {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728, 'cur': 'EUR'}], 'seat': '1'},
-        {'bid': [{'price': 0.15, 'adm': '<div>test content 4</div>', 'auid': 903535, 'h': 600, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-        {'bid': [{'price': 0.5, 'adm': '<div>test content 5</div>', 'auid': 903536, 'h': 600, 'w': 350, 'cur': 'EUR'}], 'seat': '1'},
+        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner', 'advertiserDomains': ['some_domain.com']}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903536, 'h': 600, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
+        {'bid': [{'price': 0.15, 'adm': '<div>test content 3</div>', 'auid': 903535, 'h': 90, 'w': 728, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
+        {'bid': [{'price': 0.15, 'adm': '<div>test content 4</div>', 'auid': 903535, 'h': 600, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 5</div>', 'auid': 903536, 'h': 600, 'w': 350, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
       ];
       const bidRequests = [
         {
@@ -624,6 +644,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': ['some_domain.com'],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '4e111f1b66e4',
@@ -636,6 +660,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '26d6f897b516',
@@ -648,6 +676,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '326bde7fbf69',
@@ -660,6 +692,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '1751cd90161',
@@ -672,6 +708,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         }
       ];
 
@@ -681,8 +721,8 @@ describe('VisxAdapter', function () {
 
     it('dublicate uids and sizes in one slot', function () {
       const fullResponse = [
-        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
-        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR'}], 'seat': '1'},
+        {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 903535, 'h': 250, 'w': 300, 'cur': 'EUR', 'mediaType': 'banner'}], 'seat': '1'},
       ];
       const bidRequests = [
         {
@@ -732,6 +772,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         },
         {
           'requestId': '57b2ebe70e16',
@@ -744,6 +788,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'banner',
+          },
         }
       ];
 
@@ -753,7 +801,7 @@ describe('VisxAdapter', function () {
 
     it('handles video bid', function () {
       const fullResponse = [
-        {'bid': [{'price': 0.5, 'adm': '<VAST/>', 'auid': 903537, 'w': 400, 'h': 300, 'cur': 'EUR'}], 'seat': '1'},
+        {'bid': [{'price': 0.5, 'adm': '<VAST/>', 'auid': 903537, 'w': 400, 'h': 300, 'cur': 'EUR', 'mediaType': 'video'}], 'seat': '1'},
       ];
       const bidRequests = [
         {
@@ -790,6 +838,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': [],
+            'mediaType': 'video',
+          },
         }
       ];
       const result = spec.interpretResponse({'body': {'seatbid': fullResponse}}, request);
@@ -825,6 +877,10 @@ describe('VisxAdapter', function () {
           'currency': 'EUR',
           'netRevenue': true,
           'ttl': 360,
+          'meta': {
+            'advertiserDomains': ['some_domain.com'],
+            'mediaType': 'banner',
+          },
           'ext': {
             'events': {
               'pending': pendingUrl,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
There are some cases with publishers when our bidder was used in multi format ad units set up as _banner+outstream video_ and our adapter skipped such ad units due to lack of outstream video support. Now we'll send banner bid request in case if it's supported by the ad unit.

Passing `advertiserDomains` and `mediaType` to the bid response.
