### PR TITLE
Admixer Bid Adapter: update bidder handler and read orb2

### DIFF
--- a/modules/admixerBidAdapter.js
+++ b/modules/admixerBidAdapter.js
@@ -4,7 +4,7 @@ import {config} from '../src/config.js';
 
 const BIDDER_CODE = 'admixer';
 const ALIASES = ['go2net', 'adblender'];
-const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.1.aspx';
+const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.2.aspx';
 export const spec = {
   code: BIDDER_CODE,
   aliases: ALIASES,
@@ -21,7 +21,7 @@ export const spec = {
   buildRequests: function (validRequest, bidderRequest) {
     const payload = {
       imps: [],
-      fpd: config.getLegacyFpd(config.getConfig('ortb2'))
+      ortb2: config.getConfig('ortb2'),
     };
     let endpointUrl;
     if (bidderRequest) {
@@ -43,9 +43,7 @@ export const spec = {
     }
     validRequest.forEach((bid) => {
       let imp = {};
-      Object.keys(bid).forEach(key => {
-        (key === 'ortb2Imp') ? imp.fpd = config.getLegacyImpFpd(bid[key]) : imp[key] = bid[key];
-      });
+      Object.keys(bid).forEach(key => imp[key] = bid[key]);
       payload.imps.push(imp);
     });
     const payloadString = JSON.stringify(payload);
@@ -62,26 +60,7 @@ export const spec = {
     const bidResponses = [];
     try {
       const {body: {ads = []} = {}} = serverResponse;
-      ads.forEach((bidResponse) => {
-        const bidResp = {
-          requestId: bidResponse.bidId,
-          cpm: bidResponse.cpm,
-          width: bidResponse.width,
-          height: bidResponse.height,
-          ad: bidResponse.ad,
-          ttl: bidResponse.ttl,
-          creativeId: bidResponse.creativeId,
-          netRevenue: bidResponse.netRevenue,
-          currency: bidResponse.currency,
-          vastUrl: bidResponse.vastUrl,
-          dealId: bidResponse.dealId,
-          /**
-          * currently includes meta.advertiserDomains ; networkId ; advertiserId
-          */
-          meta: bidResponse.meta,
-        };
-        bidResponses.push(bidResp);
-      });
+      ads.forEach((ad) => bidResponses.push(ad));
     } catch (e) {
       utils.logError(e);
     }

--- a/test/spec/modules/admixerBidAdapter_spec.js
+++ b/test/spec/modules/admixerBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {newBidder} from 'src/adapters/bidderFactory.js';
 import {config} from '../../../src/config.js';
 
 const BIDDER_CODE = 'admixer';
-const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.1.aspx';
+const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.2.aspx';
 const ENDPOINT_URL_CUSTOM = 'https://custom.admixer.net/prebid.aspx';
 const ZONE_ID = '2eb6bd58-865c-47ce-af7f-a918108c3fd2';
 
@@ -101,7 +101,7 @@ describe('AdmixerAdapter', function () {
           'creativeId': 'ccca3e5e-0c54-4761-9667-771322fbdffc',
           'ttl': 360,
           'netRevenue': false,
-          'bidId': '5e4e763b6bc60b',
+          'requestId': '5e4e763b6bc60b',
           'dealId': 'asd123',
           'meta': {'advertiserId': 123, 'networkId': 123, 'advertiserDomains': ['test.com']}
         }]
@@ -112,13 +112,12 @@ describe('AdmixerAdapter', function () {
       const ads = response.body.ads;
       let expectedResponse = [
         {
-          'requestId': ads[0].bidId,
+          'requestId': ads[0].requestId,
           'cpm': ads[0].cpm,
           'creativeId': ads[0].creativeId,
           'width': ads[0].width,
           'height': ads[0].height,
           'ad': ads[0].ad,
-          'vastUrl': undefined,
           'currency': ads[0].currency,
           'netRevenue': ads[0].netRevenue,
           'ttl': ads[0].ttl,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Update bidder handler. 
Now it read ortb2 instead of old fpd and return ads fully compliant pb spec (no need to map keys)
