### PR TITLE
UserID Module: allow userid to ppid sync

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -185,7 +185,7 @@ export let syncDelay;
 export let auctionDelay;
 
 /** @type {(string|undefined)} */
-export let ppidSource;
+let ppidSource;
 
 /** @param {Submodule[]} submodules */
 export function setSubmoduleRegistry(submodules) {

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -575,6 +575,8 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
             window.googletag.pubads().setPublisherProvidedId(ppidValue);
           });
         }
+      } else {
+        logWarn(`User ID - Googletag Publisher Provided ID for ${ppidSource} is not between 32 and 150 characters - ${ppidValue}`);
       }
     }
 

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -141,7 +141,7 @@ import { createEidsArray, buildEidPermissions } from './eids.js';
 import { getCoreStorageManager } from '../../src/storageManager.js';
 import {
   getPrebidInternal, isPlainObject, logError, isArray, cyrb53Hash, deepAccess, timestamp, delayExecution, logInfo, isFn,
-  logWarn, isEmptyStr, isNumber
+  logWarn, isEmptyStr, isNumber, isGptPubadsDefined
 } from '../../src/utils.js';
 import includes from 'core-js-pure/features/array/includes.js';
 
@@ -183,6 +183,9 @@ export let syncDelay;
 
 /** @type {(number|undefined)} */
 export let auctionDelay;
+
+/** @type {(string|undefined)} */
+export let ppidSource;
 
 /** @param {Submodule[]} submodules */
 export function setSubmoduleRegistry(submodules) {
@@ -557,6 +560,24 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
   initializeSubmodulesAndExecuteCallbacks(function () {
     // pass available user id data to bid adapters
     addIdDataToAdUnitBids(reqBidsConfigObj.adUnits || getGlobal().adUnits, initializedSubmodules);
+
+    // userSync.ppid should be one of the 'source' values in getUserIdsAsEids() eg pubcid.org or id5-sync.com
+    const matchingUserId = ppidSource && (getUserIdsAsEids() || []).find(userID => userID.source === ppidSource);
+    if (matchingUserId && typeof deepAccess(matchingUserId, 'uids.0.id') === 'string') {
+      const ppidValue = matchingUserId.uids[0].id.replace(/[\W_]/g, '');
+      if (ppidValue.length >= 32 && ppidValue.length <= 150) {
+        if (isGptPubadsDefined()) {
+          window.googletag.pubads().setPublisherProvidedId(ppidValue);
+        } else {
+          window.googletag = window.googletag || {};
+          window.googletag.cmd = window.googletag.cmd || [];
+          window.googletag.cmd.push(function() {
+            window.googletag.pubads().setPublisherProvidedId(ppidValue);
+          });
+        }
+      }
+    }
+
     // calling fn allows prebid to continue processing
     fn.call(this, reqBidsConfigObj);
   });
@@ -817,6 +838,7 @@ export function attachIdSystem(submodule) {
  * @param {{getConfig:function}} config
  */
 export function init(config) {
+  ppidSource = undefined;
   submodules = [];
   configRegistry = [];
   addedUserIdHook = false;
@@ -839,9 +861,10 @@ export function init(config) {
   }
 
   // listen for config userSyncs to be set
-  config.getConfig(conf => {
+  config.getConfig('userSync', conf => {
     // Note: support for 'usersync' was dropped as part of Prebid.js 4.0
     const userSync = conf.userSync;
+    ppidSource = userSync.ppid;
     if (userSync && userSync.userIds) {
       configRegistry = userSync.userIds;
       syncDelay = isNumber(userSync.syncDelay) ? userSync.syncDelay : DEFAULT_SYNC_DELAY;

--- a/test/spec/integration/faker/googletag.js
+++ b/test/spec/integration/faker/googletag.js
@@ -51,9 +51,15 @@ export function enable() {
   window.googletag = {
     _slots: [],
     _callbackMap: {},
+    _ppid: undefined,
+    cmd: [],
     pubads: function () {
       var self = this;
       return {
+        setPublisherProvidedId: function (ppid) {
+          self._ppid = ppid;
+        },
+
         getSlots: function () {
           return self._slots;
         },

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -49,6 +49,7 @@ import {flocIdSubmodule} from 'modules/flocIdSystem.js'
 import {amxIdSubmodule} from '../../../modules/amxIdSystem.js';
 import {akamaiDAPIdSubmodule} from 'modules/akamaiDAPIdSystem.js'
 import {kinessoIdSubmodule} from 'modules/kinessoIdSystem.js'
+import * as mockGpt from '../integration/faker/googletag.js';
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
@@ -114,12 +115,16 @@ describe('User ID', function () {
 
   describe('Decorate Ad Units', function () {
     beforeEach(function () {
+      // reset mockGpt so nothing else interferes
+      mockGpt.disable();
+      mockGpt.enable();
       coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
       coreStorage.setCookie('pubcid_alt', 'altpubcid200000', (new Date(Date.now() + 5000).toUTCString()));
       sinon.spy(coreStorage, 'setCookie');
     });
 
     afterEach(function () {
+      mockGpt.enable();
       $$PREBID_GLOBAL$$.requestBids.removeAll();
       config.resetConfig();
       coreStorage.setCookie.restore();
@@ -319,6 +324,28 @@ describe('User ID', function () {
       });
       expect(typeof (getGlobal()).getUserIdsAsEids).to.equal('function');
       expect((getGlobal()).getUserIdsAsEids()).to.deep.equal(createEidsArray((getGlobal()).getUserIds()));
+    });
+
+    it('should set googletag ppid correctly', function () {
+      let adUnits = [getAdUnitMock()];
+      setSubmoduleRegistry([amxIdSubmodule, sharedIdSystemSubmodule, identityLinkSubmodule]);
+      init(config);
+
+      config.setConfig({
+        userSync: {
+          ppid: 'pubcid.org',
+          userIds: [
+            { name: 'amxId', value: {'amxId': 'amx-id-value-amx-id-value-amx-id-value'} },
+            { name: 'pubCommonId', value: {'pubcid': 'pubCommon-id-value-pubCommon-id-value'} },
+            { name: 'identityLink', value: {'idl_env': 'identityLink-id-value-identityLink-id-value'} },
+          ]
+        }
+      });
+      // before ppid should not be set
+      expect(window.googletag._ppid).to.equal(undefined);
+      requestBidsHook(() => {}, {adUnits});
+      // ppid should have been set without dashes and stuff
+      expect(window.googletag._ppid).to.equal('pubCommonidvaluepubCommonidvalue');
     });
 
     it('pbjs.refreshUserIds refreshes', function() {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Addresses https://github.com/prebid/Prebid.js/issues/6430

User will need to signal to the userId Module which USER ID Submodule it wishes to sync as its `PPID`

They can do this like so:

```js
pbjs.setConfig({
        userSync: {
          ppid: 'pubcid.org',
          userIds: [
            { name: 'amxId', value: {'amxId': 'amx-id-value-amx-id-value-amx-id-value'} },
            { name: 'pubCommonId', value: {'pubcid': 'pubCommon-id-value-pubCommon-id-value'} },
            { name: 'identityLink', value: {'idl_env': 'identityLink-id-value-identityLink-id-value'} },
          ]
        }
      });
```


NOTE: This `ppid: 'pubcid.org'` value must directly map to the associated EID's SOURCE value for the given submodule as seen in the [eids.js](https://github.com/prebid/Prebid.js/blob/master/modules/userId/eids.js#L22) file.

Once this is done, extra logic is run at the time of REQUEST BIDS in order to resolve the `ppid` value and set it for googletag to consume.

GOOGLE has some strict parameters for how a ppid should be (more than 32 chars less than 150, and only alphanumeric)

DOCS: https://github.com/prebid/prebid.github.io/pull/2788