### PR TITLE
PBS Bid Adapter: Add additional ortb2 fields in request object

### DIFF
--- a/modules/enrichmentFpdModule.js
+++ b/modules/enrichmentFpdModule.js
@@ -3,11 +3,67 @@
  * @module modules/firstPartyData
  */
 import * as utils from '../src/utils.js';
-import { submodule } from '../src/hook.js'
-import { getRefererInfo } from '../src/refererDetection.js'
+import { submodule } from '../src/hook.js';
+import { getRefererInfo } from '../src/refererDetection.js';
+import { getCoreStorageManager } from '../src/storageManager.js';
 
 let ortb2 = {};
 let win = (window === window.top) ? window : window.top;
+export const coreStorage = getCoreStorageManager('enrichmentFpd');
+
+/**
+  * Find the root domain
+  * @param {string|undefined} fullDomain
+  * @return {string}
+*/
+export function findRootDomain(fullDomain = window.location.hostname) {
+  if (!coreStorage.cookiesAreEnabled()) {
+    return fullDomain;
+  }
+
+  const domainParts = fullDomain.split('.');
+  if (domainParts.length == 2) {
+    return fullDomain;
+  }
+  let rootDomain;
+  let continueSearching;
+  let startIndex = -2;
+  const TEST_COOKIE_NAME = `_rdc${Date.now()}`;
+  const TEST_COOKIE_VALUE = 'writeable';
+  do {
+    rootDomain = domainParts.slice(startIndex).join('.');
+    let expirationDate = new Date(utils.timestamp() + 10 * 1000).toUTCString();
+
+    // Write a test cookie
+    coreStorage.setCookie(
+      TEST_COOKIE_NAME,
+      TEST_COOKIE_VALUE,
+      expirationDate,
+      'Lax',
+      rootDomain,
+      undefined
+    );
+
+    // See if the write was successful
+    const value = coreStorage.getCookie(TEST_COOKIE_NAME, undefined);
+    if (value === TEST_COOKIE_VALUE) {
+      continueSearching = false;
+      // Delete our test cookie
+      coreStorage.setCookie(
+        TEST_COOKIE_NAME,
+        '',
+        'Thu, 01 Jan 1970 00:00:01 GMT',
+        undefined,
+        rootDomain,
+        undefined
+      );
+    } else {
+      startIndex += -1;
+      continueSearching = Math.abs(startIndex) <= domainParts.length;
+    }
+  } while (continueSearching);
+  return rootDomain;
+}
 
 /**
  * Checks for referer and if exists merges into ortb2 global data
@@ -39,7 +95,7 @@ function setDomain() {
 
   if (domain) {
     utils.mergeDeep(ortb2, { site: { domain: domain } });
-    utils.mergeDeep(ortb2, { site: { publisher: { domain: domain } } });
+    utils.mergeDeep(ortb2, { site: { publisher: { domain: findRootDomain(domain) } } });
   };
 }
 

--- a/modules/enrichmentFpdModule.js
+++ b/modules/enrichmentFpdModule.js
@@ -37,7 +37,10 @@ function setDomain() {
 
   let domain = parseDomain(getRefererInfo().canonicalUrl)
 
-  if (domain) utils.mergeDeep(ortb2, { site: { domain: domain } });
+  if (domain) {
+    utils.mergeDeep(ortb2, { site: { domain: domain } });
+    utils.mergeDeep(ortb2, { site: { publisher: { domain: domain } } });
+  };
 }
 
 /**

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -364,19 +364,7 @@ function addBidderFirstPartyDataToRequest(request) {
   const fpdConfigs = Object.keys(bidderConfig).reduce((acc, bidder) => {
     const currBidderConfig = bidderConfig[bidder];
     if (currBidderConfig.ortb2) {
-      const ortb2 = {};
-      if (currBidderConfig.ortb2.site) {
-        ortb2.site = currBidderConfig.ortb2.site;
-      }
-      if (currBidderConfig.ortb2.user) {
-        ortb2.user = currBidderConfig.ortb2.user;
-      }
-      if (currBidderConfig.ortb2.bcat) {
-        ortb2.bcat = currBidderConfig.ortb2.bcat;
-      }
-      if (currBidderConfig.ortb2.badv) {
-        ortb2.badv = currBidderConfig.ortb2.badv;
-      }
+      const ortb2 = utils.mergeDeep({}, currBidderConfig.ortb2);
 
       acc.push({
         bidders: [ bidder ],
@@ -854,18 +842,8 @@ const OPEN_RTB_PROTOCOL = {
     }
 
     const commonFpd = getConfig('ortb2') || {};
-    if (commonFpd.site) {
-      utils.mergeDeep(request, {site: commonFpd.site});
-    }
-    if (commonFpd.user) {
-      utils.mergeDeep(request, {user: commonFpd.user});
-    }
-    if (commonFpd.bcat) {
-      utils.mergeDeep(request, {bcat: commonFpd.bcat});
-    }
-    if (commonFpd.badv) {
-      utils.mergeDeep(request, {badv: commonFpd.badv});
-    }
+    utils.mergeDeep(request, commonFpd);
+
     addBidderFirstPartyDataToRequest(request);
 
     return request;

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -371,6 +371,12 @@ function addBidderFirstPartyDataToRequest(request) {
       if (currBidderConfig.ortb2.user) {
         ortb2.user = currBidderConfig.ortb2.user;
       }
+      if (currBidderConfig.ortb2.bcat) {
+        ortb2.bcat = currBidderConfig.ortb2.bcat;
+      }
+      if (currBidderConfig.ortb2.badv) {
+        ortb2.badv = currBidderConfig.ortb2.badv;
+      }
 
       acc.push({
         bidders: [ bidder ],
@@ -853,6 +859,12 @@ const OPEN_RTB_PROTOCOL = {
     }
     if (commonFpd.user) {
       utils.mergeDeep(request, {user: commonFpd.user});
+    }
+    if (commonFpd.bcat) {
+      utils.mergeDeep(request, {bcat: commonFpd.bcat});
+    }
+    if (commonFpd.badv) {
+      utils.mergeDeep(request, {badv: commonFpd.badv});
     }
     addBidderFirstPartyDataToRequest(request);
 

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -85,7 +85,21 @@ export const ORTB_MAP = {
       },
       publisher: {
         type: TYPES.object,
-        isArray: false
+        isArray: false,
+        children: {
+          id: { type: TYPES.string },
+          name: { type: TYPES.string },
+          cat: {
+            type: TYPES.object,
+            isArray: true,
+            childType: TYPES.string
+          },
+          domain: { type: TYPES.string },
+          ext: {
+            type: TYPES.object,
+            isArray: false
+          }
+        }
       },
     }
   },
@@ -121,5 +135,15 @@ export const ORTB_MAP = {
         }
       }
     }
+  },
+  bcat: {
+    type: TYPES.object,
+    isArray: true,
+    childType: TYPES.string
+  },
+  badv: {
+    type: TYPES.object,
+    isArray: true,
+    childType: TYPES.string
   }
 }

--- a/modules/validationFpdModule/index.js
+++ b/modules/validationFpdModule/index.js
@@ -106,6 +106,7 @@ export function filterArrayData(arr, child, path, parent) {
     switch (child.type) {
       case 'string':
         result.push(value);
+        typeBool = true;
         break;
       case 'object':
         if (mapping && mapping.children) {

--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -54,7 +54,7 @@ describe('the first party data enrichment module', function() {
     expect(validated.site.keywords).to.be.undefined;
   });
 
-  it('adds page and domain values if canonical url exists', function() {
+  it('adds page, domain, and publisher.domain values if canonical url exists', function() {
     width = 800;
     height = 500;
     canonical.href = 'https://www.domain.com/path?query=12345';
@@ -64,6 +64,7 @@ describe('the first party data enrichment module', function() {
     expect(validated.site.ref).to.equal(getRefererInfo().referer);
     expect(validated.site.page).to.equal('https://www.domain.com/path?query=12345');
     expect(validated.site.domain).to.equal('domain.com');
+    expect(validated.site.publisher.domain).to.equal('domain.com');
     expect(validated.device).to.deep.equal({ w: 800, h: 500 });
     expect(validated.site.keywords).to.be.undefined;
   });

--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
-import * as utils from 'src/utils.js';
 import { getRefererInfo } from 'src/refererDetection.js';
-import { initSubmodule } from 'modules/enrichmentFpdModule.js';
+import { initSubmodule, coreStorage } from 'modules/enrichmentFpdModule.js';
 
 describe('the first party data enrichment module', function() {
   let width;
@@ -9,6 +8,7 @@ describe('the first party data enrichment module', function() {
   let height;
   let heightStub;
   let querySelectorStub;
+  let coreStorageStub;
   let canonical;
   let keywords;
 
@@ -29,12 +29,19 @@ describe('the first party data enrichment module', function() {
     heightStub = sinon.stub(window.top, 'innerHeight').get(function() {
       return height;
     });
+    coreStorageStub = sinon.stub(coreStorage, 'getCookie');
+    coreStorageStub
+      .onFirstCall()
+      .returns(null) // co.uk
+      .onSecondCall()
+      .returns('writeable'); // domain.co.uk
   });
 
   afterEach(function() {
     widthStub.restore();
     heightStub.restore();
     querySelectorStub.restore();
+    coreStorageStub.restore();
     canonical = document.createElement('link');
     canonical.rel = 'canonical';
     keywords = document.createElement('meta');
@@ -54,17 +61,17 @@ describe('the first party data enrichment module', function() {
     expect(validated.site.keywords).to.be.undefined;
   });
 
-  it('adds page, domain, and publisher.domain values if canonical url exists', function() {
+  it('adds page domain values if canonical url exists', function() {
     width = 800;
     height = 500;
-    canonical.href = 'https://www.domain.com/path?query=12345';
+    canonical.href = 'https://www.subdomain.domain.co.uk/path?query=12345';
 
     let validated = initSubmodule({}, {});
 
     expect(validated.site.ref).to.equal(getRefererInfo().referer);
-    expect(validated.site.page).to.equal('https://www.domain.com/path?query=12345');
-    expect(validated.site.domain).to.equal('domain.com');
-    expect(validated.site.publisher.domain).to.equal('domain.com');
+    expect(validated.site.page).to.equal('https://www.subdomain.domain.co.uk/path?query=12345');
+    expect(validated.site.domain).to.equal('subdomain.domain.co.uk');
+    expect(validated.site.publisher.domain).to.equal('domain.co.uk');
     expect(validated.device).to.deep.equal({ w: 800, h: 500 });
     expect(validated.site.keywords).to.be.undefined;
   });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1745,6 +1745,8 @@ describe('S2S Adapter', function () {
           interests: ['cars']
         }
       };
+      const bcat = ['IAB25', 'IAB7-39'];
+      const badv = ['blockedAdv-1.com', 'blockedAdv-2.com'];
       const allowedBidders = [ 'rubicon', 'appnexus' ];
 
       const expected = allowedBidders.map(bidder => ({
@@ -1769,19 +1771,23 @@ describe('S2S Adapter', function () {
                   interests: ['cars']
                 }
               }
-            }
+            },
+            bcat: ['IAB25', 'IAB7-39'],
+            badv: ['blockedAdv-1.com', 'blockedAdv-2.com']
           }
         }
       }));
       const commonContextExpected = utils.mergeDeep({'page': 'http://mytestpage.com', 'publisher': {'id': '1'}}, commonContext);
 
-      config.setConfig({ fpd: { context: commonContext, user: commonUser } });
-      config.setBidderConfig({ bidders: allowedBidders, config: { fpd: { context, user } } });
+      config.setConfig({ fpd: { context: commonContext, user: commonUser, badv, bcat } });
+      config.setBidderConfig({ bidders: allowedBidders, config: { fpd: { context, user, bcat, badv } } });
       adapter.callBids(s2sBidRequest, bidRequests, addBidResponse, done, ajax);
       const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
       expect(parsedRequestBody.ext.prebid.bidderconfig).to.deep.equal(expected);
       expect(parsedRequestBody.site).to.deep.equal(commonContextExpected);
       expect(parsedRequestBody.user).to.deep.equal(commonUser);
+      expect(parsedRequestBody.badv).to.deep.equal(badv);
+      expect(parsedRequestBody.bcat).to.deep.equal(bcat);
     });
 
     describe('pbAdSlot config', function () {

--- a/test/spec/modules/validationFpdModule_spec.js
+++ b/test/spec/modules/validationFpdModule_spec.js
@@ -309,5 +309,87 @@ describe('the first party data validation module', function () {
       validated = validateFpd(duplicate);
       expect(validated).to.deep.equal(expected);
     });
+
+    it('filters bcat, badv for invalid data type', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.badv = 'adadadbcd.com';
+      duplicate.bcat = ['IAB25', 'IAB7-39'];
+
+      const expected = {
+        device: {
+          h: 911,
+          w: 1733
+        },
+        user: {
+          data: [{
+            segment: [{
+              id: 'foo'
+            }],
+            name: 'bar'
+          }]
+        },
+        site: {
+          content: {
+            data: [{
+              segment: [{
+                id: 'test'
+              }],
+              name: 'content',
+              ext: {
+                foo: 'bar'
+              }
+            }]
+          }
+        },
+        bcat: ['IAB25', 'IAB7-39']
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated).to.deep.equal(expected);
+    });
+
+    it('filters site.publisher object properties for invalid data type', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.site.publisher = {
+        id: '1',
+        domain: ['xyz.com'],
+        name: 'xyz',
+      };
+
+      const expected = {
+        device: {
+          h: 911,
+          w: 1733
+        },
+        user: {
+          data: [{
+            segment: [{
+              id: 'foo'
+            }],
+            name: 'bar'
+          }]
+        },
+        site: {
+          content: {
+            data: [{
+              segment: [{
+                id: 'test'
+              }],
+              name: 'content',
+              ext: {
+                foo: 'bar'
+              }
+            }]
+          },
+          publisher: {
+            id: '1',
+            name: 'xyz',
+          }
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated).to.deep.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [X] Feature

## Description of change

Added support for few additional **ortb2** fields in the request object created by the PrebidServer Bid Adapter:

- request.bcat
- request.badv
- request.site.publisher > domain & name properties

Example:

```(javascript)
pbjs.setConfig({
  ortb2: {
    site: {
      ...
      publisher: {
        name: 'xyz',
        domain: 'xyz.com'
      }
    },
    user: {...},
    badv: ['a.com', 'b.com'],
    bcat: ['IAB25', 'IAB7-39']
  }
})
```

Currently, `bcat` & `badv` fields can be set globally using **setConfig()** and it can also be set for specific bidders using **setBidderConfig()**. I did not find any use case of setting them at an AdUnit level, but please feel free to comment otherwise if you see any use case for it.

Here is a list of minor changes that are also related:
- Added auto field population for the `site.publisher.domain` through the Enrichment module.
- Added validations to the `site.publisher` object.
- Removed a minor bug in FPD Validation module where it would throw a misleading warning message.

>>NOTE: This PR requires a Docs PR, am just waiting for someone to validate this approach before I create one.
Please do not merge this.

Related - https://github.com/prebid/Prebid.js/issues/6528