### PR TITLE
glimpseBidAdapter: Add support for advertiserDomains

### DIFF
--- a/modules/glimpseBidAdapter.js
+++ b/modules/glimpseBidAdapter.js
@@ -3,6 +3,17 @@ import { BANNER } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'glimpse';
 
+function transformEachBidResponse(glimpseBid) {
+  const bid = glimpseBid;
+  bid.meta = { advertiserDomains: [] };
+
+  if (glimpseBid.adomain) {
+    bid.meta.advertiserDomains = glimpseBid.adomain;
+  }
+
+  return bid;
+}
+
 export const spec = {
   code: BIDDER_CODE,
   url: 'https://api.glimpseprotocol.io/cloud/v1/vault/prebid',
@@ -45,10 +56,10 @@ export const spec = {
   },
 
   interpretResponse: (serverResponse, _) => {
-    const bids = [];
+    let bids = [];
     try {
       const { body } = serverResponse;
-      bids.push(...body);
+      bids = body.map(transformEachBidResponse);
     } catch (error) {}
 
     return bids;

--- a/test/spec/modules/glimpseBidAdapter_spec.js
+++ b/test/spec/modules/glimpseBidAdapter_spec.js
@@ -61,7 +61,10 @@ const templateBidResponse = {
 };
 
 const copyBidResponse = () => ({ ...templateBidResponse });
-const copyBidderRequest = () => ({ ...templateBidderRequest, bids: copyBidRequests() });
+const copyBidderRequest = () => ({
+  ...templateBidderRequest,
+  bids: copyBidRequests(),
+});
 const copyBidRequest = () => ({ ...templateBidRequest });
 
 const copyBidRequests = () => [copyBidRequest()];
@@ -139,7 +142,9 @@ describe('GlimpseProtocolAdapter', function () {
       expect(payload.gdprConsent).to.exist;
       const { gdprConsent } = payload;
       expect(gdprConsent.gdprApplies).to.be.true;
-      expect(gdprConsent.consentString).to.equal(bidderRequest.gdprConsent.consentString);
+      expect(gdprConsent.consentString).to.equal(
+        bidderRequest.gdprConsent.consentString
+      );
     });
 
     it('should add referer info', function () {
@@ -147,7 +152,9 @@ describe('GlimpseProtocolAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(payload.refererInfo.referer).to.equal(templateBidderRequest.refererInfo.referer);
+      expect(payload.refererInfo.referer).to.equal(
+        templateBidderRequest.refererInfo.referer
+      );
     });
   });
 
@@ -174,6 +181,27 @@ describe('GlimpseProtocolAdapter', function () {
 
       const bids = spec.interpretResponse(response);
       expect(bids).to.have.length(0);
+    });
+
+    it('should include advertiserDomains field in the response', function () {
+      const response = copyBidResponses();
+
+      const bids = spec.interpretResponse(response);
+      expect(bids[0].meta.advertiserDomains).to.be.an('array').that.is.empty;
+    });
+
+    it('should reflect the value of the OpenRTB adomain field', function () {
+      const advertiserDomainsMock = ['http://example.com'];
+      let response = copyBidResponses();
+      response.body = response.body.map((bid) => {
+        return {
+          ...bid,
+          adomain: advertiserDomainsMock,
+        };
+      });
+
+      const bids = spec.interpretResponse(response);
+      expect(bids[0].meta.advertiserDomains).to.equal(advertiserDomainsMock);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This update add support for advertiserDomains in relation to #6650 