### PR TITLE
Publink Id System: add support for nonjson cookie

### DIFF
--- a/modules/publinkIdSystem.js
+++ b/modules/publinkIdSystem.js
@@ -81,13 +81,18 @@ function getlocalValue() {
     }
 
     if (typeof value === 'string') {
-      try {
-        const obj = JSON.parse(value);
-        if (obj && obj.exp && obj.exp > Date.now()) {
-          return obj.publink;
+      // if it's a json object parse it and return the publink value, otherwise assume the value is the id
+      if (value.charAt(0) === '{') {
+        try {
+          const obj = JSON.parse(value);
+          if (obj) {
+            return obj.publink;
+          }
+        } catch (e) {
+          logError(e);
         }
-      } catch (e) {
-        logError(e);
+      } else {
+        return value;
       }
     }
   }

--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -47,12 +47,6 @@ describe('PublinkIdSystem', () => {
       expect(result.id).to.equal(LOCAL_VALUE.publink);
       storage.removeDataFromLocalStorage(PUBLINK_COOKIE);
     });
-    it('ignore expired cookie', () => {
-      storage.setDataInLocalStorage(PUBLINK_COOKIE, JSON.stringify({publink: 'value', exp: Date.now() - 60 * 60 * 24 * 1000}));
-      const result = publinkIdSubmodule.getId();
-      expect(result.id).to.be.undefined;
-      storage.removeDataFromLocalStorage(PUBLINK_COOKIE);
-    });
     it('priority goes to publink_srv cookie', () => {
       storage.setCookie(PUBLINK_SRV_COOKIE, JSON.stringify(COOKIE_VALUE), COOKIE_EXPIRATION);
       storage.setDataInLocalStorage(PUBLINK_COOKIE, JSON.stringify(LOCAL_VALUE));
@@ -60,6 +54,12 @@ describe('PublinkIdSystem', () => {
       expect(result.id).to.equal(COOKIE_VALUE.publink);
       storage.setCookie(PUBLINK_SRV_COOKIE, '', DELETE_COOKIE);
       storage.removeDataFromLocalStorage(PUBLINK_COOKIE);
+    });
+    it('publink non-json cookie', () => {
+      storage.setCookie(PUBLINK_COOKIE, COOKIE_VALUE.publink, COOKIE_EXPIRATION);
+      const result = publinkIdSubmodule.getId();
+      expect(result.id).to.equal(COOKIE_VALUE.publink);
+      storage.setCookie(PUBLINK_COOKIE, '', DELETE_COOKIE);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Remove the check for exp time.  If the publink value can be read, then return it.
Accept non-JSON cookie value to make it easier to publisher to implement server-side publink.

