### PR TITLE
RadsBidAdapter: Add adomains/userIds support and change banner ad type priority

### DIFF
--- a/modules/radsBidAdapter.js
+++ b/modules/radsBidAdapter.js
@@ -7,9 +7,11 @@ const BIDDER_CODE = 'rads';
 const ENDPOINT_URL = 'https://rads.recognified.net/md.request.php';
 const ENDPOINT_URL_DEV = 'https://dcradn1.online-solution.biz/md.request.php';
 const DEFAULT_VAST_FORMAT = 'vast2';
+const GVLID = 602;
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   aliases: ['rads'],
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {

--- a/modules/radsBidAdapter.js
+++ b/modules/radsBidAdapter.js
@@ -57,7 +57,7 @@ export const spec = {
           bid_id: bidId,
         };
       }
-      prepareExtraParams(params, payload, bidderRequest);
+      prepareExtraParams(params, payload, bidderRequest, bidRequest);
 
       return {
         method: 'GET',
@@ -84,7 +84,10 @@ export const spec = {
         dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: config.getConfig('_bidderTimeout')
+        ttl: config.getConfig('_bidderTimeout'),
+        meta: {
+          advertiserDomains: response.adomain || []
+        }
       };
 
       if (response.vastXml) {
@@ -162,7 +165,15 @@ function isVideoRequest(bid) {
   return bid.mediaType === 'video' || !!utils.deepAccess(bid, 'mediaTypes.video');
 }
 
-function prepareExtraParams(params, payload, bidderRequest) {
+/**
+ * Add extra params to server request
+ *
+ * @param params
+ * @param payload
+ * @param bidderRequest
+ * @param {BidRequest} bidRequest - Bid request generated from ad slots
+ */
+function prepareExtraParams(params, payload, bidderRequest, bidRequest) {
   if (params.pfilter !== undefined) {
     payload.pfilter = params.pfilter;
   }
@@ -195,6 +206,13 @@ function prepareExtraParams(params, payload, bidderRequest) {
   }
   if (params.ip !== undefined) {
     payload.i = params.ip;
+  }
+
+  if (bidRequest.userId && bidRequest.userId.netId) {
+    payload.did_netid = bidRequest.userId.netId;
+  }
+  if (bidRequest.userId && bidRequest.userId.uid2) {
+    payload.did_uid2 = bidRequest.userId.uid2;
   }
 }
 

--- a/modules/radsBidAdapter.md
+++ b/modules/radsBidAdapter.md
@@ -25,6 +25,7 @@ RADS Bidder Adapter for Prebid.js 1.x
                     bidder: "rads",
                     params: {
                         placement: 3,   // placement ID
+                        vastFormat: "vast2", // vast2(default) or vast4 
                         devMode: true   // if true: library uses dev server for tests
                     }
                 }

--- a/test/spec/modules/radsBidAdapter_spec.js
+++ b/test/spec/modules/radsBidAdapter_spec.js
@@ -61,7 +61,11 @@ describe('radsAdapter', function () {
       ],
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
-      'auctionId': '1d1a030790a475'
+      'auctionId': '1d1a030790a475',
+      'userId': {
+        'netId': '123',
+        'uid2': '456'
+      }
     }, {
       'bidder': 'rads',
       'params': {
@@ -110,7 +114,7 @@ describe('radsAdapter', function () {
     it('sends bid request to our endpoint via GET', function () {
       expect(request[0].method).to.equal('GET');
       let data = request[0].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1');
+      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
     });
 
     it('sends bid video request to our rads endpoint via GET', function () {
@@ -124,7 +128,7 @@ describe('radsAdapter', function () {
     it('sends bid request to our endpoint via GET', function () {
       expect(request2[0].method).to.equal('GET');
       let data = request2[0].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1');
+      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
     });
 
     it('sends bid video request to our rads endpoint via GET', function () {
@@ -146,7 +150,8 @@ describe('radsAdapter', function () {
         'currency': 'EUR',
         'ttl': 60,
         'netRevenue': true,
-        'zone': '6682'
+        'zone': '6682',
+        'adomain': ['bdomain']
       }
     };
     let serverVideoResponse = {
@@ -174,7 +179,8 @@ describe('radsAdapter', function () {
       currency: 'EUR',
       netRevenue: true,
       ttl: 300,
-      ad: '<!-- test creative -->'
+      ad: '<!-- test creative -->',
+      meta: {advertiserDomains: ['bdomain']}
     }, {
       requestId: '23beaa6af6cdde',
       cpm: 0.5,
@@ -186,7 +192,8 @@ describe('radsAdapter', function () {
       netRevenue: true,
       ttl: 300,
       vastXml: '{"reason":7001,"status":"accepted"}',
-      mediaType: 'video'
+      mediaType: 'video',
+      meta: {advertiserDomains: []}
     }];
 
     it('should get the correct bid response by display ad', function () {
@@ -202,6 +209,8 @@ describe('radsAdapter', function () {
       }];
       let result = spec.interpretResponse(serverBannerResponse, bidRequest[0]);
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0].meta.advertiserDomains.length).to.equal(1);
+      expect(result[0].meta.advertiserDomains[0]).to.equal(expectedResponse[0].meta.advertiserDomains[0]);
     });
 
     it('should get the correct rads video bid response by display ad', function () {
@@ -220,6 +229,7 @@ describe('radsAdapter', function () {
       }];
       let result = spec.interpretResponse(serverVideoResponse, bidRequest[0]);
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[1]));
+      expect(result[0].meta.advertiserDomains.length).to.equal(0);
     });
 
     it('handles empty bid response', function () {

--- a/test/spec/modules/radsBidAdapter_spec.js
+++ b/test/spec/modules/radsBidAdapter_spec.js
@@ -59,6 +59,17 @@ describe('radsAdapter', function () {
       'sizes': [
         [300, 250]
       ],
+      'mediaTypes': {
+        'video': {
+          'playerSize': [640, 480],
+          'context': 'instream'
+        },
+        'banner': {
+          'sizes': [
+            [300, 250]
+          ]
+        }
+      },
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',

--- a/test/spec/modules/radsBidAdapter_spec.js
+++ b/test/spec/modules/radsBidAdapter_spec.js
@@ -66,7 +66,7 @@ describe('radsAdapter', function () {
         },
         'banner': {
           'sizes': [
-            [300, 250]
+            [100, 100], [400, 400], [500, 500]
           ]
         }
       },
@@ -93,7 +93,7 @@ describe('radsAdapter', function () {
       },
       'mediaTypes': {
         'video': {
-          'playerSize': [640, 480],
+          'playerSize': [[640, 480], [500, 500], [600, 600]],
           'context': 'instream'
         }
       },
@@ -125,13 +125,13 @@ describe('radsAdapter', function () {
     it('sends bid request to our endpoint via GET', function () {
       expect(request[0].method).to.equal('GET');
       let data = request[0].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
+      expect(data).to.equal('_f=prebid_js&_ps=6682&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&rt=bid-response&srw=100&srh=100&alt_ad_sizes%5B0%5D=400x400&alt_ad_sizes%5B1%5D=500x500&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
     });
 
     it('sends bid video request to our rads endpoint via GET', function () {
       expect(request[1].method).to.equal('GET');
       let data = request[1].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=vast2&_f=prebid_js&_ps=6682&srw=640&srh=480&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgeo%5D%5Bregion%5D=DE-BE&bcat=IAB2%2CIAB4&dvt=desktop');
+      expect(data).to.equal('_f=prebid_js&_ps=6682&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&rt=vast2&srw=640&srh=480&alt_ad_sizes%5B0%5D=500x500&alt_ad_sizes%5B1%5D=600x600&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgeo%5D%5Bregion%5D=DE-BE&bcat=IAB2%2CIAB4&dvt=desktop');
     });
 
     // with gdprConsent
@@ -139,13 +139,13 @@ describe('radsAdapter', function () {
     it('sends bid request to our endpoint via GET', function () {
       expect(request2[0].method).to.equal('GET');
       let data = request2[0].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=bid-response&_f=prebid_js&_ps=6682&srw=300&srh=250&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
+      expect(data).to.equal('_f=prebid_js&_ps=6682&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&rt=bid-response&srw=100&srh=100&alt_ad_sizes%5B0%5D=400x400&alt_ad_sizes%5B1%5D=500x500&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop&i=1.1.1.1&did_netid=123&did_uid2=456');
     });
 
     it('sends bid video request to our rads endpoint via GET', function () {
       expect(request2[1].method).to.equal('GET');
       let data = request2[1].data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid');
-      expect(data).to.equal('rt=vast2&_f=prebid_js&_ps=6682&srw=640&srh=480&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgeo%5D%5Bregion%5D=DE-BE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop');
+      expect(data).to.equal('_f=prebid_js&_ps=6682&idt=100&p=some_referrer.net&bid_id=30b31c1838de1e&rt=vast2&srw=640&srh=480&alt_ad_sizes%5B0%5D=500x500&alt_ad_sizes%5B1%5D=600x600&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&pfilter%5Bgeo%5D%5Bregion%5D=DE-BE&pfilter%5Bgdpr_consent%5D=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&pfilter%5Bgdpr%5D=true&bcat=IAB2%2CIAB4&dvt=desktop');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [ x ] Others

## Description of change
 - Added support of  adomain in meta for Prebid v5
 - Added support alternative external userIds (UID 2.0, netID)
 - Changed priority for banner ad type instead video ad type
 - Changed code for parse of sizes

- [ x ] official adapter submission
 
Doc Update here: https://github.com/prebid/prebid.github.io/pull/3020
