### PR TITLE
Include timing info in pbjs_debug=true console log

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -274,6 +274,19 @@ export function logError() {
   events.emit(CONSTANTS.EVENTS.AUCTION_DEBUG, {type: 'ERROR', arguments: arguments});
 }
 
+let getTimestamp;
+if (window.performance && window.performance.now) {
+  getTimestamp = function getTimestamp() {
+    // truncate any partial millisecond
+    return window.performance.now() | 0;
+  }
+} else {
+  const initTime = +new Date();
+  getTimestamp = function getTimestamp() {
+    return new Date() - initTime;
+  }
+}
+
 function decorateLog(args, prefix) {
   args = [].slice.call(args);
   let bidder = config.getCurrentBidder();
@@ -282,6 +295,7 @@ function decorateLog(args, prefix) {
   if (bidder) {
     args.unshift(label('#aaa'));
   }
+  args.unshift(getTimestamp());
   args.unshift(label('#3b88c3'));
   args.unshift('%cPrebid' + (bidder ? `%c${bidder}` : ''));
   return args;


### PR DESCRIPTION
Include the number of milliseconds since the page load

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
  - Improvements to pbjs_debug logging
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
  - Yes, e.g., the screenshot at https://docs.prebid.org/dev-docs/prebid-troubleshooting-guide.html will need updating. But the screenshot seems out of date even with the current code.

## Description of change

PrebidJS logging is extremely useful. One way it could be improved even further is by adding timestamps to the logs so that it's easier to get a picture of what's happening when. This PR does that.

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
  - PENDING

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
