### PR TITLE
PubMatic : Check for 'bid.ext.bidtype' key instead of 'bid.ext.Bidtype' key in translator response object.

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -866,10 +866,10 @@ function _handleEids(payload, validBidRequests) {
 
 function _checkMediaType(bid, newBid) {
   // Create a regex here to check the strings
-  if (bid.ext && bid.ext['bidType'] != undefined) {
-    newBid.mediaType = MEDIATYPE[bid.ext.bidType];
+  if (bid.ext && bid.ext['bidtype'] != undefined) {
+    newBid.mediaType = MEDIATYPE[bid.ext.bidtype];
   } else {
-    logInfo(LOG_WARN_PREFIX + 'bid.ext.bidType does not exist, checking alternatively for mediaType')
+    logInfo(LOG_WARN_PREFIX + 'bid.ext.bidtype does not exist, checking alternatively for mediaType')
     var adm = bid.adm;
     var admStr = '';
     var videoRegex = new RegExp(/VAST\s+version/);

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -866,10 +866,10 @@ function _handleEids(payload, validBidRequests) {
 
 function _checkMediaType(bid, newBid) {
   // Create a regex here to check the strings
-  if (bid.ext && bid.ext['BidType'] != undefined) {
-    newBid.mediaType = MEDIATYPE[bid.ext.BidType];
+  if (bid.ext && bid.ext['bidType'] != undefined) {
+    newBid.mediaType = MEDIATYPE[bid.ext.bidType];
   } else {
-    logInfo(LOG_WARN_PREFIX + 'bid.ext.BidType does not exist, checking alternatively for mediaType')
+    logInfo(LOG_WARN_PREFIX + 'bid.ext.bidType does not exist, checking alternatively for mediaType')
     var adm = bid.adm;
     var admStr = '';
     var videoRegex = new RegExp(/VAST\s+version/);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3457,7 +3457,7 @@ describe('PubMatic adapter', function () {
                 'h': 0,
                 'dealId': 'ASEA-MS-KLY-TTD-DESKTOP-ID-VID-6S-030420',
                 'ext': {
-                  'bidType': 1
+                  'bidtype': 1
                 }
               }],
               'ext': {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3457,7 +3457,7 @@ describe('PubMatic adapter', function () {
                 'h': 0,
                 'dealId': 'ASEA-MS-KLY-TTD-DESKTOP-ID-VID-6S-030420',
                 'ext': {
-                  'BidType': 1
+                  'bidType': 1
                 }
               }],
               'ext': {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Checking for bid.ext.**bidtype** instead of bid.ext.**BidType** key in translator's response.
