### PR TITLE
README: update contributors link to point to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ As you make code changes, the bundles will be rebuilt and the page reloaded auto
 
 ## Contribute
 
-Many SSPs, bidders, and publishers have contributed to this project. [Hundreds of bidders](https://github.com/prebid/Prebid.js/tree/master/src/adapters) are supported by Prebid.js.
+Many SSPs, bidders, and publishers have contributed to this project. [Hundreds of bidders](https://github.com/prebid/Prebid.js/tree/master/modules) are supported by Prebid.js.
 
 For guidelines, see [Contributing](./CONTRIBUTING.md).
 


### PR DESCRIPTION
## Type of change
- [X] Other: Documentation

## Description of change

Fix link to adapters in README, as adapters are inside `/modules`.