### PR TITLE
Openweb Bid Adapter: add new bid adapter

### DIFF
--- a/modules/openwebBidAdapter.js
+++ b/modules/openwebBidAdapter.js
@@ -1,0 +1,247 @@
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { ADPOD, BANNER, VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
+import find from 'core-js-pure/features/array/find.js';
+
+const ENDPOINT = 'https://ghb.spotim.market';
+const BIDDER_CODE = 'openweb';
+const DISPLAY = 'display';
+const syncsCache = {};
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: 280,
+  supportedMediaTypes: [VIDEO, BANNER, ADPOD],
+  isBidRequestValid: function (bid) {
+    return utils.isNumber(utils.deepAccess(bid, 'params.aid'));
+  },
+  getUserSyncs: function (syncOptions, serverResponses) {
+    const syncs = [];
+
+    function addSyncs(bid) {
+      const uris = bid.cookieURLs;
+      const types = bid.cookieURLSTypes || [];
+
+      if (Array.isArray(uris)) {
+        uris.forEach((uri, i) => {
+          const type = types[i] || 'image';
+
+          if ((!syncOptions.pixelEnabled && type === 'image') ||
+            (!syncOptions.iframeEnabled && type === 'iframe') ||
+            syncsCache[uri]) {
+            return;
+          }
+
+          syncsCache[uri] = true;
+          syncs.push({
+            type: type,
+            url: uri
+          })
+        })
+      }
+    }
+
+    if (syncOptions.pixelEnabled || syncOptions.iframeEnabled) {
+      utils.isArray(serverResponses) && serverResponses.forEach((response) => {
+        if (response.body) {
+          if (utils.isArray(response.body)) {
+            response.body.forEach(b => {
+              addSyncs(b);
+            })
+          } else {
+            addSyncs(response.body)
+          }
+        }
+      })
+    }
+    return syncs;
+  },
+  /**
+   * Make a server request from the list of BidRequests
+   * @param bidRequests
+   * @param adapterRequest
+   */
+  buildRequests: function (bidRequests, adapterRequest) {
+    const { tag, bids } = bidToTag(bidRequests, adapterRequest);
+    return [{
+      data: Object.assign({}, tag, { BidRequests: bids }),
+      adapterRequest,
+      method: 'POST',
+      url: ENDPOINT
+    }];
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids
+   * @param serverResponse
+   * @param bidderRequest
+   * @return {Bid[]} An array of bids which were nested inside the server
+   */
+  interpretResponse: function (serverResponse, { adapterRequest }) {
+    serverResponse = serverResponse.body;
+    let bids = [];
+
+    if (!utils.isArray(serverResponse)) {
+      return parseRTBResponse(serverResponse, adapterRequest);
+    }
+
+    serverResponse.forEach(serverBidResponse => {
+      bids = utils.flatten(bids, parseRTBResponse(serverBidResponse, adapterRequest));
+    });
+
+    return bids;
+  },
+
+  transformBidParams(params) {
+    return utils.convertTypes({
+      'aid': 'number',
+    }, params);
+  }
+};
+
+function parseRTBResponse(serverResponse, adapterRequest) {
+  const isEmptyResponse = !serverResponse || !utils.isArray(serverResponse.bids);
+  const bids = [];
+
+  if (isEmptyResponse) {
+    return bids;
+  }
+
+  serverResponse.bids.forEach(serverBid => {
+    const request = find(adapterRequest.bids, (bidRequest) => {
+      return bidRequest.bidId === serverBid.requestId;
+    });
+
+    if (serverBid.cpm !== 0 && request !== undefined) {
+      const bid = createBid(serverBid, request);
+
+      bids.push(bid);
+    }
+  });
+
+  return bids;
+}
+
+function bidToTag(bidRequests, adapterRequest) {
+  // start publisher env
+  const tag = {
+    Domain: utils.deepAccess(adapterRequest, 'refererInfo.referer')
+  };
+  if (config.getConfig('coppa') === true) {
+    tag.Coppa = 1;
+  }
+  if (utils.deepAccess(adapterRequest, 'gdprConsent.gdprApplies')) {
+    tag.GDPR = 1;
+    tag.GDPRConsent = utils.deepAccess(adapterRequest, 'gdprConsent.consentString');
+  }
+  if (utils.deepAccess(adapterRequest, 'uspConsent')) {
+    tag.USP = utils.deepAccess(adapterRequest, 'uspConsent');
+  }
+  if (utils.deepAccess(bidRequests[0], 'schain')) {
+    tag.Schain = utils.deepAccess(bidRequests[0], 'schain');
+  }
+  if (utils.deepAccess(bidRequests[0], 'userId')) {
+    tag.UserIds = utils.deepAccess(bidRequests[0], 'userId');
+  }
+  if (utils.deepAccess(bidRequests[0], 'userIdAsEids')) {
+    tag.UserEids = utils.deepAccess(bidRequests[0], 'userIdAsEids');
+  }
+  // end publisher env
+  const bids = []
+
+  for (let i = 0, length = bidRequests.length; i < length; i++) {
+    const bid = prepareBidRequests(bidRequests[i]);
+    bids.push(bid);
+  }
+
+  return { tag, bids };
+}
+
+/**
+ * Parse mediaType
+ * @param bidReq {object}
+ * @returns {object}
+ */
+function prepareBidRequests(bidReq) {
+  const mediaType = utils.deepAccess(bidReq, 'mediaTypes.video') ? VIDEO : DISPLAY;
+  const sizes = mediaType === VIDEO ? utils.deepAccess(bidReq, 'mediaTypes.video.playerSize') : utils.deepAccess(bidReq, 'mediaTypes.banner.sizes');
+  const bidReqParams = {
+    'CallbackId': bidReq.bidId,
+    'Aid': bidReq.params.aid,
+    'AdType': mediaType,
+    'Sizes': utils.parseSizesInput(sizes).join(',')
+  };
+
+  bidReqParams.PlacementId = bidReq.adUnitCode;
+  if (bidReq.params.iframe) {
+    bidReqParams.AdmType = 'iframe';
+  }
+  if (mediaType === VIDEO) {
+    const context = utils.deepAccess(bidReq, 'mediaTypes.video.context');
+    if (context === ADPOD) {
+      bidReqParams.Adpod = utils.deepAccess(bidReq, 'mediaTypes.video');
+    }
+  }
+  return bidReqParams;
+}
+
+/**
+ * Prepare all parameters for request
+ * @param bidderRequest {object}
+ * @returns {object}
+ */
+function getMediaType(bidderRequest) {
+  return utils.deepAccess(bidderRequest, 'mediaTypes.video') ? VIDEO : BANNER;
+}
+
+/**
+ * Configure new bid by response
+ * @param bidResponse {object}
+ * @param bidRequest {Object}
+ * @returns {object}
+ */
+function createBid(bidResponse, bidRequest) {
+  const mediaType = getMediaType(bidRequest)
+  const context = utils.deepAccess(bidRequest, 'mediaTypes.video.context');
+  const bid = {
+    requestId: bidResponse.requestId,
+    creativeId: bidResponse.cmpId,
+    height: bidResponse.height,
+    currency: bidResponse.cur,
+    width: bidResponse.width,
+    cpm: bidResponse.cpm,
+    netRevenue: true,
+    mediaType,
+    ttl: 300,
+    meta: {
+      advertiserDomains: bidResponse.adomain || []
+    }
+  };
+
+  if (mediaType === BANNER) {
+    return Object.assign(bid, {
+      ad: bidResponse.ad,
+      adUrl: bidResponse.adUrl,
+    });
+  }
+  if (context === ADPOD) {
+    Object.assign(bid, {
+      meta: {
+        primaryCatId: bidResponse.primaryCatId,
+      },
+      video: {
+        context: ADPOD,
+        durationSeconds: bidResponse.durationSeconds
+      }
+    });
+  }
+
+  Object.assign(bid, {
+    vastUrl: bidResponse.vastUrl
+  });
+
+  return bid;
+}
+
+registerBidder(spec);

--- a/modules/openwebBidAdapter.md
+++ b/modules/openwebBidAdapter.md
@@ -1,0 +1,27 @@
+# Overview
+
+**Module Name**: OpenWeb Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**: monetization@openweb.com
+
+# Description
+
+OpenWeb.com official prebid adapter. Available in both client and server side versions.
+OpenWeb header bidding adapter provides solution for accessing both Video and Display demand.
+
+# Test Parameters
+```
+    var adUnits = [
+      // Banner adUnit
+      {
+        code: 'div-test-div',
+        sizes: [[300, 250]],
+        bids: [{
+          bidder: 'openweb',
+          params: {
+            aid: 529814
+          }
+        }]
+      }
+    ];
+```

--- a/test/spec/modules/openwebBidAdapter_spec.js
+++ b/test/spec/modules/openwebBidAdapter_spec.js
@@ -1,0 +1,387 @@
+import { expect } from 'chai';
+import { spec } from 'modules/openwebBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
+
+const DEFAULT_ADATPER_REQ = { bidderCode: 'openweb' };
+const DISPLAY_REQUEST = {
+  'bidder': 'openweb',
+  'params': {
+    'aid': 12345
+  },
+  'schain': { ver: 1 },
+  'userId': { criteo: 2 },
+  'mediaTypes': { 'banner': { 'sizes': [300, 250] } },
+  'bidderRequestId': '7101db09af0db2',
+  'auctionId': '2e41f65424c87c',
+  'adUnitCode': 'adunit-code',
+  'bidId': '84ab500420319d',
+};
+
+const VIDEO_REQUEST = {
+  'bidder': 'openweb',
+  'mediaTypes': {
+    'video': {
+      'playerSize': [[480, 360], [640, 480]]
+    }
+  },
+  'params': {
+    'aid': 12345
+  },
+  'bidderRequestId': '7101db09af0db2',
+  'auctionId': '2e41f65424c87c',
+  'adUnitCode': 'adunit-code',
+  'bidId': '84ab500420319d'
+};
+
+const ADPOD_REQUEST = {
+  'bidder': 'openweb',
+  'mediaTypes': {
+    'video': {
+      'context': 'adpod',
+      'playerSize': [[640, 480]],
+      'anyField': 10
+    }
+  },
+  'params': {
+    'aid': 12345
+  },
+  'bidderRequestId': '7101db09af0db2',
+  'auctionId': '2e41f65424c87c',
+  'adUnitCode': 'adunit-code',
+  'bidId': '2e41f65424c87c'
+};
+
+const SERVER_VIDEO_RESPONSE = {
+  'source': { 'aid': 12345, 'pubId': 54321 },
+  'bids': [{
+    'vastUrl': 'vastUrl',
+    'requestId': '2e41f65424c87c',
+    'url': '44F2AEB9BFC881B3',
+    'creative_id': 342516,
+    'durationSeconds': 30,
+    'cmpId': 342516,
+    'height': 480,
+    'cur': 'USD',
+    'width': 640,
+    'cpm': 0.9,
+    'adomain': ['a.com']
+  }]
+};
+const SERVER_OUSTREAM_VIDEO_RESPONSE = SERVER_VIDEO_RESPONSE;
+const SERVER_DISPLAY_RESPONSE = {
+  'source': { 'aid': 12345, 'pubId': 54321 },
+  'bids': [{
+    'ad': '<!-- Creative -->',
+    'adUrl': 'adUrl',
+    'requestId': '2e41f65424c87c',
+    'creative_id': 342516,
+    'cmpId': 342516,
+    'height': 250,
+    'cur': 'USD',
+    'width': 300,
+    'cpm': 0.9
+  }],
+  'cookieURLs': ['link1', 'link2']
+};
+const SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS = {
+  'source': { 'aid': 12345, 'pubId': 54321 },
+  'bids': [{
+    'ad': '<!-- Creative -->',
+    'requestId': '2e41f65424c87c',
+    'creative_id': 342516,
+    'cmpId': 342516,
+    'height': 250,
+    'cur': 'USD',
+    'width': 300,
+    'cpm': 0.9
+  }],
+  'cookieURLs': ['link3', 'link4'],
+  'cookieURLSTypes': ['image', 'iframe']
+};
+
+const videoBidderRequest = {
+  bidderCode: 'bidderCode',
+  bids: [{ mediaTypes: { video: {} }, bidId: '2e41f65424c87c' }]
+};
+
+const displayBidderRequest = {
+  bidderCode: 'bidderCode',
+  bids: [{ bidId: '2e41f65424c87c' }]
+};
+
+const displayBidderRequestWithConsents = {
+  bidderCode: 'bidderCode',
+  bids: [{ bidId: '2e41f65424c87c' }],
+  gdprConsent: {
+    gdprApplies: true,
+    consentString: 'test'
+  },
+  uspConsent: 'iHaveIt'
+};
+
+const videoEqResponse = [{
+  vastUrl: 'vastUrl',
+  requestId: '2e41f65424c87c',
+  creativeId: 342516,
+  mediaType: 'video',
+  netRevenue: true,
+  currency: 'USD',
+  height: 480,
+  width: 640,
+  ttl: 300,
+  cpm: 0.9,
+  meta: {
+    advertiserDomains: ['a.com']
+  }
+}];
+
+const displayEqResponse = [{
+  requestId: '2e41f65424c87c',
+  creativeId: 342516,
+  mediaType: 'banner',
+  netRevenue: true,
+  currency: 'USD',
+  ad: '<!-- Creative -->',
+  adUrl: 'adUrl',
+  height: 250,
+  width: 300,
+  ttl: 300,
+  cpm: 0.9,
+  meta: {
+    advertiserDomains: []
+  }
+
+}];
+
+describe('openwebBidAdapter', () => {
+  const adapter = newBidder(spec);
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('user syncs', () => {
+    describe('as image', () => {
+      it('should be returned if pixel enabled', () => {
+        const syncs = spec.getUserSyncs({ pixelEnabled: true }, [{ body: SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS }]);
+
+        expect(syncs.map(s => s.url)).to.deep.equal([SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS.cookieURLs[0]]);
+        expect(syncs.map(s => s.type)).to.deep.equal(['image']);
+      })
+    })
+
+    describe('as iframe', () => {
+      it('should be returned if iframe enabled', () => {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [{ body: SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS }]);
+
+        expect(syncs.map(s => s.url)).to.deep.equal([SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS.cookieURLs[1]]);
+        expect(syncs.map(s => s.type)).to.deep.equal(['iframe']);
+      })
+    })
+
+    describe('user sync', () => {
+      it('should not  be returned if passed syncs where already used', () => {
+        const syncs = spec.getUserSyncs({
+          iframeEnabled: true,
+          pixelEnabled: true
+        }, [{ body: SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS }]);
+
+        expect(syncs).to.deep.equal([]);
+      })
+
+      it('should not be returned if pixel not set', () => {
+        const syncs = spec.getUserSyncs({}, [{ body: SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS }]);
+
+        expect(syncs).to.be.empty;
+      });
+    });
+    describe('user syncs with both types', () => {
+      it('should be returned if pixel and iframe enabled', () => {
+        const mockedServerResponse = Object.assign({}, SERVER_DISPLAY_RESPONSE_WITH_MIXED_SYNCS, { 'cookieURLs': ['link5', 'link6'] });
+        const syncs = spec.getUserSyncs({
+          iframeEnabled: true,
+          pixelEnabled: true
+        }, [{ body: mockedServerResponse }]);
+
+        expect(syncs.map(s => s.url)).to.deep.equal(mockedServerResponse.cookieURLs);
+        expect(syncs.map(s => s.type)).to.deep.equal(mockedServerResponse.cookieURLSTypes);
+      });
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(VIDEO_REQUEST)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, VIDEO_REQUEST);
+      delete bid.params;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', () => {
+    let videoBidRequests = [VIDEO_REQUEST];
+    let displayBidRequests = [DISPLAY_REQUEST];
+    let videoAndDisplayBidRequests = [DISPLAY_REQUEST, VIDEO_REQUEST];
+    const displayRequest = spec.buildRequests(displayBidRequests, DEFAULT_ADATPER_REQ);
+    const videoRequest = spec.buildRequests(videoBidRequests, DEFAULT_ADATPER_REQ);
+    const videoAndDisplayRequests = spec.buildRequests(videoAndDisplayBidRequests, DEFAULT_ADATPER_REQ);
+
+    it('building requests as arrays', () => {
+      expect(videoRequest).to.be.a('array');
+      expect(displayRequest).to.be.a('array');
+      expect(videoAndDisplayRequests).to.be.a('array');
+    })
+
+    it('sending as POST', () => {
+      const postActionMethod = 'POST'
+      const comparator = br => br.method === postActionMethod;
+      expect(videoRequest.every(comparator)).to.be.true;
+      expect(displayRequest.every(comparator)).to.be.true;
+      expect(videoAndDisplayRequests.every(comparator)).to.be.true;
+    });
+    it('forms correct ADPOD request', () => {
+      const pbBidReqData = spec.buildRequests([ADPOD_REQUEST], DEFAULT_ADATPER_REQ)[0].data;
+      const impRequest = pbBidReqData.BidRequests[0]
+      expect(impRequest.AdType).to.be.equal('video');
+      expect(impRequest.Adpod).to.be.a('object');
+      expect(impRequest.Adpod.anyField).to.be.equal(10);
+    })
+    it('sends correct video bid parameters', () => {
+      const data = videoRequest[0].data;
+
+      const eq = {
+        CallbackId: '84ab500420319d',
+        AdType: 'video',
+        Aid: 12345,
+        Sizes: '480x360,640x480',
+        PlacementId: 'adunit-code'
+      };
+      expect(data.BidRequests[0]).to.deep.equal(eq);
+    });
+
+    it('sends correct display bid parameters', () => {
+      const data = displayRequest[0].data;
+
+      const eq = {
+        CallbackId: '84ab500420319d',
+        AdType: 'display',
+        Aid: 12345,
+        Sizes: '300x250',
+        PlacementId: 'adunit-code'
+      };
+
+      expect(data.BidRequests[0]).to.deep.equal(eq);
+    });
+
+    it('sends correct video and display bid parameters', () => {
+      const bidRequests = videoAndDisplayRequests[0].data;
+      const expectedBidReqs = [{
+        CallbackId: '84ab500420319d',
+        AdType: 'display',
+        Aid: 12345,
+        Sizes: '300x250',
+        PlacementId: 'adunit-code'
+      }, {
+        CallbackId: '84ab500420319d',
+        AdType: 'video',
+        Aid: 12345,
+        Sizes: '480x360,640x480',
+        PlacementId: 'adunit-code'
+      }]
+
+      expect(bidRequests.BidRequests).to.deep.equal(expectedBidReqs);
+    });
+
+    describe('publisher environment', () => {
+      const sandbox = sinon.sandbox.create();
+      sandbox.stub(config, 'getConfig').callsFake((key) => {
+        const config = {
+          'coppa': true
+        };
+        return config[key];
+      });
+      const bidRequestWithPubSettingsData = spec.buildRequests([DISPLAY_REQUEST], displayBidderRequestWithConsents)[0].data;
+      sandbox.restore();
+      it('sets GDPR', () => {
+        expect(bidRequestWithPubSettingsData.GDPR).to.be.equal(1);
+        expect(bidRequestWithPubSettingsData.GDPRConsent).to.be.equal(displayBidderRequestWithConsents.gdprConsent.consentString);
+      });
+      it('sets USP', () => {
+        expect(bidRequestWithPubSettingsData.USP).to.be.equal(displayBidderRequestWithConsents.uspConsent);
+      })
+      it('sets Coppa', () => {
+        expect(bidRequestWithPubSettingsData.Coppa).to.be.equal(1);
+      })
+      it('sets Schain', () => {
+        expect(bidRequestWithPubSettingsData.Schain).to.be.deep.equal(DISPLAY_REQUEST.schain);
+      })
+      it('sets UserId\'s', () => {
+        expect(bidRequestWithPubSettingsData.UserIds).to.be.deep.equal(DISPLAY_REQUEST.userId);
+      })
+    })
+  });
+
+  describe('interpretResponse', () => {
+    let serverResponse;
+    let adapterRequest;
+    let eqResponse;
+
+    afterEach(() => {
+      serverResponse = null;
+      adapterRequest = null;
+      eqResponse = null;
+    });
+
+    it('should get correct video bid response', () => {
+      serverResponse = SERVER_VIDEO_RESPONSE;
+      adapterRequest = videoBidderRequest;
+      eqResponse = videoEqResponse;
+
+      bidServerResponseCheck();
+    });
+
+    it('should get correct display bid response', () => {
+      serverResponse = SERVER_DISPLAY_RESPONSE;
+      adapterRequest = displayBidderRequest;
+      eqResponse = displayEqResponse;
+
+      bidServerResponseCheck();
+    });
+
+    function bidServerResponseCheck() {
+      const result = spec.interpretResponse({ body: serverResponse }, { adapterRequest });
+
+      expect(result).to.deep.equal(eqResponse);
+    }
+
+    function nobidServerResponseCheck() {
+      const noBidServerResponse = { bids: [] };
+      const noBidResult = spec.interpretResponse({ body: noBidServerResponse }, { adapterRequest });
+
+      expect(noBidResult.length).to.equal(0);
+    }
+
+    it('handles video nobid responses', () => {
+      adapterRequest = videoBidderRequest;
+
+      nobidServerResponseCheck();
+    });
+
+    it('handles display nobid responses', () => {
+      adapterRequest = displayBidderRequest;
+
+      nobidServerResponseCheck();
+    });
+
+    it('forms correct ADPOD response', () => {
+      const videoBids = spec.interpretResponse({ body: SERVER_VIDEO_RESPONSE }, { adapterRequest: { bids: [ADPOD_REQUEST] } });
+      expect(videoBids[0].video.durationSeconds).to.be.equal(30);
+      expect(videoBids[0].video.context).to.be.equal('adpod');
+    })
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter 


## Description of change
<!-- Describe the change proposed in this pull request -->

- test parameters for validating bids
```
   var adUnits = [
         // Banner adUnit
         {
           code: 'div-test-div',
           sizes: [[300, 250]],
           bids: [{
             bidder: 'openweb',
             params: {
               aid: 529814
             }
           }]
         }
       ];
```

- monetization@openweb.com
- [x] official adapter submission


- [A link to a PR on the docs repo](https://github.com/prebid/prebid.github.io/pull/3101)
