### PR TITLE
ID5 Analytics: redaction process skips 'ext' on ID5 ID

### DIFF
--- a/modules/id5AnalyticsAdapter.js
+++ b/modules/id5AnalyticsAdapter.js
@@ -293,7 +293,7 @@ function transformFnFromCleanupRules(eventType) {
       for (let fragment = 0; fragment < ruleMatcher.length && match; fragment++) {
         const choices = makeSureArray(ruleMatcher[fragment]);
         match = !choices.every((choice) => choice !== '*' &&
-          (choice.startsWith('!')
+          (choice.charAt(0) === '!'
             ? path[fragment] === choice.substring(1)
             : path[fragment] !== choice));
       }

--- a/modules/id5AnalyticsAdapter.js
+++ b/modules/id5AnalyticsAdapter.js
@@ -243,10 +243,14 @@ function deepTransformingClone(obj, transform, currentPath = []) {
 // takes (obj, prop) and transforms property "prop" in object "obj".
 // The "match" is an array of path parts. Each part is either a string or an array.
 // In case of array, it represents alternatives which all would match.
-// Special path part '*' matches any subproperty
+// Special path part '*' matches any subproperty or array index.
+// Prefixing a part with "!" makes it negative match (doesn't work with multiple alternatives)
 const CLEANUP_RULES = {};
 CLEANUP_RULES[AUCTION_END] = [{
-  match: [['adUnits', 'bidderRequests'], '*', 'bids', '*', ['userId', 'crumbs'], '*'],
+  match: [['adUnits', 'bidderRequests'], '*', 'bids', '*', ['userId', 'crumbs'], '!id5id'],
+  apply: 'redact'
+}, {
+  match: [['adUnits', 'bidderRequests'], '*', 'bids', '*', ['userId', 'crumbs'], 'id5id', 'uid'],
   apply: 'redact'
 }, {
   match: [['adUnits', 'bidderRequests'], '*', 'bids', '*', 'userIdAsEids', '*', 'uids', '*', ['id', 'ext']],
@@ -288,7 +292,10 @@ function transformFnFromCleanupRules(eventType) {
       }
       for (let fragment = 0; fragment < ruleMatcher.length && match; fragment++) {
         const choices = makeSureArray(ruleMatcher[fragment]);
-        match = !choices.every((choice) => choice !== '*' && path[fragment] !== choice);
+        match = !choices.every((choice) => choice !== '*' &&
+          (choice.startsWith('!')
+            ? path[fragment] === choice.substring(1)
+            : path[fragment] !== choice));
       }
       if (match) {
         const transformfn = TRANSFORM_FUNCTIONS[transformation];

--- a/test/spec/modules/id5AnalyticsAdapter_spec.js
+++ b/test/spec/modules/id5AnalyticsAdapter_spec.js
@@ -322,12 +322,22 @@ describe('ID5 analytics adapter', () => {
       expect(body.event).to.equal('auctionEnd');
       expect(body.payload.adUnits[0].bids[0].userId).to.eql({
         'criteoId': '__ID5_REDACTED__',
-        'id5id': '__ID5_REDACTED__',
+        'id5id': {
+          'uid': '__ID5_REDACTED__',
+          'ext': {
+            'linkType': 1
+          }
+        },
         'tdid': '__ID5_REDACTED__'
       });
       expect(body.payload.bidderRequests[0].bids[0].userId).to.eql({
         'sharedid': '__ID5_REDACTED__',
-        'id5id': '__ID5_REDACTED__',
+        'id5id': {
+          'uid': '__ID5_REDACTED__',
+          'ext': {
+            'linkType': 1
+          }
+        },
         'tdid': '__ID5_REDACTED__'
       });
       body.payload.adUnits[0].bids[0].userIdAsEids.forEach((userId) => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Relaxes some aggressive cleanup in the ID5 Analytics module for data we need.
