### PR TITLE
Missena Bid Adapter: add back adapter to latest prebid version

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -1,0 +1,94 @@
+import * as utils from '../src/utils.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+
+const BIDDER_CODE = 'missena';
+const ENDPOINT_URL = 'https://bid.missena.io/';
+
+export const spec = {
+  aliases: [BIDDER_CODE],
+  code: BIDDER_CODE,
+  gvlid: 687,
+  supportedMediaTypes: [BANNER],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    return typeof bid == 'object' && !!bid.params.apiKey;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    return validBidRequests.map((bidRequest) => {
+      const payload = {
+        request_id: bidRequest.bidId,
+        timeout: bidderRequest.timeout,
+      };
+
+      if (bidderRequest && bidderRequest.refererInfo) {
+        payload.referer = bidderRequest.refererInfo.referer;
+        payload.referer_canonical = bidderRequest.refererInfo.canonicalUrl;
+      }
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.consent_string = bidderRequest.gdprConsent.consentString;
+        payload.consent_required = bidderRequest.gdprConsent.gdprApplies;
+      }
+
+      return {
+        method: 'POST',
+        url:
+          ENDPOINT_URL +
+          '?' +
+          utils.formatQS({
+            t: bidRequest.params.apiKey,
+          }),
+        data: JSON.stringify(payload),
+      };
+    });
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const bidResponses = [];
+    const response = serverResponse.body;
+
+    if (response && !response.timeout && !!response.ad) {
+      bidResponses.push(response);
+    }
+
+    return bidResponses;
+  },
+
+  /**
+   * Register bidder specific code, which will execute if bidder timed out after an auction
+   * @param {data} Containing timeout specific data
+   */
+  onTimeout: function onTimeout(timeoutData) {
+    utils.logInfo('Missena - Timeout from adapter', timeoutData);
+  },
+
+  /**
+   * Register bidder specific code, which@ will execute if a bid from this bidder won the auction
+   * @param {Bid} The bid that won the auction
+   */
+  onBidWon: function (bid) {
+    utils.logInfo('Missena - Bid won', bid);
+  },
+};
+
+registerBidder(spec);

--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -1,4 +1,4 @@
-import * as utils from '../src/utils.js';
+import { formatQS, logInfo } from '../src/utils.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
@@ -46,12 +46,7 @@ export const spec = {
 
       return {
         method: 'POST',
-        url:
-          ENDPOINT_URL +
-          '?' +
-          utils.formatQS({
-            t: bidRequest.params.apiKey,
-          }),
+        url: ENDPOINT_URL + '?' + formatQS({ t: bidRequest.params.apiKey }),
         data: JSON.stringify(payload),
       };
     });
@@ -79,7 +74,7 @@ export const spec = {
    * @param {data} Containing timeout specific data
    */
   onTimeout: function onTimeout(timeoutData) {
-    utils.logInfo('Missena - Timeout from adapter', timeoutData);
+    logInfo('Missena - Timeout from adapter', timeoutData);
   },
 
   /**
@@ -87,7 +82,7 @@ export const spec = {
    * @param {Bid} The bid that won the auction
    */
   onBidWon: function (bid) {
-    utils.logInfo('Missena - Bid won', bid);
+    logInfo('Missena - Bid won', bid);
   },
 };
 

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { spec, _getPlatform } from 'modules/missenaBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+
+describe('Missena Adapter', function () {
+  const adapter = newBidder(spec);
+
+  const bidId = 'abc';
+
+  const bid = {
+    bidder: 'missena',
+    bidId: bidId,
+    sizes: [[1, 1]],
+    params: {
+      apiKey: 'PA-34745704',
+    },
+  };
+
+  describe('codes', function () {
+    it('should return a bidder code of missena', function () {
+      expect(spec.code).to.equal('missena');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    it('should return true if the apiKey param is present', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false if the apiKey is missing', function () {
+      expect(
+        spec.isBidRequestValid(Object.assign(bid, { params: {} }))
+      ).to.equal(false);
+    });
+
+    it('should return false if the apiKey is an empty string', function () {
+      expect(
+        spec.isBidRequestValid(Object.assign(bid, { params: { apiKey: '' } }))
+      ).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const consentString = 'AAAAAAAAA==';
+
+    const bidderRequest = {
+      gdprConsent: {
+        consentString: consentString,
+        gdprApplies: true,
+      },
+      refererInfo: {
+        referer: 'https://referer',
+        canonicalUrl: 'https://canonical',
+      },
+    };
+
+    const requests = spec.buildRequests([bid, bid], bidderRequest);
+    const request = requests[0];
+    const payload = JSON.parse(request.data);
+
+    it('should return as many server requests as bidder requests', function () {
+      expect(requests.length).to.equal(2);
+    });
+
+    it('should have a post method', function () {
+      expect(request.method).to.equal('POST');
+    });
+
+    it('should send the bidder id', function () {
+      expect(payload.request_id).to.equal(bidId);
+    });
+
+    it('should send referer information to the request', function () {
+      expect(payload.referer).to.equal('https://referer');
+      expect(payload.referer_canonical).to.equal('https://canonical');
+    });
+
+    it('should send gdpr consent information to the request', function () {
+      expect(payload.consent_string).to.equal(consentString);
+      expect(payload.consent_required).to.equal(true);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const serverResponse = {
+      requestId: bidId,
+      cpm: 0.5,
+      currency: 'USD',
+      ad: '<!-- -->',
+    };
+
+    const serverTimeoutResponse = {
+      requestId: bidId,
+      timeout: true,
+      ad: '<!-- -->',
+    };
+
+    const serverEmptyAdResponse = {
+      requestId: bidId,
+      cpm: 0.5,
+      currency: 'USD',
+      ad: '',
+    };
+
+    it('should return a proper bid response', function () {
+      const result = spec.interpretResponse({ body: serverResponse }, bid);
+
+      expect(result.length).to.equal(1);
+
+      expect(Object.keys(result[0])).to.have.members(
+        Object.keys(serverResponse)
+      );
+    });
+
+    it('should return an empty response when the server answers with a timeout', function () {
+      const result = spec.interpretResponse(
+        { body: serverTimeoutResponse },
+        bid
+      );
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should return an empty response when the server answers with an empty ad', function () {
+      const result = spec.interpretResponse(
+        { body: serverEmptyAdResponse },
+        bid
+      );
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -87,6 +87,9 @@ describe('Missena Adapter', function () {
       cpm: 0.5,
       currency: 'USD',
       ad: '<!-- -->',
+      meta: {
+        advertiserDomains: ['missena.com']
+      },
     };
 
     const serverTimeoutResponse = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
This PR restores the missena adapter to the state before 412277f72b97cab72644cb4a009f58067a165899 

## Other information

As far as I understand things, the missena adapter was include by error in the #6650. 

The maintainer did not react due to competing priorities and the adapter was removed. 

I have been tasked with getting the adapter re-enabled. If there are issues with the adapter that makes it incompatible with the current Prebid.js, please let me know what are the issues so I can address them. 

Regarding the `advertiserDomains` mentioned in #6650,  for valid bids responses, the adapter returns a `meta` object with an empty `advertiserDomains`.  

 