### PR TITLE
Adomik Analytics Adapter: add key value pair

### DIFF
--- a/modules/adomikAnalyticsAdapter.js
+++ b/modules/adomikAnalyticsAdapter.js
@@ -76,6 +76,8 @@ adomikAdapter.sendTypedEvent = function() {
   const groupedTypedEvents = adomikAdapter.buildTypedEvents();
 
   const bulkEvents = {
+    testId: adomikAdapter.currentContext.testId,
+    testValue: adomikAdapter.currentContext.testValue,
     uid: adomikAdapter.currentContext.uid,
     ahbaid: adomikAdapter.currentContext.id,
     hostname: window.location.hostname,
@@ -126,6 +128,8 @@ adomikAdapter.sendTypedEvent = function() {
 };
 
 adomikAdapter.sendWonEvent = function (wonEvent) {
+  let keyValues = { testId: adomikAdapter.currentContext.testId, testValue: adomikAdapter.currentContext.testValue }
+  wonEvent = {...wonEvent, ...keyValues}
   const stringWonEvent = JSON.stringify(wonEvent)
   logInfo('Won event sent to adomik prebid analytic ' + stringWonEvent);
 
@@ -205,6 +209,8 @@ adomikAdapter.enableAnalytics = function (config) {
     adomikAdapter.currentContext = {
       uid: initOptions.id,
       url: initOptions.url,
+      testId: initOptions.testId,
+      testValue: initOptions.testValue,
       id: '',
       timeouted: false,
     }

--- a/test/spec/modules/adomikAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adomikAnalyticsAdapter_spec.js
@@ -45,6 +45,8 @@ describe('Adomik Prebid Analytic', function () {
       const initOptions = {
         id: '123456',
         url: 'testurl',
+        testId: '12345',
+        testValue: '1000'
       };
 
       const bid = {
@@ -71,6 +73,8 @@ describe('Adomik Prebid Analytic', function () {
       expect(adomikAnalytics.currentContext).to.deep.equal({
         uid: '123456',
         url: 'testurl',
+        testId: '12345',
+        testValue: '1000',
         id: '',
         timeouted: false
       });
@@ -81,6 +85,8 @@ describe('Adomik Prebid Analytic', function () {
       expect(adomikAnalytics.currentContext).to.deep.equal({
         uid: '123456',
         url: 'testurl',
+        testId: '12345',
+        testValue: '1000',
         id: 'test-test-test',
         timeouted: false
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- add key value `testId` and `testValue` in Adomik Analytics Adapter
```
      pbjs.enableAnalytics({
        provider: 'adomik',
        options: {
          testId: testId,
          testValue: testValue,
          id: id,
          url: url
        }
```

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
