### PR TITLE
Dspx Bid Adapter: remove redundant alias

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -12,7 +12,7 @@ const GVLID = 602;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: ['dspx'],
+  aliases: [],
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function(bid) {
     return !!(bid.params.placement);


### PR DESCRIPTION
Fix an issue with the `gdprEnforcement` module. See #7741

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change

- [x] Bugfix


## Description of change

Removes redundant `alias` as it is the same as the biddercode
