### PR TITLE
PBS Bid Adapter: do not pass aspectratios in ORTB2 ext data if native image definition doesn't have ratio_height/ratio_width

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -539,10 +539,13 @@ const OPEN_RTB_PROTOCOL = {
                 }
                 if (Array.isArray(params.aspect_ratios)) {
                   // pass aspect_ratios as ext data I guess?
-                  asset.ext = {
-                    aspectratios: params.aspect_ratios.map(
-                      ratio => `${ratio.ratio_width}:${ratio.ratio_height}`
-                    )
+                  const aspectRatios = params.aspect_ratios
+                    .filter((ar) => ar.ratio_width && ar.ratio_height)
+                    .map(ratio => `${ratio.ratio_width}:${ratio.ratio_height}`);
+                  if (aspectRatios.length === params.aspect_ratios.length) {
+                    asset.ext = {
+                      aspectratios: aspectRatios
+                    }
                   }
                 }
                 assets.push(newAsset({

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -542,7 +542,7 @@ const OPEN_RTB_PROTOCOL = {
                   const aspectRatios = params.aspect_ratios
                     .filter((ar) => ar.ratio_width && ar.ratio_height)
                     .map(ratio => `${ratio.ratio_width}:${ratio.ratio_height}`);
-                  if (aspectRatios.length === params.aspect_ratios.length) {
+                  if (aspectRatios.length > 0) {
                     asset.ext = {
                       aspectratios: aspectRatios
                     }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -8,6 +8,7 @@ import events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
 import { server } from 'test/mocks/xhr.js';
 import { createEidsArray } from 'modules/userId/eids.js';
+import {deepAccess, deepClone} from 'src/utils.js';
 
 let CONFIG = {
   accountId: '1',
@@ -1091,6 +1092,18 @@ describe('S2S Adapter', function () {
         ver: '1.2'
       });
     });
+
+    it('should not include ext.aspectratios if adunit\'s aspect_ratios do not define radio_width and ratio_height', () => {
+      const req = deepClone(REQUEST);
+      req.ad_units[0].mediaTypes.native.icon.aspect_ratios[0] = {'min_width': 1, 'min_height': 2};
+      adapter.callBids(req, BID_REQUESTS, addBidResponse, done, ajax);
+      const nativeReq = JSON.parse(JSON.parse(server.requests[0].requestBody).imp[0].native.request);
+      const icons = nativeReq.assets.map((a) => a.img).filter((img) => img && img.type === 1);
+      expect(icons).to.have.length(1);
+      expect(icons[0].hmin).to.equal(2);
+      expect(icons[0].wmin).to.equal(1);
+      expect(deepAccess(icons[0], 'ext.aspectratios')).to.be.undefined;
+    })
 
     it('adds site if app is not present', function () {
       const _config = {


### PR DESCRIPTION
## Type of change
Not sure: either a feature or a bugfix. See https://github.com/prebid/Prebid.js/issues/6654

## Description of change

When using Prebid Server you can specify AdUnits with native image or icon mediatypes that have min_width and min_height but no ratio_width or ratio_height. 
This is not supported according to https://docs.prebid.org/dev-docs/adunit-reference.html#adunitmediatypesnativeimageaspect_ratios, but it works for the PBS adapter, except it causes some incorrect data to be passed along in `ext`. 

This change cleans up `ext` for this case. It could be seen as a bugfix - validating/removing aspect ratio before sending it to PBS, or as a feature - support optional ratio_height and ratio_width.

