### PR TITLE
PBjs Core Targeting: allow non-string (eg. numeric) targeting segments

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -634,7 +634,9 @@ export function newTargeting(auctionManager) {
 
       return Object.keys(aut)
         .map(function(key) {
-          return {[key]: utils.isArray(aut[key]) ? aut[key] : aut[key].split(',')};
+          if (utils.isStr(aut[key])) aut[key] = aut[key].split(',');
+          if (!utils.isArray(aut[key])) aut[key] = [ aut[key] ];
+          return { [key]: aut[key] };
         });
     }
 


### PR DESCRIPTION
[Documentation shows a numeric example](https://docs.prebid.org/dev-docs/add-rtd-submodule.html#gettargetingdata) which causes an exception as we try to call `.split(',')`.

## Type of change
- [x] Bugfix

## Description of change
Allows non-string values to be passed.