### PR TITLE
AOL bid adapter: Support yahoo.com eid source value

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -38,7 +38,8 @@ const SUPPORTED_USER_ID_SOURCES = [
   'liveintent.com',
   'quantcast.com',
   'verizonmedia.com',
-  'liveramp.com'
+  'liveramp.com',
+  'yahoo.com'
 ];
 
 const pubapiTemplate = template`${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'};misc=${'misc'};${'dynamicParams'}`;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Verizon Media is now Yahoo. We are in the process of:
* Consolidating this legacy AOL bid adapter and the legacy OneVideo bid adapter into a new yssp bid adapter
* Deprecating the verizonmedia user identity module and replacing with a new Yahoo ConnectID user identity module

We have decided to add support for the new yahoo.com eid source value for the legacy AOL bid adapter as we will more than likely end up leaving the AOL bid adapter in the source code for longer than we leave the verizonmedia user identity module in the source code. 

The PR for the new user identity module is here:
https://github.com/prebid/Prebid.js/pull/7519

The documentation PR is here:
https://github.com/prebid/prebid.github.io/pull/3334

Note: Whilst the verizonmedia user ID module will remain in this codebase (and still be supported by the bid adapter) for a few more releases, we will replace all references to the verizonmedia user ID module to the Yahoo user ID module in the AOL bid adapter documentation. 
