### PR TITLE
Browi RTD - support refresh predictions & setBidRequestsData

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -42,10 +42,10 @@
  * @function?
  * @summary modify bid request data
  * @name RtdSubmodule#getBidRequestData
- * @param {SubmoduleConfig} config
- * @param {UserConsentData} userConsent
  * @param {Object} reqBidsConfigObj
  * @param {function} callback
+ * @param {SubmoduleConfig} config
+ * @param {UserConsentData} userConsent
  */
 
 /**


### PR DESCRIPTION


## Type of change
- [ ] Feature

## Description of change
This PR adds prediction according to refresh count & support for setBidRequestsData (place prediction on the ad unit)



