### PR TITLE
Adhese Bid Adapter: add adomain and adapter to 5.0

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -1,0 +1,236 @@
+'use strict';
+
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'adhese';
+const GVLID = 553;
+const USER_SYNC_BASE_URL = 'https://user-sync.adhese.com/iframe/user_sync.html';
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER, VIDEO],
+
+  isBidRequestValid: function(bid) {
+    return !!(bid.params.account && bid.params.location && (bid.params.format || bid.mediaTypes.banner.sizes));
+  },
+
+  buildRequests: function(validBidRequests, bidderRequest) {
+    if (validBidRequests.length === 0) {
+      return null;
+    }
+    const { gdprConsent, refererInfo } = bidderRequest;
+
+    const gdprParams = (gdprConsent && gdprConsent.consentString) ? { xt: [gdprConsent.consentString] } : {};
+    const refererParams = (refererInfo && refererInfo.referer) ? { xf: [base64urlEncode(refererInfo.referer)] } : {};
+    const commonParams = { ...gdprParams, ...refererParams };
+
+    const slots = validBidRequests.map(bid => ({
+      slotname: bidToSlotName(bid),
+      parameters: cleanTargets(bid.params.data)
+    }));
+
+    const payload = {
+      slots: slots,
+      parameters: commonParams,
+      vastContentAsUrl: true,
+      user: {
+        ext: {
+          eids: getEids(validBidRequests),
+        }
+      }
+    };
+
+    const account = getAccount(validBidRequests);
+    const uri = 'https://ads-' + account + '.adhese.com/json';
+
+    return {
+      method: 'POST',
+      url: uri,
+      data: JSON.stringify(payload),
+      bids: validBidRequests,
+      options: {
+        contentType: 'application/json'
+      }
+    };
+  },
+
+  interpretResponse: function(serverResponse, request) {
+    const serverAds = serverResponse.body.reduce(function(map, ad) {
+      map[ad.slotName] = ad;
+      return map;
+    }, {});
+
+    serverResponse.account = getAccount(request.bids);
+
+    return request.bids
+      .map(bid => ({
+        bid: bid,
+        ad: serverAds[bidToSlotName(bid)]
+      }))
+      .filter(item => item.ad)
+      .map(item => adResponse(item.bid, item.ad));
+  },
+
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent) {
+    if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+      const account = serverResponses[0].account;
+      if (account) {
+        let syncurl = USER_SYNC_BASE_URL + '?account=' + account;
+        if (gdprConsent) {
+          syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+          syncurl += '&consentString=' + encodeURIComponent(gdprConsent.consentString || '');
+        }
+        return [{type: 'iframe', url: syncurl}];
+      }
+    }
+    return [];
+  }
+};
+
+function adResponse(bid, ad) {
+  const price = getPrice(ad);
+  const adDetails = getAdDetails(ad);
+  const markup = getAdMarkup(ad);
+
+  const bidResponse = getbaseAdResponse({
+    requestId: bid.bidId,
+    mediaType: ad.extension.mediaType,
+    cpm: Number(price.amount),
+    currency: price.currency,
+    width: Number(ad.width),
+    height: Number(ad.height),
+    creativeId: adDetails.creativeId,
+    dealId: adDetails.dealId,
+    adhese: {
+      originData: adDetails.originData,
+      origin: adDetails.origin,
+      originInstance: adDetails.originInstance
+    },
+    meta: {
+      advertiserDomains: ad.adomain || []
+    }
+  });
+
+  if (bidResponse.mediaType === VIDEO) {
+    if (ad.cachedBodyUrl) {
+      bidResponse.vastUrl = ad.cachedBodyUrl
+    } else {
+      bidResponse.vastXml = markup;
+    }
+  } else {
+    const counter = ad.impressionCounter ? "<img src='" + ad.impressionCounter + "' style='height:1px; width:1px; margin: -1px -1px; display:none;'/>" : '';
+    bidResponse.ad = markup + counter;
+  }
+  return bidResponse;
+}
+
+function cleanTargets(target) {
+  const targets = {};
+  if (target) {
+    Object.keys(target).forEach(function (key) {
+      const val = target[key];
+      const dirtyValues = Array.isArray(val) ? val : [val];
+      const values = dirtyValues.filter(v => v === 0 || v);
+      if (values.length > 0) {
+        if (targets[key]) {
+          const distinctValues = values.filter(v => targets[key].indexOf(v) < 0);
+          targets[key].push.apply(targets[key], distinctValues);
+        } else {
+          targets[key] = values;
+        }
+      }
+    });
+  }
+  return targets;
+}
+
+function bidToSlotName(bid) {
+  if (bid.params.format) {
+    return bid.params.location + '-' + bid.params.format;
+  }
+
+  var sizes = bid.mediaTypes.banner.sizes;
+  sizes.sort();
+  var format = sizes.map(size => size[0] + 'x' + size[1]).join('_');
+
+  if (format.length > 0) {
+    return bid.params.location + '-' + format;
+  } else {
+    return bid.params.location;
+  }
+}
+
+function getAccount(validBidRequests) {
+  return validBidRequests[0].params.account;
+}
+
+function getEids(validBidRequests) {
+  if (validBidRequests[0] && validBidRequests[0].userIdAsEids) {
+    return validBidRequests[0].userIdAsEids;
+  }
+}
+
+function getbaseAdResponse(response) {
+  return Object.assign({ netRevenue: true, ttl: 360 }, response);
+}
+
+function isAdheseAd(ad) {
+  return !ad.origin || ad.origin === 'JERLICIA';
+}
+
+function getAdMarkup(ad) {
+  if (!isAdheseAd(ad) || (ad.ext === 'js' && ad.body !== undefined && ad.body !== '' && ad.body.match(/<script|<SCRIPT|<html|<HTML|<\?xml/))) {
+    return ad.body
+  } else {
+    return ad.tag;
+  }
+}
+
+function getPrice(ad) {
+  if (ad.extension && ad.extension.prebid && ad.extension.prebid.cpm) {
+    return ad.extension.prebid.cpm;
+  }
+  return { amount: 0, currency: 'USD' };
+}
+
+function getAdDetails(ad) {
+  let creativeId = '';
+  let dealId = '';
+  let originData = {};
+  let origin = '';
+  let originInstance = '';
+
+  if (isAdheseAd(ad)) {
+    creativeId = ad.id;
+    dealId = ad.orderId;
+    originData = { priority: ad.priority, orderProperty: ad.orderProperty, adFormat: ad.adFormat, adType: ad.adType, libId: ad.libId, adspaceId: ad.adspaceId, viewableImpressionCounter: ad.viewableImpressionCounter, slotId: ad.slotID, slotName: ad.slotName, advertiserId: ad.advertiserId, adId: ad.id };
+  } else {
+    creativeId = ad.origin + (ad.originInstance ? '-' + ad.originInstance : '');
+    if (ad.originData) {
+      originData = ad.originData;
+      originData.slotId = ad.slotID;
+      originData.slotName = ad.slotName;
+      originData.adType = ad.adType;
+      if (ad.adFormat) originData.adFormat = ad.adFormat;
+      if (ad.originData.seatbid && ad.originData.seatbid.length) {
+        const seatbid = ad.originData.seatbid[0];
+        if (seatbid.bid && seatbid.bid.length) {
+          const bid = seatbid.bid[0];
+          creativeId = String(bid.crid || '');
+          dealId = String(bid.dealid || '');
+        }
+      }
+    }
+    if (ad.originInstance) originInstance = ad.originInstance;
+    if (ad.origin) origin = ad.origin;
+  }
+  return { creativeId: creativeId, dealId: dealId, originData: originData, origin: origin, originInstance: originInstance };
+}
+
+function base64urlEncode(s) {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+registerBidder(spec);

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -1,0 +1,532 @@
+import {expect} from 'chai';
+import {spec} from 'modules/adheseBidAdapter.js';
+
+const BID_ID = 456;
+const TTL = 360;
+const NET_REVENUE = true;
+
+let minimalBid = function() {
+  return {
+    'bidId': BID_ID,
+    'bidder': 'adhese',
+    'params': {
+      account: 'demo',
+      location: '_main_page_',
+      format: 'leaderboard'
+    }
+  }
+};
+
+let bidWithParams = function(data) {
+  let bid = minimalBid();
+  bid.params.data = data;
+  return bid;
+};
+
+describe('AdheseAdapter', function () {
+  describe('getUserSyncs', function () {
+    const serverResponses = [{
+      account: 'demo'
+    }];
+    const gdprConsent = {
+      gdprApplies: true,
+      consentString: 'CONSENT_STRING'
+    };
+    it('should return empty when iframe disallowed', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: false }, serverResponses, gdprConsent)).to.be.empty;
+    });
+    it('should return empty when no serverResponses present', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [], gdprConsent)).to.be.empty;
+    });
+    it('should return empty when no account info present in the response', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [{}], gdprConsent)).to.be.empty;
+    });
+    it('should return usersync url when iframe allowed', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, serverResponses, gdprConsent)).to.deep.equal([{ type: 'iframe', url: 'https://user-sync.adhese.com/iframe/user_sync.html?account=demo&gdpr=1&consentString=CONSENT_STRING' }]);
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(minimalBid())).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, minimalBid());
+      delete bid.params;
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    let bidderRequest = {
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'CONSENT_STRING'
+      },
+      refererInfo: {
+        referer: 'http://prebid.org/dev-docs/subjects?_d=1'
+      }
+    };
+
+    it('should include requested slots', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data).slots[0].slotname).to.equal('_main_page_-leaderboard');
+    });
+
+    it('should include all extra bid params', function () {
+      let req = spec.buildRequests([ bidWithParams({ 'ag': '25' }) ], bidderRequest);
+
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ag': [ '25' ] });
+    });
+
+    it('should assign bid params per slot', function () {
+      let req = spec.buildRequests([ bidWithParams({ 'ag': '25' }), bidWithParams({ 'ag': '25', 'ci': 'gent' }) ], bidderRequest);
+
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ag': [ '25' ] }).and.not.to.deep.include({ 'ci': [ 'gent' ] });
+      expect(JSON.parse(req.data).slots[1].parameters).to.deep.include({ 'ag': [ '25' ] }).and.to.deep.include({ 'ci': [ 'gent' ] });
+    });
+
+    it('should split multiple target values', function () {
+      let req = spec.buildRequests([ bidWithParams({ 'ci': 'london' }), bidWithParams({ 'ci': 'gent' }) ], bidderRequest);
+
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ci': [ 'london' ] });
+      expect(JSON.parse(req.data).slots[1].parameters).to.deep.include({ 'ci': [ 'gent' ] });
+    });
+
+    it('should filter out empty params', function () {
+      let req = spec.buildRequests([ bidWithParams({ 'aa': [], 'bb': null, 'cc': '', 'dd': [ '', '' ], 'ee': [ 0, 1, null ], 'ff': 0, 'gg': [ 'x', 'y', '' ] }) ], bidderRequest);
+
+      let params = JSON.parse(req.data).slots[0].parameters;
+      expect(params).to.not.have.any.keys('aa', 'bb', 'cc', 'dd');
+      expect(params).to.deep.include({ 'ee': [ 0, 1 ], 'ff': [ 0 ], 'gg': [ 'x', 'y' ] });
+    });
+
+    it('should include gdpr consent param', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xt': [ 'CONSENT_STRING' ] });
+    });
+
+    it('should include referer param in base64url format', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
+    });
+
+    it('should include eids', function () {
+      let bid = minimalBid();
+      bid.userIdAsEids = [{ source: 'id5-sync.com', uids: [{ id: 'ID5@59sigaS-...' }] }];
+
+      let req = spec.buildRequests([ bid ], bidderRequest);
+
+      expect(JSON.parse(req.data).user.ext.eids).to.deep.equal(bid.userIdAsEids);
+    });
+
+    it('should not include eids field when userid module disabled', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data)).to.not.have.key('eids');
+    });
+
+    it('should request vast content as url', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(JSON.parse(req.data).vastContentAsUrl).to.equal(true);
+    });
+
+    it('should include bids', function () {
+      let bid = minimalBid();
+      let req = spec.buildRequests([ bid ], bidderRequest);
+
+      expect(req.bids).to.deep.equal([ bid ]);
+    });
+
+    it('should make a POST request', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(req.method).to.equal('POST');
+    });
+
+    it('should request the json endpoint', function () {
+      let req = spec.buildRequests([ minimalBid() ], bidderRequest);
+
+      expect(req.url).to.equal('https://ads-demo.adhese.com/json');
+    });
+  });
+
+  describe('interpretResponse', () => {
+    let bidRequest = {
+      bids: [ minimalBid() ]
+    };
+
+    it('should get correct ssp banner response', () => {
+      let sspBannerResponse = {
+        body: [
+          {
+            origin: 'APPNEXUS',
+            originInstance: '',
+            ext: 'js',
+            slotID: '10',
+            slotName: '_main_page_-leaderboard',
+            adType: 'leaderboard',
+            originData: {
+              seatbid: [{
+                bid: [{
+                  crid: '60613369',
+                  dealid: null
+                }],
+                seat: '958'
+              }]
+            },
+            width: '728',
+            height: '90',
+            body: '<div style="background-color:red; height:250px; width:300px"></div>',
+            tracker: 'https://hosts-demo.adhese.com/rtb_gateway/handlers/client/track/?id=a2f39296-6dd0-4b3c-be85-7baa22e7ff4a',
+            impressionCounter: 'https://hosts-demo.adhese.com/rtb_gateway/handlers/client/track/?id=a2f39296-6dd0-4b3c-be85-7baa22e7ff4a',
+            extension: {'prebid': {'cpm': {'amount': '1.000000', 'currency': 'USD'}}, mediaType: 'banner'},
+            adomain: [
+              'www.example.com'
+            ]
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        ad: '<div style="background-color:red; height:250px; width:300px"></div><img src=\'https://hosts-demo.adhese.com/rtb_gateway/handlers/client/track/?id=a2f39296-6dd0-4b3c-be85-7baa22e7ff4a\' style=\'height:1px; width:1px; margin: -1px -1px; display:none;\'/>',
+        cpm: 1,
+        currency: 'USD',
+        creativeId: '60613369',
+        dealId: '',
+        width: 728,
+        height: 90,
+        mediaType: 'banner',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        adhese: {
+          origin: 'APPNEXUS',
+          originInstance: '',
+          originData: {
+            adType: 'leaderboard',
+            seatbid: [
+              {
+                bid: [ { crid: '60613369', dealid: null } ],
+                seat: '958'
+              }
+            ],
+            slotId: '10',
+            slotName: '_main_page_-leaderboard'
+          }
+        },
+        meta: {
+          advertiserDomains: [
+            'www.example.com'
+          ]
+        },
+      }];
+      expect(spec.interpretResponse(sspBannerResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct ssp video response', () => {
+      let sspVideoResponse = {
+        body: [
+          {
+            origin: 'RUBICON',
+            ext: 'js',
+            slotName: '_main_page_-leaderboard',
+            adType: 'leaderboard',
+            width: '640',
+            height: '350',
+            body: '<?xml version="1.0" encoding="UTF-8"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:noNamespaceSchemaLocation="vast.xsd"></VAST>',
+            extension: {'prebid': {'cpm': {'amount': '2.1', 'currency': 'USD'}}, mediaType: 'video'}
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        vastXml: '<?xml version="1.0" encoding="UTF-8"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:noNamespaceSchemaLocation="vast.xsd"></VAST>',
+        cpm: 2.1,
+        currency: 'USD',
+        creativeId: 'RUBICON',
+        dealId: '',
+        width: 640,
+        height: 350,
+        mediaType: 'video',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        adhese: {
+          origin: 'RUBICON',
+          originInstance: '',
+          originData: {}
+        },
+        meta: {
+          advertiserDomains: []
+        },
+      }];
+      expect(spec.interpretResponse(sspVideoResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct ssp cache video response', () => {
+      let sspCachedVideoResponse = {
+        body: [
+          {
+            origin: 'RUBICON',
+            ext: 'js',
+            slotName: '_main_page_-leaderboard',
+            adType: 'leaderboard',
+            width: '640',
+            height: '350',
+            cachedBodyUrl: 'https://ads-demo.adhese.com/content/38983ccc-4083-4c24-932c-96f798d969b3',
+            extension: {'prebid': {'cpm': {'amount': '2.1', 'currency': 'USD'}}, mediaType: 'video'}
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        vastUrl: 'https://ads-demo.adhese.com/content/38983ccc-4083-4c24-932c-96f798d969b3',
+        cpm: 2.1,
+        currency: 'USD',
+        creativeId: 'RUBICON',
+        dealId: '',
+        width: 640,
+        height: 350,
+        mediaType: 'video',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        adhese: {
+          origin: 'RUBICON',
+          originInstance: '',
+          originData: {}
+        },
+        meta: {
+          advertiserDomains: []
+        },
+      }];
+      expect(spec.interpretResponse(sspCachedVideoResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct Adhese banner response', () => {
+      const adheseBannerResponse = {
+        body: [
+          {
+            adType: 'largeleaderboard', // it can differ from the requested slot
+            adFormat: 'largeleaderboard',
+            timeStamp: '1544009030000',
+            orderId: '22051',
+            adspaceId: '162363',
+            body: '<script id="body" type="text/javascript"></script>',
+            tag: '<script id="tag" type="text/javascript"></script>',
+            tracker: 'https://hosts-demo.adhese.com/track/tracker',
+            altText: '<ADHESE_ALT_TEXT>',
+            height: '150',
+            width: '840',
+            tagUrl: 'https://pool-demo.adhese.com/pool/lib/90511.js',
+            libId: '90511',
+            id: '742898',
+            advertiserId: '2081',
+            ext: 'js',
+            url: 'https://hosts-demo.adhese.com/raylene/url',
+            clickTag: 'https://hosts-demo.adhese.com/raylene/clickTag',
+            poolPath: 'https://hosts-demo.adhese.com/pool/lib/',
+            orderName: 'Luminus boiler comodity-Pareto -201812',
+            creativeName: 'nl_demo _network_ron_dlbd_840x150_fix_dir_asv_std_dis_brd_nrt_na_red',
+            slotName: '_main_page_-leaderboard',
+            slotID: '29306',
+            impressionCounter: 'https://hosts-demo.adhese.com/track/742898',
+            origin: 'JERLICIA',
+            originData: {},
+            auctionable: true,
+            extension: {
+              prebid: {
+                cpm: {
+                  amount: '5.96',
+                  currency: 'USD'
+                }
+              },
+              mediaType: 'banner'
+            }
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        ad: '<script id="body" type="text/javascript"></script><img src=\'https://hosts-demo.adhese.com/track/742898\' style=\'height:1px; width:1px; margin: -1px -1px; display:none;\'/>',
+        adhese: {
+          origin: '',
+          originInstance: '',
+          originData: {
+            adFormat: 'largeleaderboard',
+            adId: '742898',
+            adType: 'largeleaderboard',
+            adspaceId: '162363',
+            libId: '90511',
+            orderProperty: undefined,
+            priority: undefined,
+            viewableImpressionCounter: undefined,
+            slotId: '29306',
+            slotName: '_main_page_-leaderboard',
+            advertiserId: '2081'
+          }
+        },
+        cpm: 5.96,
+        currency: 'USD',
+        creativeId: '742898',
+        dealId: '22051',
+        width: 840,
+        height: 150,
+        mediaType: 'banner',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        meta: {
+          advertiserDomains: []
+        },
+      }];
+      expect(spec.interpretResponse(adheseBannerResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct Adhese video response', () => {
+      const adheseVideoResponse = {
+        body: [
+          {
+            adType: 'preroll',
+            adFormat: '',
+            orderId: '22248',
+            adspaceId: '164196',
+            body: '<ADHESE_BODY>',
+            height: '360',
+            width: '640',
+            tag: "<?xml version='1.0' encoding='UTF-8' standalone='no'?><VAST version='2.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='vast.xsd'></VAST>",
+            libId: '89860',
+            id: '742470',
+            advertiserId: '2263',
+            ext: 'advar',
+            orderName: 'Smartphoto EOY-20181112',
+            creativeName: 'PREROLL',
+            slotName: '_main_page_-leaderboard',
+            slotID: '41711',
+            impressionCounter: 'https://hosts-demo.adhese.com/track/742898',
+            origin: 'JERLICIA',
+            originData: {},
+            auctionable: true,
+            extension: {
+              mediaType: 'video'
+            }
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        vastXml: '<?xml version=\'1.0\' encoding=\'UTF-8\' standalone=\'no\'?><VAST version=\'2.0\' xmlns:xsi=\'http://www.w3.org/2001/XMLSchema-instance\' xsi:noNamespaceSchemaLocation=\'vast.xsd\'></VAST>',
+        adhese: {
+          origin: '',
+          originInstance: '',
+          originData: {
+            adFormat: '',
+            adId: '742470',
+            adType: 'preroll',
+            adspaceId: '164196',
+            libId: '89860',
+            orderProperty: undefined,
+            priority: undefined,
+            viewableImpressionCounter: undefined,
+            slotId: '41711',
+            slotName: '_main_page_-leaderboard',
+            advertiserId: '2263',
+          }
+        },
+        cpm: 0,
+        currency: 'USD',
+        creativeId: '742470',
+        dealId: '22248',
+        width: 640,
+        height: 360,
+        mediaType: 'video',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        meta: {
+          advertiserDomains: []
+        },
+      }];
+      expect(spec.interpretResponse(adheseVideoResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct Adhese cached video response', () => {
+      const adheseVideoResponse = {
+        body: [
+          {
+            adType: 'preroll',
+            adFormat: '',
+            orderId: '22248',
+            adspaceId: '164196',
+            body: '<ADHESE_BODY>',
+            height: '360',
+            width: '640',
+            extension: {
+              mediaType: 'video'
+            },
+            cachedBodyUrl: 'https://ads-demo.adhese.com/content/38983ccc-4083-4c24-932c-96f798d969b3',
+            libId: '89860',
+            id: '742470',
+            advertiserId: '2263',
+            ext: 'advar',
+            orderName: 'Smartphoto EOY-20181112',
+            creativeName: 'PREROLL',
+            slotName: '_main_page_-leaderboard',
+            slotID: '41711',
+            impressionCounter: 'https://hosts-demo.adhese.com/track/742898',
+            origin: 'JERLICIA',
+            originData: {},
+            auctionable: true
+          }
+        ]
+      };
+
+      let expectedResponse = [{
+        requestId: BID_ID,
+        vastUrl: 'https://ads-demo.adhese.com/content/38983ccc-4083-4c24-932c-96f798d969b3',
+        adhese: {
+          origin: '',
+          originInstance: '',
+          originData: {
+            adFormat: '',
+            adId: '742470',
+            adType: 'preroll',
+            adspaceId: '164196',
+            libId: '89860',
+            orderProperty: undefined,
+            priority: undefined,
+            viewableImpressionCounter: undefined,
+            slotId: '41711',
+            slotName: '_main_page_-leaderboard',
+            advertiserId: '2263',
+          }
+        },
+        cpm: 0,
+        currency: 'USD',
+        creativeId: '742470',
+        dealId: '22248',
+        width: 640,
+        height: 360,
+        mediaType: 'video',
+        netRevenue: NET_REVENUE,
+        ttl: TTL,
+        meta: {
+          advertiserDomains: []
+        },
+      }];
+      expect(spec.interpretResponse(adheseVideoResponse, bidRequest)).to.deep.equal(expectedResponse);
+    });
+
+    it('should return no bids for empty adserver response', () => {
+      let adserverResponse = { body: [] };
+      expect(spec.interpretResponse(adserverResponse, bidRequest)).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Re-add Adhese Bid Adapter with support for meta.advertiserDomains