### PR TITLE
Rubicon Bid Adapter: bugfix for copying params.video.language

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -947,6 +947,11 @@ function appendSiteAppDevice(data, bidRequest, bidderRequest) {
     ['site', 'device'].forEach(function(param) {
       if (data[param]) {
         data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
+        if (param === 'site') {
+          data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
+        } else {
+          data[param] = Object.assign({language: bidRequest.params.video.language}, data[param])
+        }
       }
     });
   }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -946,7 +946,6 @@ function appendSiteAppDevice(data, bidRequest, bidderRequest) {
   if (bidRequest.params.video.language) {
     ['site', 'device'].forEach(function(param) {
       if (data[param]) {
-        data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
         if (param === 'site') {
           data[param].content = Object.assign({language: bidRequest.params.video.language}, data[param].content)
         } else {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Added a slight modification in Rubicon's Bid Adapter. There is a bug in params.video.language: it's copying the value to site.content.language and device.content.language. The latter is invalid OpenRTB and should just be device.language. 
