### PR TITLE
Criteo Bid Adapter: fix creativeId with correct value

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -134,7 +134,7 @@ export const spec = {
           currency: slot.currency,
           netRevenue: true,
           ttl: slot.ttl || 60,
-          creativeId: bidId,
+          creativeId: slot.creativecode,
           width: slot.width,
           height: slot.height,
           dealId: slot.dealCode,

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -923,6 +923,7 @@ describe('The Criteo bidding adapter', function () {
             impid: 'test-requestId',
             cpm: 1.23,
             creative: 'test-ad',
+            creativecode: 'test-crId',
             width: 728,
             height: 90,
             dealCode: 'myDealCode',
@@ -944,6 +945,7 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].requestId).to.equal('test-bidId');
       expect(bids[0].cpm).to.equal(1.23);
       expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].creativeId).to.equal('test-crId');
       expect(bids[0].width).to.equal(728);
       expect(bids[0].height).to.equal(90);
       expect(bids[0].dealId).to.equal('myDealCode');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

This is a small fix to set the correct value to the `creativeId` field.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
