### PR TITLE
Relaido Bid Adapter: support imuid (with utils fix after revert)

### DIFF
--- a/modules/relaidoBidAdapter.js
+++ b/modules/relaidoBidAdapter.js
@@ -71,7 +71,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       height: height,
       pv: '$prebid.version$'
     };
-    
+
     const imuid = deepAccess(bidRequest, 'userId.imuid');
     if (imuid) {
       payload.imuid = imuid;

--- a/modules/relaidoBidAdapter.js
+++ b/modules/relaidoBidAdapter.js
@@ -6,7 +6,7 @@ import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'relaido';
 const BIDDER_DOMAIN = 'api.relaido.jp';
-const ADAPTER_VERSION = '1.0.5';
+const ADAPTER_VERSION = '1.0.6';
 const DEFAULT_TTL = 300;
 const UUID_KEY = 'relaido_uuid';
 
@@ -68,8 +68,14 @@ function buildRequests(validBidRequests, bidderRequest) {
       media_type: mediaType,
       uuid: uuid,
       width: width,
-      height: height
+      height: height,
+      pv: '$prebid.version$'
     };
+    
+    const imuid = deepAccess(bidRequest, 'userId.imuid');
+    if (imuid) {
+      payload.imuid = imuid;
+    }
 
     // It may not be encoded, so add it at the end of the payload
     payload.ref = bidderRequest.refererInfo.referer;

--- a/test/spec/modules/relaidoBidAdapter_spec.js
+++ b/test/spec/modules/relaidoBidAdapter_spec.js
@@ -367,7 +367,6 @@ describe('RelaidoAdapter', function () {
   });
 
   describe('spec.onBidWon', function () {
-
     it('Should create nurl pixel if bid nurl', function () {
       let bid = {
         bidder: bidRequest.bidder,
@@ -380,7 +379,6 @@ describe('RelaidoAdapter', function () {
         adUnitCode: bidRequest.adUnitCode,
         ref: window.location.href,
       }
-
       spec.onBidWon(bid);
       const parser = utils.parseUrl(triggerPixelStub.getCall(0).args[0]);
       const query = parser.search;
@@ -398,7 +396,6 @@ describe('RelaidoAdapter', function () {
   });
 
   describe('spec.onTimeout', function () {
-
     it('Should create nurl pixel if bid nurl', function () {
       const data = [{
         bidder: bidRequest.bidder,
@@ -408,7 +405,6 @@ describe('RelaidoAdapter', function () {
         params: [bidRequest.params],
         timeout: bidderRequest.timeout,
       }];
-
       spec.onTimeout(data);
       const parser = utils.parseUrl(triggerPixelStub.getCall(0).args[0]);
       const query = parser.search;

--- a/test/spec/modules/relaidoBidAdapter_spec.js
+++ b/test/spec/modules/relaidoBidAdapter_spec.js
@@ -76,7 +76,7 @@ describe('RelaidoAdapter', function () {
       mediaType: 'video',
     };
   });
-  
+
   afterEach(() => {
     generateUUIDStub.restore();
     triggerPixelStub.restore();
@@ -272,7 +272,7 @@ describe('RelaidoAdapter', function () {
       expect(keys[0]).to.equal('version');
       expect(keys[keys.length - 1]).to.equal('ref');
     });
-    
+
     it('should get imuid', function () {
       bidRequest.userId = {}
       bidRequest.userId.imuid = 'i.tjHcK_7fTcqnbrS_YA2vaw';
@@ -282,8 +282,6 @@ describe('RelaidoAdapter', function () {
       expect(request.data.imuid).to.equal('i.tjHcK_7fTcqnbrS_YA2vaw');
     });
   });
-  
-  
 
   describe('spec.interpretResponse', function () {
     it('should build bid response by video', function () {
@@ -382,6 +380,7 @@ describe('RelaidoAdapter', function () {
         adUnitCode: bidRequest.adUnitCode,
         ref: window.location.href,
       }
+
       spec.onBidWon(bid);
       const parser = utils.parseUrl(triggerPixelStub.getCall(0).args[0]);
       const query = parser.search;
@@ -409,6 +408,7 @@ describe('RelaidoAdapter', function () {
         params: [bidRequest.params],
         timeout: bidderRequest.timeout,
       }];
+
       spec.onTimeout(data);
       const parser = utils.parseUrl(triggerPixelStub.getCall(0).args[0]);
       const query = parser.search;


### PR DESCRIPTION
`utils.` no longer needed because of specific import of functions. I already reviewed this pr but had to revert and resubmit due to utils no longer being valid. Adding @patmmccann  on here for visibility

Original pr -> https://github.com/prebid/Prebid.js/pull/7422/files