### PR TITLE
Native puc multiple events fix

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -60,7 +60,6 @@ export function receiveMessage(ev) {
       if (data.action === 'assetRequest') {
         const message = getAssetMessage(data, adObject);
         ev.source.postMessage(JSON.stringify(message), ev.origin);
-        return;
       } else if (data.action === 'allAssetRequest') {
         const message = getAllAssetsMessage(data, adObject);
         ev.source.postMessage(JSON.stringify(message), ev.origin);
@@ -68,13 +67,13 @@ export function receiveMessage(ev) {
         adObject.height = data.height;
         adObject.width = data.width;
         resizeRemoteCreative(adObject);
+      } else {
+        const trackerType = fireNativeTrackers(data, adObject);
+        if (trackerType === 'click') { return; }
+
+        auctionManager.addWinningBid(adObject);
+        events.emit(BID_WON, adObject);
       }
-
-      const trackerType = fireNativeTrackers(data, adObject);
-      if (trackerType === 'click') { return; }
-
-      auctionManager.addWinningBid(adObject);
-      events.emit(BID_WON, adObject);
     }
   }
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->
Fire `bidWon` and impression tracker only once.  

Current implementation will fire `bidWon` and impression tracker multiple times when native is being render with PUC.  
PBJS will do that because it's firing events each time PUC sends post message. And PUC is sending 3 post messages when native ad is being rendered:
- request all assets
- resize container height
- fire native tracker

PUC code: https://github.com/prebid/prebid-universal-creative/blob/master/src/nativeRenderManager.js#L67-L69

Proposed fix will fire `onBidWon` and impression tracker only when PUC sends 'fireNativeTracker' post message.

This PR resolves #7526 issue.
