### PR TITLE
Adagio Bid Adapter: fix native clicktrackers support

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -504,8 +504,8 @@ function _parseNativeBidResponse(bid) {
     if (bid.admNative.link.url) {
       native.clickUrl = bid.admNative.link.url;
     }
-    if (Array.isArray(bid.admNative.link.clickTrackers)) {
-      native.clickTrackers = bid.admNative.link.clickTrackers
+    if (Array.isArray(bid.admNative.link.clicktrackers)) {
+      native.clickTrackers = bid.admNative.link.clicktrackers
     }
   }
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -943,7 +943,7 @@ describe('Adagio bid adapter', () => {
         ver: '1.2',
         link: {
           url: 'https://i.am.a.click.url',
-          clickTrackers: [
+          clicktrackers: [
             'https://i.am.a.clicktracker.url'
           ]
         },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fix a typo in order to handle the native clicktrackers array.

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission