### PR TITLE
JustPremium Bid Adapter: support for adserverTargeting in response

### DIFF
--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -4,7 +4,7 @@ import { deepAccess } from '../src/utils.js';
 const BIDDER_CODE = 'justpremium'
 const GVLID = 62
 const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
-const JP_ADAPTER_VERSION = '1.8'
+const JP_ADAPTER_VERSION = '1.8.1'
 const pixels = []
 
 export const spec = {
@@ -99,6 +99,11 @@ export const spec = {
           format: bid.format,
           meta: {
             advertiserDomains: bid.adomain && bid.adomain.length > 0 ? bid.adomain : []
+          }
+        }
+        if (bid.ext && bid.ext.pg) {
+          bidResponse.adserverTargeting = {
+            'hb_deal_justpremium': 'jp_pg'
           }
         }
         bidResponses.push(bidResponse)

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -97,7 +97,7 @@ describe('justpremium adapter', function () {
       expect(jpxRequest.id).to.equal(adUnits[0].params.zone)
       expect(jpxRequest.mediaTypes && jpxRequest.mediaTypes.banner && jpxRequest.mediaTypes.banner.sizes).to.not.equal('undefined')
       expect(jpxRequest.version.prebid).to.equal('$prebid.version$')
-      expect(jpxRequest.version.jp_adapter).to.equal('1.8')
+      expect(jpxRequest.version.jp_adapter).to.equal('1.8.1')
       expect(jpxRequest.pubcid).to.equal('0000000')
       expect(jpxRequest.uids.tdid).to.equal('1111111')
       expect(jpxRequest.uids.id5id.uid).to.equal('2222222')
@@ -118,7 +118,10 @@ describe('justpremium adapter', function () {
             'price': 0.52,
             'format': 'lb',
             'adm': 'creative code',
-            'adomain': ['justpremium.com']
+            'adomain': ['justpremium.com'],
+            'ext': {
+              'pg': true
+            }
           }]
         },
         'pass': {
@@ -142,6 +145,9 @@ describe('justpremium adapter', function () {
           meta: {
             advertiserDomains: ['justpremium.com']
           },
+          adserverTargeting: {
+            'hb_deal_justpremium': 'jp_pg'
+          }
         }
       ]
 
@@ -159,6 +165,7 @@ describe('justpremium adapter', function () {
       expect(result[0].netRevenue).to.equal(true)
       expect(result[0].format).to.equal('lb')
       expect(result[0].meta.advertiserDomains[0]).to.equal('justpremium.com')
+      expect(result[0].adserverTargeting).to.deep.equal({'hb_deal_justpremium': 'jp_pg'})
     })
 
     it('Verify wrong server response', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Support for adserverTargeting in response
