### PR TITLE
Prebid Core: after auction is held, if more bids are matched by adUnitCode next apply filter for bidId

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -569,11 +569,7 @@ function setupBidTargeting(bidObject, bidderRequest) {
   let keyValues;
   const cpmCheck = (isAllowZeroCpmBidsEnabled(bidObject.bidderCode)) ? bidObject.cpm >= 0 : bidObject.cpm > 0;
   if (bidObject.bidderCode && (cpmCheck || bidObject.dealId)) {
-    let bidReqs = bidderRequest.bids.filter(bid => bid.adUnitCode === bidObject.adUnitCode);
-    if (bidReqs.length > 1) {
-      bidReqs = bidReqs.filter(bid => bid.bidId === bidObject.requestId);
-    }
-    let bidReq = bidReqs.shift();
+    let bidReq = find(bidderRequest.bids, bid => bid.adUnitCode === bidObject.adUnitCode && bid.bidId === bidObject.requestId);
     keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject, bidReq);
   }
 

--- a/src/auction.js
+++ b/src/auction.js
@@ -569,7 +569,11 @@ function setupBidTargeting(bidObject, bidderRequest) {
   let keyValues;
   const cpmCheck = (isAllowZeroCpmBidsEnabled(bidObject.bidderCode)) ? bidObject.cpm >= 0 : bidObject.cpm > 0;
   if (bidObject.bidderCode && (cpmCheck || bidObject.dealId)) {
-    let bidReq = find(bidderRequest.bids, bid => bid.adUnitCode === bidObject.adUnitCode);
+    let bidReqs = bidderRequest.bids.filter(bid => bid.adUnitCode === bidObject.adUnitCode);
+    if (bidReqs.length > 1) {
+      bidReqs = bidReqs.filter(bid => bid.bidId === bidObject.requestId);
+    }
+    let bidReq = bidReqs.shift();
     keyValues = getKeyValueTargetingPairs(bidObject.bidderCode, bidObject, bidReq);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
During 'setupBidTargeting', if multiple bids requests are found, next apply filter by comparing bidId with requestId.
## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

This PR fixes #7735 issue
