### PR TITLE
operaads bid adapter: register user sync function

### DIFF
--- a/modules/operaadsBidAdapter.js
+++ b/modules/operaadsBidAdapter.js
@@ -138,9 +138,6 @@ export const spec = {
    * @return {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
-    if (syncOptions === undefined) {
-      return [];
-    }
     if ('iframeEnabled' in syncOptions && syncOptions.iframeEnabled) {
       return [{
         type: 'iframe',
@@ -148,13 +145,13 @@ export const spec = {
       }];
     }
     if ('pixelEnabled' in syncOptions && syncOptions.pixelEnabled) {
-      let pixels = deepAccess(serverResponses, '0.body.pixels')
+      const pixels = deepAccess(serverResponses, '0.body.pixels')
       if (Array.isArray(pixels)) {
-        let userSyncPixels = []
-        for (let i = 0; i < pixels.length; i++) {
+        const userSyncPixels = []
+        for (const pixel of pixels) {
           userSyncPixels.push({
             type: 'image',
-            url: pixels[i]
+            url: pixel
           })
         }
         return userSyncPixels;

--- a/test/spec/modules/operaadsBidAdapter_spec.js
+++ b/test/spec/modules/operaadsBidAdapter_spec.js
@@ -679,17 +679,26 @@ describe('Opera Ads Bid Adapter', function () {
     });
   });
 
-  describe('Test getUserSyncs', function () {
-    it('getUserSyncs should return array', function () {
-      expect(spec.getUserSyncs()).to.be.an('array').that.is.empty;
+  describe('Test getUserSyncs with both iframe and pixel disabled', function () {
+    it('getUserSyncs should return an empty array', function () {
+      const syncOptions = {};
+      expect(spec.getUserSyncs(syncOptions)).to.be.an('array').that.is.empty;
+    });
+  });
 
+  describe('Test getUserSyncs with iframe enabled', function () {
+    it('getUserSyncs should return array', function () {
       const syncOptions = {
         iframeEnabled: true
       }
       const userSyncPixels = spec.getUserSyncs(syncOptions)
       expect(userSyncPixels).to.have.lengthOf(1);
       expect(userSyncPixels[0].url).to.equal('https://s.adx.opera.com/usersync/page')
+    });
+  });
 
+  describe('Test getUserSyncs with pixel enabled', function () {
+    it('getUserSyncs should return array', function () {
       const serverResponse = {
         body: {
           'pixels': [
@@ -698,13 +707,13 @@ describe('Opera Ads Bid Adapter', function () {
           ]
         }
       };
-      const syncOptions2 = {
+      const syncOptions = {
         pixelEnabled: true
       }
-      const userSyncPixels2 = spec.getUserSyncs(syncOptions2, [serverResponse])
-      expect(userSyncPixels2).to.have.lengthOf(2);
-      expect(userSyncPixels2[0].url).to.equal('https://b1.com/usersync')
-      expect(userSyncPixels2[1].url).to.equal('https://b2.com/usersync')
+      const userSyncPixels = spec.getUserSyncs(syncOptions, [serverResponse])
+      expect(userSyncPixels).to.have.lengthOf(2);
+      expect(userSyncPixels[0].url).to.equal('https://b1.com/usersync')
+      expect(userSyncPixels[1].url).to.equal('https://b2.com/usersync')
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
