### PR TITLE
UserID: bugfix for refreshUserIds with updated info

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -722,6 +722,7 @@ function updateInitializedSubmodules(submodule) {
     if (submodule.config.name.toLowerCase() === initializedSubmodules[i].config.name.toLowerCase()) {
       updated = true;
       initializedSubmodules[i] = submodule;
+      break;
     }
   }
 

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -613,6 +613,11 @@ function refreshUserIds(options, callback) {
 
       utils.logInfo(`${MODULE_NAME} - refreshing ${submodule.submodule.name}`);
       populateSubmoduleId(submodule, consentData, storedConsentData, true);
+      updateInitializedSubmodules(submodule);
+
+      if (initializedSubmodules.length) {
+        setPrebidServerEidPermissions(initializedSubmodules);
+      }
 
       if (utils.isFn(submodule.callback)) {
         callbackSubmodules.push(submodule);
@@ -709,6 +714,20 @@ function initSubmodules(submodules, consentData) {
     carry.push(submodule);
     return carry;
   }, []);
+}
+
+function updateInitializedSubmodules(submodule) {
+  let updated = false;
+  for (let i = 0; i < initializedSubmodules.length; i++) {
+    if (submodule.config.name.toLowerCase() === initializedSubmodules[i].config.name.toLowerCase()) {
+      updated = true;
+      initializedSubmodules[i] = submodule;
+    }
+  }
+
+  if (!updated) {
+    initializedSubmodules.push(submodule);
+  }
 }
 
 /**

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -365,6 +365,46 @@ describe('User ID', function () {
       expect(mockIdCallback.callCount).to.equal(1);
     });
 
+    it('pbjs.refreshUserIds updates submodules', function() {
+      let sandbox = sinon.createSandbox();
+      let mockIdCallback = sandbox.stub().returns({id: {'MOCKID': '1111'}});
+      let mockIdSystem = {
+        name: 'mockId',
+        decode: function(value) {
+          return {
+            'mid': value['MOCKID']
+          };
+        },
+        getId: mockIdCallback
+      };
+      setSubmoduleRegistry([mockIdSystem]);
+      init(config);
+      config.setConfig({
+        userSync: {
+          syncDelay: 0,
+          userIds: [{
+            name: 'mockId',
+            value: {id: {mockId: '1111'}}
+          }]
+        }
+      });
+
+      expect(getGlobal().getUserIds().id.mockId).to.equal('1111');
+
+      // update to new config value
+      config.setConfig({
+        userSync: {
+          syncDelay: 0,
+          userIds: [{
+            name: 'mockId',
+            value: {id: {mockId: '1212'}}
+          }]
+        }
+      });
+      getGlobal().refreshUserIds({ submoduleNames: ['mockId'] });
+      expect(getGlobal().getUserIds().id.mockId).to.equal('1212');
+    });
+
     it('pbjs.refreshUserIds refreshes single', function() {
       coreStorage.setCookie('MOCKID', '', EXPIRED_COOKIE_DATE);
       coreStorage.setCookie('REFRESH', '', EXPIRED_COOKIE_DATE);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
calling pbjs.refreshUserIds() with updated UserId info does not update adUnitBids (since addIdDataToAdUnitBids is passed in initializedSubmodules which is not updated by pbjs.refreshUserIds())

## Other information
Fixes this issue: 
https://github.com/prebid/Prebid.js/issues/6783