### PR TITLE
emitting BEFORE_BIDDER_REQUEST event per bidder network request

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -230,6 +230,7 @@ export function newBidder(spec) {
       // Server requests have returned and been processed. Since `ajax` accepts a single callback,
       // we need to rig up a function which only executes after all the requests have been responded.
       const onResponse = delayExecution(configEnabledCallback(afterAllResponses), requests.length)
+      requests.forEach(_ => events.emit(CONSTANTS.EVENTS.BEFORE_BIDDER_REQUEST, bidderRequest));
       requests.forEach(processRequest);
 
       function formatGetParameters(data) {

--- a/src/constants.json
+++ b/src/constants.json
@@ -34,6 +34,7 @@
     "BIDDER_DONE": "bidderDone",
     "SET_TARGETING": "setTargeting",
     "BEFORE_REQUEST_BIDS": "beforeRequestBids",
+    "BEFORE_BIDDER_REQUEST": "beforeBidderRequest",
     "REQUEST_BIDS": "requestBids",
     "ADD_AD_UNITS": "addAdUnits",
     "AD_RENDER_FAILED": "adRenderFailed",

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -6,6 +6,8 @@ import { userSync } from 'src/userSync.js'
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 import { server } from 'test/mocks/xhr.js';
+import CONSTANTS from 'src/constants.json';
+import events from 'src/events.js';
 
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
@@ -313,6 +315,28 @@ describe('bidders created by newBidder', function () {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.callCount).to.equal(0);
+    });
+
+    it('should emit BEFORE_BIDDER_REQUEST events before network requests', function () {
+      const bidder = newBidder(spec);
+      const req = {
+        method: 'POST',
+        url: 'test.url.com',
+        data: { arg: 2 }
+      };
+
+      spec.isBidRequestValid.returns(true);
+      spec.buildRequests.returns([req, req]);
+
+      const eventEmitterSpy = sinon.spy(events, 'emit');
+      bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+
+      expect(ajaxStub.calledTwice).to.equal(true);
+      expect(eventEmitterSpy.getCalls()
+        .filter(call => call.args[0] === CONSTANTS.EVENTS.BEFORE_BIDDER_REQUEST)
+      ).to.length(2);
+
+      eventEmitterSpy.restore();
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
emitting BEFORE_BIDDER_REQUEST event every time a BidAdapter send a network request to the endpoint.

API change PR:
https://github.com/prebid/prebid.github.io/pull/3197
