### PR TITLE
Finteza Analytics Adapter: bugfix for failing unit tests

### DIFF
--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -76,10 +76,10 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_REQUESTED, bidRequest);
 
-        expect(server.requests.length).to.equal(1);
-
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);
+
+        expect(server.requests.length).to.equal(1);
 
         const url = parseUrl(server.requests[0].url);
 

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -119,10 +119,11 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
 
-        expect(server.requests.length).to.equal(3);
 
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);
+        
+        expect(server.requests.length).to.equal(2);
 
         let url = parseUrl(server.requests[0].url);
 

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -119,7 +119,7 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
 
-        expect(server.requests.length).to.equal(2);
+        expect(server.requests.length).to.equal(3);
 
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -173,10 +173,10 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_WON, bidWon);
 
-        expect(server.requests.length).to.equal(1);
-
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);
+
+        expect(server.requests.length).to.equal(1);
 
         const url = parseUrl(server.requests[0].url);
 
@@ -212,10 +212,10 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_TIMEOUT, bidTimeout);
 
-        expect(server.requests.length).to.equal(1);
-
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);
+
+        expect(server.requests.length).to.equal(1);
 
         const url = parseUrl(server.requests[0].url);
 

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -119,10 +119,9 @@ describe('finteza analytics adapter', function () {
         // Emit the events with the "real" arguments
         events.emit(constants.EVENTS.BID_RESPONSE, bidResponse);
 
-
         expect(server.requests[0].method).to.equal('GET');
         expect(server.requests[0].withCredentials).to.equal(true);
-        
+
         expect(server.requests.length).to.equal(2);
 
         let url = parseUrl(server.requests[0].url);


### PR DESCRIPTION
The Finteza analytics adapter seems to be periodically failing due to occasional container latency. Adding before hooks to solve flakiness