### PR TITLE
Smaato bid adapter: adpod support added 

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -5,7 +5,7 @@ import { ADPOD, BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'smaato';
 const SMAATO_ENDPOINT = 'https://prebid.ad.smaato.net/oapi/prebid';
-const SMAATO_CLIENT = 'prebid_js_$prebid.version$_1.2'
+const SMAATO_CLIENT = 'prebid_js_$prebid.version$_1.3'
 
 const buildOpenRtbBidRequest = (bidRequest, bidderRequest) => {
   const request = {

--- a/modules/smaatoBidAdapter.md
+++ b/modules/smaatoBidAdapter.md
@@ -62,3 +62,34 @@ var adUnits = [{
     }]
 }];
 ```
+
+For adpod adunits:
+
+```
+var adUnits = [{
+    "code": "adpod unit",
+    "mediaTypes": {
+        "video": {
+            "context": "adpod",
+            "playerSize": [640, 480],
+            "adPodDurationSec": 300,
+            "durationRangeSec": [15, 30],
+            "requireExactDuration": false,
+            "mimes": ["video/mp4"],
+            "startdelay": 0,
+            "linearity": 1,
+            "protocols": [7],
+            "skip": 1,
+            "skipmin": 5,
+            "api": [7],
+        }
+    },
+    "bids": [{
+        "bidder": "smaato",
+        "params": {
+            "publisherId": "1100042525",
+            "adbreakId": "330563103"
+        }
+    }]
+}];
+```

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -7,12 +7,6 @@ const ADTYPE_IMG = 'Img';
 const ADTYPE_RICHMEDIA = 'Richmedia';
 const ADTYPE_VIDEO = 'Video';
 
-const request = {
-  method: 'POST',
-  url: 'https://prebid.ad.smaato.net/oapi/prebid',
-  data: ''
-};
-
 const REFERRER = 'http://example.com/page.html'
 const CONSENT_STRING = 'HFIDUYFIUYIUYWIPOI87392DSU'
 
@@ -649,6 +643,14 @@ describe('smaatoBidAdapterTest', () => {
   });
 
   describe('interpretResponse', () => {
+    function buildBidRequest(payloadAsJsObj = {imp: [{}]}) {
+      return {
+        method: 'POST',
+        url: 'https://prebid.ad.smaato.net/oapi/prebid',
+        data: JSON.stringify(payloadAsJsObj)
+      }
+    }
+
     const buildOpenRtbBidResponse = (adType) => {
       let adm = '';
 
@@ -739,99 +741,184 @@ describe('smaatoBidAdapterTest', () => {
     };
 
     it('returns empty array on no bid responses', () => {
-      const response_with_empty_body = {body: {}}
+      const response_with_empty_body = {body: {}};
 
-      const bids = spec.interpretResponse(response_with_empty_body, request);
+      const bids = spec.interpretResponse(response_with_empty_body, buildBidRequest());
 
-      expect(bids).to.be.empty
+      expect(bids).to.be.empty;
     });
 
-    it('single image reponse', () => {
-      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_IMG), request);
+    describe('non ad pod', () => {
+      it('single image reponse', () => {
+        const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_IMG), buildBidRequest());
 
-      expect(bids).to.deep.equal([
-        {
-          requestId: '226416e6e6bf41',
-          cpm: 0.01,
-          width: 350,
-          height: 50,
-          ad: '<div style="cursor:pointer" onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});;window.open(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fctaurl\'));"><img src="https://prebid/static/ad.jpg" width="320" height="50"/><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
-          ttl: 300,
-          creativeId: 'CR69381',
-          dealId: '12345',
-          netRevenue: true,
-          currency: 'USD',
-          meta: {
-            advertiserDomains: ['smaato.com'],
-            agencyId: 'CM6523',
-            networkName: 'smaato',
-            mediaType: 'banner'
+        expect(bids).to.deep.equal([
+          {
+            requestId: '226416e6e6bf41',
+            cpm: 0.01,
+            width: 350,
+            height: 50,
+            ad: '<div style="cursor:pointer" onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});;window.open(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fctaurl\'));"><img src="https://prebid/static/ad.jpg" width="320" height="50"/><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
+            ttl: 300,
+            creativeId: 'CR69381',
+            dealId: '12345',
+            netRevenue: true,
+            currency: 'USD',
+            mediaType: 'banner',
+            meta: {
+              advertiserDomains: ['smaato.com'],
+              agencyId: 'CM6523',
+              networkName: 'smaato',
+              mediaType: 'banner'
+            }
           }
-        }
-      ]);
-    });
+        ]);
+      });
 
-    it('single richmedia reponse', () => {
-      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_RICHMEDIA), request);
+      it('single richmedia reponse', () => {
+        const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_RICHMEDIA), buildBidRequest());
 
-      expect(bids).to.deep.equal([
-        {
-          requestId: '226416e6e6bf41',
-          cpm: 0.01,
-          width: 350,
-          height: 50,
-          ad: '<div onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});"><div><h3>RICHMEDIA CONTENT</h3></div><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
-          ttl: 300,
-          creativeId: 'CR69381',
-          dealId: '12345',
-          netRevenue: true,
-          currency: 'USD',
-          meta: {
-            advertiserDomains: ['smaato.com'],
-            agencyId: 'CM6523',
-            networkName: 'smaato',
-            mediaType: 'banner'
+        expect(bids).to.deep.equal([
+          {
+            requestId: '226416e6e6bf41',
+            cpm: 0.01,
+            width: 350,
+            height: 50,
+            ad: '<div onclick="fetch(decodeURIComponent(\'https%3A%2F%2Fprebid%2Ftrack%2Fclick%2F1\'), {cache: \'no-cache\'});"><div><h3>RICHMEDIA CONTENT</h3></div><img src="https://prebid/track/imp/1" alt="" width="0" height="0"/><img src="https://prebid/track/imp/2" alt="" width="0" height="0"/></div>',
+            ttl: 300,
+            creativeId: 'CR69381',
+            dealId: '12345',
+            netRevenue: true,
+            currency: 'USD',
+            mediaType: 'banner',
+            meta: {
+              advertiserDomains: ['smaato.com'],
+              agencyId: 'CM6523',
+              networkName: 'smaato',
+              mediaType: 'banner'
+            }
           }
-        }
-      ]);
-    });
+        ]);
+      });
 
-    it('single video reponse', () => {
-      const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_VIDEO), request);
+      it('single video reponse', () => {
+        const bids = spec.interpretResponse(buildOpenRtbBidResponse(ADTYPE_VIDEO), buildBidRequest());
 
-      expect(bids).to.deep.equal([
-        {
-          requestId: '226416e6e6bf41',
-          cpm: 0.01,
-          width: 350,
-          height: 50,
-          vastXml: '<VAST version="2.0"></VAST>',
-          ttl: 300,
-          creativeId: 'CR69381',
-          dealId: '12345',
-          netRevenue: true,
-          currency: 'USD',
-          meta: {
-            advertiserDomains: ['smaato.com'],
-            agencyId: 'CM6523',
-            networkName: 'smaato',
-            mediaType: 'video'
+        expect(bids).to.deep.equal([
+          {
+            requestId: '226416e6e6bf41',
+            cpm: 0.01,
+            width: 350,
+            height: 50,
+            vastXml: '<VAST version="2.0"></VAST>',
+            ttl: 300,
+            creativeId: 'CR69381',
+            dealId: '12345',
+            netRevenue: true,
+            currency: 'USD',
+            mediaType: 'video',
+            meta: {
+              advertiserDomains: ['smaato.com'],
+              agencyId: 'CM6523',
+              networkName: 'smaato',
+              mediaType: 'video'
+            }
           }
-        }
-      ]);
+        ]);
+      });
+
+      it('ignores bid response with invalid ad type', () => {
+        const serverResponse = buildOpenRtbBidResponse(ADTYPE_IMG);
+        serverResponse.headers.get = (header) => {
+          if (header === 'X-SMT-ADTYPE') {
+            return undefined;
+          }
+        };
+
+        const bids = spec.interpretResponse(serverResponse, buildBidRequest());
+
+        expect(bids).to.be.empty;
+      });
     });
 
-    it('ignores bid response with invalid ad type', () => {
-      const resp = buildOpenRtbBidResponse(ADTYPE_IMG);
-      resp.headers.get = (header) => {
-        if (header === 'X-SMT-ADTYPE') {
-          return undefined;
-        }
-      }
+    describe('ad pod', () => {
+      const bidRequestWithAdpodContext = buildBidRequest({imp: [{video: {ext: {context: 'adpod'}}}]});
+      const PRIMARY_CAT_ID = 1337
+      const serverResponse = {
+        body: {
+          bidid: '04db8629-179d-4bcd-acce-e54722969006',
+          cur: 'USD',
+          ext: {},
+          id: '5ebea288-f13a-4754-be6d-4ade66c68877',
+          seatbid: [
+            {
+              bid: [
+                {
+                  adm: '<VAST version="2.0"></VAST>',
+                  adomain: [
+                    'smaato.com'
+                  ],
+                  bidderName: 'smaato',
+                  cid: 'CM6523',
+                  crid: 'CR69381',
+                  dealid: '12345',
+                  id: '6906aae8-7f74-4edd-9a4f-f49379a3cadd',
+                  impid: '226416e6e6bf41',
+                  iurl: 'https://prebid/iurl',
+                  nurl: 'https://prebid/nurl',
+                  price: 0.01,
+                  w: 350,
+                  h: 50,
+                  cat: [PRIMARY_CAT_ID],
+                  ext: {
+                    duration: 42
+                  }
+                }
+              ],
+              seat: 'CM6523'
+            }
+          ]
+        },
+        headers: {get: () => undefined}
+      };
 
-      const bids = spec.interpretResponse(resp, request);
+      it('sets required values for adpod bid from server response', () => {
+        const bids = spec.interpretResponse(serverResponse, bidRequestWithAdpodContext);
 
-      expect(bids).to.be.empty
+        expect(bids).to.deep.equal([
+          {
+            requestId: '226416e6e6bf41',
+            cpm: 0.01,
+            width: 350,
+            height: 50,
+            vastXml: '<VAST version="2.0"></VAST>',
+            ttl: 300,
+            creativeId: 'CR69381',
+            dealId: '12345',
+            netRevenue: true,
+            currency: 'USD',
+            mediaType: 'video',
+            video: {
+              context: 'adpod',
+              durationSeconds: 42
+            },
+            meta: {
+              advertiserDomains: ['smaato.com'],
+              agencyId: 'CM6523',
+              networkName: 'smaato',
+              mediaType: 'video'
+            }
+          }
+        ]);
+      });
+
+      it('sets primary category id in case of enabled brand category exclusion', () => {
+        config.setConfig({adpod: {brandCategoryExclusion: true}});
+
+        const bids = spec.interpretResponse(serverResponse, bidRequestWithAdpodContext)
+
+        expect(bids[0].meta.primaryCatId).to.be.equal(PRIMARY_CAT_ID)
+      })
     });
 
     it('uses correct TTL when expire header exists', () => {
@@ -845,9 +932,9 @@ describe('smaatoBidAdapterTest', () => {
         if (header === 'X-SMT-Expires') {
           return 2000 + (400 * 1000);
         }
-      }
+      };
 
-      const bids = spec.interpretResponse(resp, request);
+      const bids = spec.interpretResponse(resp, buildBidRequest());
 
       expect(bids[0].ttl).to.equal(400);
 
@@ -858,10 +945,10 @@ describe('smaatoBidAdapterTest', () => {
       const resp = buildOpenRtbBidResponse(ADTYPE_IMG);
       resp.body.seatbid[0].bid[0].ext = {net: false};
 
-      const bids = spec.interpretResponse(resp, request);
+      const bids = spec.interpretResponse(resp, buildBidRequest());
 
       expect(bids[0].netRevenue).to.equal(false);
-    })
+    });
   });
 
   describe('getUserSyncs', () => {

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -1,7 +1,7 @@
-import { spec } from 'modules/smaatoBidAdapter.js';
+import {spec} from 'modules/smaatoBidAdapter.js';
 import * as utils from 'src/utils.js';
-import { config } from 'src/config.js';
-import { createEidsArray } from 'modules/userId/eids.js';
+import {config} from 'src/config.js';
+import {createEidsArray} from 'modules/userId/eids.js';
 
 const ADTYPE_IMG = 'Img';
 const ADTYPE_RICHMEDIA = 'Richmedia';
@@ -9,6 +9,7 @@ const ADTYPE_VIDEO = 'Video';
 
 const REFERRER = 'http://example.com/page.html'
 const CONSENT_STRING = 'HFIDUYFIUYIUYWIPOI87392DSU'
+const AUCTION_ID = '6653';
 
 const defaultBidderRequest = {
   gdprConsent: {
@@ -19,7 +20,8 @@ const defaultBidderRequest = {
   refererInfo: {
     referer: REFERRER,
   },
-  timeout: 1200
+  timeout: 1200,
+  auctionId: AUCTION_ID
 };
 
 const BANNER_PREBID_MEDIATYPE = {
@@ -40,7 +42,6 @@ const singleBannerBidRequest = {
   sizes: [[300, 50]],
   bidId: 'bidId',
   bidderRequestId: 'bidderRequestId',
-  auctionId: 'auctionId',
   src: 'client',
   bidRequestsCount: 1,
   bidderRequestsCount: 1,
@@ -67,7 +68,7 @@ describe('smaatoBidAdapterTest', () => {
     });
 
     describe('for ad pod / long form video requests', () => {
-      const ADPOD = {video: {context: "adpod"}}
+      const ADPOD = {video: {context: 'adpod'}}
       it('is invalid, when adbreakId is missing', () => {
         expect(spec.isBidRequestValid({mediaTypes: ADPOD, params: {publisherId: '123'}})).to.be.false;
       });
@@ -83,7 +84,7 @@ describe('smaatoBidAdapterTest', () => {
       it('is invalid, when forbidden adspaceId param is present', () => {
         expect(spec.isBidRequestValid({
           mediaTypes: ADPOD,
-          params: {publisherId: '123', adbreakId: '456', adspaceId: "42"}
+          params: {publisherId: '123', adbreakId: '456', adspaceId: '42'}
         })).to.be.false;
       });
     });
@@ -102,7 +103,7 @@ describe('smaatoBidAdapterTest', () => {
       });
 
       it('is invalid, when forbidden adbreakId param is present', () => {
-        expect(spec.isBidRequestValid({params: {publisherId: '123', adspaceId: '456', adbreakId: "42"}})).to.be.false;
+        expect(spec.isBidRequestValid({params: {publisherId: '123', adspaceId: '456', adbreakId: '42'}})).to.be.false;
       });
     });
   });
@@ -314,7 +315,6 @@ describe('smaatoBidAdapterTest', () => {
           sizes: [[300, 50]],
           bidId: 'bidId',
           bidderRequestId: 'bidderRequestId',
-          auctionId: 'auctionId',
           src: 'client',
           bidRequestsCount: 1,
           bidderRequestsCount: 1,
@@ -343,7 +343,6 @@ describe('smaatoBidAdapterTest', () => {
           sizes: [[300, 50]],
           bidId: 'bidId',
           bidderRequestId: 'bidderRequestId',
-          auctionId: 'auctionId',
           src: 'client',
           bidRequestsCount: 1,
           bidderRequestsCount: 1,
@@ -358,9 +357,10 @@ describe('smaatoBidAdapterTest', () => {
       });
 
       describe('ad pod / long form video', () => {
-        describe('required parameters', () => {
+        describe('required parameters with requireExactDuration false', () => {
           const ADBREAK_ID = 'adbreakId';
           const ADPOD = 'adpod';
+          const BID_ID = '4331';
           const W = 640;
           const H = 480;
           const ADPOD_DURATION = 300;
@@ -376,21 +376,32 @@ describe('smaatoBidAdapterTest', () => {
                 playerSize: [[W, H]],
                 adPodDurationSec: ADPOD_DURATION,
                 durationRangeSec: DURATION_RANGE,
+                requireExactDuration: false
               }
             },
-            bidId: 'bidId',
+            bidId: BID_ID
           };
 
           it('sends required fields', () => {
             const reqs = spec.buildRequests([longFormVideoBidRequest], defaultBidderRequest);
 
             const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+            expect(req.id).to.be.equal(AUCTION_ID);
+            expect(req.imp.length).to.be.equal(ADPOD_DURATION / DURATION_RANGE[0]);
+            expect(req.imp[0].id).to.be.equal(BID_ID);
             expect(req.imp[0].tagid).to.be.equal(ADBREAK_ID);
             expect(req.imp[0].video.ext.context).to.be.equal(ADPOD);
             expect(req.imp[0].video.w).to.be.equal(W);
             expect(req.imp[0].video.h).to.be.equal(H);
-            expect(req.imp[0].video.ext.adpodduration).to.be.equal(ADPOD_DURATION);
-            expect(req.imp[0].video.ext.durationrange).to.be.deep.equal(DURATION_RANGE);
+            expect(req.imp[0].video.maxduration).to.be.equal(DURATION_RANGE[1]);
+            expect(req.imp[0].video.sequence).to.be.equal(1);
+            expect(req.imp[1].id).to.be.equal(BID_ID);
+            expect(req.imp[1].tagid).to.be.equal(ADBREAK_ID);
+            expect(req.imp[1].video.ext.context).to.be.equal(ADPOD);
+            expect(req.imp[1].video.w).to.be.equal(W);
+            expect(req.imp[1].video.h).to.be.equal(H);
+            expect(req.imp[1].video.maxduration).to.be.equal(DURATION_RANGE[1]);
+            expect(req.imp[1].video.sequence).to.be.equal(2);
           });
 
           it('sends brand category exclusion as true when config is set to true', () => {
@@ -418,8 +429,72 @@ describe('smaatoBidAdapterTest', () => {
             expect(req.imp[0].video.ext.brandcategoryexclusion).to.be.equal(false);
           });
         });
+        describe('required parameters with requireExactDuration true', () => {
+          const ADBREAK_ID = 'adbreakId';
+          const ADPOD = 'adpod';
+          const BID_ID = '4331';
+          const W = 640;
+          const H = 480;
+          const ADPOD_DURATION = 5;
+          const DURATION_RANGE = [5, 15, 25];
+          const longFormVideoBidRequest = {
+            params: {
+              publisherId: 'publisherId',
+              adbreakId: ADBREAK_ID,
+            },
+            mediaTypes: {
+              video: {
+                context: ADPOD,
+                playerSize: [[W, H]],
+                adPodDurationSec: ADPOD_DURATION,
+                durationRangeSec: DURATION_RANGE,
+                requireExactDuration: true
+              }
+            },
+            bidId: BID_ID
+          };
+
+          it('sends required fields', () => {
+            const reqs = spec.buildRequests([longFormVideoBidRequest], defaultBidderRequest);
+
+            const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+            expect(req.id).to.be.equal(AUCTION_ID);
+            expect(req.imp.length).to.be.equal(DURATION_RANGE.length);
+            expect(req.imp[0].id).to.be.equal(BID_ID);
+            expect(req.imp[0].tagid).to.be.equal(ADBREAK_ID);
+            expect(req.imp[0].video.ext.context).to.be.equal(ADPOD);
+            expect(req.imp[0].video.w).to.be.equal(W);
+            expect(req.imp[0].video.h).to.be.equal(H);
+            expect(req.imp[0].video.minduration).to.be.equal(DURATION_RANGE[0]);
+            expect(req.imp[0].video.maxduration).to.be.equal(DURATION_RANGE[0]);
+            expect(req.imp[0].video.sequence).to.be.equal(1);
+            expect(req.imp[1].id).to.be.equal(BID_ID);
+            expect(req.imp[1].tagid).to.be.equal(ADBREAK_ID);
+            expect(req.imp[1].video.ext.context).to.be.equal(ADPOD);
+            expect(req.imp[1].video.w).to.be.equal(W);
+            expect(req.imp[1].video.h).to.be.equal(H);
+            expect(req.imp[1].video.minduration).to.be.equal(DURATION_RANGE[1]);
+            expect(req.imp[1].video.maxduration).to.be.equal(DURATION_RANGE[1]);
+            expect(req.imp[1].video.sequence).to.be.equal(2);
+            expect(req.imp[2].id).to.be.equal(BID_ID);
+            expect(req.imp[2].tagid).to.be.equal(ADBREAK_ID);
+            expect(req.imp[2].video.ext.context).to.be.equal(ADPOD);
+            expect(req.imp[2].video.w).to.be.equal(W);
+            expect(req.imp[2].video.h).to.be.equal(H);
+            expect(req.imp[2].video.minduration).to.be.equal(DURATION_RANGE[2]);
+            expect(req.imp[2].video.maxduration).to.be.equal(DURATION_RANGE[2]);
+            expect(req.imp[2].video.sequence).to.be.equal(3);
+          });
+        });
 
         describe('forwarding of optional parameters', () => {
+          const MIMES = ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'];
+          const STARTDELAY = 0;
+          const LINEARITY = 1;
+          const SKIP = 1;
+          const PROTOCOLS = [7];
+          const SKIPMIN = 5;
+          const API = [7];
           const validBasicAdpodBidRequest = {
             params: {
               publisherId: 'publisherId',
@@ -431,19 +506,29 @@ describe('smaatoBidAdapterTest', () => {
                 playerSize: [640, 480],
                 adPodDurationSec: 300,
                 durationRangeSec: [15, 30],
+                mimes: MIMES,
+                startdelay: STARTDELAY,
+                linearity: LINEARITY,
+                skip: SKIP,
+                protocols: PROTOCOLS,
+                skipmin: SKIPMIN,
+                api: API
               }
             },
-            bidId: 'bidId',
+            bidId: 'bidId'
           };
 
-          it('sends requireexactduration field when parameter is present and of type boolean', () => {
-            const adpodRequestWithParameter = utils.deepClone(validBasicAdpodBidRequest);
-            adpodRequestWithParameter.mediaTypes.video.requireExactDuration = true;
-
-            const reqs = spec.buildRequests([adpodRequestWithParameter], defaultBidderRequest);
+          it('sends general video fields when they are present', () => {
+            const reqs = spec.buildRequests([validBasicAdpodBidRequest], defaultBidderRequest);
 
             const req = extractPayloadOfFirstAndOnlyRequest(reqs);
-            expect(req.imp[0].video.ext.requireexactduration).to.be.equal(true);
+            expect(req.imp[0].video.mimes).to.eql(MIMES);
+            expect(req.imp[0].video.startdelay).to.be.equal(STARTDELAY);
+            expect(req.imp[0].video.linearity).to.be.equal(LINEARITY);
+            expect(req.imp[0].video.skip).to.be.equal(SKIP);
+            expect(req.imp[0].video.protocols).to.eql(PROTOCOLS);
+            expect(req.imp[0].video.skipmin).to.be.equal(SKIPMIN);
+            expect(req.imp[0].video.api).to.eql(API);
           });
 
           it('sends series name when parameter is present', () => {
@@ -470,7 +555,7 @@ describe('smaatoBidAdapterTest', () => {
 
           it('sends season number as string when parameter is present', () => {
             const SEASON_NUMBER_AS_NUMBER_IN_PREBID_REQUEST = 42
-            const SEASON_NUMBER_AS_STRING_IN_OUTGOING_REQUEST = "42"
+            const SEASON_NUMBER_AS_STRING_IN_OUTGOING_REQUEST = '42'
             const adpodRequestWithParameter = utils.deepClone(validBasicAdpodBidRequest);
             adpodRequestWithParameter.mediaTypes.video.tvSeasonNumber = SEASON_NUMBER_AS_NUMBER_IN_PREBID_REQUEST;
 
@@ -553,7 +638,6 @@ describe('smaatoBidAdapterTest', () => {
         sizes: [[300, 50]],
         bidId: 'bidId',
         bidderRequestId: 'bidderRequestId',
-        auctionId: 'auctionId',
         src: 'client',
         bidRequestsCount: 1,
         bidderRequestsCount: 1,
@@ -618,7 +702,6 @@ describe('smaatoBidAdapterTest', () => {
           sizes: [[300, 50]],
           bidId: 'bidId',
           bidderRequestId: 'bidderRequestId',
-          auctionId: 'auctionId',
           src: 'client',
           bidRequestsCount: 1,
           bidderRequestsCount: 1,

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -28,11 +28,9 @@ const defaultBidderRequest = {
   timeout: 1200
 };
 
-const minimalBidderRequest = {
-  refererInfo: {
-    referer: REFERRER,
-  }
-};
+const BANNER_PREBID_MEDIATYPE = {
+  sizes: [[300, 50]]
+}
 
 const singleBannerBidRequest = {
   bidder: 'smaato',
@@ -41,39 +39,7 @@ const singleBannerBidRequest = {
     adspaceId: 'adspaceId'
   },
   mediaTypes: {
-    banner: {
-      sizes: [[300, 50]]
-    }
-  },
-  adUnitCode: '/19968336/header-bid-tag-0',
-  transactionId: 'transactionId',
-  sizes: [[300, 50]],
-  bidId: 'bidId',
-  bidderRequestId: 'bidderRequestId',
-  auctionId: 'auctionId',
-  src: 'client',
-  bidRequestsCount: 1,
-  bidderRequestsCount: 1,
-  bidderWinsCount: 0
-};
-
-const inAppBidRequest = {
-  bidder: 'smaato',
-  params: {
-    publisherId: 'publisherId',
-    adspaceId: 'adspaceId',
-    app: {
-      ifa: 'aDeviceId',
-      geo: {
-        lat: 33.3,
-        lon: -88.8
-      }
-    }
-  },
-  mediaTypes: {
-    banner: {
-      sizes: [[300, 50]]
-    }
+    banner: BANNER_PREBID_MEDIATYPE
   },
   adUnitCode: '/19968336/header-bid-tag-0',
   transactionId: 'transactionId',
@@ -107,7 +73,24 @@ describe('smaatoBidAdapterTest', () => {
   });
 
   describe('buildRequests', () => {
+    const BANNER_OPENRTB_IMP = {
+      w: 300,
+      h: 50,
+      format: [
+        {
+          h: 50,
+          w: 300
+        }
+      ]
+    }
+
     describe('common', () => {
+      const MINIMAL_BIDDER_REQUEST = {
+        refererInfo: {
+          referer: REFERRER,
+        }
+      };
+
       it('auction type is 1 (first price auction)', () => {
         const reqs = spec.buildRequests([singleBannerBidRequest], defaultBidderRequest);
 
@@ -140,16 +123,7 @@ describe('smaatoBidAdapterTest', () => {
         expect(req.imp).to.deep.equal([
           {
             id: 'bidId',
-            banner: {
-              w: 300,
-              h: 50,
-              format: [
-                {
-                  h: 50,
-                  w: 300
-                }
-              ]
-            },
+            banner: BANNER_OPENRTB_IMP,
             tagid: 'adspaceId'
           }
         ]);
@@ -175,7 +149,7 @@ describe('smaatoBidAdapterTest', () => {
       });
 
       it('sends no gdpr applies if no gdpr exists', () => {
-        const reqs = spec.buildRequests([singleBannerBidRequest], minimalBidderRequest);
+        const reqs = spec.buildRequests([singleBannerBidRequest], MINIMAL_BIDDER_REQUEST);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
         expect(req.regs.ext.gdpr).to.not.exist;
@@ -197,7 +171,7 @@ describe('smaatoBidAdapterTest', () => {
       });
 
       it('sends no us_privacy if no us_privacy exists', () => {
-        const reqs = spec.buildRequests([singleBannerBidRequest], minimalBidderRequest);
+        const reqs = spec.buildRequests([singleBannerBidRequest], MINIMAL_BIDDER_REQUEST);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
         expect(req.regs.ext.us_privacy).to.not.exist;
@@ -259,6 +233,37 @@ describe('smaatoBidAdapterTest', () => {
     });
 
     describe('buildRequests for video imps', () => {
+      const VIDEO_OUTSTREAM_PREBID_MEDIATYPE = {
+        context: 'outstream',
+        playerSize: [[768, 1024]],
+        mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+        minduration: 5,
+        maxduration: 30,
+        startdelay: 0,
+        linearity: 1,
+        protocols: [7],
+        skip: 1,
+        skipmin: 5,
+        api: [7],
+        ext: {rewarded: 0}
+      }
+      const VIDEO_OUTSTREAM_OPENRTB_IMP = {
+        mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
+        minduration: 5,
+        startdelay: 0,
+        linearity: 1,
+        h: 1024,
+        maxduration: 30,
+        skip: 1,
+        protocols: [7],
+        ext: {
+          rewarded: 0
+        },
+        skipmin: 5,
+        api: [7],
+        w: 768
+      }
+
       it('sends correct video imps', () => {
         const singleVideoBidRequest = {
           bidder: 'smaato',
@@ -267,20 +272,7 @@ describe('smaatoBidAdapterTest', () => {
             adspaceId: 'adspaceId'
           },
           mediaTypes: {
-            video: {
-              context: 'outstream',
-              playerSize: [[768, 1024]],
-              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
-              minduration: 5,
-              maxduration: 30,
-              startdelay: 0,
-              linearity: 1,
-              protocols: [7],
-              skip: 1,
-              skipmin: 5,
-              api: [7],
-              ext: {rewarded: 0}
-            }
+            video: VIDEO_OUTSTREAM_PREBID_MEDIATYPE
           },
           adUnitCode: '/19968336/header-bid-tag-0',
           transactionId: 'transactionId',
@@ -297,28 +289,7 @@ describe('smaatoBidAdapterTest', () => {
         const reqs = spec.buildRequests([singleVideoBidRequest], defaultBidderRequest);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
-        expect(req.imp).to.deep.equal([
-          {
-            id: 'bidId',
-            video: {
-              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
-              minduration: 5,
-              startdelay: 0,
-              linearity: 1,
-              h: 1024,
-              maxduration: 30,
-              skip: 1,
-              protocols: [7],
-              ext: {
-                rewarded: 0
-              },
-              skipmin: 5,
-              api: [7],
-              w: 768
-            },
-            tagid: 'adspaceId'
-          }
-        ]);
+        expect(req.imp[0].video).to.deep.equal(VIDEO_OUTSTREAM_OPENRTB_IMP);
       });
 
       it('allows combined banner and video imp in single bid request', () => {
@@ -329,23 +300,8 @@ describe('smaatoBidAdapterTest', () => {
             adspaceId: 'adspaceId'
           },
           mediaTypes: {
-            banner: {
-              sizes: [[300, 50]]
-            },
-            video: {
-              context: 'outstream',
-              playerSize: [[768, 1024]],
-              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
-              minduration: 5,
-              maxduration: 30,
-              startdelay: 0,
-              linearity: 1,
-              protocols: [7],
-              skip: 1,
-              skipmin: 5,
-              api: [7],
-              ext: {rewarded: 0}
-            }
+            banner: BANNER_PREBID_MEDIATYPE,
+            video: VIDEO_OUTSTREAM_PREBID_MEDIATYPE
           },
           adUnitCode: '/19968336/header-bid-tag-0',
           transactionId: 'transactionId',
@@ -362,63 +318,73 @@ describe('smaatoBidAdapterTest', () => {
         const reqs = spec.buildRequests([combinedBannerAndVideoBidRequest], defaultBidderRequest);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
-        expect(req.imp).to.deep.equal([
-          {
-            id: 'bidId',
-            banner: {
-              w: 300,
-              h: 50,
-              format: [
-                {
-                  h: 50,
-                  w: 300
-                }
-              ]
-            },
-            video: {
-              mimes: ['video/mp4', 'video/quicktime', 'video/3gpp', 'video/x-m4v'],
-              minduration: 5,
-              startdelay: 0,
-              linearity: 1,
-              h: 1024,
-              maxduration: 30,
-              skip: 1,
-              protocols: [7],
-              ext: {
-                rewarded: 0
-              },
-              skipmin: 5,
-              api: [7],
-              w: 768
-            },
-            tagid: 'adspaceId'
-          }
-        ]);
+        expect(req.imp[0].banner).to.deep.equal(BANNER_OPENRTB_IMP);
+        expect(req.imp[0].video).to.deep.equal(VIDEO_OUTSTREAM_OPENRTB_IMP);
       });
     });
 
     describe('in-app requests', () => {
-      it('add geo and ifa info to device object', () => {
+      const LOCATION = {
+        lat: 33.3,
+        lon: -88.8
+      }
+      const DEVICE_ID = 'aDeviceId'
+      const inAppBidRequestWithoutAppParams = {
+        bidder: 'smaato',
+        params: {
+          publisherId: 'publisherId',
+          adspaceId: 'adspaceId'
+        },
+        mediaTypes: {
+          banner: BANNER_PREBID_MEDIATYPE
+        },
+        adUnitCode: '/19968336/header-bid-tag-0',
+        transactionId: 'transactionId',
+        sizes: [[300, 50]],
+        bidId: 'bidId',
+        bidderRequestId: 'bidderRequestId',
+        auctionId: 'auctionId',
+        src: 'client',
+        bidRequestsCount: 1,
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0
+      };
+
+      it('when geo and ifa info present, then add both to device object', () => {
+        const inAppBidRequest = utils.deepClone(inAppBidRequestWithoutAppParams);
+        inAppBidRequest.params.app = {ifa: DEVICE_ID, geo: LOCATION};
+
         const reqs = spec.buildRequests([inAppBidRequest], defaultBidderRequest);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
-        expect(req.device.geo).to.deep.equal({'lat': 33.3, 'lon': -88.8});
-        expect(req.device.ifa).to.equal('aDeviceId');
+        expect(req.device.geo).to.deep.equal(LOCATION);
+        expect(req.device.ifa).to.equal(DEVICE_ID);
       });
 
-      it('when geo is missing, then add only ifa to device object', () => {
-        const inAppBidRequestWithoutGeo = utils.deepClone(inAppBidRequest);
-        delete inAppBidRequestWithoutGeo.params.app.geo
+      it('when ifa is present but geo is missing, then add only ifa to device object', () => {
+        const inAppBidRequest = utils.deepClone(inAppBidRequestWithoutAppParams);
+        inAppBidRequest.params.app = {ifa: DEVICE_ID};
 
-        const reqs = spec.buildRequests([inAppBidRequestWithoutGeo], defaultBidderRequest);
+        const reqs = spec.buildRequests([inAppBidRequest], defaultBidderRequest);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
         expect(req.device.geo).to.not.exist;
-        expect(req.device.ifa).to.equal('aDeviceId');
+        expect(req.device.ifa).to.equal(DEVICE_ID);
       });
 
-      it('add no specific device info if param does not exist', () => {
-        const reqs = spec.buildRequests([singleBannerBidRequest], defaultBidderRequest);
+      it('when geo is present but ifa is missing, then add only geo to device object', () => {
+        const inAppBidRequest = utils.deepClone(inAppBidRequestWithoutAppParams);
+        inAppBidRequest.params.app = {geo: LOCATION};
+
+        const reqs = spec.buildRequests([inAppBidRequest], defaultBidderRequest);
+
+        const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+        expect(req.device.geo).to.deep.equal(LOCATION);
+        expect(req.device.ifa).to.not.exist;
+      });
+
+      it('when app param does not exist, then add no specific device info', () => {
+        const reqs = spec.buildRequests([inAppBidRequestWithoutAppParams], defaultBidderRequest);
 
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
         expect(req.device.geo).to.not.exist;
@@ -435,9 +401,7 @@ describe('smaatoBidAdapterTest', () => {
             adspaceId: 'adspaceId'
           },
           mediaTypes: {
-            banner: {
-              sizes: [[300, 50]]
-            }
+            banner: BANNER_PREBID_MEDIATYPE
           },
           adUnitCode: '/19968336/header-bid-tag-0',
           transactionId: 'transactionId',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Adding OTT aka adpodding support for Smaato adapter.
Similar change will be done on prebid server side as well.

- contact email of the adapter’s maintainer: prebid@smaato.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
--> https://github.com/prebid/prebid.github.io/pull/3062

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
