### PR TITLE
Halo RTD Module: Enable Per-Bidder Data

### DIFF
--- a/modules/haloRtdProvider.js
+++ b/modules/haloRtdProvider.js
@@ -80,7 +80,9 @@ export function addRealTimeData(bidConfig, rtd, rtdConfig) {
     if (isPlainObject(rtd.ortb2b)) {
       let bidderConfig = config.getBidderConfig();
 
-      for (const [bidder, rtdOptions] of Object.entries(rtd.ortb2b)) {
+      Object.keys(rtd.ortb2b).forEach(bidder => {
+        let rtdOptions = rtd.ortb2b[bidder] || {};
+
         let bidderOptions = {};
         if (isPlainObject(bidderConfig[bidder])) {
           bidderOptions = bidderConfig[bidder];
@@ -90,7 +92,7 @@ export function addRealTimeData(bidConfig, rtd, rtdConfig) {
           bidders: [bidder],
           config: mergeLazy(bidderOptions, rtdOptions)
         })
-      }
+      });
     }
   }
 }

--- a/modules/haloRtdProvider.js
+++ b/modules/haloRtdProvider.js
@@ -72,7 +72,7 @@ export function addRealTimeData(bidConfig, rtd, rtdConfig) {
   if (rtdConfig.params && rtdConfig.params.handleRtd) {
     rtdConfig.params.handleRtd(bidConfig, rtd, rtdConfig, config);
   } else {
-    if (rtd.ortb2) {
+    if (isPlainObject(rtd.ortb2)) {
       let ortb2 = config.getConfig('ortb2') || {};
       config.setConfig({ortb2: mergeLazy(ortb2, rtd.ortb2)});
     }

--- a/modules/haloRtdProvider.js
+++ b/modules/haloRtdProvider.js
@@ -91,7 +91,7 @@ export function addRealTimeData(bidConfig, rtd, rtdConfig) {
         config.setBidderConfig({
           bidders: [bidder],
           config: mergeLazy(bidderOptions, rtdOptions)
-        })
+        });
       });
     }
   }

--- a/modules/haloRtdProvider.js
+++ b/modules/haloRtdProvider.js
@@ -69,12 +69,29 @@ function paramOrDefault(param, defaultVal, arg) {
  * @param {Object} rtdConfig
  */
 export function addRealTimeData(bidConfig, rtd, rtdConfig) {
-  let ortb2 = config.getConfig('ortb2') || {};
-
   if (rtdConfig.params && rtdConfig.params.handleRtd) {
     rtdConfig.params.handleRtd(bidConfig, rtd, rtdConfig, config);
-  } else if (rtd.ortb2) {
-    config.setConfig({ortb2: mergeLazy(ortb2, rtd.ortb2)});
+  } else {
+    if (rtd.ortb2) {
+      let ortb2 = config.getConfig('ortb2') || {};
+      config.setConfig({ortb2: mergeLazy(ortb2, rtd.ortb2)});
+    }
+
+    if (isPlainObject(rtd.ortb2b)) {
+      let bidderConfig = config.getBidderConfig();
+
+      for (const [bidder, rtdOptions] of Object.entries(rtd.ortb2b)) {
+        let bidderOptions = {};
+        if (isPlainObject(bidderConfig[bidder])) {
+          bidderOptions = bidderConfig[bidder];
+        }
+
+        config.setBidderConfig({
+          bidders: [bidder],
+          config: mergeLazy(bidderOptions, rtdOptions)
+        })
+      }
+    }
   }
 }
 

--- a/modules/haloRtdProvider.md
+++ b/modules/haloRtdProvider.md
@@ -4,13 +4,9 @@ Audigent is a next-generation data management platform and a first-of-a-kind
 "data agency" containing some of the most exclusive content-consuming audiences
 across desktop, mobile and social platforms.
 
-This real-time data module provides quality segmentation that can be
-provided to bid request objects destined for different SSPs in order to optimize
-targeting. Audigent maintains a large database of first-party Tradedesk Unified
-ID, Audigent Halo ID and other id provider mappings to various third-party
-segment types that are utilizable across different SSPs.  With this module,
-these segments and other data can be retrieved and supplied to your pages
-and the bidstream in real-time during the bid request cycle.
+This real-time data module provides quality first-party data, contextual data, 
+site-level data and more that can be injected into bid request objects destined 
+for different bidders in order to optimize targeting.
 
 ### Publisher Usage
 
@@ -29,7 +25,7 @@ and segment configurations.
 pbjs.setConfig(
     ...
     realTimeData: {
-        auctionDelay: auctionDelay,
+        auctionDelay: 5000,
         dataProviders: [
             {
                 name: "halo",

--- a/test/spec/modules/haloRtdProvider_spec.js
+++ b/test/spec/modules/haloRtdProvider_spec.js
@@ -114,13 +114,195 @@ describe('haloRtdProvider', function() {
         }
       };
 
-      let pbConfig = config.getConfig();
       addRealTimeData(bidConfig, rtd, rtdConfig);
 
       let ortb2Config = config.getConfig().ortb2;
 
       expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1, setConfigUserObj2, rtdUserObj1]);
       expect(ortb2Config.site.content.data).to.deep.include.members([setConfigSiteObj1, rtdSiteObj1]);
+    });
+
+    it('merges bidder-specific ortb2 data', function() {
+      let rtdConfig = {};
+      let bidConfig = {};
+
+      const configUserObj1 = {
+        name: 'www.dataprovider1.com',
+        ext: { segtax: 3 },
+        segment: [{
+          id: '1776'
+        }]
+      };
+
+      const configUserObj2 = {
+        name: 'www.dataprovider2.com',
+        ext: { segtax: 3 },
+        segment: [{
+          id: '1914'
+        }]
+      };
+
+      const configUserObj3 = {
+        name: 'www.dataprovider1.com',
+        ext: { segtax: 3 },
+        segment: [{
+          id: '2003'
+        }]
+      };
+
+      const configSiteObj1 = {
+        name: 'www.dataprovider3.com',
+        ext: {
+          segtax: 1
+        },
+        segment: [
+          {
+            id: '1812'
+          },
+          {
+            id: '1955'
+          }
+        ]
+      };
+
+      const configSiteObj2 = {
+        name: 'www.dataprovider3.com',
+        ext: {
+          segtax: 1
+        },
+        segment: [
+          {
+            id: '1812'
+          }
+        ]
+      };
+
+      config.setBidderConfig({
+        bidders: ['adbuzz'],
+        config: {
+          ortb2: {
+            user: {
+              data: [configUserObj1, configUserObj2]
+            },
+            site: {
+              content: {
+                data: [configSiteObj1]
+              }
+            }
+          }
+        }
+      });
+
+      config.setBidderConfig({
+        bidders: ['pubvisage'],
+        config: {
+          ortb2: {
+            user: {
+              data: [configUserObj3]
+            },
+            site: {
+              content: {
+                data: [configSiteObj2]
+              }
+            }
+          }
+        }
+      });
+
+      const rtdUserObj1 = {
+        name: 'www.dataprovider4.com',
+        ext: {
+          segtax: 501
+        },
+        segment: [
+          {
+            id: '1918'
+          },
+          {
+            id: '1939'
+          }
+        ]
+      };
+
+      const rtdUserObj2 = {
+        name: 'www.dataprovider2.com',
+        ext: {
+          segtax: 502
+        },
+        segment: [
+          {
+            id: '1939'
+          }
+        ]
+      };
+
+      const rtdSiteObj1 = {
+        name: 'www.dataprovider5.com',
+        ext: {
+          segtax: 1
+        },
+        segment: [
+          {
+            id: '441'
+          },
+          {
+            id: '442'
+          }
+        ]
+      };
+
+      const rtdSiteObj2 = {
+        name: 'www.dataprovider6.com',
+        ext: {
+          segtax: 2
+        },
+        segment: [
+          {
+            id: '676'
+          }
+        ]
+      };
+
+      const rtd = {
+        ortb2b: {
+          adbuzz: {
+            ortb2: {
+              user: {
+                data: [rtdUserObj1]
+              },
+              site: {
+                content: {
+                  data: [rtdSiteObj1]
+                }
+              }
+            }
+          },
+          pubvisage: {
+            ortb2: {
+              user: {
+                data: [rtdUserObj2]
+              },
+              site: {
+                content: {
+                  data: [rtdSiteObj2]
+                }
+              }
+            }
+          }
+        }
+      };
+
+      addRealTimeData(bidConfig, rtd, rtdConfig);
+
+      let ortb2Config = config.getBidderConfig().adbuzz.ortb2;
+
+      expect(ortb2Config.user.data).to.deep.include.members([configUserObj1, configUserObj2, rtdUserObj1]);
+      expect(ortb2Config.site.content.data).to.deep.include.members([configSiteObj1, rtdSiteObj1]);
+
+      ortb2Config = config.getBidderConfig().pubvisage.ortb2;
+
+      expect(ortb2Config.user.data).to.deep.include.members([configUserObj3, rtdUserObj2]);
+      expect(ortb2Config.site.content.data).to.deep.include.members([configSiteObj2, rtdSiteObj2]);
     });
 
     it('allows publisher defined rtd ortb2 logic', function() {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
This small changeset allows ortb2 data specific to individual bidders to be merged into those bidder's configs as opposed to just the global ortb2 config object.

- contact email of the adapter’s maintainer
prebid@audigent.com

## Other information
Halo RTD Module: FPD 2.0 Updates & add ID system tests: https://github.com/prebid/Prebid.js/pull/6505
Fpd 2.0 Update: https://github.com/prebid/Prebid.js/pull/6293
