### PR TITLE
Ogury Bid Adapter: fix getusersync method

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -25,7 +25,7 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
 
   return [{
     type: 'image',
-    url: `${MS_COOKIE_SYNC_DOMAIN}/v1/init-sync/bid-switch?iab_string=${gdprConsent.consentString}&source=prebid`
+    url: `${MS_COOKIE_SYNC_DOMAIN}/v1/init-sync/bid-switch?iab_string=${(gdprConsent && gdprConsent.consentString) || ''}&source=prebid`
   }]
 }
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -140,6 +140,72 @@ describe('OguryBidAdapter', function () {
       syncOptions.pixelEnabled = false;
       expect(spec.getUserSyncs(syncOptions, [], gdprConsent)).to.have.lengthOf(0);
     });
+
+    it('should return syncs array with an element of type image when consentString is undefined', () => {
+      gdprConsent = {
+        gdprApplies: true,
+        consentString: undefined
+      };
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
+
+    it('should return syncs array with an element of type image when consentString is null', () => {
+      gdprConsent = {
+        gdprApplies: true,
+        consentString: null
+      };
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
+
+    it('should return syncs array with an element of type image when gdprConsent is undefined', () => {
+      gdprConsent = undefined;
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
+
+    it('should return syncs array with an element of type image when gdprConsent is null', () => {
+      gdprConsent = null;
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
+
+    it('should return syncs array with an element of type image when gdprConsent is null and gdprApplies is false', () => {
+      gdprConsent = {
+        gdprApplies: false,
+        consentString: null
+      };
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
+
+    it('should return syncs array with an element of type image when gdprConsent is empty string and gdprApplies is false', () => {
+      gdprConsent = {
+        gdprApplies: false,
+        consentString: ''
+      };
+
+      const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+      expect(userSyncs).to.have.lengthOf(1);
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid');
+    });
   });
 
   describe('buildRequests', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Fix getUserSync errored pixel link when consent management is disabled