### PR TITLE
gptPreAuction Module: update to include MCM support

### DIFF
--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -40,7 +40,7 @@ export const appendGptSlots = adUnits => {
 
 const sanitizeSlotPath = (path) => {
   const gptConfig = config.getConfig('gptPreAuction');
-  
+
   if (gptConfig && gptConfig.mcmEnabled) {
     return path.replace(/(^\/\d*),\d*\//, '$1/');
   }

--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -33,10 +33,20 @@ export const appendGptSlots = adUnits => {
       const context = adUnit.ortb2Imp.ext.data;
       context.adserver = context.adserver || {};
       context.adserver.name = 'gam';
-      context.adserver.adslot = slot.getAdUnitPath();
+      context.adserver.adslot = sanitizeSlotPath(slot.getAdUnitPath());
     }
   });
 };
+
+const sanitizeSlotPath = (path) => {
+  const gptConfig = config.getConfig('gptPreAuction');
+  
+  if (gptConfig && gptConfig.mcmEnabled) {
+    return path.replace(/(^\/\d*),\d*\//, '$1/');
+  }
+
+  return path;
+}
 
 export const appendPbAdSlot = adUnit => {
   adUnit.ortb2Imp = adUnit.ortb2Imp || {};

--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -39,9 +39,9 @@ export const appendGptSlots = adUnits => {
 };
 
 const sanitizeSlotPath = (path) => {
-  const gptConfig = config.getConfig('gptPreAuction');
+  const gptConfig = config.getConfig('gptPreAuction') || {};
 
-  if (gptConfig && gptConfig.mcmEnabled) {
+  if (gptConfig.mcmEnabled) {
     return path.replace(/(^\/\d*),\d*\//, '$1/');
   }
 

--- a/test/spec/modules/gptPreAuction_spec.js
+++ b/test/spec/modules/gptPreAuction_spec.js
@@ -95,7 +95,7 @@ describe('GPT pre-auction module', () => {
       expect(adUnit.ortb2Imp.ext.data.adserver).to.deep.equal({ name: 'gam', adslot: 'slotCode2' });
     });
 
-    it('will trim child id if mcmEnabled is not set to true', () => {
+    it('will trim child id if mcmEnabled is set to true', () => {
       config.setConfig({ gptPreAuction: { enabled: true, mcmEnabled: true } });
       window.googletag.pubads().setSlots([
         makeSlot({ code: '/12345,21212/slotCode1', divId: 'div1' }),

--- a/test/spec/modules/gptPreAuction_spec.js
+++ b/test/spec/modules/gptPreAuction_spec.js
@@ -95,6 +95,31 @@ describe('GPT pre-auction module', () => {
       expect(adUnit.ortb2Imp.ext.data.adserver).to.deep.equal({ name: 'gam', adslot: 'slotCode2' });
     });
 
+    it('will trim child id if mcmEnabled is not set to true', () => {
+      config.setConfig({ gptPreAuction: { enabled: true, mcmEnabled: true } });
+      window.googletag.pubads().setSlots([
+        makeSlot({ code: '/12345,21212/slotCode1', divId: 'div1' }),
+        makeSlot({ code: '/12345,21212/slotCode2', divId: 'div2' }),
+        makeSlot({ code: '/12345,21212/slotCode3', divId: 'div3' })
+      ]);
+      const adUnit = { code: '/12345,21212/slotCode2', ortb2Imp: { ext: { data: {} } } };
+      appendGptSlots([adUnit]);
+      expect(adUnit.ortb2Imp.ext.data.adserver).to.be.an('object');
+      expect(adUnit.ortb2Imp.ext.data.adserver).to.deep.equal({ name: 'gam', adslot: '/12345/slotCode2' });
+    });
+
+    it('will not trim child id if mcmEnabled is not set to true', () => {
+      window.googletag.pubads().setSlots([
+        makeSlot({ code: '/12345,21212/slotCode1', divId: 'div1' }),
+        makeSlot({ code: '/12345,21212/slotCode2', divId: 'div2' }),
+        makeSlot({ code: '/12345,21212/slotCode3', divId: 'div3' })
+      ]);
+      const adUnit = { code: '/12345,21212/slotCode2', ortb2Imp: { ext: { data: {} } } };
+      appendGptSlots([adUnit]);
+      expect(adUnit.ortb2Imp.ext.data.adserver).to.be.an('object');
+      expect(adUnit.ortb2Imp.ext.data.adserver).to.deep.equal({ name: 'gam', adslot: '/12345,21212/slotCode2' });
+    });
+
     it('should use the customGptSlotMatching function if one is given', () => {
       config.setConfig({
         gptPreAuction: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The gptPreAuction module is not be compatible with the approach/format that Google uses for MCM (Multiple Customer Management). This update addresses the underlying issue by trimming the child ID from the ad unit name.  

Ad Slot Definition: `/123456,7654321/Ad_Unit_Name/1234567890`

This is currently being passed via FPD as is under imp[].ext.data.pbadslot/adserver.adslot. SSPs will have issues reading this value due to the comma separated IDs. 

Trimmed Name for FPD: `/123456/Ad_Unit_Name/1234567890`

This update also includes a config enablement via 

```
pbjs.setConfig({
    gptPreAuction:{
        mcmEnabled: trrue
    }
});
```