### PR TITLE
Yahoo SSP Bid Adapter: interstitial fix 

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -359,6 +359,10 @@ function appendImpObject(bid, openRtbObject) {
       impObject.ext.data = bid.ortb2Imp.ext.data;
     };
 
+    if (deepAccess(bid, 'ortb2Imp.instl') && isNumber(bid.ortb2Imp.instl)) {
+      impObject.instl = bid.ortb2Imp.instl;
+    };
+
     if (getPubIdMode(bid) === false) {
       impObject.tagid = bid.params.pos;
       impObject.ext.pos = bid.params.pos;

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { deepAccess, isFn, isStr, isNumber, isArray, isEmpty, isPlainObject, isBoolean, generateUUID, logInfo, logWarn } from '../src/utils.js';
+import { deepAccess, isFn, isStr, isNumber, isArray, isEmpty, isPlainObject, generateUUID, logInfo, logWarn } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 
@@ -359,7 +359,7 @@ function appendImpObject(bid, openRtbObject) {
       impObject.ext.data = bid.ortb2Imp.ext.data;
     };
 
-    if (deepAccess(bid, 'ortb2Imp.instl') && isNumber(bid.ortb2Imp.instl) && isBoolean(bid.ortb2Imp.instl)) {
+    if (deepAccess(bid, 'ortb2Imp.instl') && (bid.ortb2Imp.instl === 1)) {
       impObject.instl = bid.ortb2Imp.instl;
     };
 

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { deepAccess, isFn, isStr, isNumber, isArray, isEmpty, isPlainObject, generateUUID, logInfo, logWarn } from '../src/utils.js';
+import { deepAccess, isFn, isStr, isNumber, isArray, isEmpty, isPlainObject, isBoolean, generateUUID, logInfo, logWarn } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 
@@ -359,7 +359,7 @@ function appendImpObject(bid, openRtbObject) {
       impObject.ext.data = bid.ortb2Imp.ext.data;
     };
 
-    if (deepAccess(bid, 'ortb2Imp.instl') && isNumber(bid.ortb2Imp.instl)) {
+    if (deepAccess(bid, 'ortb2Imp.instl') && isNumber(bid.ortb2Imp.instl) && isBoolean(bid.ortb2Imp.instl)) {
       impObject.instl = bid.ortb2Imp.instl;
     };
 

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -6,7 +6,7 @@ import { Renderer } from '../src/Renderer.js';
 
 const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahoossp';
-const ADAPTER_VERSION = '1.0.1';
+const ADAPTER_VERSION = '1.0.2';
 const PREBID_VERSION = '$prebid.version$';
 const DEFAULT_BID_TTL = 300;
 const TEST_MODE_DCN = '8a969516017a7a396ec539d97f540011';
@@ -359,7 +359,7 @@ function appendImpObject(bid, openRtbObject) {
       impObject.ext.data = bid.ortb2Imp.ext.data;
     };
 
-    if (deepAccess(bid, 'ortb2Imp.instl') && (bid.ortb2Imp.instl === 1)) {
+    if (deepAccess(bid, 'ortb2Imp.instl') && isNumber(bid.ortb2Imp.instl) && (bid.ortb2Imp.instl === 1)) {
       impObject.instl = bid.ortb2Imp.instl;
     };
 

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -11,7 +11,7 @@ const DEFAULT_AD_UNIT_CODE = '/19968336/header-bid-tag-1';
 const DEFAULT_AD_UNIT_TYPE = 'banner';
 const DEFAULT_PARAMS_BID_OVERRIDE = {};
 const DEFAULT_VIDEO_CONTEXT = 'instream';
-const ADAPTER_VERSION = '1.0.1';
+const ADAPTER_VERSION = '1.0.2';
 const PREBID_VERSION = '$prebid.version$';
 const INTEGRATION_METHOD = 'prebid.js';
 

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -656,6 +656,15 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
       expect(data.imp[0].ext.data).to.deep.equal(validBidRequests[0].ortb2Imp.ext.data);
     });
+    // adUnit.ortb2Imp.instl
+    it(`should allow adUnit.ortb2Imp.instl numeric boolean to be added to the bid-request`, () => {
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
+      validBidRequests[0].ortb2Imp = {
+        instl: 1
+      };
+      const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
+      expect(data.imp[0].instl).to.deep.equal(validBidRequests[0].ortb2Imp.instl);
+    });
   });
 
   describe('e2etest mode support:', () => {

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -657,13 +657,40 @@ describe('YahooSSP Bid Adapter:', () => {
       expect(data.imp[0].ext.data).to.deep.equal(validBidRequests[0].ortb2Imp.ext.data);
     });
     // adUnit.ortb2Imp.instl
-    it(`should allow adUnit.ortb2Imp.instl numeric boolean to be added to the bid-request`, () => {
+    it(`should allow adUnit.ortb2Imp.instl numeric boolean (1) to be added to the bid-request`, () => {
       let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
       validBidRequests[0].ortb2Imp = {
         instl: 1
       };
       const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
       expect(data.imp[0].instl).to.deep.equal(validBidRequests[0].ortb2Imp.instl);
+    });
+
+    it(`should allow adUnit.ortb2Imp.instl numeric boolean (0) to be added to the bid-request`, () => {
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
+      validBidRequests[0].ortb2Imp = {
+        instl: 0
+      };
+      const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
+      expect(data.imp[0].instl).to.deep.equal(validBidRequests[0].ortb2Imp.instl);
+    });
+
+    it(`should prevent adUnit.ortb2Imp.instl boolean true to be added to the bid-request`, () => {
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
+      validBidRequests[0].ortb2Imp = {
+        instl: true
+      };
+      const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
+      expect(data.imp[0].instl).to.not.exist;
+    });
+
+    it(`should prevent adUnit.ortb2Imp.instl boolean false to be added to the bid-request`, () => {
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
+      validBidRequests[0].ortb2Imp = {
+        instl: false
+      };
+      const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
+      expect(data.imp[0].instl).to.not.exist;
     });
   });
 

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -657,7 +657,7 @@ describe('YahooSSP Bid Adapter:', () => {
       expect(data.imp[0].ext.data).to.deep.equal(validBidRequests[0].ortb2Imp.ext.data);
     });
     // adUnit.ortb2Imp.instl
-    it(`should allow adUnit.ortb2Imp.instl numeric boolean (1) to be added to the bid-request`, () => {
+    it(`should allow adUnit.ortb2Imp.instl numeric boolean "1" to be added to the bid-request`, () => {
       let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
       validBidRequests[0].ortb2Imp = {
         instl: 1
@@ -666,16 +666,7 @@ describe('YahooSSP Bid Adapter:', () => {
       expect(data.imp[0].instl).to.deep.equal(validBidRequests[0].ortb2Imp.instl);
     });
 
-    it(`should allow adUnit.ortb2Imp.instl numeric boolean (0) to be added to the bid-request`, () => {
-      let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
-      validBidRequests[0].ortb2Imp = {
-        instl: 0
-      };
-      const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
-      expect(data.imp[0].instl).to.deep.equal(validBidRequests[0].ortb2Imp.instl);
-    });
-
-    it(`should prevent adUnit.ortb2Imp.instl boolean true to be added to the bid-request`, () => {
+    it(`should prevent adUnit.ortb2Imp.instl boolean "true" to be added to the bid-request`, () => {
       let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
       validBidRequests[0].ortb2Imp = {
         instl: true
@@ -684,7 +675,7 @@ describe('YahooSSP Bid Adapter:', () => {
       expect(data.imp[0].instl).to.not.exist;
     });
 
-    it(`should prevent adUnit.ortb2Imp.instl boolean false to be added to the bid-request`, () => {
+    it(`should prevent adUnit.ortb2Imp.instl boolean "false" to be added to the bid-request`, () => {
       let { validBidRequests, bidderRequest } = generateBuildRequestMock({})
       validBidRequests[0].ortb2Imp = {
         instl: false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Added support for ortb2Imp.instl flag to be passed into the imp[0].instl
If value is number and  = 1 it will be appended to outbound bid-request by the adapter.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
const adUnits = [{
                code: 'placement',
                mediaTypes: {
                    banner: {
                        sizes: [
                            [300, 250]
                        ]
                    },
                },
                ortb2Imp: {
                    instl: 1
                },
                bids: [{
                    bidder: 'yahoossp',
                    params: {
                        dcn: '8a969516017a7a396ec539d97f540011',
                        pos: '8a969978017a7aaabab4ab0bc01a0009'
                    }
                }]
            }]
```

## Other information
@slimkrazy would you be able to review please?
Thanks in advance!
Adam
