### PR TITLE
UNICORN fix bid_request cur and site.publisher.id to comply with OpenRTB 2.5 

### DIFF
--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -58,11 +58,11 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
     id: bidderRequest.auctionId,
     at: 1,
     imp,
-    cur: UNICORN_DEFAULT_CURRENCY,
+    cur: [UNICORN_DEFAULT_CURRENCY],
     site: {
       id: deepAccess(validBidRequests[0], 'params.mediaId') || '',
       publisher: {
-        id: deepAccess(validBidRequests[0], 'params.publisherId') || 0
+        id: String(deepAccess(validBidRequests[0], 'params.publisherId') || 0)
       },
       domain: window.location.hostname,
       page: window.location.href,

--- a/test/spec/modules/unicornBidAdapter_spec.js
+++ b/test/spec/modules/unicornBidAdapter_spec.js
@@ -332,14 +332,14 @@ const openRTBRequest = {
       tagid: 'rectangle-ad-2'
     }
   ],
-  cur: 'JPY',
+  cur: ['JPY'],
   ext: {
     accountId: 12345
   },
   site: {
     id: 'example',
     publisher: {
-      id: 99999
+      id: '99999'
     },
     domain: 'uni-corn.net',
     page: 'https://uni-corn.net/',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- fix bid request `cur` and `site.publisher.id` to comply with OpenRTB 2.5
<!-- For new bidder adapters, please provide the following -->