### PR TITLE
CircleCi config: change to npm ci in unit testing workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ aliases:
   - &unit_test_steps
     - checkout
     - restore_cache: *restore_dep_cache
-    - run: npm install
+    - run: npm ci
     - save_cache: *save_dep_cache
     - run: *install
     - run: *setup_browserstack


### PR DESCRIPTION
CircleCi still uses 'npm install' in the unit testing job that automatically runs after commits. This changes to 'npm ci' for consistency with docs