### PR TITLE
Price Floors: Use gam adSlot if on bidRequest

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -64,13 +64,19 @@ function getHostNameFromReferer(referer) {
   return referrerHostname;
 }
 
+// First look into bidRequest!
+function getGptSlotFromBidRequest(bidRequest) {
+  const isGam = utils.deepAccess(bidRequest, 'ortb2Imp.ext.data.adserver.name') === 'gam';
+  return isGam && bidRequest.ortb2Imp.ext.data.adserver.adslot;
+}
+
 /**
  * @summary floor field types with their matching functions to resolve the actual matched value
  */
 export let fieldMatchingFunctions = {
   'size': (bidRequest, bidResponse) => utils.parseGPTSingleSizeArray(bidResponse.size) || '*',
   'mediaType': (bidRequest, bidResponse) => bidResponse.mediaType || 'banner',
-  'gptSlot': (bidRequest, bidResponse) => utils.getGptSlotInfoForAdUnitCode(bidRequest.adUnitCode).gptSlot,
+  'gptSlot': (bidRequest, bidResponse) => getGptSlotFromBidRequest(bidRequest) || utils.getGptSlotInfoForAdUnitCode(bidRequest.adUnitCode).gptSlot,
   'domain': (bidRequest, bidResponse) => referrerHostname || getHostNameFromReferer(getRefererInfo().referer),
   'adUnitCode': (bidRequest, bidResponse) => bidRequest.adUnitCode
 }

--- a/test/spec/integration/faker/googletag.js
+++ b/test/spec/integration/faker/googletag.js
@@ -91,4 +91,9 @@ export function disable() {
   window.googletag = undefined;
 }
 
+export function reset() {
+  disable();
+  enable();
+}
+
 enable();


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change

### Before

The Price Floors Module would use the googletag API to find the matching slot when determining floor rule selection.

### After

The module will now first check the `ortb2Imp.ext.data.adserver` object on the bidRequest to see if it is a gam adSlot. 

And if so, use that.

Otherwise it will do the slotMatching logic as before.

Should reduce some overhead.