### PR TITLE
PBJS Core: Leverage defined methods from utils in secureCreatives

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -6,7 +6,7 @@
 import events from './events.js';
 import { fireNativeTrackers, getAssetMessage, getAllAssetsMessage } from './native.js';
 import constants from './constants.json';
-import { logWarn, replaceAuctionPrice, deepAccess } from './utils.js';
+import { logWarn, replaceAuctionPrice, deepAccess, isGptPubadsDefined, isApnGetTagDefined } from './utils.js';
 import { auctionManager } from './auctionManager.js';
 import find from 'core-js-pure/features/array/find.js';
 import { isRendererRequired, executeRenderer } from './Renderer.js';
@@ -118,9 +118,9 @@ function resizeRemoteCreative({ adId, adUnitCode, width, height }) {
   }
 
   function getElementIdBasedOnAdServer(adId, adUnitCode) {
-    if (window.googletag) {
+    if (isGptPubadsDefined()) {
       return getDfpElementId(adId)
-    } else if (window.apntag) {
+    } else if (isApnGetTagDefined()) {
       return getAstElementId(adUnitCode)
     } else {
       return adUnitCode;

--- a/src/utils.js
+++ b/src/utils.js
@@ -665,6 +665,12 @@ export function isGptPubadsDefined() {
   }
 }
 
+export function isApnGetTagDefined() {
+  if (window.apntag && isFn(window.apntag.getTag)) {
+    return true;
+  }
+}
+
 // This function will get highest cpm value bid, in case of tie it will return the bid with lowest timeToRespond
 export const getHighestCpm = getHighestCpmCallback('timeToRespond', (previous, current) => previous > current);
 


### PR DESCRIPTION

## Type of change

- [x] Bugfix


## Description of change

- use isGptPubadsDefined instead of rolling our own
- add isApnGetTagDefined to utils, which does a deeper existence
  confirmation and start using it.

## Other information

See #7109 for some detail