### PR TITLE
sharedIdSystem: return pubcid instead of sharedId

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -12,7 +12,7 @@ import { uspDataHandler, coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
 const GVLID = 887;
-const storage = getStorageManager(GVLID, 'pubCommonId');
+export const storage = getStorageManager(GVLID, 'pubCommonId');
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const SHAREDID_OPT_OUT_VALUE = '00000000000000000000000000';
@@ -33,7 +33,7 @@ function storeData(config, value) {
   try {
     if (value) {
       const key = config.storage.name + SHAREDID_SUFFIX;
-      const expiresStr = (new Date(Date.now() + (storage.expires * (60 * 60 * 24 * 1000)))).toUTCString();
+      const expiresStr = (new Date(Date.now() + (config.storage.expires * (60 * 60 * 24 * 1000)))).toUTCString();
 
       if (config.storage.type === COOKIE) {
         if (storage.cookiesAreEnabled()) {
@@ -123,7 +123,7 @@ function handleResponse(pubcid, callback, config) {
             }
           }
           // Pass pubcid even though there is no change in order to trigger decode
-          callback(responseObj.sharedId);
+          callback(pubcid);
         } catch (error) {
           utils.logError(error);
         }

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,29 +1,62 @@
 import {
   sharedIdSystemSubmodule,
+  storage
 } from 'modules/sharedIdSystem.js';
 import { server } from 'test/mocks/xhr.js';
 import {uspDataHandler} from 'src/adapterManager';
 import sinon from 'sinon';
+import * as utils from 'src/utils.js';
 
 let expect = require('chai').expect;
 
 describe('SharedId System', function() {
-  const SHAREDID_RESPONSE = {sharedId: 'testsharedid'};
-  let uspConsentDataStub;
+  const UUID = '15fde1dc-1861-4894-afdf-b757272f3568';
+  const START_TIME_MILLIS = 1234;
+
+  before(function() {
+    sinon.stub(utils, 'generateUUID').returns(UUID);
+  });
+
+  after(function() {
+    utils.generateUUID.restore();
+  });
+
   describe('Xhr Requests from getId()', function() {
-    let callbackSpy = sinon.spy();
+    const SHAREDID_RESPONSE = {sharedId: 'testsharedid'};
+    const callbackSpy = sinon.spy();
+
+    let uspConsentDataStub
+    let setCookeStub;
+    let sandbox;
 
     beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+
+      uspConsentDataStub = sandbox.stub(uspDataHandler, 'getConsentData');
+      setCookeStub = sandbox.stub(storage, 'setCookie');
+
+      sandbox.stub(storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(utils, 'hasDeviceAccess').returns(true);
+
+      sandbox.useFakeTimers(START_TIME_MILLIS);
+
       callbackSpy.resetHistory();
-      uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
     });
 
     afterEach(function () {
-      uspConsentDataStub.restore();
+      sandbox.restore();
     });
 
     it('should call shared id endpoint without consent data and handle a valid response', function () {
-      let submoduleCallback = sharedIdSystemSubmodule.getId(undefined, undefined).callback;
+      let config = {
+        storage: {
+          type: 'cookie',
+          name: '_pubcid',
+          expires: 10
+        }
+      };
+
+      let submoduleCallback = sharedIdSystemSubmodule.getId(config, undefined).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];
@@ -33,7 +66,16 @@ describe('SharedId System', function() {
       request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
+      expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
+
+      expect(setCookeStub.calledThrice).to.be.true;
+
+      let testCookieName = `_gd${START_TIME_MILLIS}`;
+      expect(setCookeStub.firstCall.args).to.eql([testCookieName, '1', undefined, undefined, 'localhost']);
+      expect(setCookeStub.secondCall.args).to.eql([testCookieName, '', 'Thu, 01 Jan 1970 00:00:01 GMT', undefined, 'localhost']);
+
+      let expires = new Date(START_TIME_MILLIS + (config.storage.expires * (60 * 60 * 24 * 1000))).toUTCString();
+      expect(setCookeStub.lastCall.args).to.eql(['_pubcid_sharedid', 'testsharedid', expires, 'LAX', undefined]);
     });
 
     it('should call shared id endpoint with consent data and handle a valid response', function () {
@@ -52,7 +94,7 @@ describe('SharedId System', function() {
       request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
+      expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
 
     it('should call shared id endpoint with usp consent data and handle a valid response', function () {
@@ -72,7 +114,7 @@ describe('SharedId System', function() {
       request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
+      expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
I had a look at `sharedIdSystem.js` after the changes made in https://github.com/prebid/Prebid.js/pull/6808 for issue https://github.com/prebid/Prebid.js/issues/6640

I'm confused.

It doesn't make sense to me that the `sharedId` is passed into the callback. Should it be `pubcid` instead?

It could do with more tests. I didn't invest much time there because my understanding could be wrong.

From unit testing, I noticed `storage.expires` in the storeData function does not exist (or does it?). So I changed to `config.storage.expires`. Not sure if this is correct.