### PR TITLE
Feature/yahoo user identity module

### DIFF
--- a/modules/connectIDSystem.js
+++ b/modules/connectIDSystem.js
@@ -40,7 +40,7 @@ export const connectIDSubmodule = {
       ? {connectid: value.connectid} : undefined;
   },
   /**
-   * Gets the Yahoo Connect ID
+   * Gets the Yahoo ConnectID
    * @function
    * @param {SubmoduleConfig} [config]
    * @param {ConsentData} [consentData]

--- a/modules/connectIDSystem.js
+++ b/modules/connectIDSystem.js
@@ -1,0 +1,104 @@
+/**
+ * This module adds support for Yahoo ConnectID to the user ID module system.
+ * The {@link module:modules/userId} module is required
+ * @module modules/connectIdSystem
+ * @requires module:modules/userId
+ */
+
+import {ajax} from '../src/ajax.js';
+import {submodule} from '../src/hook.js';
+import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
+
+const MODULE_NAME = 'connectID';
+const VENDOR_ID = 25;
+const PLACEHOLDER = '__PIXEL_ID__';
+const UPS_ENDPOINT = `https://ups.analytics.yahoo.com/ups/${PLACEHOLDER}/fed`;
+
+function isEUConsentRequired(consentData) {
+  return !!(consentData && consentData.gdpr && consentData.gdpr.gdprApplies);
+}
+
+/** @type {Submodule} */
+export const connectIDSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: MODULE_NAME,
+  /**
+   * @type {Number}
+   */
+  gvlid: VENDOR_ID,
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @returns {{connectid: string} | undefined}
+   */
+  decode(value) {
+    return (typeof value === 'object' && value.connectid)
+      ? {connectid: value.connectid} : undefined;
+  },
+  /**
+   * Gets the Yahoo Connect ID
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
+   * @returns {IdResponse|undefined}
+   */
+  getId(config, consentData) {
+    const params = config.params || {};
+    if (!params || typeof params.he !== 'string' ||
+      (typeof params.pixelId === 'undefined' && typeof params.endpoint === 'undefined')) {
+      utils.logError('The connectId submodule requires the \'he\' and \'pixelId\' parameters to be defined.');
+      return;
+    }
+
+    const data = {
+      '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
+      he: params.he,
+      gdpr: isEUConsentRequired(consentData) ? '1' : '0',
+      gdpr_consent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',
+      us_privacy: consentData && consentData.uspConsent ? consentData.uspConsent : ''
+    };
+
+    if (params.pixelId) {
+      data.pixelId = params.pixelId
+    }
+
+    const resp = function (callback) {
+      const callbacks = {
+        success: response => {
+          let responseObj;
+          if (response) {
+            try {
+              responseObj = JSON.parse(response);
+            } catch (error) {
+              utils.logError(error);
+            }
+          }
+          callback(responseObj);
+        },
+        error: error => {
+          utils.logError(`${MODULE_NAME}: ID fetch encountered an error`, error);
+          callback();
+        }
+      };
+      const endpoint = UPS_ENDPOINT.replace(PLACEHOLDER, params.pixelId);
+      let url = `${params.endpoint || endpoint}?${utils.formatQS(data)}`;
+      connectIDSubmodule.getAjaxFn()(url, callbacks, null, {method: 'GET', withCredentials: true});
+    };
+    return {callback: resp};
+  },
+
+  /**
+   * Return the function used to perform XHR calls.
+   * Utilised for each of testing.
+   * @returns {Function}
+   */
+  getAjaxFn() {
+    return ajax;
+  }
+};
+
+submodule('userId', connectIDSubmodule);

--- a/modules/connectIDSystem.md
+++ b/modules/connectIDSystem.md
@@ -1,0 +1,33 @@
+## Yahoo ConnectID User ID Submodule
+
+Yahoo ConnectID user ID Module.
+
+### Prebid Params
+
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'connectID',
+            storage: {
+                name: 'connectID',
+                type: 'html5',
+                expires: 15
+            },
+            params: {
+                pixelId: 58776,
+                he: '0bef996248d63cea1529cb86de31e9547a712d9f380146e98bbd39beec70355a'
+            }
+        }]
+    }
+});
+```
+## Parameter Descriptions for the `usersync` Configuration Section
+The below parameters apply only to the Yahoo ConnectID user ID Module.
+
+| Param under usersync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | ID value for the Yahoo ConnectID module - `"connectID"` | `"connectID"` |
+| params | Required | Object | Data for Yahoo ConnectID initialization. | |
+| params.pixelId | Required | Number | The Yahoo supplied publisher specific pixel Id  | `8976` |
+| params.he | Required | String | The SHA-256 hashed user email address | `"529cb86de31e9547a712d9f380146e98bbd39beec"` |

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -181,15 +181,18 @@ const USER_IDS_CONFIG = {
     source: 'neustar.biz',
     atype: 1
   },
+
   // MediaWallah OpenLink
   'mwOpenLinkId': {
     source: 'mediawallahscript.com',
     atype: 1
   },
+
   'tapadId': {
     source: 'tapad.com',
     atype: 1
   },
+
   // Novatiq Snowflake
   'novatiq': {
     getValue: function(data) {
@@ -198,6 +201,7 @@ const USER_IDS_CONFIG = {
     source: 'novatiq.com',
     atype: 1
   },
+
   'uid2': {
     source: 'uidapi.com',
     atype: 3,
@@ -205,40 +209,54 @@ const USER_IDS_CONFIG = {
       return data.id;
     }
   },
+
   // Akamai Data Activation Platform (DAP)
   'dapId': {
     source: 'akamai.com',
     atype: 1
   },
+
   'deepintentId': {
     source: 'deepintent.com',
     atype: 3
   },
+
   // Admixer Id
   'admixerId': {
     source: 'admixer.net',
     atype: 3
   },
+
   // Adtelligent Id
   'adtelligentId': {
     source: 'adtelligent.com',
     atype: 3
   },
+
   amxId: {
     source: 'amxrtb.com',
     atype: 1,
   },
+
   'publinkId': {
     source: 'epsilon.com',
     atype: 3
   },
+
   'kpuid': {
     source: 'kpuid.com',
     atype: 3
   },
+
   'imuid': {
     source: 'intimatemerger.com',
     atype: 1
+  },
+
+  // Yahoo ConnectID
+  'connectID': {
+    source: 'yahoo.com',
+    atype: 3
   }
 };
 

--- a/test/spec/modules/connectIDSystem_spec.js
+++ b/test/spec/modules/connectIDSystem_spec.js
@@ -1,0 +1,189 @@
+import {expect} from 'chai';
+import * as utils from 'src/utils.js';
+import {connectIDSubmodule} from 'modules/connectIDSystem.js';
+
+describe('Yahoo ConnectID Submodule', () => {
+  const HASHED_EMAIL = '6bda6f2fa268bf0438b5423a9861a2cedaa5dec163c03f743cfe05c08a8397b2';
+  const PIXEL_ID = '1234';
+  const PROD_ENDPOINT = `https://ups.analytics.yahoo.com/ups/${PIXEL_ID}/fed`;
+  const OVERRIDE_ENDPOINT = 'https://foo/bar';
+
+  it('should have the correct module name declared', () => {
+    expect(connectIDSubmodule.name).to.equal('connectID');
+  });
+
+  it('should have the correct TCFv2 Vendor ID declared', () => {
+    expect(connectIDSubmodule.gvlid).to.equal(25);
+  });
+
+  describe('getId()', () => {
+    let ajaxStub;
+    let getAjaxFnStub;
+    let consentData;
+    beforeEach(() => {
+      ajaxStub = sinon.stub();
+      getAjaxFnStub = sinon.stub(connectIDSubmodule, 'getAjaxFn');
+      getAjaxFnStub.returns(ajaxStub);
+
+      consentData = {
+        gdpr: {
+          gdprApplies: 1,
+          consentString: 'GDPR_CONSENT_STRING'
+        },
+        uspConsent: 'USP_CONSENT_STRING'
+      };
+    });
+
+    afterEach(() => {
+      getAjaxFnStub.restore();
+    });
+
+    function invokeGetIdAPI(configParams, consentData) {
+      let result = connectIDSubmodule.getId({
+        params: configParams
+      }, consentData);
+      if (typeof result === 'object') {
+        result.callback(sinon.stub());
+      }
+      return result;
+    }
+
+    it('returns undefined if he and pixelId params are not passed', () => {
+      expect(invokeGetIdAPI({}, consentData)).to.be.undefined;
+      expect(ajaxStub.callCount).to.equal(0);
+    });
+
+    it('returns undefined if the pixelId param is not passed', () => {
+      expect(invokeGetIdAPI({
+        he: HASHED_EMAIL
+      }, consentData)).to.be.undefined;
+      expect(ajaxStub.callCount).to.equal(0);
+    });
+
+    it('returns undefined if the he param is not passed', () => {
+      expect(invokeGetIdAPI({
+        pixelId: PIXEL_ID
+      }, consentData)).to.be.undefined;
+      expect(ajaxStub.callCount).to.equal(0);
+    });
+
+    it('returns an object with the callback function if the correct params are passed', () => {
+      let result = invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('Makes an ajax GET request to the production API endpoint with query params', () => {
+      invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID
+      }, consentData);
+
+      const expectedParams = {
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID,
+        '1p': '0',
+        gdpr: '1',
+        gdpr_consent: consentData.gdpr.consentString,
+        us_privacy: consentData.uspConsent
+      };
+      const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+
+      expect(ajaxStub.firstCall.args[0].indexOf(`${PROD_ENDPOINT}?`)).to.equal(0);
+      expect(requestQueryParams).to.deep.equal(expectedParams);
+      expect(ajaxStub.firstCall.args[3]).to.deep.equal({method: 'GET', withCredentials: true});
+    });
+
+    it('Makes an ajax GET request to the specified override API endpoint with query params', () => {
+      invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        endpoint: OVERRIDE_ENDPOINT
+      }, consentData);
+
+      const expectedParams = {
+        he: HASHED_EMAIL,
+        '1p': '0',
+        gdpr: '1',
+        gdpr_consent: consentData.gdpr.consentString,
+        us_privacy: consentData.uspConsent
+      };
+      const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+
+      expect(ajaxStub.firstCall.args[0].indexOf(`${OVERRIDE_ENDPOINT}?`)).to.equal(0);
+      expect(requestQueryParams).to.deep.equal(expectedParams);
+      expect(ajaxStub.firstCall.args[3]).to.deep.equal({method: 'GET', withCredentials: true});
+    });
+
+    it('sets the callbacks param of the ajax function call correctly', () => {
+      invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID,
+      }, consentData);
+
+      expect(ajaxStub.firstCall.args[1]).to.be.an('object').that.has.all.keys(['success', 'error']);
+    });
+
+    it('sets GDPR consent data flag correctly when call is under GDPR jurisdiction.', () => {
+      invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID,
+      }, consentData);
+
+      const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+      expect(requestQueryParams.gdpr).to.equal('1');
+      expect(requestQueryParams.gdpr_consent).to.equal(consentData.gdpr.consentString);
+    });
+
+    it('sets GDPR consent data flag correctly when call is NOT under GDPR jurisdiction.', () => {
+      consentData.gdpr.gdprApplies = false;
+
+      invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID,
+      }, consentData);
+
+      const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+      expect(requestQueryParams.gdpr).to.equal('0');
+      expect(requestQueryParams.gdpr_consent).to.equal('');
+    });
+
+    [1, '1', true].forEach(firstPartyParamValue => {
+      it(`sets 1p payload property to '1' for a config value of ${firstPartyParamValue}`, () => {
+        invokeGetIdAPI({
+          '1p': firstPartyParamValue,
+          he: HASHED_EMAIL,
+          pixelId: PIXEL_ID,
+        }, consentData);
+
+        const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+        expect(requestQueryParams['1p']).to.equal('1');
+      });
+    });
+  });
+
+  describe('decode()', () => {
+    const VALID_API_RESPONSES = [{
+      key: 'connectid',
+      expected: '4567',
+      payload: {
+        connectid: '4567'
+      }
+    }];
+    VALID_API_RESPONSES.forEach(responseData => {
+      it('should return a newly constructed object with the connect ID for a payload with ${responseData.key} key(s)', () => {
+        expect(connectIDSubmodule.decode(responseData.payload)).to.deep.equal(
+          {connectid: responseData.expected}
+        );
+      });
+    });
+
+    [{}, '', {foo: 'bar'}].forEach((response) => {
+      it(`should return undefined for an invalid response "${JSON.stringify(response)}"`, () => {
+        expect(connectIDSubmodule.decode(response)).to.be.undefined;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
All things with Verizon Media branding are shifting to the Yahoo brand. A new bid adapter is being prepared by @adam-browning and will soon be in PR, but in the meantime here is the newly branded user identity module. 

The plan from the team is to first release the new Yahoo bid adapter - this will consume user ID data from the newly branded UserID module, then in a later release we will drop the old 'aol' adapter and add 'aol' as an alias of the new Yahoo bid adapter (config is the same). At this point we will also remove the old Verizon Media user identity module. 

Will update this PR shortly once I open a PR for the documentation site.
