### PR TITLE
PBS adapter - fix logic for undefined endpoint URLs

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -1104,9 +1104,10 @@ export function PrebidServer() {
       const request = OPEN_RTB_PROTOCOL.buildRequest(s2sBidRequest, bidRequests, validAdUnits, s2sBidRequest.s2sConfig, requestedBidders);
       const requestJson = request && JSON.stringify(request);
       utils.logInfo('BidRequest: ' + requestJson);
-      if (request && requestJson && getMatchingConsentUrl(s2sBidRequest.s2sConfig.endpoint, gdprConsent)) {
+      const endpointUrl = getMatchingConsentUrl(s2sBidRequest.s2sConfig.endpoint, gdprConsent);
+      if (request && requestJson && endpointUrl) {
         ajax(
-          getMatchingConsentUrl(s2sBidRequest.s2sConfig.endpoint, gdprConsent),
+          endpointUrl,
           {
             success: response => handleResponse(response, requestedBidders, bidRequests, addBidResponse, done, s2sBidRequest.s2sConfig),
             error: done

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -136,7 +136,7 @@ function formatUrlParams(option) {
     if (utils.isPlainObject(option[prop]) && (!option[prop].p1Consent || !option[prop].noP1Consent)) {
       ['p1Consent', 'noP1Consent'].forEach((conUrl) => {
         if (!option[prop][conUrl]) {
-          utils.logWarn(`s2sConfig.${prop}.${conUrl} was not defined in manually set s2sConfig.  This may prevent PBS requests from executing in certain cases.  Please define field manually or instead use the defaultVendor settings of host company (if avialable).`);
+          utils.logWarn(`s2sConfig.${prop}.${conUrl} not defined.  PBS request will be skipped in some P1 scenarios.`);
         }
       });
     }
@@ -1115,7 +1115,7 @@ export function PrebidServer() {
           { contentType: 'text/plain', withCredentials: true }
         );
       } else {
-        utils.logError('Prebid Server request did not execute.  Please ensure endpoint URL(s) are properly defined in your s2sConfig.  Otherwise check for warnings/errors, likely noted earlier in console logs...');
+        utils.logError('PBS request not made.  Check endpoints.');
       }
     }
   };

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -506,14 +506,55 @@ describe('S2S Adapter', function () {
       resetSyncedStatus();
     });
 
-    it('should block request if config did not define proper URL in endpoint object config', function() {
+    it('should block request if config did not define p1Consent URL in endpoint object config', function() {
       let badConfig = utils.deepClone(CONFIG);
       badConfig.endpoint = { noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
       config.setConfig({ s2sConfig: badConfig });
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
-      
+
+      adapter.callBids(badCfgRequest, BID_REQUESTS, addBidResponse, done, ajax);
+
+      expect(server.requests.length).to.equal(0);
+    });
+
+    it('should block request if config did not define noP1Consent URL in endpoint object config', function() {
+      let badConfig = utils.deepClone(CONFIG);
+      badConfig.endpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
+      config.setConfig({ s2sConfig: badConfig });
+
+      let badCfgRequest = utils.deepClone(REQUEST);
+      badCfgRequest.s2sConfig = badConfig;
+
+      let badBidderRequest = utils.deepClone(BID_REQUESTS);
+      badBidderRequest[0].gdprConsent = {
+        consentString: 'abc123',
+        addtlConsent: 'superduperconsent',
+        gdprApplies: true,
+        apiVersion: 2,
+        vendorData: {
+          purpose: {
+            consents: {
+              1: false
+            }
+          }
+        }
+      };
+
+      adapter.callBids(badCfgRequest, badBidderRequest, addBidResponse, done, ajax);
+
+      expect(server.requests.length).to.equal(0);
+    });
+
+    it('should block request if config did not define any URLs in endpoint object config', function() {
+      let badConfig = utils.deepClone(CONFIG);
+      badConfig.endpoint = {};
+      config.setConfig({ s2sConfig: badConfig });
+
+      let badCfgRequest = utils.deepClone(REQUEST);
+      badCfgRequest.s2sConfig = badConfig;
+
       adapter.callBids(badCfgRequest, BID_REQUESTS, addBidResponse, done, ajax);
 
       expect(server.requests.length).to.equal(0);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -506,6 +506,19 @@ describe('S2S Adapter', function () {
       resetSyncedStatus();
     });
 
+    it('should block request if config did not define proper URL in endpoint object config', function() {
+      let badConfig = utils.deepClone(CONFIG);
+      badConfig.endpoint = { noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
+      config.setConfig({ s2sConfig: badConfig });
+
+      let badCfgRequest = utils.deepClone(REQUEST);
+      badCfgRequest.s2sConfig = badConfig;
+      
+      adapter.callBids(badCfgRequest, BID_REQUESTS, addBidResponse, done, ajax);
+
+      expect(server.requests.length).to.equal(0);
+    });
+
     it('should not add outstrean without renderer', function () {
       config.setConfig({ s2sConfig: CONFIG });
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Fixes #7046

There was an issue present in s2sConfigs if the publisher defined the `endpoint` (or `syncEndpoint`) object config but didn't define both `p1Consent` and `noP1Consent` fields.  In this case, the field that was `undefined` would still try to make a call to PBS with an `undefined` URL for that type of user.  

This PR addresses this scenario by blocking the call to PBS entirely if a particular URL field was `undefined` for that type of user.  It will return an error for this scenario notifying what likely happened.  

Also added a warning when evaluating the s2sConfig if one of these fields were `undefined` when using the object config.

TO NOTE:
Publishers still using the old `string` version of the `endpoint` (or `syncEndpoint`) fields or who relied on the `defaultVendor` feature to populate the endpoint URLs are unaffected by this scenario/fix.  For the former, the single URL they define in the s2sConfig is still shared between consent/non-consent users.  For the latter, the URLs are still read/assigned based on the configs defined in Prebid.js.