### PR TITLE
OpenX Bid Adapter: Handle site.content.data & bug fixes

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -332,6 +332,9 @@ function appendUserIdsToQueryParams(queryParams, userIds) {
 
     if (USER_ID_CODE_TO_QUERY_ARG.hasOwnProperty(userIdProviderKey)) {
       switch (userIdProviderKey) {
+        case 'merkleId':
+          queryParams[key] = userIdObjectOrValue.id;
+          break;
         case 'flocId':
           queryParams[key] = userIdObjectOrValue.id;
           break;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1085,7 +1085,7 @@ describe('OpenxAdapter', function () {
         intentIqId: '1111-intentiqid',
         lipb: {lipbid: '1111-lipb'},
         lotamePanoramaId: '1111-lotameid',
-        merkleId: '1111-merkleid',
+        merkleId: {id: '1111-merkleid'},
         netId: 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
         parrableId: { eid: 'eidVersion.encryptionKeyReference.encryptedValue' },
         pubcid: '1111-pubcid',
@@ -1139,6 +1139,9 @@ describe('OpenxAdapter', function () {
             let userIdValue;
             // handle cases where userId key refers to an object
             switch (userIdProviderKey) {
+              case 'merkleId':
+                userIdValue = EXAMPLE_DATA_BY_ATTR.merkleId.id;
+                break;
               case 'flocId':
                 userIdValue = EXAMPLE_DATA_BY_ATTR.flocId.id;
                 break;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
- Enable OpenX bid adapter to send fpd data configured in `ortb2.site.content.data`
- Fix segment data getting encoded twice
- Fix handling of merkleId

