### PR TITLE
Between Bid Adapter: add sharedid for Prebid 5.0

### DIFF
--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -1,5 +1,5 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import { getAdUnitSizes, parseSizesInput , deepAccess } from '../src/utils.js';
+import { getAdUnitSizes, parseSizesInput, deepAccess } from '../src/utils.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 
 const BIDDER_CODE = 'between';

--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -1,5 +1,5 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import { getAdUnitSizes, parseSizesInput } from '../src/utils.js';
+import { getAdUnitSizes, parseSizesInput , deepAccess } from '../src/utils.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 
 const BIDDER_CODE = 'between';
@@ -37,6 +37,8 @@ export const spec = {
         tz: getTz(),
         fl: getFl(),
         rr: getRr(),
+        shid: getSharedId(i)('id'),
+        shid3: getSharedId(i)('third'),
         s: i.params.s,
         bidid: i.bidId,
         transactionid: i.transactionId,
@@ -144,6 +146,15 @@ export const spec = {
       url: 'https://ads.betweendigital.com/sspmatch-iframe'
     });
     return syncs;
+  }
+}
+
+function getSharedId(bid) {
+  const id = deepAccess(bid, 'userId.sharedid.id');
+  const third = deepAccess(bid, 'userId.sharedid.third');
+  return function(kind) {
+    if (kind === 'id') return id || '';
+    return third || '';
   }
 }
 

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -221,7 +221,54 @@ describe('betweenBidAdapterTests', function () {
 
     expect(req_data.sizes).to.deep.equal(['970x250', '240x400', '728x90'])
   });
-
+  
+  it('check sharedId with id and third', function() {
+    const bidRequestData = [{
+      bidId: 'bid123',
+      bidder: 'between',
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      },
+      params: {
+        s: 1112,
+      },
+      userId: {
+        sharedid: {
+          id: '01EXQE7JKNDRDDVATB0S2GX1NT',
+          third: '01EXQE7JKNDRDDVATB0S2GX1NT'
+        }
+      }
+    }];
+    const shid = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid;
+    const shid3 = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid3;
+    expect(shid).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT') && expect(shid3).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT');
+  });
+  
+  it('check sharedId with only id', function() {
+    const bidRequestData = [{
+      bidId: 'bid123',
+      bidder: 'between',
+      mediaTypes: {
+        banner: {
+          sizes: [[728, 90]]
+        }
+      },
+      params: {
+        s: 1112,
+      },
+      userId: {
+        sharedid: {
+          id: '01EXQE7JKNDRDDVATB0S2GX1NT',
+        }
+      }
+    }];
+    const shid = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid;
+    const shid3 = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid3;
+    expect(shid).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT') && expect(shid3).to.equal('');
+  });
+  
   it('check adomain', function() {
     const serverResponse = {
       body: [{

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -221,7 +221,7 @@ describe('betweenBidAdapterTests', function () {
 
     expect(req_data.sizes).to.deep.equal(['970x250', '240x400', '728x90'])
   });
-  
+
   it('check sharedId with id and third', function() {
     const bidRequestData = [{
       bidId: 'bid123',
@@ -245,7 +245,7 @@ describe('betweenBidAdapterTests', function () {
     const shid3 = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid3;
     expect(shid).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT') && expect(shid3).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT');
   });
-  
+
   it('check sharedId with only id', function() {
     const bidRequestData = [{
       bidId: 'bid123',
@@ -268,7 +268,7 @@ describe('betweenBidAdapterTests', function () {
     const shid3 = JSON.parse(spec.buildRequests(bidRequestData).data)[0].data.shid3;
     expect(shid).to.equal('01EXQE7JKNDRDDVATB0S2GX1NT') && expect(shid3).to.equal('');
   });
-  
+
   it('check adomain', function() {
     const serverResponse = {
       body: [{


### PR DESCRIPTION
This fixes an accidental deletion when moving to Prebid 5. Assumed all adapters had bothh SharedId and PubcommonID. Fix for issue #7221 