### PR TITLE
SharedIdSystem: return pubcid instead of sharedId

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -63,8 +63,8 @@ function queuePixelCallback(pixelUrl, id = '', callback) {
 }
 
 function hasOptedOut() {
-  return (storage.cookiesAreEnabled() && readValue(OPTOUT_NAME, COOKIE)) ||
-    (storage.hasLocalStorage() && readValue(OPTOUT_NAME, LOCAL_STORAGE));
+  return !!((storage.cookiesAreEnabled() && readValue(OPTOUT_NAME, COOKIE)) ||
+    (storage.hasLocalStorage() && readValue(OPTOUT_NAME, LOCAL_STORAGE)));
 }
 
 export const sharedIdSystemSubmodule = {

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -88,6 +88,11 @@ export const sharedIdSystemSubmodule = {
    * @returns {{pubcid:string}}
    */
   decode(value, config) {
+    if (hasOptedOut()) {
+      utils.logInfo('PubCommonId decode: Has opted-out');
+      return undefined;
+    }
+    utils.logInfo(' Decoded value PubCommonId ' + value);
     const idObj = {'pubcid': value};
     return idObj;
   },

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -7,170 +7,57 @@
 
 import * as utils from '../src/utils.js';
 import {submodule} from '../src/hook.js';
-import {ajax} from '../src/ajax.js';
-import { uspDataHandler, coppaDataHandler } from '../src/adapterManager.js';
+import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
 const GVLID = 887;
 const storage = getStorageManager(GVLID, 'pubCommonId');
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
-const SHAREDID_OPT_OUT_VALUE = '00000000000000000000000000';
-const SHAREDID_URL = 'https://id.sharedid.org/id';
-const SHAREDID_SUFFIX = '_sharedid';
-const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
-const SHAREDID_DEFAULT_STATE = true;
-
+const OPTOUT_NAME = '_pubcid_optout';
 const PUB_COMMON_ID = 'PublisherCommonId';
 
 /**
- * Store sharedid in either cookie or local storage
- * @param {Object} config Need config.storage object to derive key, expiry time, and storage type.
- * @param {string} value Shareid value to store
+ * Read a value either from cookie or local storage
+ * @param {string} name Name of the item
+ * @param {string} type storage type override
+ * @returns {string|null} a string if item exists
  */
-
-function storeData(config, value) {
-  try {
-    if (value) {
-      const key = config.storage.name + SHAREDID_SUFFIX;
-      const expiresStr = (new Date(Date.now() + (storage.expires * (60 * 60 * 24 * 1000)))).toUTCString();
-
-      if (config.storage.type === COOKIE) {
-        if (storage.cookiesAreEnabled()) {
-          storage.setCookie(key, value, expiresStr, 'LAX', sharedIdSystemSubmodule.domainOverride());
-        }
-      } else if (config.storage.type === LOCAL_STORAGE) {
-        if (storage.hasLocalStorage()) {
-          storage.setDataInLocalStorage(`${key}_exp`, expiresStr);
-          storage.setDataInLocalStorage(key, value);
-        }
+function readValue(name, type) {
+  if (type === COOKIE) {
+    return storage.getCookie(name);
+  } else if (type === LOCAL_STORAGE) {
+    if (storage.hasLocalStorage()) {
+      const expValue = storage.getDataFromLocalStorage(`${name}_exp`);
+      if (!expValue) {
+        return storage.getDataFromLocalStorage(name);
+      } else if ((new Date(expValue)).getTime() - Date.now() > 0) {
+        return storage.getDataFromLocalStorage(name)
       }
     }
-  } catch (error) {
-    utils.logError(error);
   }
 }
 
-/**
- * Read sharedid from cookie or local storage
- * @param config Need config.storage to derive key and storage type
- * @return {string}
- */
-function readData(config) {
-  try {
-    const key = config.storage.name + SHAREDID_SUFFIX;
-    if (config.storage.type === COOKIE) {
-      if (storage.cookiesAreEnabled()) {
-        return storage.getCookie(key);
-      }
-    } else if (config.storage.type === LOCAL_STORAGE) {
-      if (storage.hasLocalStorage()) {
-        const expValue = storage.getDataFromLocalStorage(`${key}_exp`);
-        if (!expValue) {
-          return storage.getDataFromLocalStorage(key);
-        } else if ((new Date(expValue)).getTime() - Date.now() > 0) {
-          return storage.getDataFromLocalStorage(key)
-        }
-      }
-    }
-  } catch (error) {
-    utils.logError(error);
+function queuePixelCallback(pixelUrl, id = '') {
+  if (!pixelUrl) {
+    return;
   }
+
+  // Use pubcid as a cache buster
+  const urlInfo = utils.parseUrl(pixelUrl);
+  urlInfo.search.id = encodeURIComponent('pubcid:' + id);
+  const targetUrl = utils.buildUrl(urlInfo);
+
+  return function () {
+    utils.triggerPixel(targetUrl);
+  };
 }
 
-/**
- * Delete sharedid from cookie or local storage
- * @param config Need config.storage to derive key and storage type
- */
-function delData(config) {
-  try {
-    const key = config.storage.name + SHAREDID_SUFFIX;
-    if (config.storage.type === COOKIE) {
-      if (storage.cookiesAreEnabled()) {
-        storage.setCookie(key, '', EXPIRED_COOKIE_DATE);
-      }
-    } else if (config.storage.type === LOCAL_STORAGE) {
-      storage.removeDataFromLocalStorage(`${key}_exp`);
-      storage.removeDataFromLocalStorage(key);
-    }
-  } catch (error) {
-    utils.logError(error);
-  }
+function hasOptedOut() {
+  return (storage.cookiesAreEnabled() && readValue(OPTOUT_NAME, COOKIE)) ||
+    (storage.hasLocalStorage() && readValue(OPTOUT_NAME, LOCAL_STORAGE));
 }
 
-/**
- * setup success and error handler for sharedid callback thru ajax
- * @param {string} pubcid Current pubcommon id
- * @param {function} callback userId module callback.
- * @param {Object} config Need config.storage to derive sharedid storage params
- * @return {{success: success, error: error}}
- */
-
-function handleResponse(pubcid, callback, config) {
-  return {
-    success: function (responseBody) {
-      if (responseBody) {
-        try {
-          let responseObj = JSON.parse(responseBody);
-          utils.logInfo('PubCommonId: Generated SharedId: ' + responseObj.sharedId);
-          if (responseObj.sharedId) {
-            if (responseObj.sharedId !== SHAREDID_OPT_OUT_VALUE) {
-              // Store sharedId locally
-              storeData(config, responseObj.sharedId);
-            } else {
-              // Delete local copy if the user has opted out
-              delData(config);
-            }
-          }
-          // Pass pubcid even though there is no change in order to trigger decode
-          callback(responseObj.sharedId);
-        } catch (error) {
-          utils.logError(error);
-        }
-      }
-    },
-    error: function (statusText, responseBody) {
-      utils.logInfo('PubCommonId: failed to get sharedid');
-    }
-  }
-}
-
-/**
- * Builds and returns the shared Id URL with attached consent data if applicable
- * @param {Object} consentData
- * @return {string}
- */
-function sharedIdUrl(consentData) {
-  const usPrivacyString = uspDataHandler.getConsentData();
-  let sharedIdUrl = SHAREDID_URL;
-  if (usPrivacyString && typeof usPrivacyString === 'string') {
-    sharedIdUrl = `${SHAREDID_URL}?us_privacy=${usPrivacyString}`;
-  }
-  if (!consentData || typeof consentData.gdprApplies !== 'boolean' || !consentData.gdprApplies) return sharedIdUrl;
-  if (usPrivacyString) {
-    sharedIdUrl = `${sharedIdUrl}&gdpr=1&gdpr_consent=${consentData.consentString}`
-    return sharedIdUrl;
-  }
-  sharedIdUrl = `${SHAREDID_URL}?gdpr=1&gdpr_consent=${consentData.consentString}`;
-  return sharedIdUrl
-}
-
-/**
- * Wraps pixelCallback in order to call sharedid sync
- * @param {string} pubcid Pubcommon id value
- * @param {function|undefined} pixelCallback fires a pixel to first party server
- * @param {Object} config Need config.storage to derive sharedid storage params.
- * @return {function(...[*]=)}
- */
-
-function getIdCallback(pubcid, pixelCallback, config, consentData) {
-  return function (callback) {
-    if (typeof pixelCallback === 'function') {
-      pixelCallback();
-    }
-    ajax(sharedIdUrl(consentData), handleResponse(pubcid, callback, config), undefined, {method: 'GET', withCredentials: true});
-  }
-}
 export const sharedIdSystemSubmodule = {
   /**
    * used to link submodule with config
@@ -183,20 +70,7 @@ export const sharedIdSystemSubmodule = {
    * @type {Number}
    */
   gvlid: GVLID,
-  makeCallback: function (pixelUrl, id = '') {
-    if (!pixelUrl) {
-      return;
-    }
 
-    // Use pubcid as a cache buster
-    const urlInfo = utils.parseUrl(pixelUrl);
-    urlInfo.search.id = encodeURIComponent('pubcid:' + id);
-    const targetUrl = utils.buildUrl(urlInfo);
-
-    return function () {
-      utils.triggerPixel(targetUrl);
-    };
-  },
   /**
    * decode the stored id value for passing to bid requests
    * @function
@@ -206,13 +80,6 @@ export const sharedIdSystemSubmodule = {
    */
   decode(value, config) {
     const idObj = {'pubcid': value};
-    const {params: {enableSharedId = SHAREDID_DEFAULT_STATE} = {}} = config;
-
-    if (enableSharedId) {
-      const sharedId = readData(config);
-      if (sharedId) idObj['sharedid'] = {id: sharedId};
-    }
-
     return idObj;
   },
   /**
@@ -224,12 +91,17 @@ export const sharedIdSystemSubmodule = {
    * @returns {IdResponse}
    */
   getId: function (config = {}, consentData, storedId) {
+    if (hasOptedOut()) {
+      utils.logInfo('PubCommonId: Has opted-out');
+      return {id: undefined};
+    }
     const coppa = coppaDataHandler.getCoppa();
+
     if (coppa) {
       utils.logInfo('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
       return;
     }
-    const {params: {create = true, pixelUrl, enableSharedId = SHAREDID_DEFAULT_STATE} = {}} = config;
+    const {params: {create = true, pixelUrl} = {}} = config;
     let newId = storedId;
     if (!newId) {
       try {
@@ -243,10 +115,8 @@ export const sharedIdSystemSubmodule = {
       if (!newId) newId = (create && utils.hasDeviceAccess()) ? utils.generateUUID() : undefined;
     }
 
-    const pixelCallback = this.makeCallback(pixelUrl, newId);
-    const combinedCallback = enableSharedId ? getIdCallback(newId, pixelCallback, config, consentData) : pixelCallback;
-
-    return {id: newId, callback: combinedCallback};
+    const pixelCallback = queuePixelCallback(pixelUrl, newId);
+    return {id: newId, callback: pixelCallback};
   },
   /**
    * performs action to extend an id.  There are generally two ways to extend the expiration time
@@ -259,8 +129,7 @@ export const sharedIdSystemSubmodule = {
    * having the script-side overwriting server-side.  This applies to both pubcid and sharedid.
    *
    * On the other hand, if there is no pixelUrl, then the extendId should return storedId so that
-   * its expiration time is updated.  Sharedid, however, will have to be updated by this submodule
-   * separately.
+   * its expiration time is updated.
    *
    * @function
    * @param {SubmoduleParams} [config]
@@ -269,34 +138,22 @@ export const sharedIdSystemSubmodule = {
    * @returns {IdResponse|undefined}
    */
   extendId: function(config = {}, consentData, storedId) {
+    if (hasOptedOut()) {
+      utils.logInfo('PubCommonId: Has opted-out');
+      return {id: undefined};
+    }
     const coppa = coppaDataHandler.getCoppa();
     if (coppa) {
       utils.logInfo('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
       return;
     }
-    const {params: {extend = false, pixelUrl, enableSharedId = SHAREDID_DEFAULT_STATE} = {}} = config;
+    const {params: {extend = false, pixelUrl} = {}} = config;
 
     if (extend) {
-      try {
-        if (typeof window[PUB_COMMON_ID] === 'object') {
-          if (enableSharedId) {
-            // If the page includes its own pubcid module, then there is nothing to do
-            // except to update sharedid's expiration time
-            storeData(config, readData(config));
-          }
-          return;
-        }
-      } catch (e) {
-      }
-
       if (pixelUrl) {
-        const callback = this.makeCallback(pixelUrl, storedId);
+        const callback = queuePixelCallback(pixelUrl, storedId);
         return {callback: callback};
       } else {
-        if (enableSharedId) {
-          // Update with the same value to extend expiration time
-          storeData(config, readData(config));
-        }
         return {id: storedId};
       }
     }

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,38 +1,129 @@
 import {
-  sharedIdSystemSubmodule,
+  sharedIdSystemSubmodule
 } from 'modules/sharedIdSystem.js';
-import { server } from 'test/mocks/xhr.js';
-import {uspDataHandler} from 'src/adapterManager';
+import {coppaDataHandler, uspDataHandler} from 'src/adapterManager';
 import sinon from 'sinon';
+import * as utils from 'src/utils.js';
+import { coreStorage } from 'modules/userId/index.js'
 
 let expect = require('chai').expect;
 
 describe('SharedId System', function() {
-  const SHAREDID_RESPONSE = {sharedId: 'testsharedid'};
-  let uspConsentDataStub;
-  describe('Xhr Requests from getId()', function() {
-    let callbackSpy = sinon.spy();
+  const UUID = '15fde1dc-1861-4894-afdf-b757272f3568';
+  const OPTOUT_NAME = '_pubcid_optout';
+  const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
+  const EXPIRE_COOKIE_TIME = 864000000;
+
+  before(function() {
+    sinon.stub(utils, 'generateUUID').returns(UUID);
+  });
+
+  after(function() {
+    utils.generateUUID.restore();
+  });
+
+  function removeOptOutCookie() {
+    coreStorage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
+  }
+  describe('SharedId System getId()', function() {
+    const callbackSpy = sinon.spy();
+
+    let coppaDataHandlerDataStub
+    let sandbox;
 
     beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+
+      coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
+      sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
-      uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
     });
 
     afterEach(function () {
-      uspConsentDataStub.restore();
+      coppaDataHandlerDataStub.returns('false');
+      removeOptOutCookie();
+      sandbox.restore();
     });
 
-    it('should call pixel when pixelUrl is configured', function () {
-      const config = {params: {extend: false, pixelUrl: 'https://test.com'}};
+    it('should call UUID', function () {
+      let config = {
+        storage: {
+          type: 'cookie',
+          name: '_pubcid',
+          expires: 10
+        }
+      };
+
       let submoduleCallback = sharedIdSystemSubmodule.getId(config, undefined).callback;
       submoduleCallback(callbackSpy);
-
-      let request = server.requests[0];
-      // expect(request.url).to.equal('https://test.com');
-      expect(request.withCredentials).to.be.true;
-
-      // request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
       expect(callbackSpy.calledOnce).to.be.true;
+      expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
+    });
+    it('should log message opted out', function() {
+      coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      const infoMessageSpy = sinon.spy(utils, 'logInfo');
+      sharedIdSystemSubmodule.getId({});
+      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: Has opted-out');
+      infoMessageSpy.restore();
+    });
+    it('should log message if coppa is set', function() {
+      coppaDataHandlerDataStub.returns('true');
+      const infoMessageSpy = sinon.spy(utils, 'logInfo');
+      sharedIdSystemSubmodule.getId({})
+
+      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      infoMessageSpy.restore();
+    });
+  });
+  describe('SharedId System extendId()', function() {
+    const callbackSpy = sinon.spy();
+
+    let coppaDataHandlerDataStub
+    let sandbox;
+
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+
+      coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
+      sandbox.stub(utils, 'hasDeviceAccess').returns(true);
+      callbackSpy.resetHistory();
+    });
+
+    afterEach(function () {
+      coppaDataHandlerDataStub.returns('false');
+      removeOptOutCookie();
+      sandbox.restore();
+    });
+
+    it('should call UUID', function () {
+      let config = {
+        params: {
+          extend: true
+        },
+        storage: {
+          type: 'cookie',
+          name: '_pubcid',
+          expires: 10
+        }
+      };
+
+      let pubcommId = sharedIdSystemSubmodule.extendId(config, undefined, 'TestId').id;
+      expect(pubcommId).to.equal('TestId');
+    });
+    it('should log message opted out', function() {
+      coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      const infoMessageSpy = sinon.spy(utils, 'logInfo');
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
+      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: Has opted-out');
+      infoMessageSpy.restore();
+    });
+    it('should log message if coppa is set', function() {
+      coppaDataHandlerDataStub.returns('true');
+      const infoMessageSpy = sinon.spy(utils, 'logInfo');
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
+
+      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      infoMessageSpy.restore();
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -22,57 +22,17 @@ describe('SharedId System', function() {
       uspConsentDataStub.restore();
     });
 
-    it('should call shared id endpoint without consent data and handle a valid response', function () {
-      let submoduleCallback = sharedIdSystemSubmodule.getId(undefined, undefined).callback;
+    it('should call pixel when pixelUrl is configured', function () {
+      const config = {params: {extend: false, pixelUrl: 'https://test.com'}};
+      let submoduleCallback = sharedIdSystemSubmodule.getId(config, undefined).callback;
       submoduleCallback(callbackSpy);
 
       let request = server.requests[0];
-      expect(request.url).to.equal('https://id.sharedid.org/id');
+      // expect(request.url).to.equal('https://test.com');
       expect(request.withCredentials).to.be.true;
 
-      request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
-
+      // request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
-    });
-
-    it('should call shared id endpoint with consent data and handle a valid response', function () {
-      let consentData = {
-        gdprApplies: true,
-        consentString: 'abc12345234',
-      };
-
-      let submoduleCallback = sharedIdSystemSubmodule.getId(undefined, consentData).callback;
-      submoduleCallback(callbackSpy);
-
-      let request = server.requests[0];
-      expect(request.url).to.equal('https://id.sharedid.org/id?gdpr=1&gdpr_consent=abc12345234');
-      expect(request.withCredentials).to.be.true;
-
-      request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
-
-      expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
-    });
-
-    it('should call shared id endpoint with usp consent data and handle a valid response', function () {
-      uspConsentDataStub.returns('1YYY');
-      let consentData = {
-        gdprApplies: true,
-        consentString: 'abc12345234',
-      };
-
-      let submoduleCallback = sharedIdSystemSubmodule.getId(undefined, consentData).callback;
-      submoduleCallback(callbackSpy);
-
-      let request = server.requests[0];
-      expect(request.url).to.equal('https://id.sharedid.org/id?us_privacy=1YYY&gdpr=1&gdpr_consent=abc12345234');
-      expect(request.withCredentials).to.be.true;
-
-      request.respond(200, {}, JSON.stringify(SHAREDID_RESPONSE));
-
-      expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.equal(SHAREDID_RESPONSE.sharedId);
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -24,8 +24,8 @@ describe('SharedId System', function() {
     utils.logInfo.restore();
   });
 
-  function removeOptOutCookie() {
-    coreStorage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
+  function optinCookie() {
+    coreStorage.setCookie(OPTOUT_NAME, null, EXPIRED_COOKIE_DATE);
   }
   describe('SharedId System getId()', function() {
     const callbackSpy = sinon.spy();
@@ -35,7 +35,6 @@ describe('SharedId System', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
@@ -43,7 +42,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      removeOptOutCookie();
+      optinCookie();
       sandbox.restore();
     });
 
@@ -68,7 +67,8 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.getId({})
+      sharedIdSystemSubmodule.getId({});
+      optinCookie();
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });
@@ -87,7 +87,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      removeOptOutCookie();
+      optinCookie();
       sandbox.restore();
     });
 
@@ -113,7 +113,8 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
+      optinCookie();
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -25,7 +25,6 @@ describe('SharedId System', function() {
   after(function() {
     utils.generateUUID.restore();
     utils.logInfo.restore();
-    optinCookie();
   });
 
   function optinCookie() {
@@ -41,11 +40,11 @@ describe('SharedId System', function() {
       sandbox = sinon.sandbox.create();
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
+      coppaDataHandlerDataStub.returns('');
       callbackSpy.resetHistory();
     });
 
     afterEach(function () {
-      coppaDataHandlerDataStub.returns('false');
       optinCookie();
       sandbox.restore();
     });
@@ -64,16 +63,17 @@ describe('SharedId System', function() {
       expect(callbackSpy.calledOnce).to.be.true;
       expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
-    it('should log message opted out', function() {
-      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
-      sharedIdSystemSubmodule.getId({});
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
-    });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
       sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
+    it('should log message opted out', function() {
+      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      sharedIdSystemSubmodule.getId({});
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
+    });
+
   });
   describe('SharedId System extendId()', function() {
     const callbackSpy = sinon.spy();
@@ -86,10 +86,10 @@ describe('SharedId System', function() {
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
+      coppaDataHandlerDataStub.returns('');
     });
 
     afterEach(function () {
-      coppaDataHandlerDataStub.returns('false');
       optinCookie();
       sandbox.restore();
     });
@@ -109,15 +109,15 @@ describe('SharedId System', function() {
       let pubcommId = sharedIdSystemSubmodule.extendId(config, undefined, 'TestId').id;
       expect(pubcommId).to.equal('TestId');
     });
-    it('should log message opted out', function() {
-      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
-    });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+    });
+    it('should log message opted out', function() {
+      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,63 +1,39 @@
-import {
-  sharedIdSystemSubmodule
-} from 'modules/sharedIdSystem.js';
-import {coppaDataHandler, uspDataHandler} from 'src/adapterManager';
+import {sharedIdSystemSubmodule, storage} from 'modules/sharedIdSystem.js';
+import {coppaDataHandler} from 'src/adapterManager';
 
-import { newStorageManager } from 'src/storageManager.js';
 import sinon from 'sinon';
 import * as utils from 'src/utils.js';
-const storage = newStorageManager(sharedIdSystemSubmodule.gvlid, 'pubCommonId');
 
 let expect = require('chai').expect;
 
-describe('SharedId System', function() {
+describe('SharedId System', function () {
   const UUID = '15fde1dc-1861-4894-afdf-b757272f3568';
-  const OPTOUT_NAME = '_pubcid_optout';
-  const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
-  const EXPIRE_COOKIE_TIME = 864000000;
 
-  before(function() {
+  before(function () {
     sinon.stub(utils, 'generateUUID').returns(UUID);
     sinon.stub(utils, 'logInfo');
   });
 
-  after(function() {
+  after(function () {
     utils.generateUUID.restore();
     utils.logInfo.restore();
   });
-
-  function optout() {
-    cookiesAreEnabledStub.returns(true);
-    storage.setCookie(
-      OPTOUT_NAME,
-      'true',
-      (new Date(Date.now() + EXPIRE_COOKIE_TIME).toUTCString()),
-      'lax'
-    );
-  }
-  function optinCookie() {
-    storage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
-  }
-  describe('SharedId System getId()', function() {
+  describe('SharedId System getId()', function () {
     const callbackSpy = sinon.spy();
 
     let coppaDataHandlerDataStub
     let sandbox;
-    let cookiesAreEnabledStub;
 
-    beforeEach(function() {
+    beforeEach(function () {
       sandbox = sinon.sandbox.create();
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       coppaDataHandlerDataStub.returns('');
-      cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
       callbackSpy.resetHistory();
     });
 
     afterEach(function () {
-      optinCookie();
       sandbox.restore();
-      cookiesAreEnabledStub.restore();
     });
 
     it('should call UUID', function () {
@@ -74,41 +50,27 @@ describe('SharedId System', function() {
       expect(callbackSpy.calledOnce).to.be.true;
       expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
-    it('should log message if coppa is set', function() {
+    it('should log message if coppa is set', function () {
       coppaDataHandlerDataStub.returns('true');
       sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
-    it('should log message opted out', function() {
-      coppaDataHandlerDataStub.returns('');
-      optout();
-      sharedIdSystemSubmodule.getId({});
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
-    });
   });
-  describe('SharedId System extendId()', function() {
+  describe('SharedId System extendId()', function () {
     const callbackSpy = sinon.spy();
-
     let coppaDataHandlerDataStub;
     let sandbox;
-    let cookiesAreEnabledStub;
 
-    beforeEach(function() {
+    beforeEach(function () {
       sandbox = sinon.sandbox.create();
-
-      cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
       coppaDataHandlerDataStub.returns('');
     });
-
     afterEach(function () {
-      optinCookie();
       sandbox.restore();
-      cookiesAreEnabledStub.restore();
     });
-
     it('should call UUID', function () {
       let config = {
         params: {
@@ -120,20 +82,13 @@ describe('SharedId System', function() {
           expires: 10
         }
       };
-
       let pubcommId = sharedIdSystemSubmodule.extendId(config, undefined, 'TestId').id;
       expect(pubcommId).to.equal('TestId');
     });
-    it('should log message if coppa is set', function() {
+    it('should log message if coppa is set', function () {
       coppaDataHandlerDataStub.returns('true');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
-    });
-    it('should log message opted out', function() {
-      coppaDataHandlerDataStub.returns('');
-      optout();
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -24,8 +24,8 @@ describe('SharedId System', function() {
     utils.logInfo.restore();
   });
 
-  function optinCookie() {
-    coreStorage.setCookie(OPTOUT_NAME, null, EXPIRED_COOKIE_DATE);
+  function removeOptOutCookie() {
+    coreStorage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
   }
   describe('SharedId System getId()', function() {
     const callbackSpy = sinon.spy();
@@ -35,6 +35,7 @@ describe('SharedId System', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
+
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
@@ -42,7 +43,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      optinCookie();
+      removeOptOutCookie();
       sandbox.restore();
     });
 
@@ -67,8 +68,7 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.getId({});
-      optinCookie();
+      sharedIdSystemSubmodule.getId({})
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });
@@ -87,7 +87,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      optinCookie();
+      removeOptOutCookie();
       sandbox.restore();
     });
 
@@ -113,8 +113,7 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
-      optinCookie();
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -73,7 +73,6 @@ describe('SharedId System', function() {
       sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
     });
-
   });
   describe('SharedId System extendId()', function() {
     const callbackSpy = sinon.spy();

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -63,15 +63,14 @@ describe('SharedId System', function() {
       coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
       const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.getId({});
-      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: Has opted-out');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
       infoMessageSpy.restore();
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
       const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.getId({})
-
-      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
       infoMessageSpy.restore();
     });
   });
@@ -114,7 +113,8 @@ describe('SharedId System', function() {
       coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
       const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
-      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: Has opted-out');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
+
       infoMessageSpy.restore();
     });
     it('should log message if coppa is set', function() {
@@ -122,7 +122,8 @@ describe('SharedId System', function() {
       const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
 
-      expect(infoMessageSpy.lastCall.lastArg).to.eq('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+
       infoMessageSpy.restore();
     });
   });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -2,9 +2,12 @@ import {
   sharedIdSystemSubmodule
 } from 'modules/sharedIdSystem.js';
 import {coppaDataHandler, uspDataHandler} from 'src/adapterManager';
+
+import { newStorageManager } from 'src/storageManager.js';
 import sinon from 'sinon';
 import * as utils from 'src/utils.js';
-import { coreStorage } from 'modules/userId/index.js'
+import { coreStorage } from 'modules/userId/index.js';
+const storage = newStorageManager();
 
 let expect = require('chai').expect;
 
@@ -22,10 +25,11 @@ describe('SharedId System', function() {
   after(function() {
     utils.generateUUID.restore();
     utils.logInfo.restore();
+    optinCookie();
   });
 
   function optinCookie() {
-    coreStorage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
+    storage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
   }
   describe('SharedId System getId()', function() {
     const callbackSpy = sinon.spy();
@@ -61,7 +65,7 @@ describe('SharedId System', function() {
       expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
     it('should log message opted out', function() {
-      coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
       sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
     });
@@ -106,7 +110,7 @@ describe('SharedId System', function() {
       expect(pubcommId).to.equal('TestId');
     });
     it('should log message opted out', function() {
-      coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
+      storage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
     });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -16,10 +16,12 @@ describe('SharedId System', function() {
 
   before(function() {
     sinon.stub(utils, 'generateUUID').returns(UUID);
+    sinon.stub(utils, 'logInfo');
   });
 
   after(function() {
     utils.generateUUID.restore();
+    utils.logInfo.restore();
   });
 
   function removeOptOutCookie() {
@@ -61,17 +63,13 @@ describe('SharedId System', function() {
     });
     it('should log message opted out', function() {
       coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
-      const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
-      infoMessageSpy.restore();
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.getId({})
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
-      infoMessageSpy.restore();
     });
   });
   describe('SharedId System extendId()', function() {
@@ -82,7 +80,6 @@ describe('SharedId System', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
@@ -111,20 +108,13 @@ describe('SharedId System', function() {
     });
     it('should log message opted out', function() {
       coreStorage.setCookie(OPTOUT_NAME, 'true', EXPIRE_COOKIE_TIME);
-      const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: Has opted-out');
-
-      infoMessageSpy.restore();
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      const infoMessageSpy = sinon.spy(utils, 'logInfo');
       sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
-
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
-
-      infoMessageSpy.restore();
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -24,7 +24,7 @@ describe('SharedId System', function() {
     utils.logInfo.restore();
   });
 
-  function removeOptOutCookie() {
+  function optinCookie() {
     coreStorage.setCookie(OPTOUT_NAME, '', EXPIRED_COOKIE_DATE);
   }
   describe('SharedId System getId()', function() {
@@ -35,7 +35,6 @@ describe('SharedId System', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-
       coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
@@ -43,7 +42,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      removeOptOutCookie();
+      optinCookie();
       sandbox.restore();
     });
 
@@ -68,7 +67,7 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.getId({})
+      sharedIdSystemSubmodule.getId({});
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });
@@ -87,7 +86,7 @@ describe('SharedId System', function() {
 
     afterEach(function () {
       coppaDataHandlerDataStub.returns('false');
-      removeOptOutCookie();
+      optinCookie();
       sandbox.restore();
     });
 
@@ -113,7 +112,7 @@ describe('SharedId System', function() {
     });
     it('should log message if coppa is set', function() {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId')
+      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
     });
   });


### PR DESCRIPTION
- [x] Bugfix
This is for the issue reported in https://github.com/prebid/Prebid.js/pull/7099.
Apart from fixing the issue mentioned in https://github.com/prebid/Prebid.js/pull/7099. This PR has cleaned up the SharedIdSystem to removed calls to sharedId endpoint.