### PR TITLE
DeepIntent Bid Adapter: secure flag set using proper protocol value

### DIFF
--- a/modules/deepintentBidAdapter.js
+++ b/modules/deepintentBidAdapter.js
@@ -162,7 +162,7 @@ function buildImpression(bid) {
   impression = {
     id: bid.bidId,
     tagid: bid.params.tagId || '',
-    secure: window.location.protocol === 'https' ? 1 : 0,
+    secure: window.location.protocol === 'https:' ? 1 : 0,
     displaymanager: 'di_prebid',
     displaymanagerver: DI_M_V,
     ext: buildCustomParams(bid)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Set secure flag using correct comparison with window.location.protocol in buildImpressions function
