### PR TITLE
Pubmatic Analytics Adapter: extend timeout on flaky tests

### DIFF
--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -304,7 +304,7 @@ describe('pubmatic analytics adapter', function () {
 
     it('Logger: best case + win tracker', function() {
       this.timeout(5000)
-      
+
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
         return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
       });

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -303,6 +303,8 @@ describe('pubmatic analytics adapter', function () {
     });
 
     it('Logger: best case + win tracker', function() {
+      this.timeout(5000)
+      
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
         return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
       });
@@ -413,6 +415,7 @@ describe('pubmatic analytics adapter', function () {
     it('bidCpmAdjustment: USD: Logger: best case + win tracker', function() {
       const bidCopy = utils.deepClone(BID);
       bidCopy.cpm = bidCopy.originalCpm * 2; //  bidCpmAdjustment => bidCpm * 2
+      this.timeout(5000)
 
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
         return [bidCopy, MOCK.BID_RESPONSE[1]]


### PR DESCRIPTION
Extending the timeout seems to have helped a lot with the amount of flakiness in the Prebid Analytics Adapter. Adding an extended timeout to two pubmatic tests that commonly fail due to the test timing out. Ran this through CircleCI several times without any issues.