### PR TITLE
PrebidServer Bid Adapter: add appnexuspsp to S2S Vendors

### DIFF
--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -13,6 +13,15 @@ export const S2S_VENDORS = {
     },
     timeout: 1000
   },
+  'appnexuspsp': {
+    adapter: 'prebidServer',
+    enabled: true,
+    endpoint: {
+      p1Consent: 'https://ib.adnxs.com/openrtb2/prebid',
+      noP1Consent: 'https://ib.adnxs-simple.com/openrtb2/prebid'
+    },
+    timeout: 1000
+  },
   'rubicon': {
     adapter: 'prebidServer',
     enabled: true,

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2579,6 +2579,27 @@ describe('S2S Adapter', function () {
       expect(vendorConfig).to.have.property('timeout', 750);
     });
 
+    it('should configure the s2sConfig object with appnexuspsp vendor defaults unless specified by user', function () {
+      const options = {
+        accountId: '123',
+        bidders: ['appnexus'],
+        defaultVendor: 'appnexuspsp',
+        timeout: 750
+      };
+
+      config.setConfig({ s2sConfig: options });
+      sinon.assert.notCalled(logErrorSpy);
+
+      let vendorConfig = config.getConfig('s2sConfig');
+      expect(vendorConfig).to.have.property('accountId', '123');
+      expect(vendorConfig).to.have.property('adapter', 'prebidServer');
+      expect(vendorConfig.bidders).to.deep.equal(['appnexus']);
+      expect(vendorConfig.enabled).to.be.true;
+      expect(vendorConfig.endpoint).to.deep.equal({p1Consent: 'https://ib.adnxs.com/openrtb2/prebid', noP1Consent: 'https://ib.adnxs-simple.com/openrtb2/prebid'});
+      expect(vendorConfig.syncEndpoint).to.be.undefined;
+      expect(vendorConfig).to.have.property('timeout', 750);
+    });
+
     it('should configure the s2sConfig object with rubicon vendor defaults unless specified by user', function () {
       const options = {
         accountId: 'abc',


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
Adding a new `defaultVendor` option for the PBS adapter.

It is expected that the `syncEndpoint` is not present, as this system handles it differently on the back-end.