### PR TITLE
Dev Tools (Babel): update babel target browser versions

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -16,12 +16,12 @@ module.exports = {
       {
         "targets": {
           "browsers": [
-            "chrome >= 70",
+            "chrome >= 75",
             "safari >=10",
-            "edge >= 14",
+            "edge >= 70",
             "ff >= 70",
             "ie >= 11",
-            "ios >= 9"
+            "ios >= 11"
           ]
         }
       }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -16,10 +16,10 @@ module.exports = {
       {
         "targets": {
           "browsers": [
-            "chrome >= 75",
-            "safari >=10",
+            "chrome >= 67",
+            "safari >=11.1",
             "edge >= 14",
-            "ff >= 78",
+            "ff >= 60",
             "ie >= 11",
             "ios >= 9"
           ]

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -16,10 +16,10 @@ module.exports = {
       {
         "targets": {
           "browsers": [
-            "chrome >= 67",
-            "safari >=11.1",
+            "chrome >= 70",
+            "safari >=10",
             "edge >= 14",
-            "ff >= 60",
+            "ff >= 70",
             "ie >= 11",
             "ios >= 9"
           ]

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -16,12 +16,12 @@ module.exports = {
       {
         "targets": {
           "browsers": [
-            "chrome >= 61",
-            "safari >=8",
+            "chrome >= 75",
+            "safari >=10",
             "edge >= 14",
-            "ff >= 57",
+            "ff >= 78",
             "ie >= 11",
-            "ios >= 8"
+            "ios >= 9"
           ]
         }
       }


### PR DESCRIPTION
Updates babel target browser versions to more recent versions. We could even go higher probably. Ios version change reduces the core bundle size by about 10% though

Per issue #6913 
