### PR TITLE
Adyoulike bidder - Video playerSize format

### DIFF
--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -86,6 +86,11 @@ export const spec = {
         }
         if (mediatype === VIDEO) {
           accumulator[bidReq.bidId].Video = bidReq.mediaTypes.video;
+
+          const size = bidReq.mediaTypes.video.playerSize;
+          if (Array.isArray(size) && !Array.isArray(size[0])) {
+            accumulator[bidReq.bidId].Video.playerSize = [size];
+          }
         }
         return accumulator;
       }, {}),


### PR DESCRIPTION
## Type of change
Minor improvement.
make sure the video size format is consistent.


## Description of change
The player size is sent with Array of array's like multiple size are needed even if only one size is necessary. 
This improvement makes sure this behavior won't change and break our ad server video response.

- contact email of the adapter’s maintainer
guillaume.andouard@adyoulike.com

- [*] official adapter submission

please see: 
 https://github.com/prebid/Prebid.js/issues/7217e