### PR TITLE
VideoByte Bid Adapter: add new bid adapter

### DIFF
--- a/modules/videobyteBidAdapter.js
+++ b/modules/videobyteBidAdapter.js
@@ -1,0 +1,268 @@
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import * as utils from '../src/utils.js';
+import {VIDEO} from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'videobyte';
+const DEFAULT_BID_TTL = 300;
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_NET_REVENUE = true;
+const VIDEO_ORTB_PARAMS = [
+  'mimes',
+  'minduration',
+  'maxduration',
+  'placement',
+  'protocols',
+  'startdelay',
+  'skip',
+  'skipafter',
+  'minbitrate',
+  'maxbitrate',
+  'delivery',
+  'playbackmethod',
+  'api',
+  'linearity'
+];
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [VIDEO],
+  VERSION: '1.0.0',
+  ENDPOINT: 'https://x.videobyte.com/ortb/',
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bidRequest The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bidRequest) {
+    return validateVideo(bidRequest);
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param bidRequests - an array of bid requests
+   * @param bidderRequest
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (bidRequests, bidderRequest) {
+    if (!bidRequests) {
+      return;
+    }
+    return bidRequests.map(bidRequest => {
+      const {params} = bidRequest;
+      let pubId = params.pubId;
+      if (bidRequest.params.video && bidRequest.params.video.e2etest) {
+        utils.logMessage('E2E test mode enabled');
+        pubId = 'e2etest'
+      }
+      return {
+        method: 'POST',
+        url: spec.ENDPOINT + pubId,
+        data: JSON.stringify(buildRequestData(bidRequest, bidderRequest)),
+      }
+    });
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param bidRequest
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse) {
+    const bidResponses = [];
+    const response = (serverResponse || {}).body;
+    // one seat  with (optional) bids for each impression
+    if (response && response.seatbid && response.seatbid.length === 1 && response.seatbid[0].bid && response.seatbid[0].bid.length === 1) {
+      const bid = response.seatbid[0].bid[0]
+      if (bid.adm && bid.price) {
+        let bidResponse = {
+          requestId: response.id,
+          bidderCode: spec.code,
+          cpm: bid.price,
+          width: bid.w,
+          height: bid.h,
+          ttl: DEFAULT_BID_TTL,
+          creativeId: bid.crid,
+          netRevenue: DEFAULT_NET_REVENUE,
+          currency: DEFAULT_CURRENCY,
+          mediaType: 'video',
+          vastXml: bid.adm,
+          meta: {
+            advertiserDomains: bid.adomain
+          }
+        };
+        bidResponses.push(bidResponse)
+      }
+    } else {
+      utils.logError('invalid server response received');
+    }
+    return bidResponses;
+  },
+
+}
+
+// BUILD REQUESTS: VIDEO
+function buildRequestData(bidRequest, bidderRequest) {
+  const {params} = bidRequest;
+
+  const videoAdUnit = utils.deepAccess(bidRequest, 'mediaTypes.video', {});
+  const videoBidderParams = utils.deepAccess(bidRequest, 'params.video', {});
+
+  const videoParams = {
+    ...videoAdUnit,
+    ...videoBidderParams // Bidder Specific overrides
+  };
+
+  if (bidRequest.params.video && bidRequest.params.video.e2etest) {
+    videoParams.playerSize = [[640, 480]]
+    videoParams.conext = 'instream'
+  }
+
+  const video = {
+    w: parseInt(videoParams.playerSize[0][0], 10),
+    h: parseInt(videoParams.playerSize[0][1], 10),
+  }
+
+  // Obtain all ORTB params related video from Ad Unit
+  VIDEO_ORTB_PARAMS.forEach((param) => {
+    if (videoParams.hasOwnProperty(param)) {
+      video[param] = videoParams[param];
+    }
+  });
+
+  // Placement Inference Rules:
+  // - If no placement is defined then default to 1 (In Stream)
+  video.placement = video.placement || 2;
+
+  // - If product is instream (for instream context) then override placement to 1
+  if (params.context === 'instream') {
+    video.startdelay = video.startdelay || 0;
+    video.placement = 1;
+  }
+
+  // bid floor
+  const bidFloorRequest = {
+    currency: bidRequest.params.cur || 'USD',
+    mediaType: 'video',
+    size: '*'
+  };
+  let floorData = bidRequest.params
+  if (utils.isFn(bidRequest.getFloor)) {
+    floorData = bidRequest.getFloor(bidFloorRequest);
+  } else {
+    if (params.bidfloor) {
+      floorData = {floor: params.bidfloor, currency: params.currency || 'USD'};
+    }
+  }
+
+  const openrtbRequest = {
+    id: bidRequest.bidId,
+    imp: [
+      {
+        id: '1',
+        video: video,
+        secure: isSecure() ? 1 : 0,
+        bidfloor: floorData.floor,
+        bidfloorcur: floorData.currency
+      }
+    ],
+    site: {
+      domain: window.location.hostname,
+      page: window.location.href,
+      ref: bidRequest.refererInfo ? bidRequest.refererInfo.referer || null : null
+    },
+    ext: {
+      hb: 1,
+      prebidver: '$prebid.version$',
+      adapterver: spec.VERSION,
+    },
+  };
+
+  // content
+  if (videoParams.content && utils.isPlainObject(videoParams.content)) {
+    openrtbRequest.site.content = {};
+    const contentStringKeys = ['id', 'title', 'series', 'season', 'genre', 'contentrating', 'language'];
+    const contentNumberkeys = ['episode', 'prodq', 'context', 'livestream', 'len'];
+    const contentArrayKeys = ['cat'];
+    const contentObjectKeys = ['ext'];
+    for (const contentKey in videoBidderParams.content) {
+      if (
+        (contentStringKeys.indexOf(contentKey) > -1 && utils.isStr(videoParams.content[contentKey])) ||
+        (contentNumberkeys.indexOf(contentKey) > -1 && utils.isNumber(videoParams.content[contentKey])) ||
+        (contentObjectKeys.indexOf(contentKey) > -1 && utils.isPlainObject(videoParams.content[contentKey])) ||
+        (contentArrayKeys.indexOf(contentKey) > -1 && utils.isArray(videoParams.content[contentKey]) &&
+          videoParams.content[contentKey].every(catStr => utils.isStr(catStr)))) {
+        openrtbRequest.site.content[contentKey] = videoParams.content[contentKey];
+      } else {
+        utils.logMessage('videobyte bid adapter validation error: ', contentKey, ' is either not supported is OpenRTB V2.5 or value is undefined');
+      }
+    }
+  }
+
+  // adding schain object
+  if (bidRequest.schain) {
+    utils.deepSetValue(openrtbRequest, 'source.ext.schain', bidRequest.schain);
+    openrtbRequest.source.ext.schain.nodes[0].rid = openrtbRequest.id;
+  }
+
+  // Attaching GDPR Consent Params
+  if (bidderRequest.gdprConsent) {
+    utils.deepSetValue(openrtbRequest, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
+    utils.deepSetValue(openrtbRequest, 'regs.ext.gdpr', (bidderRequest.gdprConsent.gdprApplies ? 1 : 0));
+  }
+
+  // CCPA
+  if (bidderRequest.uspConsent) {
+    utils.deepSetValue(openrtbRequest, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+  }
+  return openrtbRequest;
+}
+
+function validateVideo(bidRequest) {
+  if (!bidRequest.params) {
+    return false;
+  }
+
+  if (!bidRequest.params.pubId) {
+    utils.logError('failed validation: publisher id not declared');
+    return false;
+  }
+
+  const videoAdUnit = utils.deepAccess(bidRequest, 'mediaTypes.video', {});
+  const videoBidderParams = utils.deepAccess(bidRequest, 'params.video', {});
+
+  if (videoBidderParams && videoBidderParams.e2etest) {
+    return true;
+  }
+
+  const videoParams = {
+    ...videoAdUnit,
+    ...videoBidderParams // Bidder Specific overrides
+  };
+
+  if (!videoParams.context) {
+    utils.logError('failed validation: context id not declared');
+    return false;
+  }
+  if (videoParams.context !== 'instream') {
+    utils.logError('failed validation: only context instream is supported ');
+    return false;
+  }
+
+  if (typeof videoParams.playerSize === 'undefined' || !Array.isArray(videoParams.playerSize) || !Array.isArray(videoParams.playerSize[0])) {
+    utils.logError('failed validation: player size not declared or is not in format [[w,h]]');
+    return false;
+  }
+
+  return true;
+}
+
+function isSecure() {
+  return document.location.protocol === 'https:';
+}
+
+registerBidder(spec);

--- a/modules/videobyteBidAdapter.md
+++ b/modules/videobyteBidAdapter.md
@@ -1,0 +1,78 @@
+# Overview
+
+```
+Module Name: VideoByte Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@videobyte.com
+```
+
+# Description
+
+Module that connects to VideoByte's demand sources
+
+*Note:* The Video SSP ad server will respond with an VAST XML to load into your defined player.
+
+## Instream Video adUnit using mediaTypes.video
+*Note:* By default, the adapter will read the mandatory parameters from mediaTypes.video.
+*Note:* The Video SSP ad server will respond with an VAST XML to load into your defined player.
+```
+  var adUnits = [
+    {
+        code: 'video1',
+          mediaTypes: {
+            video: {
+                  context: 'instream',
+                  playerSize: [640, 480],
+                  mimes: ['video/mp4', 'application/javascript'],
+                  protocols: [2,5],
+                  api: [2],
+                  position: 1,
+                  delivery: [2],
+                  minduration: 10,
+                  maxduration: 30,
+                  placement: 1,
+                  playbackmethod: [1,5],
+                  protocols: [2,5],
+                  api: [2],
+            }
+          },
+          bids: [
+            {
+              bidder: 'videobyte',
+              params: {
+                bidfloor: 0.5,
+                pubId: 'e2etest'
+              }
+            }
+          ]
+      }
+  ]
+```
+
+# End To End testing mode
+By passing bid.params.video.e2etest = true you will be able to receive a test creative
+
+```
+var adUnits = [
+    {
+      code: 'video-1',
+      mediaTypes: {
+        video: {
+          context: "instream",
+          playerSize: [[640, 480]],
+          mimes: ['video/mp4'],
+        }
+      },
+      bids: [
+        {
+          bidder: 'videobyte',
+          params: {
+            video: {
+              e2etest: true
+            }
+          }
+        }
+      ]
+    }
+]
+```

--- a/test/spec/modules/videobyteBidAdapter_spec.js
+++ b/test/spec/modules/videobyteBidAdapter_spec.js
@@ -563,4 +563,64 @@ describe('VideoByteBidAdapter', function () {
       expect(data.regs.ext.us_privacy).to.equal(bidderRequest.uspConsent);
     });
   });
+
+  describe('getUserSyncs', function () {
+    const ortbResponse = {
+      'body': {
+        'ext': {
+          'usersync': {
+            'sovrn': {
+              'status': 'none',
+              'syncs': [
+                {
+                  'url': 'urlsovrn',
+                  'type': 'iframe'
+                }
+              ]
+            },
+            'appnexus': {
+              'status': 'none',
+              'syncs': [
+                {
+                  'url': 'urlappnexus',
+                  'type': 'pixel'
+                }
+              ]
+            }
+          }
+        }
+      }
+    };
+    it('handles no parameters', function () {
+      let opts = spec.getUserSyncs({});
+      expect(opts).to.be.an('array').that.is.empty;
+    });
+    it('returns non if sync is not allowed', function () {
+      let opts = spec.getUserSyncs({iframeEnabled: false, pixelEnabled: false});
+
+      expect(opts).to.be.an('array').that.is.empty;
+    });
+
+    it('iframe sync enabled should return results', function () {
+      let opts = spec.getUserSyncs({iframeEnabled: true, pixelEnabled: false}, [ortbResponse]);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].type).to.equal('iframe');
+      expect(opts[0].url).to.equal(ortbResponse.body.ext.usersync['sovrn'].syncs[0].url);
+    });
+
+    it('pixel sync enabled should return results', function () {
+      let opts = spec.getUserSyncs({iframeEnabled: false, pixelEnabled: true}, [ortbResponse]);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].type).to.equal('image');
+      expect(opts[0].url).to.equal(ortbResponse.body.ext.usersync['appnexus'].syncs[0].url);
+    });
+
+    it('all sync enabled should return only iframe result', function () {
+      let opts = spec.getUserSyncs({iframeEnabled: true, pixelEnabled: true}, [ortbResponse]);
+
+      expect(opts.length).to.equal(1);
+    });
+  });
 });

--- a/test/spec/modules/videobyteBidAdapter_spec.js
+++ b/test/spec/modules/videobyteBidAdapter_spec.js
@@ -1,0 +1,566 @@
+import { expect } from 'chai';
+import { spec } from 'modules/videobyteBidAdapter.js';
+
+describe('VideoByteBidAdapter', function () {
+  let bidRequest;
+  let bidderRequest = {
+    'bidderCode': 'videobyte',
+    'auctionId': 'e158486f-8c7f-472f-94ce-b0cbfbb50ab4',
+    'bidderRequestId': '1e498b84fffc39',
+    'bids': bidRequest,
+    'auctionStart': 1520001292880,
+    'timeout': 3000,
+    'start': 1520001292884,
+    'doneCbCallCount': 0,
+    'refererInfo': {
+      'numIframes': 1,
+      'reachedTop': true,
+      'referer': 'test.com'
+    }
+  };
+  let mockConfig;
+
+  beforeEach(function () {
+    bidRequest = {
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [[640, 480]],
+        }
+      },
+      bidder: 'videobyte',
+      sizes: [640, 480],
+      bidId: '30b3efwfwe1e',
+      adUnitCode: 'video1',
+      params: {
+        video: {
+          playerWidth: 640,
+          playerHeight: 480,
+          mimes: ['video/mp4', 'application/javascript'],
+          protocols: [2, 5],
+          api: [2],
+          position: 1,
+          delivery: [2],
+          sid: 134,
+          rewarded: 1,
+          placement: 1,
+          hp: 1,
+          inventoryid: 123
+        },
+        site: {
+          id: 1,
+          page: 'https://test.com',
+          referrer: 'http://test.com'
+        },
+        pubId: 'vb12345'
+      }
+    };
+  });
+
+  describe('spec.isBidRequestValid', function () {
+    it('should return false when mediaTypes is empty', function () {
+      bidRequest.mediaTypes = {};
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+
+    it('should return true (skip validations) when e2etest = true', function () {
+      bidRequest.params.video = {
+        e2etest: true
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
+
+    it('should return true when mediaTypes.video has all mandatory params', function () {
+      bidRequest.mediaTypes.video = {
+        context: 'instream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4', 'application/javascript'],
+      }
+      bidRequest.params.video = {};
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
+
+    it('should return true when params.video has all override params instead of mediaTypes.video', function () {
+      bidRequest.mediaTypes.video = {
+        context: 'instream'
+      };
+      bidRequest.params.video = {
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4', 'application/javascript']
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
+
+    it('should return true when mimes is passed in params.video', function () {
+      bidRequest.mediaTypes.video = {
+        context: 'instream',
+        playerSize: [[640, 480]]
+      };
+      bidRequest.video = {
+        mimes: ['video/mp4', 'application/javascript']
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
+
+    it('should return false when both mediaTypes.video and params.video Objects are missing', function () {
+      bidRequest.mediaTypes = {};
+      bidRequest.params = {
+        pubId: 'brxd'
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+
+    it('should return false when both mediaTypes.video and params.video are missing mimes and player size', function () {
+      bidRequest.mediaTypes = {
+        video: {
+          context: 'instream'
+        }
+      };
+      bidRequest.params = {
+        pubId: 'brxd'
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+
+    it('should return false when the "pubId" param is missing', function () {
+      bidRequest.params = {
+        video: {
+          playerWidth: 480,
+          playerHeight: 640,
+          mimes: ['video/mp4', 'application/javascript'],
+        }
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+    it('should return false when the "pubId" param is missing', function () {
+      bidRequest.params = {
+        video: {
+          playerWidth: 480,
+          playerHeight: 640,
+          mimes: ['video/mp4', 'application/javascript'],
+        }
+      };
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+
+    it('should return false when no bid params are passed', function () {
+      bidRequest.params = {};
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+    });
+  });
+
+  describe('spec.buildRequests', function () {
+    it('should create a POST request for every bid', function () {
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.equal(spec.ENDPOINT + bidRequest.params.pubId);
+    });
+
+    it('should attach request data', function () {
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      const [width, height] = bidRequest.sizes;
+      const VERSION = '1.0.0';
+      expect(data.imp[0].video.w).to.equal(width);
+      expect(data.imp[0].video.h).to.equal(height);
+      expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);
+      expect(data.ext.prebidver).to.equal('$prebid.version$');
+      expect(data.ext.adapterver).to.equal(spec.VERSION);
+    });
+
+    it('should set pubId to e2etest when bid.params.video.e2etest = true', function () {
+      bidRequest.params.video.e2etest = true;
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.equal(spec.ENDPOINT + 'e2etest');
+    });
+
+    it('should attach End 2 End test data', function () {
+      bidRequest.params.video.e2etest = true;
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].bidfloor).to.not.exist;
+      expect(data.imp[0].video.w).to.equal(640);
+      expect(data.imp[0].video.h).to.equal(480);
+    });
+
+    it('should send Global schain', function () {
+      bidRequest.params.video.sid = null;
+      const globalSchain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [{
+          asi: 'some-platform.com',
+          sid: '111111',
+          rid: bidRequest.id,
+          hp: 1
+        }]
+      };
+      bidRequest.schain = globalSchain;
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      const schain = data.source.ext.schain;
+      expect(schain.nodes.length).to.equal(1);
+      expect(schain).to.deep.equal(globalSchain);
+    });
+
+    describe('content object validations', function () {
+      it('should not accept content object if value is Undefined ', function () {
+        bidRequest.params.video.content = null;
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.undefined;
+      });
+      it('should not accept content object if value is is Array ', function () {
+        bidRequest.params.video.content = [];
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.undefined;
+      });
+      it('should not accept content object if value is Number ', function () {
+        bidRequest.params.video.content = 123456;
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.undefined;
+      });
+      it('should not accept content object if value is String ', function () {
+        bidRequest.params.video.content = 'keyValuePairs';
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.undefined;
+      });
+      it('should not accept content object if value is Boolean ', function () {
+        bidRequest.params.video.content = true;
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.undefined;
+      });
+      it('should accept content object if value is Object ', function () {
+        bidRequest.params.video.content = {};
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.a('object');
+      });
+
+      it('should not append unsupported content object keys', function () {
+        bidRequest.params.video.content = {
+          fake: 'news',
+          unreal: 'param',
+          counterfit: 'data'
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.empty;
+      });
+
+      it('should not append content string parameters if value is not string ', function () {
+        bidRequest.params.video.content = {
+          id: 1234,
+          title: ['Title'],
+          series: ['Series'],
+          season: ['Season'],
+          genre: ['Genre'],
+          contentrating: {1: 'C-Rating'},
+          language: {1: 'EN'}
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
+      });
+      it('should not append content Number parameters if value is not Number ', function () {
+        bidRequest.params.video.content = {
+          episode: '1',
+          context: 'context',
+          livestream: {0: 'stream'},
+          len: [360],
+          prodq: [1],
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
+      });
+      it('should not append content Array parameters if value is not Array ', function () {
+        bidRequest.params.video.content = {
+          cat: 'categories',
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
+      });
+      it('should not append content ext if value is not Object ', function () {
+        bidRequest.params.video.content = {
+          ext: 'content.ext',
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.be.a('object');
+        expect(data.site.content).to.be.empty
+      });
+      it('should append supported parameters if value match validations ', function () {
+        bidRequest.params.video.content = {
+          id: '1234',
+          title: 'Title',
+          series: 'Series',
+          season: 'Season',
+          cat: [
+            'IAB1'
+          ],
+          genre: 'Genre',
+          contentrating: 'C-Rating',
+          language: 'EN',
+          episode: 1,
+          prodq: 1,
+          context: 1,
+          livestream: 0,
+          len: 360,
+          ext: {}
+        };
+        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const data = JSON.parse(requests[0].data);
+        expect(data.site.content).to.deep.equal(bidRequest.params.video.content);
+      });
+    });
+  });
+  describe('price floor module validations', function () {
+    beforeEach(function () {
+      bidRequest.getFloor = (floorObj) => {
+        return {
+          floor: bidRequest.floors.values[floorObj.mediaType + '|640x480'],
+          currency: floorObj.currency,
+          mediaType: floorObj.mediaType
+        }
+      }
+    });
+
+    it('should get bidfloor from getFloor method', function () {
+      bidRequest.params.cur = 'EUR';
+      bidRequest.floors = {
+        currency: 'EUR',
+        values: {
+          'video|640x480': 5.55
+        }
+      };
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].bidfloor).is.a('number');
+      expect(data.imp[0].bidfloor).to.equal(5.55);
+    });
+    it('should get bidfloor from params method', function () {
+      bidRequest.params.bidfloor = 4.0;
+      bidRequest.params.currency = 'EUR';
+      bidRequest.getFloor = null;
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].bidfloor).is.a('number');
+      expect(data.imp[0].bidfloor).to.equal(4.0);
+      expect(data.imp[0].bidfloorcur).to.equal('EUR');
+    });
+
+    it('should use adUnit/module currency & floor instead of bid.params.bidfloor', function () {
+      bidRequest.params.cur = 'EUR';
+      bidRequest.params.bidfloor = 3.33;
+      bidRequest.floors = {
+        currency: 'EUR',
+        values: {
+          'video|640x480': 5.55
+        }
+      };
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].bidfloor).is.a('number');
+      expect(data.imp[0].bidfloor).to.equal(5.55);
+    });
+
+    it('should load video floor when multi-format adUnit is present', function () {
+      bidRequest.params.cur = 'EUR';
+      bidRequest.mediaTypes.banner = {
+        sizes: [
+          [640, 480]
+        ]
+      };
+      bidRequest.floors = {
+        currency: 'EUR',
+        values: {
+          'banner|640x480': 2.22,
+          'video|640x480': 9.99
+        }
+      };
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].bidfloor).is.a('number');
+      expect(data.imp[0].bidfloor).to.equal(9.99);
+    })
+  })
+
+  describe('spec.interpretResponse', function () {
+    it('should return no bids if the response is not valid', function () {
+      const bidResponse = spec.interpretResponse({
+        body: null
+      }, {
+        bidRequest
+      });
+      expect(bidResponse.length).to.equal(0);
+    });
+
+    it('should return no bids if the response "nurl" and "adm" are missing', function () {
+      const serverResponse = {
+        seatbid: [{
+          bid: [{
+            price: 6.01
+          }]
+        }]
+      };
+      const bidResponse = spec.interpretResponse({
+        body: serverResponse
+      }, {
+        bidRequest
+      });
+      expect(bidResponse.length).to.equal(0);
+    });
+
+    it('should return no bids if the response "price" is missing', function () {
+      const serverResponse = {
+        seatbid: [{
+          bid: [{
+            adm: '<VAST></VAST>'
+          }]
+        }]
+      };
+      const bidResponse = spec.interpretResponse({
+        body: serverResponse
+      }, {
+        bidRequest
+      });
+      expect(bidResponse.length).to.equal(0);
+    });
+
+    it('should return a valid video bid response with just "adm"', function () {
+      const serverResponse = {
+        id: '123',
+        seatbid: [{
+          bid: [{
+            id: 1,
+            adid: 123,
+            crid: 2,
+            price: 6.01,
+            adm: '<VAST></VAST>',
+            adomain: [
+              'videobyte.com'
+            ],
+            w: 640,
+            h: 480
+          }]
+        }],
+        cur: 'USD'
+      };
+      const bidResponse = spec.interpretResponse({
+        body: serverResponse
+      }, {
+        bidRequest
+      });
+      let o = {
+        requestId: serverResponse.id,
+        bidderCode: spec.code,
+        cpm: serverResponse.seatbid[0].bid[0].price,
+        creativeId: serverResponse.seatbid[0].bid[0].crid,
+        vastXml: serverResponse.seatbid[0].bid[0].adm,
+        width: 640,
+        height: 480,
+        mediaType: 'video',
+        currency: 'USD',
+        ttl: 300,
+        netRevenue: true,
+        meta: {
+          advertiserDomains: ['videobyte.com']
+        }
+      };
+      expect(bidResponse[0]).to.deep.equal(o);
+    });
+
+    it('should default ttl to 300', function () {
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse[0].ttl).to.equal(300);
+    });
+    it('should not allow ttl above 3601, default to 300', function () {
+      bidRequest.params.video.ttl = 3601;
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse[0].ttl).to.equal(300);
+    });
+    it('should not allow ttl below 1, default to 300', function () {
+      bidRequest.params.video.ttl = 0;
+      const serverResponse = {seatbid: [{bid: [{id: 1, adid: 123, crid: 2, price: 6.01, adm: '<VAST></VAST>'}]}], cur: 'USD'};
+      const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
+      expect(bidResponse[0].ttl).to.equal(300);
+    });
+  });
+
+  describe('when GDPR and uspConsent applies', function () {
+    beforeEach(function () {
+      bidderRequest = {
+        'gdprConsent': {
+          'consentString': 'test-gdpr-consent-string',
+          'gdprApplies': true
+        },
+        'uspConsent': '1YN-',
+        'bidderCode': 'videobyte',
+        'auctionId': 'e158486f-8c7f-472f-94ce-b0cbfbb50ab4',
+        'bidderRequestId': '1e498b84fffc39',
+        'bids': bidRequest,
+        'auctionStart': 1520001292880,
+        'timeout': 3000,
+        'start': 1520001292884,
+        'doneCbCallCount': 0,
+        'refererInfo': {
+          'numIframes': 1,
+          'reachedTop': true,
+          'referer': 'test.com'
+        }
+      };
+
+      mockConfig = {
+        consentManagement: {
+          gdpr: {
+            cmpApi: 'iab',
+            timeout: 3000,
+            allowAuctionWithoutConsent: 'cancel'
+          },
+          usp: {
+            cmpApi: 'iab',
+            timeout: 1000,
+            allowAuctionWithoutConsent: 'cancel'
+          }
+        }
+      };
+    });
+
+    it('should send a signal to specify that GDPR applies to this request', function () {
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(request[0].data);
+      expect(data.regs.ext.gdpr).to.equal(1);
+    });
+
+    it('should send the consent string', function () {
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(request[0].data);
+      expect(data.user.ext.consent).to.equal(bidderRequest.gdprConsent.consentString);
+    });
+
+    it('should send the uspConsent string', function () {
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(request[0].data);
+      expect(data.regs.ext.us_privacy).to.equal(bidderRequest.uspConsent);
+    });
+
+    it('should send the uspConsent and GDPR ', function () {
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(request[0].data);
+      expect(data.regs.ext.gdpr).to.equal(1);
+      expect(data.regs.ext.us_privacy).to.equal(bidderRequest.uspConsent);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x ] New bidder adapter  

## Description of change
Adding VideoByte prebid adapter

- test parameters for validating bids
```
{
          bidder: 'videobyte',
          params: {
            video: {
              e2etest: true
            }
          }
}
```

- contact email of the adapter’s maintainer: prebid@videobyte.com

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/3040
