### PR TITLE
PBS Bid adapter: timeout user syncs if they never load

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -483,15 +483,38 @@ export function insertElement(elm, doc, target, asLastChildChild) {
 }
 
 /**
+ * Returns a promise that completes when the given element triggers a 'load' or 'error' DOM event, or when
+ * `timeout` milliseconds have elapsed.
+ *
+ * @param {HTMLElement} element
+ * @param {Number} [timeout]
+ * @returns {Promise}
+ */
+export function waitForElementToLoad(element, timeout) {
+  return new Promise((resolve) => {
+    const onLoad = function() {
+      element.removeEventListener('load', onLoad);
+      element.removeEventListener('error', onLoad);
+      resolve();
+    };
+    element.addEventListener('load', onLoad);
+    element.addEventListener('error', onLoad);
+    if (timeout != null) {
+      window.setTimeout(onLoad, timeout);
+    }
+  });
+}
+
+/**
  * Inserts an image pixel with the specified `url` for cookie sync
  * @param {string} url URL string of the image pixel to load
  * @param  {function} [done] an optional exit callback, used when this usersync pixel is added during an async process
+ * @param  {Number} [timeout] an optional timeout in milliseconds for the image to load before calling `done`
  */
-export function triggerPixel(url, done) {
+export function triggerPixel(url, done, timeout) {
   const img = new Image();
   if (done && internal.isFn(done)) {
-    img.addEventListener('load', done);
-    img.addEventListener('error', done);
+    waitForElementToLoad(img, timeout).then(done);
   }
   img.src = url;
 }
@@ -539,18 +562,18 @@ export function insertHtmlIntoIframe(htmlCode) {
  * @param  {string} url URL to be requested
  * @param  {string} encodeUri boolean if URL should be encoded before inserted. Defaults to true
  * @param  {function} [done] an optional exit callback, used when this usersync pixel is added during an async process
+ * @param  {Number} [timeout] an optional timeout in milliseconds for the iframe to load before calling `done`
  */
-export function insertUserSyncIframe(url, done) {
+export function insertUserSyncIframe(url, done, timeout) {
   let iframeHtml = internal.createTrackPixelIframeHtml(url, false, 'allow-scripts allow-same-origin');
   let div = document.createElement('div');
   div.innerHTML = iframeHtml;
   let iframe = div.firstChild;
   if (done && internal.isFn(done)) {
-    iframe.addEventListener('load', done);
-    iframe.addEventListener('error', done);
+    waitForElementToLoad(iframe, timeout).then(done);
   }
   internal.insertElement(iframe, document, 'html', true);
-};
+}
 
 /**
  * Creates a snippet of HTML that retrieves the specified `url`

--- a/src/utils.js
+++ b/src/utils.js
@@ -491,16 +491,20 @@ export function insertElement(elm, doc, target, asLastChildChild) {
  * @returns {Promise}
  */
 export function waitForElementToLoad(element, timeout) {
+  let timer = null;
   return new Promise((resolve) => {
     const onLoad = function() {
       element.removeEventListener('load', onLoad);
       element.removeEventListener('error', onLoad);
+      if (timer != null) {
+        window.clearTimeout(timer);
+      }
       resolve();
     };
     element.addEventListener('load', onLoad);
     element.addEventListener('error', onLoad);
     if (timeout != null) {
-      window.setTimeout(onLoad, timeout);
+      timer = window.setTimeout(onLoad, timeout);
     }
   });
 }

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -2,6 +2,7 @@ import { getAdServerTargeting } from 'test/fixtures/fixtures.js';
 import { expect } from 'chai';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils.js';
+import {waitForElementToLoad} from 'src/utils.js';
 
 var assert = require('assert');
 
@@ -1195,6 +1196,43 @@ describe('Utils', function () {
       it('should return a string value, not a number', function() {
         const stringOne = 'string1';
         expect(typeof utils.cyrb53Hash(stringOne)).to.equal('string');
+      });
+    });
+  });
+
+  describe('waitForElementToLoad', () => {
+    let element;
+    let callbacks;
+
+    function callback() {
+      callbacks++;
+    }
+
+    function delay(delay = 0) {
+      return new Promise((resolve) => {
+        window.setTimeout(resolve, delay);
+      })
+    }
+
+    beforeEach(() => {
+      callbacks = 0;
+      element = window.document.createElement('div');
+    });
+
+    it('should respect timeout if set', () => {
+      waitForElementToLoad(element, 50).then(callback);
+      return delay(60).then(() => {
+        expect(callbacks).to.equal(1);
+      });
+    });
+
+    ['load', 'error'].forEach((event) => {
+      it(`should complete on '${event} event'`, () => {
+        waitForElementToLoad(element).then(callback);
+        element.dispatchEvent(new Event(event));
+        return delay().then(() => {
+          expect(callbacks).to.equal(1);
+        })
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
﻿In some situations the browser never triggers load/error events for user syncs, so the PBS adapter remains stuck (https://github.com/prebid/Prebid.js/issues/6354). This adds a timeout for image/iframe syncs.

## Other information

Doc changes: https://github.com/prebid/prebid.github.io/pull/3424