### PR TITLE
PBS Bid Adapter: separately define ratio width/height in Native (Issue #6654)

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -537,7 +537,7 @@ const OPEN_RTB_PROTOCOL = {
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
                   throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
                 }
-                if (Array.isArray(params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
+                if (Array.isArray(params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height)) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -537,7 +537,7 @@ const OPEN_RTB_PROTOCOL = {
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
                   throw 'invalid img sizes (must provide sizes or min_height & min_width)';
                 }
-                if (params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
+                if (Array.isArray(params.aspect_ratios)) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -537,7 +537,7 @@ const OPEN_RTB_PROTOCOL = {
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
                   throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
                 }
-                if (Array.isArray(params.aspect_ratios)) {
+                if (params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -535,9 +535,9 @@ const OPEN_RTB_PROTOCOL = {
                   hmin: deepAccess(params, 'aspect_ratios.0.min_height')
                 });
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
-                  throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
+                  throw 'invalid img sizes (must provide sizes or min_height & min_width)';
                 }
-                if (Array.isArray(params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height)) {
+                if (params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -537,7 +537,7 @@ const OPEN_RTB_PROTOCOL = {
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
                   throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
                 }
-                if (Array.isArray((params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height)) {
+                if (Array.isArray(params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -537,7 +537,7 @@ const OPEN_RTB_PROTOCOL = {
                 if (!((asset.w && asset.h) || (asset.hmin && asset.wmin))) {
                   throw 'invalid img sizes (must provide sizes or min_height & min_width if using aspect_ratios)';
                 }
-                if (params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height) {
+                if (Array.isArray((params.aspect_ratios.ratio_width && params.aspect_ratios.ratio_height)) {
                   // pass aspect_ratios as ext data I guess?
                   asset.ext = {
                     aspectratios: params.aspect_ratios.map(

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -602,6 +602,29 @@ describe('Adf adapter', function () {
 
             assert.doesNotThrow(() => spec.buildRequests(validBidRequests, { refererInfo: { referer: 'page' } }));
           });
+          
+          it('should not throw error if min_width & min_height not defined', function () {
+            const validBidRequests = [{
+              bidId: 'bidId',
+              params: { mid: 1000 },
+              nativeParams: {
+                image: {
+                  aspect_ratios: [{
+                    min_width: 100,
+                    min_height: 300
+                  }]
+                },
+                icon: {
+                  aspect_ratios: [{
+                    min_width: 10,
+                    min_height: 25
+                  }]
+                }
+              }
+            }];
+
+            assert.doesNotThrow(() => spec.buildRequests(validBidRequests, { refererInfo: { referer: 'page' } }));
+          });
         });
 
         it('should expect any dimensions if min_width not passed', function () {

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -602,7 +602,7 @@ describe('Adf adapter', function () {
 
             assert.doesNotThrow(() => spec.buildRequests(validBidRequests, { refererInfo: { referer: 'page' } }));
           });
-          
+
           it('should not throw error if min_width & min_height not defined', function () {
             const validBidRequests = [{
               bidId: 'bidId',


### PR DESCRIPTION
Fix for Issue #6654