### PR TITLE
Adf adapter: new bidder params added, multiformat bids supported

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -164,9 +164,6 @@ export const spec = {
             assets
           }
         };
-
-        bid.mediaType = NATIVE;
-        return imp;
       }
 
       const bannerParams = deepAccess(bid, 'mediaTypes.banner');
@@ -183,18 +180,14 @@ export const spec = {
         imp.banner = {
           format
         };
-        bid.mediaType = BANNER;
-
-        return imp;
       }
 
       const videoParams = deepAccess(bid, 'mediaTypes.video');
       if (videoParams) {
         imp.video = videoParams;
-        bid.mediaType = VIDEO;
-
-        return imp;
       }
+
+      return imp;
     });
 
     const request = {
@@ -254,6 +247,7 @@ export const spec = {
     return bids.map((bid, id) => {
       const bidResponse = bidResponses[id];
       if (bidResponse) {
+        const mediaType = deepAccess(bidResponse, 'ext.prebid.type');
         const result = {
           requestId: bid.bidId,
           cpm: bidResponse.price,
@@ -261,12 +255,12 @@ export const spec = {
           ttl: 360,
           netRevenue: bid.netRevenue === 'net',
           currency: cur,
-          mediaType: bid.mediaType,
+          mediaType,
           width: bidResponse.w,
           height: bidResponse.h,
           dealId: bidResponse.dealid,
           meta: {
-            mediaType: bid.mediaType,
+            mediaType,
             advertiserDomains: bidResponse.adomain
           }
         };
@@ -274,10 +268,10 @@ export const spec = {
         if (bidResponse.native) {
           result.native = parseNative(bidResponse);
         } else {
-          result[ bid.mediaType === VIDEO ? 'vastXml' : 'ad' ] = bidResponse.adm;
+          result[ mediaType === VIDEO ? 'vastXml' : 'ad' ] = bidResponse.adm;
         }
 
-        if (!bid.renderer && bid.mediaType === VIDEO && deepAccess(bid, 'mediaTypes.video.context') === 'outstream') {
+        if (!bid.renderer && mediaType === VIDEO && deepAccess(bid, 'mediaTypes.video.context') === 'outstream') {
           result.renderer = Renderer.install({id: bid.bidId, url: OUTSTREAM_RENDERER_URL, adUnitCode: bid.adUnitCode});
           result.renderer.setRender(renderer);
         }


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- new bidder params added
- multiformat bids supported

- contact email of the adapter’s maintainer Scope.FL.Scripts@adform.com
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/3343

## Other information

