### PR TITLE
Adf Bid Adapter: add adform alias

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -15,7 +15,10 @@ const { getConfig } = config;
 
 const BIDDER_CODE = 'adf';
 const GVLID = 50;
-const BIDDER_ALIAS = [ { code: 'adformOpenRTB', gvlid: GVLID } ];
+const BIDDER_ALIAS = [
+  { code: 'adformOpenRTB', gvlid: GVLID },
+  { code: 'adform', gvlid: GVLID }
+];
 const NATIVE_ASSET_IDS = { 0: 'title', 2: 'icon', 3: 'image', 5: 'sponsoredBy', 4: 'body', 1: 'cta' };
 const NATIVE_PARAMS = {
   title: {

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -1,18 +1,21 @@
 // jshint esversion: 6, es3: false, node: true
-import {assert, expect} from 'chai';
-import {spec} from 'modules/adfBidAdapter.js';
-import { NATIVE } from 'src/mediaTypes.js';
+import { assert } from 'chai';
+import { spec } from 'modules/adfBidAdapter.js';
 import { config } from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('Adf adapter', function () {
-  let serverResponse, bidRequest, bidResponses;
   let bids = [];
 
   describe('backwards-compatibility', function () {
     it('should have adformOpenRTB alias defined', function () {
       assert.equal(spec.aliases[0].code, 'adformOpenRTB');
       assert.equal(spec.aliases[0].gvlid, 50);
+    });
+
+    it('should have adform alias defined', function () {
+      assert.equal(spec.aliases[1].code, 'adform');
+      assert.equal(spec.aliases[1].gvlid, 50);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
After prebid-5.0 / master merge adform alias is missing. Adding it for partial publisher configuration backwards compatibility.

- contact email of the adapter’s maintainer Scope.FL.Scripts@adform.com
- [x] official adapter submission

