### PR TITLE
tappx Bid Adapter: add internal Tappx params and refactor pageUrl

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -252,7 +252,6 @@ function buildOneRequest(validBidRequests, bidderRequest) {
     let bundle = _extractPageUrl(validBidRequests, bidderRequest);
     let site = {};
     site.name = bundle;
-    site.bundle = bundle;
     site.domain = bundle;
     publisher.name = bundle;
     publisher.domain = bundle;
@@ -368,12 +367,6 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   geo.country = utils.deepAccess(validBidRequests, 'params.geo.country');
   // < Device object
 
-  // > Params
-  let params = {};
-  params.host = 'tappx.com';
-  params.bidfloor = BIDFLOOR;
-  // < Params
-
   // > GDPR
   let user = {};
   user.ext = {};
@@ -428,7 +421,6 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   payload.ext = payloadExt;
 
   payload.device = device;
-  payload.params = params;
   payload.regs = regs;
   // < Payload
 

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -8,7 +8,7 @@ import { config } from '../src/config.js';
 const BIDDER_CODE = 'tappx';
 const TTL = 360;
 const CUR = 'USD';
-const TAPPX_BIDDER_VERSION = '0.1.10623';
+const TAPPX_BIDDER_VERSION = '0.1.10714';
 const TYPE_CNN = 'prebidjs';
 const LOG_PREFIX = '[TAPPX]: ';
 const VIDEO_SUPPORT = ['instream'];

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -514,14 +514,14 @@ export function _extractPageUrl(validBidRequests, bidderRequest) {
     }
   }
 
-  if (typeof domainUrl == 'undefined' || domainUrl == null) {
-    domainUrl = window.location.hostname;
-  }
-
   try {
     domainUrl = domainUrl.match(/^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img)[0].replace(/^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?/img, '');
   } catch (error) {
     domainUrl = undefined;
+  }
+
+  if (typeof domainUrl == 'undefined' || domainUrl == null) {
+    domainUrl = window.location.hostname;
   }
 
   return domainUrl;

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -225,6 +225,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   hostDomain = hostInfo.domain;
 
   const TAPPXKEY = utils.deepAccess(validBidRequests, 'params.tappxkey');
+  const MKTAG = utils.deepAccess(validBidRequests, 'params.mktag');
   const BIDFLOOR = utils.deepAccess(validBidRequests, 'params.bidfloor');
   const BIDEXTRA = utils.deepAccess(validBidRequests, 'params.ext');
   const bannerMediaType = utils.deepAccess(validBidRequests, 'mediaTypes.banner');
@@ -339,7 +340,6 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   }
 
   let bidder = {};
-  bidder.tappxkey = TAPPXKEY;
   bidder.endpoint = ENDPOINT;
   bidder.host = hostInfo.url;
   bidder.bidfloor = BIDFLOOR;
@@ -410,6 +410,13 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   }
   // < GDPR
 
+  // > Payload Ext
+  let payloadExt = {};
+  payloadExt.bidder = {};
+  payloadExt.bidder.tappxkey = TAPPXKEY;
+  payloadExt.bidder.mktag = MKTAG;
+  // < Payload Ext
+
   // > Payload
   payload.id = validBidRequests.auctionId;
   payload.test = utils.deepAccess(validBidRequests, 'params.test') ? 1 : 0;
@@ -418,6 +425,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   payload.bidder = BIDDER_CODE;
   payload.imp = [imp];
   payload.user = user;
+  payload.ext = payloadExt;
 
   payload.device = device;
   payload.params = params;

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -408,6 +408,8 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   payloadExt.bidder = {};
   payloadExt.bidder.tappxkey = TAPPXKEY;
   payloadExt.bidder.mktag = MKTAG;
+  payloadExt.bidder.bcid = utils.deepAccess(validBidRequests, 'params.bcid');
+  payloadExt.bidder.bcrid = utils.deepAccess(validBidRequests, 'params.bcrid');
   // < Payload Ext
 
   // > Payload

--- a/modules/tappxBidAdapter.md
+++ b/modules/tappxBidAdapter.md
@@ -29,7 +29,12 @@ Ads sizes available: [300,250], [320,50], [320,480], [480,320], [728,90], [768,1
                             tappxkey: "pub-1234-android-1234",
                             endpoint: "ZZ1234PBJS",
                             bidfloor: 0.005,
-                            test: true // Optional for testing purposes
+                            mktag: "123456",                // Optional: tappx mktag
+                            test: true,                     // Optional: for testing purposes
+                            domainUrl: "www.example.com",   // Optional: add domain site
+                            ext: {                          // Optional: extra params
+                                foo: "bar"
+                            }
                         }
                     }
                 ]
@@ -62,21 +67,26 @@ Ads sizes available: [300,250], [320,50], [320,480], [480,320], [728,90], [768,1
                     tappxkey: "pub-1234-desktop-1234",
                     endpoint: "VZ12TESTCTV",
                     bidfloor: 0.005,
-                    test: true,
-                    video: {                                  // optional
-                        skippable: true,                      // optional
-                        minduration: 5,                       // optional
-                        maxduration: 30,                      // optional
-                        startdelay: 5,                        // optional
-                        playbackmethod: [1,3],                // optional
-                        api: [ 1, 2 ],                        // optional
-                        protocols: [ 2, 3 ],                  // optional
-                        battr: [ 13, 14 ],                    // optional
-                        linearity: 1,                         // optional
-                        placement: 2,                         // optional
-                        minbitrate: 10,                       // optional
-                        maxbitrate: 10                        // optional
-                    }
+                    mktag: "123456",                // Optional: tappx mktag
+                    test: true,                     // Optional: for testing purposes
+                    domainUrl: "www.example.com",   // Optional: add domain site
+                    video: {                        // Optional
+                        skippable: true,            // Optional
+                        minduration: 5,             // Optional
+                        maxduration: 30,            // Optional
+                        startdelay: 5,              // Optional
+                        playbackmethod: [1,3],      // Optional
+                        api: [ 1, 2 ],              // Optional
+                        protocols: [ 2, 3 ],        // Optional
+                        battr: [ 13, 14 ],          // Optional
+                        linearity: 1,               // Optional
+                        placement: 2,               // Optional
+                        minbitrate: 10,             // Optional
+                        maxbitrate: 10              // Optional
+                    },
+                    ext: {                          // Optional: extra params
+                                foo: "bar"
+                            }
                 }
             }]
         }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature
- [X] Refactoring (no functional changes, no api changes)


## Description of change
<!-- Describe the change proposed in this pull request -->
- We have moved and added some internal parameters (tappxkey, mktag, bcid, bcrid) for the requests.
- We have updated the way we receive the pageUrl to expand the information of our requests.