### PR TITLE
Prebid Server Bid Adapter: change debug flag to boolean

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -751,7 +751,7 @@ const OPEN_RTB_PROTOCOL = {
 
     // set debug flag if in debug mode
     if (getConfig('debug')) {
-      request.ext.prebid = Object.assign(request.ext.prebid, {debug: 1})
+      request.ext.prebid = Object.assign(request.ext.prebid, {debug: true})
     }
 
     // s2sConfig video.ext.prebid is passed through openrtb to PBS

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2730,5 +2730,16 @@ describe('S2S Adapter', function () {
 
       expect(requestBid.coopSync).to.be.undefined;
     });
+
+    it('adds debug flag', function () {
+      config.setConfig({debug: true});
+
+      let bidRequest = utils.deepClone(BID_REQUESTS);
+
+      adapter.callBids(REQUEST, bidRequest, addBidResponse, done, ajax);
+      let requestBid = JSON.parse(server.requests[0].requestBody);
+
+      expect(requestBid.ext.prebid.debug).is.equal(true);
+    });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X ] Bugfix


## Description of change

My definition in https://github.com/prebid/Prebid.js/issues/5986 was not specific enough to be successful. We ended up passing ext.prebid.debug:1 to PBS, but PBS-Go requires this to be a boolean.

Changing the data type and adding a unit test case.