### PR TITLE
Just Premium Bid Adapter: add meta.advertiserDomains to bid response

### DIFF
--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -90,7 +90,10 @@ export const spec = {
           netRevenue: true,
           currency: bid.currency || 'USD',
           ttl: bid.ttl || spec.time,
-          format: bid.format
+          format: bid.format,
+          meta: {
+            advertiserDomains: bid.adomain && bid.adomain.length > 0 ? bid.adomain : []
+          }
         }
         bidResponses.push(bidResponse)
       }

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -103,7 +103,8 @@ describe('justpremium adapter', function () {
             'width': 970,
             'price': 0.52,
             'format': 'lb',
-            'adm': 'creative code'
+            'adm': 'creative code',
+            'adomain': ['justpremium.com']
           }]
         },
         'pass': {
@@ -123,7 +124,10 @@ describe('justpremium adapter', function () {
           netRevenue: true,
           currency: 'USD',
           ttl: 60000,
-          format: 'lb'
+          format: 'lb',
+          meta: {
+            advertiserDomains: ['justpremium.com']
+          },
         }
       ]
 
@@ -140,6 +144,7 @@ describe('justpremium adapter', function () {
       expect(result[0].creativeId).to.equal(3213123)
       expect(result[0].netRevenue).to.equal(true)
       expect(result[0].format).to.equal('lb')
+      expect(result[0].meta.advertiserDomains[0]).to.equal('justpremium.com')
     })
 
     it('Verify wrong server response', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add meta.advertiserDomains as requested in #6650.