### PR TITLE
OneVideo Bid Adapter: bugfix for validation conflict

### DIFF
--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -52,12 +52,12 @@ export const spec = {
         utils.logError('Failed validation: Dynamic Ad Placement cannot be used with context Outstream (params.video.display=1)');
         return false;
       };
-    };
-
-    // DAP Validation
-    if (bid.mediaTypes.banner && bid.params.video && !bid.params.video.display) {
-      utils.logError('Failed validation: If you are trying to use Dynamic Ad Placement you must pass params.video.display=1');
-      return false;
+    } else if (bid.mediaTypes.banner) {
+      // DAP Validation
+      if (bid.mediaTypes.banner && bid.params.video && !bid.params.video.display) {
+        utils.logError('Failed validation: If you are trying to use Dynamic Ad Placement you must pass params.video.display=1');
+        return false;
+      };
     };
 
     // Publisher Id (Exchange) validation

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -4,7 +4,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'oneVideo';
 export const spec = {
   code: 'oneVideo',
-  VERSION: '3.1.1',
+  VERSION: '3.1.2',
   ENDPOINT: 'https://ads.adaptv.advertising.com/rtb/openrtb?ext_id=',
   E2ETESTENDPOINT: 'https://ads-wc.v.ssp.yahoo.com/rtb/openrtb?ext_id=',
   SYNC_ENDPOINT1: 'https://pixel.advertising.com/ups/57304/sync?gdpr=&gdpr_consent=&_origin=0&redir=true',

--- a/modules/oneVideoBidAdapter.js
+++ b/modules/oneVideoBidAdapter.js
@@ -52,12 +52,6 @@ export const spec = {
         utils.logError('Failed validation: Dynamic Ad Placement cannot be used with context Outstream (params.video.display=1)');
         return false;
       };
-    } else if (bid.mediaTypes.banner) {
-      // DAP Validation
-      if (bid.mediaTypes.banner && bid.params.video && !bid.params.video.display) {
-        utils.logError('Failed validation: If you are trying to use Dynamic Ad Placement you must pass params.video.display=1');
-        return false;
-      };
     };
 
     // Publisher Id (Exchange) validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prebid.js",
-  "version": "5.1.0-pre",
+  "version": "5.2.0-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "5.1.0-pre",
+      "version": "5.2.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",
@@ -88,7 +88,7 @@
         "lodash": "^4.17.21",
         "mocha": "^5.0.0",
         "morgan": "^1.10.0",
-        "opn": "^6.0.0",
+        "open": "^8.2.0",
         "resolve-from": "^5.0.0",
         "sinon": "^4.1.3",
         "through2": "^4.0.2",
@@ -7876,6 +7876,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -19729,6 +19738,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+      "dev": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
@@ -19736,28 +19762,6 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/opn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-      "deprecated": "The package has been renamed to `open`",
-      "dev": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/opn/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/optimist": {
@@ -33999,6 +34003,12 @@
       "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -43623,28 +43633,22 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
-    },
-    "opn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
-      },
-      "dependencies": {
-        "is-wsl": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-          "dev": true
-        }
-      }
     },
     "optimist": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prebid.js",
-  "version": "5.2.0-pre",
+  "version": "5.1.0-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "5.2.0-pre",
+      "version": "5.1.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",
@@ -88,7 +88,7 @@
         "lodash": "^4.17.21",
         "mocha": "^5.0.0",
         "morgan": "^1.10.0",
-        "open": "^8.2.0",
+        "opn": "^6.0.0",
         "resolve-from": "^5.0.0",
         "sinon": "^4.1.3",
         "through2": "^4.0.2",
@@ -7876,15 +7876,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -19738,23 +19729,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
-      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
-      "dev": true,
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
@@ -19762,6 +19736,28 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/opn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+      "deprecated": "The package has been renamed to `open`",
+      "dev": true,
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/opn/node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/optimist": {
@@ -34003,12 +33999,6 @@
       "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
       "dev": true
     },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -43633,22 +43623,28 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "open": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
-      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
-      "dev": true,
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      }
-    },
     "opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
+    },
+    "opn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+          "dev": true
+        }
+      }
     },
     "optimist": {
       "version": "0.6.1",

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -237,11 +237,12 @@ describe('OneVideoBidAdapter', function () {
           },
           video: {
             context: 'outstream',
-            playerSize: [640, 480]
+            playerSize: [640, 480],
+            mimes: ['video/mp4', 'application/javascript'],
           }
         }
       }
-      expect(spec.isBidRequestValid(bidRequest)).to.equal(false);
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     })
   });
 

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -238,10 +238,25 @@ describe('OneVideoBidAdapter', function () {
           video: {
             context: 'outstream',
             playerSize: [640, 480],
-            mimes: ['video/mp4', 'application/javascript'],
+            mimes: ['video/mp4', 'application/javascript']
           }
+        },
+        bidder: 'oneVideo',
+        sizes: [640, 480],
+        bidId: '30b3efwfwe1e',
+        adUnitCode: 'video1',
+        params: {
+          video: {
+            protocols: [2, 5],
+            api: [2]
+          },
+          site: {
+            page: 'https://news.yahoo.com/portfolios',
+            referrer: 'http://www.yahoo.com'
+          },
+          pubId: 'brxd'
         }
-      }
+      };
       expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
     })
   });

--- a/test/spec/modules/oneVideoBidAdapter_spec.js
+++ b/test/spec/modules/oneVideoBidAdapter_spec.js
@@ -280,7 +280,7 @@ describe('OneVideoBidAdapter', function () {
       const placement = bidRequest.params.video.placement;
       const rewarded = bidRequest.params.video.rewarded;
       const inventoryid = bidRequest.params.video.inventoryid;
-      const VERSION = '3.1.1';
+      const VERSION = '3.1.2';
       expect(data.imp[0].video.w).to.equal(width);
       expect(data.imp[0].video.h).to.equal(height);
       expect(data.imp[0].bidfloor).to.equal(bidRequest.params.bidfloor);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Urgent fix to validation conflict between our Dynamic Ad Placement validation and Multi-Format ad unit support.
We have removed the faulty DAP validation.

<!-- For new bidder adapters, please provide the following -->
This test is to validate that the adapter fires a bid-request to HBExchange when the adUnit has more that just mediaTypes.video.
No need to get a response.
```
const videoAdUnits = [{
            code: 'video1',
            mediaTypes: {
                video: {
                    context: 'outstream',
                    playerSize: [640, 480],
                    mimes: ['video/mp4', 'application/javascript']
                },
                banner: {
                    sizes: [[620,1],[620,350]]
                }
            },
            bids: [{
                bidder: 'oneVideo',
                params: {
                    video: {
                        protocols: [2, 5, 6],
                        api: [2],
                        placement: 1,
                    },
                    pubId: 'HBExchange'
                }
            }]
        }];
```

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Hi @DeepthiNeeladri & @kprasadpvv,
Could you please review as soon as possible. 
We have a partner that is affected by this.

Thanks in advance!
Adam