### PR TITLE
Glimpse Bid Adapter: Capture target demand provider & account id + use storage manager

### DIFF
--- a/modules/glimpseBidAdapter.js
+++ b/modules/glimpseBidAdapter.js
@@ -1,19 +1,22 @@
 import { BANNER } from '../src/mediaTypes.js'
+import { config } from '../src/config.js'
 import { getStorageManager } from '../src/storageManager.js'
 import { isArray } from '../src/utils.js'
 import { registerBidder } from '../src/adapters/bidderFactory.js'
 
 const storageManager = getStorageManager()
 
+const GVLID = 1012
 const BIDDER_CODE = 'glimpse'
 const ENDPOINT = 'https://api.glimpsevault.io/ads/serving/public/v1/prebid'
 const LOCAL_STORAGE_KEY = {
-  glimpse: {
+  vault: {
     jwt: 'gp_vault_jwt',
   },
 }
 
 export const spec = {
+  gvlid: GVLID,
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER],
 
@@ -37,20 +40,28 @@ export const spec = {
    * @returns {ServerRequest}
    */
   buildRequests: (validBidRequests, bidderRequest) => {
-    const networkId = window.networkId || -1
-    const bids = validBidRequests.map(processBidRequest)
+    const demo = config.getConfig('glimpse.demo') || false
+    const account = config.getConfig('glimpse.account') || -1
+    const demand = config.getConfig('glimpse.demand') || 'glimpse'
+    const keywords = config.getConfig('glimpse.keywords') || {}
+
+    const auth = getVaultJwt()
     const referer = getReferer(bidderRequest)
     const gdprConsent = getGdprConsentChoice(bidderRequest)
-    const jwt = getVaultJwt()
+    const bids = validBidRequests.map((bidRequest) => {
+      return processBidRequest(bidRequest, keywords)
+    })
 
     const data = {
-      auth: jwt,
+      auth,
       data: {
         bidderCode: spec.code,
-        networkId,
-        bids,
+        demo,
+        account,
+        demand,
         referer,
         gdprConsent,
+        bids,
       }
     }
 
@@ -65,10 +76,9 @@ export const spec = {
   /**
    * Parse response from Glimpse server
    * @param bidResponse {ServerResponse}
-   * @param bidRequest {BidRequest}
    * @returns {Bid[]}
    */
-  interpretResponse: (bidResponse, bidRequest) => {
+  interpretResponse: (bidResponse) => {
     const isValidResponse = isValidBidResponse(bidResponse)
 
     if (isValidResponse) {
@@ -81,16 +91,20 @@ export const spec = {
   },
 }
 
-function processBidRequest(bidRequest) {
+function processBidRequest(bidRequest, globalKeywords) {
   const sizes = normalizeSizes(bidRequest.sizes)
-  const keywords = bidRequest.params.keywords || []
+  const bidKeywords = bidRequest.params.keywords || {}
+  const keywords = {
+    ...globalKeywords,
+    ...bidKeywords,
+  }
 
   return {
+    unitCode: bidRequest.adUnitCode,
     bidId: bidRequest.bidId,
     placementId: bidRequest.params.placementId,
-    unitCode: bidRequest.adUnitCode,
-    sizes,
     keywords,
+    sizes,
   }
 }
 
@@ -124,7 +138,8 @@ function getReferer(bidderRequest) {
 function getGdprConsentChoice(bidderRequest) {
   const hasGdprConsent =
     hasValue(bidderRequest) &&
-    hasValue(bidderRequest.gdprConsent)
+    hasValue(bidderRequest.gdprConsent) &&
+    hasStringValue(bidderRequest.gdprConsent.consentString)
 
   if (hasGdprConsent) {
     return bidderRequest.gdprConsent
@@ -138,11 +153,11 @@ function getGdprConsentChoice(bidderRequest) {
 }
 
 function setVaultJwt(auth) {
-  storageManager.setDataInLocalStorage(LOCAL_STORAGE_KEY.glimpse.jwt, auth)
+  storageManager.setDataInLocalStorage(LOCAL_STORAGE_KEY.vault.jwt, auth)
 }
 
 function getVaultJwt() {
-  return storageManager.getDataFromLocalStorage(LOCAL_STORAGE_KEY.glimpse.jwt) || ''
+  return storageManager.getDataFromLocalStorage(LOCAL_STORAGE_KEY.vault.jwt) || ''
 }
 
 function isValidBidResponse(bidResponse) {

--- a/test/spec/modules/glimpseBidAdapter_spec.js
+++ b/test/spec/modules/glimpseBidAdapter_spec.js
@@ -1,3 +1,4 @@
+import { BANNER } from '../../../src/mediaTypes'
 import { expect } from 'chai'
 import { newBidder } from 'src/adapters/bidderFactory.js'
 import { spec } from 'modules/glimpseBidAdapter.js'
@@ -78,6 +79,20 @@ function getDeepCopy(object) {
 
 describe('GlimpseProtocolAdapter', () => {
   const glimpseAdapter = newBidder(spec)
+
+  describe('spec', () => {
+    it('Has defined the glimpse gvlid', () => {
+      expect(spec.gvlid).to.equal(1012)
+    })
+
+    it('Has defined glimpse as the bidder', () => {
+      expect(spec.code).to.equal('glimpse')
+    })
+
+    it('Has defined valid mediaTypes', () => {
+      expect(spec.supportedMediaTypes).to.deep.equal([BANNER])
+    })
+  })
 
   describe('Inherited functions', () => {
     it('Functions exist and are valid types', () => {
@@ -162,6 +177,24 @@ describe('GlimpseProtocolAdapter', () => {
   describe('buildRequests', () => {
     const bidRequests = [getBidRequest()]
     const bidderRequest = getBidderRequest()
+
+    it('Adds a demo flag', () => {
+      const request = spec.buildRequests(bidRequests, bidderRequest)
+      const payload = JSON.parse(request.data)
+      expect(payload.data.demo).to.be.false
+    })
+
+    it('Adds an account id', () => {
+      const request = spec.buildRequests(bidRequests, bidderRequest)
+      const payload = JSON.parse(request.data)
+      expect(payload.data.account).to.equal(-1)
+    })
+
+    it('Adds a demand provider', () => {
+      const request = spec.buildRequests(bidRequests, bidderRequest)
+      const payload = JSON.parse(request.data)
+      expect(payload.data.demand).to.equal('glimpse')
+    })
 
     it('Adds GDPR consent', () => {
       const request = spec.buildRequests(bidRequests, bidderRequest)


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- Use the provided storage manager, rather than dealing with local storage directly
- Capture the target demand provider & account id
- Add flag to trigger randomly-generated demo bid response