### PR TITLE
OpenX Bid Adapter: read first party data segments

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -318,6 +318,10 @@ function appendUserIdsToQueryParams(queryParams, userIds) {
           break;
         case 'lipb':
           queryParams[key] = userIdObjectOrValue.lipbid;
+          if (Array.isArray(userIdObjectOrValue.segments) && userIdObjectOrValue.segments.length > 0) {
+            const liveIntentSegments = 'liveintent:' + userIdObjectOrValue.segments.join('|')
+            queryParams.sm = `${queryParams.sm ? queryParams.sm + encodeURIComponent(',') : ''}${encodeURIComponent(liveIntentSegments)}`;
+          }
           break;
         case 'parrableId':
           queryParams[key] = userIdObjectOrValue.eid;

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -248,6 +248,24 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     nocache: new Date().getTime()
   };
 
+  const firstPartyData = config.getConfig('ortb2.user.data')
+  if (Array.isArray(firstPartyData) && firstPartyData.length > 0) {
+    const sm = firstPartyData
+      .filter(
+        data => (Array.isArray(data.segment) &&
+                data.segment.length > 0 &&
+                data.name !== undefined &&
+                data.name.length > 0)
+      )
+      .map(
+        data => data.name + ':' + data.segment.map(seg => seg.id).join('|')
+      )
+      .join(',')
+    if (sm.length > 0) {
+      defaultParams.sm = encodeURIComponent(sm);
+    }
+  }
+
   if (bids[0].params.platform) {
     defaultParams.ph = bids[0].params.platform;
   }

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -263,10 +263,8 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
         acc[name] = (acc[name] || []).concat(data.segment.map(seg => seg.id));
         return acc;
       }, {})
-    const sm = Object.entries(fpd)
-      .map(
-        ([name, segs], _) => name + ':' + segs.join('|')
-      )
+    const sm = Object.keys(fpd)
+      .map((name, _) => name + ':' + fpd[name].join('|'))
       .join(',')
     if (sm.length > 0) {
       defaultParams.sm = encodeURIComponent(sm);

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1534,18 +1534,32 @@ describe('OpenxAdapter', function () {
       describe('with segments', function () {
         const TESTS = [
           {
-            name: 'should send out the provider/segment data from first party config',
+            name: 'should send proprietary segment data from first party config',
             config: {
               ortb2: {
                 user: {
                   data: [
-                    {name: 'dmp1', segment: [{id: 'foo'}, {id: 'bar'}]},
+                    {name: 'dmp1', ext: {segtax: 4}, segment: [{id: 'foo'}, {id: 'bar'}]},
                     {name: 'dmp2', segment: [{id: 'baz'}]},
                   ]
                 }
               }
             },
-            expect: 'dmp1:foo|bar,dmp2:baz',
+            expect: 'dmp1/4:foo|bar,dmp2:baz',
+          },
+          {
+            name: 'should combine same provider segment data from first party config',
+            config: {
+              ortb2: {
+                user: {
+                  data: [
+                    {name: 'dmp1', ext: {segtax: 4}, segment: [{id: 'foo'}, {id: 'bar'}]},
+                    {name: 'dmp1', ext: {}, segment: [{id: 'baz'}]},
+                  ]
+                }
+              }
+            },
+            expect: 'dmp1/4:foo|bar,dmp1:baz',
           },
           {
             name: 'should not send any segment data if first party config is incomplete',

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -122,6 +122,84 @@ describe('OpenxAdapter', function () {
     }
   };
 
+  // Sample bid requests
+
+  const BANNER_BID_REQUESTS_WITH_MEDIA_TYPES = [{
+    bidder: 'openx',
+    params: {
+      unit: '11',
+      delDomain: 'test-del-domain'
+    },
+    adUnitCode: '/adunit-code/test-path',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250], [300, 600]]
+      }
+    },
+    bidId: 'test-bid-id-1',
+    bidderRequestId: 'test-bid-request-1',
+    auctionId: 'test-auction-1',
+    ortb2Imp: { ext: { data: { pbadslot: '/12345/my-gpt-tag-0' } } },
+  }, {
+    bidder: 'openx',
+    params: {
+      unit: '22',
+      delDomain: 'test-del-domain'
+    },
+    adUnitCode: 'adunit-code',
+    mediaTypes: {
+      banner: {
+        sizes: [[728, 90]]
+      }
+    },
+    bidId: 'test-bid-id-2',
+    bidderRequestId: 'test-bid-request-2',
+    auctionId: 'test-auction-2',
+    ortb2Imp: { ext: { data: { pbadslot: '/12345/my-gpt-tag-1' } } },
+  }];
+
+  const VIDEO_BID_REQUESTS_WITH_MEDIA_TYPES = [{
+    bidder: 'openx',
+    mediaTypes: {
+      video: {
+        playerSize: [640, 480]
+      }
+    },
+    params: {
+      unit: '12345678',
+      delDomain: 'test-del-domain'
+    },
+    adUnitCode: 'adunit-code',
+
+    bidId: '30b31c1838de1e',
+    bidderRequestId: '22edbae2733bf6',
+    auctionId: '1d1a030790a475',
+    transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e',
+    ortb2Imp: { ext: { data: { pbadslot: '/12345/my-gpt-tag-0' } } },
+  }];
+
+  const MULTI_FORMAT_BID_REQUESTS = [{
+    bidder: 'openx',
+    params: {
+      unit: '12345678',
+      delDomain: 'test-del-domain'
+    },
+    adUnitCode: 'adunit-code',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      },
+      video: {
+        playerSize: [300, 250]
+      }
+    },
+    bidId: '30b31c1838de1e',
+    bidderRequestId: '22edbae2733bf6',
+    auctionId: '1d1a030790a475',
+    transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e',
+    ortb2Imp: { ext: { data: { pbadslot: '/12345/my-gpt-tag-0' } } },
+  }];
+
   describe('inherited functions', function () {
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
@@ -181,28 +259,8 @@ describe('OpenxAdapter', function () {
 
     describe('when request is for a multiformat ad', function () {
       describe('and request config uses mediaTypes video and banner', () => {
-        const multiformatBid = {
-          bidder: 'openx',
-          params: {
-            unit: '12345678',
-            delDomain: 'test-del-domain'
-          },
-          adUnitCode: 'adunit-code',
-          mediaTypes: {
-            banner: {
-              sizes: [[300, 250]]
-            },
-            video: {
-              playerSize: [300, 250]
-            }
-          },
-          bidId: '30b31c1838de1e',
-          bidderRequestId: '22edbae2733bf6',
-          auctionId: '1d1a030790a475',
-          transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e'
-        };
         it('should return true multisize when required params found', function () {
-          expect(spec.isBidRequestValid(multiformatBid)).to.equal(true);
+          expect(spec.isBidRequestValid(MULTI_FORMAT_BID_REQUESTS[0])).to.equal(true);
         });
       });
     });
@@ -327,39 +385,7 @@ describe('OpenxAdapter', function () {
   });
 
   describe('buildRequests for banner ads', function () {
-    const bidRequestsWithMediaTypes = [{
-      'bidder': 'openx',
-      'params': {
-        'unit': '11',
-        'delDomain': 'test-del-domain'
-      },
-      'adUnitCode': '/adunit-code/test-path',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250], [300, 600]]
-        }
-      },
-      'bidId': 'test-bid-id-1',
-      'bidderRequestId': 'test-bid-request-1',
-      'auctionId': 'test-auction-1',
-      'ortb2Imp': { ext: { data: { pbadslot: '/12345/my-gpt-tag-0' } } }
-    }, {
-      'bidder': 'openx',
-      'params': {
-        'unit': '22',
-        'delDomain': 'test-del-domain'
-      },
-      'adUnitCode': 'adunit-code',
-      mediaTypes: {
-        banner: {
-          sizes: [[728, 90]]
-        }
-      },
-      'bidId': 'test-bid-id-2',
-      'bidderRequestId': 'test-bid-request-2',
-      'auctionId': 'test-auction-2',
-      'ortb2Imp': { ext: { data: { pbadslot: '/12345/my-gpt-tag-1' } } }
-    }];
+    const bidRequestsWithMediaTypes = BANNER_BID_REQUESTS_WITH_MEDIA_TYPES;
 
     const bidRequestsWithPlatform = [{
       'bidder': 'openx',
@@ -1235,25 +1261,7 @@ describe('OpenxAdapter', function () {
   });
 
   describe('buildRequests for video', function () {
-    const bidRequestsWithMediaTypes = [{
-      'bidder': 'openx',
-      'mediaTypes': {
-        video: {
-          playerSize: [640, 480]
-        }
-      },
-      'params': {
-        'unit': '12345678',
-        'delDomain': 'test-del-domain'
-      },
-      'adUnitCode': 'adunit-code',
-
-      'bidId': '30b31c1838de1e',
-      'bidderRequestId': '22edbae2733bf6',
-      'auctionId': '1d1a030790a475',
-      'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e',
-      'ortb2Imp': { ext: { data: { pbadslot: '/12345/my-gpt-tag-0' } } }
-    }];
+    const bidRequestsWithMediaTypes = VIDEO_BID_REQUESTS_WITH_MEDIA_TYPES;
     const mockBidderRequest = {refererInfo: {}};
 
     it('should send bid request to openx url via GET, with mediaTypes having video parameter', function () {
@@ -1506,26 +1514,7 @@ describe('OpenxAdapter', function () {
   });
 
   describe('buildRequest for multi-format ad', function () {
-    const multiformatBid = {
-      bidder: 'openx',
-      params: {
-        unit: '12345678',
-        delDomain: 'test-del-domain'
-      },
-      adUnitCode: 'adunit-code',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
-        },
-        video: {
-          playerSize: [300, 250]
-        }
-      },
-      bidId: '30b31c1838de1e',
-      bidderRequestId: '22edbae2733bf6',
-      auctionId: '1d1a030790a475',
-      transactionId: '4008d88a-8137-410b-aa35-fbfdabcb478e'
-    };
+    const multiformatBid = MULTI_FORMAT_BID_REQUESTS[0];
     let mockBidderRequest = {refererInfo: {}};
 
     it('should default to a banner request', function () {
@@ -1535,6 +1524,78 @@ describe('OpenxAdapter', function () {
       expect(dataParams.divids).to.have.string(multiformatBid.adUnitCode);
     });
   });
+
+  describe('buildRequests for all kinds of ads', function () {
+    utils._each({
+      banner: BANNER_BID_REQUESTS_WITH_MEDIA_TYPES,
+      video: VIDEO_BID_REQUESTS_WITH_MEDIA_TYPES,
+      multi: MULTI_FORMAT_BID_REQUESTS
+    }, (bidRequests, name) => {
+      describe('when first party data is configured', function () {
+        const TESTS = [
+          {
+            name: 'should send out the two providers with their segments',
+            config: {
+              ortb2: {
+                user: {
+                  data: [
+                    {name: 'dmp1', segment: [{id: 'foo'}, {id: 'bar'}]},
+                    {name: 'dmp2', segment: [{id: 'baz'}]},
+                  ]
+                }
+              }
+            },
+            expect: 'dmp1:foo|bar,dmp2:baz',
+          },
+          {
+            name: 'should not send segments if config is incomplete',
+            config: {
+              ortb2: {
+                user: {
+                  data: [
+                    {name: 'provider-with-no-segments'},
+                    {segment: [{id: 'segments-with-no-provider'}]},
+                    {},
+                  ]
+                }
+              }
+            }
+          }
+        ];
+        utils._each(TESTS, (t) => {
+          context('in ortb2.user.data', function () {
+            let configStub;
+
+            beforeEach(function () {
+              let fpdConfig = t.config
+              configStub = sinon
+                .stub(config, 'getConfig')
+                .withArgs('ortb2.user.data')
+                .callsFake((key) => {
+                  return utils.deepAccess(fpdConfig, key);
+                });
+            });
+
+            afterEach(function () {
+              config.getConfig.restore();
+            });
+
+            const mockBidderRequest = {refererInfo: {}};
+            it(`${t.name} for type ${name}`, function () {
+              const request = spec.buildRequests(bidRequests, mockBidderRequest)
+              expect(request.length).to.equal(1);
+              if (t.expect) {
+                expect(request[0].data.sm).to.exist;
+                expect(request[0].data.sm).to.equal(encodeURIComponent(t.expect));
+              } else {
+                expect(request[0].data.sm).to.not.exist;
+              }
+            });
+          });
+        });
+      });
+    });
+  })
 
   describe('interpretResponse for banner ads', function () {
     beforeEach(function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
1. Read fpd segment data from ortb2.user.data and send out in `sm` query parameter. Intended for permutive but others will also work.
2. Read [liveintent segments](https://docs.prebid.org/dev-docs/modules/userId.html#liveintent-nonid) from request `userId.lipb.segments` and send in the same `sm` query parameter.
3. (tests refactor) Moved bid request samples higher so they can be reused in the new tests without duplicating them again.
