### PR TITLE
Orbidder Bid Adapter: set gvlid to otto vendor id for GDPR

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -38,6 +38,7 @@ function isBidResponseValid(bidResponse) {
 
 export const spec = {
   code: 'orbidder',
+  gvlid: 559,
   hostname: 'https://orbidder.otto.de',
   supportedMediaTypes: [BANNER, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Some of our partners like to use the GDPR Enforcement Module.
To let this work, we have to set the gvlid to the otto vendor id 559 at the orbidder module specs.

Contact: realtime-siggi@otto.de