### PR TITLE
Prebid Core: Restore use of server-side adapter without client-side adapter

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -556,11 +556,11 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
 
   let _s2sConfigs = [];
   const s2sBidders = [];
-  config.getConfig('s2sConfig', config => {
-    if (config && config.s2sConfig) {
-      _s2sConfigs = Array.isArray(config.s2sConfig) ? config.s2sConfig : [config.s2sConfig];
-    }
-  });
+  const s2sConfig = config.getConfig('s2sConfig');
+
+  if (s2sConfig) {
+    _s2sConfigs = Array.isArray(s2sConfig) ? s2sConfig : [s2sConfig];
+  }
 
   _s2sConfigs.forEach(s2sConfig => {
     s2sBidders.push(...s2sConfig.bidders);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -554,12 +554,11 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
 
   logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
-  let _s2sConfigs = [];
   const s2sBidders = [];
-  const s2sConfig = config.getConfig('s2sConfig');
+  let _s2sConfigs = config.getConfig('s2sConfig') || [];
 
-  if (s2sConfig) {
-    _s2sConfigs = Array.isArray(s2sConfig) ? s2sConfig : [s2sConfig];
+  if (!Array.isArray(_s2sConfigs)) {
+    _s2sConfigs = [_s2sConfigs];
   }
 
   _s2sConfigs.forEach(s2sConfig => {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -554,11 +554,12 @@ $$PREBID_GLOBAL$$.requestBids = hook('async', function ({ bidsBackHandler, timeo
 
   logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
 
+  let _s2sConfigs = [];
   const s2sBidders = [];
-  let _s2sConfigs = config.getConfig('s2sConfig') || [];
+  const s2sConfig = config.getConfig('s2sConfig');
 
-  if (!Array.isArray(_s2sConfigs)) {
-    _s2sConfigs = [_s2sConfigs];
+  if (s2sConfig && s2sConfig.bidders) {
+    _s2sConfigs = Array.isArray(s2sConfig) ? s2sConfig : [s2sConfig];
   }
 
   _s2sConfigs.forEach(s2sConfig => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- Bugfix

## Description of change
Fixes a bug that requires client-side adapter codes to be imported for server-side bidding. This obviates the need to import client-side adapter specifications. Additionally, this resolves the regression introduced by the original version of this PR found in #7662. 


## Other information
Issue: #6361 
Issue: #6388 
