### PR TITLE
Sublime Bid Adapter : send notid in pixel & use timeout from timeoutData

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -40,7 +40,8 @@ export function log(msg, obj) {
 export const state = {
   zoneId: '',
   transactionId: '',
-  notifyId: ''
+  notifyId: '',
+  timeout: config.getConfig('bidderTimeout'),
 };
 
 /**
@@ -68,7 +69,7 @@ export function sendEvent(eventName, sspName) {
     puid: state.transactionId || state.notifyId,
     notid: state.notifyId || '',
     pbav: SUBLIME_VERSION,
-    pubtimeout: config.getConfig('bidderTimeout'),
+    pubtimeout: state.timeout,
     pubpbv: '$prebid.version$',
     device: detectDevice(),
   };
@@ -108,6 +109,8 @@ function buildRequests(validBidRequests, bidderRequest) {
     currencyCode: config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY,
     timeout: (typeof bidderRequest === 'object' && !!bidderRequest) ? bidderRequest.timeout : config.getConfig('bidderTimeout'),
   };
+
+  setState({ timeout: commonPayload.timeout });
 
   // RefererInfo
   if (bidderRequest && bidderRequest.refererInfo) {
@@ -221,7 +224,7 @@ function interpretResponse(serverResponse, bidRequest) {
 
 /**
  * Send pixel when bidWon event is triggered
- * @param {Object} timeoutData
+ * @param {Object} bid
  */
 function onBidWon(bid) {
   log('Bid won', bid);
@@ -230,10 +233,16 @@ function onBidWon(bid) {
 
 /**
  * Send debug when we timeout
- * @param {Object} timeoutData
+ * @param {Array[{}]} timeoutData
  */
 function onTimeout(timeoutData) {
   log('Timeout from adapter', timeoutData);
+
+  const timeout = utils.deepAccess(timeoutData, '0.timeout');
+  if (timeout) {
+    // Set timeout to the one we got from the bid
+    setState({ timeout });
+  }
   sendEvent('bidtimeout');
 }
 
@@ -241,12 +250,15 @@ export const spec = {
   code: BIDDER_CODE,
   gvlid: BIDDER_GVLID,
   aliases: [],
-  sendEvent: sendEvent,
   isBidRequestValid: isBidRequestValid,
   buildRequests: buildRequests,
   interpretResponse: interpretResponse,
   onBidWon: onBidWon,
   onTimeout: onTimeout,
+  // Exposed for test purpose
+  sendEvent: sendEvent,
+  setState: setState,
+  state: state,
 };
 
 registerBidder(spec);

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -9,7 +9,7 @@ const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
 const DEFAULT_TTL = 600;
 const SUBLIME_ANTENNA = 'antenna.ayads.co';
-const SUBLIME_VERSION = '0.7.2';
+const SUBLIME_VERSION = '0.7.3';
 
 /**
  * Identify the current device type
@@ -66,7 +66,7 @@ export function sendEvent(eventName, sspName) {
     e: eventName,
     src: 'pa',
     puid: state.transactionId || state.notifyId,
-    trId: state.transactionId || state.notifyId,
+    notid: state.notifyId || '',
     pbav: SUBLIME_VERSION,
     pubtimeout: config.getConfig('bidderTimeout'),
     pubpbv: '$prebid.version$',

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -16,7 +16,7 @@ describe('Sublime Adapter', function() {
       'e',
       'src',
       'puid',
-      'trId',
+      'notid',
       'pbav',
       'pubpbv',
       'device',
@@ -167,7 +167,7 @@ describe('Sublime Adapter', function() {
           sspname: 'foo',
           netRevenue: true,
           ttl: 600,
-          pbav: '0.7.2',
+          pbav: '0.7.3',
           ad: '',
         },
       ];
@@ -210,7 +210,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- Creative -->',
-        pbav: '0.7.2',
+        pbav: '0.7.3',
         sspname: 'sublime'
       };
 
@@ -263,7 +263,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- ad -->',
-        pbav: '0.7.2',
+        pbav: '0.7.3',
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -4,10 +4,10 @@ import { newBidder } from 'src/adapters/bidderFactory.js';
 
 let utils = require('src/utils');
 
-describe('Sublime Adapter', function() {
+describe('Sublime Adapter', function () {
   const adapter = newBidder(spec);
 
-  describe('sendEvent', function() {
+  describe('sendEvent', function () {
     let sandbox;
     const triggeredPixelProperties = [
       't',
@@ -40,13 +40,13 @@ describe('Sublime Adapter', function() {
     });
   })
 
-  describe('inherited functions', function() {
-    it('exists and is a function', function() {
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', function() {
+  describe('isBidRequestValid', function () {
     const bid = {
       bidder: 'sublime',
       params: {
@@ -55,18 +55,18 @@ describe('Sublime Adapter', function() {
       },
     };
 
-    it('should return true when required params found', function() {
+    it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not passed', function() {
+    it('should return false when required params are not passed', function () {
       const bid = Object.assign({}, bid);
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
   });
 
-  describe('buildRequests', function() {
+  describe('buildRequests', function () {
     const bidRequests = [
       {
         bidder: 'sublime',
@@ -103,24 +103,24 @@ describe('Sublime Adapter', function() {
 
     const request = spec.buildRequests(bidRequests, bidderRequest);
 
-    it('should have a post method', function() {
+    it('should have a post method', function () {
       expect(request[0].method).to.equal('POST');
       expect(request[1].method).to.equal('POST');
     });
 
-    it('should contains a request id equals to the bid id', function() {
+    it('should contains a request id equals to the bid id', function () {
       for (let i = 0; i < request.length; i = i + 1) {
         expect(JSON.parse(request[i].data).requestId).to.equal(bidRequests[i].bidId);
       }
     });
 
-    it('should have an url that contains bid keyword', function() {
+    it('should have an url that contains bid keyword', function () {
       expect(request[0].url).to.match(/bid/);
       expect(request[1].url).to.match(/bid/);
     });
   });
 
-  describe('buildRequests: default arguments', function() {
+  describe('buildRequests: default arguments', function () {
     const bidRequests = [{
       bidder: 'sublime',
       adUnitCode: 'sublime_code',
@@ -134,12 +134,12 @@ describe('Sublime Adapter', function() {
 
     const request = spec.buildRequests(bidRequests);
 
-    it('should have an url that match the default endpoint', function() {
+    it('should have an url that match the default endpoint', function () {
       expect(request[0].url).to.equal('https://pbjs.sskzlabs.com/bid');
     });
   });
 
-  describe('interpretResponse', function() {
+  describe('interpretResponse', function () {
     const serverResponse = {
       'request_id': '3db3773286ee59',
       'sspname': 'foo',
@@ -147,11 +147,11 @@ describe('Sublime Adapter', function() {
       'ad': '<!-- Creative -->',
     };
 
-    it('should get correct bid response', function() {
+    it('should get correct bid response', function () {
       // Mock the fire method
       top.window.sublime = {
         analytics: {
-          fire: function() {}
+          fire: function () { }
         }
       };
 
@@ -171,11 +171,11 @@ describe('Sublime Adapter', function() {
           ad: '',
         },
       ];
-      const result = spec.interpretResponse({body: serverResponse});
+      const result = spec.interpretResponse({ body: serverResponse });
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('should get correct default size for 1x1', function() {
+    it('should get correct default size for 1x1', function () {
       const serverResponse = {
         'requestId': 'xyz654_2',
         'sspname': 'sublime',
@@ -197,7 +197,7 @@ describe('Sublime Adapter', function() {
         }
       };
 
-      const result = spec.interpretResponse({body: serverResponse}, bidRequest);
+      const result = spec.interpretResponse({ body: serverResponse }, bidRequest);
 
       const expectedResponse = {
         requestId: 'xyz654_2',
@@ -301,7 +301,7 @@ describe('Sublime Adapter', function() {
       });
     });
 
-    it('should add advertiserDomains', function() {
+    it('should add advertiserDomains', function () {
       const responseWithAdvertiserDomains = utils.deepClone(serverResponse);
       responseWithAdvertiserDomains.advertiserDomains = ['a_sublime_adomain'];
 
@@ -319,7 +319,7 @@ describe('Sublime Adapter', function() {
     });
   });
 
-  describe('onBidWon', function() {
+  describe('onBidWon', function () {
     let sandbox;
     const bid = { foo: 'bar' };
 
@@ -332,6 +332,34 @@ describe('Sublime Adapter', function() {
       spec.onBidWon(bid);
       const params = utils.parseUrl(utils.triggerPixel.args[0][0]).search;
       expect(params.e).to.equal('bidwon');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+  });
+
+  describe('onTimeout', function () {
+    let sandbox;
+    // Array of bids that timed out
+    const timeoutData = [{
+      timeout: 1234
+    }];
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+
+    it('should trigger "bidtimeout" pixel', function () {
+      sandbox.spy(utils, 'triggerPixel');
+      spec.onTimeout(timeoutData);
+      const params = utils.parseUrl(utils.triggerPixel.args[0][0]).search;
+      expect(params.e).to.equal('bidtimeout');
+    });
+
+    it('should set timeout value in state', function () {
+      spec.onTimeout(timeoutData);
+      expect(spec.state).to.deep.equal({ timeout: 1234, debug: false, notifyId: undefined, transactionId: undefined, zoneId: 123 });
     });
 
     afterEach(function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
- Replace trId with notid (notifyId) in our pixels
- Use timeoutData to retrieve timeout value
- Use bidRequest to retrieve timeout value
- Updating tests
- Bumping version to 0.7.3


Contact email of the adapter’s maintainer : pbjs@sublime.xyz
