### PR TITLE
Limelight Digital Bid Adapter: Add optional Publisher ID field

### DIFF
--- a/modules/limelightDigitalBidAdapter.js
+++ b/modules/limelightDigitalBidAdapter.js
@@ -158,7 +158,8 @@ function buildPlacement(bidRequest) {
           height: size[1]
         }
       }),
-      type: bidRequest.params.adUnitType.toUpperCase()
+      type: bidRequest.params.adUnitType.toUpperCase(),
+      publisherId: bidRequest.params.publisherId
     }
   }
 }

--- a/test/spec/modules/limelightDigitalBidAdapter_spec.js
+++ b/test/spec/modules/limelightDigitalBidAdapter_spec.js
@@ -9,7 +9,8 @@ describe('limelightDigitalAdapter', function () {
     params: {
       host: 'exchange.ortb.net',
       adUnitId: 123,
-      adUnitType: 'banner'
+      adUnitType: 'banner',
+      publisherId: 'perfectPublisher'
     },
     placementCode: 'placement_0',
     auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
@@ -41,7 +42,8 @@ describe('limelightDigitalAdapter', function () {
     params: {
       host: 'exchange.ortb.net',
       adUnitId: 789,
-      adUnitType: 'video'
+      adUnitType: 'video',
+      publisherId: 'secondPerfectPublisher'
     },
     placementCode: 'placement_2',
     auctionId: 'e4771143-6aa7-41ec-8824-ced4342c96c8',
@@ -89,7 +91,7 @@ describe('limelightDigitalAdapter', function () {
         expect(data.deviceHeight).to.be.a('number')
         expect(data.secure).to.be.a('boolean')
         data.adUnits.forEach(adUnit => {
-          expect(adUnit).to.have.all.keys('id', 'bidId', 'type', 'sizes', 'transactionId')
+          expect(adUnit).to.have.all.keys('id', 'bidId', 'type', 'sizes', 'transactionId', 'publisherId')
           expect(adUnit.id).to.be.a('number')
           expect(adUnit.bidId).to.be.a('string')
           expect(adUnit.type).to.be.a('string')
@@ -456,10 +458,10 @@ describe('limelightDigitalAdapter', function () {
 });
 
 function validateAdUnit(adUnit, bid) {
-  expect(adUnit.id).to.equal(bid.params.adUnitId)
-  expect(adUnit.bidId).to.equal(bid.bidId)
-  expect(adUnit.type).to.equal(bid.params.adUnitType.toUpperCase())
-  expect(adUnit.transactionId).to.equal(bid.transactionId)
+  expect(adUnit.id).to.equal(bid.params.adUnitId);
+  expect(adUnit.bidId).to.equal(bid.bidId);
+  expect(adUnit.type).to.equal(bid.params.adUnitType.toUpperCase());
+  expect(adUnit.transactionId).to.equal(bid.transactionId);
   let bidSizes = [];
   if (bid.mediaTypes) {
     if (bid.mediaTypes.video && bid.mediaTypes.video.playerSize) {
@@ -478,4 +480,5 @@ function validateAdUnit(adUnit, bid) {
       height: size[1]
     }
   }));
+  expect(adUnit.publisherId).to.equal(bid.params.publisherId);
 }


### PR DESCRIPTION
## Type of change
- [x] Bidder adapter related changes

## Description of change
This PR adds optional `publisherId` field into Limelight Digital Bid Adapter

- test parameters for validating bids
```
var adUnits = [{
    code: 'placementCode',
    mediaTypes: {
        banner: {
            sizes: [[300, 250]]
        }
    },
    bids: [{
        bidder: 'limelightDigital',
        params: {
            host: 'exchange.ortb.net',
            adUnitId: 0,
            adUnitType: 'banner'
        }
    }]
}];
```
```
var videoAdUnit = [{
    code: 'video1',
    sizes: [[300, 250]],
    bids: [{
        bidder: 'limelightDigital',
        params: {
            host: 'exchange.ortb.net',
            adUnitId: 0,
            adUnitType: 'video'
        }
    }]
}];
```

- contact email of the adapter’s maintainer engineering@project-limelight.com
- [x] official adapter submission

- A link to a PR on the docs repo https://github.com/prebid/prebid.github.io/pull/3405
