### PR TITLE
Adagio Bid Adapter: add support for Prebid Server

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -157,13 +157,18 @@ export function getAdagioScript() {
     if (isValid) {
       loadExternalScript(ADAGIO_TAG_URL, BIDDER_CODE);
     } else {
-      // ensure adagio removing for next time.
-      // It's an antipattern regarding the TCF2 enforcement logic
-      // but it's the only way to respect the user choice update.
-      window.localStorage.removeItem(ADAGIO_LOCALSTORAGE_KEY);
-      // Extra data from external script.
-      // This key is removed only if localStorage is not accessible.
-      window.localStorage.removeItem('adagio');
+      // Try-catch to avoid error when 3rd party cookies is disabled (e.g. in privacy mode)
+      try {
+        // ensure adagio removing for next time.
+        // It's an antipattern regarding the TCF2 enforcement logic
+        // but it's the only way to respect the user choice update.
+        window.localStorage.removeItem(ADAGIO_LOCALSTORAGE_KEY);
+        // Extra data from external script.
+        // This key is removed only if localStorage is not accessible.
+        window.localStorage.removeItem('adagio');
+      } catch (e) {
+        utils.logInfo(`${LOG_PREFIX} unable to clear Adagio scripts from localstorage.`);
+      }
     }
   });
 }

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -84,7 +84,7 @@ export const GlobalExchange = (function() {
 
     prepareExchangeData(storageValue) {
       const adagioStorage = JSON.parse(storageValue, function(name, value) {
-        if (!name.startsWith('_') || name === '') {
+        if (name.charAt(0) !== '_' || name === '') {
           return value;
         }
       });
@@ -796,7 +796,7 @@ function getPrintNumber(adUnitCode, bidderRequest) {
   if (!bidderRequest.bids || !bidderRequest.bids.length) {
     return 1;
   }
-  const adagioBid = bidderRequest.bids.find(bid => bid.adUnitCode === adUnitCode);
+  const adagioBid = find(bidderRequest.bids, bid => bid.adUnitCode === adUnitCode);
   return adagioBid.bidRequestsCount || 1;
 }
 
@@ -1065,8 +1065,8 @@ export const spec = {
    * @returns {object} updated params
    */
   transformBidParams(params, isOrtb, adUnit, bidRequests) {
-    const adagioBidderRequest = bidRequests.find(bidRequest => bidRequest.bidderCode === 'adagio');
-    const adagioBid = adagioBidderRequest.bids.find(bid => bid.adUnitCode === adUnit.code);
+    const adagioBidderRequest = find(bidRequests, bidRequest => bidRequest.bidderCode === 'adagio');
+    const adagioBid = find(adagioBidderRequest.bids, bid => bid.adUnitCode === adUnit.code);
 
     if (isOrtb) {
       autoFillParams(adagioBid);

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -12,7 +12,6 @@ import { Renderer } from '../src/Renderer.js';
 import { OUTSTREAM } from '../src/video.js';
 const BIDDER_CODE = 'adagio';
 const LOG_PREFIX = 'Adagio:';
-export const VERSION = '2.11.0';
 const FEATURES_VERSION = '1';
 export const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
@@ -58,7 +57,66 @@ export const ORTB_VIDEO_PARAMS = {
 
 let currentWindow;
 
-const EXT_DATA = {}
+export const GlobalExchange = (function() {
+  let features;
+  let exchangeData = {};
+
+  return {
+    clearFeatures: function() {
+      features = undefined;
+    },
+
+    clearExchangeData: function() {
+      exchangeData = {};
+    },
+
+    getOrSetGlobalFeatures: function () {
+      if (!features) {
+        features = {
+          page_dimensions: getPageDimensions().toString(),
+          viewport_dimensions: getViewPortDimensions().toString(),
+          user_timestamp: getTimestampUTC().toString(),
+          dom_loading: getDomLoadingDuration().toString(),
+        }
+      }
+      return features;
+    },
+
+    prepareExchangeData(storageValue) {
+      const adagioStorage = JSON.parse(storageValue, function(name, value) {
+        if (!name.startsWith('_') || name === '') {
+          return value;
+        }
+      });
+      let random = utils.deepAccess(adagioStorage, 'session.rnd');
+      let newSession = false;
+
+      if (internal.isNewSession(adagioStorage)) {
+        newSession = true;
+        random = Math.random();
+      }
+
+      const data = {
+        session: {
+          new: newSession,
+          rnd: random
+        }
+      }
+
+      utils.mergeDeep(exchangeData, adagioStorage, data);
+
+      internal.enqueue({
+        action: 'session',
+        ts: Date.now(),
+        data: exchangeData
+      });
+    },
+
+    getExchangeData() {
+      return exchangeData
+    }
+  };
+})();
 
 export function adagioScriptFromLocalStorageCb(ls) {
   try {
@@ -129,37 +187,6 @@ function isSafeFrameWindow() {
   return !!(ws.$sf && ws.$sf.ext);
 }
 
-// Get localStorage "adagio" data to be passed to the request
-export function prepareExchange(storageValue) {
-  const adagioStorage = JSON.parse(storageValue, function(name, value) {
-    if (!name.startsWith('_') || name === '') {
-      return value;
-    }
-  });
-  let random = utils.deepAccess(adagioStorage, 'session.rnd');
-  let newSession = false;
-
-  if (internal.isNewSession(adagioStorage)) {
-    newSession = true;
-    random = Math.random();
-  }
-
-  const data = {
-    session: {
-      new: newSession,
-      rnd: random
-    }
-  }
-
-  utils.mergeDeep(EXT_DATA, adagioStorage, data);
-
-  internal.enqueue({
-    action: 'session',
-    ts: Date.now(),
-    data: EXT_DATA
-  });
-}
-
 function initAdagio() {
   if (canAccessTopWindow()) {
     currentWindow = (canAccessTopWindow()) ? utils.getWindowTop() : utils.getWindowSelf();
@@ -172,12 +199,12 @@ function initAdagio() {
   w.ADAGIO.pbjsAdUnits = w.ADAGIO.pbjsAdUnits || [];
   w.ADAGIO.queue = w.ADAGIO.queue || [];
   w.ADAGIO.versions = w.ADAGIO.versions || {};
-  w.ADAGIO.versions.adagioBidderAdapter = VERSION;
+  w.ADAGIO.versions.pbjs = '$prebid.version$';
   w.ADAGIO.isSafeFrameWindow = isSafeFrameWindow();
 
   storage.getDataFromLocalStorage('adagio', (storageData) => {
     try {
-      internal.prepareExchange(storageData);
+      GlobalExchange.prepareExchangeData(storageData);
     } catch (e) {
       utils.logError(LOG_PREFIX, e);
     }
@@ -186,229 +213,12 @@ function initAdagio() {
   getAdagioScript();
 }
 
-export const _features = {
-  getPrintNumber(adUnitCode) {
-    const adagioAdUnit = internal.getOrAddAdagioAdUnit(adUnitCode);
-    return adagioAdUnit.printNumber || 1;
-  },
-
-  getPageDimensions() {
-    if (isSafeFrameWindow() || !canAccessTopWindow()) {
-      return '';
-    }
-
-    // the page dimension can be computed on window.top only.
-    const wt = utils.getWindowTop();
-    const body = wt.document.querySelector('body');
-
-    if (!body) {
-      return '';
-    }
-    const html = wt.document.documentElement;
-    const pageWidth = Math.max(body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollWidth, html.offsetWidth);
-    const pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
-
-    return `${pageWidth}x${pageHeight}`;
-  },
-
-  getViewPortDimensions() {
-    if (!isSafeFrameWindow() && !canAccessTopWindow()) {
-      return '';
-    }
-
-    const viewportDims = { w: 0, h: 0 };
-
-    if (isSafeFrameWindow()) {
-      const ws = utils.getWindowSelf();
-
-      if (typeof ws.$sf.ext.geom !== 'function') {
-        utils.logWarn(`${LOG_PREFIX} cannot use the $sf.ext.geom() safeFrame API method`);
-        return '';
-      }
-
-      const sfGeom = ws.$sf.ext.geom().win;
-      viewportDims.w = Math.round(sfGeom.w);
-      viewportDims.h = Math.round(sfGeom.h);
-    } else {
-      // window.top based computing
-      const wt = utils.getWindowTop();
-
-      if (wt.innerWidth) {
-        viewportDims.w = wt.innerWidth;
-        viewportDims.h = wt.innerHeight;
-      } else {
-        const d = wt.document;
-        const body = d.querySelector('body');
-
-        if (!body) {
-          return '';
-        }
-
-        viewportDims.w = d.querySelector('body').clientWidth;
-        viewportDims.h = d.querySelector('body').clientHeight;
-      }
-    }
-
-    return `${viewportDims.w}x${viewportDims.h}`;
-  },
-
-  /**
-   * domLoading feature is computed on window.top if reachable.
-   */
-  getDomLoadingDuration() {
-    let domLoadingDuration = -1;
-    let performance;
-
-    performance = (canAccessTopWindow()) ? utils.getWindowTop().performance : utils.getWindowSelf().performance;
-
-    if (performance && performance.timing && performance.timing.navigationStart > 0) {
-      const val = performance.timing.domLoading - performance.timing.navigationStart;
-      if (val > 0) {
-        domLoadingDuration = val;
-      }
-    }
-
-    return domLoadingDuration;
-  },
-
-  getSlotPosition(params) {
-    const { adUnitElementId, postBid } = params;
-
-    if (!adUnitElementId) {
-      return '';
-    }
-
-    if (!isSafeFrameWindow() && !canAccessTopWindow()) {
-      return '';
-    }
-
-    const position = { x: 0, y: 0 };
-
-    if (isSafeFrameWindow()) {
-      const ws = utils.getWindowSelf();
-
-      if (typeof ws.$sf.ext.geom !== 'function') {
-        utils.logWarn(`${LOG_PREFIX} cannot use the $sf.ext.geom() safeFrame API method`);
-        return '';
-      }
-
-      const sfGeom = ws.$sf.ext.geom().self;
-      position.x = Math.round(sfGeom.t);
-      position.y = Math.round(sfGeom.l);
-    } else if (canAccessTopWindow()) {
-      // window.top based computing
-      const wt = utils.getWindowTop();
-      const d = wt.document;
-
-      let domElement;
-
-      if (postBid === true) {
-        const ws = utils.getWindowSelf();
-        const currentElement = ws.document.getElementById(adUnitElementId);
-        domElement = internal.getElementFromTopWindow(currentElement, ws);
-      } else {
-        domElement = wt.document.getElementById(adUnitElementId);
-      }
-
-      if (!domElement) {
-        return '';
-      }
-
-      let box = domElement.getBoundingClientRect();
-
-      const docEl = d.documentElement;
-      const body = d.body;
-      const clientTop = d.clientTop || body.clientTop || 0;
-      const clientLeft = d.clientLeft || body.clientLeft || 0;
-      const scrollTop = wt.pageYOffset || docEl.scrollTop || body.scrollTop;
-      const scrollLeft = wt.pageXOffset || docEl.scrollLeft || body.scrollLeft;
-
-      const elComputedStyle = wt.getComputedStyle(domElement, null);
-      const elComputedDisplay = elComputedStyle.display || 'block';
-      const mustDisplayElement = elComputedDisplay === 'none';
-
-      if (mustDisplayElement) {
-        domElement.style = domElement.style || {};
-        domElement.style.display = 'block';
-        box = domElement.getBoundingClientRect();
-        domElement.style.display = elComputedDisplay;
-      }
-      position.x = Math.round(box.left + scrollLeft - clientLeft);
-      position.y = Math.round(box.top + scrollTop - clientTop);
-    } else {
-      return '';
-    }
-
-    return `${position.x}x${position.y}`;
-  },
-
-  getTimestampUTC() {
-    // timestamp returned in seconds
-    return Math.floor(new Date().getTime() / 1000) - new Date().getTimezoneOffset() * 60;
-  },
-
-  getDevice() {
-    const ws = utils.getWindowSelf();
-    const ua = ws.navigator.userAgent;
-
-    if ((/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i).test(ua)) {
-      return 5; // "tablet"
-    }
-    if ((/Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/).test(ua)) {
-      return 4; // "phone"
-    }
-    return 2; // personal computers
-  },
-
-  getBrowser() {
-    const ws = utils.getWindowSelf();
-    const ua = ws.navigator.userAgent;
-    const uaLowerCase = ua.toLowerCase();
-    return /Edge\/\d./i.test(ua) ? 'edge' : uaLowerCase.indexOf('chrome') > 0 ? 'chrome' : uaLowerCase.indexOf('firefox') > 0 ? 'firefox' : uaLowerCase.indexOf('safari') > 0 ? 'safari' : uaLowerCase.indexOf('opera') > 0 ? 'opera' : uaLowerCase.indexOf('msie') > 0 || ws.MSStream ? 'ie' : 'unknow';
-  },
-
-  getOS() {
-    const ws = utils.getWindowSelf();
-    const ua = ws.navigator.userAgent;
-    const uaLowerCase = ua.toLowerCase();
-    return uaLowerCase.indexOf('linux') > 0 ? 'linux' : uaLowerCase.indexOf('mac') > 0 ? 'mac' : uaLowerCase.indexOf('win') > 0 ? 'windows' : '';
-  },
-
-  getUrl(refererInfo) {
-    // top has not been reached, it means we are not sure
-    // to get the proper page url.
-    if (!refererInfo.reachedTop) {
-      return;
-    }
-    return refererInfo.referer;
-  },
-
-  getUrlFromParams(params) {
-    const { postBidOptions } = params;
-    if (postBidOptions && postBidOptions.url) {
-      return postBidOptions.url;
-    }
-  }
-};
-
 function enqueue(ob) {
   const w = internal.getCurrentWindow();
 
   w.ADAGIO = w.ADAGIO || {};
   w.ADAGIO.queue = w.ADAGIO.queue || [];
   w.ADAGIO.queue.push(ob);
-};
-
-function getOrAddAdagioAdUnit(adUnitCode) {
-  const w = internal.getCurrentWindow();
-
-  w.ADAGIO = w.ADAGIO || {};
-
-  if (w.ADAGIO.adUnits[adUnitCode]) {
-    return w.ADAGIO.adUnits[adUnitCode];
-  }
-
-  return w.ADAGIO.adUnits[adUnitCode] = {};
 };
 
 function getPageviewId() {
@@ -420,28 +230,11 @@ function getPageviewId() {
   return w.ADAGIO.pageviewId;
 };
 
-function computePrintNumber(adUnitCode) {
-  let printNumber = 1;
-  const w = internal.getCurrentWindow();
-
-  if (
-    w.ADAGIO &&
-    w.ADAGIO.adUnits && w.ADAGIO.adUnits[adUnitCode] &&
-    w.ADAGIO.adUnits[adUnitCode].pageviewId === internal.getPageviewId() &&
-    w.ADAGIO.adUnits[adUnitCode].printNumber
-  ) {
-    printNumber = parseInt(w.ADAGIO.adUnits[adUnitCode].printNumber, 10) + 1;
-  }
-
-  return printNumber;
-};
-
 function getDevice() {
   const language = navigator.language ? 'language' : 'userLanguage';
   return {
     userAgent: navigator.userAgent,
     language: navigator[language],
-    deviceType: _features.getDevice(),
     dnt: utils.getDNT() ? 1 : 0,
     geo: {},
     js: 1
@@ -504,72 +297,12 @@ function getElementFromTopWindow(element, currentWindow) {
   }
 };
 
-function autoDetectAdUnitElementId(adUnitCode) {
+function autoDetectAdUnitElementIdFromGpt(adUnitCode) {
   const autoDetectedAdUnit = utils.getGptSlotInfoForAdUnitCode(adUnitCode);
-  let adUnitElementId = null;
 
   if (autoDetectedAdUnit && autoDetectedAdUnit.divId) {
-    adUnitElementId = autoDetectedAdUnit.divId;
+    return autoDetectedAdUnit.divId;
   }
-
-  return adUnitElementId;
-};
-
-function autoDetectEnvironment() {
-  const device = _features.getDevice();
-  const map = { 2: 'desktop', 4: 'mobile', 5: 'tablet' };
-  return map[device] || 'unknown';
-};
-
-function supportIObs() {
-  const currentWindow = internal.getCurrentWindow();
-  return !!(currentWindow && currentWindow.IntersectionObserver && currentWindow.IntersectionObserverEntry &&
-    currentWindow.IntersectionObserverEntry.prototype && 'intersectionRatio' in currentWindow.IntersectionObserverEntry.prototype);
-}
-
-function getFeatures(bidRequest, bidderRequest) {
-  const { adUnitCode, params } = bidRequest;
-  const { adUnitElementId } = params;
-  const { refererInfo } = bidderRequest;
-
-  if (!adUnitElementId) {
-    utils.logWarn(`${LOG_PREFIX} unable to get params.adUnitElementId. Continue without tiv.`);
-  }
-
-  const features = {
-    print_number: _features.getPrintNumber(adUnitCode).toString(),
-    page_dimensions: _features.getPageDimensions().toString(),
-    viewport_dimensions: _features.getViewPortDimensions().toString(),
-    dom_loading: _features.getDomLoadingDuration().toString(),
-    // layout: features.getLayout().toString(),
-    adunit_position: _features.getSlotPosition(params).toString(),
-    user_timestamp: _features.getTimestampUTC().toString(),
-    device: _features.getDevice().toString(),
-    url: _features.getUrl(refererInfo) || _features.getUrlFromParams(params) || '',
-    browser: _features.getBrowser(),
-    os: _features.getOS()
-  };
-
-  Object.keys(features).forEach((prop) => {
-    if (features[prop] === '') {
-      delete features[prop];
-    }
-  });
-
-  const adUnitFeature = {};
-
-  adUnitFeature[adUnitElementId] = {
-    features: features,
-    version: FEATURES_VERSION
-  };
-
-  internal.enqueue({
-    action: 'features',
-    ts: Date.now(),
-    data: adUnitFeature
-  });
-
-  return features;
 };
 
 function isRendererPreferredFromPublisher(bidRequest) {
@@ -604,23 +337,16 @@ function isNewSession(adagioStorage) {
 
 export const internal = {
   enqueue,
-  getOrAddAdagioAdUnit,
   getPageviewId,
-  computePrintNumber,
   getDevice,
   getSite,
   getElementFromTopWindow,
-  autoDetectAdUnitElementId,
-  autoDetectEnvironment,
-  getFeatures,
   getRefererInfo,
   adagioScriptFromLocalStorageCb,
   getCurrentWindow,
-  supportIObs,
   canAccessTopWindow,
   isRendererPreferredFromPublisher,
-  isNewSession,
-  prepareExchange
+  isNewSession
 };
 
 function _getGdprConsent(bidderRequest) {
@@ -863,84 +589,287 @@ function _getFloors(bidRequest) {
   return floors;
 }
 
+/**
+ * Try to find the value of `paramName` and set it to adUnit.params if
+ * it has not already been set.
+ * This function will check through:
+ * - bidderSettings object
+ * - ortb2.site.ext.data FPD…
+ *
+ * @param {*} bid
+ * @param {String} paramName
+ */
+export function setExtraParam(bid, paramName) {
+  bid.params = bid.params || {};
+
+  // eslint-disable-next-line
+  if (!!(bid.params[paramName])) {
+    return;
+  }
+
+  const adgGlobalConf = config.getConfig('adagio') || {};
+  const ortb2Conf = config.getConfig('ortb2');
+
+  const detected = adgGlobalConf[paramName] || utils.deepAccess(ortb2Conf, `site.ext.data.${paramName}`, null);
+  if (detected) {
+    bid.params[paramName] = detected;
+  }
+}
+
+function autoFillParams(bid) {
+  // adUnitElementId …
+  const adgGlobalConf = config.getConfig('adagio') || {};
+
+  bid.params = bid.params || {};
+
+  // adgGlobalConf.siteId is a shortcut to facilitate the integration for publisher.
+  if (adgGlobalConf.siteId) {
+    bid.params.organizationId = adgGlobalConf.siteId.split(':')[0];
+    bid.params.site = adgGlobalConf.siteId.split(':')[1];
+  }
+
+  // Edge case. Useful when Prebid Manager cannot handle properly params setting…
+  if (adgGlobalConf.useAdUnitCodeAsPlacement === true || bid.params.useAdUnitCodeAsPlacement === true) {
+    bid.params.placement = bid.adUnitCode;
+  }
+
+  bid.params.adUnitElementId = utils.deepAccess(bid, 'ortb2Imp.ext.data.elementId', null) || bid.params.adUnitElementId;
+
+  if (!bid.params.adUnitElementId) {
+    if (adgGlobalConf.useAdUnitCodeAsAdUnitElementId === true || bid.params.useAdUnitCodeAsAdUnitElementId === true) {
+      bid.params.adUnitElementId = bid.adUnitCode;
+    } else {
+      bid.params.adUnitElementId = autoDetectAdUnitElementIdFromGpt(bid.adUnitCode);
+    }
+  }
+
+  // extra params
+  setExtraParam(bid, 'environment');
+  setExtraParam(bid, 'pagetype');
+  setExtraParam(bid, 'category');
+  setExtraParam(bid, 'subcategory');
+}
+
+function getPageDimensions() {
+  if (isSafeFrameWindow() || !canAccessTopWindow()) {
+    return '';
+  }
+
+  // the page dimension can be computed on window.top only.
+  const wt = utils.getWindowTop();
+  const body = wt.document.querySelector('body');
+
+  if (!body) {
+    return '';
+  }
+  const html = wt.document.documentElement;
+  const pageWidth = Math.max(body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollWidth, html.offsetWidth);
+  const pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+
+  return `${pageWidth}x${pageHeight}`;
+}
+
+/**
+* @todo Move to prebid Core as Utils.
+* @returns
+*/
+function getViewPortDimensions() {
+  if (!isSafeFrameWindow() && !canAccessTopWindow()) {
+    return '';
+  }
+
+  const viewportDims = { w: 0, h: 0 };
+
+  if (isSafeFrameWindow()) {
+    const ws = utils.getWindowSelf();
+
+    if (typeof ws.$sf.ext.geom !== 'function') {
+      utils.logWarn(LOG_PREFIX, 'Unable to compute from safeframe api.');
+      return '';
+    }
+
+    const sfGeom = ws.$sf.ext.geom();
+
+    if (!sfGeom || !sfGeom.win) {
+      utils.logWarn(LOG_PREFIX, 'Unable to compute from safeframe api. Missing `geom().win` property');
+      return '';
+    }
+
+    viewportDims.w = Math.round(sfGeom.w);
+    viewportDims.h = Math.round(sfGeom.h);
+  } else {
+    // window.top based computing
+    const wt = utils.getWindowTop();
+    viewportDims.w = wt.innerWidth;
+    viewportDims.h = wt.innerHeight;
+  }
+
+  return `${viewportDims.w}x${viewportDims.h}`;
+}
+
+function getSlotPosition(adUnitElementId) {
+  if (!adUnitElementId) {
+    return '';
+  }
+
+  if (!isSafeFrameWindow() && !canAccessTopWindow()) {
+    return '';
+  }
+
+  const position = { x: 0, y: 0 };
+
+  if (isSafeFrameWindow()) {
+    const ws = utils.getWindowSelf();
+
+    if (typeof ws.$sf.ext.geom !== 'function') {
+      utils.logWarn(LOG_PREFIX, 'Unable to compute from safeframe api.');
+      return '';
+    }
+
+    const sfGeom = ws.$sf.ext.geom();
+
+    if (!sfGeom || !sfGeom.self) {
+      utils.logWarn(LOG_PREFIX, 'Unable to compute from safeframe api. Missing `geom().self` property');
+      return '';
+    }
+
+    position.x = Math.round(sfGeom.t);
+    position.y = Math.round(sfGeom.l);
+  } else if (canAccessTopWindow()) {
+    // window.top based computing
+    const wt = utils.getWindowTop();
+    const d = wt.document;
+
+    let domElement;
+
+    if (utils.inIframe() === true) {
+      const ws = utils.getWindowSelf();
+      const currentElement = ws.document.getElementById(adUnitElementId);
+      domElement = internal.getElementFromTopWindow(currentElement, ws);
+    } else {
+      domElement = wt.document.getElementById(adUnitElementId);
+    }
+
+    if (!domElement) {
+      return '';
+    }
+
+    let box = domElement.getBoundingClientRect();
+
+    const docEl = d.documentElement;
+    const body = d.body;
+    const clientTop = d.clientTop || body.clientTop || 0;
+    const clientLeft = d.clientLeft || body.clientLeft || 0;
+    const scrollTop = wt.pageYOffset || docEl.scrollTop || body.scrollTop;
+    const scrollLeft = wt.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+    const elComputedStyle = wt.getComputedStyle(domElement, null);
+    const elComputedDisplay = elComputedStyle.display || 'block';
+    const mustDisplayElement = elComputedDisplay === 'none';
+
+    if (mustDisplayElement) {
+      domElement.style = domElement.style || {};
+      domElement.style.display = 'block';
+      box = domElement.getBoundingClientRect();
+      domElement.style.display = elComputedDisplay;
+    }
+    position.x = Math.round(box.left + scrollLeft - clientLeft);
+    position.y = Math.round(box.top + scrollTop - clientTop);
+  } else {
+    return '';
+  }
+
+  return `${position.x}x${position.y}`;
+}
+
+function getTimestampUTC() {
+  // timestamp returned in seconds
+  return Math.floor(new Date().getTime() / 1000) - new Date().getTimezoneOffset() * 60;
+}
+
+function getPrintNumber(adUnitCode, bidderRequest) {
+  if (!bidderRequest.bids || !bidderRequest.bids.length) {
+    return 1;
+  }
+  const adagioBid = bidderRequest.bids.find(bid => bid.adUnitCode === adUnitCode);
+  return adagioBid.bidRequestsCount || 1;
+}
+
+/**
+  * domLoading feature is computed on window.top if reachable.
+  */
+function getDomLoadingDuration() {
+  let domLoadingDuration = -1;
+  let performance;
+
+  performance = (canAccessTopWindow()) ? utils.getWindowTop().performance : utils.getWindowSelf().performance;
+
+  if (performance && performance.timing && performance.timing.navigationStart > 0) {
+    const val = performance.timing.domLoading - performance.timing.navigationStart;
+    if (val > 0) {
+      domLoadingDuration = val;
+    }
+  }
+
+  return domLoadingDuration;
+}
+
+function storeRequestInAdagioNS(bidRequest) {
+  const w = getCurrentWindow();
+  // Store adUnits config.
+  // If an adUnitCode has already been stored, it will be replaced.
+  w.ADAGIO = w.ADAGIO || {};
+  w.ADAGIO.pbjsAdUnits = w.ADAGIO.pbjsAdUnits.filter((adUnit) => adUnit.code !== bidRequest.adUnitCode);
+
+  let printNumber
+  if (bidRequest.features && bidRequest.features.print_number) {
+    printNumber = bidRequest.features.print_number;
+  } else if (bidRequest.params.features && bidRequest.params.features.print_number) {
+    printNumber = bidRequest.params.features.print_number;
+  }
+
+  w.ADAGIO.pbjsAdUnits.push({
+    code: bidRequest.adUnitCode,
+    mediaTypes: bidRequest.mediaTypes || {},
+    sizes: (bidRequest.mediaTypes && bidRequest.mediaTypes.banner && Array.isArray(bidRequest.mediaTypes.banner.sizes)) ? bidRequest.mediaTypes.banner.sizes : bidRequest.sizes,
+    bids: [{
+      bidder: bidRequest.bidder,
+      params: bidRequest.params // use the updated bid.params object with auto-detected params
+    }],
+    auctionId: bidRequest.auctionId,
+    pageviewId: internal.getPageviewId(),
+    printNumber
+  });
+
+  // (legacy) Store internal adUnit information
+  w.ADAGIO.adUnits[bidRequest.adUnitCode] = {
+    auctionId: bidRequest.auctionId,
+    pageviewId: internal.getPageviewId(),
+    printNumber,
+  };
+}
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
   supportedMediaTypes: SUPPORTED_MEDIA_TYPES,
 
   isBidRequestValid(bid) {
-    const { adUnitCode, auctionId, sizes, bidder, params, mediaTypes } = bid;
-    if (!params) {
-      utils.logWarn(`${LOG_PREFIX} the "params" property is missing.`);
-      return false;
-    }
+    bid.params = bid.params || {};
 
-    const { organizationId, site } = params;
-    const adUnitElementId = (params.useAdUnitCodeAsAdUnitElementId === true)
-      ? adUnitCode
-      : params.adUnitElementId || internal.autoDetectAdUnitElementId(adUnitCode);
-    const placement = (params.useAdUnitCodeAsPlacement === true) ? adUnitCode : params.placement;
-    const environment = params.environment || internal.autoDetectEnvironment();
-    const supportIObs = internal.supportIObs();
+    autoFillParams(bid);
 
-    // insure auto-detected params are kept in `bid` object.
-    bid.params = {
-      ...params,
-      adUnitElementId,
-      environment,
-      placement,
-      supportIObs
-    };
-
-    const debugData = () => ({
-      action: 'pb-dbg',
-      ts: Date.now(),
-      data: {
-        bid
-      }
-    });
-
-    const refererInfo = internal.getRefererInfo();
-
-    if (!refererInfo.reachedTop) {
+    if (!internal.getRefererInfo().reachedTop) {
       utils.logWarn(`${LOG_PREFIX} the main page url is unreachabled.`);
-      internal.enqueue(debugData());
-
-      return false;
-    } else if (!(organizationId && site && placement)) {
-      utils.logWarn(`${LOG_PREFIX} at least one required param is missing.`);
-      internal.enqueue(debugData());
-
+      // internal.enqueue(debugData());
       return false;
     }
 
-    const w = internal.getCurrentWindow();
-    const pageviewId = internal.getPageviewId();
-    const printNumber = internal.computePrintNumber(adUnitCode);
-
-    // Store adUnits config.
-    // If an adUnitCode has already been stored, it will be replaced.
-    w.ADAGIO = w.ADAGIO || {};
-    w.ADAGIO.pbjsAdUnits = w.ADAGIO.pbjsAdUnits.filter((adUnit) => adUnit.code !== adUnitCode);
-    w.ADAGIO.pbjsAdUnits.push({
-      code: adUnitCode,
-      mediaTypes: mediaTypes || {},
-      sizes: (mediaTypes && mediaTypes.banner && Array.isArray(mediaTypes.banner.sizes)) ? mediaTypes.banner.sizes : sizes,
-      bids: [{
-        bidder,
-        params: bid.params // use the updated bid.params object with auto-detected params
-      }],
-      auctionId,
-      pageviewId,
-      printNumber
-    });
-
-    // (legacy) Store internal adUnit information
-    w.ADAGIO.adUnits[adUnitCode] = {
-      auctionId,
-      pageviewId,
-      printNumber,
-    };
+    if (!(bid.params.organizationId && bid.params.site && bid.params.placement)) {
+      utils.logWarn(`${LOG_PREFIX} at least one required param is missing.`);
+      // internal.enqueue(debugData());
+      return false;
+    }
 
     return true;
   },
@@ -955,8 +884,32 @@ export const spec = {
     const coppa = _getCoppa();
     const schain = _getSchain(validBidRequests[0]);
     const eids = _getEids(validBidRequests[0]) || [];
+
     const adUnits = utils._map(validBidRequests, (bidRequest) => {
-      bidRequest.features = internal.getFeatures(bidRequest, bidderRequest);
+      const globalFeatures = GlobalExchange.getOrSetGlobalFeatures();
+      const features = {
+        ...globalFeatures,
+        print_number: getPrintNumber(bidRequest.adUnitCode, bidderRequest).toString(),
+        adunit_position: getSlotPosition(bidRequest.params.adUnitElementId) // adUnitElementId à déplacer ???
+      };
+
+      Object.keys(features).forEach((prop) => {
+        if (features[prop] === '') {
+          delete features[prop];
+        }
+      });
+
+      bidRequest.features = features;
+
+      internal.enqueue({
+        action: 'features',
+        ts: Date.now(),
+        data: {
+          features: bidRequest.features,
+          params: bidRequest.params,
+          adUnitCode: bidRequest.adUnitCode
+        }
+      });
 
       // Handle priceFloors module
       bidRequest.floors = _getFloors(bidRequest);
@@ -964,6 +917,8 @@ export const spec = {
       if (utils.deepAccess(bidRequest, 'mediaTypes.video')) {
         _buildVideoBidRequest(bidRequest);
       }
+
+      storeRequestInAdagioNS(bidRequest);
 
       return bidRequest;
     });
@@ -975,6 +930,7 @@ export const spec = {
 
       // remove useless props
       delete adUnitCopy.floorData;
+      delete adUnitCopy.params.siteId;
 
       groupedAdUnits[adUnitCopy.params.organizationId] = groupedAdUnits[adUnitCopy.params.organizationId] || [];
       groupedAdUnits[adUnitCopy.params.organizationId].push(adUnitCopy);
@@ -995,7 +951,7 @@ export const spec = {
           site: site,
           pageviewId: pageviewId,
           adUnits: groupedAdUnits[organizationId],
-          data: EXT_DATA,
+          data: GlobalExchange.getExchangeData(),
           regs: {
             gdpr: gdprConsent,
             coppa: coppa,
@@ -1006,7 +962,6 @@ export const spec = {
             eids: eids
           },
           prebidVersion: '$prebid.version$',
-          adapterVersion: VERSION,
           featuresVersion: FEATURES_VERSION
         },
         options: {
@@ -1094,6 +1049,39 @@ export const spec = {
 
     return syncs;
   },
+
+  /**
+   * Handle custom logic in s2s context
+   *
+   * @param {*} params
+   * @param {boolean} isOrtb Is an s2s context
+   * @param {*} adUnit
+   * @param {*} bidRequests
+   * @returns {object} updated params
+   */
+  transformBidParams(params, isOrtb, adUnit, bidRequests) {
+    const adagioBidderRequest = bidRequests.find(bidRequest => bidRequest.bidderCode === 'adagio');
+    const adagioBid = adagioBidderRequest.bids.find(bid => bid.adUnitCode === adUnit.code);
+
+    if (isOrtb) {
+      autoFillParams(adagioBid);
+
+      const globalFeatures = GlobalExchange.getOrSetGlobalFeatures();
+      adagioBid.params.features = {
+        ...globalFeatures,
+        print_number: getPrintNumber(adagioBid.adUnitCode, adagioBidderRequest).toString(),
+        adunit_position: getSlotPosition(adagioBid.params.adUnitElementId) // adUnitElementId à déplacer ???
+      }
+
+      adagioBid.params.pageviewId = internal.getPageviewId();
+      adagioBid.params.prebidVersion = '$prebid.version$';
+      adagioBid.params.data = GlobalExchange.getExchangeData();
+
+      storeRequestInAdagioNS(adagioBid);
+    }
+
+    return adagioBid.params;
+  }
 };
 
 initAdagio();

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -8,187 +8,227 @@ Maintainer: dev@adagio.io
 
 Connects to Adagio demand source to fetch bids.
 
+## Configuration
+
+Adagio require several params. These params must be set at Prebid.js global config level or at adUnit level.
+
+Below, the list of Adagio params and where they can be set.
+
+| Param name | Global config | AdUnit config |
+| ---------- | ------------- | ------------- |
+| siteId | x |
+| organizationId (obsolete) | | x
+| site (obsolete) | | x
+| pagetype | x | x
+| environment | x | x
+| category | x | x
+| subcategory | x | x
+| useAdUnitCodeAsAdUnitElementId | x | x
+| useAdUnitCodeAsPlacement | x | x
+| placement | | x
+| adUnitElementId | | x
+| debug | | x
+| video | | x
+| native | | x
+
+### Global configuration
+
+The global configuration is used to store params once instead of duplicate them to each adUnit. The values will be used as "params" in the ad-request.
+
+```javascript
+pbjs.setConfig({
+  debug: false,
+  // …,
+  adagio: {
+    siteId: '1002:adagio-io', // Required. Provided by Adagio
+
+    // The following params are limited to 30 characters,
+    // and can only contain the following characters:
+    // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
+    // - dashes `-`
+    // - underscores `_`
+    // Also, each param can have at most 50 unique active values (case-insensitive).
+    pagetype: 'article', // Highly recommended. The pagetype describes what kind of content will be present in the page.
+    environment: 'mobile', // Recommended. Environment where the page is displayed.
+    category: 'sport', // Recommended. Category of the content displayed in the page.
+    subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
+    useAdUnitCodeAsAdUnitElementId: false, // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
+    useAdUnitCodeAsPlacement: false, // Optional. Use it to by-pass placement and use the adUnit code as value
+  },
+});
+```
+
+### adUnit configuration
+
+```javascript
+var adUnits = [
+  {
+    code: 'dfp_banniere_atf',
+    bids: [{
+      bidder: 'adagio',
+      params: {
+        placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
+        adUnitElementId: 'article_outstream', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
+        // Optional debug mode, used to get a bid response with expected cpm.
+        debug: {
+          enabled: true,
+          cpm: 3.00 // default to 1.00
+        },
+        video: {
+          skip: 0
+          // OpenRTB 2.5 video options defined here override ones defined in mediaTypes.
+        },
+        native: {
+          // Optional OpenRTB Native 1.2 request object. Only `context`, `plcmttype` fields are supported.
+          context: 1,
+          plcmttype: 2
+        },
+      }
+    }]
+  }
+];
+```
+
 ## Test Parameters
 
 ```javascript
-    var adUnits = [
-      {
-        code: 'dfp_banniere_atf',
-        mediaTypes: {
-          banner: {
-            sizes: [[300, 250], [300, 600]],
-          }
-        },
-        bids: [{
-          bidder: 'adagio', // Required
-          params: {
-            organizationId: '1002', // Required - Organization ID provided by Adagio.
-            site: 'adagio-io', // Required - Site Name provided by Adagio.
-            placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
-            adUnitElementId: 'article_outstream', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
 
-            // The following params are limited to 30 characters,
-            // and can only contain the following characters:
-            // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
-            // - dashes `-`
-            // - underscores `_`
-            // Also, each param can have at most 50 unique active values (case-insensitive).
-            pagetype: 'article', // Highly recommended. The pagetype describes what kind of content will be present in the page.
-            environment: 'mobile', // Recommended. Environment where the page is displayed.
-            category: 'sport', // Recommended. Category of the content displayed in the page.
-            subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
-            postBid: false, // Optional. Use it in case of Post-bid integration only.
-            useAdUnitCodeAsAdUnitElementId: false, // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
-            useAdUnitCodeAsPlacement: false, // Optional. Use it to by-pass placement and use the adUnit code as value
-            // Optional debug mode, used to get a bid response with expected cpm.
-            debug: {
-              enabled: true,
-              cpm: 3.00 // default to 1.00
-            }
-          }
-        }]
-      },
-      {
-        code: 'article_outstream',
-        mediaTypes: {
-          video: {
-            context: 'outstream',
-            playerSize: [640, 480],
-            mimes: ['video/mp4'],
-            skip: 1
-            // Other OpenRTB 2.5 video options…
-          }
-        },
-        bids: [{
-          bidder: 'adagio', // Required
-          params: {
-            organizationId: '1002', // Required - Organization ID provided by Adagio.
-            site: 'adagio-io', // Required - Site Name provided by Adagio.
-            placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
-            adUnitElementId: 'article_outstream', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
-
-            // The following params are limited to 30 characters,
-            // and can only contain the following characters:
-            // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
-            // - dashes `-`
-            // - underscores `_`
-            // Also, each param can have at most 50 unique active values (case-insensitive).
-            pagetype: 'article', // Highly recommended. The pagetype describes what kind of content will be present in the page.
-            environment: 'mobile', // Recommended. Environment where the page is displayed.
-            category: 'sport', // Recommended. Category of the content displayed in the page.
-            subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
-            postBid: false, // Optional. Use it in case of Post-bid integration only.
-            useAdUnitCodeAsAdUnitElementId: false, // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
-            useAdUnitCodeAsPlacement: false, // Optional. Use it to by-pass placement and use the adUnit code as value
-            video: {
-              skip: 0
-              // OpenRTB 2.5 video options defined here override ones defined in mediaTypes.
-            },
-            // Optional debug mode, used to get a bid response with expected cpm.
-            debug: {
-              enabled: true,
-              cpm: 3.00 // default to 1.00
-            }
-          }
-        }]
-      },
-      {
-        code: 'article_native',
-        mediaTypes: {
-          native: {
-            // generic Prebid options
-            title: {
-                required: true,
-                len: 80
-            },
-            // …
-            // Custom Adagio data assets
-            ext: {
-              adagio_bvw: {
-                required: false
-              }
-            }
-          }
-        },
-        bids: [{
-          bidder: 'adagio', // Required
-          params: {
-            organizationId: '1002', // Required - Organization ID provided by Adagio.
-            site: 'adagio-io', // Required - Site Name provided by Adagio.
-            placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
-            adUnitElementId: 'article_native', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
-
-            // The following params are limited to 30 characters,
-            // and can only contain the following characters:
-            // - alphanumeric (A-Z+a-z+0-9, case-insensitive)
-            // - dashes `-`
-            // - underscores `_`
-            // Also, each param can have at most 50 unique active values (case-insensitive).
-            pagetype: 'article', // Highly recommended. The pagetype describes what kind of content will be present in the page.
-            environment: 'mobile', // Recommended. Environment where the page is displayed.
-            category: 'sport', // Recommended. Category of the content displayed in the page.
-            subcategory: 'handball', // Optional. Subcategory of the content displayed in the page.
-            postBid: false, // Optional. Use it in case of Post-bid integration only.
-            useAdUnitCodeAsAdUnitElementId: false, // Optional. Use it by-pass adUnitElementId and use the adUnit code as value
-            useAdUnitCodeAsPlacement: false, // Optional. Use it to by-pass placement and use the adUnit code as value
-            // Optional OpenRTB Native 1.2 request object. Only `context`, `plcmttype` fields are supported.
-            native: {
-              context: 1,
-              plcmttype: 2
-            },
-            // Optional debug mode, used to get a bid response with expected cpm.
-            debug: {
-              enabled: true,
-              cpm: 3.00 // default to 1.00
-            }
-          }
-        }]
-      }
-    ];
-
-    pbjs.addAdUnits(adUnits);
-
-    pbjs.bidderSettings = {
-      adagio: {
-        alwaysUseBid: true,
-        adserverTargeting: [
-          {
-            key: "site",
-            val: function (bidResponse) {
-              return bidResponse.site;
-            }
-          },
-          {
-            key: "environment",
-            val: function (bidResponse) {
-              return bidResponse.environment;
-            }
-          },
-          {
-            key: "placement",
-            val: function (bidResponse) {
-              return bidResponse.placement;
-            }
-          },
-          {
-            key: "pagetype",
-            val: function (bidResponse) {
-              return bidResponse.pagetype;
-            }
-          },
-          {
-            key: "category",
-            val: function (bidResponse) {
-              return bidResponse.category;
-            }
-          },
-          {
-            key: "subcategory",
-            val: function (bidResponse) {
-              return bidResponse.subcategory;
-            }
-          }
-        ]
-      }
+  pbjs.setConfig({
+    debug: true,
+    adagio: {
+      pagetype: 'article',
+      environment: 'mobile',
+      category: 'sport',
+      subcategory: 'handball',
+      useAdUnitCodeAsAdUnitElementId: false,
+      useAdUnitCodeAsPlacement: false,
     }
+  });
+
+  var adUnits = [
+    {
+      code: 'dfp_banniere_atf',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]],
+        }
+      },
+      bids: [{
+        bidder: 'adagio', // Required
+        params: {
+          placement: 'in_article',
+          adUnitElementId: 'article_outstream',
+          debug: {
+            enabled: true,
+            cpm: 3.00 // default to 1.00
+          }
+        }
+      }]
+    },
+    {
+      code: 'article_outstream',
+      mediaTypes: {
+        video: {
+          context: 'outstream',
+          playerSize: [640, 480],
+          mimes: ['video/mp4'],
+          skip: 1
+        }
+      },
+      bids: [{
+        bidder: 'adagio',
+        params: {
+          placement: 'in_article',
+          adUnitElementId: 'article_outstream',
+          video: {
+            skip: 0
+          },
+          debug: {
+            enabled: true,
+            cpm: 3.00
+          }
+        }
+      }]
+    },
+    {
+      code: 'article_native',
+      mediaTypes: {
+        native: {
+          // generic Prebid options
+          title: {
+              required: true,
+              len: 80
+          },
+          // …
+          // Custom Adagio data assets
+          ext: {
+            adagio_bvw: {
+              required: false
+            }
+          }
+        }
+      },
+      bids: [{
+        bidder: 'adagio',
+        params: {
+          placement: 'in_article',
+          adUnitElementId: 'article_native',
+          native: {
+            context: 1,
+            plcmttype: 2
+          },
+          debug: {
+            enabled: true,
+            cpm: 3.00
+          }
+        }
+      }]
+    }
+  ];
+
+  pbjs.addAdUnits(adUnits);
+
+  pbjs.bidderSettings = {
+    adagio: {
+      alwaysUseBid: true,
+      adserverTargeting: [
+        {
+          key: "site",
+          val: function (bidResponse) {
+            return bidResponse.site;
+          }
+        },
+        {
+          key: "environment",
+          val: function (bidResponse) {
+            return bidResponse.environment;
+          }
+        },
+        {
+          key: "placement",
+          val: function (bidResponse) {
+            return bidResponse.placement;
+          }
+        },
+        {
+          key: "pagetype",
+          val: function (bidResponse) {
+            return bidResponse.pagetype;
+          }
+        },
+        {
+          key: "category",
+          val: function (bidResponse) {
+            return bidResponse.category;
+          }
+        },
+        {
+          key: "subcategory",
+          val: function (bidResponse) {
+            return bidResponse.subcategory;
+          }
+        }
+      ]
+    }
+  }
 ```

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -654,7 +654,7 @@ const OPEN_RTB_PROTOCOL = {
       const ext = adUnit.bids.reduce((acc, bid) => {
         const adapter = adapterManager.bidderRegistry[bid.bidder];
         if (adapter && adapter.getSpec().transformBidParams) {
-          bid.params = adapter.getSpec().transformBidParams(bid.params, true);
+          bid.params = adapter.getSpec().transformBidParams(bid.params, true, adUnit, bidRequests);
         }
         acc[bid.bidder] = (s2sConfig.adapterOptions && s2sConfig.adapterOptions[bid.bidder]) ? Object.assign({}, bid.params, s2sConfig.adapterOptions[bid.bidder]) : bid.params;
         return acc;

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1,20 +1,23 @@
-import find from 'core-js-pure/features/array/find.js';
-import { expect, util } from 'chai';
+import { expect } from 'chai';
 import {
   _features,
   internal as adagio,
   adagioScriptFromLocalStorageCb,
   getAdagioScript,
   storage,
+  setExtraParam,
   spec,
   ENDPOINT,
   VERSION,
-  RENDERER_URL
+  RENDERER_URL,
+  GlobalExchange
 } from '../../../modules/adagioBidAdapter.js';
 import { loadExternalScript } from '../../../src/adloader.js';
 import * as utils from '../../../src/utils.js';
 import { config } from '../../../src/config.js';
 import { NATIVE } from '../../../src/mediaTypes.js';
+import * as prebidGlobal from 'src/prebidGlobal.js';
+import { executeRenderer } from '../../../src/Renderer.js';
 
 const BidRequestBuilder = function BidRequestBuilder(options) {
   const defaults = {
@@ -115,6 +118,9 @@ describe('Adagio bid adapter', () => {
     window.ADAGIO.versions.adagioBidderAdapter = VERSION;
     window.ADAGIO.pageviewId = 'dda61753-4059-4f75-b0bf-3f60bd2c4d9a';
 
+    GlobalExchange.clearFeatures();
+    GlobalExchange.clearExchangeData();
+
     adagioMock = sinon.mock(adagio);
     utilsMock = sinon.mock(utils);
 
@@ -130,12 +136,65 @@ describe('Adagio bid adapter', () => {
     sandbox.restore();
   });
 
+  describe('get and set params at adUnit level from global Prebid configuration', function() {
+    it('should set params get from ortb2 config or bidderSettings. Priority to bidderSetting', function() {
+      const bid = new BidRequestBuilder().build();
+
+      sandbox.stub(config, 'getConfig').callsFake(key => {
+        const config = {
+          adagio: {
+            pagetype: 'article'
+          },
+          ortb2: {
+            site: {
+              ext: {
+                data: {
+                  environment: 'desktop',
+                  pagetype: 'abc'
+                }
+              }
+            }
+          }
+        };
+        return utils.deepAccess(config, key);
+      });
+
+      setExtraParam(bid, 'environment');
+      expect(bid.params.environment).to.equal('desktop');
+
+      setExtraParam(bid, 'pagetype')
+      expect(bid.params.pagetype).to.equal('article');
+    });
+
+    it('should use the adUnit param unit if defined', function() {
+      const bid = new BidRequestBuilder({ params: { pagetype: 'article' } }).build();
+      sandbox.stub(config, 'getConfig').withArgs('adagio').returns({
+        pagetype: 'ignore-me'
+      });
+      setExtraParam(bid, 'pagetype')
+      expect(bid.params.pagetype).to.equal('article');
+    });
+  })
+
   describe('isBidRequestValid()', function() {
     it('should return true when required params have been found', function() {
       const bid = new BidRequestBuilder().withParams().build();
 
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
+
+    it('should compute organizationId and site params from global BidderSettings config', function() {
+      sandbox.stub(adagio, 'getRefererInfo').returns({ reachedTop: true });
+      sandbox.stub(config, 'getConfig').withArgs('adagio').returns({
+        siteId: '1000:SITE-NAME'
+      });
+
+      const bid = new BidRequestBuilder({
+        params: { placement: 'PAVE_ATF' }
+      }).build();
+
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    })
 
     it('should return false if bid.params is missing', function() {
       sandbox.spy(utils, 'logWarn');
@@ -156,7 +215,7 @@ describe('Adagio bid adapter', () => {
       expect(spec.isBidRequestValid(bid01)).to.equal(true);
       expect(bid01.params.adUnitElementId).to.equal('adunit-code');
       expect(bid01.params.placement).to.equal('adunit-code');
-    })
+    });
 
     it('should return false when a required param is missing', function() {
       const bid01 = new BidRequestBuilder({ params: {
@@ -174,9 +233,16 @@ describe('Adagio bid adapter', () => {
         site: 'SITE-NAME'
       }}).build();
 
+      sandbox.stub(config, 'getConfig').withArgs('adagio').returns({
+        siteId: '1000'
+      });
+
+      const bid04 = new BidRequestBuilder({ params: { placement: 'PAVE_ATF' } }).build();
+
       expect(spec.isBidRequestValid(bid01)).to.equal(false);
       expect(spec.isBidRequestValid(bid02)).to.equal(false);
       expect(spec.isBidRequestValid(bid03)).to.equal(false);
+      expect(spec.isBidRequestValid(bid04)).to.equal(false);
     });
 
     it('should return false when refererInfo.reachedTop is false', function() {
@@ -187,134 +253,6 @@ describe('Adagio bid adapter', () => {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
       sinon.assert.callCount(utils.logWarn, 1);
       sinon.assert.calledWith(utils.logWarn, 'Adagio: the main page url is unreachabled.');
-    });
-
-    it('should log warning and enqueue the bid object in ADAGIO.queue when isBidRequestValid is false', function() {
-      sandbox.stub(Date, 'now').returns(12345);
-      sandbox.spy(utils, 'logWarn');
-      sandbox.spy(adagio, 'enqueue');
-
-      const bid = new BidRequestBuilder({'params': {
-        organizationId: '1000',
-        placement: 'PAVE_ATF'
-      }}).build();
-
-      const expectedEnqueued = {
-        action: 'pb-dbg',
-        ts: 12345,
-        data: { bid }
-      };
-
-      spec.isBidRequestValid(bid);
-
-      sinon.assert.calledWith(adagio.enqueue, expectedEnqueued);
-      sinon.assert.callCount(utils.logWarn, 1);
-    });
-
-    describe('Store ADAGIO global in window.top or window.self depending on context', function() {
-      const bid01 = new BidRequestBuilder({
-        adUnitCode: 'adunit-code-01',
-        sizes: [[300, 250], [300, 600]]
-      }).withParams().build();
-
-      const bid02 = new BidRequestBuilder({
-        adUnitCode: 'adunit-code-02',
-        mediaTypes: {
-          banner: { sizes: [[300, 250]] }
-        },
-      }).withParams().build();
-
-      const bid03 = new BidRequestBuilder({
-        adUnitCode: 'adunit-code-02',
-        mediaTypes: {
-          banner: { sizes: [[300, 600]] }
-        },
-      }).withParams().build();
-
-      const expected = [
-        {
-          code: 'adunit-code-01',
-          sizes: [[300, 250], [300, 600]],
-          mediaTypes: {},
-          bids: [{
-            bidder: 'adagio',
-            params: {
-              organizationId: '1000',
-              placement: 'PAVE_ATF',
-              site: 'SITE-NAME',
-              adUnitElementId: 'gpt-adunit-code',
-              environment: 'desktop',
-              supportIObs: true
-            }
-          }],
-          auctionId: '4fd1ca2d-846c-4211-b9e5-321dfe1709c9',
-          pageviewId: 'dda61753-4059-4f75-b0bf-3f60bd2c4d9a',
-          printNumber: 1,
-        },
-        {
-          code: 'adunit-code-02',
-          sizes: [[300, 600]],
-          mediaTypes: {
-            banner: { sizes: [[300, 600]] }
-          },
-          bids: [{
-            bidder: 'adagio',
-            params: {
-              organizationId: '1000',
-              placement: 'PAVE_ATF',
-              site: 'SITE-NAME',
-              adUnitElementId: 'gpt-adunit-code',
-              environment: 'desktop',
-              supportIObs: true
-            }
-          }],
-          auctionId: '4fd1ca2d-846c-4211-b9e5-321dfe1709c9',
-          pageviewId: 'dda61753-4059-4f75-b0bf-3f60bd2c4d9a',
-          printNumber: 2,
-        }
-      ];
-
-      it('should store bids config once by bid in window.top if it accessible', function() {
-        sandbox.stub(adagio, 'getCurrentWindow').returns(window.top);
-        sandbox.stub(adagio, 'supportIObs').returns(true);
-
-        // replace by the values defined in beforeEach
-        window.top.ADAGIO = {
-          ...window.ADAGIO
-        };
-
-        spec.isBidRequestValid(bid01);
-        spec.isBidRequestValid(bid02);
-        spec.isBidRequestValid(bid03);
-
-        expect(find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-01')).to.deep.eql(expected[0]);
-        expect(find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-02')).to.deep.eql(expected[1]);
-      });
-
-      it('should detect IntersectionObserver support', function() {
-        sandbox.stub(adagio, 'getCurrentWindow').returns(window.top);
-        sandbox.stub(adagio, 'supportIObs').returns(false);
-
-        window.top.ADAGIO = {
-          ...window.ADAGIO
-        };
-
-        spec.isBidRequestValid(bid01);
-        const validBidReq = find(window.top.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-01');
-        expect(validBidReq.bids[0].params.supportIObs).to.equal(false);
-      });
-
-      it('should store bids config once by bid in current window', function() {
-        sandbox.stub(adagio, 'getCurrentWindow').returns(window.self);
-        sandbox.stub(adagio, 'supportIObs').returns(true);
-
-        spec.isBidRequestValid(bid01);
-        spec.isBidRequestValid(bid02);
-        spec.isBidRequestValid(bid03);
-
-        expect(find(window.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-01')).to.deep.eql(expected[0]);
-        expect(find(window.ADAGIO.pbjsAdUnits, aU => aU.code === 'adunit-code-02')).to.deep.eql(expected[1]);
-      });
     });
   });
 
@@ -331,7 +269,6 @@ describe('Adagio bid adapter', () => {
       'user',
       'schain',
       'prebidVersion',
-      'adapterVersion',
       'featuresVersion',
       'data'
     ];
@@ -360,7 +297,6 @@ describe('Adagio bid adapter', () => {
       sandbox.stub(adagio, 'getDevice').returns({ a: 'a' });
       sandbox.stub(adagio, 'getSite').returns({ domain: 'adagio.io', 'page': 'https://adagio.io/hb' });
       sandbox.stub(adagio, 'getPageviewId').returns('1234-567');
-      sandbox.stub(adagio, 'getFeatures').returns({});
 
       const bid01 = new BidRequestBuilder().withParams().build();
       const bidderRequest = new BidderRequestBuilder().build();
@@ -377,23 +313,10 @@ describe('Adagio bid adapter', () => {
     it('should enqueue computed features for collect usage', function() {
       sandbox.stub(Date, 'now').returns(12345);
 
-      for (const prop in _features) {
-        sandbox.stub(_features, prop).returns('');
-      }
-
-      adagioMock.expects('enqueue').withExactArgs({
-        action: 'features',
-        ts: 12345,
-        data: {
-          'gpt-adunit-code': {
-            features: {},
-            version: '1'
-          }
-        }
-      }).atLeast(1);
-
       const bid01 = new BidRequestBuilder().withParams().build();
       const bidderRequest = new BidderRequestBuilder().build();
+
+      adagioMock.expects('enqueue').withArgs(sinon.match({ action: 'features' })).atLeast(1);
 
       const requests = spec.buildRequests([bid01], bidderRequest);
 
@@ -497,7 +420,7 @@ describe('Adagio bid adapter', () => {
         const requests = spec.buildRequests([bid01], bidderRequest);
         expect(requests).to.have.lengthOf(1);
         expect(requests[0].data.adUnits[0].mediaTypes.video).to.deep.equal(expected);
-        sinon.assert.calledTwice(utils.logWarn);
+        sinon.assert.calledTwice(utils.logWarn.withArgs(sinon.match(new RegExp(/^Adagio: The OpenRTB/))));
       });
     });
 
@@ -997,6 +920,20 @@ describe('Adagio bid adapter', () => {
         expect(bidResponse.height).to.equal(250);
         expect(bidResponse.vastUrl).to.match(/^data:text\/xml;/)
       });
+
+      it('should execute Adagio outstreamPlayer if defined', function() {
+        window.ADAGIO.outstreamPlayer = sinon.stub();
+        const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
+        executeRenderer(bidResponse.renderer, bidResponse)
+        sinon.assert.calledOnce(window.ADAGIO.outstreamPlayer);
+        delete window.ADAGIO.outstreamPlayer;
+      });
+
+      it('should logError if Adagio outstreamPlayer is not defined', function() {
+        const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
+        executeRenderer(bidResponse.renderer, bidResponse)
+        utilsMock.expects('logError').withExactArgs('Adagio: Adagio outstream player is not defined').once();
+      });
     });
 
     describe('Response with native add', () => {
@@ -1199,12 +1136,52 @@ describe('Adagio bid adapter', () => {
     });
   });
 
-  describe('Adagio features', function() {
+  describe('transformBidParams', function() {
+    it('Compute additional params in s2s mode', function() {
+      GlobalExchange.prepareExchangeData('{}');
+
+      sandbox.stub(window.top.document, 'getElementById').returns(
+        fixtures.getElementById()
+      );
+      sandbox.stub(window.top, 'getComputedStyle').returns({ display: 'block' });
+      sandbox.stub(utils, 'inIframe').returns(false);
+
+      const adUnit = {
+        code: 'adunit-code',
+        params: {
+          organizationId: '1000'
+        }
+      };
+      const bid01 = new BidRequestBuilder({
+        'mediaTypes': {
+          banner: { sizes: [[300, 250]] }
+        }
+      }).withParams().build();
+
+      const params = spec.transformBidParams({ organizationId: '1000' }, true, adUnit, [{ bidderCode: 'adagio', bids: [bid01] }]);
+
+      expect(params.organizationId).to.exist;
+      expect(params.organizationId).to.exist;
+      expect(params.features).to.exist;
+      expect(params.features.page_dimensions).to.exist;
+      expect(params.features.adunit_position).to.exist;
+      expect(params.features.dom_loading).to.exist;
+      expect(params.features.print_number).to.exist;
+      expect(params.features.user_timestamp).to.exist;
+      expect(params.placement).to.exist;
+      expect(params.adUnitElementId).to.exist;
+      expect(params.site).to.exist;
+      expect(params.data.session).to.exist;
+    });
+  });
+
+  describe('Adagio features when prebid in top.window', function() {
     it('should return all expected features when all expected bidder params are available', function() {
       sandbox.stub(window.top.document, 'getElementById').returns(
         fixtures.getElementById()
       );
       sandbox.stub(window.top, 'getComputedStyle').returns({ display: 'block' });
+      sandbox.stub(utils, 'inIframe').returns(false);
 
       const bidRequest = new BidRequestBuilder({
         'mediaTypes': {
@@ -1214,7 +1191,8 @@ describe('Adagio bid adapter', () => {
 
       const bidderRequest = new BidderRequestBuilder().build();
 
-      const result = adagio.getFeatures(bidRequest, bidderRequest);
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
 
       expect(result.adunit_position).to.match(/^[\d]+x[\d]+$/);
       expect(result.page_dimensions).to.match(/^[\d]+x[\d]+$/);
@@ -1222,13 +1200,15 @@ describe('Adagio bid adapter', () => {
       expect(result.print_number).to.be.a('String');
       expect(result.dom_loading).to.be.a('String');
       expect(result.user_timestamp).to.be.a('String');
-      expect(result.url).to.be.a('String');
-      expect(result.device).to.be.a('String');
-      expect(result.os).to.be.a('String');
-      expect(result.browser).to.be.a('String');
+      expect(result.url).to.not.exist;
+      expect(result.device).to.not.exist;
+      expect(result.os).to.not.exist;
+      expect(result.browser).to.not.exist;
     });
 
     it('should return all expected features when `adUnitElementId` param is not available', function() {
+      sandbox.stub(utils, 'inIframe').returns(false);
+
       const bidRequest = new BidRequestBuilder({
         params: {
           organizationId: '1000',
@@ -1242,7 +1222,8 @@ describe('Adagio bid adapter', () => {
 
       const bidderRequest = new BidderRequestBuilder().build();
 
-      const result = adagio.getFeatures(bidRequest, bidderRequest);
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
 
       expect(result.adunit_position).to.not.exist;
       expect(result.page_dimensions).to.be.a('String');
@@ -1250,16 +1231,23 @@ describe('Adagio bid adapter', () => {
       expect(result.print_number).to.be.a('String');
       expect(result.dom_loading).to.be.a('String');
       expect(result.user_timestamp).to.be.a('String');
-      expect(result.url).to.be.a('String');
-      expect(result.device).to.be.a('String');
-      expect(result.os).to.be.a('String');
-      expect(result.browser).to.be.a('String');
+    });
+  });
+
+  describe('Adagio features when prebid in Safeframe', function() {
+    beforeEach(function () {
+      window.$sf = $sf;
     });
 
-    it('should not return feature with an empty value', function() {
-      sandbox.stub(_features, 'getDomLoadingDuration').returns('');
-      sandbox.stub(_features, 'getUrl').returns('');
-      sandbox.stub(_features, 'getBrowser').returns('');
+    afterEach(function () {
+      delete window.$sf;
+    });
+
+    it('should return all expected features when prebid is in safeframe iframe', function() {
+      sandbox.stub(window.$sf.ext, 'geom').returns({
+        win: {t: 23, r: 1920, b: 1200, l: 0, w: 1920, h: 1177},
+        self: {t: 210, r: 1159, b: 460, l: 859, w: 300, h: 250},
+      });
 
       const bidRequest = new BidRequestBuilder({
         'mediaTypes': {
@@ -1269,178 +1257,85 @@ describe('Adagio bid adapter', () => {
 
       const bidderRequest = new BidderRequestBuilder().build();
 
-      const result = adagio.getFeatures(bidRequest, bidderRequest);
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
 
+      expect(result.page_dimensions).to.not.exist;
+      expect(result.viewport_dimensions).to.be.a('String');
+      expect(result.print_number).to.be.a('String');
+      expect(result.dom_loading).to.be.a('String');
+      expect(result.user_timestamp).to.be.a('String');
+      expect(result.adunit_position).to.exist;
+    });
+
+    it('should return all expected features when prebid safeframe api not properly implemented', function() {
+      const bidRequest = new BidRequestBuilder({
+        'mediaTypes': {
+          banner: { sizes: [[300, 250]] }
+        }
+      }).withParams().build();
+
+      const bidderRequest = new BidderRequestBuilder().build();
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
+
+      expect(result.page_dimensions).to.not.exist;
+      expect(result.viewport_dimensions).to.not.exist;
+      expect(result.print_number).to.be.a('String');
+      expect(result.dom_loading).to.be.a('String');
+      expect(result.user_timestamp).to.be.a('String');
       expect(result.adunit_position).to.not.exist;
-      expect(result.page_dimensions).to.exist;
-      expect(result.viewport_dimensions).to.exist;
-      expect(result.print_number).to.exist;
-      expect(result.dom_loading).to.not.exist;
-      expect(result.user_timestamp).to.exist;
-      expect(result.url).to.not.exist;
-      expect(result.device).to.exist;
-      expect(result.os).to.exist;
-      expect(result.browser).to.not.exist;
     });
 
-    describe('getPageDimensions feature', function() {
-      afterEach(() => {
-        delete window.$sf;
-      });
+    it('should return all expected features when prebid safeframe api not properly implemented bis', function() {
+      window.$sf.ext.geom = undefined;
 
-      it('should not compute the page dimensions in cross-origin iframe', function() {
-        sandbox.stub(utils, 'getWindowTop').throws();
-        const result = _features.getPageDimensions();
-        expect(result).to.eq('');
-      });
+      const bidRequest = new BidRequestBuilder({
+        'mediaTypes': {
+          banner: { sizes: [[300, 250]] }
+        }
+      }).withParams().build();
 
-      it('should not compute the page dimensions even with safeFrame api', function() {
-        window.$sf = $sf;
-        const result = _features.getPageDimensions();
-        expect(result).to.eq('');
-      });
+      const bidderRequest = new BidderRequestBuilder().build();
 
-      it('should not compute the page dimensions if <body> is not in the DOM', function() {
-        sandbox.stub(window.top.document, 'querySelector').withArgs('body').returns(null);
-        const result = _features.getPageDimensions();
-        expect(result).to.eq('');
-      });
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
 
-      it('should compute the page dimensions based on body and viewport dimensions', function() {
-        sandbox.stub(window.top.document, 'querySelector').withArgs('body').returns({ scrollWidth: 1360, offsetWidth: 1280, scrollHeight: 2000, offsetHeight: 1000 });
-        const result = _features.getPageDimensions();
-        expect(result).to.eq('1360x2000');
-      });
-    });
-
-    describe('getViewPortDimensions feature', function() {
-      afterEach(() => {
-        delete window.$sf;
-      });
-
-      it('should not compute the viewport dimensions in cross-origin iframe', function() {
-        sandbox.stub(utils, 'getWindowTop').throws();
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('');
-      });
-
-      it('should compute the viewport dimensions in cross-origin iframe w/ safeFrame api', function() {
-        window.$sf = $sf;
-        sandbox.stub(window.$sf.ext, 'geom').returns({
-          win: {t: 23, r: 1920, b: 1200, l: 0, w: 1920, h: 1177},
-          self: {t: 210, r: 1159, b: 460, l: 859, w: 300, h: 250},
-        });
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('1920x1177');
-      });
-
-      it('should not compute the viewport dimensions if safeFrame api is misimplemented', function() {
-        window.$sf = {
-          ext: { geom: 'nothing' }
-        };
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('');
-      });
-
-      it('should not compute the viewport dimensions if <body> is not in the DOM', function() {
-        const querySelectorSpy = sandbox.spy(() => null);
-        sandbox.stub(utils, 'getWindowTop').returns({
-          location: { href: 'https://mytest.io' },
-          document: { querySelector: querySelectorSpy }
-        });
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('');
-      });
-
-      it('should compute the viewport dimensions based on window', function() {
-        sandbox.stub(utils, 'getWindowTop').returns({
-          location: { href: 'https://mytest.io' },
-          innerWidth: 960,
-          innerHeight: 3000
-        });
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('960x3000');
-      });
-
-      it('should compute the viewport dimensions based on body', function() {
-        const querySelectorSpy = sandbox.spy(() => ({ clientWidth: 1024, clientHeight: 2000 }));
-        sandbox.stub(utils, 'getWindowTop').returns({
-          location: { href: 'https://mytest.io' },
-          document: { querySelector: querySelectorSpy }
-        });
-        const result = _features.getViewPortDimensions();
-        expect(result).to.eq('1024x2000');
-      });
-    });
-
-    describe('getSlotPosition feature', function() {
-      let getElementByIdStub;
-      let getComputedStyleStub;
-
-      beforeEach(() => {
-        getElementByIdStub = sandbox.stub(window.top.document, 'getElementById');
-        getElementByIdStub.returns(fixtures.getElementById());
-        getComputedStyleStub = sandbox.stub(window.top, 'getComputedStyle');
-        getComputedStyleStub.returns({ display: 'block' });
-      });
-
-      afterEach(() => {
-        delete window.$sf;
-        getElementByIdStub.restore();
-        getComputedStyleStub.restore();
-      });
-
-      it('should not compute the slot position in cross-origin iframe', function() {
-        sandbox.stub(utils, 'getWindowTop').throws();
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('');
-      });
-
-      it('should compute the slot position in cross-origin iframe w/ safeFrame api', function() {
-        window.$sf = $sf;
-        sandbox.stub(window.$sf.ext, 'geom').returns({
-          win: {t: 23, r: 1920, b: 1200, l: 0, w: 1920, h: 1177},
-          self: {t: 210, r: 1159, b: 460, l: 859, w: 300, h: 250},
-        });
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('210x859');
-      });
-
-      it('should not compute the slot position if safeFrame api is misimplemented', function() {
-        window.$sf = {
-          ext: { geom: 'nothing' }
-        };
-        utilsMock.expects('logWarn').once();
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('');
-        utilsMock.verify();
-      });
-
-      it('should not compute the slot position due to unreachable adUnitElementId', function() {
-        getElementByIdStub.returns(null);
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('');
-      });
-
-      it('should use a quick switch to display slot and compute position', function() {
-        getComputedStyleStub.returns({ display: 'none' });
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('800x300');
-      });
-
-      it('should compute the slot position based on window.top w/o postBid param', function() {
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: false });
-        expect(result).to.eq('800x300');
-      });
-
-      it.skip('should compute the slot position inside the parent window (window.top) when safeFrame is not available and postBid params is `true`', function() {
-        const result = _features.getSlotPosition({ adUnitElementId: 'gpt-adunit-code', postBid: true });
-        // expect(result).to.eq('800x300');
-      });
+      expect(result.page_dimensions).to.not.exist;
+      expect(result.viewport_dimensions).to.not.exist;
+      expect(result.print_number).to.be.a('String');
+      expect(result.dom_loading).to.be.a('String');
+      expect(result.user_timestamp).to.be.a('String');
+      expect(result.adunit_position).to.not.exist;
     });
   });
 
-  describe('optional params auto detection', function() {
+  describe('Adagio features when prebid in crossdomain iframe', function() {
+    it('should return all expected features', function() {
+      sandbox.stub(utils, 'getWindowTop').throws();
+
+      const bidRequest = new BidRequestBuilder({
+        'mediaTypes': {
+          banner: { sizes: [[300, 250]] }
+        }
+      }).withParams().build();
+
+      const bidderRequest = new BidderRequestBuilder().build();
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
+
+      expect(result.page_dimensions).to.not.exist;
+      expect(result.viewport_dimensions).to.not.exist;
+      expect(result.print_number).to.be.a('String');
+      expect(result.dom_loading).to.be.a('String');
+      expect(result.user_timestamp).to.be.a('String');
+      expect(result.adunit_position).to.not.exist;
+    });
+  });
+
+  describe.skip('optional params auto detection', function() {
     it('should auto detect environment', function() {
       const getDeviceStub = sandbox.stub(_features, 'getDevice');
 
@@ -1460,7 +1355,7 @@ describe('Adagio bid adapter', () => {
     });
   });
 
-  describe('print number handling', function() {
+  describe.skip('print number handling', function() {
     it('should return 1 if no adunit-code found. This means it is the first auction', function() {
       sandbox.stub(adagio, 'getPageviewId').returns('abc-def');
       expect(adagio.computePrintNumber('adunit-code')).to.eql(1);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -970,7 +970,6 @@ describe('Adagio bid adapter', () => {
         ],
         assets: [
           {
-            required: 1,
             title: {
               text: 'My title'
             }
@@ -1018,34 +1017,32 @@ describe('Adagio bid adapter', () => {
       };
 
       const bidRequestNative = utils.deepClone(bidRequest)
-      bidRequestNative.mediaTypes = {
-        native: {
-          sendTargetingKeys: false,
+      bidRequestNative.nativeParams = {
+        sendTargetingKeys: false,
 
-          clickUrl: {
-            required: true,
-          },
-          title: {
-            required: true,
-          },
-          body: {
-            required: true,
-          },
-          sponsoredBy: {
-            required: false
-          },
-          image: {
-            required: true
-          },
-          icon: {
-            required: true
-          },
-          privacyLink: {
-            required: false
-          },
-          ext: {
-            adagio_bvw: {}
-          }
+        clickUrl: {
+          required: true,
+        },
+        title: {
+          required: true,
+        },
+        body: {
+          required: true,
+        },
+        sponsoredBy: {
+          required: false
+        },
+        image: {
+          required: true
+        },
+        icon: {
+          required: true
+        },
+        privacyLink: {
+          required: false
+        },
+        ext: {
+          adagio_bvw: {}
         }
       };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [x] Other

## Description of change
This PR is about to add Prebid Server support in the Adagio bidder adapter.

We need to add computed params to the bidrequest and actually the easiest/proper way is to use the adapter `spec.bidTransformParams()` method.  I had to update the signature of `bidTransformParams()` to pass context.

In order  to facilitate the review, here the other points we  worked on:
- we remove our `_features` functions wrapper
- some function were useless as we can auto-detect server side (`getOs`, `getBrowser`, …)
- we take advantage of `bidRequestsCount` property instead of compute it by ourself
- we allow some global params to be set at global config (pbjs.setConfig()) or at First Party Data level (`ortb2.site.ext`)


- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

Link to a PR on the docs repo: 
