### PR TITLE
Justpremium, dspx, VisX, Yieldlab bid adapters: Add missing GVL IDs

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -7,9 +7,11 @@ const BIDDER_CODE = 'dspx';
 const ENDPOINT_URL = 'https://buyer.dspx.tv/request/';
 const ENDPOINT_URL_DEV = 'https://dcbuyer.dspx.tv/request/';
 const DEFAULT_VAST_FORMAT = 'vast2';
+const GVLID = 937;
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   aliases: ['dspx'],
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -7,7 +7,7 @@ const BIDDER_CODE = 'dspx';
 const ENDPOINT_URL = 'https://buyer.dspx.tv/request/';
 const ENDPOINT_URL_DEV = 'https://dcbuyer.dspx.tv/request/';
 const DEFAULT_VAST_FORMAT = 'vast2';
-const GVLID = 937;
+const GVLID = 602;
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -2,12 +2,14 @@ import { registerBidder } from '../src/adapters/bidderFactory.js'
 import { deepAccess } from '../src/utils.js';
 
 const BIDDER_CODE = 'justpremium'
+const GVLID = 62;
 const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
 const JP_ADAPTER_VERSION = '1.7'
 const pixels = []
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   time: 60000,
 
   isBidRequestValid: (bid) => {

--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -2,7 +2,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js'
 import { deepAccess } from '../src/utils.js';
 
 const BIDDER_CODE = 'justpremium'
-const GVLID = 62;
+const GVLID = 62
 const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
 const JP_ADAPTER_VERSION = '1.7'
 const pixels = []

--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -5,6 +5,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { INSTREAM as VIDEO_INSTREAM } from '../src/video.js';
 const { parseSizesInput, getKeys, logError, deepAccess } = utils;
 const BIDDER_CODE = 'visx';
+const GVLID = 154
 const BASE_URL = 'https://t.visx.net';
 const ENDPOINT_URL = BASE_URL + '/hb';
 const TIME_TO_LIVE = 360;
@@ -30,6 +31,7 @@ const currencyWhiteList = ['EUR', 'USD', 'GBP', 'PLN'];
 const RE_EMPTY_OR_ONLY_COMMAS = /^,*$/;
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {
     if (_isVideoBid(bid)) {

--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -5,7 +5,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { INSTREAM as VIDEO_INSTREAM } from '../src/video.js';
 const { parseSizesInput, getKeys, logError, deepAccess } = utils;
 const BIDDER_CODE = 'visx';
-const GVLID = 154
+const GVLID = 154;
 const BASE_URL = 'https://t.visx.net';
 const ENDPOINT_URL = BASE_URL + '/hb';
 const TIME_TO_LIVE = 360;

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -9,9 +9,11 @@ const BIDDER_CODE = 'yieldlab'
 const BID_RESPONSE_TTL_SEC = 300
 const CURRENCY_CODE = 'EUR'
 const OUTSTREAMPLAYER_URL = 'https://ad.adition.com/dynamic.ad?a=o193092&ma_loadEvent=ma-start-event'
+const GVLID = 70
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [VIDEO, BANNER],
 
   isBidRequestValid: function (bid) {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

Add GVL IDs to some bidders that are missing it. The `gdprEnforcement` module otherwise blocks user syncs.

## Other information

- VisX: @mk0x9 
- DSPX: @onlsol 
- Yieldlab: @mirkorean 
- Just Premium: @nwlosinski 


