### PR TITLE
Rubicon Bid Adapter: segtax values for IAB expanded 

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -978,7 +978,7 @@ function applyFPD(bidRequest, mediaType, data) {
 
   let fpd = utils.mergeDeep({}, config.getConfig('ortb2') || {}, BID_FPD);
   let impData = utils.deepAccess(bidRequest.ortb2Imp, 'ext.data') || {};
-  const SEGTAX = {user: [4], site: [1, 2]};
+  const SEGTAX = {user: [4], site: [1, 2, 5, 6]};
   const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
   const validate = function(prop, key, parentName) {
     if (key === 'data' && Array.isArray(prop)) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -884,14 +884,27 @@ describe('the rubicon adapter', function () {
                   'ext': { 'segtax': 1 },
                   'segment': [
                     { 'id': '987' }
+		    ]
+		  }, {
+		    'name': 'www.dataprovider1.com',
+		    'ext': { 'segtax': 2 },
+		    'segment': [
+		      { 'id': '432' }
+		    ]
+                }, {
+                  'name': 'www.dataprovider1.com',
+                  'ext': { 'segtax': 5 },
+                  'segment': [
+                    { 'id': '55' }
                   ]
                 }, {
                   'name': 'www.dataprovider1.com',
-                  'ext': { 'segtax': 2 },
+                  'ext': { 'segtax': 6 },
                   'segment': [
-                    { 'id': '432' }
+                    { 'id': '66' }
                   ]
-                }]
+                }
+                ]
               }
             };
             const user = {
@@ -932,7 +945,7 @@ describe('the rubicon adapter', function () {
               'tg_v.gender': 'M',
               'tg_v.age': '40',
               'tg_v.iab': '687,123',
-              'tg_i.iab': '987,432',
+              'tg_i.iab': '987,432,55,66',
               'tg_v.yob': '1984',
               'tg_i.rating': '4-star,5-star',
               'tg_i.page': 'home',


### PR DESCRIPTION
## Type of change
- [ X ] Enhancement

## Description of change
The segtax values for IAB have been expanded to prefer 5 and 6 over 1 and 2. The rubicon adapter will accept any of these for IAB contextual.

