### PR TITLE
Rubicon Analytics: pass along userId providers

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -293,6 +293,10 @@ function sendMessage(auctionId, bidWonId, trigger) {
       auction.serverTimeoutMillis = serverConfig.timeout;
     }
 
+    if (auctionCache.userIds.length) {
+      auction.user = {ids: auctionCache.userIds};
+    }
+
     message.auctions = [auction];
 
     let bidsWon = Object.keys(auctionCache.bidsWon).reduce((memo, adUnitCode) => {
@@ -585,6 +589,9 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         }
         cacheEntry.gdprConsent = utils.deepAccess(args, 'bidderRequests.0.gdprConsent');
         cacheEntry.session = storage.localStorageIsEnabled() && updateRpaCookie();
+        cacheEntry.userIds = Object.keys(utils.deepAccess(args, 'bidderRequests.0.bids.0.userId', {})).map(id => {
+          return {provider: id, hasId: true}
+        });
         cache.auctions[args.auctionId] = cacheEntry;
         // register to listen to gpt events if not done yet
         if (!cache.gpt.registered && utils.isGptPubadsDefined()) {

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -853,6 +853,42 @@ describe('rubicon analytics adapter', function () {
       expect(message).to.deep.equal(ANALYTICS_MESSAGE);
     });
 
+    it('should pass along user ids', function () {
+      let auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
+      auctionInit.bidderRequests[0].bids[0].userId = {
+        criteoId: 'sadfe4334',
+        lotamePanoramaId: 'asdf3gf4eg',
+        pubcid: 'dsfa4545-svgdfs5',
+        sharedId: {id1: 'asdf', id2: 'sadf4344'}
+      };
+
+      events.emit(AUCTION_INIT, auctionInit);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+
+      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+      events.emit(BID_WON, MOCK.BID_WON[0]);
+      events.emit(BID_WON, MOCK.BID_WON[1]);
+
+      expect(server.requests.length).to.equal(1);
+      let request = server.requests[0];
+
+      let message = JSON.parse(request.requestBody);
+      validate(message);
+
+      expect(message.auctions[0].user).to.deep.equal({
+        ids: [
+          {provider: 'criteoId', 'hasId': true},
+          {provider: 'lotamePanoramaId', 'hasId': true},
+          {provider: 'pubcid', 'hasId': true},
+          {provider: 'sharedId', 'hasId': true},
+        ]
+      });
+    });
+
     it('should handle bidResponse dimensions correctly', function () {
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
       events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
This PR adds logic to pass along what userId providers were able to retrieve and pass along an ID in the auction.