### PR TITLE
Rubicon Bid Adapter: Update DFP adunit code passing logic + remove pbadslot passing

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -979,7 +979,7 @@ function applyFPD(bidRequest, mediaType, data) {
   let fpd = utils.mergeDeep({}, config.getConfig('ortb2') || {}, BID_FPD);
   let impData = utils.deepAccess(bidRequest.ortb2Imp, 'ext.data') || {};
   const SEGTAX = {user: [4], site: [1, 2]};
-  const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
+  const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'p_gpid', keywords: 'kw'};
   const validate = function(prop, key, parentName) {
     if (key === 'data' && Array.isArray(prop)) {
       return prop.filter(name => name.segment && utils.deepAccess(name, 'ext.segtax') && SEGTAX[parentName] &&
@@ -1009,10 +1009,10 @@ function applyFPD(bidRequest, mediaType, data) {
   Object.keys(impData).forEach((key) => {
     if (key === 'adserver') {
       ['name', 'adslot'].forEach(prop => {
-        if (impData[key][prop]) impData[key][prop] = impData[key][prop].toString().replace(/^\/+/, '');
+        if (impData[key][prop]) impData[key][prop] = impData[key][prop].toString();
       });
     } else if (key === 'pbadslot') {
-      impData[key] = impData[key].toString().replace(/^\/+/, '');
+      impData[key] = impData[key].toString();
     }
   });
 
@@ -1031,7 +1031,11 @@ function applyFPD(bidRequest, mediaType, data) {
       });
     });
     Object.keys(impData).forEach((key) => {
-      (key === 'adserver') ? addBannerData(impData[key].adslot, name, key) : addBannerData(impData[key], 'site', key);
+      if (key === 'adserver' && impData[key].name === 'gam') {
+        addBannerData(impData[key].adslot, name, key);
+      } else if (key !== 'adserver' && key !== 'pbadslot') {
+        addBannerData(impData[key], 'site', key);
+      }
     });
   } else {
     if (Object.keys(impData).length) {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1006,16 +1006,6 @@ function applyFPD(bidRequest, mediaType, data) {
     data[loc] = (data[loc]) ? data[loc].concat(',', val) : val;
   }
 
-  Object.keys(impData).forEach((key) => {
-    if (key === 'adserver') {
-      ['name', 'adslot'].forEach(prop => {
-        if (impData[key][prop]) impData[key][prop] = impData[key][prop].toString();
-      });
-    } else if (key === 'pbadslot') {
-      impData[key] = impData[key].toString();
-    }
-  });
-
   if (mediaType === BANNER) {
     ['site', 'user'].forEach(name => {
       Object.keys(fpd[name]).forEach((key) => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1378,7 +1378,7 @@ describe('the rubicon adapter', function () {
             expect(data).to.not.have.property('tg_i.pbadslot');
           });
 
-          it('should send \"tg_i.pbadslot\" if \"ortb2Imp.ext.data.pbadslot\" value is a valid string', function () {
+          it('should NOT send \"tg_i.pbadslot\" even if \"ortb2Imp.ext.data.pbadslot\" value is a valid string', function () {
             bidderRequest.bids[0].ortb2Imp = {
               ext: {
                 data: {
@@ -1391,25 +1391,7 @@ describe('the rubicon adapter', function () {
             const data = parseQuery(request.data);
 
             expect(data).to.be.an('Object');
-            expect(data).to.have.property('tg_i.pbadslot');
-            expect(data['tg_i.pbadslot']).to.equal('abc');
-          });
-
-          it('should send \"tg_i.pbadslot\" if \"ortb2Imp.ext.data.pbadslot\" value is a valid string, but all leading slash characters should be removed', function () {
-            bidderRequest.bids[0].ortb2Imp = {
-              ext: {
-                data: {
-                  pbadslot: '/a/b/c'
-                }
-              }
-            }
-
-            const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
-            const data = parseQuery(request.data);
-
-            expect(data).to.be.an('Object');
-            expect(data).to.have.property('tg_i.pbadslot');
-            expect(data['tg_i.pbadslot']).to.equal('a/b/c');
+            expect(data).to.not.have.property('tg_i.pbadslot');
           });
         });
 
@@ -1457,11 +1439,12 @@ describe('the rubicon adapter', function () {
             expect(data).to.not.have.property('tg_i.dfp_ad_unit_code');
           });
 
-          it('should send \"tg_i.dfp_ad_unit_code\" if \"ortb2Imp.ext.data.adServer.adslot\" value is a valid string', function () {
+          it('should NOT send \"tg_i.dfp_ad_unit_code\" if \"ortb2Imp.ext.data.adServer.adslot\" value is a valid string but not from GAM', function () {
             bidderRequest.bids[0].ortb2Imp = {
               ext: {
                 data: {
                   adserver: {
+                    name: 'notGam',
                     adslot: 'abc'
                   }
                 }
@@ -1472,16 +1455,36 @@ describe('the rubicon adapter', function () {
             const data = parseQuery(request.data);
 
             expect(data).to.be.an('Object');
-            expect(data).to.have.property('tg_i.dfp_ad_unit_code');
-            expect(data['tg_i.dfp_ad_unit_code']).to.equal('abc');
+            expect(data).to.not.have.property('p_gpid');
           });
 
-          it('should send \"tg_i.dfp_ad_unit_code\" if \"ortb2Imp.ext.data.adServer.adslot\" value is a valid string, but all leading slash characters should be removed', function () {
+          it('should send \"tg_i.dfp_ad_unit_code\" if \"ortb2Imp.ext.data.adServer.adslot\" value is a valid string', function () {
             bidderRequest.bids[0].ortb2Imp = {
               ext: {
                 data: {
                   adserver: {
-                    adslot: 'a/b/c'
+                    name: 'gam',
+                    adslot: 'abc'
+                  }
+                }
+              }
+            }
+
+            const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+            const data = parseQuery(request.data);
+
+            expect(data).to.be.an('Object');
+            expect(data).to.have.property('p_gpid');
+            expect(data['p_gpid']).to.equal('abc');
+          });
+
+          it('should send \"tg_i.dfp_ad_unit_code\" if \"ortb2Imp.ext.data.adServer.adslot\" value is a valid string, but all leading slash characters should NOT be removed', function () {
+            bidderRequest.bids[0].ortb2Imp = {
+              ext: {
+                data: {
+                  adserver: {
+                    name: 'gam',
+                    adslot: '/a/b/c'
                   }
                 }
               }
@@ -1491,8 +1494,8 @@ describe('the rubicon adapter', function () {
             const data = parseQuery(request.data);
 
             expect(data).to.be.an('Object');
-            expect(data).to.have.property('tg_i.dfp_ad_unit_code');
-            expect(data['tg_i.dfp_ad_unit_code']).to.equal('a/b/c');
+            expect(data).to.have.property('p_gpid');
+            expect(data['p_gpid']).to.equal('/a/b/c');
           });
         });
       });


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change

### Regarding ortb2Imp adserver 
PREVIOUS FUNCTIONALITY:
if bidderRequest.bids[x].ortb2Imp.ext.data.adserver.adslot was present, we always sent it

NOW:
We only send it if bidderRequest.bids[x].ortb2Imp.ext.data.adserver.name === 'gam'


### Regarding ortb2Imp pbadslot 
PREVIOUS FUNCTIONALITY:
if bidderRequest.bids[x].ortb2Imp.ext.data.pbadslot was present, we always sent it

NOW:
We NEVER send it


### Regarding removing leading slashes
PREVIOUS FUNCTIONALITY:
if bidderRequest.bids[x].ortb2Imp.ext.data.adserver.adslot wasdefined with a leading `/` we removed it

NOW:
We do not remove it