### PR TITLE
Gumgum Bid Adapter: add adUnitCode to requests

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -286,7 +286,8 @@ function buildRequests(validBidRequests, bidderRequest) {
       schain,
       transactionId,
       userId = {},
-      ortb2Imp
+      ortb2Imp,
+      adUnitCode = ''
     } = bidRequest;
     const { currency, floor } = _getFloor(mediaTypes, params.bidfloor, bidRequest);
     const eids = getEids(userId);
@@ -301,6 +302,13 @@ function buildRequests(validBidRequests, bidderRequest) {
       lt && (data.lt = lt);
       data.to = to;
     }
+
+    /**
+     * ADTS-169 adds ad unit code to requests since pbadslot is not
+     * widely supported by our pubs. also, `auc` was taken, so property
+     * stands for 'ad unit name'
+     */
+    if (adUnitCode) data.aun = adUnitCode
 
     // ADTS-134 Retrieve ID envelopes
     for (const eid in eids) data[eid] = eids[eid];

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -303,11 +303,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       data.to = to;
     }
 
-    /**
-     * ADTS-169 adds ad unit code to requests since pbadslot is not
-     * widely supported by our pubs. also, `auc` was taken, so property
-     * stands for 'ad unit name'
-     */
+    // ADTS-169 add adUnitCode to requests
     if (adUnitCode) data.aun = adUnitCode
 
     // ADTS-134 Retrieve ID envelopes

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -152,6 +152,12 @@ describe('gumgumAdapter', function () {
     const zoneParam = { 'zone': '123a' };
     const pubIdParam = { 'pubId': 123 };
 
+    it('should set aun if the adUnitCode is available', function () {
+      const request = { ...bidRequests[0] };
+      const bidRequest = spec.buildRequests([request])[0];
+      expect(bidRequest.data.aun).to.equal(bidRequests[0].adUnitCode);
+    });
+
     it('should set pubId param if found', function () {
       const request = { ...bidRequests[0], params: pubIdParam };
       const bidRequest = spec.buildRequests([request])[0];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Add adUnitCode to our bid requests as the `aun` property (ad unit name; `auc` for ad unit code was taken :/ ).

We are aware that `pbadslot` is the preferred method for reporting on the ID of the ad unit. We are currently sending this as part of our requests when it is available. However, we have found that many of our pubs are not configuring this, so this is an attempt to retrieve some sort of ID when the `pbadslot` is not available.