### PR TITLE
Prebid Core: Support for Devcontainer for VSCode, Docker Desktop, Codespaces, etc.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="16"
+ARG VARIANT="12"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG VARIANT="16"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt update
+RUN apt install -y google-chrome-stable xvfb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,9 @@
 
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
+	"extensions": [
+		"nickdodd79.gulptasks"
+	],
 
 	// 9999 is web server, 9876 is karma
 	"forwardPorts": [9876, 9999],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node
+{
+	"name": "Ubuntu",
+
+	"build": {
+		"dockerfile": "Dockerfile",		
+		"args": { "VARIANT": "12" }
+	},
+
+	"postCreateCommand": "bash .devcontainer/postCreate.sh",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// 9999 is web server, 9876 is karma
+	"forwardPorts": [9876, 9999],
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,6 @@
+echo "Post Create Starting"
+
+nvm install
+nvm use
+npm install gulp-cli -g
+npm ci


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ x ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ x ] Other

## Description of change
This change updates the dot folders to include a "devcontainer" definition which support VSCode dev containers, Docker Desktop devcontainers and GitHub Codespaces based development.

I would be happy to provide Prebid specific instructions, but they aren't any different than local development and Codespaces are well documented here https://github.com/features/codespaces and VSCode containers are well documented here. https://code.visualstudio.com/docs/remote/containers

With a very small amount and knowledge and effort on the part of a developer this can be easily adapted to a generally useful dev environment that is usable outside VSCode/Docker Desktop/Codespaces.

In summary, it codifies, generalizes and makes repeatable the "How to get started as a developer" steps in the project readme while also providing containerized development and port forwarded access to the port 9999 gulp serve server for development, etc.