### PR TITLE
Vrtcal Bid Adapter: add adomain and make 5.0 compliant

### DIFF
--- a/modules/vrtcalBidAdapter.js
+++ b/modules/vrtcalBidAdapter.js
@@ -73,7 +73,7 @@ export const spec = {
       if (response.seatbid[0].bid[0].adomain && response.seatbid[0].bid[0].adomain.length) {
 	    bidResponse.meta = {
 	      advertiserDomains: response.seatbid[0].bid[0].adomain
-	    };
+	      };
       }
 
       bidResponses.push(bidResponse);

--- a/modules/vrtcalBidAdapter.js
+++ b/modules/vrtcalBidAdapter.js
@@ -71,9 +71,9 @@ export const spec = {
       };
 
       if (response.seatbid[0].bid[0].adomain && response.seatbid[0].bid[0].adomain.length) {
-	    bidResponse.meta = {
-	      advertiserDomains: response.seatbid[0].bid[0].adomain
-	      };
+        bidResponse.meta = {
+          advertiserDomains: response.seatbid[0].bid[0].adomain
+        };
       }
 
       bidResponses.push(bidResponse);

--- a/modules/vrtcalBidAdapter.js
+++ b/modules/vrtcalBidAdapter.js
@@ -1,0 +1,94 @@
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import {ajax} from '../src/ajax.js';
+
+export const spec = {
+  code: 'vrtcal',
+  supportedMediaTypes: [BANNER],
+  isBidRequestValid: function (bid) {
+    if (bid.bidId == '' || bid.auctionId == '') { return false; } else { return true; }// No extras params required
+  },
+  buildRequests: function (bidRequests) {
+    const requests = bidRequests.map(function (bid) {
+      const params = {
+
+        prebidJS: 1,
+        prebidAdUnitCode: bid.adUnitCode,
+        id: bid.bidId,
+        imp: [{
+          id: '1',
+          banner: {
+          },
+          bidfloor: 0.75
+        }],
+        site: {
+          id: 'VRTCAL_FILLED',
+          name: 'VRTCAL_FILLED',
+          cat: ['VRTCAL_FILLED'],
+          domain: decodeURIComponent(window.location.href).replace('https://', '').replace('http://', '').split('/')[0]
+
+        },
+        device: {
+          ua: 'VRTCAL_FILLED',
+          ip: 'VRTCAL_FILLED'
+        }
+      };
+
+      if (typeof (bid.mediaTypes) !== 'undefined' && typeof (bid.mediaTypes.banner) !== 'undefined' && typeof (bid.mediaTypes.banner.sizes) !== 'undefined') {
+        params.imp[0].banner.w = bid.mediaTypes.banner.sizes[0][0];
+        params.imp[0].banner.h = bid.mediaTypes.banner.sizes[0][1];
+      } else {
+        params.imp[0].banner.w = bid.sizes[0][0];
+        params.imp[0].banner.h = bid.sizes[0][1];
+      }
+
+      return {method: 'POST', url: 'https://rtb.vrtcal.com/bidder_prebid.vap?ssp=1804', data: JSON.stringify(params), options: {withCredentials: false, crossOrigin: true}}
+    });
+
+    return requests;
+  },
+  interpretResponse: function (serverResponse, bidRequest) {
+    if (!serverResponse || !serverResponse.body) {
+      return [];
+    }
+
+    const bidResponses = [];
+
+    var response = serverResponse.body;
+
+    if (response) {
+      const bidResponse = {
+        requestId: response.id,
+        cpm: response.seatbid[0].bid[0].price,
+        width: response.seatbid[0].bid[0].w,
+        height: response.seatbid[0].bid[0].h,
+        creativeId: response.seatbid[0].bid[0].crid,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 900,
+        ad: response.seatbid[0].bid[0].adm,
+        nurl: response.seatbid[0].bid[0].nurl
+      };
+
+      if (response.seatbid[0].bid[0].adomain && response.seatbid[0].bid[0].adomain.length) {
+	    bidResponse.meta = {
+	      advertiserDomains: response.seatbid[0].bid[0].adomain
+	    };
+      }
+
+      bidResponses.push(bidResponse);
+    }
+    return bidResponses;
+  },
+  onBidWon: function(bid) {
+    if (!bid.nurl) { return false; }
+    const winUrl = bid.nurl.replace(
+      /\$\{AUCTION_PRICE\}/,
+      bid.cpm
+    );
+    ajax(winUrl, null);
+    return true;
+  }
+};
+
+registerBidder(spec);

--- a/test/spec/modules/vrtcalBidAdapter_spec.js
+++ b/test/spec/modules/vrtcalBidAdapter_spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai'
+import { spec } from 'modules/vrtcalBidAdapter'
+import { newBidder } from 'src/adapters/bidderFactory'
+
+describe('vrtcalBidAdapter', function () {
+  const adapter = newBidder(spec)
+
+  let bidRequest = {
+    bidId: 'bidID0001',
+    transactionId: 'transID0001',
+    sizes: [[ 300, 250 ]]
+  }
+
+  describe('isBidRequestValid', function () {
+    it('should return true 100% of time as no special additional params are required, thus no additional validation needed', function () {
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true
+    })
+  })
+
+  describe('buildRequests', function () {
+    let bidRequests = [
+      {
+        'bidder': 'vrtcal',
+        'adUnitCode': 'adunit0001',
+        'sizes': [[300, 250]],
+        'bidId': 'bidID0001',
+        'bidderRequestId': 'br0001',
+        'auctionId': 'auction0001',
+      }
+    ];
+
+    const request = spec.buildRequests(bidRequests);
+
+    it('sends bid request to our endpoint via POST', function () {
+      expect(request[0].method).to.equal('POST');
+    });
+
+    it('adUnitCode should be sent as prebidAdUnitCode parameters on any requests', function () {
+      expect(request[0].data).to.match(/"prebidAdUnitCode":"adunit0001"/);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('should form compliant bid object response', function () {
+      let res = {
+        body: {
+          id: 'bidID0001',
+          seatbid: [{
+            bid: [{
+              id: 'VRTB_240d3c8a3c12b68_1',
+              impid: '1',
+              price: 0.7554,
+              adm: 'TEST AD',
+              nurl: 'https://adplatform.vrtcal.com/wintracker',
+              w: 300,
+              h: 250,
+              crid: 'v2_1064_vrt_vrtcaltestdisplay2_300_250',
+              adomain: ['vrtcal.com']
+            }],
+            seat: '16'
+          }],
+          cur: 'USD'
+        }
+      }
+
+      let ir = spec.interpretResponse(res, bidRequest)
+
+      expect(ir.length).to.equal(1)
+
+      let en = ir[0]
+
+      expect(en.requestId != null &&
+            en.cpm != null && typeof en.cpm === 'number' &&
+            en.width != null && typeof en.width === 'number' &&
+            en.height != null && typeof en.height === 'number' &&
+            en.ad != null &&
+            en.creativeId != null
+      ).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
adomain support added to last master Vrtcal .js adapter
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
