### PR TITLE
UNICORN fix bid_request cur and site.publisher.id to comply with OpenRTB 2.5 

### DIFF
--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -58,11 +58,11 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
     id: bidderRequest.auctionId,
     at: 1,
     imp,
-    cur: UNICORN_DEFAULT_CURRENCY,
+    cur: [UNICORN_DEFAULT_CURRENCY],
     site: {
       id: deepAccess(validBidRequests[0], 'params.mediaId') || '',
       publisher: {
-        id: deepAccess(validBidRequests[0], 'params.publisherId') || 0
+        id: String(deepAccess(validBidRequests[0], 'params.publisherId') || 0)
       },
       domain: window.location.hostname,
       page: window.location.href,

--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -8,7 +8,7 @@ const BIDDER_CODE = 'unicorn';
 const UNICORN_ENDPOINT = 'https://ds.uncn.jp/pb/0/bid.json';
 const UNICORN_DEFAULT_CURRENCY = 'JPY';
 const UNICORN_PB_COOKIE_KEY = '__pb_unicorn_aud';
-const UNICORN_PB_VERSION = '1.0';
+const UNICORN_PB_VERSION = '1.1';
 
 /**
  * Placement ID and Account ID are required.

--- a/test/spec/modules/unicornBidAdapter_spec.js
+++ b/test/spec/modules/unicornBidAdapter_spec.js
@@ -332,14 +332,14 @@ const openRTBRequest = {
       tagid: 'rectangle-ad-2'
     }
   ],
-  cur: 'JPY',
+  cur: ['JPY'],
   ext: {
     accountId: 12345
   },
   site: {
     id: 'example',
     publisher: {
-      id: 99999
+      id: '99999'
     },
     domain: 'uni-corn.net',
     page: 'https://uni-corn.net/',

--- a/test/spec/modules/unicornBidAdapter_spec.js
+++ b/test/spec/modules/unicornBidAdapter_spec.js
@@ -357,7 +357,7 @@ const openRTBRequest = {
     ext: {
       stype: 'prebid_uncn',
       bidder: 'unicorn',
-      prebid_version: '1.0'
+      prebid_version: '1.1'
     }
   }
 };
@@ -444,7 +444,7 @@ const serverResponse = {
 const request = {
   method: 'POST',
   url: 'https://ds.uncn.jp/pb/0/bid.json',
-  data: '{"id":"5ebea288-f13a-4754-be6d-4ade66c68877","at":1,"imp":[{"id":"216255f234b602","banner":{"w":300,"h":250},"format":[{"w":300,"h":250},{"w":336,"h":280}],"secure":1,"bidfloor":0,"tagid":"/19968336/header-bid-tag-0"},{"id":"31e2b28ced2475","banner":{"w":"300","h":"250"},"format":[{"w":"300","h":"250"}],"secure":1,"bidfloor":0"tagid":"/19968336/header-bid-tag-1"},{"id":"40a333e047a9bd","banner":{"w":300,"h":250},"format":[{"w":300,"h":250}],"secure":1,"bidfloor":0,"tagid":"/19968336/header-bid-tag-2"}],"cur":"JPY","site":{"id":"uni-corn.net","publisher":{"id":12345},"domain":"uni-corn.net","page":"https://uni-corn.net/","ref":"https://uni-corn.net/"},"device":{"language":"ja","ua":"Mozilla/5.0 (Linux; Android 8.0.0; ONEPLUS A5000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36"},"user":{"id":"69d9e1c2-801e-4901-a665-fad467550fec"},"bcat":[],"source":{"ext":{"stype":"prebid_uncn","bidder":"unicorn","prebid_version":"1.0"}}}'
+  data: '{"id":"5ebea288-f13a-4754-be6d-4ade66c68877","at":1,"imp":[{"id":"216255f234b602","banner":{"w":300,"h":250},"format":[{"w":300,"h":250},{"w":336,"h":280}],"secure":1,"bidfloor":0,"tagid":"/19968336/header-bid-tag-0"},{"id":"31e2b28ced2475","banner":{"w":"300","h":"250"},"format":[{"w":"300","h":"250"}],"secure":1,"bidfloor":0"tagid":"/19968336/header-bid-tag-1"},{"id":"40a333e047a9bd","banner":{"w":300,"h":250},"format":[{"w":300,"h":250}],"secure":1,"bidfloor":0,"tagid":"/19968336/header-bid-tag-2"}],"cur":"JPY","site":{"id":"uni-corn.net","publisher":{"id":12345},"domain":"uni-corn.net","page":"https://uni-corn.net/","ref":"https://uni-corn.net/"},"device":{"language":"ja","ua":"Mozilla/5.0 (Linux; Android 8.0.0; ONEPLUS A5000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36"},"user":{"id":"69d9e1c2-801e-4901-a665-fad467550fec"},"bcat":[],"source":{"ext":{"stype":"prebid_uncn","bidder":"unicorn","prebid_version":"1.1"}}}'
 };
 
 const interpretedBids = [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- increment prebid_version from 1.0 to 1.1
- fix bid request `cur` and `site.publisher.id` to comply with OpenRTB 2.5
<!-- For new bidder adapters, please provide the following -->