### PR TITLE
IX Bid Adapter: Prioritizing PBJS priceFloors module floors over IX bidder floors

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -208,24 +208,7 @@ function _applyFloor(bid, imp, mediaType) {
     }
   }
 
-  if (adapterFloor && moduleFloor) {
-    if (adapterFloor.currency !== moduleFloor.currency) {
-      utils.logWarn('The bid floor currency mismatch between IX params and priceFloors module config');
-      return;
-    }
-
-    if (adapterFloor.floor > moduleFloor.floor) {
-      imp.bidfloor = adapterFloor.floor;
-      imp.bidfloorcur = adapterFloor.currency;
-      imp.ext.fl = FLOOR_SOURCE.IX;
-    } else {
-      imp.bidfloor = moduleFloor.floor;
-      imp.bidfloorcur = moduleFloor.currency;
-      imp.ext.fl = FLOOR_SOURCE.PBJS;
-    }
-    return;
-  }
-
+  // Prioritize module floor over bidder.param floor
   if (moduleFloor) {
     imp.bidfloor = moduleFloor.floor;
     imp.bidfloorcur = moduleFloor.currency;
@@ -234,8 +217,6 @@ function _applyFloor(bid, imp, mediaType) {
     imp.bidfloor = adapterFloor.floor;
     imp.bidfloorcur = adapterFloor.currency;
     imp.ext.fl = FLOOR_SOURCE.IX;
-  } else {
-    utils.logInfo('IX Bid Adapter: No floors available, no floors applied');
   }
 }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1336,7 +1336,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.sid).to.equal(sidValue);
     });
 
-    it('video impression has #priceFloors floors', function () {
+    it('video impression should contain floors from priceFloors module', function () {
       const bid = utils.deepClone(ONE_VIDEO[0]);
       const flr = 5.5
       const floorInfo = {floor: flr, currency: 'USD'};
@@ -1352,7 +1352,7 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.ext.fl).to.equal('p');
     });
 
-    it('banner imp has floors from #priceFloors module', function () {
+    it('banner impression should contain floors from priceFloors module', function () {
       const floor300x250 = 3.25
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0])
 
@@ -1370,16 +1370,13 @@ describe('IndexexchangeAdapter', function () {
       expect(imp1.ext.fl).to.equal('p');
     });
 
-    it('ix adapter floors chosen over #priceFloors ', function () {
+    it('should default to ix floors when priceFloors Module is not implemented', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 
-      const floorhi = 4.5
-      const floorlow = 3.5
+      bid.params.bidFloor = 4.5;
+      bid.params.bidFloorCur = 'USD';
 
-      bid.params.bidFloor = floorhi
-      bid.params.bidFloorCur = 'USD'
-
-      const floorInfo = { floor: floorlow, currency: 'USD' };
+      const floorInfo = null;
       bid.getFloor = function () {
         return floorInfo;
       };
@@ -1387,21 +1384,21 @@ describe('IndexexchangeAdapter', function () {
       // check if floors are in imp
       const requestBidFloor = spec.buildRequests([bid])[0];
       const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(floorhi);
+      expect(imp1.bidfloor).to.equal(bid.params.bidFloor);
       expect(imp1.bidfloorcur).to.equal(bid.params.bidFloorCur);
       expect(imp1.ext.fl).to.equal('x');
     });
 
-    it(' #priceFloors floors chosen over ix adapter floors', function () {
+    it('should prioritize Floors Module over IX param floors', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
 
-      const floorhi = 4.5
-      const floorlow = 3.5
+      const floor1 = 4.5
+      const floor2 = 3.5
 
-      bid.params.bidFloor = floorlow
+      bid.params.bidFloor = floor2
       bid.params.bidFloorCur = 'USD'
 
-      const floorInfo = { floor: floorhi, currency: 'USD' };
+      const floorInfo = { floor: floor1, currency: 'USD' };
       bid.getFloor = function () {
         return floorInfo;
       };
@@ -1409,8 +1406,8 @@ describe('IndexexchangeAdapter', function () {
       // check if floors are in imp
       const requestBidFloor = spec.buildRequests([bid])[0];
       const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(floorhi);
-      expect(imp1.bidfloorcur).to.equal(bid.params.bidFloorCur);
+      expect(imp1.bidfloor).to.equal(floorInfo.floor);
+      expect(imp1.bidfloorcur).to.equal(floorInfo.currency);
       expect(imp1.ext.fl).to.equal('p');
     });
 
@@ -1426,7 +1423,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.fl).to.equal('x');
     });
 
-    it('missing sizes #priceFloors ', function () {
+    it('missing sizes impressions should contain floors from priceFloors module ', function () {
       const bid = utils.deepClone(ONE_BANNER[0]);
       bid.mediaTypes.banner.sizes.push([500, 400])
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
IX adapter will prioritize sending the  priceFloors module floor over the IX bidder params floor
- [x] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
