### PR TITLE
Optimera RTD : check for new data on auction init

### DIFF
--- a/modules/optimeraRtdProvider.js
+++ b/modules/optimeraRtdProvider.js
@@ -65,6 +65,12 @@ export let device = 'default';
 export let optimeraTargeting = {};
 
 /**
+ * Flag to indicateo if a new score file should be fetched.
+ * @type {string}
+ */
+export let fetchScoreFile = true;
+
+/**
  * Make the request for the Score File.
  */
 export function scoreFileRequest() {
@@ -109,6 +115,17 @@ export function returnTargetingData(adUnits, config) {
 }
 
 /**
+ * Fetch a new score file when an auction starts.
+ * Only fetch the new file if a new score file is needed.
+ */
+export function onAuctionInit(auctionDetails, config, userConsent) {
+  setScoresURL();
+  if (fetchScoreFile) {
+    scoreFileRequest();
+  }
+}
+
+/**
  * Initialize the Module.
  */
 export function init(moduleConfig) {
@@ -134,14 +151,25 @@ export function init(moduleConfig) {
 
 /**
  * Set the score file url.
- * This fully-formed URL for the data endpoint request to fetch
+ *
+ * This fully-formed URL is for the data endpoint request to fetch
  * the targeting values. This is not a js library, rather JSON
  * which has the targeting values for the page.
+ *
+ * The score file url is based on the web page url. If the new score file URL
+ * has been updated, set the fetchScoreFile flag to true to is can be fetched.
+ *
  */
 export function setScoresURL() {
   const optimeraHost = window.location.host;
   const optimeraPathName = window.location.pathname;
-  scoresURL = `${scoresBaseURL}${clientID}/${optimeraHost}${optimeraPathName}.js`;
+  let newScoresURL = `${scoresBaseURL}${clientID}/${optimeraHost}${optimeraPathName}.js`;
+  if (scoresURL !== newScoresURL) {
+    scoresURL = newScoresURL;
+    fetchScoreFile = true;
+  } else {
+    fetchScoreFile = false;
+  }
 }
 
 /**
@@ -170,9 +198,13 @@ export const optimeraSubmodule = {
    */
   name: 'optimeraRTD',
   /**
+   * get data when an auction starts
+   * @function
+   */
+  onAuctionInitEvent: onAuctionInit,
+  /**
    * get data and send back to realTimeData module
    * @function
-   * @param {string[]} adUnitsCodes
    */
   getTargetingData: returnTargetingData,
   init,

--- a/test/spec/modules/optimeraRtdProvider_spec.js
+++ b/test/spec/modules/optimeraRtdProvider_spec.js
@@ -81,4 +81,9 @@ describe('Optimera RTD error logging', () => {
     optimeraRTD.init(conf.dataProviders[0]);
     expect(utils.logError.called).to.equal(true);
   });
+
+  it('if adUnits is not an array should log an error', () => {
+    optimeraRTD.returnTargetingData('test');
+    expect(utils.logError.called).to.equal(true);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Whenever an new auction starts, there currently is not a check to see if a new data file is needed to update the targeting.  

This fix will run on the onAuctionInitEvent event and check if a new dataset is needed. If so, it will request a new data file to apply the updated targeting.

- [x] official adapter submission
