### PR TITLE
eslint Build: support spread operator for spec files

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -8,7 +8,8 @@ module.exports = {
     '$$PREBID_GLOBAL$$': false
   },
   parserOptions: {
-    sourceType: 'module'
+    sourceType: 'module',
+    ecmaVersion: 2018
   },
   rules: {
     'comma-dangle': 'off',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The `ecmaVersion` option is missing in `spec/.eslintrc.js` file. Without this option, the spread-operator is not supported.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Related to #7313 
