### PR TITLE
Wipes Bid Adapter: make 5.0 compliant

### DIFF
--- a/modules/wipesBidAdapter.js
+++ b/modules/wipesBidAdapter.js
@@ -1,0 +1,71 @@
+import * as utils from '../src/utils.js';
+import {config} from '../src/config.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER} from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'wipes';
+const ALIAS_BIDDER_CODE = ['wi'];
+const SUPPORTED_MEDIA_TYPES = [BANNER]
+const ENDPOINT_URL = 'https://adn-srv.reckoner-api.com/v1/prebid';
+
+function isBidRequestValid(bid) {
+  switch (true) {
+    case !!(bid.params.asid):
+      break;
+    default:
+      utils.logWarn(`isBidRequestValid Error. ${bid.params}, please check your implementation.`);
+      return false;
+  }
+  return true;
+}
+
+function buildRequests(validBidRequests, bidderRequest) {
+  return validBidRequests.map(bidRequest => {
+    const bidId = bidRequest.bidId
+    const params = bidRequest.params;
+    const asid = params.asid;
+    return {
+      method: 'GET',
+      url: ENDPOINT_URL,
+      data: {
+        asid: asid,
+        bid_id: bidId,
+      }
+    }
+  });
+}
+
+function interpretResponse(serverResponse, bidRequest) {
+  const bidResponses = [];
+  const response = serverResponse.body;
+  const cpm = response.cpm || 0;
+  if (cpm !== 0) {
+    const netRevenue = (response.netRevenue === undefined) ? true : response.netRevenue;
+    const bidResponse = {
+      requestId: response.bid_id,
+      cpm: cpm,
+      width: response.width,
+      height: response.height,
+      creativeId: response.video_creative_id || 0,
+      dealId: response.deal_id,
+      currency: 'JPY',
+      netRevenue: netRevenue,
+      ttl: config.getConfig('_bidderTimeout'),
+      referrer: bidRequest.data.r || '',
+      mediaType: BANNER,
+      ad: response.ad_tag,
+    };
+    bidResponses.push(bidResponse);
+  }
+  return bidResponses;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ALIAS_BIDDER_CODE,
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  supportedMediaTypes: SUPPORTED_MEDIA_TYPES
+}
+registerBidder(spec);

--- a/test/spec/modules/wipesBidAdapter_spec.js
+++ b/test/spec/modules/wipesBidAdapter_spec.js
@@ -1,0 +1,150 @@
+import {expect} from 'chai';
+import {spec} from 'modules/wipesBidAdapter.js';
+import {newBidder} from 'src/adapters/bidderFactory.js';
+
+const ENDPOINT_URL = 'https://adn-srv.reckoner-api.com/v1/prebid';
+
+describe('wipesBidAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('isBidRequestValid', function () {
+    let bid = {
+      'bidder': 'wipes',
+      'params': {
+        asid: 'dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ'
+      },
+      'adUnitCode': 'adunit-code',
+      'bidId': '51ef8751f9aead',
+      'bidderRequestId': '15246a574e859f',
+      'auctionId': 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when asid not passed correctly', function () {
+      bid.params.asid = '';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when require params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    let bidRequests = [
+      {
+        'bidder': 'wipes',
+        'params': {
+          asid: 'dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ'
+        },
+        'adUnitCode': 'adunit-code',
+        'bidId': '51ef8751f9aead',
+        'bidderRequestId': '15246a574e859f',
+        'auctionId': 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      },
+      {
+        'bidder': 'wipes',
+        'params': {
+          asid: 'dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ'
+        },
+        'adUnitCode': 'adunit-code2',
+        'bidId': '51ef8751f9aead',
+        'bidderRequestId': '15246a574e859f',
+        'auctionId': 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      }
+    ];
+
+    let bidderRequest = {
+      refererInfo: {
+        numIframes: 0,
+        reachedTop: true,
+        referer: 'http://example.com',
+        stack: ['http://example.com']
+      }
+    };
+
+    const request = spec.buildRequests(bidRequests, bidderRequest);
+
+    it('sends bid request to our endpoint via GET', function () {
+      expect(request[0].method).to.equal('GET');
+      expect(request[1].method).to.equal('GET');
+    });
+
+    it('attaches source and version to endpoint URL as query params', function () {
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+      expect(request[1].url).to.equal(ENDPOINT_URL);
+    });
+
+    it('adUnitCode should be sent as uc parameters on any requests', function () {
+      expect(request[0].data.asid).to.equal('dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ');
+      expect(request[1].data.asid).to.equal('dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    let bidRequestVideo = [
+      {
+        'method': 'GET',
+        'url': ENDPOINT_URL,
+        'data': {
+          'asid': 'dWyPondh2EGB_bNlrVjzIXRZO9F0k1dpo0I8ZvQ',
+          'bid_id': '23beaa6af6cdde',
+        }
+      }
+    ];
+
+    let serverResponseVideo = {
+      body: {
+        'uuid': 'a42947f8-f8fd-4cf7-bb72-31a87ab1f6ff',
+        'ad_tag': '<!-- adtag -->',
+        'height': 160,
+        'width': 300,
+        'cpm': 850,
+        'status_message': '',
+        'currency': 'JPY',
+        'video_creative_id': 600004,
+        'bid_id': '23beaa6af6cdde'
+      }
+    };
+
+    it('should get the correct bid response for video', function () {
+      let expectedResponse = [{
+        'requestId': '23beaa6af6cdde',
+        'cpm': 850,
+        'width': 300,
+        'height': 160,
+        'creativeId': '600004',
+        'dealId': undefined,
+        'currency': 'JPY',
+        'netRevenue': true,
+        'ttl': 3000,
+        'referrer': '',
+        'mediaType': 'banner',
+        'ad': '<!-- adtag -->'
+      }];
+      let result = spec.interpretResponse(serverResponseVideo, bidRequestVideo[0]);
+      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+      expect(result[0].mediaType).to.equal(expectedResponse[0].mediaType);
+    });
+
+    it('handles empty bid response', function () {
+      let response = {
+        body: {
+          'uid': 'a42947f8-f8fd-4cf7-bb72-31a87ab1f6ff',
+          'height': 0,
+          'crid': '',
+          'statusMessage': '',
+          'width': 0,
+          'cpm': 0
+        }
+      };
+      let result = spec.interpretResponse(response, bidRequestVideo[0]);
+      expect(result.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
