### PR TITLE
Publink UserId Submodule: publinkIdSystem_spec.js test fix on ie11

### DIFF
--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -88,6 +88,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
+        request.url = request.url.replace(':443','');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&gdpr=1&gdpr_consent=myconsentstring');
 
         request.respond(200, {}, JSON.stringify(serverResponse));
@@ -101,6 +102,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
+        request.url = request.url.replace(':443','');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$');
 
         request.respond(204, {}, JSON.stringify(serverResponse));
@@ -125,6 +127,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
+        request.url = request.url.replace(':443','');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&us_privacy=1YNN');
 
         request.respond(200, {}, JSON.stringify(serverResponse));

--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -88,7 +88,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
-        request.url = request.url.replace(':443','');
+        request.url = request.url.replace(':443', '');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&gdpr=1&gdpr_consent=myconsentstring');
 
         request.respond(200, {}, JSON.stringify(serverResponse));
@@ -102,7 +102,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
-        request.url = request.url.replace(':443','');
+        request.url = request.url.replace(':443', '');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$');
 
         request.respond(204, {}, JSON.stringify(serverResponse));
@@ -127,7 +127,7 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
-        request.url = request.url.replace(':443','');
+        request.url = request.url.replace(':443', '');
         expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&us_privacy=1YNN');
 
         request.respond(200, {}, JSON.stringify(serverResponse));


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
https://app.circleci.com/pipelines/github/prebid/Prebid.js/8067/workflows/7312b412-4840-4c0e-b3a6-79bd9994a203/jobs/17937
demonstrates ie11 is appending :443 to the tested string. This pr simply replaces that with empty string before the test. 