### PR TITLE
Yieldlab Adapter: Add pvid option for cookieless environments

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -8,7 +8,7 @@ import { config } from '../src/config.js';
 const BIDDER_CODE = 'tappx';
 const TTL = 360;
 const CUR = 'USD';
-const TAPPX_BIDDER_VERSION = '0.1.10607';
+const TAPPX_BIDDER_VERSION = '0.1.10610';
 const TYPE_CNN = 'prebidjs';
 const LOG_PREFIX = '[TAPPX]: ';
 const VIDEO_SUPPORT = ['instream'];
@@ -375,7 +375,15 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   // > GDPR
 
   // Universal ID
-  const eidsArr = utils.deepAccess(validBidRequests, 'userIdAsEids');
+  let eidsArr = utils.deepAccess(validBidRequests, 'userIdAsEids');
+  if (typeof eidsArr !== 'undefined') {
+    eidsArr = eidsArr.filter(
+      uuid =>
+        uuid !== null &&
+          (uuid.source !== undefined && uuid.source !== null && typeof uuid.uids[0].id == 'string') &&
+          (uuid.uids[0].id !== undefined && uuid.uids[0].id !== null && typeof uuid.uids[0].id == 'string')
+    )
+  }
   payload.user = {
     ext: {
       eids: eidsArr

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -49,6 +49,14 @@ const REQUEST = {
   }
 }
 
+const VIDEO_REQUEST = Object.assign({}, REQUEST, {
+  'mediaTypes': {
+    'video': {
+      'context': 'instream'
+    }
+  }
+})
+
 const RESPONSE = {
   advertiser: 'yieldlab',
   curl: 'https://www.yieldlab.de',
@@ -62,6 +70,10 @@ const RESPONSE = {
 
 const VIDEO_RESPONSE = Object.assign({}, RESPONSE, {
   'adtype': 'VIDEO'
+})
+
+const PVID_RESPONSE = Object.assign({}, VIDEO_RESPONSE, {
+  'pvid': '43513f11-55a0-4a83-94e5-0ebc08f54a2c'
 })
 
 const REQPARAMS = {
@@ -217,13 +229,6 @@ describe('yieldlabBidAdapter', function () {
     })
 
     it('should add vastUrl when type is video', function () {
-      const VIDEO_REQUEST = Object.assign({}, REQUEST, {
-        'mediaTypes': {
-          'video': {
-            'context': 'instream'
-          }
-        }
-      })
       const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST], queryParams: REQPARAMS})
 
       expect(result[0].requestId).to.equal('2d925f27f5079f')
@@ -234,13 +239,6 @@ describe('yieldlabBidAdapter', function () {
     })
 
     it('should append gdpr parameters to vastUrl', function () {
-      const VIDEO_REQUEST = Object.assign({}, REQUEST, {
-        'mediaTypes': {
-          'video': {
-            'context': 'instream'
-          }
-        }
-      })
       const result = spec.interpretResponse({body: [VIDEO_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST], queryParams: REQPARAMS_GDPR})
 
       expect(result[0].vastUrl).to.include('&gdpr=true')
@@ -262,6 +260,13 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].renderer.url).to.equal('https://ad.adition.com/dynamic.ad?a=o193092&ma_loadEvent=ma-start-event')
       expect(result[0].width).to.equal(640)
       expect(result[0].height).to.equal(480)
+    })
+
+    it('should add pvid to adtag urls when present', function () {
+      const result = spec.interpretResponse({body: [PVID_RESPONSE]}, {validBidRequests: [VIDEO_REQUEST], queryParams: REQPARAMS})
+
+      expect(result[0].ad).to.include('&pvid=43513f11-55a0-4a83-94e5-0ebc08f54a2c')
+      expect(result[0].vastUrl).to.include('&pvid=43513f11-55a0-4a83-94e5-0ebc08f54a2c')
     })
   })
 })


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
In cookieless environments we will respond with a pvid, that needs to be appended to the adtag/vasturls. 

You can force a pvid in cookieless environments with bidder params - customParams: { pvid: true }