### PR TITLE
PBjs Core (Targeting): bugfix for issue #7323 adding extra spaces

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -634,7 +634,7 @@ export function newTargeting(auctionManager) {
 
       return Object.keys(aut)
         .map(function(key) {
-          if (utils.isStr(aut[key])) aut[key] = aut[key].split(',');
+          if (utils.isStr(aut[key])) aut[key] = aut[key].split(',').map(s => s.trim());
           if (!utils.isArray(aut[key])) aut[key] = [ aut[key] ];
           return { [key]: aut[key] };
         });

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -337,7 +337,7 @@ export function newTargeting(auctionManager) {
    *      "div-gpt-ad-1460505748561-0": [{"hb_bidder": ["appnexusAst"]}]
    *    },
    *    {
-   *      "div-gpt-ad-1460505748561-0": [{"hb_bidder_appnexusAs": ["appnexusAst"]}]
+   *      "div-gpt-ad-1460505748561-0": [{"hb_bidder_appnexusAs": ["appnexusAst", "other"]}]
    *    }
    * ]
    * ```
@@ -346,7 +346,7 @@ export function newTargeting(auctionManager) {
    * {
    *  "div-gpt-ad-1460505748561-0": {
    *    "hb_bidder": "appnexusAst",
-   *    "hb_bidder_appnexusAs": "appnexusAst"
+   *    "hb_bidder_appnexusAs": "appnexusAst,other"
    *  }
    * }
    * ```
@@ -360,7 +360,7 @@ export function newTargeting(auctionManager) {
         [Object.keys(targeting)[0]]: targeting[Object.keys(targeting)[0]]
           .map(target => {
             return {
-              [Object.keys(target)[0]]: target[Object.keys(target)[0]].join(', ')
+              [Object.keys(target)[0]]: target[Object.keys(target)[0]].join(',')
             };
           }).reduce((p, c) => Object.assign(c, p), {})
       };

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -309,7 +309,7 @@ describe('targeting tests', function () {
         ['string', '2.3', '2.3'],
         ['number', 2.3, '2.3'],
         ['boolean', true, 'true'],
-        ['string-separated', '2.3,4.5', '2.3,4.5'],
+        ['string-separated', '2.3, 4.5', '2.3, 4.5'],
         ['array-of-string', ['2.3', '4.5'], '2.3,4.5'],
         ['array-of-number', [2.3, 4.5], '2.3,4.5'],
         ['array-of-boolean', [true, false], 'true,false']

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -309,10 +309,10 @@ describe('targeting tests', function () {
         ['string', '2.3', '2.3'],
         ['number', 2.3, '2.3'],
         ['boolean', true, 'true'],
-        ['string-separated', '2.3,4.5', '2.3, 4.5'],
-        ['array-of-string', ['2.3', '4.5'], '2.3, 4.5'],
-        ['array-of-number', [2.3, 4.5], '2.3, 4.5'],
-        ['array-of-boolean', [true, false], 'true, false']
+        ['string-separated', '2.3,4.5', '2.3,4.5'],
+        ['array-of-string', ['2.3', '4.5'], '2.3,4.5'],
+        ['array-of-number', [2.3, 4.5], '2.3,4.5'],
+        ['array-of-boolean', [true, false], 'true,false']
       ];
       pairs.forEach(([type, value, result]) => {
         it(`accepts ${type}`, function() {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -309,7 +309,7 @@ describe('targeting tests', function () {
         ['string', '2.3', '2.3'],
         ['number', 2.3, '2.3'],
         ['boolean', true, 'true'],
-        ['string-separated', '2.3, 4.5', '2.3, 4.5'],
+        ['string-separated', '2.3, 4.5', '2.3,4.5'],
         ['array-of-string', ['2.3', '4.5'], '2.3,4.5'],
         ['array-of-number', [2.3, 4.5], '2.3,4.5'],
         ['array-of-boolean', [true, false], 'true,false']


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This should fix issue #7323 by avoid join targeting keys with comma + space (later we split by comma and keep an extra space in front of some values and the targeting does not work)

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
