### PR TITLE
Adomik Analytics Adapter: change bid.placementCode to bid.adUnitCode

### DIFF
--- a/modules/adomikAnalyticsAdapter.js
+++ b/modules/adomikAnalyticsAdapter.js
@@ -12,6 +12,7 @@ const bidRequested = CONSTANTS.EVENTS.BID_REQUESTED;
 const bidResponse = CONSTANTS.EVENTS.BID_RESPONSE;
 const bidWon = CONSTANTS.EVENTS.BID_WON;
 const bidTimeout = CONSTANTS.EVENTS.BID_TIMEOUT;
+const ua = navigator.userAgent;
 
 let adomikAdapter = Object.assign(adapter({}),
   {
@@ -67,6 +68,10 @@ adomikAdapter.initializeBucketEvents = function() {
   adomikAdapter.bucketEvents = [];
 }
 
+adomikAdapter.maxPartLength = function () {
+  return (ua.includes(' MSIE ')) ? 1600 : 60000;
+};
+
 adomikAdapter.sendTypedEvent = function() {
   const groupedTypedEvents = adomikAdapter.buildTypedEvents();
 
@@ -108,9 +113,10 @@ adomikAdapter.sendTypedEvent = function() {
   // Encode object in base64
   const encodedBuf = window.btoa(stringBulkEvents);
 
-  // Create final url and split it in 1600 characters max (+endpoint length)
+  // Create final url and split it (+endpoint length)
   const encodedUri = encodeURIComponent(encodedBuf);
-  const splittedUrl = encodedUri.match(/.{1,1600}/g);
+  const maxLength = adomikAdapter.maxPartLength();
+  const splittedUrl = encodedUri.match(new RegExp(`.{1,${maxLength}}`, 'g'));
 
   splittedUrl.forEach((split, i) => {
     const partUrl = `${split}&id=${adomikAdapter.currentContext.id}&part=${i}&on=${splittedUrl.length - 1}`;
@@ -121,7 +127,7 @@ adomikAdapter.sendTypedEvent = function() {
 
 adomikAdapter.sendWonEvent = function (wonEvent) {
   const stringWonEvent = JSON.stringify(wonEvent)
-  logInfo('Won event sent to adomik prebid analytic ' + wonEvent);
+  logInfo('Won event sent to adomik prebid analytic ' + stringWonEvent);
 
   // Encode object in base64
   const encodedBuf = window.btoa(stringWonEvent);

--- a/test/spec/modules/adomikAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adomikAnalyticsAdapter_spec.js
@@ -1,5 +1,6 @@
 import adomikAnalytics from 'modules/adomikAnalyticsAdapter.js';
 import {expect} from 'chai';
+
 let events = require('src/events');
 let adapterManager = require('src/adapterManager').default;
 let constants = require('src/constants.json');
@@ -8,6 +9,7 @@ describe('Adomik Prebid Analytic', function () {
   let sendEventStub;
   let sendWonEventStub;
   let clock;
+
   before(function () {
     clock = sinon.useFakeTimers();
   });
@@ -91,7 +93,7 @@ describe('Adomik Prebid Analytic', function () {
         type: 'request',
         event: {
           bidder: 'BIDDERTEST',
-          placementCode: 'placementtest',
+          placementCode: '0000',
         }
       });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

- change the placementCode we save on bidRequested events to from `bid.placementCode` to `bid.adUnitCode`
- do not split sent events in GET requests unless browser is IE and version < 11 