### PR TITLE
Use array instead of string template to allow . in adUnitCode value

### DIFF
--- a/modules/multibid/index.js
+++ b/modules/multibid/index.js
@@ -129,9 +129,9 @@ export function addBidResponseHook(fn, adUnitCode, bid) {
         utils.logWarn(`Filtering multibid received from bidder ${bid.bidderCode}: ` + ((multibidUnits[adUnitCode][bid.bidderCode].maxReached) ? `Maximum bid limit reached for ad unit code ${adUnitCode}` : 'Bid cpm under floors value.'));
       }
     } else {
-      if (utils.deepAccess(bid, 'floorData.floorValue')) utils.deepSetValue(multibidUnits, `${adUnitCode}.${bid.bidderCode}`, {floor: utils.deepAccess(bid, 'floorData.floorValue')});
+      if (utils.deepAccess(bid, 'floorData.floorValue')) utils.deepSetValue(multibidUnits, [adUnitCode, bid.bidderCode], {floor: utils.deepAccess(bid, 'floorData.floorValue')});
 
-      utils.deepSetValue(multibidUnits, `${adUnitCode}.${bid.bidderCode}`, {ads: [bid]});
+      utils.deepSetValue(multibidUnits, [adUnitCode, bid.bidderCode], {ads: [bid]});
       if (multibidUnits[adUnitCode][bid.bidderCode].ads.length === multiConfig[bid.bidderCode].maxbids) multibidUnits[adUnitCode][bid.bidderCode].maxReached = true;
 
       fn.call(this, adUnitCode, bid);


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
There's an error with the multibid module when the adUnitCode value contains a `.`.  For example, adUnitCode = "ad.unit", when `deepSetValue` parses the param, it creates `multibidUnits[ad][unit]` instead of `multibidUnits[ad.unit]`. The evaluation on Line 134 errors as `multbidUnits[ad.unit]` is undefined. 