### PR TITLE
Adkernel Bid Adapter: User ID module support

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -404,6 +404,10 @@ function buildRtbRequest(imps, bidderRequest, schain) {
   if (schain) {
     utils.deepSetValue(req, 'source.ext.schain', schain);
   }
+  let eids = getExtendedUserIds(bidderRequest);
+  if (eids) {
+    utils.deepSetValue(req, 'user.ext.eids', eids);
+  }
   return req;
 }
 
@@ -433,6 +437,13 @@ function createSite(refInfo) {
     site.keywords = keywords.content;
   }
   return site;
+}
+
+function getExtendedUserIds(bidderRequest) {
+  let eids = utils.deepAccess(bidderRequest, 'bids.0.userIdAsEids');
+  if (utils.isArray(eids)) {
+    return eids;
+  }
 }
 
 /**

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -28,7 +28,15 @@ describe('Adkernel adapter', function () {
         banner: {
           sizes: [[728, 90]]
         }
-      }
+      },
+      userIdAsEids: [
+        {
+          source: 'crwdcntrl.net',
+          uids: [
+            {atype: 1, id: '97d09fbba28542b7acbb6317c9534945a702b74c5993c352f332cfe83f40cdd9'}
+          ]
+        }
+      ]
     }, bid3_host2 = {
       bidder: 'adkernel',
       params: {zoneId: 1, host: 'rtb-private.adkernel.com'},
@@ -251,6 +259,7 @@ describe('Adkernel adapter', function () {
 
   function buildRequest(bidRequests, bidderRequest = DEFAULT_BIDDER_REQUEST, dnt = true) {
     let dntmock = sandbox.stub(utils, 'getDNT').callsFake(() => dnt);
+    bidderRequest.bids = bidRequests;
     let pbRequests = spec.buildRequests(bidRequests, bidderRequest);
     dntmock.restore();
     let rtbRequests = pbRequests.map(r => JSON.parse(r.data));
@@ -380,6 +389,17 @@ describe('Adkernel adapter', function () {
       };
       let [_, bidRequests] = buildRequest([bid]);
       expect(bidRequests[0].imp[0]).to.have.property('bidfloor', 0.145);
+    });
+
+    it('should forward user ids if available', function() {
+      let bid = Object.assign({}, bid2_zone2);
+      let [_, bidRequests] = buildRequest([bid]);
+      expect(bidRequests[0]).to.have.property('user');
+      expect(bidRequests[0].user).to.have.property('ext');
+      expect(bidRequests[0].user.ext).to.have.property('eids');
+      expect(bidRequests[0].user.ext.eids).to.be.an('array').that.is.not.empty;
+      expect(bidRequests[0].user.ext.eids[0]).to.have.property('source');
+      expect(bidRequests[0].user.ext.eids[0]).to.have.property('uids');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Added support of user id module

- prebid-dev@adkernel.com
- [x] official adapter submission