### PR TITLE
Revert #7662 "Prebid Core: Restore use of server-side adapter without client-side adapter"

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -554,12 +554,13 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
 
   logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
+  let _s2sConfigs = [];
   const s2sBidders = [];
-  let _s2sConfigs = config.getConfig('s2sConfig') || [];
-
-  if (!Array.isArray(_s2sConfigs)) {
-    _s2sConfigs = [_s2sConfigs];
-  }
+  config.getConfig('s2sConfig', config => {
+    if (config && config.s2sConfig) {
+      _s2sConfigs = Array.isArray(config.s2sConfig) ? config.s2sConfig : [config.s2sConfig];
+    }
+  });
 
   _s2sConfigs.forEach(s2sConfig => {
     s2sBidders.push(...s2sConfig.bidders);


### PR DESCRIPTION
Reverts prebid/Prebid.js#7662

Even though PR fixes the issue, it opens much bigger one. Now, pbjs won't work properly if there is no `s2s` config at all.  

@jorgeluisrocha Please run your code on `integrationExamples/gpt/hello_world.html` and you'll see the issue I'm mentioning.