### PR TITLE
Livewrapper Analytics Adapter: prioritize reporting Livewrapped floor data

### DIFF
--- a/modules/livewrappedAnalyticsAdapter.js
+++ b/modules/livewrappedAnalyticsAdapter.js
@@ -81,6 +81,7 @@ let livewrappedAnalyticsAdapter = Object.assign(adapter({EMPTYURL, ANALYTICSTYPE
         bidResponse.ttr = args.timeToRespond;
         bidResponse.readyToSend = 1;
         bidResponse.mediaType = args.mediaType == 'native' ? 2 : (args.mediaType == 'video' ? 4 : 1);
+        bidResponse.floorData = args.floorData;
         if (!bidResponse.ttr) {
           bidResponse.ttr = time - bidResponse.start;
         }
@@ -108,6 +109,7 @@ let livewrappedAnalyticsAdapter = Object.assign(adapter({EMPTYURL, ANALYTICSTYPE
         logInfo('LIVEWRAPPED_BID_WON:', args);
         let wonBid = cache.auctions[args.auctionId].bids[args.requestId];
         wonBid.won = true;
+        wonBid.floorData = args.floorData;
         if (wonBid.sendStatus != 0) {
           livewrappedAnalyticsAdapter.sendEvents();
         }
@@ -226,7 +228,7 @@ function getResponses(gdpr, auctionIds) {
           IsBid: bid.isBid,
           mediaType: bid.mediaType,
           gdpr: gdprPos,
-          floor: bid.floorData ? bid.floorData.floorValue : bid.lwFloor,
+          floor: bid.lwFloor ? bid.lwFloor : (bid.floorData ? bid.floorData.floorValue : undefined),
           floorCur: bid.floorData ? bid.floorData.floorCurrency : undefined,
           auctionId: auctionIdPos,
           auc: bid.auc,
@@ -263,7 +265,7 @@ function getWins(gdpr, auctionIds) {
           cpm: bid.cpm,
           mediaType: bid.mediaType,
           gdpr: gdprPos,
-          floor: bid.floorData ? bid.floorData.floorValue : bid.lwFloor,
+          floor: bid.lwFloor ? bid.lwFloor : (bid.floorData ? bid.floorData.floorValue : undefined),
           floorCur: bid.floorData ? bid.floorData.floorCurrency : undefined,
           auctionId: auctionIdPos,
           auc: bid.auc,

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -416,18 +416,28 @@ describe('Livewrapped analytics adapter', function () {
           {
             'bidder': 'livewrapped',
             'adUnitCode': 'panorama_d_1',
-            'bidId': '2ecff0db240757',
-            'floorData': {
-              'floorValue': 1.1,
-              'floorCurrency': 'SEK'
-            }
+            'bidId': '2ecff0db240757'
           }
         ],
         'start': 1519149562216
       });
 
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
-      events.emit(BID_WON, MOCK.BID_WON[0]);
+      events.emit(BID_RESPONSE, Object.assign({},
+        MOCK.BID_RESPONSE[0],
+        {
+          'floorData': {
+            'floorValue': 1.1,
+            'floorCurrency': 'SEK'
+          }
+        }));
+      events.emit(BID_WON, Object.assign({},
+        MOCK.BID_WON[0],
+        {
+          'floorData': {
+            'floorValue': 1.1,
+            'floorCurrency': 'SEK'
+          }
+        }));
       events.emit(AUCTION_END, MOCK.AUCTION_END);
 
       clock.tick(BID_WON_TIMEOUT + 1000);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The floor price data being sent into Livewrapped analytics prioritized sending data from the floor price module. However, data coming from the Livewrapped wrapper holds more information required for our floor price optimization than what the floor price module brings so when Livewrapped data is available, send that instead.