### PR TITLE
Gumgum Bid Adapter: use nearest matching h/w dimensions from bid request

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -1,5 +1,6 @@
-import { logError, logWarn, parseSizesInput, _each, deepAccess } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { _each, deepAccess, logError, logWarn, parseSizesInput } from '../src/utils.js';
+
 import { config } from '../src/config.js'
 import { getStorageManager } from '../src/storageManager.js';
 import includes from 'core-js-pure/features/array/includes';
@@ -488,7 +489,12 @@ function interpretResponse(serverResponse, bidRequest) {
   } else if (product === 5 && includes(sizes, '1x1')) {
     sizes = ['1x1'];
   } else if (product === 2 && includes(sizes, '1x1')) {
-    sizes = responseWidth && responseHeight ? [`${responseWidth}x${responseHeight}`] : parseSizesInput(bidRequest.sizes)
+    const requestSizesThatMatchResponse = (bidRequest.sizes && bidRequest.sizes.reduce((result, current) => {
+      const [ width, height ] = current;
+      if (responseWidth === width || responseHeight === height) result.push(current.join('x'));
+      return result
+    }, [])) || [];
+    sizes = requestSizesThatMatchResponse.length ? requestSizesThatMatchResponse : utils.parseSizesInput(bidRequest.sizes)
   }
 
   let [width, height] = sizes[0].split('x');

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -494,7 +494,7 @@ function interpretResponse(serverResponse, bidRequest) {
       if (responseWidth === width || responseHeight === height) result.push(current.join('x'));
       return result
     }, [])) || [];
-    sizes = requestSizesThatMatchResponse.length ? requestSizesThatMatchResponse : utils.parseSizesInput(bidRequest.sizes)
+    sizes = requestSizesThatMatchResponse.length ? requestSizesThatMatchResponse : parseSizesInput(bidRequest.sizes)
   }
 
   let [width, height] = sizes[0].split('x');

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -683,11 +683,24 @@ describe('gumgumAdapter', function () {
         expect(result[0].height).to.equal('1');
       });
 
-      it('uses response width and height for inscreen product', function () {
-        const result = spec.interpretResponse({ body: serverResponse }, bidRequest)[0];
-        expect(result.width).to.equal(serverResponse.ad.width.toString());
-        expect(result.height).to.equal(serverResponse.ad.height.toString());
-      });
+      it('uses request size that nearest matches response size for in-screen', function () {
+        const request = { ...bidRequest };
+        const body = { ...serverResponse };
+        const expectedSize = [ 300, 50 ];
+        let result;
+
+        request.pi = 2;
+        request.sizes.unshift(expectedSize);
+
+        // typical ad server response values for in-screen
+        body.ad.width = 300;
+        body.ad.height = 100;
+
+        result = spec.interpretResponse({ body }, request)[0];
+
+        expect(result.width = expectedSize[0]);
+        expect(result.height = expectedSize[1]);
+      })
 
       it('defaults to use bidRequest sizes', function () {
         const { ad, jcsi, pag, thms, meta } = serverResponse


### PR DESCRIPTION
…uest

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Instead of using the response width and height as-is, we should use the nearest matching dimensions from the bid request