### PR TITLE
Adnuntius Bidder: Deal ID and domain change

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -112,6 +112,7 @@ export const spec = {
             height: Number(ad.creativeHeight),
             creativeId: ad.creativeId,
             currency: (ad.bid) ? ad.bid.currency : 'EUR',
+            dealId: ad.dealId || '',
             meta: {
               advertiserDomains: (ad.destinationUrls.destination) ? [ad.destinationUrls.destination.split('/')[2]] : []
 

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -199,6 +199,32 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL);
     });
+
+    it('should pass segments if available in config', function () {
+      config.setConfig({
+        segments: ['segment1', 'segment2']
+      });
+      const request = spec.buildRequests(bidRequests);
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
+    });
+  });
+
+  describe('user privacy', function () {
+    it('should send GDPR Consent data if gdprApplies', function () {
+      let request = spec.buildRequests(bidRequests, { gdprConsent: { gdprApplies: true, consentString: 'consentString' } });
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_CONSENT);
+    });
+
+    it('should not send GDPR Consent data if gdprApplies equals undefined', function () {
+      let request = spec.buildRequests(bidRequests, { gdprConsent: { gdprApplies: undefined, consentString: 'consentString' } });
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+    });
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -201,10 +201,52 @@ describe('adnuntiusBidAdapter', function () {
     });
 
     it('should pass segments if available in config', function () {
-      config.setConfig({
-        segments: ['segment1', 'segment2']
+      config.setBidderConfig({
+        bidders: ['adnuntius', 'other'],
+        config: {
+          ortb2: {
+            user: {
+              data: [{
+                name: 'adnuntius',
+                segment: [{ id: 'segment1' }, { id: 'segment2' }]
+              },
+              {
+                name: 'other',
+                segment: ['segment3']
+              }],
+            }
+          }
+        }
       });
-      const request = spec.buildRequests(bidRequests);
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidRequests));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
+    });
+
+    it('should skip segments in config if not either id or array of strings', function () {
+      config.setBidderConfig({
+        bidders: ['adnuntius', 'other'],
+        config: {
+          ortb2: {
+            user: {
+              data: [{
+                name: 'adnuntius',
+                segment: [{ id: 'segment1' }, { id: 'segment2' }, { id: 'segment3' }]
+              },
+              {
+                name: 'other',
+                segment: [{
+                  notright: 'segment4'
+                }]
+              }],
+            }
+          }
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidRequests));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Added the possibility to do deal ID's from the adserver and changed the domain to which requests are sent to handle latency.


- contact email of the adapter’s maintainer
mikael@adnuntius.com
- [x] official adapter submission
