### PR TITLE
Prebid Core: Fix Media Type Price Granularity

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -716,7 +716,7 @@ export function getKeyValueTargetingPairs(bidderCode, custBidObj, bidReq) {
   // 1) set the keys from "standard" setting or from prebid defaults
   if (bidderSettings) {
     // initialize default if not set
-    const standardSettings = getStandardBidderSettings(custBidObj.mediaType, bidderCode, bidReq);
+    const standardSettings = getStandardBidderSettings(custBidObj.mediaType, bidderCode);
     setKeys(keyValues, standardSettings, custBidObj, bidReq);
 
     // 2) set keys from specific bidder setting override if they exist


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Media Type Price Granularity has not really been working as expected since its adoption.

Whichever bid came back first (its mediaType) would be used for all price bucket targeting for that page load.

We need the logic to grab the correct priceGran to run on each adServerTargeting execute.

think this fixes #6545 