### PR TITLE
SharedID module: update tests to assert on behavior rather than logs

### DIFF
--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -50,10 +50,10 @@ describe('SharedId System', function () {
       expect(callbackSpy.calledOnce).to.be.true;
       expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
-    it('should log message if coppa is set', function () {
+    it('should abort if coppa is set', function () {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.getId({});
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      const result = sharedIdSystemSubmodule.getId({});
+      expect(result).to.be.undefined;
     });
   });
   describe('SharedId System extendId()', function () {
@@ -85,10 +85,10 @@ describe('SharedId System', function () {
       let pubcommId = sharedIdSystemSubmodule.extendId(config, undefined, 'TestId').id;
       expect(pubcommId).to.equal('TestId');
     });
-    it('should log message if coppa is set', function () {
+    it('should abort if coppa is set', function () {
       coppaDataHandlerDataStub.returns('true');
-      sharedIdSystemSubmodule.extendId({}, undefined, 'TestId');
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
+      const result = sharedIdSystemSubmodule.extendId({params: {extend: true}}, undefined, 'TestId');
+      expect(result).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
﻿Update tests that fail spuriously: https://github.com/prebid/Prebid.js/issues/7355

I was not able to reproduce the failures, but in debugging I ruled out the possibility of module loading order and I believe the most likely culprit is other tests asynchronously calling `utils.logInfo` that sometimes happen in-between these tests' setup and assertions.

This may not be the real issue, but IMO testing log messages makes little sense anyway, so I updated them to test the actual SOT behavior.

