### PR TITLE
Prebid Core: Add readConfig functionality to clone the config instead of referencing it

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -312,7 +312,27 @@ export function newConfig() {
         return memo;
       }, {});
     }
-    return deepClone(config);
+    return Object.assign({}, config);
+  }
+
+  /*
+   * Returns a clone of the configuration object if called without parameters,
+   * or single configuration property if given a string matching a configuration
+   * property name.  Allows deep access e.g. getConfig('currency.adServerCurrency')
+   *
+   * If called with callback parameter, or a string and a callback parameter,
+   * subscribes to configuration updates. See `subscribe` function for usage.
+   *
+   * The object returned is a deepClone of the `config` property.
+   */
+  function readConfig(...args) {
+    if (args.length <= 1 && typeof args[0] !== 'function') {
+      const option = args[0];
+      const configClone = deepClone(_getConfig());
+      return option ? utils.deepAccess(configClone, option) : configClone;
+    }
+
+    return subscribe(...args);
   }
 
   /*
@@ -629,6 +649,7 @@ export function newConfig() {
     getCurrentBidder,
     resetBidder,
     getConfig,
+    readConfig,
     setConfig,
     setDefaults,
     resetConfig,

--- a/src/config.js
+++ b/src/config.js
@@ -316,7 +316,7 @@ export function newConfig() {
   }
 
   /*
-   * Returns a clone of the configuration object if called without parameters,
+   * Returns the configuration object if called without parameters,
    * or single configuration property if given a string matching a configuration
    * property name.  Allows deep access e.g. getConfig('currency.adServerCurrency')
    *

--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@ import { isValidPriceConfig } from './cpmBucketManager.js';
 import find from 'core-js-pure/features/array/find.js';
 import includes from 'core-js-pure/features/array/includes.js';
 import Set from 'core-js-pure/features/set';
-import { mergeDeep } from './utils.js';
+import { mergeDeep, deepClone } from './utils.js';
 
 const from = require('core-js-pure/features/array/from.js');
 const utils = require('./utils.js');
@@ -312,7 +312,7 @@ export function newConfig() {
         return memo;
       }, {});
     }
-    return Object.assign({}, config);
+    return deepClone(config);
   }
 
   /*

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -897,6 +897,7 @@ $$PREBID_GLOBAL$$.markWinningBidAsUsed = function (markBidRequest) {
  * @alias module:pbjs.getConfig
  */
 $$PREBID_GLOBAL$$.getConfig = config.getConfig;
+$$PREBID_GLOBAL$$.readConfig = config.readConfig;
 
 /**
  * Set Prebid config options.

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -6,6 +6,7 @@ const utils = require('src/utils');
 
 let getConfig;
 let setConfig;
+let readConfig;
 let getBidderConfig;
 let setBidderConfig;
 let setDefaults;
@@ -17,6 +18,7 @@ describe('config API', function () {
     const config = newConfig();
     getConfig = config.getConfig;
     setConfig = config.setConfig;
+    readConfig = config.readConfig;
     getBidderConfig = config.getBidderConfig;
     setBidderConfig = config.setBidderConfig;
     setDefaults = config.setDefaults;
@@ -35,6 +37,15 @@ describe('config API', function () {
 
   it('getConfig returns an object', function () {
     expect(getConfig()).to.be.a('object');
+  });
+
+  it('readConfig returns deepCopy of the internal config object', function () {
+    setConfig({ foo: {biz: 'bar'} });
+    const config1 = readConfig('foo');
+    config1.biz = 'buz';
+    const config2 = readConfig('foo');
+    expect(readConfig()).to.be.a('object');
+    expect(config1.biz).to.not.equal(config2.biz);
   });
 
   it('sets and gets arbitrary configuration properties', function () {

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -48,6 +48,58 @@ describe('config API', function () {
     expect(config1.biz).to.not.equal(config2.biz);
   });
 
+  it('readConfig retrieves arbitrary configuration properties', function () {
+    setConfig({ baz: 'qux' });
+    expect(readConfig('baz')).to.equal('qux');
+  });
+
+  it('readConfig has subscribe functionality for adding listeners to config updates', function () {
+    const listener = sinon.spy();
+
+    readConfig(listener);
+
+    setConfig({ foo: 'bar' });
+
+    sinon.assert.calledOnce(listener);
+    sinon.assert.calledWith(listener, { foo: 'bar' });
+  });
+
+  it('readConfig subscribers can unsubscribe', function () {
+    const listener = sinon.spy();
+
+    const unsubscribe = getConfig(listener);
+
+    unsubscribe();
+
+    readConfig({ logging: true });
+
+    sinon.assert.notCalled(listener);
+  });
+
+  it('readConfig subscribers can subscribe to topics', function () {
+    const listener = sinon.spy();
+
+    readConfig('logging', listener);
+
+    setConfig({ logging: true, foo: 'bar' });
+
+    sinon.assert.calledOnce(listener);
+    sinon.assert.calledWithExactly(listener, { logging: true });
+  });
+
+  it('readConfig topic subscribers are only called when that topic is changed', function () {
+    const listener = sinon.spy();
+    const wildcard = sinon.spy();
+
+    readConfig('subject', listener);
+    readConfig(wildcard);
+
+    setConfig({ foo: 'bar' });
+
+    sinon.assert.notCalled(listener);
+    sinon.assert.calledOnce(wildcard);
+  });
+
   it('sets and gets arbitrary configuration properties', function () {
     setConfig({ baz: 'qux' });
     expect(getConfig('baz')).to.equal('qux');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Related to issue: https://github.com/prebid/Prebid.js/issues/7238
When adapters retrieve the config object by calling `config.getConfig()`, they are also able to manipulate the underlying object.

This is because the `_getConfig()` function uses `Object.assign()` when returning the configuration.

Since `Object. assign()` copies an object's reference value, we can get scenarios where one adapter updates the config and another adapter is affected. 

For example:

Step 1: Config set by `setConfig()` on the page

```
pbjs.setConfig({
    ortb2: {
        user: {
            gender: “M”
        }
    }
});
```

Step 2: Another adapter updates the config by first calling `config.getConfig()`

```
var fpd = getConfig(‘ortb2’)
fpd.user.gender = “F”
```

Step 3: Downstream adapters now retrieve the manipulated config object
```
var fpd = getConfig(‘ortb2’)
console.log(fpd)
// Output: {ortb2: { user: {gender: “F”}}}
```

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```
Currently, Sovrn adapter retrieves the `fpd` by calling getConfig(‘ortb2’), and using that `fpd` object the updating ortb2.user.ext for their request.

https://github.com/prebid/Prebid.js/blob/master/modules/sovrnBidAdapter.js#L86-L118

In the case where Sovrn is loaded before Index Exchange, the IX adapter will see the changes made by Sovrn

## Test Page
- Go to https://bastello.com/ix/prebid-fpd2.php
- Open the console in the dev tools

## Steps to Reproduce

1. Verify the config object set by pbjs.setConfig() 
   - You can look at the page source for this (L49-L203)
2. Refresh the page and call the following function in the console
   - pbjs.getConfig('ortb2')
3. Verify the returned object is not the same as the one being set at the page level.
   - You will see the `eids` & `tpid` being added to the configuration by the sovrn adapter.


