### PR TITLE
Pixfuture Bid Adapter: changed directory path

### DIFF
--- a/modules/pixfutureBidAdapter.js
+++ b/modules/pixfutureBidAdapter.js
@@ -112,7 +112,7 @@ export const spec = {
       }
 
       const ret = {
-        url: `${hostname}/auc/auc.php`,
+        url: `${hostname}/`,
         method: 'POST',
         options: {withCredentials: false},
         data: {


### PR DESCRIPTION
Changed directory path in the line #115  from url: `${hostname}/auc/auc.php` to ${hostname}/

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Changed directory path in the line #115
```
