### PR TITLE
Yieldlab Bid Adapter: fix for utils root no longer being valid

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -268,13 +268,13 @@ function createSchainString (schain) {
  * @returns {Object}
  */
 function getContentObject(bid) {
-  if (bid.params.iabContent && utils.isPlainObject(bid.params.iabContent)) {
+  if (bid.params.iabContent && isPlainObject(bid.params.iabContent)) {
     return bid.params.iabContent
   }
 
   const globalContent = config.getConfig('ortb2.site') ? config.getConfig('ortb2.site.content')
     : config.getConfig('ortb2.app.content')
-  if (globalContent && utils.isPlainObject(globalContent)) {
+  if (globalContent && isPlainObject(globalContent)) {
     return globalContent
   }
   return undefined


### PR DESCRIPTION
#7413 had the 'utils' root in some of the code. We updated all adapters to no longer require that root. This fixes the issue. Adding @patmmccann for visibility since I am merging this pr myself