### PR TITLE
IX Bid Adapter :  reading video `placement` property

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -3,6 +3,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import find from 'core-js-pure/features/array/find.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { INSTREAM, OUTSTREAM } from '../src/video.js';
 
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
@@ -104,6 +105,7 @@ function bidToVideoImp(bid) {
 
   imp.video = videoParamRef ? utils.deepClone(bid.params.video) : {};
 
+  // copy all video properties to imp object
   for (const adUnitProperty in videoAdUnitRef) {
     if (VIDEO_PARAMS_ALLOW_LIST.indexOf(adUnitProperty) !== -1 && !imp.video.hasOwnProperty(adUnitProperty)) {
       imp.video[adUnitProperty] = videoAdUnitRef[adUnitProperty];
@@ -112,19 +114,20 @@ function bidToVideoImp(bid) {
 
   if (imp.video.minduration > imp.video.maxduration) {
     utils.logError('IX Bid Adapter: video minduration [' + imp.video.minduration +
-    '] cannot be greater than video maxduration [' + imp.video.maxduration + ']');
+      '] cannot be greater than video maxduration [' + imp.video.maxduration + ']');
     return {};
   }
 
   const context = (videoParamRef && videoParamRef.context) || (videoAdUnitRef && videoAdUnitRef.context);
 
-  if (context) {
-    if (context === 'instream') {
+  // if placement not already defined, pick one based on `context`
+  if (context && !imp.video.hasOwnProperty('placement')) {
+    if (context === INSTREAM) {
       imp.video.placement = 1;
-    } else if (context === 'outstream') {
+    } else if (context === OUTSTREAM) {
       imp.video.placement = 4;
     } else {
-      utils.logWarn(`IX Bid Adapter: video context '${context}' is not supported`);
+      utils.logWarn(`IX Bid Adapter: Video context '${context}' is not supported`);
     }
   }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1873,7 +1873,29 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal(sidValue); // TODO undefined - 400x600
     });
 
-    it('should set correct placement if context is outstream', function () {
+    it('should not use default placement values when placement is defined at adUnit level', function () {
+      const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
+      bid.mediaTypes.video.context = 'outstream';
+      bid.mediaTypes.video.placement = 2;
+      const request = spec.buildRequests([bid])[0];
+      const impression = JSON.parse(request.data.r).imp[0];
+
+      expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
+      expect(impression.video.placement).to.equal(2);
+    });
+
+    it('should set correct default placement, if context is instream', function () {
+      const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
+      bid.mediaTypes.video.context = 'instream';
+      const request = spec.buildRequests([bid])[0];
+      const impression = JSON.parse(request.data.r).imp[0];
+
+      expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
+      expect(impression.video).to.exist;
+      expect(impression.video.placement).to.equal(1);
+    });
+
+    it('should set correct default placement, if context is outstream', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.context = 'outstream';
       const request = spec.buildRequests([bid])[0];
@@ -1881,7 +1903,6 @@ describe('IndexexchangeAdapter', function () {
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
       expect(impression.video).to.exist;
-      expect(impression.video.placement).to.exist;
       expect(impression.video.placement).to.equal(4);
     });
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1891,7 +1891,6 @@ describe('IndexexchangeAdapter', function () {
       const impression = JSON.parse(request.data.r).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
-      expect(impression.video).to.exist;
       expect(impression.video.placement).to.equal(1);
     });
 
@@ -1902,7 +1901,6 @@ describe('IndexexchangeAdapter', function () {
       const impression = JSON.parse(request.data.r).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
-      expect(impression.video).to.exist;
       expect(impression.video.placement).to.equal(4);
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
To read `placement` property from video params.
If thats not present, set a default `placement`

- [x] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->