### PR TITLE
PubLink id system: adds params for site id and api key

### DIFF
--- a/modules/publinkIdSystem.js
+++ b/modules/publinkIdSystem.js
@@ -19,7 +19,7 @@ const PUBLINK_S2S_COOKIE = '_publink_srv';
 export const storage = getStorageManager(GVLID);
 
 function isHex(s) {
-  return (typeof s === 'string' && /^[A-F0-9]+$/i.test(s));
+  return /^[A-F0-9]+$/i.test(s);
 }
 
 function publinkIdUrl(params, consentData) {
@@ -29,10 +29,15 @@ function publinkIdUrl(params, consentData) {
     mpn: 'Prebid.js',
     mpv: '$prebid.version$',
   };
+
   if (consentData) {
     url.search.gdpr = (consentData.gdprApplies) ? 1 : 0;
     url.search.gdpr_consent = consentData.consentString;
   }
+
+  if (params.site_id) { url.search.sid = params.site_id; }
+
+  if (params.api_key) { url.search.apikey = params.api_key; }
 
   const usPrivacyString = uspDataHandler.getConsentData();
   if (usPrivacyString && typeof usPrivacyString === 'string') {

--- a/modules/publinkIdSystem.md
+++ b/modules/publinkIdSystem.md
@@ -7,7 +7,10 @@ Publink user id module
 | Param Name | Required | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Yes | String | module identifier | `"publinkId"` |
-| params.e | Yes | String | hashed email address | `"e80b5017098950fc58aad83c8c14978e"` |
+| params.e | Yes | String | hashed email address | `"7D320454942620664D96EF78ED4E3A2A"` |
+| params.api_key | Yes | String | api key for access | `"7ab62359-bdc0-4095-b573-ef474fb55d24"` |
+| params.site_id | Yes | String | site identifier | `"123456"` |
+
 
 ### Example configuration for Publink
 ```
@@ -20,7 +23,9 @@ pbjs.setConfig({
                    type: "html5"
                },
                params: {
-                   e: "e80b5017098950fc58aad83c8c14978e", // example hashed email (md5)
+                   e: "7D320454942620664D96EF78ED4E3A2A",           // example hashed email (md5)
+                   site_id: "123456",                               // provided by Epsilon
+                   api_key: "7ab62359-bdc0-4095-b573-ef474fb55d2"   // provided by Epsilon
                }
            }],
        }

--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -3,6 +3,7 @@ import {getStorageManager} from '../../../src/storageManager';
 import {server} from 'test/mocks/xhr.js';
 import sinon from 'sinon';
 import {uspDataHandler} from '../../../src/adapterManager';
+import {parseUrl} from '../../../src/utils';
 
 export const storage = getStorageManager(24);
 const TEST_COOKIE_VALUE = 'cookievalue';
@@ -83,14 +84,22 @@ describe('PublinkIdSystem', () => {
       });
 
       it('Fetch with consent data', () => {
-        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7'}};
+        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7', site_id: '102030'}};
         const consentData = {gdprApplies: 1, consentString: 'myconsentstring'};
         let submoduleCallback = publinkIdSubmodule.getId(config, consentData).callback;
         submoduleCallback(callbackSpy);
 
-        let request = server.requests[0];
-        request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$&gdpr=1&gdpr_consent=myconsentstring');
+        const request = server.requests[0];
+        const parsed = parseUrl(request.url);
+
+        expect(parsed.hostname).to.equal('proc.ad.cpe.dotomi.com');
+        expect(parsed.pathname).to.equal('/cvx/client/sync/publink');
+        expect(parsed.search.mpn).to.equal('Prebid.js');
+        expect(parsed.search.mpv).to.equal('$prebid.version$');
+        expect(parsed.search.gdpr).to.equal('1');
+        expect(parsed.search.gdpr_consent).to.equal('myconsentstring');
+        expect(parsed.search.sid).to.equal('102030');
+        expect(parsed.search.apikey).to.be.undefined;
 
         request.respond(200, {}, JSON.stringify(serverResponse));
         expect(callbackSpy.calledOnce).to.be.true;
@@ -103,8 +112,12 @@ describe('PublinkIdSystem', () => {
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
-        request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$');
+        const parsed = parseUrl(request.url);
+
+        expect(parsed.hostname).to.equal('proc.ad.cpe.dotomi.com');
+        expect(parsed.pathname).to.equal('/cvx/client/sync/publink');
+        expect(parsed.search.mpn).to.equal('Prebid.js');
+        expect(parsed.search.mpv).to.equal('$prebid.version$');
 
         request.respond(204, {}, JSON.stringify(serverResponse));
         expect(callbackSpy.called).to.be.false;
@@ -133,13 +146,19 @@ describe('PublinkIdSystem', () => {
       });
 
       it('Fetch with usprivacy data', () => {
-        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7'}};
+        const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7', api_key: 'abcdefg'}};
         let submoduleCallback = publinkIdSubmodule.getId(config).callback;
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];
-        request.url = request.url.replace(':443', '');
-        expect(request.url).to.equal('https://proc.ad.cpe.dotomi.com/cvx/client/sync/publink?deh=ca11c0ca7&mpn=Prebid.js&mpv=$prebid.version$&us_privacy=1YNN');
+        const parsed = parseUrl(request.url);
+
+        expect(parsed.hostname).to.equal('proc.ad.cpe.dotomi.com');
+        expect(parsed.pathname).to.equal('/cvx/client/sync/publink');
+        expect(parsed.search.mpn).to.equal('Prebid.js');
+        expect(parsed.search.mpv).to.equal('$prebid.version$');
+        expect(parsed.search.us_privacy).to.equal('1YNN');
+        expect(parsed.search.apikey).to.equal('abcdefg');
 
         request.respond(200, {}, JSON.stringify(serverResponse));
         expect(callbackSpy.calledOnce).to.be.true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Adds two params for PubLink ID.  The caller needs to contact Epsilon to obtain either a site ID, or an api key, which are then included thru configuration.

Also fixed unit tests to compare URL parameters separately.  

- contact email of the adapter’s maintainer: pyang@conversantmedia.com

- A link to a PR on the docs repo at [3306](https://github.com/prebid/prebid.github.io/pull/3306)
