### PR TITLE
YieldOne Bid Adapter: add Flux Wrapper support.

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -221,13 +221,13 @@ function getBannerSizes(bidRequest, enabledOldFormat = true) {
     sizes = sizes || bidRequest.sizes;
   }
 
-  const result = parseSizesInput(sizes).join(',');
-  return result;
+  return parseSizesInput(sizes).join(',');
 }
 
 /**
  * @param  {Object} bidRequest -
  * @param  {boolean} [enabledOldFormat = true] - default: `true`.
+ * @param  {boolean} [enabledFlux = true] - default: `true`.
  * @return {{w: number, h: number}} -
  */
 function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
@@ -268,8 +268,7 @@ function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
     }
   }
 
-  const result = playerSize || DEFAULT_VIDEO_SIZE;
-  return result;
+  return playerSize || DEFAULT_VIDEO_SIZE;
 }
 
 function newRenderer(response) {

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, isEmpty, parseSizesInput, isStr, logWarn } from '../src/utils.js';
+import * as utils from '../src/utils.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
@@ -10,6 +10,8 @@ const USER_SYNC_URL = 'https://y.one.impact-ad.jp/push_sync';
 const VIDEO_PLAYER_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 const CMER_PLAYER_URL = 'https://an.cmertv.com/hb/renderer/cmertv-video-yone-prebid.min.js';
 const VIEWABLE_PERCENTAGE_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/prebid-adformat-config.js';
+
+const DEFAULT_VIDEO_SIZE = {w: 640, h: 360};
 
 export const spec = {
   code: BIDDER_CODE,
@@ -40,21 +42,23 @@ export const spec = {
         t: 'i'
       };
 
-      const videoMediaType = deepAccess(bidRequest, 'mediaTypes.video');
-      if ((isEmpty(bidRequest.mediaType) && isEmpty(bidRequest.mediaTypes)) ||
-      (bidRequest.mediaType === BANNER || (bidRequest.mediaTypes && bidRequest.mediaTypes[BANNER]))) {
-        const sizes = deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
-        payload.sz = parseSizesInput(sizes).join(',');
-      } else if (bidRequest.mediaType === VIDEO || videoMediaType) {
-        const sizes = deepAccess(bidRequest, 'mediaTypes.video.playerSize') || bidRequest.sizes;
-        const size = parseSizesInput(sizes)[0];
-        payload.w = size.split('x')[0];
-        payload.h = size.split('x')[1];
+      const mediaType = getMediaType(bidRequest);
+      switch (mediaType) {
+        case BANNER:
+          payload.sz = getBannerSizes(bidRequest);
+          break;
+        case VIDEO:
+          const videoSize = getVideoSize(bidRequest);
+          payload.w = videoSize.w;
+          payload.h = videoSize.h;
+          break;
+        default:
+          break;
       }
 
       // LiveRampID
-      const idlEnv = deepAccess(bidRequest, 'userId.idl_env');
-      if (isStr(idlEnv) && !isEmpty(idlEnv)) {
+      const idlEnv = utils.deepAccess(bidRequest, 'userId.idl_env');
+      if (utils.isStr(idlEnv) && !utils.isEmpty(idlEnv)) {
         payload.lr_env = idlEnv;
       }
 
@@ -167,6 +171,107 @@ export const spec = {
   },
 }
 
+/**
+ * NOTE: server side does not yet support multiple formats.
+ * @param  {Object} bidRequest -
+ * @param  {boolean} [enabledOldFormat = true] - default: `true`.
+ * @return {string|null} - `"banner"` or `"video"` or `null`.
+ */
+function getMediaType(bidRequest, enabledOldFormat = true) {
+  let hasBannerType = Boolean(utils.deepAccess(bidRequest, 'mediaTypes.banner'));
+  let hasVideoType = Boolean(utils.deepAccess(bidRequest, 'mediaTypes.video'));
+
+  if (enabledOldFormat) {
+    hasBannerType = hasBannerType || bidRequest.mediaType === BANNER ||
+      (utils.isEmpty(bidRequest.mediaTypes) && utils.isEmpty(bidRequest.mediaType));
+    hasVideoType = hasVideoType || bidRequest.mediaType === VIDEO;
+  }
+
+  if (hasBannerType && hasVideoType) {
+    const playerParams = utils.deepAccess(bidRequest, 'params.playerParams')
+    if (playerParams) {
+      return VIDEO;
+    } else {
+      return BANNER;
+    }
+  } else if (hasBannerType) {
+    return BANNER;
+  } else if (hasVideoType) {
+    return VIDEO;
+  }
+
+  return null;
+}
+
+/**
+ * NOTE:
+ *   If `mediaTypes.banner` exists, then `mediaTypes.banner.sizes` must also exist.
+ *   The reason for this is that Prebid.js will perform the verification and
+ *   if `mediaTypes.banner.sizes` is inappropriate, it will delete the entire `mediaTypes.banner`.
+ * @param  {Object} bidRequest -
+ * @param  {Object} bidRequest.banner -
+ * @param  {Array<string>} bidRequest.banner.sizes -
+ * @param  {boolean} [enabledOldFormat = true] - default: `true`.
+ * @return {string} - strings like `"300x250"` or `"300x250,728x90"`.
+ */
+function getBannerSizes(bidRequest, enabledOldFormat = true) {
+  let sizes = utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes');
+
+  if (enabledOldFormat) {
+    sizes = sizes || bidRequest.sizes;
+  }
+
+  const result = utils.parseSizesInput(sizes).join(',');
+  return result;
+}
+
+/**
+ * @param  {Object} bidRequest -
+ * @param  {boolean} [enabledOldFormat = true] - default: `true`.
+ * @return {{w: number, h: number}} -
+ */
+function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
+  /**
+   * @param  {Array<number, number> | Array<Array<number, number>>} sizes -
+   * @return {{w: number, h: number} | null} -
+   */
+  const _getPlayerSize = (sizes) => {
+    let result = null;
+
+    const size = utils.parseSizesInput(sizes)[0];
+    if (utils.isEmpty(size)) {
+      return result;
+    }
+
+    const splited = size.split('x');
+    const sizeObj = {w: parseInt(splited[0], 10), h: parseInt(splited[1], 10)};
+    const _isValidPlayerSize = !(utils.isEmpty(sizeObj)) && (isFinite(sizeObj.w) && isFinite(sizeObj.h));
+    if (!_isValidPlayerSize) {
+      return result;
+    }
+
+    result = sizeObj;
+    return result;
+  }
+
+  let playerSize = _getPlayerSize(utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize'));
+
+  if (enabledOldFormat) {
+    playerSize = playerSize || _getPlayerSize(bidRequest.sizes);
+  }
+
+  if (enabledFlux) {
+    // NOTE: `video.playerSize` in Flux is always [1,1].
+    if (playerSize && (playerSize.w === 1 && playerSize.h === 1)) {
+      // NOTE: `params.playerSize` is a specific object to support `FLUX`.
+      playerSize = _getPlayerSize(utils.deepAccess(bidRequest, 'params.playerSize'));
+    }
+  }
+
+  const result = playerSize || DEFAULT_VIDEO_SIZE;
+  return result;
+}
+
 function newRenderer(response) {
   const renderer = Renderer.install({
     id: response.uid,
@@ -177,7 +282,7 @@ function newRenderer(response) {
   try {
     renderer.setRender(outstreamRender);
   } catch (err) {
-    logWarn('Prebid Error calling setRender on newRenderer', err);
+    utils.logWarn('Prebid Error calling setRender on newRenderer', err);
   }
 
   return renderer;
@@ -199,7 +304,7 @@ function newCmerRenderer(response) {
   try {
     renderer.setRender(cmerRender);
   } catch (err) {
-    logWarn('Prebid Error calling setRender on newRenderer', err);
+    utils.logWarn('Prebid Error calling setRender on newRenderer', err);
   }
 
   return renderer;

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -1,4 +1,4 @@
-import * as utils from '../src/utils.js';
+import {deepAccess, isEmpty, isStr, logWarn, parseSizesInput} from '../src/utils.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
@@ -57,8 +57,8 @@ export const spec = {
       }
 
       // LiveRampID
-      const idlEnv = utils.deepAccess(bidRequest, 'userId.idl_env');
-      if (utils.isStr(idlEnv) && !utils.isEmpty(idlEnv)) {
+      const idlEnv = deepAccess(bidRequest, 'userId.idl_env');
+      if (isStr(idlEnv) && !isEmpty(idlEnv)) {
         payload.lr_env = idlEnv;
       }
 
@@ -178,17 +178,17 @@ export const spec = {
  * @return {string|null} - `"banner"` or `"video"` or `null`.
  */
 function getMediaType(bidRequest, enabledOldFormat = true) {
-  let hasBannerType = Boolean(utils.deepAccess(bidRequest, 'mediaTypes.banner'));
-  let hasVideoType = Boolean(utils.deepAccess(bidRequest, 'mediaTypes.video'));
+  let hasBannerType = Boolean(deepAccess(bidRequest, 'mediaTypes.banner'));
+  let hasVideoType = Boolean(deepAccess(bidRequest, 'mediaTypes.video'));
 
   if (enabledOldFormat) {
     hasBannerType = hasBannerType || bidRequest.mediaType === BANNER ||
-      (utils.isEmpty(bidRequest.mediaTypes) && utils.isEmpty(bidRequest.mediaType));
+      (isEmpty(bidRequest.mediaTypes) && isEmpty(bidRequest.mediaType));
     hasVideoType = hasVideoType || bidRequest.mediaType === VIDEO;
   }
 
   if (hasBannerType && hasVideoType) {
-    const playerParams = utils.deepAccess(bidRequest, 'params.playerParams')
+    const playerParams = deepAccess(bidRequest, 'params.playerParams')
     if (playerParams) {
       return VIDEO;
     } else {
@@ -215,13 +215,13 @@ function getMediaType(bidRequest, enabledOldFormat = true) {
  * @return {string} - strings like `"300x250"` or `"300x250,728x90"`.
  */
 function getBannerSizes(bidRequest, enabledOldFormat = true) {
-  let sizes = utils.deepAccess(bidRequest, 'mediaTypes.banner.sizes');
+  let sizes = deepAccess(bidRequest, 'mediaTypes.banner.sizes');
 
   if (enabledOldFormat) {
     sizes = sizes || bidRequest.sizes;
   }
 
-  const result = utils.parseSizesInput(sizes).join(',');
+  const result = parseSizesInput(sizes).join(',');
   return result;
 }
 
@@ -238,14 +238,14 @@ function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
   const _getPlayerSize = (sizes) => {
     let result = null;
 
-    const size = utils.parseSizesInput(sizes)[0];
-    if (utils.isEmpty(size)) {
+    const size = parseSizesInput(sizes)[0];
+    if (isEmpty(size)) {
       return result;
     }
 
     const splited = size.split('x');
     const sizeObj = {w: parseInt(splited[0], 10), h: parseInt(splited[1], 10)};
-    const _isValidPlayerSize = !(utils.isEmpty(sizeObj)) && (isFinite(sizeObj.w) && isFinite(sizeObj.h));
+    const _isValidPlayerSize = !(isEmpty(sizeObj)) && (isFinite(sizeObj.w) && isFinite(sizeObj.h));
     if (!_isValidPlayerSize) {
       return result;
     }
@@ -254,7 +254,7 @@ function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
     return result;
   }
 
-  let playerSize = _getPlayerSize(utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize'));
+  let playerSize = _getPlayerSize(deepAccess(bidRequest, 'mediaTypes.video.playerSize'));
 
   if (enabledOldFormat) {
     playerSize = playerSize || _getPlayerSize(bidRequest.sizes);
@@ -264,7 +264,7 @@ function getVideoSize(bidRequest, enabledOldFormat = true, enabledFlux = true) {
     // NOTE: `video.playerSize` in Flux is always [1,1].
     if (playerSize && (playerSize.w === 1 && playerSize.h === 1)) {
       // NOTE: `params.playerSize` is a specific object to support `FLUX`.
-      playerSize = _getPlayerSize(utils.deepAccess(bidRequest, 'params.playerSize'));
+      playerSize = _getPlayerSize(deepAccess(bidRequest, 'params.playerSize'));
     }
   }
 
@@ -282,7 +282,7 @@ function newRenderer(response) {
   try {
     renderer.setRender(outstreamRender);
   } catch (err) {
-    utils.logWarn('Prebid Error calling setRender on newRenderer', err);
+    logWarn('Prebid Error calling setRender on newRenderer', err);
   }
 
   return renderer;
@@ -304,7 +304,7 @@ function newCmerRenderer(response) {
   try {
     renderer.setRender(cmerRender);
   } catch (err) {
-    utils.logWarn('Prebid Error calling setRender on newRenderer', err);
+    logWarn('Prebid Error calling setRender on newRenderer', err);
   }
 
   return renderer;

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -7,6 +7,8 @@ const ENDPOINT = 'https://y.one.impact-ad.jp/h_bid';
 const USER_SYNC_URL = 'https://y.one.impact-ad.jp/push_sync';
 const VIDEO_PLAYER_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/dac-video-prebid.min.js';
 
+const DEFAULT_VIDEO_SIZE = {w: 640, h: 360};
+
 describe('yieldoneBidAdapter', function() {
   const adapter = newBidder(spec);
 
@@ -40,32 +42,7 @@ describe('yieldoneBidAdapter', function() {
   });
 
   describe('buildRequests', function () {
-    let bidRequests = [
-      {
-        'bidder': 'yieldone',
-        'params': {
-          placementId: '36891'
-        },
-        'adUnitCode': 'adunit-code1',
-        'sizes': [[300, 250], [336, 280]],
-        'bidId': '23beaa6af6cdde',
-        'bidderRequestId': '19c0c1efdf37e7',
-        'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
-      },
-      {
-        'bidder': 'yieldone',
-        'params': {
-          placementId: '47919'
-        },
-        'adUnitCode': 'adunit-code2',
-        'sizes': [[300, 250]],
-        'bidId': '382091349b149f"',
-        'bidderRequestId': '"1f9c98192de251"',
-        'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
-      }
-    ];
-
-    let bidderRequest = {
+    const bidderRequest = {
       refererInfo: {
         numIframes: 0,
         reachedTop: true,
@@ -74,49 +51,318 @@ describe('yieldoneBidAdapter', function() {
       }
     };
 
-    const request = spec.buildRequests(bidRequests, bidderRequest);
+    describe('Basic', function () {
+      const bidRequests = [
+        {
+          'bidder': 'yieldone',
+          'params': {placementId: '36891'},
+          'adUnitCode': 'adunit-code1',
+          'bidId': '23beaa6af6cdde',
+          'bidderRequestId': '19c0c1efdf37e7',
+          'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
+        },
+        {
+          'bidder': 'yieldone',
+          'params': {placementId: '47919'},
+          'adUnitCode': 'adunit-code2',
+          'bidId': '382091349b149f"',
+          'bidderRequestId': '"1f9c98192de251"',
+          'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
+        }
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
 
-    it('sends bid request to our endpoint via GET', function () {
-      expect(request[0].method).to.equal('GET');
-      expect(request[1].method).to.equal('GET');
+      it('sends bid request to our endpoint via GET', function () {
+        expect(request[0].method).to.equal('GET');
+        expect(request[1].method).to.equal('GET');
+      });
+      it('attaches source and version to endpoint URL as query params', function () {
+        expect(request[0].url).to.equal(ENDPOINT);
+        expect(request[1].url).to.equal(ENDPOINT);
+      });
+      it('adUnitCode should be sent as uc parameters on any requests', function () {
+        expect(request[0].data.uc).to.equal('adunit-code1');
+        expect(request[1].data.uc).to.equal('adunit-code2');
+      });
     });
 
-    it('attaches source and version to endpoint URL as query params', function () {
-      expect(request[0].url).to.equal(ENDPOINT);
-      expect(request[1].url).to.equal(ENDPOINT);
+    describe('Old Format', function () {
+      const bidRequests = [
+        {
+          params: {placementId: '0'},
+          mediaType: 'banner',
+          sizes: [[300, 250], [336, 280]],
+        },
+        {
+          params: {placementId: '1'},
+          mediaType: 'banner',
+          sizes: [[336, 280]],
+        },
+        {
+          // It doesn't actually exist.
+          params: {placementId: '2'},
+        },
+        {
+          params: {placementId: '3'},
+          mediaType: 'video',
+          sizes: [[1280, 720], [1920, 1080]],
+        },
+        {
+          params: {placementId: '4'},
+          mediaType: 'video',
+          sizes: [[1920, 1080]],
+        },
+        {
+          params: {placementId: '5'},
+          mediaType: 'video',
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+
+      it('parameter sz has more than one size on banner requests', function () {
+        expect(request[0].data.sz).to.equal('300x250,336x280');
+        expect(request[1].data.sz).to.equal('336x280');
+        expect(request[2].data.sz).to.equal('');
+        expect(request[3].data).to.not.have.property('sz');
+        expect(request[4].data).to.not.have.property('sz');
+        expect(request[5].data).to.not.have.property('sz');
+      });
+
+      it('width and height should be set as separate parameters on outstream requests', function () {
+        expect(request[0].data).to.not.have.property('w');
+        expect(request[1].data).to.not.have.property('w');
+        expect(request[2].data).to.not.have.property('w');
+        expect(request[3].data.w).to.equal(1280);
+        expect(request[3].data.h).to.equal(720);
+        expect(request[4].data.w).to.equal(1920);
+        expect(request[4].data.h).to.equal(1080);
+        expect(request[5].data.w).to.equal(DEFAULT_VIDEO_SIZE.w);
+        expect(request[5].data.h).to.equal(DEFAULT_VIDEO_SIZE.h);
+      });
     });
 
-    it('parameter sz has more than one size on banner requests', function () {
-      expect(request[0].data.sz).to.equal('300x250,336x280');
-      expect(request[1].data.sz).to.equal('300x250');
+    describe('New Format', function () {
+      const bidRequests = [
+        {
+          params: {placementId: '0'},
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+          },
+        },
+        {
+          params: {placementId: '1'},
+          mediaTypes: {
+            banner: {
+              sizes: [[336, 280]],
+            },
+          },
+        },
+        {
+          // It doesn't actually exist.
+          params: {placementId: '2'},
+          mediaTypes: {
+            banner: {
+            },
+          },
+        },
+        {
+          params: {placementId: '3'},
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [[1280, 720], [1920, 1080]],
+            },
+          },
+        },
+        {
+          params: {placementId: '4'},
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [1920, 1080],
+            },
+          },
+        },
+        {
+          params: {placementId: '5'},
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+            },
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+
+      it('parameter sz has more than one size on banner requests', function () {
+        expect(request[0].data.sz).to.equal('300x250,336x280');
+        expect(request[1].data.sz).to.equal('336x280');
+        expect(request[2].data.sz).to.equal('');
+        expect(request[3].data).to.not.have.property('sz');
+        expect(request[4].data).to.not.have.property('sz');
+        expect(request[5].data).to.not.have.property('sz');
+      });
+
+      it('width and height should be set as separate parameters on outstream requests', function () {
+        expect(request[0].data).to.not.have.property('w');
+        expect(request[1].data).to.not.have.property('w');
+        expect(request[2].data).to.not.have.property('w');
+        expect(request[3].data.w).to.equal(1280);
+        expect(request[3].data.h).to.equal(720);
+        expect(request[4].data.w).to.equal(1920);
+        expect(request[4].data.h).to.equal(1080);
+        expect(request[5].data.w).to.equal(DEFAULT_VIDEO_SIZE.w);
+        expect(request[5].data.h).to.equal(DEFAULT_VIDEO_SIZE.h);
+      });
     });
 
-    it('width and height should be set as separate parameters on outstream requests', function () {
-      const bidRequest = Object.assign({}, bidRequests[0]);
-      bidRequest.mediaTypes = {};
-      bidRequest.mediaTypes.video = {context: 'outstream'};
-      const request = spec.buildRequests([bidRequest], bidderRequest);
-      expect(request[0].data.w).to.equal('300');
-      expect(request[0].data.h).to.equal('250');
+    describe('Multiple Format', function () {
+      const bidRequests = [
+        {
+          // It will be treated as a banner.
+          params: {
+            placementId: '0',
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [1920, 1080],
+            },
+          },
+        },
+        {
+          // It will be treated as a video.
+          params: {
+            placementId: '1',
+            playerParams: {},
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [1920, 1080],
+            },
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+
+      it('parameter sz has more than one size on banner requests', function () {
+        expect(request[0].data.sz).to.equal('300x250,336x280');
+        expect(request[1].data).to.not.have.property('sz');
+      });
+
+      it('width and height should be set as separate parameters on outstream requests', function () {
+        expect(request[0].data).to.not.have.property('w');
+        expect(request[1].data.w).to.equal(1920);
+        expect(request[1].data.h).to.equal(1080);
+      });
     });
 
-    it('adUnitCode should be sent as uc parameters on any requests', function () {
-      expect(request[0].data.uc).to.equal('adunit-code1');
-      expect(request[1].data.uc).to.equal('adunit-code2');
+    describe('FLUX Format', function () {
+      const bidRequests = [
+        {
+          // It will be treated as a banner.
+          params: {
+            placementId: '0',
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [[1, 1]],
+            },
+          },
+        },
+        {
+          // It will be treated as a video.
+          params: {
+            placementId: '1',
+            playerParams: {},
+            playerSize: [1920, 1080],
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [[1, 1]],
+            },
+          },
+        },
+        {
+          // It will be treated as a video.
+          params: {
+            placementId: '2',
+            playerParams: {},
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [336, 280]],
+            },
+            video: {
+              context: 'outstream',
+              playerSize: [[1, 1]],
+            },
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+
+      it('parameter sz has more than one size on banner requests', function () {
+        expect(request[0].data.sz).to.equal('300x250,336x280');
+        expect(request[1].data).to.not.have.property('sz');
+        expect(request[2].data).to.not.have.property('sz');
+      });
+
+      it('width and height should be set as separate parameters on outstream requests', function () {
+        expect(request[0].data).to.not.have.property('w');
+        expect(request[1].data.w).to.equal(1920);
+        expect(request[1].data.h).to.equal(1080);
+        expect(request[2].data.w).to.equal(DEFAULT_VIDEO_SIZE.w);
+        expect(request[2].data.h).to.equal(DEFAULT_VIDEO_SIZE.h);
+      });
     });
 
-    describe('userid idl_env should be passed to querystring', function () {
-      const bid = deepClone([bidRequests[0]]);
-
+    describe('LiveRampID', function () {
       it('dont send LiveRampID if undefined', function () {
-        bid[0].userId = {};
-        const request = spec.buildRequests(bid, bidderRequest);
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+          },
+          {
+            params: {placementId: '1'},
+            userId: {},
+          },
+          {
+            params: {placementId: '2'},
+            userId: undefined,
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
         expect(request[0].data).to.not.have.property('lr_env');
+        expect(request[1].data).to.not.have.property('lr_env');
+        expect(request[2].data).to.not.have.property('lr_env');
       });
 
       it('should send LiveRampID if available', function () {
-        bid[0].userId = {idl_env: 'idl_env_sample'};
-        const request = spec.buildRequests(bid, bidderRequest);
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+            userId: {idl_env: 'idl_env_sample'},
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
         expect(request[0].data.lr_env).to.equal('idl_env_sample');
       });
     });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Supported multi format ads
- Supported [1, 1] size for video type

- contact email of the adapter’s maintainer
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/