### PR TITLE
Seedtag : add requestCount to bid request

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -75,9 +75,19 @@ function buildBidRequest(validBidRequest) {
     }
   );
 
-    if (hasVideoMediaType(validBidRequest)) {
-      bidRequest.videoParams = getVideoParams(validBidRequest)
-    }
+  const bidRequest = {
+    id: validBidRequest.bidId,
+    transactionId: validBidRequest.transactionId,
+    sizes: validBidRequest.sizes,
+    supplyTypes: mediaTypes,
+    adUnitId: params.adUnitId,
+    placement: params.placement,
+    requestCount: validBidRequest.bidderRequestsCount
+  };
+
+  if (hasVideoMediaType(validBidRequest)) {
+    bidRequest.videoParams = getVideoParams(validBidRequest)
+  }
 
   return bidRequest;
 }
@@ -145,7 +155,6 @@ export const spec = {
   code: BIDDER_CODE,
   aliases: [SEEDTAG_ALIAS],
   supportedMediaTypes: [BANNER, VIDEO],
-  requestCount: {},
   /**
    * Determines whether or not the given bid request is valid.
    *
@@ -172,17 +181,7 @@ export const spec = {
       timeout: bidderRequest.timeout,
       version: '$prebid.version$',
       connectionType: getConnectionType(),
-      bidRequests: utils._map(validBidRequests, (validBidRequest) => {
-        const bidRequest = buildBidRequest(validBidRequest)
-
-        // append the count to the bidRequest
-        const adunitId = bidRequest.adUnitId
-        const count = this.requestCount[adunitId] || 0
-        this.requestCount[adunitId] = count + 1
-        bidRequest.requestCount = this.requestCount[adunitId]
-
-        return bidRequest
-      })
+      bidRequests: utils._map(validBidRequests, buildBidRequest)
     };
 
     if (payload.cmp) {

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -82,8 +82,12 @@ function buildBidRequest(validBidRequest) {
     supplyTypes: mediaTypes,
     adUnitId: params.adUnitId,
     placement: params.placement,
-    requestCount: validBidRequest.bidderRequestsCount
+    requestCount: validBidRequest.bidderRequestsCount || 1 // FIXME : in unit test the parameter bidderRequestsCount is undefined
   };
+
+  if (params.adPosition) {
+    bidRequest.adPosition = params.adPosition;
+  }
 
   if (hasVideoMediaType(validBidRequest)) {
     bidRequest.videoParams = getVideoParams(validBidRequest)

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -291,6 +291,7 @@ describe('Seedtag Adapter', function() {
         expect(bannerBid.sizes[0][1]).to.equal(250)
         expect(bannerBid.sizes[1][0]).to.equal(300)
         expect(bannerBid.sizes[1][1]).to.equal(600)
+        expect(bannerBid.requestCount).to.equal(1)
       })
       it('should request an InStream Video', function() {
         const videoBid = bidRequests[1]
@@ -307,6 +308,7 @@ describe('Seedtag Adapter', function() {
         expect(videoBid.sizes[0][1]).to.equal(250)
         expect(videoBid.sizes[1][0]).to.equal(300)
         expect(videoBid.sizes[1][1]).to.equal(600)
+        expect(videoBid.requestCount).to.equal(1)
       })
     })
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
add a new parameter to the bidder request payload : requestCount

Uses `bidderRequestCount` to pass the number of request to our SSP
