### PR TITLE
TheMediaGrid Bid Adapter: add playwire as alias

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -29,6 +29,7 @@ let hasSynced = false;
 
 export const spec = {
   code: BIDDER_CODE,
+  aliases: ['playwire'],
   supportedMediaTypes: [ BANNER, VIDEO ],
   /**
    * Determines whether or not the given bid request is valid.

--- a/modules/playwireBidAdapter.md
+++ b/modules/playwireBidAdapter.md
@@ -1,0 +1,61 @@
+# Overview
+
+Module Name: Playwire Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: grid-tech@themediagrid.com
+
+# Description
+
+Module that connects to Grid demand source to fetch bids.
+The adapter is GDPR compliant and supports banner and video (instream and outstream).
+
+# Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'test-div',
+               sizes: [[300, 250]],
+               bids: [
+                   {
+                       bidder: "playwire",
+                       params: {
+                           uid: '1',
+                           bidFloor: 0.5
+                       }
+                   }
+               ]
+           },{
+               code: 'test-div',
+               sizes: [[728, 90]],
+               bids: [
+                   {
+                       bidder: "playwire",
+                       params: {
+                           uid: 2,
+                           keywords: {
+                               brandsafety: ['disaster'],
+                               topic: ['stress', 'fear']
+                           }
+                       }
+                   }
+               ]
+           },
+           {
+               code: 'test-div',
+               sizes: [[728, 90]],
+               mediaTypes: { video: {
+                   context: 'instream',
+                   playerSize: [728, 90],
+                   mimes: ['video/mp4']
+               },
+               bids: [
+                   {
+                       bidder: "playwire",
+                       params: {
+                           uid: 11
+                       }
+                   }
+               ]
+          }
+       ];
+```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
Added Playwire as alias for TheMediaGrid Bid Adapter

- grid-tech@themediagrid.com
- [x] official adapter submission

- A link to a PR on the docs repo https://github.com/prebid/prebid.github.io/pull/3254
