### PR TITLE
Build: move browser targets to package.json

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -14,13 +14,7 @@ module.exports = {
     [
       useLocal('@babel/preset-env'),
       {
-        "targets": {
-          "browsers": [
-            ">0.25%",
-            "not ie 11",
-            "not op_mini all"
-          ]
-        }
+        "useBuiltIns": "entry"
       }
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "type": "git",
     "url": "https://github.com/prebid/Prebid.js.git"
   },
+  "browserslist": [
+    "> 0.25%",
+    "not IE 11",
+    "not op_mini all"
+  ],
   "keywords": [
     "advertising",
     "auction",


### PR DESCRIPTION
This changes the way we set targets to use browseerlist in the package.json from the .babelrc file. The current way seemed to be using the same targets from the 5.20 version (reduces the main package size by about 10%)