### PR TITLE
GetIntent bid adapter: update to v5 requirements

### DIFF
--- a/modules/getintentBidAdapter.js
+++ b/modules/getintentBidAdapter.js
@@ -1,0 +1,220 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { isInteger } from '../src/utils.js';
+import * as utils from '../src/utils.js';
+
+const BIDDER_CODE = 'getintent';
+const IS_NET_REVENUE = true;
+const BID_HOST = 'px.adhigh.net';
+const BID_BANNER_PATH = '/rtb/direct_banner';
+const BID_VIDEO_PATH = '/rtb/direct_vast';
+const BID_RESPONSE_TTL_SEC = 360;
+const FLOOR_PARAM = 'floor';
+const CURRENCY_PARAM = 'cur';
+const DEFAULT_CURRENCY = 'RUB';
+const VIDEO_PROPERTIES = {
+  'protocols': 'protocols',
+  'mimes': 'mimes',
+  'min_dur': 'minduration',
+  'max_dur': 'maxduration',
+  'min_btr': 'minbitrate',
+  'max_btr': 'maxbitrate',
+  'vi_format': null,
+  'api': 'api',
+  'skippable': 'skip',
+};
+const SKIPPABLE_ALLOW = 'ALLOW';
+const SKIPPABLE_NOT_ALLOW = 'NOT_ALLOW';
+
+const OPTIONAL_PROPERTIES = [
+  'sid'
+];
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['getintentAdapter'],
+  supportedMediaTypes: ['video', 'banner'],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid to validate.
+   * @return {boolean} True if this is a valid bid, and false otherwise.
+   * */
+  isBidRequestValid: function(bid) {
+    return !!(bid && bid.params && bid.params.pid && bid.params.tid);
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} bidRequests - an array of bids.
+   * @return ServerRequest[]
+   */
+  buildRequests: function(bidRequests) {
+    return bidRequests.map(bidRequest => {
+      let giBidRequest = buildGiBidRequest(bidRequest);
+      return {
+        method: 'GET',
+        url: buildUrl(giBidRequest),
+        data: giBidRequest,
+      };
+    });
+  },
+
+  /**
+   * Callback for bids, after the call to DSP completes.
+   * Parse the response from the server into a list of bids.
+   *
+   * @param {object} serverResponse A response from the GetIntent's server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function(serverResponse) {
+    let responseBody = serverResponse.body;
+    const bids = [];
+    if (responseBody && responseBody.no_bid !== 1) {
+      let size = parseSize(responseBody.size);
+      let bid = {
+        requestId: responseBody.bid_id,
+        ttl: BID_RESPONSE_TTL_SEC,
+        netRevenue: IS_NET_REVENUE,
+        currency: responseBody.currency,
+        creativeId: responseBody.creative_id,
+        cpm: responseBody.cpm,
+        width: size[0],
+        height: size[1],
+        meta: {
+          advertiserDomains: responseBody.adomain || [],
+        }
+      };
+      if (responseBody.vast_url) {
+        bid.mediaType = 'video';
+        bid.vastUrl = responseBody.vast_url;
+      } else {
+        bid.mediaType = 'banner';
+        bid.ad = responseBody.ad;
+      }
+      bids.push(bid);
+    }
+    return bids;
+  }
+
+}
+
+function buildUrl(bid) {
+  return 'https://' + BID_HOST + (bid.is_video ? BID_VIDEO_PATH : BID_BANNER_PATH);
+}
+
+/**
+ * Builds GI bid request from BidRequest.
+ *
+ * @param {BidRequest} bidRequest.
+ * @return {object} GI bid request.
+ * */
+function buildGiBidRequest(bidRequest) {
+  let giBidRequest = {
+    bid_id: bidRequest.bidId,
+    pid: bidRequest.params.pid, // required
+    tid: bidRequest.params.tid, // required
+    known: bidRequest.params.known || 1,
+    is_video: bidRequest.mediaType === 'video',
+    resp_type: 'JSON',
+    provider: 'direct.prebidjs'
+  };
+  if (bidRequest.sizes) {
+    giBidRequest.size = produceSize(bidRequest.sizes);
+  }
+
+  const currency = utils.getBidIdParameter(CURRENCY_PARAM, bidRequest.params);
+  const floorInfo = getBidFloor(bidRequest, currency);
+  if (floorInfo.floor) {
+    giBidRequest[FLOOR_PARAM] = floorInfo.floor;
+  }
+  if (floorInfo.currency) {
+    giBidRequest[CURRENCY_PARAM] = floorInfo.currency;
+  }
+
+  if (giBidRequest.is_video) {
+    addVideo(bidRequest.params.video, bidRequest.mediaTypes.video, giBidRequest);
+  }
+  addOptional(bidRequest.params, giBidRequest, OPTIONAL_PROPERTIES);
+  return giBidRequest;
+}
+
+function getBidFloor(bidRequest, currency) {
+  let floorInfo = {};
+
+  if (utils.isFn(bidRequest.getFloor)) {
+    floorInfo = bidRequest.getFloor({
+      currency: currency || DEFAULT_CURRENCY,
+      mediaType: bidRequest.mediaType,
+      size: bidRequest.sizes || '*'
+    });
+  }
+
+  return {
+    floor: floorInfo.floor || bidRequest.params[FLOOR_PARAM] || 0,
+    currency: floorInfo.currency || currency || '',
+  };
+}
+
+function addVideo(videoParams, mediaTypesVideoParams, giBidRequest) {
+  videoParams = videoParams || {};
+  mediaTypesVideoParams = mediaTypesVideoParams || {};
+
+  for (let videoParam in VIDEO_PROPERTIES) {
+    let paramValue;
+
+    const mediaTypesVideoParam = VIDEO_PROPERTIES[videoParam];
+    if (videoParams.hasOwnProperty(videoParam)) {
+      paramValue = videoParams[videoParam];
+    } else if (mediaTypesVideoParam !== null && mediaTypesVideoParams.hasOwnProperty(mediaTypesVideoParam)) {
+      if (mediaTypesVideoParam === 'skip') {
+        paramValue = mediaTypesVideoParams[mediaTypesVideoParam] === 1 ? SKIPPABLE_ALLOW : SKIPPABLE_NOT_ALLOW;
+      } else {
+        paramValue = mediaTypesVideoParams[mediaTypesVideoParam];
+      }
+    }
+
+    if (typeof paramValue !== 'undefined') {
+      giBidRequest[videoParam] = Array.isArray(paramValue) ? paramValue.join(',') : paramValue;
+    }
+  }
+}
+
+function addOptional(params, request, props) {
+  for (let i = 0; i < props.length; i++) {
+    if (params.hasOwnProperty(props[i])) {
+      request[props[i]] = params[props[i]];
+    }
+  }
+}
+
+/**
+ * @param {String} s The string representing a size (e.g. "300x250").
+ * @return {Number[]} An array with two elements: [width, height] (e.g.: [300, 250]).
+ * */
+function parseSize(s) {
+  return s.split('x').map(Number);
+}
+
+/**
+ * @param {Array} sizes An array of sizes/numbers to be joined into single string.
+ *                      May be an array (e.g. [300, 250]) or array of arrays (e.g. [[300, 250], [640, 480]].
+ * @return {String} The string with sizes, e.g. array of sizes [[50, 50], [80, 80]] becomes "50x50,80x80" string.
+ * */
+function produceSize (sizes) {
+  function sizeToStr(s) {
+    if (Array.isArray(s) && s.length === 2 && isInteger(s[0]) && isInteger(s[1])) {
+      return s.join('x');
+    } else {
+      throw "Malformed parameter 'sizes'";
+    }
+  }
+  if (Array.isArray(sizes) && Array.isArray(sizes[0])) {
+    return sizes.map(sizeToStr).join(',');
+  } else {
+    return sizeToStr(sizes);
+  }
+}
+
+registerBidder(spec);

--- a/test/spec/modules/getintentBidAdapter_spec.js
+++ b/test/spec/modules/getintentBidAdapter_spec.js
@@ -1,0 +1,220 @@
+import { expect } from 'chai'
+import { spec } from 'modules/getintentBidAdapter.js'
+import {deepClone} from 'src/utils';
+
+describe('GetIntent Adapter Tests:', function () {
+  const bidRequests = [{
+    bidId: 'bid12345',
+    params: {
+      pid: 'p1000',
+      tid: 't1000'
+    },
+    sizes: [[300, 250]]
+  },
+  {
+    bidId: 'bid54321',
+    params: {
+      pid: 'p1000',
+      tid: 't1000'
+    },
+    sizes: [[50, 50], [100, 100]]
+  }];
+  const videoBidRequest = {
+    mediaTypes: {
+      video: {
+        protocols: [1, 2, 3],
+        mimes: ['video/mp4'],
+        minduration: 5,
+        maxduration: 30,
+        minbitrate: 500,
+        maxbitrate: 1000,
+        api: [2],
+        skip: 1
+      }
+    },
+    bidId: 'bid789',
+    params: {
+      pid: 'p1001',
+      tid: 't1001',
+    },
+    sizes: [300, 250],
+    mediaType: 'video'
+  };
+  const videoBidRequestWithVideoParams = {
+    mediaTypes: {
+      video: {
+        protocols: [1, 2, 3],
+        mimes: ['video/mp4'],
+        minduration: 5,
+        maxduration: 30,
+        minbitrate: 500,
+        maxbitrate: 1000,
+        api: [2],
+        skip: 0
+      }
+    },
+    bidId: 'bid789',
+    params: {
+      pid: 'p1001',
+      tid: 't1001',
+      video: {
+        mimes: ['video/mp4', 'application/javascript'],
+        max_dur: 20,
+        api: [1, 2],
+        skippable: 'ALLOW'
+      }
+    },
+    sizes: [300, 250],
+    mediaType: 'video'
+  };
+
+  it('Verify build request', function () {
+    const serverRequests = spec.buildRequests(bidRequests);
+    let serverRequest = serverRequests[0];
+    expect(serverRequest.url).to.equal('https://px.adhigh.net/rtb/direct_banner');
+    expect(serverRequest.method).to.equal('GET');
+    expect(serverRequest.data.bid_id).to.equal('bid12345');
+    expect(serverRequest.data.pid).to.equal('p1000');
+    expect(serverRequest.data.tid).to.equal('t1000');
+    expect(serverRequest.data.size).to.equal('300x250');
+    expect(serverRequest.data.is_video).to.equal(false);
+    serverRequest = serverRequests[1];
+    expect(serverRequest.data.size).to.equal('50x50,100x100');
+  });
+
+  it('Verify build video request', function () {
+    const serverRequests = spec.buildRequests([videoBidRequest]);
+    let serverRequest = serverRequests[0];
+    expect(serverRequest.url).to.equal('https://px.adhigh.net/rtb/direct_vast');
+    expect(serverRequest.method).to.equal('GET');
+    expect(serverRequest.data.bid_id).to.equal('bid789');
+    expect(serverRequest.data.pid).to.equal('p1001');
+    expect(serverRequest.data.tid).to.equal('t1001');
+    expect(serverRequest.data.size).to.equal('300x250');
+    expect(serverRequest.data.is_video).to.equal(true);
+    expect(serverRequest.data.protocols).to.equal('1,2,3');
+    expect(serverRequest.data.mimes).to.equal('video/mp4');
+    expect(serverRequest.data.min_dur).to.equal(5);
+    expect(serverRequest.data.max_dur).to.equal(30);
+    expect(serverRequest.data.min_btr).to.equal(500);
+    expect(serverRequest.data.max_btr).to.equal(1000);
+    expect(serverRequest.data.api).to.equal('2');
+    expect(serverRequest.data.skippable).to.equal('ALLOW');
+  });
+
+  it('Verify build video request with video params', function () {
+    const serverRequests = spec.buildRequests([videoBidRequestWithVideoParams]);
+    let serverRequest = serverRequests[0];
+    expect(serverRequest.url).to.equal('https://px.adhigh.net/rtb/direct_vast');
+    expect(serverRequest.method).to.equal('GET');
+    expect(serverRequest.data.bid_id).to.equal('bid789');
+    expect(serverRequest.data.pid).to.equal('p1001');
+    expect(serverRequest.data.tid).to.equal('t1001');
+    expect(serverRequest.data.size).to.equal('300x250');
+    expect(serverRequest.data.is_video).to.equal(true);
+    expect(serverRequest.data.mimes).to.equal('video/mp4,application/javascript');
+    expect(serverRequest.data.max_dur).to.equal(20);
+    expect(serverRequest.data.api).to.equal('1,2');
+    expect(serverRequest.data.skippable).to.equal('ALLOW');
+  });
+
+  it('Verify bid floor without price floors module', function() {
+    const bidRequestWithFloor = deepClone(bidRequests[0]);
+    bidRequestWithFloor.params.floor = 10
+    bidRequestWithFloor.params.cur = 'USD'
+
+    const serverRequests = spec.buildRequests([bidRequestWithFloor]);
+    let serverRequest = serverRequests[0];
+    expect(serverRequest.data.cur).to.equal('USD');
+    expect(serverRequest.data.floor).to.equal(10);
+  });
+
+  it('Verify bid floor with price floors module', function() {
+    const bidRequestWithFloor = deepClone(bidRequests[0]);
+    bidRequestWithFloor.params.floor = 10
+    bidRequestWithFloor.params.cur = 'USD'
+    const getFloorResponse = {floor: 5, currency: 'EUR'};
+    bidRequestWithFloor.getFloor = () => getFloorResponse;
+
+    const serverRequests = spec.buildRequests([bidRequestWithFloor]);
+    let serverRequest = serverRequests[0];
+    expect(serverRequest.data.cur).to.equal('EUR');
+    expect(serverRequest.data.floor).to.equal(5);
+  });
+
+  it('Verify parse response', function () {
+    const serverResponse = {
+      body: {
+        bid_id: 'bid12345',
+        cpm: 2.25,
+        currency: 'USD',
+        size: '300x250',
+        creative_id: '1000',
+        ad: 'Ad markup'
+      },
+      headers: {
+      }
+    };
+    const bids = spec.interpretResponse(serverResponse);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(2.25);
+    expect(bid.currency).to.equal('USD');
+    expect(bid.creativeId).to.equal('1000');
+    expect(bid.width).to.equal(300);
+    expect(bid.height).to.equal(250);
+    expect(bid.requestId).to.equal('bid12345');
+    expect(bid.mediaType).to.equal('banner');
+    expect(bid.ad).to.equal('Ad markup');
+  });
+
+  it('Verify parse video response', function () {
+    const serverResponse = {
+      body: {
+        bid_id: 'bid789',
+        cpm: 3.25,
+        currency: 'USD',
+        size: '300x250',
+        creative_id: '2000',
+        vast_url: 'https://vast.xml/url'
+      },
+      headers: {
+      }
+    };
+    const bids = spec.interpretResponse(serverResponse);
+    expect(bids).to.have.lengthOf(1);
+    const bid = bids[0];
+    expect(bid.cpm).to.equal(3.25);
+    expect(bid.currency).to.equal('USD');
+    expect(bid.creativeId).to.equal('2000');
+    expect(bid.width).to.equal(300);
+    expect(bid.height).to.equal(250);
+    expect(bid.requestId).to.equal('bid789');
+    expect(bid.mediaType).to.equal('video');
+    expect(bid.vastUrl).to.equal('https://vast.xml/url');
+  });
+
+  it('Verify bidder code', function () {
+    expect(spec.code).to.equal('getintent');
+  });
+
+  it('Verify bidder aliases', function () {
+    expect(spec.aliases).to.have.lengthOf(1);
+    expect(spec.aliases[0]).to.equal('getintentAdapter');
+  });
+
+  it('Verify supported media types', function () {
+    expect(spec.supportedMediaTypes).to.have.lengthOf(2);
+    expect(spec.supportedMediaTypes[0]).to.equal('video');
+    expect(spec.supportedMediaTypes[1]).to.equal('banner');
+  });
+
+  it('Verify if bid request valid', function () {
+    expect(spec.isBidRequestValid(bidRequests[0])).to.equal(true);
+    expect(spec.isBidRequestValid(bidRequests[1])).to.equal(true);
+    expect(spec.isBidRequestValid({})).to.equal(false);
+    expect(spec.isBidRequestValid({ params: {} })).to.equal(false);
+    expect(spec.isBidRequestValid({ params: { test: 123 } })).to.equal(false);
+    expect(spec.isBidRequestValid({ params: { pid: 111, tid: 222 } })).to.equal(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Other

## Description of change
Adapter adopted with Prebid v5 requirements
- use floors module for bid floors
- add advertiserDomains to bid response
- support video parameters at the adunit level
- update tests

## Test parameters for validating bids
```
const adUnits = [
			{
				code: 'adunit-code-1',
				mediaTypes: {
					banner: {
						sizes: [[300, 250], [300, 600]],
					}
				},
				bids: [
					{
						bidder: "getintent",
						params: {
							pid: "7",
							tid: "test01",
						},
						mediaType: "banner"
					},
				],
			},
			{
				code: 'adunit-code-2',
				mediaTypes: {
					video: {
						playerSize: [320, 250],
					},
				},
				bids: [
					{
						bidder: "getintent",
						params: {
							pid: "7",
							tid: "test01",
						},
						mediaType: "video"
					},
				],
			}
		];
```

- contact email of the adapter’s maintainer: a.fominov@qvant.ru
- [x] official adapter submission

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/3132
