### PR TITLE
Rubicon Bid Adapter: segtax change

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -978,7 +978,7 @@ function applyFPD(bidRequest, mediaType, data) {
 
   let fpd = utils.mergeDeep({}, config.getConfig('ortb2') || {}, BID_FPD);
   let impData = utils.deepAccess(bidRequest.ortb2Imp, 'ext.data') || {};
-  const SEGTAX = {user: [3], site: [1, 2]};
+  const SEGTAX = {user: [4], site: [1, 2]};
   const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
   const validate = function(prop, key, parentName) {
     if (key === 'data' && Array.isArray(prop)) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -897,7 +897,7 @@ describe('the rubicon adapter', function () {
             const user = {
               data: [{
                 'name': 'www.dataprovider1.com',
-                'ext': { 'segtax': 3 },
+                'ext': { 'segtax': 4 },
                 'segment': [
                   { 'id': '687' },
                   { 'id': '123' }


### PR DESCRIPTION
## Type of change
- [X ] Bugfix

## Description of change

As discussed in issue #6057 , we've changed the audience segtax from 3 to 4. Updating the rubicon adapter to reflect this. 

Confirmed that no other adapter refers specifically to segtax.
