### PR TITLE
IX Bid Adapter: capture errors in LS and send errors in request

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1,6 +1,9 @@
 import { deepAccess, parseGPTSingleSizeArray, inIframe, deepClone, logError, logWarn, isFn, contains, isInteger, isArray, deepSetValue, parseQueryStringParameters, isEmpty, mergeDeep, convertTypes } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
+import { EVENTS } from '../src/constants.json';
+import { getStorageManager } from '../src/storageManager.js';
+import events from '../src/events.js';
 import find from 'core-js-pure/features/array/find.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { INSTREAM, OUTSTREAM } from '../src/video.js';
@@ -20,15 +23,23 @@ const VIDEO_TIME_TO_LIVE = 3600; // 1hr
 const NET_REVENUE = true;
 const MAX_REQUEST_SIZE = 8000;
 const MAX_REQUEST_LIMIT = 4;
-
 const PRICE_TO_DOLLAR_FACTOR = {
   JPY: 1
 };
 const USER_SYNC_URL = 'https://js-sec.indexww.com/um/ixmatch.html';
 const RENDERER_URL = 'https://js-sec.indexww.com/htv/video-player.js';
 const FLOOR_SOURCE = { PBJS: 'p', IX: 'x' };
-// determines which eids we send and the rtiPartner field in ext
-
+export const ERROR_CODES = {
+  BID_SIZE_INVALID_FORMAT: 1,
+  BID_SIZE_NOT_INCLUDED: 2,
+  PROPERTY_NOT_INCLUDED: 3,
+  SITE_ID_INVALID_VALUE: 4,
+  BID_FLOOR_INVALID_FORMAT: 5,
+  IX_FPD_EXCEEDS_MAX_SIZE: 6,
+  EXCEEDS_MAX_SIZE: 7,
+  PB_FPD_EXCEEDS_MAX_SIZE: 8,
+  VIDEO_DURATION_INVALID: 9
+};
 const FIRST_PARTY_DATA = {
   SITE: [
     'id', 'name', 'domain', 'cat', 'sectioncat', 'pagecat', 'page', 'ref', 'search', 'mobile',
@@ -36,7 +47,6 @@ const FIRST_PARTY_DATA = {
   ],
   USER: ['id', 'buyeruid', 'yob', 'gender', 'keywords', 'customdata', 'geo', 'data', 'ext']
 };
-
 const SOURCE_RTI_MAPPING = {
   'liveramp.com': 'idl',
   'netid.de': 'NETID',
@@ -45,7 +55,6 @@ const SOURCE_RTI_MAPPING = {
   'uidapi.com': 'UID2',
   'adserver.org': 'TDID'
 };
-
 const PROVIDERS = [
   'britepoolid',
   'id5id',
@@ -62,9 +71,7 @@ const PROVIDERS = [
   'TDID',
   'flocId'
 ];
-
 const REQUIRED_VIDEO_PARAMS = ['mimes', 'minduration', 'maxduration']; // note: protocol/protocols is also reqd
-
 const VIDEO_PARAMS_ALLOW_LIST = [
   'mimes', 'minduration', 'maxduration', 'protocols', 'protocol',
   'startdelay', 'placement', 'linearity', 'skip', 'skipmin',
@@ -73,6 +80,9 @@ const VIDEO_PARAMS_ALLOW_LIST = [
   'delivery', 'pos', 'companionad', 'api', 'companiontype', 'ext',
   'playerSize', 'w', 'h'
 ];
+const LOCAL_STORAGE_KEY = 'ixdiag';
+let hasRegisteredHandler = false;
+export const storage = getStorageManager(GLOBAL_VENDOR_ID, BIDDER_CODE);
 
 /**
  * Transform valid bid request config object to banner impression object that will be sent to ad server.
@@ -125,7 +135,10 @@ function bidToVideoImp(bid) {
   }
 
   if (imp.video.minduration > imp.video.maxduration) {
-    logError(`IX Bid Adapter: video minduration [${imp.video.minduration}] cannot be greater than video maxduration [${imp.video.maxduration}]`);
+    logError(
+      `IX Bid Adapter: video minduration [${imp.video.minduration}] cannot be greater than video maxduration [${imp.video.maxduration}]`,
+      { bidder: BIDDER_CODE, code: ERROR_CODES.VIDEO_DURATION_INVALID }
+    );
     return {};
   }
 
@@ -497,6 +510,13 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
     r.ext.ixdiag[key] = ixdiag[key];
   }
 
+  // Get cached errors stored in LocalStorage
+  const cachedErrors = getCachedErrors();
+
+  if (!isEmpty(cachedErrors)) {
+    r.ext.ixdiag.err = cachedErrors;
+  }
+
   // if an schain is provided, send it along
   if (validBidRequests[0].schain) {
     r.source = {
@@ -575,7 +595,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   const baseRequestSize = `${baseUrl}${parseQueryStringParameters({ ...payload, r: JSON.stringify(r) })}`.length;
 
   if (baseRequestSize > MAX_REQUEST_SIZE) {
-    logError('ix bidder: Base request size has exceeded maximum request size.');
+    logError('IX Bid Adapter: Base request size has exceeded maximum request size.', { bidder: BIDDER_CODE, code: ERROR_CODES.EXCEEDS_MAX_SIZE });
     return requests;
   }
 
@@ -605,7 +625,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         }
         currentRequestSize += fpdRequestSize;
       } else {
-        logError('ix bidder: IX config FPD request size has exceeded maximum request size.');
+        logError('IX Bid Adapter: IX config FPD request size has exceeded maximum request size.', { bidder: BIDDER_CODE, code: ERROR_CODES.IX_FPD_EXCEEDS_MAX_SIZE });
       }
     }
 
@@ -706,7 +726,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         const fpdRequestSize = encodeURIComponent(JSON.stringify({ ...site, ...user })).length;
         currentRequestSize += fpdRequestSize;
       } else {
-        logError('ix bidder: FPD request size has exceeded maximum request size.');
+        logError('IX Bid Adapter: FPD request size has exceeded maximum request size.', { bidder: BIDDER_CODE, code: ERROR_CODES.PB_FPD_EXCEEDS_MAX_SIZE });
       }
     }
 
@@ -939,10 +959,99 @@ function createMissingBannerImp(bid, imp, newSize) {
 }
 
 /**
+ * @typedef {Array[message: string, err: Object<bidder: string, code: number>]} ErrorData
+ * @property {string} message - The error message.
+ * @property {object} err - The error object.
+ * @property {string} err.bidder - The bidder of the error.
+ * @property {string} err.code - The error code.
+ */
+
+/**
+ * Error Event handler that receives type and arguments in a data object.
+ *
+ * @param {ErrorData} data
+ */
+function errorEventHandler(data) {
+  if (!storage.localStorageIsEnabled()) {
+    return;
+  }
+
+  let currentStorage;
+
+  try {
+    currentStorage = JSON.parse(storage.getDataFromLocalStorage(LOCAL_STORAGE_KEY) || '{}');
+  } catch (e) {
+    logWarn('ix can not read ixdiag from localStorage.');
+  }
+
+  const todayDate = new Date();
+
+  Object.keys(currentStorage).map((errorDate) => {
+    const date = new Date(errorDate);
+
+    if (date.setDate(date.getDate() + 7) - todayDate < 0) {
+      delete currentStorage[errorDate];
+    }
+  });
+
+  if (data.type === 'ERROR' && data.arguments && data.arguments[1] && data.arguments[1].bidder === BIDDER_CODE) {
+    const todayString = todayDate.toISOString().slice(0, 10);
+
+    const errorCode = data.arguments[1].code;
+
+    if (errorCode) {
+      currentStorage[todayString] = currentStorage[todayString] || {};
+
+      if (!Number(currentStorage[todayString][errorCode])) {
+        currentStorage[todayString][errorCode] = 0;
+      }
+
+      currentStorage[todayString][errorCode]++;
+    };
+  }
+
+  storage.setDataInLocalStorage(LOCAL_STORAGE_KEY, JSON.stringify(currentStorage));
+}
+
+/**
+ * Get ixdiag stored in LocalStorage and format to be added to request payload
+ *
+ * @returns {Object} Object with error codes and counts
+ */
+function getCachedErrors() {
+  if (!storage.localStorageIsEnabled()) {
+    return;
+  }
+
+  const errors = {};
+  let currentStorage;
+
+  try {
+    currentStorage = JSON.parse(storage.getDataFromLocalStorage(LOCAL_STORAGE_KEY) || '{}');
+  } catch (e) {
+    logError('ix can not read ixdiag from localStorage.');
+    return null;
+  }
+
+  Object.keys(currentStorage).forEach((date) => {
+    Object.keys(currentStorage[date]).forEach((code) => {
+      if (typeof currentStorage[date][code] === 'number') {
+        errors[code] = errors[code]
+          ? errors[code] + currentStorage[date][code]
+          : currentStorage[date][code];
+      }
+    });
+  });
+
+  return errors;
+}
+
+/**
+ *
  * Initialize Outstream Renderer
  * @param {Object} bid
  */
-function outstreamRenderer (bid) {
+function outstreamRenderer(bid) {
   bid.renderer.push(() => {
     var config = {
       width: bid.width,
@@ -959,7 +1068,7 @@ function outstreamRenderer (bid) {
  * @param {string} id
  * @returns {Renderer}
  */
-function createRenderer (id) {
+function createRenderer(id) {
   const renderer = Renderer.install({
     id: id,
     url: RENDERER_URL,
@@ -993,6 +1102,12 @@ export const spec = {
    * @return {boolean}     True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
+    if (!hasRegisteredHandler) {
+      events.on(EVENTS.AUCTION_DEBUG, errorEventHandler);
+      events.on(EVENTS.AD_RENDER_FAILED, errorEventHandler);
+      hasRegisteredHandler = true;
+    }
+
     const paramsVideoRef = deepAccess(bid, 'params.video');
     const paramsSize = deepAccess(bid, 'params.size');
     const mediaTypeBannerSizes = deepAccess(bid, 'mediaTypes.banner.sizes');
@@ -1002,6 +1117,7 @@ export const spec = {
     const hasBidFloorCur = bid.params.hasOwnProperty('bidFloorCur');
 
     if (bid.hasOwnProperty('mediaType') && !(contains(SUPPORTED_AD_TYPES, bid.mediaType))) {
+      logWarn('IX Bid Adapter: media type is not supported.');
       return false;
     }
 
@@ -1013,26 +1129,26 @@ export const spec = {
       // since there is an ix bidder level size, make sure its valid
       const ixSize = getFirstSize(paramsSize);
       if (!ixSize) {
-        logError('ix bidder params: size has invalid format.');
+        logError('IX Bid Adapter: size has invalid format.', { bidder: BIDDER_CODE, code: ERROR_CODES.BID_SIZE_INVALID_FORMAT });
         return false;
       }
       // check if the ix bidder level size, is present in ad unit level
       if (!includesSize(bid.sizes, ixSize) &&
         !(includesSize(mediaTypeVideoPlayerSize, ixSize)) &&
         !(includesSize(mediaTypeBannerSizes, ixSize))) {
-        logError('ix bidder params: bid size is not included in ad unit sizes or player size.');
+        logError('IX Bid Adapter: bid size is not included in ad unit sizes or player size.', { bidder: BIDDER_CODE, code: ERROR_CODES.BID_SIZE_NOT_INCLUDED });
         return false;
       }
     }
 
     if (typeof bid.params.siteId !== 'string' && typeof bid.params.siteId !== 'number') {
-      logError('ix bidder params: siteId must be string or number value.');
+      logError('IX Bid Adapter: siteId must be string or number value.', { bidder: BIDDER_CODE, code: ERROR_CODES.SITE_ID_INVALID_VALUE });
       return false;
     }
 
     if (hasBidFloor || hasBidFloorCur) {
       if (!(hasBidFloor && hasBidFloorCur && isValidBidFloorParams(bid.params.bidFloor, bid.params.bidFloorCur))) {
-        logError('ix bidder params: bidFloor / bidFloorCur parameter has invalid format.');
+        logError('IX Bid Adapter: bidFloor / bidFloorCur parameter has invalid format.', { bidder: BIDDER_CODE, code: ERROR_CODES.BID_FLOOR_INVALID_FORMAT });
         return false;
       }
     }
@@ -1041,7 +1157,7 @@ export const spec = {
       const errorList = checkVideoParams(mediaTypeVideoRef, paramsVideoRef);
       if (errorList.length) {
         errorList.forEach((err) => {
-          logError(err);
+          logError(err, { bidder: BIDDER_CODE, code: ERROR_CODES.PROPERTY_NOT_INCLUDED });
         });
         return false;
       }
@@ -1161,6 +1277,16 @@ export const spec = {
         }
 
         bids.push(bid);
+      }
+
+      if (deepAccess(requestBid, 'ext.ixdiag.err')) {
+        if (storage.localStorageIsEnabled()) {
+          try {
+            storage.removeDataFromLocalStorage(LOCAL_STORAGE_KEY);
+          } catch (e) {
+            logError('ix can not clear ixdiag from localStorage.');
+          }
+        }
       }
     }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2611,7 +2611,7 @@ describe('IndexexchangeAdapter', function () {
     it('should log ERROR_CODES.EXCEEDS_MAX_SIZE in LocalStorage when there is logError called.', () => {
       const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
       bid.bidderRequestId = Array(8000).join('#');
-      
+
       expect(spec.isBidRequestValid(bid)).to.be.true;
       spec.buildRequests([bid]);
       expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.EXCEEDS_MAX_SIZE]: 2 } });

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2,7 +2,7 @@ import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 import { expect } from 'chai';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { spec } from 'modules/ixBidAdapter.js';
+import { spec, storage, ERROR_CODES } from '../../../modules/ixBidAdapter.js';
 import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('IndexexchangeAdapter', function () {
@@ -1236,7 +1236,7 @@ describe('IndexexchangeAdapter', function () {
     afterEach(function () {
       config.setConfig({
         ortb2: {}
-      })
+      });
     });
 
     it('should not set ixdiag.fpd value if not defined', function () {
@@ -2512,6 +2512,219 @@ describe('IndexexchangeAdapter', function () {
       const r = JSON.parse(bid[0].data.r);
 
       expect(r.regs.coppa).to.be.undefined;
+    });
+  });
+
+  describe('LocalStorage ixdiag', () => {
+    let TODAY = new Date().toISOString().slice(0, 10);
+    const key = 'ixdiag';
+
+    let sandbox;
+    let setDataInLocalStorageStub;
+    let getDataFromLocalStorageStub;
+    let removeDataFromLocalStorageStub;
+    let localStorageValues = {};
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      setDataInLocalStorageStub = sandbox.stub(storage, 'setDataInLocalStorage').callsFake((key, value) => localStorageValues[key] = value)
+      getDataFromLocalStorageStub = sandbox.stub(storage, 'getDataFromLocalStorage').callsFake((key) => localStorageValues[key])
+      removeDataFromLocalStorageStub = sandbox.stub(storage, 'removeDataFromLocalStorage').callsFake((key) => delete localStorageValues[key])
+      sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
+    });
+
+    afterEach(() => {
+      setDataInLocalStorageStub.restore();
+      getDataFromLocalStorageStub.restore();
+      removeDataFromLocalStorageStub.restore();
+      localStorageValues = {};
+      sandbox.restore();
+
+      config.setConfig({
+        fpd: {},
+        ix: {},
+      })
+    });
+
+    it('should not log error in LocalStorage when there is no logError called.', () => {
+      const bid = DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0];
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+      expect(localStorageValues[key]).to.be.undefined;
+    });
+
+    it('should log ERROR_CODES.BID_SIZE_INVALID_FORMAT in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.size = ['400', 100];
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.BID_SIZE_INVALID_FORMAT]: 1 } });
+    });
+
+    it('should log ERROR_CODES.BID_SIZE_NOT_INCLUDED in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.size = [407, 100];
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.BID_SIZE_NOT_INCLUDED]: 1 } });
+    });
+
+    it('should log ERROR_CODES.PROPERTY_NOT_INCLUDED in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.video = {};
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.PROPERTY_NOT_INCLUDED]: 4 } });
+    });
+
+    it('should log ERROR_CODES.SITE_ID_INVALID_VALUE in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.siteId = false;
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.SITE_ID_INVALID_VALUE]: 1 } });
+    });
+
+    it('should log ERROR_CODES.BID_FLOOR_INVALID_FORMAT in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.bidFloor = true;
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.BID_FLOOR_INVALID_FORMAT]: 1 } });
+    });
+
+    it('should log ERROR_CODES.IX_FPD_EXCEEDS_MAX_SIZE in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+
+      config.setConfig({
+        ix: {
+          firstPartyData: {
+            cd: Array(1700).join('#')
+          }
+        }
+      });
+
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+      spec.buildRequests([bid]);
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.IX_FPD_EXCEEDS_MAX_SIZE]: 2 } });
+    });
+
+    it('should log ERROR_CODES.EXCEEDS_MAX_SIZE in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.bidderRequestId = Array(8000).join('#');
+      
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+      spec.buildRequests([bid]);
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.EXCEEDS_MAX_SIZE]: 2 } });
+    });
+
+    it('should log ERROR_CODES.PB_FPD_EXCEEDS_MAX_SIZE in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+
+      config.setConfig({
+        fpd: {
+          site: {
+            data: {
+              pageType: Array(5700).join('#')
+            }
+          }
+        }
+      });
+
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+      spec.buildRequests([bid]);
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.PB_FPD_EXCEEDS_MAX_SIZE]: 2 } });
+    });
+
+    it('should log ERROR_CODES.VIDEO_DURATION_INVALID in LocalStorage when there is logError called.', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.video.minduration = 1;
+      bid.params.video.maxduration = 0;
+
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+      spec.buildRequests([bid]);
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.VIDEO_DURATION_INVALID]: 2 } });
+    });
+
+    it('should increment errors for errorCode', () => {
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.video = {};
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.PROPERTY_NOT_INCLUDED]: 4 } });
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.PROPERTY_NOT_INCLUDED]: 8 } });
+    });
+
+    it('should add new errorCode to ixdiag.', () => {
+      let bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.size = ['400', 100];
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.BID_SIZE_INVALID_FORMAT]: 1 } });
+
+      bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.siteId = false;
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({
+        [TODAY]: {
+          [ERROR_CODES.BID_SIZE_INVALID_FORMAT]: 1,
+          [ERROR_CODES.SITE_ID_INVALID_VALUE]: 1
+        }
+      });
+    });
+
+    it('should clear errors with successful response', () => {
+      const ixdiag = { [TODAY]: { '1': 1, '3': 8, '4': 1 } };
+      setDataInLocalStorageStub(key, JSON.stringify(ixdiag));
+
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal(ixdiag);
+
+      const request = DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0];
+      expect(spec.isBidRequestValid(request)).to.be.true;
+
+      const data = {
+        ...utils.deepClone(DEFAULT_BIDDER_REQUEST_DATA[0]),
+        r: JSON.stringify({
+          id: '345',
+          imp: [
+            {
+              id: '1a2b3c4e',
+            }
+          ],
+          ext: {
+            ixdiag: {
+              err: {
+                '4': 8
+              }
+            }
+          }
+        }),
+      };
+
+      const validBidRequests = [
+        DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0],
+        DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]
+      ];
+
+      spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data, validBidRequests });
+
+      expect(localStorageValues[key]).to.be.undefined;
+    });
+
+    it('should clear errors after 7 day expiry errorCode', () => {
+      const EXPIRED_DATE = '2019-12-12';
+
+      const ixdiag = { [EXPIRED_DATE]: { '1': 1, '3': 8, '4': 1 }, [TODAY]: { '3': 8, '4': 1 } };
+      setDataInLocalStorageStub(key, JSON.stringify(ixdiag));
+
+      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
+      bid.params.size = ['400', 100];
+
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(JSON.parse(localStorageValues[key])[EXPIRED_DATE]).to.be.undefined;
+      expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { '1': 1, '3': 8, '4': 1 } })
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

When `utils.logError()` we have a `errorEventHandler()` that gets called to store the error in LocalStorage. These errors are sent in to the `/cygnus` endpoint, when there is successful response received, errors are cleared from LocalStorage. 