### PR TITLE
TrustX Bid Adapter: fix for segments format

### DIFF
--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -429,9 +429,10 @@ function addSegments(name, segName, segments, data, bidConfigName) {
   if (segments && segments.length) {
     data.push({
       name: name,
-      segment: segments.map((seg) => {
-        return {name: segName, value: seg};
-      })
+      segment: segments
+        .map((seg) => seg && (seg.id || seg))
+        .filter((seg) => seg && (typeof seg === 'string' || typeof seg === 'number'))
+        .map((seg) => ({ name: segName, value: seg.toString() }))
     });
   } else if (bidConfigName) {
     const configData = config.getConfig('ortb2.user.data');
@@ -445,9 +446,10 @@ function addSegments(name, segName, segments, data, bidConfigName) {
     if (segData && segData.length) {
       data.push({
         name: name,
-        segment: segData.map((seg) => {
-          return {name: segName, value: seg};
-        })
+        segment: segData
+          .map((seg) => seg && (seg.id || seg))
+          .filter((seg) => seg && (typeof seg === 'string' || typeof seg === 'number'))
+          .map((seg) => ({ name: segName, value: seg.toString() }))
       });
     }
   }

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -402,7 +402,7 @@ describe('TrustXAdapter', function () {
     });
 
     it('if segment is present in permutive targeting, payload must have right params', function () {
-      const permSegments = ['test_perm_1', 'test_perm_2'];
+      const permSegments = [{id: 'test_perm_1'}, {id: 'test_perm_2'}];
       const bidRequestsWithPermutiveTargeting = bidRequests.map((bid) => {
         return Object.assign({
           rtd: {
@@ -421,8 +421,8 @@ describe('TrustXAdapter', function () {
       expect(payload.user.data).to.deep.equal([{
         name: 'permutive',
         segment: [
-          {name: 'p_standard', value: permSegments[0]},
-          {name: 'p_standard', value: permSegments[1]}
+          {name: 'p_standard', value: permSegments[0].id},
+          {name: 'p_standard', value: permSegments[1].id}
         ]
       }]);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
<!-- Describe the change proposed in this pull request -->
Fixed segments format in request to send segment value as string


- paul@trustx.org
- [x] official adapter submission
