### PR TITLE
Prebid core: move generation of 'installedModules' to babel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -141,12 +141,6 @@ function watch(done) {
   done();
 };
 
-function makeModuleList(modules) {
-  return modules.map(module => {
-    return '"' + module + '"'
-  });
-}
-
 function makeDevpackPkg() {
   var cloned = _.cloneDeep(webpackConfig);
   cloned.devtool = 'source-map';
@@ -158,7 +152,6 @@ function makeDevpackPkg() {
   return gulp.src([].concat(moduleSources, analyticsSources, 'src/prebid.js'))
     .pipe(helpers.nameModules(externalModules))
     .pipe(webpackStream(cloned, webpack))
-    .pipe(replace(/('|")v\$prebid\.modulesList\$('|")/g, makeModuleList(externalModules)))
     .pipe(gulp.dest('build/dev'))
     .pipe(connect.reload());
 }
@@ -176,7 +169,6 @@ function makeWebpackPkg() {
     .pipe(helpers.nameModules(externalModules))
     .pipe(webpackStream(cloned, webpack))
     .pipe(terser())
-    .pipe(replace(/('|")v\$prebid\.modulesList\$('|")/g, makeModuleList(externalModules)))
     .pipe(gulpif(file => file.basename === 'prebid-core.js', header(banner, { prebid: prebid })))
     .pipe(gulp.dest('build/dist'));
 }

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -1,11 +1,13 @@
 
 let t = require('@babel/core').types;
 let prebid = require('../package.json');
+const path = require('path');
 
 module.exports = function(api, options) {
+  const pbGlobal = options.globalVarName || prebid.globalVarName;
   let replace = {
     '$prebid.version$': prebid.version,
-    '$$PREBID_GLOBAL$$': options.globalVarName || prebid.globalVarName,
+    '$$PREBID_GLOBAL$$': pbGlobal,
     '$$REPO_AND_VERSION$$': `${prebid.repository.url.split('/')[3]}_prebid_${prebid.version}`
   };
 
@@ -13,8 +15,33 @@ module.exports = function(api, options) {
     '$$REPO_AND_VERSION$$'
   ];
 
+  const PREBID_ROOT = path.resolve(__dirname, '..');
+
+  function getModuleName(filename) {
+    const modPath = path.parse(path.relative(PREBID_ROOT, filename));
+    if (modPath.ext.toLowerCase() !== '.js') {
+      return null;
+    }
+    if (modPath.dir === 'modules') {
+      // modules/moduleName.js -> moduleName
+      return modPath.name;
+    }
+    if (modPath.name.toLowerCase() === 'index' && path.dirname(modPath.dir) === 'modules') {
+      // modules/moduleName/index.js -> moduleName
+      return path.basename(modPath.dir);
+    }
+    return null;
+  }
+
   return {
     visitor: {
+      Program(path, state) {
+        const modName = getModuleName(state.filename);
+        if (modName != null) {
+          // append "registration" of module file to $$PREBID_GLOBAL$$.installedModules
+          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`).program.body);
+        }
+      },
       StringLiteral(path) {
         Object.keys(replace).forEach(name => {
           if (path.node.value.includes(name)) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -47,8 +47,7 @@ $$PREBID_GLOBAL$$.libLoaded = true;
 $$PREBID_GLOBAL$$.version = 'v$prebid.version$';
 logInfo('Prebid.js v$prebid.version$ loaded');
 
-// modules list generated from build
-$$PREBID_GLOBAL$$.installedModules = ['v$prebid.modulesList$'];
+$$PREBID_GLOBAL$$.installedModules = $$PREBID_GLOBAL$$.installedModules || [];
 
 // create adUnit array
 $$PREBID_GLOBAL$$.adUnits = $$PREBID_GLOBAL$$.adUnits || [];


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

﻿`pbjs.installedModules` does not work correctly when using prebid as an npm dependency (https://github.com/prebid/Prebid.js/issues/7287), because it's generated by a gulp task.

This moves generation of `installedModules` to the `pbjsGlobals` babel plugin that we ask npm consumers to use for prebid.
