### PR TITLE
OpenX Bid Adapter: add uid2 and removes verizonMediaId

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -33,7 +33,7 @@ export const USER_ID_CODE_TO_QUERY_ARG = {
   quantcastId: 'quantcastid', // Quantcast ID
   tapadId: 'tapadid', // Tapad Id
   tdid: 'ttduuid', // The Trade Desk Unified ID
-  verizonMediaId: 'verizonmediaid', // Verizon Media ConnectID
+  uid2: 'uid2', // Unified ID 2.0
 };
 
 export const spec = {
@@ -291,6 +291,9 @@ function appendUserIdsToQueryParams(queryParams, userIds) {
 
     if (USER_ID_CODE_TO_QUERY_ARG.hasOwnProperty(userIdProviderKey)) {
       switch (userIdProviderKey) {
+        case 'uid2':
+          queryParams[key] = userIdObjectOrValue.id;
+          break;
         case 'lipb':
           queryParams[key] = userIdObjectOrValue.lipbid;
           break;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1066,7 +1066,7 @@ describe('OpenxAdapter', function () {
         quantcastId: '1111-quantcastid',
         tapadId: '111-tapadid',
         tdid: '1111-tdid',
-        verizonMediaId: '1111-verizonmediaid',
+        uid2: {id: '1111-uid2'}
       };
 
       // generates the same set of tests for each id provider
@@ -1104,6 +1104,9 @@ describe('OpenxAdapter', function () {
             let userIdValue;
             // handle cases where userId key refers to an object
             switch (userIdProviderKey) {
+              case 'uid2':
+                userIdValue = EXAMPLE_DATA_BY_ATTR.uid2.id;
+                break;
               case 'lipb':
                 userIdValue = EXAMPLE_DATA_BY_ATTR.lipb.lipbid;
                 break;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change

removes verizonMediaId per https://github.com/prebid/Prebid.js/issues/6930 and adds uid2