### PR TITLE
Mediasquare bidder: add metrics to onBidWon Event

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -106,6 +106,9 @@ export const spec = {
             'advertiserDomains': value['adomain']
           }
         };
+        if ('match' in value) {
+          bidResponse['mediasquare']['match'] = value['match'];
+        }
         if ('native' in value) {
           bidResponse['native'] = value['native'];
           bidResponse['mediaType'] = 'native';

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -165,7 +165,7 @@ export const spec = {
       if (bid.hasOwnProperty(paramsToSearchFor[i])) { params.push(paramsToSearchFor[i] + '=' + bid[paramsToSearchFor[i]]); }
     }
     if (params.length > 0) { params = '?' + params.join('&'); }
-    ajax(endpoint + BIDDER_ENDPOINT_WINNING + params, null);
+    ajax(endpoint + BIDDER_ENDPOINT_WINNING + params, null, undefined, {method: 'GET', withCredentials: true});
     return true;
   }
 

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -156,6 +156,7 @@ export const spec = {
     if (bid.hasOwnProperty('mediasquare')) {
       if (bid['mediasquare'].hasOwnProperty('bidder')) { params.push('bidder=' + bid['mediasquare']['bidder']); }
       if (bid['mediasquare'].hasOwnProperty('code')) { params.push('code=' + bid['mediasquare']['code']); }
+      if (bid['mediasquare'].hasOwnProperty('match')) { params.push('match=' + bid['mediasquare']['match']); }
     };
     for (let i = 0; i < paramsToSearchFor.length; i++) {
       if (bid.hasOwnProperty(paramsToSearchFor[i])) { params.push(paramsToSearchFor[i] + '=' + bid[paramsToSearchFor[i]]); }

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -144,6 +144,7 @@ describe('MediaSquare bid adapter tests', function () {
     const request = spec.buildRequests(DEFAULT_PARAMS, DEFAULT_OPTIONS);
     BID_RESPONSE.body.responses[0].match = true;
     const response = spec.interpretResponse(BID_RESPONSE, request);
+    const bid = response[0];
     expect(bid.mediasquare.match).to.exist;
     expect(bid.mediasquare.match).to.equal(true);
   });

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -140,7 +140,13 @@ describe('MediaSquare bid adapter tests', function () {
     expect(bid.meta.advertiserDomains).to.exist;
     expect(bid.meta.advertiserDomains).to.have.lengthOf(1);
   });
-
+  it('Verifies match', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS, DEFAULT_OPTIONS);
+    BID_RESPONSE.body.responses[0].match = true;
+    const response = spec.interpretResponse(BID_RESPONSE, request);
+    expect(bid.mediasquare.match).to.exist;
+    expect(bid.mediasquare.match).to.equal(true);
+  });
   it('Verifies bidder code', function () {
     expect(spec.code).to.equal('mediasquare');
   });


### PR DESCRIPTION
## Type of change
- [ ] Feature

## Description of change
### Features
Add one metric to the pixel fired by the onBidWonEvent
Add withCredentials to ajax options in onBidWonEvent