### PR TITLE
Aja Bid Adapter: add adomain and adapter in v5

### DIFF
--- a/modules/ajaBidAdapter.js
+++ b/modules/ajaBidAdapter.js
@@ -1,0 +1,197 @@
+import { Renderer } from '../src/Renderer.js';
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { VIDEO, BANNER, NATIVE } from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'aja';
+const URL = 'https://ad.as.amanad.adtdp.com/v2/prebid';
+const SDK_TYPE = 5;
+const AD_TYPE = {
+  BANNER: 1,
+  NATIVE: 2,
+  VIDEO: 3,
+};
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [VIDEO, BANNER, NATIVE],
+
+  isBidRequestValid: function(bid) {
+    return !!(bid.params.asi);
+  },
+
+  buildRequests: function(validBidRequests, bidderRequest) {
+    var bidRequests = [];
+    for (var i = 0, len = validBidRequests.length; i < len; i++) {
+      var bid = validBidRequests[i];
+      var queryString = '';
+      const asi = utils.getBidIdParameter('asi', bid.params);
+      queryString = utils.tryAppendQueryString(queryString, 'asi', asi);
+      queryString = utils.tryAppendQueryString(queryString, 'skt', SDK_TYPE);
+      queryString = utils.tryAppendQueryString(queryString, 'prebid_id', bid.bidId);
+      queryString = utils.tryAppendQueryString(queryString, 'prebid_ver', '$prebid.version$');
+
+      if (bidderRequest && bidderRequest.refererInfo) {
+        queryString = utils.tryAppendQueryString(queryString, 'page_url', bidderRequest.refererInfo.referer);
+      }
+
+      bidRequests.push({
+        method: 'GET',
+        url: URL,
+        data: queryString
+      });
+    }
+
+    return bidRequests;
+  },
+
+  interpretResponse: function(bidderResponse, request) {
+    const bidderResponseBody = bidderResponse.body;
+
+    if (!bidderResponseBody.is_ad_return) {
+      return [];
+    }
+
+    const ad = bidderResponseBody.ad;
+
+    const bid = {
+      requestId: ad.prebid_id,
+      cpm: ad.price,
+      creativeId: ad.creative_id,
+      dealId: ad.deal_id,
+      currency: ad.currency || 'USD',
+      netRevenue: true,
+      ttl: 300, // 5 minutes
+      meta: {
+        advertiserDomains: ad.adomain || []
+      },
+    }
+
+    if (AD_TYPE.VIDEO === ad.ad_type) {
+      const videoAd = bidderResponseBody.ad.video;
+      Object.assign(bid, {
+        vastXml: videoAd.vtag,
+        width: videoAd.w,
+        height: videoAd.h,
+        renderer: newRenderer(bidderResponseBody),
+        adResponse: bidderResponseBody,
+        mediaType: VIDEO
+      });
+    } else if (AD_TYPE.BANNER === ad.ad_type) {
+      const bannerAd = bidderResponseBody.ad.banner;
+      Object.assign(bid, {
+        width: bannerAd.w,
+        height: bannerAd.h,
+        ad: bannerAd.tag,
+        mediaType: BANNER
+      });
+      try {
+        bannerAd.imps.forEach(impTracker => {
+          const tracker = utils.createTrackPixelHtml(impTracker);
+          bid.ad += tracker;
+        });
+      } catch (error) {
+        utils.logError('Error appending tracking pixel', error);
+      }
+    } else if (AD_TYPE.NATIVE === ad.ad_type) {
+      const nativeAds = ad.native.template_and_ads.ads;
+
+      nativeAds.forEach(nativeAd => {
+        const assets = nativeAd.assets;
+
+        Object.assign(bid, {
+          mediaType: NATIVE
+        });
+
+        bid.native = {
+          title: assets.title,
+          body: assets.description,
+          cta: assets.cta_text,
+          sponsoredBy: assets.sponsor,
+          clickUrl: assets.lp_link,
+          impressionTrackers: nativeAd.imps,
+          privacyLink: assets.adchoice_url,
+        };
+
+        if (assets.img_main !== undefined) {
+          bid.native.image = {
+            url: assets.img_main,
+            width: parseInt(assets.img_main_width, 10),
+            height: parseInt(assets.img_main_height, 10)
+          };
+        }
+
+        if (assets.img_icon !== undefined) {
+          bid.native.icon = {
+            url: assets.img_icon,
+            width: parseInt(assets.img_icon_width, 10),
+            height: parseInt(assets.img_icon_height, 10)
+          };
+        }
+      });
+    }
+
+    return [bid];
+  },
+
+  getUserSyncs: function(syncOptions, serverResponses) {
+    const syncs = [];
+    if (!serverResponses.length) {
+      return syncs;
+    }
+
+    const bidderResponseBody = serverResponses[0].body;
+
+    if (syncOptions.pixelEnabled && bidderResponseBody.syncs) {
+      bidderResponseBody.syncs.forEach(sync => {
+        syncs.push({
+          type: 'image',
+          url: sync
+        });
+      });
+    }
+
+    if (syncOptions.iframeEnabled && bidderResponseBody.sync_htmls) {
+      bidderResponseBody.sync_htmls.forEach(sync => {
+        syncs.push({
+          type: 'iframe',
+          url: sync
+        });
+      });
+    }
+
+    return syncs;
+  },
+}
+
+function newRenderer(bidderResponse) {
+  const renderer = Renderer.install({
+    id: bidderResponse.ad.prebid_id,
+    url: bidderResponse.ad.video.purl,
+    loaded: false,
+  });
+
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    utils.logWarn('Prebid Error calling setRender on newRenderer', err);
+  }
+
+  return renderer;
+}
+
+function outstreamRender(bid) {
+  bid.renderer.push(() => {
+    window.aja_vast_player.init({
+      vast_tag: bid.adResponse.ad.video.vtag,
+      ad_unit_code: bid.adUnitCode, // target div id to render video
+      width: bid.width,
+      height: bid.height,
+      progress: bid.adResponse.ad.video.progress,
+      loop: bid.adResponse.ad.video.loop,
+      inread: bid.adResponse.ad.video.inread
+    });
+  });
+}
+
+registerBidder(spec);

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -1,0 +1,322 @@
+import { spec } from 'modules/ajaBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+
+const ENDPOINT = 'https://ad.as.amanad.adtdp.com/v2/prebid';
+
+describe('AjaAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('isBidRequestValid', function () {
+    let bid = {
+      'bidder': 'aja',
+      'params': {
+        'asi': '123456'
+      },
+      'adUnitCode': 'adunit',
+      'sizes': [[300, 250]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'asi': 0
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    let bidRequests = [
+      {
+        'bidder': 'aja',
+        'params': {
+          'asi': '123456'
+        },
+        'adUnitCode': 'adunit',
+        'sizes': [[300, 250]],
+        'bidId': '30b31c1838de1e',
+        'bidderRequestId': '22edbae2733bf6',
+        'auctionId': '1d1a030790a475',
+      }
+    ];
+
+    let bidderRequest = {
+      refererInfo: {
+        referer: 'https://hoge.com'
+      }
+    };
+
+    it('sends bid request to ENDPOINT via GET', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      expect(requests[0].url).to.equal(ENDPOINT);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].data).to.equal('asi=123456&skt=5&prebid_id=30b31c1838de1e&prebid_ver=$prebid.version$&page_url=https%3A%2F%2Fhoge.com&');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('should get correct banner bid response', function () {
+      let response = {
+        'is_ad_return': true,
+        'ad': {
+          'ad_type': 1,
+          'prebid_id': '51ef8751f9aead',
+          'price': 12.34,
+          'currency': 'USD',
+          'creative_id': '123abc',
+          'banner': {
+            'w': 300,
+            'h': 250,
+            'tag': '<div></div>',
+            'imps': [
+              'https://as.amanad.adtdp.com/v1/imp'
+            ]
+          },
+          'adomain': [
+            'www.example.com'
+          ]
+        },
+        'syncs': [
+          'https://example.com'
+        ]
+      };
+
+      let expectedResponse = [
+        {
+          'requestId': '51ef8751f9aead',
+          'cpm': 12.34,
+          'creativeId': '123abc',
+          'dealId': undefined,
+          'width': 300,
+          'height': 250,
+          'ad': '<div></div>',
+          'mediaType': 'banner',
+          'currency': 'USD',
+          'ttl': 300,
+          'netRevenue': true,
+          'meta': {
+            'advertiserDomains': [
+              'www.example.com'
+            ]
+          }
+        }
+      ];
+
+      let bidderRequest;
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+    });
+
+    it('handles video responses', function () {
+      let response = {
+        'is_ad_return': true,
+        'ad': {
+          'ad_type': 3,
+          'prebid_id': '51ef8751f9aead',
+          'price': 12.34,
+          'currency': 'JPY',
+          'creative_id': '123abc',
+          'video': {
+            'w': 300,
+            'h': 250,
+            'vtag': '<VAST></VAST>',
+            'purl': 'https://cdn/player',
+            'progress': true,
+            'loop': false,
+            'inread': false
+          }
+        },
+        'syncs': [
+          'https://example.com'
+        ]
+      };
+
+      let bidderRequest;
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
+      expect(result[0]).to.have.property('vastXml');
+      expect(result[0]).to.have.property('renderer');
+      expect(result[0]).to.have.property('mediaType', 'video');
+    });
+
+    it('handles native response', function () {
+      let response = {
+        'is_ad_return': true,
+        'ad': {
+          'ad_type': 2,
+          'prebid_id': '51ef8751f9aead',
+          'price': 12.34,
+          'currency': 'JPY',
+          'creative_id': '123abc',
+          'native': {
+            'template_and_ads': {
+              'head': '',
+              'body_wrapper': '',
+              'body': '',
+              'ads': [
+                {
+                  'ad_format_id': 10,
+                  'assets': {
+                    'ad_spot_id': '123abc',
+                    'index': 0,
+                    'adchoice_url': 'https://aja-kk.co.jp/optout',
+                    'cta_text': 'cta',
+                    'img_icon': 'https://example.com/img_icon',
+                    'img_icon_width': '50',
+                    'img_icon_height': '50',
+                    'img_main': 'https://example.com/img_main',
+                    'img_main_width': '200',
+                    'img_main_height': '100',
+                    'lp_link': 'https://example.com/lp?k=v',
+                    'sponsor': 'sponsor',
+                    'title': 'ad_title',
+                    'description': 'ad_desc'
+                  },
+                  'imps': [
+                    'https://example.com/imp'
+                  ],
+                  'inviews': [
+                    'https://example.com/inview'
+                  ],
+                  'jstracker': '',
+                  'disable_trimming': false
+                }
+              ]
+            }
+          }
+        },
+        'syncs': [
+          'https://example.com'
+        ]
+      };
+
+      let expectedResponse = [
+        {
+          'requestId': '51ef8751f9aead',
+          'cpm': 12.34,
+          'creativeId': '123abc',
+          'dealId': undefined,
+          'mediaType': 'native',
+          'currency': 'JPY',
+          'ttl': 300,
+          'netRevenue': true,
+          'native': {
+            'title': 'ad_title',
+            'body': 'ad_desc',
+            'cta': 'cta',
+            'sponsoredBy': 'sponsor',
+            'image': {
+              'url': 'https://example.com/img_main',
+              'width': 200,
+              'height': 100
+            },
+            'icon': {
+              'url': 'https://example.com/img_icon',
+              'width': 50,
+              'height': 50
+            },
+            'clickUrl': 'https://example.com/lp?k=v',
+            'impressionTrackers': [
+              'https://example.com/imp'
+            ],
+            'privacyLink': 'https://aja-kk.co.jp/optout'
+          },
+          'meta': {
+            'advertiserDomains': []
+          }
+        }
+      ];
+
+      let bidderRequest;
+      let result = spec.interpretResponse({ body: response }, {bidderRequest})
+      expect(result).to.deep.equal(expectedResponse)
+    });
+
+    it('handles nobid responses', function () {
+      let response = {
+        'is_ad_return': false,
+        'ad': {}
+      };
+
+      let bidderRequest;
+      let result = spec.interpretResponse({ body: response }, {bidderRequest});
+      expect(result.length).to.equal(0);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    const bidResponse1 = {
+      body: {
+        'is_ad_return': true,
+        'ad': { /* ad body */ },
+        'syncs': [
+          'https://example.test/pixel/1'
+        ],
+        'sync_htmls': [
+          'https://example.test/iframe/1'
+        ]
+      }
+    };
+
+    const bidResponse2 = {
+      body: {
+        'is_ad_return': true,
+        'ad': { /* ad body */ },
+        'syncs': [
+          'https://example.test/pixel/2'
+        ]
+      }
+    };
+
+    it('should use a sync url from first response (pixel and iframe)', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, [bidResponse1, bidResponse2]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://example.test/pixel/1'
+        },
+        {
+          type: 'iframe',
+          url: 'https://example.test/iframe/1'
+        }
+      ]);
+    });
+
+    it('handle empty response (e.g. timeout)', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, []);
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('returns empty syncs when not pixel enabled and not iframe enabled', function () {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false, iframeEnabled: false }, [bidResponse1]);
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('returns pixel syncs when pixel enabled and not iframe enabled', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: false }, [bidResponse1]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://example.test/pixel/1'
+        }
+      ]);
+    });
+
+    it('returns iframe syncs when not pixel enabled and iframe enabled', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false, iframeEnabled: true }, [bidResponse1]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'https://example.test/iframe/1'
+        }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Re-add Aja Bid Adapter with support for meta.advertiserDomains