### PR TITLE
Impactify Bid Adapter: Add meta.advertiserDomains support

### DIFF
--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -1,0 +1,266 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import * as utils from '../src/utils.js';
+import { config } from '../src/config.js';
+import {ajax} from '../src/ajax.js';
+
+const BIDDER_CODE = 'impactify';
+const BIDDER_ALIAS = ['imp'];
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_VIDEO_WIDTH = 640;
+const DEFAULT_VIDEO_HEIGHT = 480;
+const ORIGIN = 'https://sonic.impactify.media';
+const LOGGER_URI = 'https://logger.impactify.media';
+const AUCTIONURI = '/bidder';
+const COOKIESYNCURI = '/static/cookie_sync.html';
+const GVLID = 606;
+const GETCONFIG = config.getConfig;
+
+const getDeviceType = () => {
+  // OpenRTB Device type
+  if ((/ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle/i.test(navigator.userAgent.toLowerCase()))) {
+    return 5;
+  }
+  if ((/iphone|ipod|android|blackberry|opera|mini|windows\sce|palm|smartphone|iemobile/i.test(navigator.userAgent.toLowerCase()))) {
+    return 4;
+  }
+  return 2;
+}
+
+const createOpenRtbRequest = (validBidRequests, bidderRequest) => {
+  // Create request and set imp bids inside
+  let request = {
+    id: bidderRequest.auctionId,
+    validBidRequests,
+    cur: [DEFAULT_CURRENCY],
+    imp: []
+  };
+
+  // Force impactify debugging parameter
+  if (window.localStorage.getItem('_im_db_bidder') == 3) {
+    request.test = 3;
+  }
+
+  // Set device/user/site
+  if (!request.device) request.device = {};
+  if (!request.site) request.site = {};
+  request.device = {
+    w: window.innerWidth,
+    h: window.innerHeight,
+    devicetype: getDeviceType(),
+    ua: navigator.userAgent,
+    js: 1,
+    dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+    language: ((navigator.language || navigator.userLanguage || '').split('-'))[0] || 'en',
+  };
+  request.site = {page: bidderRequest.refererInfo.referer};
+
+  // Handle privacy settings for GDPR/CCPA/COPPA
+  let gdprApplies = 0;
+  if (bidderRequest.gdprConsent) {
+    if (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') gdprApplies = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+    utils.deepSetValue(request, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
+  }
+  utils.deepSetValue(request, 'regs.ext.gdpr', gdprApplies);
+
+  if (bidderRequest.uspConsent) {
+    utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+    this.syncStore.uspConsent = bidderRequest.uspConsent;
+  }
+
+  if (GETCONFIG('coppa') == true) utils.deepSetValue(request, 'regs.coppa', 1);
+
+  if (bidderRequest.uspConsent) {
+    utils.deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+  }
+
+  // Set buyer uid
+  utils.deepSetValue(request, 'user.buyeruid', utils.generateUUID());
+
+  // Create imps with bids
+  validBidRequests.forEach((bid) => {
+    let imp = {
+      id: bid.bidId,
+      bidfloor: bid.params.bidfloor ? bid.params.bidfloor : 0,
+      ext: {
+        impactify: {
+          appId: bid.params.appId,
+          format: bid.params.format,
+          style: bid.params.style
+        },
+      },
+      video: {
+        playerSize: [DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT],
+        context: 'outstream',
+        mimes: ['video/mp4'],
+      },
+    };
+    if (bid.params.container) {
+      imp.ext.impactify.container = bid.params.container;
+    }
+    request.imp.push(imp);
+  });
+
+  return request;
+};
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: ['video'],
+  aliases: BIDDER_ALIAS,
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    if (!bid.params.appId || typeof bid.params.appId != 'string' || !bid.params.format || typeof bid.params.format != 'string' || !bid.params.style || typeof bid.params.style != 'string') {
+      return false;
+    }
+    if (bid.params.format != 'screen' && bid.params.format != 'display') {
+      return false;
+    }
+    if (bid.params.style != 'inline' && bid.params.style != 'impact' && bid.params.style != 'static') {
+      return false;
+    }
+
+    return true;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @param {bidderRequest} - the bidding request
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    // Create a clean openRTB request
+    let request = createOpenRtbRequest(validBidRequests, bidderRequest);
+
+    return {
+      method: 'POST',
+      url: ORIGIN + AUCTIONURI,
+      data: JSON.stringify(request),
+    };
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const serverBody = serverResponse.body;
+    let bidResponses = [];
+
+    if (!serverBody) {
+      return bidResponses;
+    }
+
+    if (!serverBody.seatbid || !serverBody.seatbid.length) {
+      return [];
+    }
+
+    serverBody.seatbid.forEach((seatbid) => {
+      if (seatbid.bid.length) {
+        bidResponses = [
+          ...bidResponses,
+          ...seatbid.bid
+            .filter((bid) => bid.price > 0)
+            .map((bid) => ({
+              id: bid.id,
+              requestId: bid.impid,
+              cpm: bid.price,
+              currency: serverBody.cur,
+              netRevenue: true,
+              ad: bid.adm,
+              width: bid.w || 0,
+              height: bid.h || 0,
+              ttl: 300,
+              creativeId: bid.crid || 0,
+              hash: bid.hash,
+              expiry: bid.expiry,
+              meta: {
+                advertiserDomains: bid.adomain && bid.adomain.length ? bid.adomain : []
+              }
+            })),
+        ];
+      }
+    });
+
+    return bidResponses;
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: function (
+    syncOptions,
+    serverResponses,
+    gdprConsent,
+    uspConsent
+  ) {
+    if (!serverResponses || serverResponses.length === 0) {
+      return [];
+    }
+
+    if (!syncOptions.iframeEnabled) {
+      return [];
+    }
+
+    let params = '';
+    if (gdprConsent && typeof gdprConsent.consentString === 'string') {
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        params += `?gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        params += `?gdpr_consent=${gdprConsent.consentString}`;
+      }
+    }
+
+    if (uspConsent) {
+      params += `${params ? '&' : '?'}us_privacy=${encodeURIComponent(uspConsent)}`;
+    }
+
+    if (document.location.search.match(/pbs_debug=true/)) params += `&pbs_debug=true`;
+
+    return [{
+      type: 'iframe',
+      url: ORIGIN + COOKIESYNCURI + params
+    }];
+  },
+
+  /**
+   * Register bidder specific code, which will execute if a bid from this bidder won the auction
+   * @param {Bid} The bid that won the auction
+  */
+  onBidWon: function(bid) {
+    ajax(`${LOGGER_URI}/log/bidder/won`, null, JSON.stringify(bid), {
+      method: 'POST',
+      contentType: 'application/json'
+    });
+
+    return true;
+  },
+
+  /**
+   * Register bidder specific code, which will execute if bidder timed out after an auction
+   * @param {data} Containing timeout specific data
+  */
+  onTimeout: function(data) {
+    ajax(`${LOGGER_URI}/log/bidder/timeout`, null, JSON.stringify(data[0]), {
+      method: 'POST',
+      contentType: 'application/json'
+    });
+
+    return true;
+  }
+};
+registerBidder(spec);

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -1,0 +1,399 @@
+import { expect } from 'chai';
+import { spec } from 'modules/impactifyBidAdapter.js';
+import * as utils from 'src/utils.js';
+
+const BIDDER_CODE = 'impactify';
+const BIDDER_ALIAS = ['imp'];
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_VIDEO_WIDTH = 640;
+const DEFAULT_VIDEO_HEIGHT = 480;
+const ORIGIN = 'https://sonic.impactify.media';
+const LOGGER_URI = 'https://logger.impactify.media';
+const AUCTIONURI = '/bidder';
+const COOKIESYNCURI = '/static/cookie_sync.html';
+const GVLID = 606;
+
+var gdprData = {
+  'consentString': 'BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA',
+  'gdprApplies': true
+};
+
+describe('ImpactifyAdapter', function () {
+  describe('isBidRequestValid', function () {
+    let validBid = {
+      bidder: 'impactify',
+      params: {
+        appId: '1',
+        format: 'screen',
+        style: 'inline'
+      }
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(validBid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, validBid);
+      delete bid.params;
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when appId is missing', () => {
+      const bid = utils.deepClone(validBid);
+      delete bid.params.appId;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when appId is not a string', () => {
+      const bid = utils.deepClone(validBid);
+
+      bid.params.appId = 123;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.appId = false;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.appId = void (0);
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.appId = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when format is missing', () => {
+      const bid = utils.deepClone(validBid);
+      delete bid.params.format;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when format is not a string', () => {
+      const bid = utils.deepClone(validBid);
+
+      bid.params.format = 123;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.format = false;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.format = void (0);
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.format = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when format is not equals to screen or display', () => {
+      const bid = utils.deepClone(validBid);
+      if (bid.params.format != 'screen' && bid.params.format != 'display') {
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      }
+    });
+
+    it('should return false when style is missing', () => {
+      const bid = utils.deepClone(validBid);
+      delete bid.params.style;
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when style is not a string', () => {
+      const bid = utils.deepClone(validBid);
+
+      bid.params.style = 123;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.style = false;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.style = void (0);
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      bid.params.style = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+  describe('buildRequests', function () {
+    let videoBidRequests = [
+      {
+        bidder: 'impactify',
+        params: {
+          appId: '1',
+          format: 'screen',
+          style: 'inline'
+        },
+        mediaTypes: {
+          video: {
+            context: 'instream'
+          }
+        },
+        adUnitCode: 'adunit-code',
+        sizes: [[DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT]],
+        bidId: '123456789',
+        bidderRequestId: '987654321',
+        auctionId: '19ab94a9-b0d7-4ed7-9f80-ad0c033cf1b1',
+        transactionId: 'f7b2c372-7a7b-11eb-9439-0242ac130002'
+      }
+    ];
+    let videoBidderRequest = {
+      bidderRequestId: '98845765110',
+      auctionId: '165410516454',
+      bidderCode: 'impactify',
+      bids: [
+        {
+          ...videoBidRequests[0]
+        }
+      ],
+      refererInfo: {
+        referer: 'https://impactify.io'
+      }
+    };
+
+    it('sends video bid request to ENDPOINT via POST', function () {
+      const request = spec.buildRequests(videoBidRequests, videoBidderRequest);
+      expect(request.url).to.equal(ORIGIN + AUCTIONURI);
+      expect(request.method).to.equal('POST');
+    });
+  });
+  describe('interpretResponse', function () {
+    it('should get correct bid response', function () {
+      let response = {
+        id: '19ab94a9-b0d7-4ed7-9f80-ad0c033cf1b1',
+        seatbid: [
+          {
+            bid: [
+              {
+                id: '65820304700829014',
+                impid: '462c08f20d428',
+                price: 3.40,
+                adm: '<script type="text/javascript" src="https://ad.impactify.io/static/ad/tag.js"></script>',
+                adid: '97517771',
+                iurl: 'https://fra1-ib.adnxs.com/cr?id=97517771',
+                cid: '9325',
+                crid: '97517771',
+                w: 1,
+                h: 1,
+                hash: 'test',
+                expiry: 166192938,
+                meta: {'advertiserDomains': ['testdomain.com']},
+                ext: {
+                  prebid: {
+                    'type': 'video'
+                  },
+                  bidder: {
+                    prebid: {
+                      type: 'video',
+                      video: {
+                        duration: 30,
+                        primary_category: ''
+                      }
+                    },
+                    bidder: {
+                      appnexus: {
+                        brand_id: 182979,
+                        auction_id: 8657683934873599656,
+                        bidder_id: 2,
+                        bid_ad_type: 1,
+                        creative_info: {
+                          video: {
+                            duration: 30,
+                            mimes: [
+                              'video/x-flv',
+                              'video/mp4',
+                              'video/webm'
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            seat: 'impactify'
+          }
+        ],
+        cur: DEFAULT_CURRENCY,
+        ext: {
+          responsetimemillis: {
+            impactify: 114
+          },
+          prebid: {
+            auctiontimestamp: 1614587024591
+          }
+        }
+      };
+      let bidderRequest = {
+        bids: [
+          {
+            bidId: '462c08f20d428',
+            adUnitCode: '/19968336/header-bid-tag-1',
+            auctionId: '19ab94a9-b0d7-4ed7-9f80-ad0c033cf1b1',
+            bidder: 'impactify',
+            sizes: [[DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT]],
+            mediaTypes: {
+              video: {
+                context: 'outstream'
+              }
+            }
+          },
+        ]
+      }
+      let expectedResponse = [
+        {
+          id: '65820304700829014',
+          requestId: '462c08f20d428',
+          cpm: 3.40,
+          currency: DEFAULT_CURRENCY,
+          netRevenue: true,
+          ad: '<script type="text/javascript" src="https://ad.impactify.io/static/ad/tag.js"></script>',
+          width: 1,
+          height: 1,
+          hash: 'test',
+          expiry: 166192938,
+          meta: {'advertiserDomains': ['testdomain.com']},
+          ttl: 300,
+          creativeId: '97517771'
+        }
+      ];
+      let result = spec.interpretResponse({ body: response }, bidderRequest);
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+    });
+  });
+  describe('getUserSyncs', function () {
+    let videoBidRequests = [
+      {
+        bidder: 'impactify',
+        params: {
+          appId: '1',
+          format: 'screen',
+          style: 'inline'
+        },
+        mediaTypes: {
+          video: {
+            context: 'instream'
+          }
+        },
+        adUnitCode: 'adunit-code',
+        sizes: [[DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT]],
+        bidId: '123456789',
+        bidderRequestId: '987654321',
+        auctionId: '19ab94a9-b0d7-4ed7-9f80-ad0c033cf1b1',
+        transactionId: 'f7b2c372-7a7b-11eb-9439-0242ac130002'
+      }
+    ];
+    let videoBidderRequest = {
+      bidderRequestId: '98845765110',
+      auctionId: '165410516454',
+      bidderCode: 'impactify',
+      bids: [
+        {
+          ...videoBidRequests[0]
+        }
+      ],
+      refererInfo: {
+        referer: 'https://impactify.io'
+      }
+    };
+    let validResponse = {
+      id: '19ab94a9-b0d7-4ed7-9f80-ad0c033cf1b1',
+      seatbid: [
+        {
+          bid: [
+            {
+              id: '65820304700829014',
+              impid: '462c08f20d428',
+              price: 3.40,
+              adm: '<script type="text/javascript" src="https://ad.impactify.io/static/ad/tag.js"></script>',
+              adid: '97517771',
+              iurl: 'https://fra1-ib.adnxs.com/cr?id=97517771',
+              cid: '9325',
+              crid: '97517771',
+              w: 1,
+              h: 1,
+              hash: 'test',
+              expiry: 166192938,
+              meta: {'advertiserDomains': ['testdomain.com']},
+              ext: {
+                prebid: {
+                  'type': 'video'
+                },
+                bidder: {
+                  prebid: {
+                    type: 'video',
+                    video: {
+                      duration: 30,
+                      primary_category: ''
+                    }
+                  },
+                  bidder: {
+                    appnexus: {
+                      brand_id: 182979,
+                      auction_id: 8657683934873599656,
+                      bidder_id: 2,
+                      bid_ad_type: 1,
+                      creative_info: {
+                        video: {
+                          duration: 30,
+                          mimes: [
+                            'video/x-flv',
+                            'video/mp4',
+                            'video/webm'
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          seat: 'impactify'
+        }
+      ],
+      cur: DEFAULT_CURRENCY,
+      ext: {
+        responsetimemillis: {
+          impactify: 114
+        },
+        prebid: {
+          auctiontimestamp: 1614587024591
+        }
+      }
+    };
+    it('should return empty response if server response is false', function () {
+      const result = spec.getUserSyncs('bad', false, gdprData);
+      expect(result).to.be.empty;
+    });
+    it('should return empty response if server response is empty', function () {
+      const result = spec.getUserSyncs('bad', [], gdprData);
+      expect(result).to.be.empty;
+    });
+    it('should append the various values if they exist', function() {
+      const result = spec.getUserSyncs({iframeEnabled: true}, validResponse, gdprData);
+      expect(result[0].url).to.include('gdpr=1');
+      expect(result[0].url).to.include('gdpr_consent=BOh7mtYOh7mtYAcABBENCU-AAAAncgPIXJiiAoao0PxBFkgCAC8ACIAAQAQQAAIAAAIAAAhBGAAAQAQAEQgAAAAAAABAAAAAAAAAAAAAAACAAAAAAAACgAAAAABAAAAQAAAAAAA');
+    });
+  });
+
+  describe('On winning bid', function () {
+    const bid = {
+      ad: '<script type="text/javascript" src="https://ad.impactify.io/static/ad/tag.js"></script>',
+      cpm: '2'
+    };
+    const result = spec.onBidWon(bid);
+    assert.ok(result);
+  });
+
+  describe('On bid Time out', function () {
+    const bid = {
+      ad: '<script type="text/javascript" src="https://ad.impactify.io/static/ad/tag.js"></script>',
+      cpm: '2'
+    };
+    const result = spec.onTimeout(bid);
+    assert.ok(result);
+  });
+})


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Added bid.meta.advertiserDomains support. Addresses #6466 to be ready for Prebid 5.x