### PR TITLE
Criteo Bid Adapter: fix crashes when video parameters are 0

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -321,12 +321,20 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
           protocols: bidRequest.mediaTypes.video.protocols,
           maxduration: bidRequest.mediaTypes.video.maxduration,
           api: bidRequest.mediaTypes.video.api,
-          skip: bidRequest.mediaTypes.video.skip || bidRequest.params.video.skip,
-          placement: bidRequest.mediaTypes.video.placement || bidRequest.params.video.placement,
-          minduration: bidRequest.mediaTypes.video.minduration || bidRequest.params.video.minduration,
-          playbackmethod: bidRequest.mediaTypes.video.playbackmethod || bidRequest.params.video.playbackmethod,
-          startdelay: bidRequest.mediaTypes.video.startdelay || bidRequest.params.video.startdelay
+          skip: bidRequest.mediaTypes.video.skip,
+          placement: bidRequest.mediaTypes.video.placement,
+          minduration: bidRequest.mediaTypes.video.minduration,
+          playbackmethod: bidRequest.mediaTypes.video.playbackmethod,
+          startdelay: bidRequest.mediaTypes.video.startdelay
         };
+        const paramsVideo = bidRequest.params.video;
+        if (paramsVideo !== undefined) {
+          video.skip = video.skip || paramsVideo.skip || 0;
+          video.placement = video.placement || paramsVideo.placement;
+          video.minduration = video.minduration || paramsVideo.minduration;
+          video.playbackmethod = video.playbackmethod || paramsVideo.playbackmethod;
+          video.startdelay = video.startdelay || paramsVideo.startdelay || 0;
+        }
 
         slot.video = video;
       }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -772,6 +772,44 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.slots[0].video.placement).to.equal(2);
     });
 
+    it('should properly build a video request when mediaTypes.video.skip=0', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          mediaTypes: {
+            video: {
+              playerSize: [ [300, 250] ],
+              mimes: ['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg'],
+              minduration: 1,
+              maxduration: 30,
+              playbackmethod: [2, 3, 4, 5, 6],
+              api: [1, 2, 3, 4, 5, 6],
+              protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+              skip: 0
+            }
+          },
+          params: {
+            networkId: 123
+          }
+        }
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
+      expect(request.method).to.equal('POST');
+      const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['300x250']);
+      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg']);
+      expect(ortbRequest.slots[0].video.minduration).to.equal(1);
+      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
+      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([2, 3, 4, 5, 6]);
+      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2, 3, 4, 5, 6]);
+      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(ortbRequest.slots[0].video.skip).to.equal(0);
+    });
+
     it('should properly build a request with ceh', function () {
       const bidRequests = [
         {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
Fix crashes when bidRequest.mediaTypes.video.{skip, startdelay} is set to 0 #7307 
