### PR TITLE
Adagio Bid Adapter: added missing PBS params

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -340,6 +340,16 @@ function isNewSession(adagioStorage) {
   )
 }
 
+function setPlayerName(bidRequest) {
+  const playerName = (internal.isRendererPreferredFromPublisher(bidRequest)) ? 'other' : 'adagio';
+
+  if (playerName === 'other') {
+    utils.logWarn(`${LOG_PREFIX} renderer.backupOnly has not been set. Adagio recommends to use its own player to get expected behavior.`);
+  }
+
+  return playerName;
+}
+
 export const internal = {
   enqueue,
   getPageviewId,
@@ -414,11 +424,7 @@ function _buildVideoBidRequest(bidRequest) {
   };
 
   if (videoParams.context && videoParams.context === OUTSTREAM) {
-    bidRequest.mediaTypes.video.playerName = (internal.isRendererPreferredFromPublisher(bidRequest)) ? 'other' : 'adagio';
-
-    if (bidRequest.mediaTypes.video.playerName === 'other') {
-      utils.logWarn(`${LOG_PREFIX} renderer.backupOnly has not been set. Adagio recommends to use its own player to get expected behavior.`);
-    }
+    bidRequest.mediaTypes.video.playerName = setPlayerName(bidRequest);
   }
 
   // Only whitelisted OpenRTB options need to be validated.
@@ -1071,6 +1077,8 @@ export const spec = {
     if (isOrtb) {
       autoFillParams(adagioBid);
 
+      adagioBid.params.auctionId = utils.deepAccess(adagioBidderRequest, 'auctionId');
+
       const globalFeatures = GlobalExchange.getOrSetGlobalFeatures();
       adagioBid.params.features = {
         ...globalFeatures,
@@ -1081,6 +1089,10 @@ export const spec = {
       adagioBid.params.pageviewId = internal.getPageviewId();
       adagioBid.params.prebidVersion = '$prebid.version$';
       adagioBid.params.data = GlobalExchange.getExchangeData();
+
+      if (utils.deepAccess(adagioBid, 'mediaTypes.video.context') === OUTSTREAM) {
+        adagioBid.params.playerName = setPlayerName(adagioBid);
+      }
 
       storeRequestInAdagioNS(adagioBid);
     }

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1151,14 +1151,24 @@ describe('Adagio bid adapter', () => {
       };
       const bid01 = new BidRequestBuilder({
         'mediaTypes': {
-          banner: { sizes: [[300, 250]] }
+          banner: { sizes: [[300, 250]] },
+          video: {
+            context: 'outstream',
+            playerSize: [300, 250],
+            renderer: {
+              url: 'https://url.tld',
+              render: () => true
+            }
+          }
         }
       }).withParams().build();
 
-      const params = spec.transformBidParams({ organizationId: '1000' }, true, adUnit, [{ bidderCode: 'adagio', bids: [bid01] }]);
+      const params = spec.transformBidParams({ organizationId: '1000' }, true, adUnit, [{ bidderCode: 'adagio', auctionId: bid01.auctionId, bids: [bid01] }]);
 
       expect(params.organizationId).to.exist;
-      expect(params.organizationId).to.exist;
+      expect(params.auctionId).to.exist;
+      expect(params.playerName).to.exist;
+      expect(params.playerName).to.equal('other');
       expect(params.features).to.exist;
       expect(params.features.page_dimensions).to.exist;
       expect(params.features.adunit_position).to.exist;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Add some missing properties we have to send to the Adagio Prebid Server Adapter.

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

## Other information
The `auctionId` is temporary passed as params for now, waiting for #6836