### PR TITLE
VIS.X Bid Adapter: iframe sync support & optional video params

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -168,16 +168,21 @@ export const spec = {
     return bidResponses;
   },
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent) {
-    if (syncOptions.pixelEnabled) {
-      var query = [];
-      if (gdprConsent) {
-        if (gdprConsent.consentString) {
-          query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString));
-        }
-        query.push('gdpr_applies=' + encodeURIComponent(
-          (typeof gdprConsent.gdprApplies === 'boolean')
-            ? Number(gdprConsent.gdprApplies) : 1));
+    var query = [];
+    if (gdprConsent) {
+      if (gdprConsent.consentString) {
+        query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString));
       }
+      query.push('gdpr_applies=' + encodeURIComponent(
+        (typeof gdprConsent.gdprApplies === 'boolean')
+          ? Number(gdprConsent.gdprApplies) : 1));
+    }
+    if (syncOptions.iframeEnabled) {
+      return [{
+        type: 'iframe',
+        url: buildUrl(ADAPTER_SYNC_PATH) + '?iframe=1' + (query.length ? '&' + query.join('&') : '')
+      }];
+    } else if (syncOptions.pixelEnabled) {
       return [{
         type: 'image',
         url: buildUrl(ADAPTER_SYNC_PATH) + (query.length ? '?' + query.join('&') : '')
@@ -230,7 +235,7 @@ function makeVideo(videoParams = {}) {
       return result;
     }, { w: deepAccess(videoParams, 'playerSize.0.0'), h: deepAccess(videoParams, 'playerSize.0.1') });
 
-  if (video.w && video.h && video.mimes) {
+  if (video.w && video.h) {
     return video;
   }
 }
@@ -344,18 +349,6 @@ function _isValidVideoBid(bid, logErrors = false) {
   if (!(videoMediaType.playerSize && parseSizesInput(deepAccess(videoMediaType, 'playerSize', [])))) {
     if (logErrors) {
       logError(LOG_ERROR_MESS.videoMissing + 'playerSize');
-    }
-    result = false;
-  }
-  if (!videoMediaType.mimes) {
-    if (logErrors) {
-      logError(LOG_ERROR_MESS.videoMissing + 'mimes');
-    }
-    result = false;
-  }
-  if (!videoMediaType.protocols) {
-    if (logErrors) {
-      logError(LOG_ERROR_MESS.videoMissing + 'protocols');
     }
     result = false;
   }

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -44,7 +44,8 @@ describe('VisxAdapter', function () {
       videoBid.mediaTypes = {
         video: {
           context: 'instream',
-          playerSize: [[400, 300]]
+          mimes: ['video/mp4'],
+          protocols: [3, 6]
         }
       };
       expect(spec.isBidRequestValid(videoBid)).to.equal(false);
@@ -55,9 +56,7 @@ describe('VisxAdapter', function () {
       videoBid.mediaTypes = {
         video: {
           context: 'instream',
-          playerSize: [[400, 300]],
-          mimes: ['video/mp4'],
-          protocols: [3, 6]
+          playerSize: [[400, 300]]
         }
       };
       expect(spec.isBidRequestValid(videoBid)).to.equal(true);
@@ -1151,6 +1150,51 @@ describe('VisxAdapter', function () {
       const data = { timeout: 3000, bidId: '23423', params: { uid: 1 } };
       spec.onTimeout(data);
       expect(utils.triggerPixel.calledOnceWith('https://t.visx.net/track/bid_timeout?data=' + JSON.stringify(data))).to.equal(true);
+    });
+  });
+
+  describe('user sync', function () {
+    function parseUrl(url) {
+      const [, path, querySt] = url.match(/^https?:\/\/[^\/]+(?:\/([^?]+)?)?(?:\?(.+)?)?$/) || [];
+      const query = {};
+      (querySt || '').split('&').forEach((q) => {
+        var kv = q.split('=');
+        if (kv[0]) {
+          query[kv[0]] = decodeURIComponent(kv[1] || '');
+        }
+      });
+      return { path, query };
+    }
+    it('should call iframe', function () {
+      let syncs = spec.getUserSyncs({
+        iframeEnabled: true
+      });
+
+      expect(Array.isArray(syncs)).to.equal(true);
+      expect(syncs.length).to.equal(1);
+      expect(syncs[0]).to.have.property('type', 'iframe');
+      expect(syncs[0]).to.have.property('url');
+      expect(syncs[0].url).to.be.an('string');
+
+      const { path, query } = parseUrl(syncs[0].url);
+      expect(path).to.equal('push_sync');
+      expect(query).to.deep.equal({iframe: '1'});
+    });
+
+    it('should call image', function () {
+      let syncs = spec.getUserSyncs({
+        pixelEnabled: true
+      });
+
+      expect(Array.isArray(syncs)).to.equal(true);
+      expect(syncs.length).to.equal(1);
+      expect(syncs[0]).to.have.property('type', 'image');
+      expect(syncs[0]).to.have.property('url');
+      expect(syncs[0].url).to.be.an('string');
+
+      const { path, query } = parseUrl(syncs[0].url);
+      expect(path).to.equal('push_sync');
+      expect(query).to.deep.equal({});
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Other

## Description of change
In case if iframe syncs are allowed by the publisher, our adapter calls the iframe sync instead of the pixel one. Also make `mimes` and `protocols` fields for video bids optional.