### PR TITLE
Adss 1297 improve gpid support

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -298,8 +298,10 @@ function buildRequests(validBidRequests, bidderRequest) {
     // ADTS-134 Retrieve ID envelopes
     for (const eid in eids) data[eid] = eids[eid];
 
-    // ADJS-1024
-    if (utils.deepAccess(ortb2Imp, 'ext.data.adserver.name')) {
+    // ADJS-1024 & ADSS-1297
+    if (utils.deepAccess(ortb2Imp, 'ext.data.pbadslot')) {
+      gpid = utils.deepAccess(ortb2Imp, 'ext.data.pbadslot')
+    } else if (utils.deepAccess(ortb2Imp, 'ext.data.adserver.name')) {
       gpid = ortb2Imp.ext.data.adserver.adslot
     }
 

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -229,11 +229,19 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data).to.not.have.property('irisid');
     });
 
-    it('should set the global placement id (gpid)', function () {
+    it('should set the global placement id (gpid) if in adserver property', function () {
       const req = { ...bidRequests[0], ortb2Imp: { ext: { data: { adserver: { name: 'test', adslot: 123456 } } } } }
       const bidRequest = spec.buildRequests([req])[0];
       expect(bidRequest.data).to.have.property('gpid');
       expect(bidRequest.data.gpid).to.equal(123456);
+    });
+
+    it('should set the global placement id (gpid) if in pbadslot property', function () {
+      const pbadslot = 'abc123'
+      const req = { ...bidRequests[0], ortb2Imp: { ext: { data: { pbadslot } } } }
+      const bidRequest = spec.buildRequests([req])[0];
+      expect(bidRequest.data).to.have.property('gpid');
+      expect(bidRequest.data.gpid).to.equal(pbadslot);
     });
 
     it('should set the bid floor if getFloor module is not present but static bid floor is defined', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Improves our GPID support by checking within the `pbadslot` property before checking in the older `adserver.adslot` property