### PR TITLE
Documentation: fix undefined variable in postbid_prebidServer_example.html

### DIFF
--- a/integrationExamples/postbid/postbid_prebidServer_example.html
+++ b/integrationExamples/postbid/postbid_prebidServer_example.html
@@ -14,11 +14,12 @@
       })();
 
     pbjs.que.push(function() {
+        var sizes = [[300, 250]];
         var adUnits = [{
             code: 'postbid_iframe',
             mediaTypes: {
               banner: {
-                sizes: [[300, 250]]
+                sizes: sizes
               }
             },
             bids: [


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

This is extremely minor, it just makes the example page not blow up if the adapter doesn't bid, which generally only happens if you happen to load the test page on localhost:9999.  The bidsBackHandler assumes that sizes is defined in that execution path.