### PR TITLE
IX Bid Adapter: Use openrtb imp[].banner.format to build requests

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -16,6 +16,8 @@ const CENT_TO_DOLLAR_FACTOR = 100;
 const BANNER_TIME_TO_LIVE = 300;
 const VIDEO_TIME_TO_LIVE = 3600; // 1hr
 const NET_REVENUE = true;
+const MAX_REQUEST_SIZE = 8000;
+const MAX_REQUEST_LIMIT = 4;
 
 const PRICE_TO_DOLLAR_FACTOR = {
   JPY: 1
@@ -48,7 +50,7 @@ const PROVIDERS = [
   'pubcid',
   'TDID',
   'flocId'
-]
+];
 
 const REQUIRED_VIDEO_PARAMS = ['mimes', 'minduration', 'maxduration']; // note: protocol/protocols is also reqd
 
@@ -75,8 +77,8 @@ function bidToBannerImp(bid) {
     imp.banner.w = impSize[0];
     imp.banner.h = impSize[1];
     // populate sid with size if not id
-    if (!(utils.deepAccess(imp, 'ext.sid'))) {
-      imp.ext.sid = `${impSize[0]}x${impSize[1]}`;
+    if (!utils.deepAccess(imp, 'ext.sid')) {
+      imp.ext.sid = utils.parseGPTSingleSizeArray(impSize);
     }
   }
 
@@ -112,8 +114,7 @@ function bidToVideoImp(bid) {
   }
 
   if (imp.video.minduration > imp.video.maxduration) {
-    utils.logError('IX Bid Adapter: video minduration [' + imp.video.minduration +
-      '] cannot be greater than video maxduration [' + imp.video.maxduration + ']');
+    utils.logError(`IX Bid Adapter: video minduration [${imp.video.minduration}] cannot be greater than video maxduration [${imp.video.maxduration}]`);
     return {};
   }
 
@@ -137,7 +138,7 @@ function bidToVideoImp(bid) {
       imp.video.w = impSize[0];
       imp.video.h = impSize[1];
       if (!(utils.deepAccess(imp, 'ext.sid'))) {
-        imp.ext.sid = `${impSize[0]}x${impSize[1]}`;
+        imp.ext.sid = utils.parseGPTSingleSizeArray(impSize);
       }
     } else {
       utils.logWarn('IX Bid Adapter: Video size is missing in [mediaTypes.video] missing');
@@ -326,7 +327,7 @@ function checkVideoParams(bid, mediaTypeVideoRef, paramsVideoRef) {
     const propInVideoRef = paramsVideoRef && paramsVideoRef.hasOwnProperty(property);
 
     if (!propInMediaType && !propInVideoRef) {
-      utils.logError('IX Bid Adapter: ' + property + ' is not included in either the adunit or params level');
+      utils.logError(`IX Bid Adapter: ${property} is not included in either the adunit or params level`);
       reqParamsPresent = false;
     }
   }
@@ -468,11 +469,13 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
 
   // Since bidderRequestId are the same for different bid request, just use the first one.
   r.id = validBidRequests[0].bidderRequestId.toString();
-
   r.site = {};
   r.ext = {};
   r.ext.source = 'prebid';
   r.ext.ixdiag = {};
+  r.ext.ixdiag.msd = 0;
+  r.ext.ixdiag.msi = 0;
+  r.imp = [];
 
   // getting ixdiags for adunits of the video, outstream & multi format (MF) style
   let ixdiag = buildIXDiag(validBidRequests);
@@ -539,10 +542,31 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   }
 
   const payload = {};
+  // Use the siteId in the first bid request as the main siteId.
+  payload.s = validBidRequests[0].params.siteId;
+  payload.v = version;
+  payload.ac = 'j';
+  payload.sd = 1;
+
+  if (version === VIDEO_ENDPOINT_VERSION) {
+    payload.nf = 1;
+  }
 
   // Parse additional runtime configs.
   const bidderCode = (bidderRequest && bidderRequest.bidderCode) || 'ix';
   const otherIxConfig = config.getConfig(bidderCode);
+  const requests = [];
+  let requestSequenceNumber = 0;
+  const transactionIds = Object.keys(impressions);
+  const baseRequestSize = `${baseUrl}${utils.parseQueryStringParameters({ ...payload, r: JSON.stringify(r) })}`.length;
+
+  if (baseRequestSize > MAX_REQUEST_SIZE) {
+    utils.logError('ix bidder: Base request size has exceeded maximum request size.');
+    return requests;
+  }
+
+  let currentRequestSize = baseRequestSize;
+
   if (otherIxConfig) {
     // Append firstPartyData to r.site.page if firstPartyData exists.
     if (typeof otherIxConfig.firstPartyData === 'object') {
@@ -570,75 +594,71 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
     }
   }
 
-  // Use the siteId in the first bid request as the main siteId.
-  payload.s = validBidRequests[0].params.siteId;
-  payload.v = version;
-  payload.ac = 'j';
-  payload.sd = 1;
-  if (version === VIDEO_ENDPOINT_VERSION) {
-    payload.nf = 1;
-  }
-
-  const requests = [];
-
-  const request = {
-    method: 'GET',
-    url: baseUrl,
-    data: payload
-  };
-
-  const BASE_REQ_SIZE = new Blob([`${request.url}${utils.parseQueryStringParameters({ ...request.data, r: JSON.stringify(r) })}`]).size;
-  let currReqSize = BASE_REQ_SIZE;
-
-  const MAX_REQ_SIZE = 8000;
-  const MAX_REQ_LIMIT = 4;
-  let sn = 0;
-  let msi = 0;
-  let msd = 0;
-  r.ext.ixdiag.msd = 0;
-  r.ext.ixdiag.msi = 0;
-  r.imp = [];
-  let i = 0;
-  const transactionIds = Object.keys(impressions);
-  let currMissingImps = [];
-
-  while (i < transactionIds.length && requests.length < MAX_REQ_LIMIT) {
-    const impObj = impressions[transactionIds[i]];
-    msd = utils.deepAccess(impObj, 'missingCount') && utils.deepAccess(impObj, 'ixImps') ? impObj.missingCount : 0;
-
-    if (BASE_REQ_SIZE < MAX_REQ_SIZE) {
-      trimImpressions(impObj, MAX_REQ_SIZE - BASE_REQ_SIZE);
-    } else {
-      utils.logError('ix bidder: Base request size has exceeded maximum request size.');
+  for (let adUnitIndex = 0; adUnitIndex < transactionIds.length; adUnitIndex++) {
+    if (currentRequestSize >= MAX_REQUEST_SIZE || requests.length >= MAX_REQUEST_LIMIT) {
+      break;
     }
 
-    msi = utils.deepAccess(impObj, 'missingImps') && utils.deepAccess(impObj, 'ixImps') ? impObj.missingImps.length : 0;
+    const adUnitImpressions = impressions[transactionIds[adUnitIndex]];
+    const { missingCount = 0, missingImps: missingBannerImpressions = [], ixImps = [] } = adUnitImpressions;
+    let wasAdUnitImpressionsTrimmed = false;
+    let remainingRequestSize = MAX_REQUEST_SIZE - currentRequestSize;
+    const sourceImpressions = { ixImps, missingBannerImpressions };
+    const impressionObjects = Object.keys(sourceImpressions)
+      .map((key) => sourceImpressions[key])
+      .filter(item => Array.isArray(item))
+      .reduce((acc, curr) => acc.concat(...curr), []);
 
-    let currImpsSize = new Blob([encodeURIComponent(JSON.stringify(impObj))]).size;
-    currReqSize += currImpsSize;
-    if (currReqSize < MAX_REQ_SIZE) {
-      // since not reading params.size, ixImps can be undefined/empty
-      if (impObj.ixImps && impObj.ixImps.length > 0) {
-        // pushing ix configured sizes first
-        r.imp.push(...impObj.ixImps);
+    let currentImpressionSize = encodeURIComponent(JSON.stringify({ impressionObjects })).length;
+
+    while (currentImpressionSize > remainingRequestSize) {
+      wasAdUnitImpressionsTrimmed = true;
+      impressionObjects.pop();
+      currentImpressionSize = encodeURIComponent(JSON.stringify({ impressionObjects })).length;
+    }
+
+    if (BANNER in impressionObjects[0]) {
+      const { id, banner: { topframe } } = impressionObjects[0];
+      const _bannerImpression = {
+        id,
+        banner: {
+          topframe,
+          format: impressionObjects.map(({ banner: { w, h }, ext }) => ({ w, h, ext }))
+        },
       }
-      // update msd msi
-      r.ext.ixdiag.msd += msd;
-      r.ext.ixdiag.msi += msi;
 
-      if (impObj.hasOwnProperty('missingImps') && impObj.missingImps.length > 0) {
-        currMissingImps.push(...impObj.missingImps);
+      if ('bidfloor' in impressionObjects[0]) {
+        _bannerImpression.bidfloor = impressionObjects[0].bidfloor;
       }
 
-      i++;
+      if ('bidfloorcur' in impressionObjects[0]) {
+        _bannerImpression.bidfloorcur = impressionObjects[0].bidfloorcur;
+      }
+
+      if ('ext' in impressionObjects[0]) {
+        _bannerImpression.ext = impressionObjects[0].ext;
+      }
+
+      r.imp.push(_bannerImpression);
+      r.ext.ixdiag.msd += missingCount;
+      r.ext.ixdiag.msi += missingBannerImpressions.length;
     } else {
-      // pushing missing sizes after configured ones
-      const clonedPayload = utils.deepClone(payload);
+      r.imp.push(...impressionObjects);
+    }
 
-      r.imp.push(...currMissingImps);
-      r.ext.ixdiag.sn = sn;
-      clonedPayload.sn = sn;
-      sn++;
+    currentRequestSize += currentImpressionSize;
+    remainingRequestSize = MAX_REQUEST_SIZE - currentRequestSize;
+
+    const isLastAdUnit = adUnitIndex === transactionIds.length - 1;
+
+    if (wasAdUnitImpressionsTrimmed || isLastAdUnit) {
+      const clonedPayload = utils.deepClone(payload);
+      if (!isLastAdUnit || requestSequenceNumber) {
+        r.ext.ixdiag.sn = requestSequenceNumber;
+        clonedPayload.sn = requestSequenceNumber;
+      }
+
+      requestSequenceNumber++;
       clonedPayload.r = JSON.stringify(r);
 
       requests.push({
@@ -646,31 +666,12 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         url: baseUrl,
         data: clonedPayload
       });
-      currMissingImps = [];
-      currReqSize = BASE_REQ_SIZE;
+
+      currentRequestSize = baseRequestSize;
       r.imp = [];
-      msd = 0;
-      msi = 0;
       r.ext.ixdiag.msd = 0;
       r.ext.ixdiag.msi = 0;
     }
-  }
-
-  if (currReqSize > BASE_REQ_SIZE && currReqSize < MAX_REQ_SIZE && requests.length < MAX_REQ_LIMIT) {
-    const clonedPayload = utils.deepClone(payload);
-    r.imp.push(...currMissingImps);
-
-    if (requests.length > 0) {
-      r.ext.ixdiag.sn = sn;
-      clonedPayload.sn = sn;
-    }
-    clonedPayload.r = JSON.stringify(r);
-
-    requests.push({
-      method: 'GET',
-      url: baseUrl,
-      data: clonedPayload
-    });
   }
 
   return requests;
@@ -750,27 +751,6 @@ function buildIXDiag(validBidRequests) {
 
 /**
  *
- * @param {Object} impressions containing ixImps and possibly missingImps
- *
- */
-function trimImpressions(impressions, maxSize) {
-  let currSize = new Blob([encodeURIComponent(JSON.stringify(impressions))]).size;
-  if (currSize < maxSize) {
-    return;
-  }
-
-  while (currSize > maxSize) {
-    if (impressions.hasOwnProperty('missingImps') && impressions.missingImps.length > 0) {
-      impressions.missingImps.pop();
-    } else if (impressions.hasOwnProperty('ixImps') && impressions.ixImps.length > 0) {
-      impressions.ixImps.pop();
-    }
-    currSize = new Blob([encodeURIComponent(JSON.stringify(impressions))]).size;
-  }
-}
-
-/**
- *
  * @param  {array}   bannerSizeList list of banner sizes
  * @param  {array}   bannerSize the size to be removed
  * @return {boolean} true if successfully removed, false if not found
@@ -826,7 +806,7 @@ function updateMissingSizes(validBidRequest, missingBannerSizes, imp) {
  */
 function createMissingBannerImp(bid, imp, newSize) {
   const newImp = utils.deepClone(imp);
-  newImp.ext.sid = `${newSize[0]}x${newSize[1]}`;
+  newImp.ext.sid = utils.parseGPTSingleSizeArray(newSize);
   newImp.banner.w = newSize[0];
   newImp.banner.h = newSize[1];
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -635,19 +635,12 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         _bannerImpression.bidfloorcur = impressionObjects[0].bidfloorcur;
       }
 
-      if ('ext' in impressionObjects[0]) {
-        _bannerImpression.ext = impressionObjects[0].ext;
-      }
-
       r.imp.push(_bannerImpression);
       r.ext.ixdiag.msd += missingCount;
       r.ext.ixdiag.msi += missingBannerImpressions.length;
     } else {
       r.imp.push(...impressionObjects);
     }
-
-    currentRequestSize += currentImpressionSize;
-    remainingRequestSize = MAX_REQUEST_SIZE - currentRequestSize;
 
     const isLastAdUnit = adUnitIndex === transactionIds.length - 1;
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1277,14 +1277,14 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { dfp_ad_unit_code } = JSON.parse(requests[0].data.r).imp[0].ext;
+      const { dfp_ad_unit_code } = JSON.parse(requests[0].data.r).imp[0].banner.format[0].ext;
       expect(dfp_ad_unit_code).to.equal(AD_UNIT_CODE);
     });
 
     it('should not send dfp_adunit_code in request if ortb2Imp.ext.data.adserver.adslot does not exists', function () {
       const validBids = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { dfp_ad_unit_code } = JSON.parse(requests[0].data.r).imp[0].ext;
+      const { dfp_ad_unit_code } = JSON.parse(requests[0].data.r).imp[0].banner.format[0].ext;
 
       expect(dfp_ad_unit_code).to.not.exist;
     });
@@ -1482,15 +1482,12 @@ describe('IndexexchangeAdapter', function () {
 
     it('impression without mediaType should have correct format and value', function () {
       const impression = JSON.parse(queryWithoutMediaType.r).imp[0];
-      const sidValue = `${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`;
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
       expect(impression.banner.format).to.be.length(1);
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
       expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal(sidValue);
     });
 
     it('impression should have sid if id is configured as number', function () {
@@ -1503,8 +1500,8 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
       expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal('50');
+      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+      expect(impression.banner.format[0].ext.sid).to.equal('50');
     });
 
     it('impression should have sid if id is configured as string', function () {
@@ -1517,8 +1514,8 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
       expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal('abc');
+      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+      expect(impression.banner.format[0].ext.sid).to.equal('abc');
     });
 
     describe('first party data', () => {
@@ -1608,8 +1605,6 @@ describe('IndexexchangeAdapter', function () {
 
         expect(bannerImpression.banner.format).to.be.length(2);
         expect(bannerImpression.banner.topframe).to.be.oneOf([0, 1]);
-        expect(bannerImpression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-        expect(bannerImpression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(DEFAULT_BANNER_VALID_BID[0].params.size));
 
         bannerImpression.banner.format.map(({ w, h, ext }, index) => {
           const size = DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[index];
@@ -1740,8 +1735,6 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.id).to.equal(bid.bidId);
       expect(impression.banner.format).to.be.length(bid.mediaTypes.banner.sizes.length);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext.siteID).to.equal(bid.params.siteId.toString());
-      expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(bid.params.size));
 
       impression.banner.format.map(({ w, h, ext }, index) => {
         const size = bid.mediaTypes.banner.sizes[index];
@@ -1777,8 +1770,6 @@ describe('IndexexchangeAdapter', function () {
 
         expect(impression.banner.format).to.be.length(2);
         expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-        expect(impression.ext.siteID).to.equal(bids[impressionIndex].params.siteId);
-        expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(firstSizeObject));
 
         impression.banner.format.map(({ w, h, ext }, index) => {
           const size = bids[impressionIndex].mediaTypes.banner.sizes[index];
@@ -1850,8 +1841,6 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.video.mimes[1]).to.equal('video/webm');
 
       expect(impression.video.skippable).to.equal(false);
-      expect(impression.ext.siteID).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal(sidValue);
     });
 
     it('should not use default placement values when placement is defined at adUnit level', function () {
@@ -1980,8 +1969,6 @@ describe('IndexexchangeAdapter', function () {
           expect(impression.id).to.equal(bid.bidId);
           expect(impression.banner.format).to.be.length(bid.mediaTypes.banner.sizes.length);
           expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-          expect(impression.ext.siteID).to.equal(bid.params.siteId.toString());
-          expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray((bid.params.size)));
 
           impression.banner.format.map(({ w, h, ext }, index) => {
             const size = bid.mediaTypes.banner.sizes[index];

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -26,7 +26,7 @@ describe('IndexexchangeAdapter', function () {
       }
     ]
   };
-  const div_many_sizes = [
+  const LARGE_SET_OF_SIZES = [
     [300, 250],
     [600, 410],
     [336, 280],
@@ -210,7 +210,7 @@ describe('IndexexchangeAdapter', function () {
       bidder: 'ix',
       params: {
         siteId: '123',
-        size: [300, 250]
+        size: [300, 250],
       },
       mediaTypes: {
         video: {
@@ -218,7 +218,7 @@ describe('IndexexchangeAdapter', function () {
           playerSize: [600, 700]
         },
         banner: {
-          sizes: [[300, 250], [300, 600]]
+          sizes: [[300, 250], [300, 600], [400, 500]]
         }
       },
       adUnitCode: 'div-gpt-ad-1460505748562-0',
@@ -409,7 +409,7 @@ describe('IndexexchangeAdapter', function () {
     netId: 'testnetid123', // NetId
     IDP: 'userIDP000', // IDP
     fabrickId: 'fabrickId9000', // FabrickId
-    uid2: {id: 'testuid2'} // UID 2.0
+    uid2: { id: 'testuid2' } // UID 2.0
   };
 
   const DEFAULT_USERIDASEIDS_DATA = createEidsArray(DEFAULT_USERID_DATA);
@@ -461,7 +461,7 @@ describe('IndexexchangeAdapter', function () {
 
   const DEFAULT_USERID_BID_DATA = {
     lotamePanoramaId: 'bd738d136bdaa841117fe9b331bb4',
-    flocId: {id: '1234', version: 'chrome.1.2'}
+    flocId: { id: '1234', version: 'chrome.1.2' }
   };
 
   const DEFAULT_FLOC_USERID_PAYLOAD = [
@@ -929,7 +929,7 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).to.deep.include(DEFAULT_USERID_PAYLOAD[4]);
     });
 
-    it('IX adapter reads floc id from prebid userId and adds it to eids when there is not other eids', function() {
+    it('IX adapter reads floc id from prebid userId and adds it to eids when there is not other eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userId = utils.deepClone(DEFAULT_USERID_BID_DATA);
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
@@ -939,7 +939,7 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).to.deep.include(DEFAULT_FLOC_USERID_PAYLOAD[0]);
     });
 
-    it('IX adapter reads floc id from prebid userId and appends it to eids', function() {
+    it('IX adapter reads floc id from prebid userId and appends it to eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
       cloneValidBid[0].userId = utils.deepClone(DEFAULT_USERID_BID_DATA);
@@ -955,10 +955,10 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).to.deep.include(DEFAULT_FLOC_USERID_PAYLOAD[0]);
     });
 
-    it('IX adapter reads empty floc obj from prebid userId it, floc is not added to eids', function() {
+    it('IX adapter reads empty floc obj from prebid userId it, floc is not added to eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
-      cloneValidBid[0].userId = {'flocId': {}}
+      cloneValidBid[0].userId = { 'flocId': {} }
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
       const payload = JSON.parse(request.data.r);
 
@@ -971,10 +971,10 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).should.not.include(DEFAULT_FLOC_USERID_PAYLOAD[0]);
     });
 
-    it('IX adapter reads floc obj from prebid userId it version is missing, floc is not added to eids', function() {
+    it('IX adapter reads floc obj from prebid userId it version is missing, floc is not added to eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
-      cloneValidBid[0].userId = {'flocId': {'id': 'abcd'}}
+      cloneValidBid[0].userId = { 'flocId': { 'id': 'abcd' } }
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
       const payload = JSON.parse(request.data.r);
 
@@ -987,10 +987,10 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).should.not.include(DEFAULT_FLOC_USERID_PAYLOAD[0]);
     });
 
-    it('IX adapter reads floc obj from prebid userId it ID is missing, floc is not added to eids', function() {
+    it('IX adapter reads floc obj from prebid userId it ID is missing, floc is not added to eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
-      cloneValidBid[0].userId = {'flocId': {'version': 'chrome.a.b.c'}}
+      cloneValidBid[0].userId = { 'flocId': { 'version': 'chrome.a.b.c' } }
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
       const payload = JSON.parse(request.data.r);
 
@@ -1003,10 +1003,10 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.user.eids).should.not.include(DEFAULT_FLOC_USERID_PAYLOAD[0]);
     });
 
-    it('IX adapter reads floc id with empty id from prebid userId and it does not added to eids', function() {
+    it('IX adapter reads floc id with empty id from prebid userId and it does not added to eids', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
-      cloneValidBid[0].userId = {flocID: {id: '', ver: 'chrome.1.2.3'}};
+      cloneValidBid[0].userId = { flocID: { id: '', ver: 'chrome.1.2.3' } };
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
       const payload = JSON.parse(request.data.r);
 
@@ -1293,15 +1293,24 @@ describe('IndexexchangeAdapter', function () {
       const payload = JSON.parse(query.r);
       expect(payload.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidderRequestId);
       expect(payload.id).to.be.a('string');
-      expect(payload.site).to.exist;
       expect(payload.site.page).to.equal(DEFAULT_OPTION.refererInfo.referer);
       expect(payload.site.ref).to.equal(document.referrer);
-      expect(payload.ext).to.exist;
       expect(payload.ext.source).to.equal('prebid');
       expect(payload.source.ext.schain).to.deep.equal(SAMPLE_SCHAIN);
-      expect(payload.imp).to.exist;
       expect(payload.imp).to.be.an('array');
-      expect(payload.imp).to.have.lengthOf(2);
+      expect(payload.imp).to.have.lengthOf(1);
+    });
+
+    it('payload should have correct format and value for r.id when bidderRequestId is a number ', function () {
+      const bidWithIntId = utils.deepClone(DEFAULT_BANNER_VALID_BID);
+      bidWithIntId[0].bidderRequestId = 123456;
+
+      request = spec.buildRequests(bidWithIntId, DEFAULT_OPTION)[0];
+
+      const payload = JSON.parse(request.data.r);
+      expect(bidWithIntId[0].bidderRequestId).to.be.a('number');
+      expect(payload.id).to.equal(bidWithIntId[0].bidderRequestId.toString());
+      expect(payload.id).to.be.a('string');
     });
 
     it('payload should have correct format and value for r.id when bidderRequestId is a number ', function () {
@@ -1323,182 +1332,150 @@ describe('IndexexchangeAdapter', function () {
 
     it('impression should have correct format and value', function () {
       const impression = JSON.parse(query.r).imp[0];
-      const sidValue = `${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`;
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(impression.banner).to.exist;
-      expect(impression.banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(impression.banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
-      expect(impression.banner.topframe).to.exist;
+      expect(impression.banner.format).to.be.length(2);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext).to.exist;
-      expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal(sidValue);
+
+      impression.banner.format.map(({ w, h, ext }, index) => {
+        const size = DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[index];
+        const sidValue = utils.parseGPTSingleSizeArray(size);
+
+        expect(w).to.equal(size[0]);
+        expect(h).to.equal(size[1]);
+        expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+        expect(ext.sid).to.equal(sidValue);
+      });
     });
 
-    it('video impression should contain floors from priceFloors module', function () {
-      const bid = utils.deepClone(ONE_VIDEO[0]);
-      const flr = 5.5
-      const floorInfo = {floor: flr, currency: 'USD'};
-      bid.getFloor = function () {
-        return floorInfo;
-      }
+    describe('build requests with price floors', () => {
+      const highFloor = 4.5;
+      const lowFloor = 3.5;
+      const currency = 'USD';
 
-      // check if floors are in imp
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(flr);
-      expect(imp1.bidfloorcur).to.equal('USD');
-      expect(imp1.ext.fl).to.equal('p');
-    });
+      it('video impression should contain floors from priceFloors module', function () {
+        const bid = utils.deepClone(ONE_VIDEO[0]);
+        const expectedFloor = 3.25;
+        bid.getFloor = () => ({ floor: expectedFloor, currency });
+        const request = spec.buildRequests([bid])[0];
+        const impression = JSON.parse(request.data.r).imp[0];
 
-    it('banner impression should contain floors from priceFloors module', function () {
-      const floor300x250 = 3.25
-      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0])
+        expect(impression.bidfloor).to.equal(expectedFloor);
+        expect(impression.bidfloorcur).to.equal(currency);
+        expect(impression.ext.fl).to.equal('p');
+      });
 
-      const floorInfo = { floor: floor300x250, currency: 'USD' };
-      bid.getFloor = function () {
-        return floorInfo;
-      };
+      it('banner impression should contain floors from priceFloors module', function () {
+        const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0])
+        const expectedFloor = 3.25;
+        bid.getFloor = () => ({ floor: expectedFloor, currency });
+        const request = spec.buildRequests([bid])[0];
+        const impression = JSON.parse(request.data.r).imp[0];
 
-      // check if floors are in imp
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
+        expect(impression.bidfloor).to.equal(expectedFloor);
+        expect(impression.bidfloorcur).to.equal(currency);
+        expect(impression.banner.format[0].ext.fl).to.equal('p');
+      });
 
-      expect(imp1.bidfloorcur).to.equal('USD');
-      expect(imp1.bidfloor).to.equal(floor300x250);
-      expect(imp1.ext.fl).to.equal('p');
-    });
+      it('should default to ix floors when priceFloors Module is not implemented', function () {
+        const bid = utils.deepClone(ONE_BANNER[0]);
+        bid.params.bidFloor = highFloor;
+        bid.params.bidFloorCur = 'USD'
+        const request = spec.buildRequests([bid])[0];
+        const impression = JSON.parse(request.data.r).imp[0];
 
-    it('should default to ix floors when priceFloors Module is not implemented', function () {
-      const bid = utils.deepClone(ONE_BANNER[0]);
+        expect(impression.bidfloor).to.equal(highFloor);
+        expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
+        expect(impression.banner.format[0].ext.fl).to.equal('x');
+      });
 
-      bid.params.bidFloor = 4.5;
-      bid.params.bidFloorCur = 'USD';
+      it('should prioritize priceFloors Module over IX param floors', function () {
+        const bid = utils.deepClone(ONE_BANNER[0]);
+        bid.params.bidFloor = lowFloor;
+        bid.params.bidFloorCur = 'USD';
+        const expectedFloor = highFloor;
+        bid.getFloor = () => ({ floor: expectedFloor, currency });
+        const requestBidFloor = spec.buildRequests([bid])[0];
+        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
 
-      const floorInfo = null;
-      bid.getFloor = function () {
-        return floorInfo;
-      };
+        expect(impression.bidfloor).to.equal(highFloor);
+        expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
+        expect(impression.banner.format[0].ext.fl).to.equal('p');
+      });
 
-      // check if floors are in imp
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(bid.params.bidFloor);
-      expect(imp1.bidfloorcur).to.equal(bid.params.bidFloorCur);
-      expect(imp1.ext.fl).to.equal('x');
-    });
+      it('impression should have bidFloor and bidFloorCur if configured', function () {
+        const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+        bid.params.bidFloor = 50;
+        bid.params.bidFloorCur = 'USD';
+        const requestBidFloor = spec.buildRequests([bid])[0];
+        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
 
-    it('should prioritize Floors Module over IX param floors', function () {
-      const bid = utils.deepClone(ONE_BANNER[0]);
+        expect(impression.bidfloor).to.equal(bid.params.bidFloor);
+        expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
+        expect(impression.banner.format[0].ext.fl).to.equal('x');
+      });
 
-      const floor1 = 4.5
-      const floor2 = 3.5
+      it('missing sizes impressions should contain floors from priceFloors module ', function () {
+        const bid = utils.deepClone(ONE_BANNER[0]);
+        bid.mediaTypes.banner.sizes.push([500, 400])
 
-      bid.params.bidFloor = floor2
-      bid.params.bidFloorCur = 'USD'
+        const expectedFloor = 3.25;
+        bid.getFloor = () => ({ floor: expectedFloor, currency });
 
-      const floorInfo = { floor: floor1, currency: 'USD' };
-      bid.getFloor = function () {
-        return floorInfo;
-      };
+        sinon.spy(bid, 'getFloor');
 
-      // check if floors are in imp
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(floorInfo.floor);
-      expect(imp1.bidfloorcur).to.equal(floorInfo.currency);
-      expect(imp1.ext.fl).to.equal('p');
-    });
+        const requestBidFloor = spec.buildRequests([bid])[0];
+        expect(bid.getFloor.getCall(0).args[0].mediaType).to.equal('banner');
+        expect(bid.getFloor.getCall(0).args[0].size[0]).to.equal(300);
+        expect(bid.getFloor.getCall(0).args[0].size[1]).to.equal(250);
 
-    it('impression should have bidFloor and bidFloorCur if configured', function () {
-      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
-      bid.params.bidFloor = 50;
-      bid.params.bidFloorCur = 'USD';
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        expect(bid.getFloor.getCall(1).args[0].mediaType).to.equal('banner');
+        expect(bid.getFloor.getCall(1).args[0].size[0]).to.equal(500);
+        expect(bid.getFloor.getCall(1).args[0].size[1]).to.equal(400);
 
-      expect(impression.bidfloor).to.equal(bid.params.bidFloor);
-      expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
-      expect(impression.ext.fl).to.equal('x');
-    });
+        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        expect(impression.bidfloor).to.equal(expectedFloor);
+        expect(impression.bidfloorcur).to.equal(currency);
+      });
 
-    it('missing sizes impressions should contain floors from priceFloors module ', function () {
-      const bid = utils.deepClone(ONE_BANNER[0]);
-      bid.mediaTypes.banner.sizes.push([500, 400])
+      it('banner impressions should have pricefloors in AdUnit', function () {
+        const bid = utils.deepClone(ONE_BANNER[0]);
 
-      const floorInfo = { floor: 3.25, currency: 'USD' };
-      bid.getFloor = function () {
-        return floorInfo;
-      };
+        const expectedFloor = 4.3;
+        bid.floors = {
+          currency: 'USD',
+          schema: {
+            delimiter: '|',
+            fields: ['mediaType', 'size']
+          },
+          values: {
+            'banner|300x250': expectedFloor,
+            'banner|600x500': 6.5,
+            'banner|*': 7.5
+          }
+        };
+        bid.getFloor = () => ({ floor: expectedFloor, currency });
 
-      sinon.spy(bid, 'getFloor');
+        sinon.spy(bid, 'getFloor');
 
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      // called getFloor with 300 x 250
-      expect(bid.getFloor.getCall(0).args[0].mediaType).to.equal('banner');
-      expect(bid.getFloor.getCall(0).args[0].size[0]).to.equal(300);
-      expect(bid.getFloor.getCall(0).args[0].size[1]).to.equal(250);
+        const requestBidFloor = spec.buildRequests([bid])[0];
+        expect(bid.getFloor.getCall(0).args[0].mediaType).to.equal('banner');
+        expect(bid.getFloor.getCall(0).args[0].size[0]).to.equal(300);
+        expect(bid.getFloor.getCall(0).args[0].size[1]).to.equal(250);
 
-      // called getFloor with 500 x 400
-      expect(bid.getFloor.getCall(1).args[0].mediaType).to.equal('banner');
-      expect(bid.getFloor.getCall(1).args[0].size[0]).to.equal(500);
-      expect(bid.getFloor.getCall(1).args[0].size[1]).to.equal(400);
-
-      // both will have same floors due to mock getFloor
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(3.25);
-      expect(imp1.bidfloorcur).to.equal('USD');
-
-      const imp2 = JSON.parse(requestBidFloor.data.r).imp[1];
-      expect(imp2.bidfloor).to.equal(3.25);
-      expect(imp2.bidfloorcur).to.equal('USD');
-    });
-
-    it('#pricefloors inAdUnit, banner impressions should have floors', function () {
-      const bid = utils.deepClone(ONE_BANNER[0]);
-
-      const flr = 4.3
-      bid.floors = {
-        currency: 'USD',
-        schema: {
-          delimiter: '|',
-          fields: ['mediaType', 'size']
-        },
-        values: {
-          'banner|300x250': flr,
-          'banner|600x500': 6.5,
-          'banner|*': 7.5
-        }
-      };
-      const floorInfo = { floor: flr, currency: 'USD' };
-      bid.getFloor = function () {
-        return floorInfo;
-      };
-
-      sinon.spy(bid, 'getFloor');
-
-      const requestBidFloor = spec.buildRequests([bid])[0];
-      // called getFloor with 300 x 250
-      expect(bid.getFloor.getCall(0).args[0].mediaType).to.equal('banner');
-      expect(bid.getFloor.getCall(0).args[0].size[0]).to.equal(300);
-      expect(bid.getFloor.getCall(0).args[0].size[1]).to.equal(250);
-
-      const imp1 = JSON.parse(requestBidFloor.data.r).imp[0];
-      expect(imp1.bidfloor).to.equal(flr);
-      expect(imp1.bidfloorcur).to.equal('USD');
+        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        expect(impression.bidfloor).to.equal(expectedFloor);
+        expect(impression.bidfloorcur).to.equal(currency);
+      });
     });
 
     it('payload without mediaType should have correct format and value', function () {
       const payload = JSON.parse(queryWithoutMediaType.r);
 
       expect(payload.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidderRequestId);
-      expect(payload.site).to.exist;
       expect(payload.site.page).to.equal(DEFAULT_OPTION.refererInfo.referer);
       expect(payload.site.ref).to.equal(document.referrer);
-      expect(payload.ext).to.exist;
       expect(payload.ext.source).to.equal('prebid');
-      expect(payload.imp).to.exist;
       expect(payload.imp).to.be.an('array');
       expect(payload.imp).to.have.lengthOf(1);
     });
@@ -1508,12 +1485,10 @@ describe('IndexexchangeAdapter', function () {
       const sidValue = `${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`;
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(impression.banner).to.exist;
-      expect(impression.banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(impression.banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
-      expect(impression.banner.topframe).to.exist;
+      expect(impression.banner.format).to.be.length(1);
+      expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
+      expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext).to.exist;
       expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
       expect(impression.ext.sid).to.equal(sidValue);
     });
@@ -1525,12 +1500,9 @@ describe('IndexexchangeAdapter', function () {
       const impression = JSON.parse(requestBidFloor.data.r).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(impression.banner).to.exist;
-      expect(impression.banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);// undefined - 300
-      expect(impression.banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
-      expect(impression.banner.topframe).to.exist;
+      expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
+      expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext).to.exist;
       expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
       expect(impression.ext.sid).to.equal('50');
     });
@@ -1540,131 +1512,148 @@ describe('IndexexchangeAdapter', function () {
       bid.params.id = 'abc';
       const requestBidFloor = spec.buildRequests([bid])[0];
       const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(impression.banner).to.exist;
-      expect(impression.banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(impression.banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
-      expect(impression.banner.topframe).to.exist;
+      expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
+      expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.ext).to.exist;
       expect(impression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
       expect(impression.ext.sid).to.equal('abc');
     });
 
-    it('should add first party data to page url in bid request if it exists in config', function () {
-      config.setConfig({
-        ix: {
-          firstPartyData: {
-            ab: 123,
-            cd: '123#ab',
-            'e/f': 456,
-            'h?g': '456#cd'
+    describe('first party data', () => {
+      it('should add first party data to page url in bid request if it exists in config', function () {
+        config.setConfig({
+          ix: {
+            firstPartyData: {
+              ab: 123,
+              cd: '123#ab',
+              'e/f': 456,
+              'h?g': '456#cd'
+            }
           }
-        }
+        });
+
+        const requestWithFirstPartyData = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
+        const pageUrl = JSON.parse(requestWithFirstPartyData.data.r).site.page;
+        const expectedPageUrl = DEFAULT_OPTION.refererInfo.referer + '?ab=123&cd=123%23ab&e%2Ff=456&h%3Fg=456%23cd';
+        expect(pageUrl).to.equal(expectedPageUrl);
       });
 
-      const requestWithFirstPartyData = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-      const pageUrl = JSON.parse(requestWithFirstPartyData.data.r).site.page;
-      const expectedPageUrl = DEFAULT_OPTION.refererInfo.referer + '?ab=123&cd=123%23ab&e%2Ff=456&h%3Fg=456%23cd';
-      expect(pageUrl).to.equal(expectedPageUrl);
-    });
+      it('should not set first party data if it is not an object', function () {
+        config.setConfig({
+          ix: {
+            firstPartyData: 500
+          }
+        });
 
-    it('should not set first party data if it is not an object', function () {
-      config.setConfig({
-        ix: {
-          firstPartyData: 500
-        }
+        const requestFirstPartyDataNumber = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
+        const pageUrl = JSON.parse(requestFirstPartyDataNumber.data.r).site.page;
+
+        expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
       });
 
-      const requestFirstPartyDataNumber = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-      const pageUrl = JSON.parse(requestFirstPartyDataNumber.data.r).site.page;
+      it('should not set first party or timeout if it is not present', function () {
+        config.setConfig({
+          ix: {}
+        });
 
-      expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
-    });
+        const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
+        const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
 
-    it('should not set first party or timeout if it is not present', function () {
-      config.setConfig({
-        ix: {}
+        expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
+        expect(requestWithoutConfig.data.t).to.be.undefined;
       });
 
-      const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-      const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
+      it('should not set first party or timeout if it is setConfig is not called', function () {
+        const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
+        const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
 
-      expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
-      expect(requestWithoutConfig.data.t).to.be.undefined;
-    });
-
-    it('should not set first party or timeout if it is setConfig is not called', function () {
-      const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-      const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
-
-      expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
-      expect(requestWithoutConfig.data.t).to.be.undefined;
-    });
-
-    it('should set timeout if publisher set it through setConfig', function () {
-      config.setConfig({
-        ix: {
-          timeout: 500
-        }
+        expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.referer);
+        expect(requestWithoutConfig.data.t).to.be.undefined;
       });
-      const requestWithTimeout = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
 
-      expect(requestWithTimeout.data.t).to.equal(500);
-    });
+      it('should set timeout if publisher set it through setConfig', function () {
+        config.setConfig({
+          ix: {
+            timeout: 500
+          }
+        });
+        const requestWithTimeout = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
 
-    it('should set timeout if timeout is a string', function () {
-      config.setConfig({
-        ix: {
-          timeout: '500'
-        }
+        expect(requestWithTimeout.data.t).to.equal(500);
       });
-      const requestStringTimeout = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
 
-      expect(requestStringTimeout.data.t).to.be.undefined;
+      it('should set timeout if timeout is a string', function () {
+        config.setConfig({
+          ix: {
+            timeout: '500'
+          }
+        });
+        const requestStringTimeout = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
+
+        expect(requestStringTimeout.data.t).to.be.undefined;
+      });
     });
 
-    it('request should contain both banner and video requests', function () {
+    describe('request should contain both banner and video requests', function () {
       const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], DEFAULT_VIDEO_VALID_BID[0]]);
 
-      const bannerImp = JSON.parse(request[0].data.r).imp[0];
-      expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(2);
-      expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
-      expect(bannerImp.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(bannerImp.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
-      expect(bannerImp.banner).to.exist;
-      expect(bannerImp.banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(bannerImp.banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
+      it('should have banner request', () => {
+        const bannerImpression = JSON.parse(request[0].data.r).imp[0];
 
-      const videoImp = JSON.parse(request[1].data.r).imp[0];
-      expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
-      expect(videoImp.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
-      expect(videoImp.video).to.exist;
-      expect(videoImp.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
-      expect(videoImp.video.h).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[1]);
+        expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(1);
+        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
+        expect(bannerImpression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
+
+        expect(bannerImpression.banner.format).to.be.length(2);
+        expect(bannerImpression.banner.topframe).to.be.oneOf([0, 1]);
+        expect(bannerImpression.ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+        expect(bannerImpression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(DEFAULT_BANNER_VALID_BID[0].params.size));
+
+        bannerImpression.banner.format.map(({ w, h, ext }, index) => {
+          const size = DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[index];
+          const sidValue = utils.parseGPTSingleSizeArray(size);
+
+          expect(w).to.equal(size[0]);
+          expect(h).to.equal(size[1]);
+          expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+          expect(ext.sid).to.equal(sidValue);
+        });
+      });
+
+      it('should have video request', () => {
+        const videoImpression = JSON.parse(request[1].data.r).imp[0];
+
+        expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
+        expect(videoImpression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
+        expect(videoImpression.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
+        expect(videoImpression.video.h).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[1]);
+      });
     });
 
     it('single request under 8k size limit for large ad unit', function () {
       const options = {};
-      const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
-      bid1.mediaTypes.banner.sizes = div_many_sizes;
-      const requests = spec.buildRequests([bid1], options);
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
+      const requests = spec.buildRequests([bid], options);
 
-      const reqSize = new Blob([`${requests[0].url}?${utils.parseQueryStringParameters(requests[0].data)}`]).size;
+      const reqSize = `${requests[0].url}?${utils.parseQueryStringParameters(requests[0].data)}`.length;
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(1);
       expect(reqSize).to.be.lessThan(8000);
+      expect(requests[0].data.sn).to.be.undefined;
     });
 
     it('2 requests due to 2 ad units, one larger than url size', function () {
-      const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
-      bid1.mediaTypes.banner.sizes = div_many_sizes;
-      bid1.params.siteId = '124';
-      bid1.adUnitCode = 'div-gpt-1'
-      bid1.transactionId = '152e36d1-1241-4242-t35e-y1dv34d12315';
-      bid1.bidId = '2f6g5s5e';
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
+      bid.params.siteId = '124';
+      bid.adUnitCode = 'div-gpt-1'
+      bid.transactionId = '152e36d1-1241-4242-t35e-y1dv34d12315';
+      bid.bidId = '2f6g5s5e';
 
-      const requests = spec.buildRequests([bid1, DEFAULT_BANNER_VALID_BID[0]], DEFAULT_OPTION);
+      const requests = spec.buildRequests([bid, DEFAULT_BANNER_VALID_BID[0]], DEFAULT_OPTION);
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(2);
       expect(requests[0].data.sn).to.be.equal(0);
@@ -1673,7 +1662,7 @@ describe('IndexexchangeAdapter', function () {
 
     it('6 ad units should generate only 4 requests', function () {
       const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
-      bid1.mediaTypes.banner.sizes = div_many_sizes;
+      bid1.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
       bid1.params.siteId = '121';
       bid1.adUnitCode = 'div-gpt-1'
       bid1.transactionId = 'tr1';
@@ -1699,9 +1688,8 @@ describe('IndexexchangeAdapter', function () {
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(4);
 
-      // check if seq number increases
       for (var i = 0; i < requests.length; i++) {
-        const reqSize = new Blob([`${requests[i].url}?${utils.parseQueryStringParameters(requests[i].data)}`]).size;
+        const reqSize = `${requests[i].url}?${utils.parseQueryStringParameters(requests[i].data)}`.length;
         expect(reqSize).to.be.lessThan(8000);
         let payload = JSON.parse(requests[i].data.r);
         if (requests.length > 1) {
@@ -1727,12 +1715,14 @@ describe('IndexexchangeAdapter', function () {
       bid3.mediaTypes.banner.sizes = [[330, 331], [332, 333], [300, 250]];
 
       const requests = spec.buildRequests([bid1, bid2, bid3], DEFAULT_OPTION);
+
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(1);
 
       const impressions = JSON.parse(requests[0].data.r).imp;
       expect(impressions).to.be.an('array');
-      expect(impressions).to.have.lengthOf(9);
+      expect(impressions).to.have.lengthOf(3);
+      expect(requests[0].data.sn).to.be.undefined;
     });
 
     it('request should contain the extra banner ad sizes that IX is not configured for using the first site id in the ad unit', function () {
@@ -1745,24 +1735,23 @@ describe('IndexexchangeAdapter', function () {
       bid2.params.bidId = '2b3c4d5e';
 
       const request = spec.buildRequests([bid, bid2], DEFAULT_OPTION)[0];
-      const impressions = JSON.parse(request.data.r).imp;
+      const impression = JSON.parse(request.data.r).imp[0];
 
-      expect(impressions).to.be.an('array');
-      expect(impressions).to.have.lengthOf(4);
+      expect(impression.id).to.equal(bid.bidId);
+      expect(impression.banner.format).to.be.length(bid.mediaTypes.banner.sizes.length);
+      expect(impression.banner.topframe).to.be.oneOf([0, 1]);
+      expect(impression.ext.siteID).to.equal(bid.params.siteId.toString());
+      expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(bid.params.size));
 
-      expect(impressions[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
-      expect(impressions[1].ext.siteID).to.equal(bid2.params.siteId)
-      expect(impressions[2].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
-      expect(impressions[3].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString())
+      impression.banner.format.map(({ w, h, ext }, index) => {
+        const size = bid.mediaTypes.banner.sizes[index];
+        const sidValue = utils.parseGPTSingleSizeArray(size);
 
-      expect(impressions[0].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(impressions[0].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
-      expect(impressions[1].banner.w).to.equal(bid2.params.size[0]);
-      expect(impressions[1].banner.h).to.equal(bid2.params.size[1]);
-      expect(impressions[2].banner.w).to.equal(bid.mediaTypes.banner.sizes[2][0]);
-      expect(impressions[2].banner.h).to.equal(bid.mediaTypes.banner.sizes[2][1]);
-      expect(impressions[3].banner.w).to.equal(bid.mediaTypes.banner.sizes[3][0]);
-      expect(impressions[3].banner.h).to.equal(bid.mediaTypes.banner.sizes[3][1]);
+        expect(w).to.equal(size[0]);
+        expect(h).to.equal(size[1]);
+        expect(ext.siteID).to.equal(index === 1 ? bid2.params.siteId : bid.params.siteId);
+        expect(ext.sid).to.equal(sidValue);
+      });
     });
 
     it('request should contain the extra banner ad sizes and their corresponding site ids when there is multiple ad units', function () {
@@ -1775,33 +1764,32 @@ describe('IndexexchangeAdapter', function () {
       bid.sizes = [[336, 280], [970, 90]]
       bid.mediaTypes.banner.sizes = [[336, 280], [970, 90]]
 
-      const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], bid], DEFAULT_OPTION)[0];
+      const bids = [DEFAULT_BANNER_VALID_BID[0], bid];
+      const request = spec.buildRequests(bids, DEFAULT_OPTION)[0];
 
       const impressions = JSON.parse(request.data.r).imp;
       expect(impressions).to.be.an('array');
-      expect(impressions).to.have.lengthOf(4);
-      expect(impressions[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impressions[1].ext.siteID).to.equal(bid.params.siteId);
-      expect(impressions[2].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
-      expect(impressions[3].ext.siteID).to.equal(bid.params.siteId);
+      expect(impressions).to.have.lengthOf(2);
+      expect(request.data.sn).to.be.undefined;
 
-      expect(impressions[0].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
-      expect(impressions[0].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
+      impressions.map((impression, impressionIndex) => {
+        const firstSizeObject = bids[impressionIndex].mediaTypes.banner.sizes[0];
 
-      expect(impressions[1].banner.w).to.equal(bid.params.size[0]);
-      expect(impressions[1].banner.h).to.equal(bid.params.size[1]);
+        expect(impression.banner.format).to.be.length(2);
+        expect(impression.banner.topframe).to.be.oneOf([0, 1]);
+        expect(impression.ext.siteID).to.equal(bids[impressionIndex].params.siteId);
+        expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray(firstSizeObject));
 
-      expect(impressions[2].banner.w).to.equal(DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][0]);
-      expect(impressions[2].banner.h).to.equal(DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][1]);
+        impression.banner.format.map(({ w, h, ext }, index) => {
+          const size = bids[impressionIndex].mediaTypes.banner.sizes[index];
+          const sidValue = utils.parseGPTSingleSizeArray(size);
 
-      expect(impressions[3].banner.w).to.equal(bid.mediaTypes.banner.sizes[1][0]);
-      expect(impressions[3].banner.h).to.equal(bid.mediaTypes.banner.sizes[1][1]);
-
-      expect(impressions[0].ext.sid).to.equal(`${DEFAULT_BANNER_VALID_BID[0].params.size[0].toString()}x${DEFAULT_BANNER_VALID_BID[0].params.size[1].toString()}`);
-      expect(impressions[1].ext.sid).to.equal(`${bid.params.size[0].toString()}x${bid.params.size[1].toString()}`);
-
-      expect(impressions[2].ext.sid).to.equal(`${DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][0].toString()}x${DEFAULT_BANNER_VALID_BID[0].mediaTypes.banner.sizes[1][1].toString()}`);
-      expect(impressions[3].ext.sid).to.equal(`${bid.mediaTypes.banner.sizes[1][0].toString()}x${bid.mediaTypes.banner.sizes[1][1].toString()}`);
+          expect(w).to.equal(size[0]);
+          expect(h).to.equal(size[1]);
+          expect(ext.siteID).to.equal(bids[impressionIndex].params.siteId.toString());
+          expect(ext.sid).to.equal(sidValue);
+        });
+      });
     });
 
     it('request should not contain the extra video ad sizes that IX is not configured for', function () {
@@ -1823,14 +1811,14 @@ describe('IndexexchangeAdapter', function () {
 
       it('request should not contain missing sizes if detectMissingSizes = false', function () {
         const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
-        bid1.mediaTypes.banner.sizes = div_many_sizes;
+        bid1.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
 
         const requests = spec.buildRequests([bid1, DEFAULT_BANNER_VALID_BID[0]], DEFAULT_OPTION);
 
         const impressions = JSON.parse(requests[0].data.r).imp;
 
         expect(impressions).to.be.an('array');
-        expect(impressions).to.have.lengthOf(2);
+        expect(impressions).to.have.lengthOf(1);
       });
     });
   });
@@ -1850,24 +1838,20 @@ describe('IndexexchangeAdapter', function () {
 
     it('impression should have correct format and value', function () {
       const impression = JSON.parse(query.r).imp[0];
-      const sidValue = `${DEFAULT_VIDEO_VALID_BID[0].params.size[0].toString()}x${DEFAULT_VIDEO_VALID_BID[0].params.size[1].toString()}`;
+      const sidValue = utils.parseGPTSingleSizeArray(DEFAULT_VIDEO_VALID_BID[0].params.size);
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
-      expect(impression.video).to.exist;
       expect(impression.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
       expect(impression.video.h).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[1]);
-      expect(impression.video.placement).to.exist;
       expect(impression.video.placement).to.equal(1);
       expect(impression.video.minduration).to.exist;
       expect(impression.video.minduration).to.equal(0);
-      expect(impression.video.mimes).to.exist;
       expect(impression.video.mimes[0]).to.equal('video/mp4');
       expect(impression.video.mimes[1]).to.equal('video/webm');
 
       expect(impression.video.skippable).to.equal(false);
-      expect(impression.ext).to.exist;
       expect(impression.ext.siteID).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.siteId.toString());
-      expect(impression.ext.sid).to.equal(sidValue); // TODO undefined - 400x600
+      expect(impression.ext.sid).to.equal(sidValue);
     });
 
     it('should not use default placement values when placement is defined at adUnit level', function () {
@@ -1901,7 +1885,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.video.placement).to.equal(4);
     });
 
-    it('should handle unexpected context', function() {
+    it('should handle unexpected context', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.context = 'VaccineJanssen';
       const request = spec.buildRequests([bid])[0];
@@ -1949,16 +1933,14 @@ describe('IndexexchangeAdapter', function () {
   });
 
   describe('buildRequestMultiFormat', function () {
-    describe('only banner bidder params set', function () {
+    it('only banner bidder params set', function () {
       const request = spec.buildRequests(DEFAULT_MULTIFORMAT_BANNER_VALID_BID)
-
-      const bannerImp = JSON.parse(request[0].data.r).imp[0];
-      expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(2);
+      const bannerImpression = JSON.parse(request[0].data.r).imp[0];
+      expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(1);
       expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
-      expect(bannerImp.id).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].bidId);
-      expect(bannerImp.banner).to.exist;
-      expect(bannerImp.banner.w).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[0]);
-      expect(bannerImp.banner.h).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[1]);
+      expect(bannerImpression.id).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].bidId);
+      expect(bannerImpression.banner.format[0].w).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[0]);
+      expect(bannerImpression.banner.format[0].h).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[1]);
     });
 
     describe('only video bidder params set', function () {
@@ -1968,10 +1950,10 @@ describe('IndexexchangeAdapter', function () {
         expect(JSON.parse(request[1].data.r).imp).to.have.lengthOf(1);
         expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
         expect(videoImp.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
-        expect(videoImp.video).to.exist;
         expect(videoImp.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[0]);
         expect(videoImp.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[1]);
       });
+
       it('should get missing sizes count 0 when params.size not used', function () {
         const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
         delete bid.params.size;
@@ -1981,25 +1963,46 @@ describe('IndexexchangeAdapter', function () {
         expect(diagObj.msi).to.equal(0);
       });
     });
+
     describe('both banner and video bidder params set', function () {
-      const request = spec.buildRequests([DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0], DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]]);
+      const bids = [DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0], DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]];
+      const request = spec.buildRequests(bids);
+
+      it('should return valid banner requests', function () {
+        const impressions = JSON.parse(request[0].data.r).imp;
+
+        expect(impressions).to.have.lengthOf(2);
+        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
+
+        impressions.map((impression, index) => {
+          const bid = bids[index];
+
+          expect(impression.id).to.equal(bid.bidId);
+          expect(impression.banner.format).to.be.length(bid.mediaTypes.banner.sizes.length);
+          expect(impression.banner.topframe).to.be.oneOf([0, 1]);
+          expect(impression.ext.siteID).to.equal(bid.params.siteId.toString());
+          expect(impression.ext.sid).to.equal(utils.parseGPTSingleSizeArray((bid.params.size)));
+
+          impression.banner.format.map(({ w, h, ext }, index) => {
+            const size = bid.mediaTypes.banner.sizes[index];
+            const sidValue = utils.parseGPTSingleSizeArray(size);
+
+            expect(w).to.equal(size[0]);
+            expect(h).to.equal(size[1]);
+            expect(ext.siteID).to.equal(bid.params.siteId.toString());
+            expect(ext.sid).to.equal(sidValue);
+          });
+        });
+      });
 
       it('should return valid banner and video requests', function () {
-        const bannerImp = JSON.parse(request[0].data.r).imp[0];
-        expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(4);
-        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
-        expect(bannerImp.id).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].bidId);
-        expect(bannerImp.banner).to.exist;
-        expect(bannerImp.banner.w).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[0]);
-        expect(bannerImp.banner.h).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[1]);
+        const videoImpression = JSON.parse(request[1].data.r).imp[0];
 
-        const videoImp = JSON.parse(request[1].data.r).imp[0];
         expect(JSON.parse(request[1].data.r).imp).to.have.lengthOf(1);
         expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
-        expect(videoImp.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
-        expect(videoImp.video).to.exist;
-        expect(videoImp.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[0]);
-        expect(videoImp.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[1]);
+        expect(videoImpression.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
+        expect(videoImpression.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[0]);
+        expect(videoImpression.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[1]);
       });
 
       it('should contain all correct IXdiag properties', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

In this PR, we are updating the `buildRequest` function to build requests using `imp[].banner.format`
