### PR TITLE
Openx Analytics Adapter: optimize config, endpoint override, & send late impression

### DIFF
--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -47,8 +47,6 @@ const UTM_TO_CAMPAIGN_PROPERTIES = {
  * @property {string} publisherPlatformId
  * @property {number} publisherAccountId
  * @property {number} sampling
- * @property {boolean} enableV2
- * @property {boolean} testPipeline
  * @property {Object} campaign
  * @property {number} payloadWaitTime
  * @property {number} payloadWaitTimePadding
@@ -142,8 +140,6 @@ function isValidConfig({options: analyticsOptions}) {
     ['publisherPlatformId', 'string', !hasOrgId],
     ['publisherAccountId', 'number', !hasOrgId],
     ['sampling', 'number', false],
-    ['enableV2', 'boolean', false],
-    ['testPipeline', 'boolean', false],
     ['adIdKey', 'string', false],
     ['payloadWaitTime', 'number', false],
     ['payloadWaitTimePadding', 'number', false],
@@ -271,7 +267,7 @@ function prebidAnalyticsEventHandler({eventType, args}) {
  * @property {Array<BidResponse>} bidsReceived //: []
  * @property {Array<BidResponse>} winningBids //: []
  * @property {number} timeout //: 3000
- * @property {Object} config //: {publisherPlatformId: "a3aece0c-9e80-4316-8deb-faf804779bd1", publisherAccountId: 537143056, sampling: 1, enableV2: true}/*
+ * @property {Object} config //: {publisherPlatformId: "a3aece0c-9e80-4316-8deb-faf804779bd1", publisherAccountId: 537143056, sampling: 1}/*
  */
 
 function onAuctionInit({auctionId, timestamp: startTime, timeout, adUnitCodes}) {

--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -535,7 +535,7 @@ function delayedSend(auction) {
 
   auction.auctionSendDelayTimer = setTimeout(() => {
     let payload = JSON.stringify([buildAuctionPayload(auction)]);
-    ajax(ENDPOINT, deleteAuctionMap, payload, { contentType: 'application/json' });
+    ajax(analyticsConfig.endpoint || ENDPOINT, deleteAuctionMap, payload, { contentType: 'application/json' });
 
     function deleteAuctionMap() {
       delete auctionMap[auction.id];

--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -46,6 +46,8 @@ const UTM_TO_CAMPAIGN_PROPERTIES = {
  * @property {string} orgId
  * @property {string} publisherPlatformId
  * @property {number} publisherAccountId
+ * @property {string} configId
+ * @property {string} optimizerConfig
  * @property {number} sampling
  * @property {Object} campaign
  * @property {number} payloadWaitTime
@@ -139,6 +141,8 @@ function isValidConfig({options: analyticsOptions}) {
     ['orgId', 'string', hasOrgId],
     ['publisherPlatformId', 'string', !hasOrgId],
     ['publisherAccountId', 'number', !hasOrgId],
+    ['configId', 'string', false],
+    ['optimizerConfig', 'string', false],
     ['sampling', 'number', false],
     ['adIdKey', 'string', false],
     ['payloadWaitTime', 'number', false],
@@ -603,7 +607,7 @@ function getAuctionByGoogleTagSLot(slot) {
 
 function buildAuctionPayload(auction) {
   let {startTime, endTime, state, timeout, auctionOrder, userIds, adUnitCodeToAdUnitMap} = auction;
-  let {orgId, publisherPlatformId, publisherAccountId, campaign} = analyticsConfig;
+  let {orgId, publisherPlatformId, publisherAccountId, campaign, testCode, configId, optimizerConfig} = analyticsConfig;
 
   return {
     adapterVersion: ADAPTER_VERSION,
@@ -611,6 +615,8 @@ function buildAuctionPayload(auction) {
     orgId,
     publisherPlatformId,
     publisherAccountId,
+    configId,
+    optimizerConfig,
     campaign,
     state,
     startTime,
@@ -620,7 +626,7 @@ function buildAuctionPayload(auction) {
     deviceType: detectMob() ? 'Mobile' : 'Desktop',
     deviceOSType: detectOS(),
     browser: detectBrowser(),
-    testCode: analyticsConfig.testCode,
+    testCode: testCode,
     // return an array of module name that have user data
     userIdProviders: buildUserIdProviders(userIds),
     adUnits: buildAdUnitsPayload(adUnitCodeToAdUnitMap),

--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -620,10 +620,12 @@ function getAuctionByGoogleTagSLot(slot) {
 }
 
 function buildAuctionPayload(auction) {
-  let {startTime, endTime, state, timeout, auctionOrder, userIds, adUnitCodeToAdUnitMap} = auction;
+  let {startTime, endTime, state, timeout, auctionOrder, userIds, adUnitCodeToAdUnitMap, id} = auction;
+  const auctionId = id;
   let {orgId, publisherPlatformId, publisherAccountId, campaign, testCode, configId, optimizerConfig} = analyticsConfig;
 
   return {
+    auctionId,
     adapterVersion: ADAPTER_VERSION,
     schemaVersion: SCHEMA_VERSION,
     orgId,

--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -437,7 +437,18 @@ function onBidWon(bidResponse) {
     `${auctionId}.adUnitCodeToAdUnitMap.${adUnitCode}.bidRequestsMap.${requestId}.bids.${adId}`);
 
   if (winningBid) {
-    winningBid.winner = true
+    winningBid.winner = true;
+    const auction = auctionMap[auctionId];
+    if (auction.sent) {
+      const endpoint = (analyticsConfig.endpoint || ENDPOINT) + 'event';
+      const bidder = auction.adUnitCodeToAdUnitMap[adUnitCode].bidRequestsMap[requestId].bidder;
+      ajax(`${endpoint}?t=win&b=${adId}&a=${analyticsConfig.orgId}&bidder=${bidder}&ts=${auction.startTime}`,
+        () => {
+          utils.logInfo(`Openx Analytics - Sending complete impression event for ${adId} at ${Date.now()}`)
+        });
+    } else {
+      utils.logInfo(`Openx Analytics - impression event for ${adId} will be sent with auction data`)
+    }
   }
 }
 
@@ -529,17 +540,20 @@ function getPageOffset() {
 }
 
 function delayedSend(auction) {
+  if (auction.sent) {
+    return;
+  }
   const delayTime = auction.adunitCodesRenderedCount === auction.adUnitCodesCount
     ? analyticsConfig.payloadWaitTime
     : analyticsConfig.payloadWaitTime + analyticsConfig.payloadWaitTimePadding;
 
   auction.auctionSendDelayTimer = setTimeout(() => {
+    auction.sent = true; // any BidWon emitted after this will be recorded separately
     let payload = JSON.stringify([buildAuctionPayload(auction)]);
-    ajax(analyticsConfig.endpoint || ENDPOINT, deleteAuctionMap, payload, { contentType: 'application/json' });
 
-    function deleteAuctionMap() {
-      delete auctionMap[auction.id];
-    }
+    ajax(analyticsConfig.endpoint || ENDPOINT, () => {
+      utils.logInfo(`OpenX Analytics - Sending complete auction at ${Date.now()}`);
+    }, payload, { contentType: 'application/json' });
   }, delayTime);
 }
 
@@ -655,6 +669,7 @@ function buildAuctionPayload(auction) {
             timedOut,
             bidResponses: utils._map(bidRequest.bids, (bidderBidResponse) => {
               let {
+                adId,
                 cpm,
                 creativeId,
                 ts,
@@ -673,6 +688,7 @@ function buildAuctionPayload(auction) {
               } = bidderBidResponse;
 
               return {
+                bidId: adId,
                 microCpm: cpm * 1000000,
                 netRevenue,
                 currency,

--- a/test/spec/modules/openxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/openxAnalyticsAdapter_spec.js
@@ -63,7 +63,6 @@ describe('openx analytics adapter', function() {
       publisherAccountId: 123,
       publisherPlatformId: 'test-platform-id',
       sample: 1.0,
-      enableV2: true,
       payloadWaitTime: SLOT_LOAD_WAIT_TIME,
       payloadWaitTimePadding: SLOT_LOAD_WAIT_TIME
     };

--- a/test/spec/modules/openxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/openxAnalyticsAdapter_spec.js
@@ -301,6 +301,10 @@ describe('openx analytics adapter', function() {
       it('should track the configId', function () {
         expect(auction.configId).to.equal(DEFAULT_V2_ANALYTICS_CONFIG.configId);
       });
+
+      it('should track the auction Id', function () {
+        expect(auction.auctionId).to.equal(auctionInit.auctionId);
+      });
     });
 
     describe('when there is a custom test code', function () {

--- a/test/spec/modules/openxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/openxAnalyticsAdapter_spec.js
@@ -62,6 +62,8 @@ describe('openx analytics adapter', function() {
       orgId: 'test-org-id',
       publisherAccountId: 123,
       publisherPlatformId: 'test-platform-id',
+      configId: 'my_config',
+      optimizerConfig: 'my my optimizer',
       sample: 1.0,
       payloadWaitTime: SLOT_LOAD_WAIT_TIME,
       payloadWaitTimePadding: SLOT_LOAD_WAIT_TIME
@@ -290,6 +292,14 @@ describe('openx analytics adapter', function() {
 
       it('should track the orgId', function () {
         expect(auction.publisherAccountId).to.equal(DEFAULT_V2_ANALYTICS_CONFIG.publisherAccountId);
+      });
+
+      it('should track the optimizerConfig', function () {
+        expect(auction.optimizerConfig).to.equal(DEFAULT_V2_ANALYTICS_CONFIG.optimizerConfig);
+      });
+
+      it('should track the configId', function () {
+        expect(auction.configId).to.equal(DEFAULT_V2_ANALYTICS_CONFIG.configId);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
- Record configId/optimizerConfig/auctionId
- Send impressions separately if late
- Allow overriding endpoint