### PR TITLE
PBjs core: new BIDDER_ERROR event and onBidderError function called when ajax call fail

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -618,4 +618,9 @@ adapterManager.callBidViewableBidder = function(bidder, bid) {
   tryCallBidderMethod(bidder, 'onBidViewable', bid);
 };
 
+adapterManager.callBidderError = function(bidder, error, bidderRequest) {
+  const param = { error, bidderRequest };
+  tryCallBidderMethod(bidder, 'onBidderError', param);
+};
+
 export default adapterManager;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -335,10 +335,11 @@ export function newBidder(spec) {
 
         // If the server responds with an error, there's not much we can do. Log it, and make sure to
         // call onResponse() so that we're one step closer to calling done().
-        function onFailure(err) {
+        function onFailure(errorMessage, error) {
           onTimelyResponse(spec.code);
-
-          logError(`Server call for ${spec.code} failed: ${err}. Continuing without bids.`);
+          adapterManager.callBidderError(spec.code, error, bidderRequest)
+          events.emit(CONSTANTS.EVENTS.BIDDER_ERROR, { error, bidderRequest });
+          logError(`Server call for ${spec.code} failed: ${errorMessage} ${error.status}. Continuing without bids.`);
           onResponse();
         }
       }

--- a/src/constants.json
+++ b/src/constants.json
@@ -32,6 +32,7 @@
     "NO_BID": "noBid",
     "BID_WON": "bidWon",
     "BIDDER_DONE": "bidderDone",
+    "BIDDER_ERROR": "bidderError",
     "SET_TARGETING": "setTargeting",
     "BEFORE_REQUEST_BIDS": "beforeRequestBids",
     "BEFORE_BIDDER_HTTP": "beforeBidderHttp",

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -436,6 +436,37 @@ describe('adapterManager tests', function () {
     });
   }); // end onBidViewable
 
+  describe('onBidderError', function () {
+    const bidder = 'appnexus';
+    const appnexusSpec = { onBidderError: sinon.stub() };
+    const appnexusAdapter = {
+      bidder,
+      getSpec: function() { return appnexusSpec; },
+    }
+    before(function () {
+      config.setConfig({s2sConfig: { enabled: false }});
+    });
+
+    beforeEach(function () {
+      adapterManager.bidderRegistry[bidder] = appnexusAdapter;
+    });
+
+    afterEach(function () {
+      delete adapterManager.bidderRegistry[bidder];
+    });
+
+    it('should call spec\'s onBidderError callback when callBidderError is called', function () {
+      const bidderRequest = getBidRequests().find(bidRequest => bidRequest.bidderCode === bidder);
+      const xhrErrorMock = {
+        status: 500,
+        statusText: 'Internal Server Error'
+      };
+      adapterManager.callBidderError(bidder, xhrErrorMock, bidderRequest);
+      sinon.assert.calledOnce(appnexusSpec.onBidderError);
+      sinon.assert.calledWithExactly(appnexusSpec.onBidderError, { error: xhrErrorMock, bidderRequest });
+    });
+  }); // end onBidderError
+
   describe('S2S tests', function () {
     beforeEach(function () {
       config.setConfig({s2sConfig: CONFIG});


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

When the ajax request fail a new error event `BIDDER_ERROR` will be emitte and adapters can registering to the new function onBidderError.  #6756
