### PR TITLE
Dependencies: Fix dependabot dependency path parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16202,7 +16202,7 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
+      "version": ">=1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
@@ -17385,7 +17385,7 @@
       "dev": true,
       "requires": {
         "is-core-module": "2.4.0",
-        "path-parse": "1.0.7"
+        "path-parse": ">=1.0.7"
       }
     },
     "resolve-alpn": {


### PR DESCRIPTION
Fixes new security recommendation only because of dependabot scary warning. No real impact to Prebid on the security side other than better maintainability. https://github.com/prebid/Prebid.js/security/dependabot/package-lock.json/path-parse/closed