### PR TITLE
Fluct Bid Adapter: ie polyfill for url search params

### DIFF
--- a/allowedModules.js
+++ b/allowedModules.js
@@ -5,7 +5,7 @@ const sharedWhiteList = [
   'core-js-pure/features/set', // ie11 supports Set but not Set#values
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
-  'core-js-pure/features/array/from' // no ie11
+  'core-js-pure/features/array/from', // no ie11
   'core-js-pure/web/url-search-params' // no ie11
 ];
 

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -6,7 +6,7 @@ const sharedWhiteList = [
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
   'core-js-pure/features/array/from' // no ie11
-  'core-js-pure/features/web/url-search-params' // no ie11
+  'core-js-pure/features/url-search-params' // no ie11
 ];
 
 module.exports = {

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -6,7 +6,7 @@ const sharedWhiteList = [
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
   'core-js-pure/features/array/from' // no ie11
-  'core-js-pure/features/web/url-search-params' // no ie11
+  'core-js-pure/web/url-search-params' // no ie11
 ];
 
 module.exports = {

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -6,7 +6,7 @@ const sharedWhiteList = [
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
   'core-js-pure/features/array/from' // no ie11
-  'core-js-pure/features/url-search-params' // no ie11
+  'core-js-pure/web/url-search-params' // no ie11
 ];
 
 module.exports = {

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -6,7 +6,7 @@ const sharedWhiteList = [
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
   'core-js-pure/features/array/from' // no ie11
-  'core-js-pure/web/url-search-params' // no ie11
+  'core-js-pure/features/web/url-search-params' // no ie11
 ];
 
 module.exports = {

--- a/allowedModules.js
+++ b/allowedModules.js
@@ -6,6 +6,7 @@ const sharedWhiteList = [
   'core-js-pure/features/string/includes', // no ie11
   'core-js-pure/features/number/is-integer', // no ie11,
   'core-js-pure/features/array/from' // no ie11
+  'core-js-pure/features/web/url-search-params' // no ie11
 ];
 
 module.exports = {

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js'
+import URLSearchParams from 'core-js-pure'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure/web'
+import URLSearchParams from 'core-js-pure/web/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure/features/url-search-params'
+import URLSearchParams from 'core-js-pure/web'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure/web/url-search-params'
+import URLSearchParams from 'core-js-pure/features/web/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure/features/urlsearchparams'
+import URLSearchParams from 'core-js-pure/web/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure'
+import URLSearchParams from 'core-js-pure/features/urlsearchparams'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js-pure/features/web/url-search-params'
+import URLSearchParams from 'core-js-pure/features/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import URLSearchParams from 'core-js/features/url-search-params'
+import URLSearchParams from 'core-js'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,5 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import 'core-js/features/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,6 @@
 import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import 'core-js/features/url-search-params'
+import URLSearchParams from 'core-js/features/url-search-params'
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid';


### PR DESCRIPTION
I merged this pr and missed that UrlSearchParams is not supported in ie11. This polyfills it per Issue #7467 . Sorry about the LGTM mess. I was missing a comma so it was mad. Should be good to go now though