### PR TITLE
Gumgum Bid Adapter: remove slotid type checking 

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -336,7 +336,7 @@ function buildRequests(validBidRequests, bidderRequest) {
         const [maxw, maxh] = getGreatestDimensions(sizes);
         data.maxw = maxw;
         data.maxh = maxh;
-        data.si = parseInt(params.slot, 10);
+        data.si = params.slot;
         data.pi = 3;
         data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
       } else if (params.native) {
@@ -391,7 +391,7 @@ function handleLegacyParams(params, sizes) {
     const [maxw, maxh] = getGreatestDimensions(sizes);
     data.maxw = maxw;
     data.maxh = maxh;
-    data.si = parseInt(params.inSlot, 10);
+    data.si = params.inSlot;
     data.pi = 3;
     data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
   }

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -340,7 +340,7 @@ function buildRequests(validBidRequests, bidderRequest) {
         data.pi = 3;
         data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
       } else if (params.native) {
-        data.ni = parseInt(params.native, 10);
+        data.ni = params.native;
         data.pi = 5;
       } else if (mediaTypes.video) {
         data.pi = mediaTypes.video.linearity === 2 ? 6 : 7; // invideo : video
@@ -396,7 +396,7 @@ function handleLegacyParams(params, sizes) {
     data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
   }
   if (params.ICV) {
-    data.ni = parseInt(params.ICV, 10);
+    data.ni = params.ICV;
     data.pi = 5;
   }
   if (params.videoPubID) {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -177,7 +177,27 @@ describe('gumgumAdapter', function () {
       expect(slotZoneBidRequest.data.maxh).to.equal(600);
       expect(slotPubIdBidRequest.data.maxw).to.equal(300);
       expect(slotPubIdBidRequest.data.maxh).to.equal(600);
-    })
+    });
+
+    // if slot ID is set up incorrectly by a pub, we should send the invalid ID to be
+    // invalidated by ad server instead of trying to force integer type. forcing
+    // integer type can result in incorrect slot IDs that correlate to the incorrect pub ID
+    it('should send params.slot or params.inSlot as string when configured incorrectly', function () {
+      const invalidSlotId = '9gkal1cn';
+      const slotRequest = { ...bidRequests[0] };
+      const legacySlotRequest = { ...bidRequests[0] };
+      let req;
+      let legReq;
+
+      slotRequest.params.slot = invalidSlotId;
+      legacySlotRequest.params.inSlot = invalidSlotId;
+
+      req = spec.buildRequests([ slotRequest ])[0];
+      legReq = spec.buildRequests([ legacySlotRequest ])[0];
+
+      expect(req.data.si).to.equal(invalidSlotId);
+      expect(legReq.data.si).to.equal(invalidSlotId);
+    });
 
     it('should set the iriscat param when found', function () {
       const request = { ...bidRequests[0], params: { iriscat: 'abc123' } }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We have found that when slot IDs are configured incorrectly by the publisher, the use of `parseInt` to force the value to be a number can cause us to send the incorrect slot ID which can then map to the wrong publisher on our end. This change will allow us to send a string value to our ad server endpoint so that it can be invalidated there if the value is the incorrect type. It was chosen to send an invalid request as opposed to causing it to fail the `isBidRequestValid` method in order to more easily pinpoint the issue when a pub configured the slot ID incorrectly.