### PR TITLE
PubMatic Bid Adapter: fix a typo in outstreamAU param name docs

### DIFF
--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -25,7 +25,7 @@ var adUnits = [
       bidder: 'pubmatic',
       params: {
         publisherId: '156209',               // required, must be a string, not an integer or other js type.
-        oustreamAU: 'renderer_test_pubmatic',   // required if mediaTypes-> video-> context is 'outstream' and optional if renderer is defined in adUnits or in mediaType video. This value can be get by BlueBillyWig Team.
+        outstreamAU: 'renderer_test_pubmatic',   // required if mediaTypes-> video-> context is 'outstream' and optional if renderer is defined in adUnits or in mediaType video. This value can be get by BlueBillyWig Team.
         adSlot: 'pubmatic_test2',            // optional, must be a string, not an integer or other js type.
         pmzoneid: 'zone1, zone11',           // optional
         lat: '40.712775',                    // optional


### PR DESCRIPTION

## Type of change
- [ X ] Other

## Description of change
PubMatic: fixing a typo in `outstreamAU` param name in documentation, it was mentioned as `oustreamAU`

- contact email of the adapter’s maintainer: @pm-harshad-mane 
- [ X ] official adapter submission

