### PR TITLE
GMOSSP Bid Adapter: add IM uid support

### DIFF
--- a/modules/gmosspBidAdapter.js
+++ b/modules/gmosspBidAdapter.js
@@ -2,9 +2,11 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'gmossp';
 const ENDPOINT = 'https://sp.gmossp-sp.jp/hb/prebid/query.ad';
+const storage = getStorageManager();
 
 export const spec = {
   code: BIDDER_CODE,
@@ -32,6 +34,7 @@ export const spec = {
     const urlInfo = getUrlInfo(bidderRequest.refererInfo);
     const cur = getCurrencyType();
     const dnt = utils.getDNT() ? '1' : '0';
+    const imuid = storage.getCookie('_im_uid.1000283') || '';
 
     for (let i = 0; i < validBidRequests.length; i++) {
       let queryString = '';
@@ -46,6 +49,7 @@ export const spec = {
       queryString = utils.tryAppendQueryString(queryString, 'bid', bid);
       queryString = utils.tryAppendQueryString(queryString, 'ver', ver);
       queryString = utils.tryAppendQueryString(queryString, 'sid', sid);
+      queryString = utils.tryAppendQueryString(queryString, 'im_uid', imuid);
       queryString = utils.tryAppendQueryString(queryString, 'url', urlInfo.url);
       queryString = utils.tryAppendQueryString(queryString, 'ref', urlInfo.ref);
       queryString = utils.tryAppendQueryString(queryString, 'cur', cur);

--- a/test/spec/modules/gmosspBidAdapter_spec.js
+++ b/test/spec/modules/gmosspBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/gmosspBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import {getStorageManager} from 'src/storageManager';
 import * as utils from 'src/utils.js';
 
 const ENDPOINT = 'https://sp.gmossp-sp.jp/hb/prebid/query.ad';
@@ -35,6 +36,7 @@ describe('GmosspAdapter', function () {
   });
 
   describe('buildRequests', function () {
+    const storage = getStorageManager();
     const bidRequests = [
       {
         bidder: 'gmossp',
@@ -60,19 +62,21 @@ describe('GmosspAdapter', function () {
           referer: 'https://hoge.com'
         }
       };
+      storage.setCookie('_im_uid.1000283', 'h.0a4749e7ffe09fa6');
 
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests[0].url).to.equal(ENDPOINT);
       expect(requests[0].method).to.equal('GET');
-      expect(requests[0].data).to.equal('tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=$prebid.version$&sid=123456&url=https%3A%2F%2Fhoge.com&cur=JPY&dnt=0&');
+      expect(requests[0].data).to.equal('tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=$prebid.version$&sid=123456&im_uid=h.0a4749e7ffe09fa6&url=https%3A%2F%2Fhoge.com&cur=JPY&dnt=0&');
     });
 
-    it('should use fallback if refererInfo.referer in bid request is empty', function () {
+    it('should use fallback if refererInfo.referer in bid request is empty and _im_uid.1000283 cookie is empty', function () {
       const bidderRequest = {
         refererInfo: {
           referer: ''
         }
       };
+      storage.setCookie('_im_uid.1000283', '');
 
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       const result = 'tid=791e9d84-af92-4903-94da-24c7426d9d0c&bid=2b84475b5b636e&ver=$prebid.version$&sid=123456&url=' + encodeURIComponent(window.top.location.href) + '&cur=JPY&dnt=0&';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders -->
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other
## Description of change
We have added new request parameter, Intimate Merger uid.
Since the uid is set in cookie, storageManager.js also has been added.
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
{
  bidder: 'gmossp',
  params: {
    sid: '61590'
  }
}
- contact email of the adapter's maintainer
dev@ml.gmo-am.jp
- [x] official adapter submission