### PR TITLE
Smart Ad Server: add advertiser domain support and read more mediaTypes.video params

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -161,6 +161,11 @@ export const spec = {
           bidResponse.ad = response.ad;
         }
 
+        // WE DON'T FULLY SUPPORT THIS ATM - future spot for adomain code; creating a stub for 5.0 compliance
+        if (response.adomain) {
+          bidResponse.meta = Object.assign({}, bidResponse.meta, { advertiserDomains: [] });
+        }
+
         bidResponses.push(bidResponse);
       }
     } catch (error) {

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -88,27 +88,24 @@ export const spec = {
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
 
-        //We use the mediaType.Video.params when availabe however we override with bidder.param if available.
+        // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocol)
         var startDelay = -1;
-        if (!bid.params.video.startDelay){
-          switch (videoMediaType.startdelay)
-          {
-            case 0:
-              startDelay = 1;
-            break;
-            case -1:
-              startDelay = 2;
-            break;
-            case -2:
-              startDelay = 3;
-            break;
-            default:
-              startDelay = -1;
-          }
+
+        if (bid.params.video.startDelay){
+          startDelay = bid.params.video.startDelay
         }
-        else{
-          startDelay = bid.params.video.startDelay;
+        else if (videoMediaType.startdelay == 0)
+        {
+          startDelay = 1;
+        }
+        else if (videoMediaType.startdelay == -1)
+        {
+          startDelay = 2;
+        }
+        else if (videoMediaType.startdelay == -2)
+        {
+          startDelay = 3;
         }
 
         // Specific attributes for instream.
@@ -187,9 +184,6 @@ export const spec = {
           bidResponse.adUrl = response.adUrl;
           bidResponse.ad = response.ad;
         }
-
-        // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
-
 
         bidResponses.push(bidResponse);
       }

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -86,7 +86,8 @@ export const spec = {
           h: size[1]
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
-        var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocol)
+        // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
+        var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocols)
         var startDelay = 2;
 
         if (bid.params.video.startDelay) {
@@ -162,7 +163,6 @@ export const spec = {
           netRevenue: response.isNetCpm,
           ttl: response.ttl,
           dspPixels: response.dspPixels,
-          // WE DON'T FULLY SUPPORT THIS ATM - will always return empty array until implemented on our side.
           meta: { advertiserDomains: response.adomain ? response.adomain : [] }
         };
 

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -89,10 +89,10 @@ export const spec = {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         // Assign a default protocol, the highest value possible means we are retrocompatible with all older values.
         var protocol = null;
-        if (bid.params.video.protocol){
+        if (bid.params.video.protocol) {
           protocol = bid.params.video.protocol;
         } else if (videoMediaType.protocols) {
-          Math.max(videoMediaType.protocols);
+          protocol = Math.max(videoMediaType.protocols);
         }
 
         // Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -86,9 +86,8 @@ export const spec = {
           h: size[1]
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
-        // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocol)
-        var startDelay = -1;
+        var startDelay = 2;
 
         if (bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -87,17 +87,17 @@ export const spec = {
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
-        // Assign a default protocol, the higher value means we are retrocompatible. Increase this to latest version when necessary.
-        var protocol = 4.0;
+        // Assign a default protocol, the highest value possible means we are retrocompatible with all older values.
+        var protocol = 8;
         if (bid.params.video.protocol){
           protocol = bid.params.video.protocol;
         }
-        //Checks if not : null, undefined, Nan, emptyString, 0 or false
         else if (videoMediaType.protocols)
         {
           protocol = Math.max(videoMediaType.protocols);
         }
 
+        //Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.
         var startDelay = 2;
         if (bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -12,7 +12,6 @@ import {
 import {
   createEidsArray
 } from './userId/eids.js';
-import { defaultConfig } from 'sinon';
 const BIDDER_CODE = 'smartadserver';
 const GVL_ID = 45;
 export const spec = {
@@ -87,24 +86,17 @@ export const spec = {
           h: size[1]
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
-
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocol)
         var startDelay = -1;
 
-        if (bid.params.video.startDelay){
+        if (bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay
-        }
-        else if (videoMediaType.startdelay == 0)
-        {
+        } else if (videoMediaType.startdelay == 0) {
           startDelay = 1;
-        }
-        else if (videoMediaType.startdelay == -1)
-        {
+        } else if (videoMediaType.startdelay == -1) {
           startDelay = 2;
-        }
-        else if (videoMediaType.startdelay == -2)
-        {
+        } else if (videoMediaType.startdelay == -2) {
           startDelay = 3;
         }
 

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -87,9 +87,18 @@ export const spec = {
         }));
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
-        var protocol = bid.params.video.protocol ? bid.params.video.protocol : Math.max(videoMediaType.protocols)
-        var startDelay = 2;
+        // Assign a default protocol, the higher value means we are retrocompatible. Increase this to latest version when necessary.
+        var protocol = 4.0;
+        if (bid.params.video.protocol){
+          protocol = bid.params.video.protocol;
+        }
+        //Checks if not : null, undefined, Nan, emptyString, 0 or false
+        else if (videoMediaType.protocols)
+        {
+          protocol = Math.max(videoMediaType.protocols);
+        }
 
+        var startDelay = 2;
         if (bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay
         } else if (videoMediaType.startdelay == 0) {

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -89,15 +89,15 @@ export const spec = {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         // Assign a default protocol, the highest value possible means we are retrocompatible with all older values.
         var protocol = null;
-        if (bid.params.video.protocol) {
+        if (bid.params.video && bid.params.video.protocol) {
           protocol = bid.params.video.protocol;
-        } else if (videoMediaType.protocols) {
-          protocol = Math.max(videoMediaType.protocols);
+        } else if (Array.isArray(videoMediaType.protocols)) {
+          protocol = Math.max.apply(Math, videoMediaType.protocols);
         }
 
         // Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.
         var startDelay = 2;
-        if (bid.params.video.startDelay) {
+        if (bid.params.video && bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay
         } else if (videoMediaType.startdelay == 0) {
           startDelay = 1;

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -88,7 +88,12 @@ export const spec = {
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         // Assign a default protocol, the highest value possible means we are retrocompatible with all older values.
-        var protocol = bid.params.video.protocol ? bid.params.video.protocol : videoMediaType.protocols ? Math.max(videoMediaType.protocols) : null;
+        var protocol = null;
+        if (bid.params.video.protocol){
+          protocol = bid.params.video.protocol;
+        } else if (videoMediaType.protocols) {
+          Math.max(videoMediaType.protocols);
+        }
 
         // Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.
         var startDelay = 2;

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -88,16 +88,9 @@ export const spec = {
       } else if (videoMediaType && (videoMediaType.context === 'instream' || videoMediaType.context === 'outstream')) {
         // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
         // Assign a default protocol, the highest value possible means we are retrocompatible with all older values.
-        var protocol = 8;
-        if (bid.params.video.protocol){
-          protocol = bid.params.video.protocol;
-        }
-        else if (videoMediaType.protocols)
-        {
-          protocol = Math.max(videoMediaType.protocols);
-        }
+        var protocol = bid.params.video.protocol ? bid.params.video.protocol : videoMediaType.protocols ? Math.max(videoMediaType.protocols) : null;
 
-        //Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.
+        // Default value for all exotic cases set to bid.params.video.startDelay midroll hence 2.
         var startDelay = 2;
         if (bid.params.video.startDelay) {
           startDelay = bid.params.video.startDelay

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -540,126 +540,128 @@ describe('Smart bid adapter tests', function () {
       expect(request[1]).to.not.be.empty;
     });
 
-    it('Verify videoData assigns values from meta', function () {
-      config.setConfig({
-        'currency': {
-          'adServerCurrency': 'EUR'
-        }
+    describe('Instream videoData meta & params tests', function () {
+      it('Verify videoData assigns values from meta', function () {
+        config.setConfig({
+          'currency': {
+            'adServerCurrency': 'EUR'
+          }
+        });
+        const request = spec.buildRequests([{
+          adUnitCode: 'sas_42',
+          bidId: 'abcd1234',
+          bidder: 'smartadserver',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+              protocols: [8, 2],
+              startdelay: 0
+            }
+          },
+          params: {
+            siteId: '1234',
+            pageId: '5678',
+            formatId: '90',
+            target: 'test=prebid',
+            bidfloor: 0.420,
+            buId: '7569',
+            appName: 'Mozilla',
+            ckId: 42,
+          },
+          requestId: 'efgh5678',
+          transactionId: 'zsfgzzg'
+        }]);
+
+        expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+        expect(request[0]).to.have.property('method').and.to.equal('POST');
+        const requestContent = JSON.parse(request[0].data);
+        expect(requestContent).to.have.property('videoData');
+        expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(8);
+        expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(1);
       });
-      const request = spec.buildRequests([{
-        adUnitCode: 'sas_42',
-        bidId: 'abcd1234',
-        bidder: 'smartadserver',
-        mediaTypes: {
-          video: {
-            context: 'instream',
-            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
-            protocols: [8, 2],
-            startdelay: 0
+
+      it('Verify videoData default values assigned', function () {
+        config.setConfig({
+          'currency': {
+            'adServerCurrency': 'EUR'
           }
-        },
-        params: {
-          siteId: '1234',
-          pageId: '5678',
-          formatId: '90',
-          target: 'test=prebid',
-          bidfloor: 0.420,
-          buId: '7569',
-          appName: 'Mozilla',
-          ckId: 42,
-        },
-        requestId: 'efgh5678',
-        transactionId: 'zsfgzzg'
-      }]);
+        });
+        const request = spec.buildRequests([{
+          adUnitCode: 'sas_42',
+          bidId: 'abcd1234',
+          bidder: 'smartadserver',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              playerSize: [[640, 480]] // It seems prebid.js transforms the player size array into an array of array...
+            }
+          },
+          params: {
+            siteId: '1234',
+            pageId: '5678',
+            formatId: '90',
+            target: 'test=prebid',
+            bidfloor: 0.420,
+            buId: '7569',
+            appName: 'Mozilla',
+            ckId: 42,
+          },
+          requestId: 'efgh5678',
+          transactionId: 'zsfgzzg'
+        }]);
 
-      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
-      expect(request[0]).to.have.property('method').and.to.equal('POST');
-      const requestContent = JSON.parse(request[0].data);
-      expect(requestContent).to.have.property('videoData');
-      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(8);
-      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(1);
-    });
-
-    it('Verify videoData default values assigned', function () {
-      config.setConfig({
-        'currency': {
-          'adServerCurrency': 'EUR'
-        }
+        expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+        expect(request[0]).to.have.property('method').and.to.equal('POST');
+        const requestContent = JSON.parse(request[0].data);
+        expect(requestContent).to.have.property('videoData');
+        expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
+        expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
       });
-      const request = spec.buildRequests([{
-        adUnitCode: 'sas_42',
-        bidId: 'abcd1234',
-        bidder: 'smartadserver',
-        mediaTypes: {
-          video: {
-            context: 'instream',
-            playerSize: [[640, 480]] // It seems prebid.js transforms the player size array into an array of array...
+
+      it('Verify videoData params override meta values', function () {
+        config.setConfig({
+          'currency': {
+            'adServerCurrency': 'EUR'
           }
-        },
-        params: {
-          siteId: '1234',
-          pageId: '5678',
-          formatId: '90',
-          target: 'test=prebid',
-          bidfloor: 0.420,
-          buId: '7569',
-          appName: 'Mozilla',
-          ckId: 42,
-        },
-        requestId: 'efgh5678',
-        transactionId: 'zsfgzzg'
-      }]);
+        });
+        const request = spec.buildRequests([{
+          adUnitCode: 'sas_42',
+          bidId: 'abcd1234',
+          bidder: 'smartadserver',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+              protocols: [8, 2],
+              startdelay: 0
+            }
+          },
+          params: {
+            siteId: '1234',
+            pageId: '5678',
+            formatId: '90',
+            target: 'test=prebid',
+            bidfloor: 0.420,
+            buId: '7569',
+            appName: 'Mozilla',
+            ckId: 42,
+            video: {
+              protocol: 6,
+              startDelay: 3
+            }
+          },
+          requestId: 'efgh5678',
+          transactionId: 'zsfgzzg'
+        }]);
 
-      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
-      expect(request[0]).to.have.property('method').and.to.equal('POST');
-      const requestContent = JSON.parse(request[0].data);
-      expect(requestContent).to.have.property('videoData');
-      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
-      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
-    });
-
-    it('Verify videoData params override meta values', function () {
-      config.setConfig({
-        'currency': {
-          'adServerCurrency': 'EUR'
-        }
+        expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+        expect(request[0]).to.have.property('method').and.to.equal('POST');
+        const requestContent = JSON.parse(request[0].data);
+        expect(requestContent).to.have.property('videoData');
+        expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
+        expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(3);
       });
-      const request = spec.buildRequests([{
-        adUnitCode: 'sas_42',
-        bidId: 'abcd1234',
-        bidder: 'smartadserver',
-        mediaTypes: {
-          video: {
-            context: 'instream',
-            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
-            protocols: [8, 2],
-            startdelay: 0
-          }
-        },
-        params: {
-          siteId: '1234',
-          pageId: '5678',
-          formatId: '90',
-          target: 'test=prebid',
-          bidfloor: 0.420,
-          buId: '7569',
-          appName: 'Mozilla',
-          ckId: 42,
-          video: {
-            protocol: 6,
-            startDelay: 3
-          }
-        },
-        requestId: 'efgh5678',
-        transactionId: 'zsfgzzg'
-      }]);
-
-      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
-      expect(request[0]).to.have.property('method').and.to.equal('POST');
-      const requestContent = JSON.parse(request[0].data);
-      expect(requestContent).to.have.property('videoData');
-      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
-      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(3);
     });
   });
 
@@ -763,6 +765,130 @@ describe('Smart bid adapter tests', function () {
           data: 'invalid Json'
         })
       }).to.not.throw();
+    });
+  });
+
+  describe('Outstream videoData meta & params tests', function () {
+    it('Verify videoData assigns values from meta', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+            protocols: [8, 2],
+            startdelay: 0
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid-outstream',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(8);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(1);
+    });
+
+    it('Verify videoData default values assigned', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            playerSize: [[640, 480]] // It seems prebid.js transforms the player size array into an array of array...
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid-outstream',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
+    });
+
+    it('Verify videoData params override meta values', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+            protocols: [8, 2],
+            startdelay: 0
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid-outstream',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+          video: {
+            protocol: 6,
+            startDelay: 3
+          }
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(3);
     });
   });
 

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -432,7 +432,7 @@ describe('Smart bid adapter tests', function () {
         appName: 'Mozilla',
         ckId: 42,
         video: {
-          protocol: 6
+          protocol: 6,
         }
       },
       requestId: 'efgh5678',
@@ -538,6 +538,128 @@ describe('Smart bid adapter tests', function () {
       }, INSTREAM_DEFAULT_PARAMS[0]]);
       expect(request[0]).to.be.empty;
       expect(request[1]).to.not.be.empty;
+    });
+
+    it('Verify videoData assigns values from meta', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+            protocols: [8, 2],
+            startdelay: 0
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(8);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(1);
+    });
+
+    it('Verify videoData default values assigned', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            playerSize: [[640, 480]] // It seems prebid.js transforms the player size array into an array of array...
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
+    });
+
+    it('Verify videoData params override meta values', function () {
+      config.setConfig({
+        'currency': {
+          'adServerCurrency': 'EUR'
+        }
+      });
+      const request = spec.buildRequests([{
+        adUnitCode: 'sas_42',
+        bidId: 'abcd1234',
+        bidder: 'smartadserver',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            playerSize: [[640, 480]], // It seems prebid.js transforms the player size array into an array of array...
+            protocols: [8, 2],
+            startdelay: 0
+          }
+        },
+        params: {
+          siteId: '1234',
+          pageId: '5678',
+          formatId: '90',
+          target: 'test=prebid',
+          bidfloor: 0.420,
+          buId: '7569',
+          appName: 'Mozilla',
+          ckId: 42,
+          video: {
+            protocol: 6,
+            startDelay: 3
+          }
+        },
+        requestId: 'efgh5678',
+        transactionId: 'zsfgzzg'
+      }]);
+
+      expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
+      expect(request[0]).to.have.property('method').and.to.equal('POST');
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.have.property('videoData');
+      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
+      expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(3);
     });
   });
 

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -432,7 +432,7 @@ describe('Smart bid adapter tests', function () {
         appName: 'Mozilla',
         ckId: 42,
         video: {
-          protocol: 6,
+          protocol: 6
         }
       },
       requestId: 'efgh5678',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Two features are added here:

Firstly https://github.com/prebid/Prebid.js/issues/6512
This change updates the smartadserver bidder to read more from the mediaTypes.video params.

Secondly https://github.com/prebid/Prebid.js/issues/6650
Added meta.advertiserDomains according to the above issue and to be compatible with the next newer version.