### PR TITLE
Sonobi Bid Adapter: remove outstream bid.ad

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -230,6 +230,7 @@ export const spec = {
           delete bids.width;
           delete bids.height;
         } else if (mediaType === 'outstream' && bidRequest) {
+          delete bids.ad; // Some pubs expect bids.ad to be a vast xml structure, we have a vatUrl so lets delete this.
           bids.mediaType = 'video';
           bids.vastUrl = createCreative(bidResponse.sbi_dc, bid.sbi_aid);
           bids.renderer = newRenderer(bidRequest.adUnitCode, bids, deepAccess(

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -752,6 +752,7 @@ describe('SonobiBidAdapter', function () {
           expect(resp.width).to.equal(prebidResponse[i].width);
           expect(resp.height).to.equal(prebidResponse[i].height);
           expect(resp.renderer).to.be.ok;
+          expect(resp.ad).to.equal(undefined);
         } else if (resp.mediaType === 'video') {
           expect(resp.vastUrl.indexOf('vast.xml')).to.be.greaterThan(0);
           expect(resp.ad).to.be.undefined;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
A publisher requested that we remove the bid.ad value for outstream since we provide the vastUrl


- apex.prebid@sonobi.com
- [x] official adapter submission