### PR TITLE
Adagio Bid Adapter: Fix unavailable localStorage error for legacy 4.43.x (#7128)

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -99,13 +99,18 @@ export function getAdagioScript() {
     if (isValid) {
       loadExternalScript(ADAGIO_TAG_URL, BIDDER_CODE);
     } else {
-      // ensure adagio removing for next time.
-      // It's an antipattern regarding the TCF2 enforcement logic
-      // but it's the only way to respect the user choice update.
-      window.localStorage.removeItem(ADAGIO_LOCALSTORAGE_KEY);
-      // Extra data from external script.
-      // This key is removed only if localStorage is not accessible.
-      window.localStorage.removeItem('adagio');
+      // Try-catch to avoid error when 3rd party cookies is disabled (e.g. in privacy mode)
+      try {
+        // ensure adagio removing for next time.
+        // It's an antipattern regarding the TCF2 enforcement logic
+        // but it's the only way to respect the user choice update.
+        window.localStorage.removeItem(ADAGIO_LOCALSTORAGE_KEY);
+        // Extra data from external script.
+        // This key is removed only if localStorage is not accessible.
+        window.localStorage.removeItem('adagio');
+      } catch (e) {
+        utils.logInfo(`${LOG_PREFIX} unable to clear Adagio scripts from localstorage.`);
+      }
     }
   });
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix the opened issue #7128.

Note: this bug has already been fixed for Prebid.js 5.x, 

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission
