### PR TITLE
Sortable Bid Adapter: Set gpid

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -227,6 +227,7 @@ export const spec = {
           rv.ext[partner] = params;
         });
       }
+      rv.ext.gpid = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
       return rv;
     });
     const gdprConsent = bidderRequest && bidderRequest.gdprConsent;

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -112,6 +112,13 @@ describe('sortableBidAdapter', function() {
           'key2': 'val2'
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'data': {
+            'pbadslot': 'abc/123'
+          }
+        }
+      },
       'sizes': [
         [300, 250]
       ],
@@ -174,6 +181,10 @@ describe('sortableBidAdapter', function() {
       expect(requestBody.site.publisher.id).to.equal('example.com');
       expect(requestBody.imp[0].tagid).to.equal('403370');
       expect(requestBody.imp[0].floor).to.equal(0.21);
+    });
+
+    it('includes pbadslot in the bid request', function () {
+      expect(requestBody.imp[0].ext.gpid).to.equal('abc/123');
     });
 
     it('sets domain and href correctly', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

Send GPID to bidder by setting value of imp[].ext.gpid to value of ortb2Imp.ext.data.pbadslot

