### PR TITLE
PublinkId - validate hash and fix decode

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -373,6 +373,7 @@ function collectEids(bidRequests) {
   if (utils.isArray(request.userIdAsEids) && request.userIdAsEids.length > 0) {
     // later following white-list can be converted to block-list if needed
     const requiredSourceValues = {
+      'epsilon.com': 1,
       'adserver.org': 1,
       'liveramp.com': 1,
       'criteo.com': 1,

--- a/modules/publinkIdSystem.js
+++ b/modules/publinkIdSystem.js
@@ -18,6 +18,10 @@ const PUBLINK_S2S_COOKIE = '_publink_srv';
 
 export const storage = getStorageManager(GVLID);
 
+function isHex(s) {
+  return (typeof s === 'string' && /^[A-F0-9]+$/i.test(s));
+}
+
 function publinkIdUrl(params, consentData) {
   let url = utils.parseUrl('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink');
   url.search = {
@@ -49,8 +53,13 @@ function makeCallback(config = {}, consentData) {
         }
       }
     };
+
     if (config.params && config.params.e) {
-      ajax(publinkIdUrl(config.params, consentData), handleResponse, undefined, options);
+      if (isHex(config.params.e)) {
+        ajax(publinkIdUrl(config.params, consentData), handleResponse, undefined, options);
+      } else {
+        utils.logError('params.e must be a hex string');
+      }
     }
   };
 }
@@ -96,11 +105,11 @@ export const publinkIdSubmodule = {
   /**
    * decode the stored id value for passing to bid requests
    * @function
-   * @param {string} id encrypted userid
+   * @param {string} publinkId encrypted userid
    * @returns {{publinkId: string} | undefined}
    */
   decode(publinkId) {
-    return {publink: publinkId};
+    return {publinkId: publinkId};
   },
 
   /**
@@ -108,6 +117,8 @@ export const publinkIdSubmodule = {
    * Use a publink cookie first if it is present, otherwise use prebids copy, if neither are available callout to get a new id
    * @function
    * @param {SubmoduleConfig} [config] Config object with params and storage properties
+   * @param {ConsentData|undefined} consentData GDPR consent
+   * @param {(Object|undefined)} storedId Previously cached id
    * @returns {IdResponse}
    */
   getId: function(config, consentData, storedId) {

--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -10,7 +10,7 @@ describe('PublinkIdSystem', () => {
   describe('decode', () => {
     it('decode', () => {
       const result = publinkIdSubmodule.decode(TEST_COOKIE_VALUE);
-      expect(result).deep.equals({publink: TEST_COOKIE_VALUE});
+      expect(result).deep.equals({publinkId: TEST_COOKIE_VALUE});
     });
   });
 
@@ -69,6 +69,7 @@ describe('PublinkIdSystem', () => {
       expect(result).to.exist;
       expect(result.callback).to.be.a('function');
     });
+
     it('Use local copy', () => {
       const result = publinkIdSubmodule.getId({}, undefined, TEST_COOKIE_VALUE);
       expect(result).to.be.undefined;
@@ -82,14 +83,14 @@ describe('PublinkIdSystem', () => {
       });
 
       it('Fetch with consent data', () => {
-        const config = {storage: {type: 'cookie'}, params: {e: 'hashedemailvalue'}};
+        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7'}};
         const consentData = {gdprApplies: 1, consentString: 'myconsentstring'};
         let submoduleCallback = publinkIdSubmodule.getId(config, consentData).callback;
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
         request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&gdpr=1&gdpr_consent=myconsentstring');
+        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$&gdpr=1&gdpr_consent=myconsentstring');
 
         request.respond(200, {}, JSON.stringify(serverResponse));
         expect(callbackSpy.calledOnce).to.be.true;
@@ -97,16 +98,26 @@ describe('PublinkIdSystem', () => {
       });
 
       it('server doesnt respond', () => {
-        const config = {storage: {type: 'cookie'}, params: {e: 'hashedemailvalue'}};
+        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7'}};
         let submoduleCallback = publinkIdSubmodule.getId(config).callback;
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
         request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$');
+        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$');
 
         request.respond(204, {}, JSON.stringify(serverResponse));
-        expect(callbackSpy.calledOnce).to.be.false;
+        expect(callbackSpy.called).to.be.false;
+      });
+
+      it('reject plain email address', () => {
+        const config = {storage: {type: 'cookie'}, params: {e: 'tester@test.com'}};
+        const consentData = {gdprApplies: 1, consentString: 'myconsentstring'};
+        let submoduleCallback = publinkIdSubmodule.getId(config, consentData).callback;
+        submoduleCallback(callbackSpy);
+
+        expect(server.requests).to.have.lengthOf(0);
+        expect(callbackSpy.called).to.be.false;
       });
     });
 
@@ -122,13 +133,13 @@ describe('PublinkIdSystem', () => {
       });
 
       it('Fetch with usprivacy data', () => {
-        const config = {storage: {type: 'cookie'}, params: {e: 'hashedemailvalue'}};
+        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7'}};
         let submoduleCallback = publinkIdSubmodule.getId(config).callback;
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
         request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=hashedemailvalue&mpn=Prebid.js&mpv=$prebid.version$&us_privacy=1YNN');
+        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$&us_privacy=1YNN');
 
         request.respond(200, {}, JSON.stringify(serverResponse));
         expect(callbackSpy.calledOnce).to.be.true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

- Check params.e to reject plain email addresses.  It should only accept hex strings.
- Fix decode to return 'publinkId' instead of 'publink'
- Pick up PubLink in conversant bid adapter


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer: pyang@conversantmedia.com
- [ ] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
