### PR TITLE
Eplanning & Adapter Manager: fix testing of innerwidth to fix current build

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { config } from './config.js';
 import {logWarn, isPlainObject, deepAccess, deepClone, getWindowTop} from './utils.js';
 import includes from 'core-js-pure/features/array/includes.js';
@@ -128,15 +127,11 @@ function evaluateSizeConfig(configs) {
       let ruleMatch = false;
 
       try {
-        console.log(`WINDOW MATCH MEDIA - BEFORE`);
         ruleMatch = getWindowTop().matchMedia(config.mediaQuery).matches;
-        console.log(`WINDOW MATCH MEDIA - AFTER - ${ruleMatch}`);
       } catch (e) {
         logWarn('Unfriendly iFrame blocks sizeConfig from being correctly evaluated');
 
-        console.log(`MATCH MEDIA - BEFORE`);
         ruleMatch = matchMedia(config.mediaQuery).matches;
-        console.log(`MATCH MEDIA - AFTER - ${ruleMatch}`);
       }
 
       if (ruleMatch) {

--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { config } from './config.js';
 import {logWarn, isPlainObject, deepAccess, deepClone, getWindowTop} from './utils.js';
 import includes from 'core-js-pure/features/array/includes.js';
@@ -127,11 +128,15 @@ function evaluateSizeConfig(configs) {
       let ruleMatch = false;
 
       try {
+        console.log(`WINDOW MATCH MEDIA - BEFORE`);
         ruleMatch = getWindowTop().matchMedia(config.mediaQuery).matches;
+        console.log(`WINDOW MATCH MEDIA - AFTER - ${ruleMatch}`);
       } catch (e) {
         logWarn('Unfriendly iFrame blocks sizeConfig from being correctly evaluated');
 
+        console.log(`MATCH MEDIA - BEFORE`);
         ruleMatch = matchMedia(config.mediaQuery).matches;
+        console.log(`MATCH MEDIA - AFTER - ${ruleMatch}`);
       }
 
       if (ruleMatch) {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -331,21 +331,22 @@ describe('E-Planning Adapter', function () {
     let sandbox;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
+      setupSingleWindow(sandBox, 800);
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    const createWindow = () => {
+    const createWindow = (innerWidth) => {
       const win = {};
       win.self = win;
-      win.innerWidth = 1025;
+      win.innerWidth = innerWidth;
       return win;
     };
 
-    function setupSingleWindow(sandBox) {
-      const win = createWindow();
+    function setupSingleWindow(sandBox, innerWidth) {
+      const win = createWindow(innerWidth);
       sandBox.stub(utils, 'getWindowSelf').returns(win);
     }
 
@@ -518,7 +519,8 @@ describe('E-Planning Adapter', function () {
 
     it('should return the e parameter with a value according to the sizes in order corresponding to the desktop priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForDesktop];
-      setupSingleWindow(sandbox);
+      // overwrite default innerWdith for tests with a larger one we consider "Desktop" or NOT Mobile
+      setupSingleWindow(sandbox, 1025);
       console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('300x250_0:300x250,300x600,970x250');

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -331,7 +331,7 @@ describe('E-Planning Adapter', function () {
     let sandbox;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
-      setupSingleWindow(sandBox, 800);
+      setupSingleWindow(sandbox, 800);
     });
 
     afterEach(() => {
@@ -345,9 +345,9 @@ describe('E-Planning Adapter', function () {
       return win;
     };
 
-    function setupSingleWindow(sandBox, innerWidth) {
+    function setupSingleWindow(sandbox, innerWidth) {
       const win = createWindow(innerWidth);
-      sandBox.stub(utils, 'getWindowSelf').returns(win);
+      sandbox.stub(utils, 'getWindowSelf').returns(win);
     }
 
     it('should create the url correctly', function () {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -329,9 +329,12 @@ describe('E-Planning Adapter', function () {
   describe('buildRequests', function () {
     let bidRequests = [validBid];
     let sandbox;
+    let getWindowSelfStub;
+    let innerWidth;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
-      setupSingleWindow(sandbox, 800);
+      getWindowSelfStub = sandbox.stub(utils, 'getWindowSelf');
+      getWindowSelfStub.returns(createWindow(800));
     });
 
     afterEach(() => {
@@ -344,11 +347,6 @@ describe('E-Planning Adapter', function () {
       win.innerWidth = innerWidth;
       return win;
     };
-
-    function setupSingleWindow(sandbox, innerWidth) {
-      const win = createWindow(innerWidth);
-      sandbox.stub(utils, 'getWindowSelf').returns(win);
-    }
 
     it('should create the url correctly', function () {
       const url = spec.buildRequests(bidRequests, bidderRequest).url;
@@ -520,7 +518,7 @@ describe('E-Planning Adapter', function () {
     it('should return the e parameter with a value according to the sizes in order corresponding to the desktop priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForDesktop];
       // overwrite default innerWdith for tests with a larger one we consider "Desktop" or NOT Mobile
-      setupSingleWindow(sandbox, 1025);
+      getWindowSelfStub.returns(createWindow(1025));
       console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('300x250_0:300x250,300x600,970x250');

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { expect } from 'chai';
 import { spec, storage } from 'modules/eplanningBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
@@ -510,6 +511,7 @@ describe('E-Planning Adapter', function () {
 
     it('should return the e parameter with a value according to the sizes in order corresponding to the mobile priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForMobile];
+      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('320x50_0:320x50,300x50,970x250');
     });
@@ -517,12 +519,14 @@ describe('E-Planning Adapter', function () {
     it('should return the e parameter with a value according to the sizes in order corresponding to the desktop priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForDesktop];
       setupSingleWindow(sandbox);
+      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('300x250_0:300x250,300x600,970x250');
     });
 
     it('should return the e parameter with a value according to the sizes in order as they are sent from the ad units', function () {
       let bidRequestsPrioritySizes2 = [validBidSizesNotExistingInPriorityListForMobile];
+      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes2, bidderRequest).data.e;
       expect(e).to.equal('970x250_0:970x250,300x70,160x600');
     });

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { expect } from 'chai';
 import { spec, storage } from 'modules/eplanningBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
@@ -510,7 +509,6 @@ describe('E-Planning Adapter', function () {
 
     it('should return the e parameter with a value according to the sizes in order corresponding to the mobile priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForMobile];
-      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('320x50_0:320x50,300x50,970x250');
     });
@@ -519,14 +517,12 @@ describe('E-Planning Adapter', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForDesktop];
       // overwrite default innerWdith for tests with a larger one we consider "Desktop" or NOT Mobile
       getWindowSelfStub.returns(createWindow(1025));
-      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('300x250_0:300x250,300x600,970x250');
     });
 
     it('should return the e parameter with a value according to the sizes in order as they are sent from the ad units', function () {
       let bidRequestsPrioritySizes2 = [validBidSizesNotExistingInPriorityListForMobile];
-      console.log(`INNER WIDTH IS: ${window.self.innerWidth}`);
       const e = spec.buildRequests(bidRequestsPrioritySizes2, bidderRequest).data.e;
       expect(e).to.equal('970x250_0:970x250,300x70,160x600');
     });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1718,6 +1718,7 @@ describe('adapterManager tests', function () {
       beforeEach(function () {
         allS2SBidders.length = 0;
         clientTestAdapters.length = 0;
+        sandBox.stub(utils, 'getWindowTop').returns(window);
         sinon.stub(window, 'matchMedia').callsFake(() => ({matches: true}));
       });
 
@@ -1749,7 +1750,7 @@ describe('adapterManager tests', function () {
 
       it('should not filter video bids', function () {
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
           'sizesSupported': [
             [728, 90],
             [300, 250]
@@ -1788,7 +1789,7 @@ describe('adapterManager tests', function () {
 
       it('should not filter native bids', function () {
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
           'sizesSupported': [
             [728, 90],
             [300, 250]
@@ -1839,7 +1840,7 @@ describe('adapterManager tests', function () {
         }, {});
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
           'sizesSupported': validSizes,
           'labels': ['tablet', 'phone']
         }]);
@@ -1862,7 +1863,7 @@ describe('adapterManager tests', function () {
         });
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
           'sizesSupported': [],
           'labels': ['tablet', 'phone']
         }]);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1718,8 +1718,7 @@ describe('adapterManager tests', function () {
       beforeEach(function () {
         allS2SBidders.length = 0;
         clientTestAdapters.length = 0;
-        sandBox.stub(utils, 'getWindowTop').returns(window);
-        sinon.stub(window, 'matchMedia').callsFake(() => ({matches: true}));
+        sinon.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
       });
 
       afterEach(function () {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1749,7 +1749,7 @@ describe('adapterManager tests', function () {
 
       it('should not filter video bids', function () {
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
           'sizesSupported': [
             [728, 90],
             [300, 250]
@@ -1788,7 +1788,7 @@ describe('adapterManager tests', function () {
 
       it('should not filter native bids', function () {
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
           'sizesSupported': [
             [728, 90],
             [300, 250]
@@ -1839,7 +1839,7 @@ describe('adapterManager tests', function () {
         }, {});
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
           'sizesSupported': validSizes,
           'labels': ['tablet', 'phone']
         }]);
@@ -1862,7 +1862,7 @@ describe('adapterManager tests', function () {
         });
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
           'sizesSupported': [],
           'labels': ['tablet', 'phone']
         }]);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1835,7 +1835,7 @@ describe('adapterManager tests', function () {
         }, {});
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444x)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
           'sizesSupported': validSizes,
           'labels': ['tablet', 'phone']
         }]);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1835,7 +1835,7 @@ describe('adapterManager tests', function () {
         }, {});
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 4444x)',
           'sizesSupported': validSizes,
           'labels': ['tablet', 'phone']
         }]);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { expect } from 'chai';
 import adapterManager, { allS2SBidders, clientTestAdapters, gdprDataHandler, coppaDataHandler } from 'src/adapterManager.js';
 import {
@@ -66,7 +65,6 @@ var badAdapterMock = {
 };
 
 describe('adapterManager tests', function () {
-  console.log(`STARTING ADAPTER MANAGER TESTS`);
   let orgAppnexusAdapter;
   let orgAdequantAdapter;
   let orgPrebidServerAdapter;
@@ -81,7 +79,6 @@ describe('adapterManager tests', function () {
   });
 
   after(function () {
-    console.log(`FINISHED ADAPTER MANAGER TESTS`);
     adapterManager.bidderRegistry['appnexus'] = orgAppnexusAdapter;
     adapterManager.bidderRegistry['adequant'] = orgAdequantAdapter;
     adapterManager.bidderRegistry['prebidServer'] = orgPrebidServerAdapter;
@@ -1830,7 +1827,6 @@ describe('adapterManager tests', function () {
       });
 
       it('should filter sizes using size config', function () {
-        console.log(`STARTING SIZE CONFIG TEST`);
         let validSizes = [
           [728, 90],
           [300, 250]

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1716,13 +1716,14 @@ describe('adapterManager tests', function () {
 
     describe('sizeMapping', function () {
       beforeEach(function () {
+        sandbox = sinon.sandbox.create();
         allS2SBidders.length = 0;
         clientTestAdapters.length = 0;
-        sinon.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
+        // always have matchMedia return true for us
+        sandbox.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
       });
 
       afterEach(function () {
-        matchMedia.restore();
         config.resetConfig();
         setSizeConfig([]);
       });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { expect } from 'chai';
 import adapterManager, { allS2SBidders, clientTestAdapters, gdprDataHandler, coppaDataHandler } from 'src/adapterManager.js';
 import {
@@ -65,6 +66,7 @@ var badAdapterMock = {
 };
 
 describe('adapterManager tests', function () {
+  console.log(`STARTING ADAPTER MANAGER TESTS`);
   let orgAppnexusAdapter;
   let orgAdequantAdapter;
   let orgPrebidServerAdapter;
@@ -79,6 +81,7 @@ describe('adapterManager tests', function () {
   });
 
   after(function () {
+    console.log(`FINISHED ADAPTER MANAGER TESTS`);
     adapterManager.bidderRegistry['appnexus'] = orgAppnexusAdapter;
     adapterManager.bidderRegistry['adequant'] = orgAdequantAdapter;
     adapterManager.bidderRegistry['prebidServer'] = orgPrebidServerAdapter;
@@ -1824,6 +1827,7 @@ describe('adapterManager tests', function () {
       });
 
       it('should filter sizes using size config', function () {
+        console.log(`STARTING SIZE CONFIG TEST`);
         let validSizes = [
           [728, 90],
           [300, 250]
@@ -1835,7 +1839,7 @@ describe('adapterManager tests', function () {
         }, {});
 
         setSizeConfig([{
-          'mediaQuery': '(min-width: 768px) and (max-width: 4444px)',
+          'mediaQuery': '(min-width: 768px) and (max-width: 1199px)',
           'sizesSupported': validSizes,
           'labels': ['tablet', 'phone']
         }]);

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1715,6 +1715,7 @@ describe('adapterManager tests', function () {
     });
 
     describe('sizeMapping', function () {
+      let sandbox;
       beforeEach(function () {
         sandbox = sinon.sandbox.create();
         allS2SBidders.length = 0;
@@ -1724,6 +1725,7 @@ describe('adapterManager tests', function () {
       });
 
       afterEach(function () {
+        sandbox.restore();
         config.resetConfig();
         setSizeConfig([]);
       });


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- 
## Description of change
Something changed in the browserstack tests.

After looking into it a bit, it seems the `window` innerWidth and other similar features may be returning different things than previous.

The `E Planning` Tests seemed to be written with the assumption that `innerWidth` would resolve to something lower than 1024, which they treated as "Mobile"

For Adapter Manager Tests, it looks like it might center around the [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) function, which may be returning the opposite as to what the tests expects... perhaps the mocking is not working?