### PR TITLE
Medianet Bid Adapter: send screen size instead of browser size

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -114,8 +114,8 @@ function getSize(size) {
 
 function getWindowSize() {
   return {
-    w: window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || -1,
-    h: window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || -1
+    w: window.screen.width || -1,
+    h: window.screen.height || -1
   }
 }
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Sending screen size instead of browser size in bid request

- [x] official adapter submission
- contact email of the adapter’s maintainer: prebid-support@media.net
