### PR TITLE
Prebid Core: add AD_RENDER_SUCCEEDED event

### DIFF
--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -18,6 +18,7 @@ const {
     BIDDER_DONE,
     SET_TARGETING,
     AD_RENDER_FAILED,
+    AD_RENDER_SUCCEEDED,
     AUCTION_DEBUG,
     ADD_AD_UNITS
   }
@@ -113,6 +114,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
         [SET_TARGETING]: args => this.enqueue({ eventType: SET_TARGETING, args }),
         [AUCTION_END]: args => this.enqueue({ eventType: AUCTION_END, args }),
         [AD_RENDER_FAILED]: args => this.enqueue({ eventType: AD_RENDER_FAILED, args }),
+        [AD_RENDER_SUCCEEDED]: args => this.enqueue({ eventType: AD_RENDER_SUCCEEDED, args }),
         [AUCTION_DEBUG]: args => this.enqueue({ eventType: AUCTION_DEBUG, args }),
         [ADD_AD_UNITS]: args => this.enqueue({ eventType: ADD_AD_UNITS, args }),
         [AUCTION_INIT]: args => {

--- a/src/constants.json
+++ b/src/constants.json
@@ -37,6 +37,7 @@
     "REQUEST_BIDS": "requestBids",
     "ADD_AD_UNITS": "addAdUnits",
     "AD_RENDER_FAILED": "adRenderFailed",
+    "AD_RENDER_SUCCEEDED": "adRenderSucceeded",
     "TCF2_ENFORCEMENT": "tcf2Enforcement",
     "AUCTION_DEBUG": "auctionDebug",
     "BID_VIEWABLE": "bidViewable",

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -9,6 +9,7 @@ const BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
 const BID_WON = CONSTANTS.EVENTS.BID_WON;
 const BID_TIMEOUT = CONSTANTS.EVENTS.BID_TIMEOUT;
 const AD_RENDER_FAILED = CONSTANTS.EVENTS.AD_RENDER_FAILED;
+const AD_RENDER_SUCCEEDED = CONSTANTS.EVENTS.AD_RENDER_SUCCEEDED;
 const AUCTION_DEBUG = CONSTANTS.EVENTS.AUCTION_DEBUG;
 const ADD_AD_UNITS = CONSTANTS.EVENTS.ADD_AD_UNITS;
 
@@ -84,6 +85,17 @@ FEATURE: Analytics Adapters API
 
       let result = JSON.parse(server.requests[0].requestBody);
       expect(result).to.deep.equal({args: {call: 'adRenderFailed'}, eventType: 'adRenderFailed'});
+    });
+
+    it('SHOULD call global when a adRenderSucceeded event occurs', function () {
+      const eventType = AD_RENDER_SUCCEEDED;
+      const args = { call: 'adRenderSucceeded' };
+
+      adapter.enableAnalytics();
+      events.emit(eventType, args);
+
+      let result = JSON.parse(server.requests[0].requestBody);
+      expect(result).to.deep.equal({args: {call: 'adRenderSucceeded'}, eventType: 'adRenderSucceeded'});
     });
 
     it('SHOULD call global when an auction debug event occurs', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change

This adds a new event, AD_RENDER_SUCCEEDED, which is emited by renderAd when rendering is successful. It also adds a test in the same manner as the tests that exist for AD_RENDER_FAILED.

doc patch: https://github.com/prebid/prebid.github.io/pull/3045

## Other information

This is related to work to enable #6909