### PR TITLE
Added Insticator Bidder Adapter

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -1,0 +1,272 @@
+import { config } from '../src/config.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import {
+  deepAccess,
+  generateUUID,
+  logError,
+} from '../src/utils.js';
+import { getStorageManager } from '../src/storageManager.js';
+
+export const storage = getStorageManager();
+const BIDDER_CODE = 'insticator';
+const ENDPOINT = 'https://ex.ingage.tech/v1/openrtb'; // production endpoint
+const USER_ID_KEY = 'hb_insticator_uid';
+const USER_ID_COOKIE_EXP = 2592000000; // 30 days
+const BID_TTL = 300; // 5 minutes
+
+config.setDefaults({
+  insticator: {
+    endpointUrl: ENDPOINT,
+    bidTTL: BID_TTL,
+  },
+});
+
+function getUserId() {
+  let uid;
+
+  if (storage.localStorageIsEnabled()) {
+    uid = localStorage.getItem(USER_ID_KEY);
+  } else {
+    uid = storage.getCookie(USER_ID_KEY);
+  }
+
+  if (uid && uid.length !== 36) {
+    uid = undefined;
+  }
+
+  return uid;
+}
+
+function setUserId(userId) {
+  if (storage.localStorageIsEnabled()) {
+    localStorage.setItem(USER_ID_KEY, userId);
+  }
+
+  if (storage.cookiesAreEnabled()) {
+    const expires = new Date(Date.now() + USER_ID_COOKIE_EXP).toISOString();
+    storage.setCookie(USER_ID_KEY, userId, expires);
+  }
+}
+
+function buildImpression(bidRequest) {
+  const format = [];
+  const sizes =
+    deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
+
+  for (const size of sizes) {
+    format.push({
+      w: size[0],
+      h: size[1],
+    });
+  }
+
+  return {
+    id: bidRequest.bidId,
+    tagid: bidRequest.adUnitCode,
+    banner: {
+      format,
+    },
+    ext: {
+      insticator: {
+        adUnitId: bidRequest.params.adUnitId,
+      },
+    },
+  };
+}
+
+function buildDevice() {
+  const device = {
+    w: window.innerWidth,
+    h: window.innerHeight,
+    js: true,
+    ext: {
+      localStorage: storage.localStorageIsEnabled(),
+      cookies: storage.cookiesAreEnabled(),
+    },
+  };
+
+  const deviceConfig = config.getConfig('device');
+
+  if (typeof deviceConfig === 'object') {
+    Object.assign(device, deviceConfig);
+  }
+
+  return device;
+}
+
+function buildRegs(bidderRequest) {
+  if (bidderRequest.gdprConsent) {
+    return {
+      ext: {
+        gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+        gdprConsentString: bidderRequest.gdprConsent.consentString,
+      },
+    };
+  }
+
+  return {};
+}
+
+function buildUser() {
+  const userId = getUserId() || generateUUID();
+
+  setUserId(userId);
+
+  return {
+    id: userId,
+  };
+}
+
+function buildRequest(validBidRequests, bidderRequest) {
+  const req = {
+    id: bidderRequest.bidderRequestId,
+    tmax: bidderRequest.timeout,
+    source: {
+      fd: 1,
+      tid: bidderRequest.auctionId,
+    },
+    site: {
+      domain: location.hostname,
+      page: location.href,
+      ref: bidderRequest.refererInfo.referer,
+    },
+    device: buildDevice(),
+    regs: buildRegs(bidderRequest),
+    user: buildUser(),
+    imp: validBidRequests.map((bidRequest) => buildImpression(bidRequest)),
+  };
+
+  const params = config.getConfig('insticator.params');
+
+  if (params) {
+    req.ext = {
+      insticator: params,
+    };
+  }
+
+  return req;
+}
+
+function buildBid(bid, bidderRequest) {
+  const originalBid = bidderRequest.bids.find((b) => b.bidId === bid.impid);
+
+  return {
+    requestId: bid.impid,
+    creativeId: bid.crid,
+    cpm: bid.price,
+    currency: 'USD',
+    netRevenue: true,
+    ttl: bid.exp || config.getConfig('insticator.bidTTL') || BID_TTL,
+    width: bid.w,
+    height: bid.h,
+    mediaType: 'banner',
+    ad: bid.adm,
+    adUnitCode: originalBid.adUnitCode,
+  };
+}
+
+function buildBidSet(seatbid, bidderRequest) {
+  return seatbid.bid.map((bid) => buildBid(bid, bidderRequest));
+}
+
+function validateSize(size) {
+  return (
+    size instanceof Array &&
+    size.length === 2 &&
+    typeof size[0] === 'number' &&
+    typeof size[1] === 'number'
+  );
+}
+
+function validateSizes(sizes) {
+  return (
+    sizes instanceof Array &&
+    sizes.length > 0 &&
+    sizes.map(validateSize).reduce((a, b) => a && b, true)
+  );
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid: function (bid) {
+    if (!bid.params.adUnitId) {
+      logError('insticator: missing adUnitId bid parameter');
+      return false;
+    }
+
+    if (!(BANNER in bid.mediaTypes)) {
+      logError('insticator: expected banner in mediaTypes');
+      return false;
+    }
+
+    if (
+      !validateSizes(bid.sizes) &&
+      !validateSizes(bid.mediaTypes.banner.sizes)
+    ) {
+      logError('insticator: banner sizes not specified or invalid');
+      return false;
+    }
+
+    return true;
+  },
+
+  buildRequests: function (validBidRequests, bidderRequest) {
+    const requests = [];
+
+    if (validBidRequests.length > 0) {
+      requests.push({
+        method: 'POST',
+        url: config.getConfig('insticator.endpointUrl') || ENDPOINT,
+        options: {
+          contentType: 'application/json',
+          withCredentials: true,
+        },
+        data: JSON.stringify(buildRequest(validBidRequests, bidderRequest)),
+        bidderRequest,
+      });
+    }
+
+    return requests;
+  },
+
+  interpretResponse: function (serverResponse, request) {
+    const bidderRequest = request.bidderRequest;
+    const body = serverResponse.body;
+
+    if (!body || body.id !== bidderRequest.bidderRequestId) {
+      logError('insticator: response id does not match bidderRequestId');
+      return [];
+    }
+
+    if (!body.seatbid) {
+      return [];
+    }
+
+    const bidsets = body.seatbid.map((seatbid) =>
+      buildBidSet(seatbid, bidderRequest)
+    );
+
+    return bidsets.reduce((a, b) => a.concat(b), []);
+  },
+
+  getUserSyncs: function (options, responses) {
+    const syncs = [];
+
+    for (const response of responses) {
+      if (
+        response.body &&
+        response.body.ext &&
+        response.body.ext.sync instanceof Array
+      ) {
+        syncs.push(...response.body.ext.sync);
+      }
+    }
+
+    return syncs;
+  },
+};
+
+registerBidder(spec);

--- a/modules/insticatorBidAdapter.md
+++ b/modules/insticatorBidAdapter.md
@@ -1,0 +1,49 @@
+Overview
+========
+
+```
+Module Name: Insticator Adapter
+Module Type: Bidder Adapter
+Maintainer: contact@insticator.com
+```
+
+Description
+===========
+
+This module connects publishers to Insticator exchange of demand sources through Prebid.js. 
+
+### Supported Media Types
+
+| Type | Support
+| --- | ---
+| Banner | Fully supported for all approved sizes.
+
+# Bid Parameters
+
+Each of the Insticator-specific parameters provided under the `adUnits[].bids[].params`
+object are detailed here.
+
+### Banner
+
+| Key | Scope | Type | Description
+| --- | --- | --- | ---
+| adUnitId | Required | String | The ad unit ID provided by Insticator. 
+
+
+# Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'test-div',
+               sizes: [[300, 250]],
+               bids: [
+                   {
+                       bidder: 'insticator',
+                       params: {
+                           adUnitId: 'test'
+                       }
+                   }
+               ]
+           }
+	]
+```

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -1,0 +1,398 @@
+import { expect } from 'chai';
+import { spec, storage } from '../../../modules/insticatorBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js'
+import { userSync } from '../../../src/userSync.js';
+
+const USER_ID_KEY = 'hb_insticator_uid';
+const USER_ID_DUMMY_VALUE = '74f78609-a92d-4cf1-869f-1b244bbfb5d2';
+const USER_ID_STUBBED = '12345678-1234-1234-1234-123456789abc';
+
+let utils = require('src/utils.js');
+
+describe('InsticatorBidAdapter', function () {
+  const adapter = newBidder(spec);
+
+  let bidRequest = {
+    bidder: 'insticator',
+    adUnitCode: 'adunit-code',
+    params: {
+      adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+    },
+    sizes: [[300, 250], [300, 600]],
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250], [300, 600]]
+      }
+    },
+    bidId: '30b31c1838de1e',
+  };
+
+  let bidderRequest = {
+    bidderRequestId: '22edbae2733bf6',
+    auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
+    timeout: 300,
+    gdprConsent: {
+      consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+      vendorData: {},
+      gdprApplies: true
+    },
+    refererInfo: {
+      numIframes: 0,
+      reachedTop: true,
+      referer: 'https://example.com',
+      stack: ['https://example.com']
+    },
+  };
+
+  describe('.code', function () {
+    it('should return a bidder code of insticator', function () {
+      expect(spec.code).to.equal('insticator')
+    })
+  })
+
+  describe('inherited functions', function () {
+    it('should exist and be a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function')
+    })
+  })
+
+  describe('isBidRequestValid', function () {
+    it('should return true if the bid is valid', function () {
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    });
+
+    it('should return false if there is no adUnitId param', () => {
+      expect(spec.isBidRequestValid({...bidRequest, ...{params: {}}})).to.be.false;
+    });
+
+    it('should return false if there is no mediaTypes', () => {
+      expect(spec.isBidRequestValid({...bidRequest, ...{mediaTypes: {}}})).to.be.false;
+    });
+
+    it('should return false if there are no banner sizes and no sizes', () => {
+      bidRequest.mediaTypes.banner = {};
+      expect(spec.isBidRequestValid({...bidRequest, ...{sizes: {}}})).to.be.false;
+    });
+
+    it('should return true if there is sizes and no banner sizes', () => {
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    });
+
+    it('should return true if there is banner sizes and no sizes', () => {
+      bidRequest.mediaTypes.banner.sizes = [[300, 250], [300, 600]];
+      expect(spec.isBidRequestValid({...bidRequest, ...{sizes: {}}})).to.be.true;
+    });
+  });
+
+  describe('buildRequests', function () {
+    let getDataFromLocalStorageStub, localStorageIsEnabledStub;
+    let getCookieStub, cookiesAreEnabledStub;
+    let sandbox;
+
+    beforeEach(() => {
+      getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+      localStorageIsEnabledStub = sinon.stub(storage, 'localStorageIsEnabled');
+      getCookieStub = sinon.stub(storage, 'getCookie');
+      cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
+
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(utils, 'generateUUID').returns(USER_ID_STUBBED);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      getDataFromLocalStorageStub.restore();
+      localStorageIsEnabledStub.restore();
+      getCookieStub.restore();
+      cookiesAreEnabledStub.restore();
+    });
+
+    const serverRequests = spec.buildRequests([bidRequest], bidderRequest);
+    it('should create a request', function () {
+      expect(serverRequests).to.have.length(1);
+    });
+
+    const serverRequest = serverRequests[0];
+    it('should create a request object with method, URL, options and data', function () {
+      expect(serverRequest).to.exist;
+      expect(serverRequest.method).to.exist;
+      expect(serverRequest.url).to.exist;
+      expect(serverRequest.options).to.exist;
+      expect(serverRequest.data).to.exist;
+    });
+
+    it('should return POST method', function () {
+      expect(serverRequest.method).to.equal('POST');
+    });
+
+    it('should return valid URL', function () {
+      expect(serverRequest.url).to.equal('https://ex.ingage.tech/v1/openrtb');
+    });
+
+    it('should return valid options', function () {
+      expect(serverRequest.options).to.be.an('object');
+      expect(serverRequest.options.contentType).to.equal('application/json');
+      expect(serverRequest.options.withCredentials).to.be.true;
+    });
+
+    it('should return valid data if array of bids is valid', function () {
+      localStorageIsEnabledStub.returns(true);
+      cookiesAreEnabledStub.returns(false);
+      localStorage.setItem(USER_ID_KEY, USER_ID_DUMMY_VALUE);
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+
+      expect(data).to.be.an('object');
+      expect(data).to.have.all.keys('id', 'tmax', 'source', 'site', 'device', 'regs', 'user', 'imp');
+      expect(data.id).to.equal(bidderRequest.bidderRequestId);
+      expect(data.tmax).to.equal(bidderRequest.timeout);
+      expect(data.source).to.eql({
+        fd: 1,
+        tid: bidderRequest.auctionId,
+      });
+      expect(data.site).to.be.an('object');
+      expect(data.site.domain).not.to.be.empty;
+      expect(data.site.page).not.to.be.empty;
+      expect(data.site.ref).to.equal(bidderRequest.refererInfo.referer);
+      expect(data.device).to.be.an('object');
+      expect(data.device.w).to.equal(window.innerWidth);
+      expect(data.device.h).to.equal(window.innerHeight);
+      expect(data.device.js).to.equal(true);
+      expect(data.device.ext).to.be.an('object');
+      expect(data.device.ext.localStorage).to.equal(true);
+      expect(data.device.ext.cookies).to.equal(false);
+      expect(data.regs).to.be.an('object');
+      expect(data.regs.ext.gdpr).to.equal(1);
+      expect(data.regs.ext.gdprConsentString).to.equal(bidderRequest.gdprConsent.consentString);
+      expect(data.user).to.be.an('object');
+      expect(data.user.id).to.equal(USER_ID_DUMMY_VALUE);
+      expect(data.imp).to.be.an('array').that.have.lengthOf(1);
+      expect(data.imp).to.deep.equal([{
+        id: bidRequest.bidId,
+        tagid: bidRequest.adUnitCode,
+        banner: {
+          format: [
+            {w: 300, h: 250},
+            {w: 300, h: 600},
+          ]
+        },
+        ext: {
+          insticator: {
+            adUnitId: bidRequest.params.adUnitId,
+          },
+        }
+      }]);
+    });
+
+    it('should generate new userId if not valid user is stored', function () {
+      localStorageIsEnabledStub.returns(true);
+      localStorage.setItem(USER_ID_KEY, 'fake-user-id');
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+
+      expect(data.user.id).to.equal(USER_ID_STUBBED);
+    });
+    it('should return empty regs object if no gdprConsent is passed', function () {
+      const requests = spec.buildRequests([bidRequest], {...bidderRequest, ...{gdprConsent: false}});
+      const data = JSON.parse(requests[0].data);
+      expect(data.regs).to.be.an('object').that.is.empty;
+    });
+    it('should return empty array if no valid requests are passed', function () {
+      expect(spec.buildRequests([], bidderRequest)).to.be.an('array').that.have.lengthOf(0);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const bidRequests = {
+      method: 'POST',
+      url: 'https://ex.ingage.tech/v1/openrtb',
+      options: {
+        contentType: 'application/json',
+        withCredentials: true,
+      },
+      data: '',
+      bidderRequest: {
+        bidderRequestId: '22edbae2733bf6',
+        auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
+        timeout: 300,
+        bids: [
+          {
+            bidder: 'insticator',
+            params: {
+              adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+            },
+            adUnitCode: 'adunit-code-1',
+            sizes: [[300, 250], [300, 600]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [300, 600]]
+              }
+            },
+            bidId: 'bid1',
+          },
+          {
+            bidder: 'insticator',
+            params: {
+              adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+            },
+            adUnitCode: 'adunit-code-2',
+            sizes: [[120, 600], [300, 600], [160, 600]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [300, 600]]
+              }
+            },
+            bidId: 'bid2',
+          },
+          {
+            bidder: 'insticator',
+            params: {
+              adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+            },
+            adUnitCode: 'adunit-code-3',
+            sizes: [[120, 600], [300, 600], [160, 600]],
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [300, 600]]
+              }
+            },
+            bidId: 'bid3',
+          }
+        ]
+      }
+    };
+
+    const bidResponse = {
+      body: {
+        id: '22edbae2733bf6',
+        bidid: 'foo9876',
+        cur: 'USD',
+        seatbid: [
+          {
+            seat: 'some-dsp',
+            bid: [
+              {
+                impid: 'bid1',
+                crid: 'crid1',
+                price: 0.5,
+                w: 300,
+                h: 200,
+                adm: 'adm1',
+                exp: 60,
+              },
+              {
+                impid: 'bid2',
+                crid: 'crid2',
+                price: 1.5,
+                w: 600,
+                h: 200,
+                adm: 'adm2'
+              },
+              {
+                impid: 'bid3',
+                crid: 'crid3',
+                price: 5.0,
+                w: 300,
+                h: 200,
+                adm: 'adm3'
+              }
+            ],
+          },
+        ]
+      }
+    };
+
+    const prebidResponse = [
+      {
+        requestId: 'bid1',
+        creativeId: 'crid1',
+        cpm: 0.5,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 60,
+        width: 300,
+        height: 200,
+        mediaType: 'banner',
+        ad: 'adm1',
+        adUnitCode: 'adunit-code-1',
+      },
+      {
+        requestId: 'bid2',
+        creativeId: 'crid2',
+        cpm: 1.5,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 300,
+        width: 600,
+        height: 200,
+        mediaType: 'banner',
+        ad: 'adm2',
+        adUnitCode: 'adunit-code-2',
+      },
+      {
+        requestId: 'bid3',
+        creativeId: 'crid3',
+        cpm: 5.0,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 300,
+        width: 300,
+        height: 200,
+        mediaType: 'banner',
+        ad: 'adm3',
+        adUnitCode: 'adunit-code-3',
+      },
+    ];
+
+    it('should map bidResponse to prebidResponse', function () {
+      const response = spec.interpretResponse(bidResponse, bidRequests);
+      response.forEach((resp, i) => {
+        expect(resp).to.deep.equal(prebidResponse[i]);
+      });
+    });
+
+    it('should return empty response if bidderRequestId is invalid', function () {
+      const response = Object.assign({}, bidResponse);
+      response.body.id = 'fake-id';
+      expect(spec.interpretResponse(response, bidRequests)).to.have.length(0);
+    });
+
+    it('should return empty response if there is no seatbid array in response', function () {
+      const response = Object.assign({}, bidResponse);
+      delete response.body.seatbid;
+      expect(spec.interpretResponse(response, bidRequests)).to.have.length(0);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    const bidResponse = [{
+      body: {
+        ext: {
+          sync: [{
+            code: 'so',
+            delay: 0
+          }]
+        }
+      }
+    }];
+
+    it('should return one user sync', function () {
+      expect(spec.getUserSyncs({}, bidResponse)).to.deep.equal([{
+        code: 'so',
+        delay: 0
+      }]);
+    })
+
+    it('should return an empty array when sync is enabled but there are no bidResponses', function () {
+      expect(spec.getUserSyncs({}, [])).to.have.length(0);
+    })
+
+    it('should return an empty array when sync is enabled but no sync ext returned', function () {
+      const response = Object.assign({}, bidResponse[0]);
+      delete response.body.ext.sync;
+      expect(spec.getUserSyncs({}, [response])).to.have.length(0);
+    })
+  });
+});


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added Insticator Bidder Adapter

- test parameters for validating bids
```
{
   bidder: 'insticator',
   params: {
       adUnitId: 'test'
   }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/3187
