### PR TITLE
AirGrid RTD Submodule: Initial Release

### DIFF
--- a/integrationExamples/gpt/airgridRtdProvider_example.html
+++ b/integrationExamples/gpt/airgridRtdProvider_example.html
@@ -64,6 +64,22 @@
             ],
           },
         });
+        pbjs.setBidderConfig({
+          bidders: ['appnexus', 'pubmatic', 'space'],
+          config: {
+            ortb2: {
+              user: {
+                ext: {
+                  data: {
+                    registered: true,
+                    interests: ['cars']
+                  }
+                }
+              }
+            }
+          }
+        }); 
+        
         pbjs.addAdUnits(adUnits);
         pbjs.requestBids({ bidsBackHandler: sendAdserverRequest });
       });

--- a/integrationExamples/gpt/airgridRtdProvider_example.html
+++ b/integrationExamples/gpt/airgridRtdProvider_example.html
@@ -1,0 +1,136 @@
+<html>
+  <head>
+    <script>
+      var matchedAudiences = ["sport", "travel"];
+      window.localStorage.setItem(
+        "edkt_matched_audience_ids",
+        JSON.stringify(matchedAudiences)
+      );
+    </script>
+    <script>
+      var FAILSAFE_TIMEOUT = 2000;
+
+      var adUnits = [
+        {
+          code: "test-div",
+          mediaTypes: {
+            banner: {
+              sizes: [
+                [300, 250],
+                [300, 600],
+                [728, 90],
+              ],
+            },
+          },
+          bids: [
+            {
+              bidder: "appnexus",
+              params: {
+                placementId: 13144370,
+              },
+            },
+          ],
+        },
+      ];
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+    </script>
+    <script src="../../build/dev/prebid.js" async></script>
+
+    <script>
+      var googletag = googletag || {};
+      var AUCTION_DELAY = 2000;
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function () {
+        googletag.pubads().disableInitialLoad();
+      });
+
+      pbjs.que.push(function () {
+        pbjs.setConfig({
+          debug: true,
+          realTimeData: {
+            auctionDelay: AUCTION_DELAY,
+            dataProviders: [
+              {
+                name: "airgrid",
+                waitForIt: true,
+                params: {
+                  apiKey: "key123",
+                  accountId: "sdk",
+                  publisherId: "pub123",
+                },
+              },
+            ],
+          },
+        });
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({ bidsBackHandler: sendAdserverRequest });
+      });
+
+      function sendAdserverRequest() {
+        document.getElementById("airgrid_audiences").innerHTML =
+          window.localStorage.getItem("edkt_matched_audience_ids");
+
+        if (pbjs.adserverRequestSent) return;
+        pbjs.adserverRequestSent = true;
+        googletag.cmd.push(function () {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        });
+      }
+
+      setTimeout(function () {
+        sendAdserverRequest();
+      }, FAILSAFE_TIMEOUT);
+    </script>
+
+    <script>
+      (function () {
+        var gads = document.createElement("script");
+        gads.async = true;
+        gads.type = "text/javascript";
+        var useSSL = "https:" == document.location.protocol;
+        gads.src =
+          (useSSL ? "https:" : "http:") +
+          "//www.googletagservices.com/tag/js/gpt.js";
+        var node = document.getElementsByTagName("script")[0];
+        node.parentNode.insertBefore(gads, node);
+      })();
+    </script>
+
+    <script>
+      googletag.cmd.push(function () {
+        googletag
+          .defineSlot(
+            "/112115922/FL_PB_MedRect",
+            [
+              [300, 250],
+              [300, 600],
+            ],
+            "test-div"
+          )
+          .addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+    </script>
+  </head>
+
+  <body>
+    <h2>AirGrid RTD Prebid</h2>
+
+    <div id="test-div">
+      <script>
+        googletag.cmd.push(function () {
+          googletag.display("test-div");
+        });
+      </script>
+    </div>
+
+    AirGrid Audiences:
+    <div id="airgrid_audiences"></div>
+  </body>
+</html>

--- a/integrationExamples/gpt/airgridRtdProvider_example.html
+++ b/integrationExamples/gpt/airgridRtdProvider_example.html
@@ -65,21 +65,21 @@
           },
         });
         pbjs.setBidderConfig({
-          bidders: ['appnexus', 'pubmatic', 'space'],
+          bidders: ["appnexus", "pubmatic"],
           config: {
             ortb2: {
               user: {
                 ext: {
                   data: {
                     registered: true,
-                    interests: ['cars']
-                  }
-                }
-              }
-            }
-          }
-        }); 
-        
+                    interests: ["cars"],
+                  },
+                },
+              },
+            },
+          },
+        });
+
         pbjs.addAdUnits(adUnits);
         pbjs.requestBids({ bidsBackHandler: sendAdserverRequest });
       });

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -37,7 +37,7 @@ export function attachScriptTagToDOM(rtdConfig) {
       n.async = true;
       n.src = 'https://cdn.edkt.io/' + p + '/edgekit.min.js';
       var a = document.getElementsByTagName('head')[0];
-      a.parentNode.insertBefore(n, a);
+      a.parentNode.insertBefore(n, a.nextSibling);
     };
     edktInitializor.load(edktInitializor.accountId);
   }

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * This module adds the AirGrid provider to the real time data module
  * The {@link module:modules/realTimeData} module is required

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -87,7 +87,7 @@ export function setAudiencesUsingBidderOrtb2(rtdConfig, audiences) {
   const allBiddersConfig = config.getBidderConfig();
   const agOrtb2 = {}
   deepSetValue(agOrtb2, 'ortb2.user.ext.data.airgrid', audiences || []);
-  
+
   bidders.forEach((bidder) => {
     let bidderConfig = {};
     if (isPlainObject(allBiddersConfig[bidder])) {
@@ -127,7 +127,7 @@ export function passAudiencesToBidders(bidConfig, onDone, rtdConfig, userConsent
     if (adUnits) {
       setAudiencesToAppNexusAdUnits(adUnits, audiences);
     }
-  } 
+  }
   onDone();
 };
 

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -67,9 +67,7 @@ function setAudiencesToAppNexusAdUnits(adUnits, audiences) {
   adUnits.forEach((adUnit) => {
     adUnit.bids.forEach((bid) => {
       if (bid.bidder && bid.bidder === 'appnexus') {
-        if (!bid.params) bid.params = {};
-        if (!bid.params.keywords) bid.params.keywords = {};
-        bid.params.keywords.perid = audiences;
+        deepSetValue(bid, 'params.keywords.perid', audiences || []);
       }
     })
   })

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -1,0 +1,109 @@
+/**
+ * This module adds the AirGrid provider to the real time data module
+ * The {@link module:modules/realTimeData} module is required
+ * The module will fetch real-time audience data from AirGrid
+ * @module modules/airgridRtdProvider
+ * @requires module:modules/realTimeData
+ */
+
+import {submodule} from '../src/hook.js';
+import {getGlobal} from '../src/prebidGlobal.js';
+import {getStorageManager} from '../src/storageManager.js';
+
+const MODULE_NAME = 'realTimeData';
+const SUBMODULE_NAME = 'airgrid';
+const AG_TCF_ID = 782;
+export const AG_AUDIENCE_IDS_KEY = 'edkt_matched_audience_ids'
+
+export const storage = getStorageManager(AG_TCF_ID, SUBMODULE_NAME);
+
+/**
+ * Attach script tag to DOM
+ * @param {Object} rtdConfig
+ */
+export function attachScriptTagToDOM(rtdConfig) {
+  var edktInitializor = window.edktInitializor = window.edktInitializor || {};
+  if (!edktInitializor.invoked) {
+    edktInitializor.invoked = true;
+    edktInitializor.accountId = rtdConfig.params.accountId;
+    edktInitializor.publisherId = rtdConfig.params.publisherId;
+    edktInitializor.apiKey = rtdConfig.params.apiKey;
+    edktInitializor.load = function(e) {
+      var p = e || 'sdk';
+      var n = document.createElement('script');
+      n.type = 'text/javascript';
+      n.async = true;
+      n.src = 'https://cdn.edkt.io/' + p + '/edgekit.min.js';
+      var a = document.getElementsByTagName('head')[0];
+      a.parentNode.insertBefore(n, a);
+    };
+    edktInitializor.load(edktInitializor.accountId);
+  }
+}
+
+/**
+ * Fetch audiences from localStorage
+ * @return {Array}
+ */
+export function getMatchedAudiencesFromStorage() {
+  const audiences = storage.getDataFromLocalStorage(AG_AUDIENCE_IDS_KEY);
+  if (!audiences) return []
+  try {
+    return JSON.parse(audiences);
+  } catch (e) {
+    return [];
+  }
+}
+
+/**
+ * Mutates the adUnits object
+ * @param {Object} adUnits
+ * @param {Array} audiences
+ */
+function appendAudiencesToAdUnits(adUnits, audiences) {
+  adUnits.forEach((adUnit) => {
+    adUnit.bids.forEach((bid) => {
+      if (bid.bidder && bid.bidder === 'appnexus') {
+        if (!bid.params) bid.params = {};
+        if (!bid.params.keywords) bid.params.keywords = {};
+        bid.params.keywords.perid = audiences;
+      }
+    })
+  })
+}
+
+/**
+ * Module init
+ * @param {Object} rtdConfig
+ * @param {Object} userConsent
+ * @return {boolean}
+ */
+function init(rtdConfig, userConsent) {
+  attachScriptTagToDOM(rtdConfig);
+  return true;
+}
+
+/**
+ * Real-time data retrieval from AirGrid
+ * @param {Object} reqBidsConfigObj
+ * @param {function} onDone
+ * @param {Object} rtdConfig
+ * @param {Object} userConsent
+ */
+export function getRealTimeData(bidConfig, onDone, rtdConfig, userConsent) {
+  const adUnits = bidConfig.adUnits || getGlobal().adUnits;
+  const audiences = getMatchedAudiencesFromStorage();
+  if (adUnits && audiences.length > 0) {
+    appendAudiencesToAdUnits(adUnits, audiences);
+  }
+  onDone();
+};
+
+/** @type {RtdSubmodule} */
+export const airgridSubmodule = {
+  name: SUBMODULE_NAME,
+  init: init,
+  getBidRequestData: getRealTimeData
+};
+
+submodule(MODULE_NAME, airgridSubmodule);

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -36,8 +36,7 @@ export function attachScriptTagToDOM(rtdConfig) {
       n.type = 'text/javascript';
       n.async = true;
       n.src = 'https://cdn.edkt.io/' + p + '/edgekit.min.js';
-      var a = document.getElementsByTagName('head')[0];
-      a.parentNode.insertBefore(n, a.nextSibling);
+      document.getElementsByTagName('head')[0].appendChild(n);
     };
     edktInitializor.load(edktInitializor.accountId);
   }

--- a/modules/airgridRtdProvider.md
+++ b/modules/airgridRtdProvider.md
@@ -1,0 +1,5 @@
+# AirGrid
+
+```
+gulp serve-fast --notest --modules=appnexusBidAdapter,rubiconBidAdapter,rtdModule,airgridRtdProvider
+```

--- a/modules/airgridRtdProvider.md
+++ b/modules/airgridRtdProvider.md
@@ -39,6 +39,7 @@ pbjs.setConfig(
                     apiKey: 'apiKey',
                     accountId: 'accountId',
                     publisherId: 'publisherId',
+                    bidders: ['appnexus', 'pubmatic']
                 }
             }
         ]
@@ -51,11 +52,14 @@ pbjs.setConfig(
 
 | Name  |Type | Description   | Notes  |
 | :------------ | :------------ | :------------ |:------------ |
-| name | String | RTD sub module name | Always 'airgrid' |
-| waitForIt | Boolean | Wether to delay auction for module response | Optional. Defaults to false |
-| params.apiKey | Boolean | Publisher partner specific API key | Required |
-| params.accountId | String | Publisher partner specific account ID | Required |
-| params.publisherId | String | Publisher partner specific publisher ID | Required |
+| name | `String` | RTD sub module name | Always 'airgrid' |
+| waitForIt | `Boolean` | Wether to delay auction for module response | Optional. Defaults to false |
+| params.apiKey | `Boolean` | Publisher partner specific API key | Required |
+| params.accountId | `String` | Publisher partner specific account ID | Required |
+| params.publisherId | `String` | Publisher partner specific publisher ID | Required |
+| params.bidders | `Array` | Bidders with which to share segment information | Optional |
+
+_Note: Although the module supports passing segment data to any bidder using the ORTB2 spec, there is no way for this to be currently monetised. Please reach out to support, to discuss using bidders other than Xandr/AppNexus._
 
 If you do not have your own `apiKey`, `accountId` & `publisherId` please reach out to [support@airgrid.io](mailto:support@airgrid.io)
 
@@ -63,11 +67,21 @@ If you do not have your own `apiKey`, `accountId` & `publisherId` please reach o
 
 To view an example of the on page setup required:
 
-`gulp serve-fast --modules=rtdModule,airgridRtdProvider,appnexusBidAdapter`
+```bash
+gulp serve-fast --modules=rtdModule,airgridRtdProvider,appnexusBidAdapter
+```
 
 Then in your browser access:
 
-`http://localhost:9999/integrationExamples/gpt/airgridRtdProvider_example.html`
+```
+http://localhost:9999/integrationExamples/gpt/airgridRtdProvider_example.html
+```
+
+Run the unit tests, just on the AirGrid RTD module test file:
+
+```bash
+gulp test --file "test/spec/modules/airgridRtdProvider_spec.js" 
+```
 
 ## Support
 

--- a/modules/airgridRtdProvider.md
+++ b/modules/airgridRtdProvider.md
@@ -1,5 +1,81 @@
+ ---
+ layout: page_v2
+ title: AirGrid RTD SubModule
+ description: Client-side, cookieless and privacy-first audiences.
+ page_type: module
+ module_type: rtd
+ module_code : example
+ enable_download : true
+ sidebarType : 1
+ ---
+
 # AirGrid
 
+AirGrid is a privacy-first, cookie-less audience platform. Designed to help publishers increase inventory yield,
+whilst providing audience signal to buyers in the bid request, without exposing raw user level data to any party.
+
+This real-time data module provides quality first-party data, contextual data, site-level data and more that is 
+injected into bid request objects destined for different bidders in order to optimize targeting.
+
+## Usage
+
+Compile the Halo RTD module into your Prebid build:
+
+`gulp build --modules=rtdModule,airgridRtdProvider,appnexusBidAdapter`
+
+Add the AirGrid RTD provider to your Prebid config. In this example we will configure publisher 1234 to retrieve segments from Audigent. See the "Parameter Descriptions" below for more detailed information of the configuration parameters. 
+
+```js
+pbjs.setConfig(
+    ...
+    realTimeData: {
+        auctionDelay: 1000,
+        dataProviders: [
+            {
+                name: 'airgrid',
+                waitForIt: true,
+                params: {
+                    // These are unique values for each account.
+                    apiKey: 'apiKey',
+                    accountId: 'accountId',
+                    publisherId: 'publisherId',
+                }
+            }
+        ]
+    }
+    ...
+}
 ```
-gulp serve-fast --notest --modules=appnexusBidAdapter,rubiconBidAdapter,rtdModule,airgridRtdProvider
-```
+
+### Parameter Descriptions
+
+| Name  |Type | Description   | Notes  |
+| :------------ | :------------ | :------------ |:------------ |
+| name | String | RTD sub module name | Always 'airgrid' |
+| waitForIt | Boolean | Wether to delay auction for module response | Optional. Defaults to false |
+| params.apiKey | Boolean | Publisher partner specific API key | Required |
+| params.accountId | String | Publisher partner specific account ID | Required |
+| params.publisherId | String | Publisher partner specific publisher ID | Required |
+
+If you do not have your own `apiKey`, `accountId` & `publisherId` please reach out to [support@airgrid.io](mailto:support@airgrid.io)
+
+## Testing
+
+To view an example of the on page setup required:
+
+`gulp serve-fast --modules=rtdModule,airgridRtdProvider,appnexusBidAdapter`
+
+Then in your browser access:
+
+`http://localhost:9999/integrationExamples/gpt/airgridRtdProvider_example.html`
+
+## Support
+
+If you require further assistance or are interested in discussing the module functionality please reach out to:
+- [hello@airgrid.io](mailto:hello@airgrid.io) for general questions.
+- [support@airgrid.io](mailto:support@airgrid.io) for technical questions.
+
+You are also able to find more examples and other integration routes on the [AirGrid docs site](docs.airgrid.io).
+
+Happy Coding! 😊
+The AirGrid Team.

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -89,7 +89,7 @@ describe('airgrid RTD Submodule', function() {
       const allBiddersConfig = config.getBidderConfig();
       const bidders = RTD_CONFIG.dataProviders[0].params.bidders;
       Object.keys(allBiddersConfig).forEach((bidder) => {
-        if (!bidders.includes(bidder)) return;
+        if (bidders.indexOf(bidder) === -1) return;
         expect(deepAccess(allBiddersConfig[bidder], 'ortb2.user.ext.data.airgrid')).to.eql(MATCHED_AUDIENCES);
       });
     });

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {config} from 'src/config.js';
 import {deepAccess} from 'src/utils.js'
 import {getAdUnits} from '../../fixtures/fixtures.js';

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -85,7 +85,7 @@ describe('airgrid RTD Submodule', function() {
       getDataFromLocalStorageStub.withArgs(agRTD.AG_AUDIENCE_IDS_KEY).returns(JSON.stringify(MATCHED_AUDIENCES));
       const audiences = agRTD.getMatchedAudiencesFromStorage();
       agRTD.setAudiencesUsingBidderOrtb2(RTD_CONFIG.dataProviders[0], audiences);
-      
+
       const allBiddersConfig = config.getBidderConfig();
       const bidders = RTD_CONFIG.dataProviders[0].params.bidders;
       Object.keys(allBiddersConfig).forEach((bidder) => {

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -1,0 +1,84 @@
+import {config} from 'src/config.js';
+import {deepAccess} from '../../../src/utils.js'
+import {getAdUnits} from '../../fixtures/fixtures.js';
+import * as agRTD from 'modules/airgridRtdProvider.js';
+
+const MATCHED_AUDIENCES = ['travel', 'sport'];
+const RTD_CONFIG = {
+  auctionDelay: 250,
+  dataProviders: [{
+    name: 'airgrid',
+    waitForIt: true,
+    params: {
+      apiKey: 'key123',
+      accountId: 'sdk',
+      publisherId: 'pub123',
+    }
+  }]
+};
+
+describe('airgrid RTD Submodule', function() {
+  let getDataFromLocalStorageStub;
+
+  beforeEach(function() {
+    config.resetConfig();
+    getDataFromLocalStorageStub = sinon.stub(agRTD.storage, 'getDataFromLocalStorage');
+  });
+
+  afterEach(function () {
+    getDataFromLocalStorageStub.restore();
+  });
+
+  describe('Initialise module', function() {
+    it('should initalise and return true', function () {
+		  expect(agRTD.airgridSubmodule.init(RTD_CONFIG.dataProviders[0])).to.equal(true);
+    });
+    it('should attach script to DOM with correct config', function() {
+      agRTD.attachScriptTagToDOM(RTD_CONFIG);
+      expect(window.edktInitializor.invoked).to.be.true;
+      expect(window.edktInitializor.apiKey).to.equal(RTD_CONFIG.dataProviders[0].params.apiKey);
+      expect(window.edktInitializor.accountId).to.equal(RTD_CONFIG.dataProviders[0].params.accountId);
+      expect(window.edktInitializor.publisherId).to.equal(RTD_CONFIG.dataProviders[0].params.publisherId);
+    });
+  });
+
+  describe('Get matched audiences', function() {
+    it('gets matched audiences from local storage', function() {
+      getDataFromLocalStorageStub.withArgs(agRTD.AG_AUDIENCE_IDS_KEY).returns(JSON.stringify(MATCHED_AUDIENCES));
+
+      const audiences = agRTD.getMatchedAudiencesFromStorage();
+      expect(audiences).to.have.members(MATCHED_AUDIENCES);
+    });
+  });
+
+  describe('Add matched audiences', function() {
+    it('merges matched audiences on appnexus AdUnits', function() {
+      const adUnits = getAdUnits();
+      getDataFromLocalStorageStub.withArgs(agRTD.AG_AUDIENCE_IDS_KEY).returns(JSON.stringify(MATCHED_AUDIENCES));
+      agRTD.getRealTimeData({ adUnits }, () => {}, {}, {});
+
+      adUnits.forEach(adUnit => {
+        adUnit.bids.forEach(bid => {
+          const { bidder, params } = bid;
+          if (bidder === 'appnexus') {
+            expect(deepAccess(params, 'keywords.perid')).to.eql(MATCHED_AUDIENCES);
+          }
+        });
+      });
+    });
+    it('does not merge audiences, since none are matched', function() {
+      const adUnits = getAdUnits();
+      getDataFromLocalStorageStub.withArgs(agRTD.AG_AUDIENCE_IDS_KEY).returns(undefined);
+      agRTD.getRealTimeData({ adUnits }, () => {}, {}, {});
+
+      adUnits.forEach(adUnit => {
+        adUnit.bids.forEach(bid => {
+          const { bidder, params } = bid;
+          if (bidder === 'appnexus') {
+            expect(deepAccess(params, 'keywords.perid')).to.be.undefined;
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature


## Description of change

This PR adds a new RTD submodule, this module augments the bid `Bids/AdUnits` for the AppNexus/Xandr bid adapter by attaching segment values to the `keywords` param.

The flow of the module:
- Inject a 3rd party script into the DOM, we do not need to wait for this script to load, we do this in an async manner.
- Fetch audience values from `localStorage` using the `StorageManager`
- If audiences are available augment the `bids` object


`dennis@airgrid.io`

## Other information
As noted above this module loads 3rd party JS into the page.