### PR TITLE
Rubicon Bid Adapter: Fix non IE11 Test .remove()

### DIFF
--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -3211,7 +3211,7 @@ describe('the rubicon adapter', function () {
             width: 640
           });
           // cleanup
-          adUnit.remove();
+          adUnit.parentNode.removeChild(adUnit);
         });
       });
 


### PR DESCRIPTION

## Type of change
- [X] Bugfix

## Description of change
IE does not support element.remove()

So we use parentNode.removeChild