### PR TITLE
NextMillennium Bid Adapter: refresh_count for adUnitCode is added

### DIFF
--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -1,4 +1,4 @@
-import { isStr, _each, getBidIdParameter, getWindowTop } from '../src/utils.js';
+import { isStr, _each, getBidIdParameter } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 
@@ -18,13 +18,13 @@ export const spec = {
 
   buildRequests: function(validBidRequests, bidderRequest) {
     const requests = [];
-    const nmmRefreshCounts = (getWindowTop()).nmmRefreshCounts || {};
+    window.nmmRefreshCounts = window.nmmRefreshCounts || {};
 
     _each(validBidRequests, function(bid) {
-      nmmRefreshCounts[bid.adUnitCode] = nmmRefreshCounts[bid.adUnitCode] || 0;
+      window.nmmRefreshCounts[bid.adUnitCode] = window.nmmRefreshCounts[bid.adUnitCode] || 0;
       const postBody = {
         'id': bid.auctionId,
-        'refresh_count': nmmRefreshCounts[bid.adUnitCode]++,
+        'refresh_count': window.nmmRefreshCounts[bid.adUnitCode]++,
         'ext': {
           'prebid': {
             'storedrequest': {

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -1,4 +1,4 @@
-import { isStr, _each, getBidIdParameter } from '../src/utils.js';
+import { isStr, _each, getBidIdParameter, getWindowTop } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 
@@ -18,10 +18,13 @@ export const spec = {
 
   buildRequests: function(validBidRequests, bidderRequest) {
     const requests = [];
+    const nmmRefreshCounts = (getWindowTop()).nmmRefreshCounts || {};
 
     _each(validBidRequests, function(bid) {
+      nmmRefreshCounts[bid.adUnitCode] = nmmRefreshCounts[bid.adUnitCode] || 0;
       const postBody = {
         'id': bid.auctionId,
+        'refresh_count': nmmRefreshCounts[bid.adUnitCode]++,
         'ext': {
           'prebid': {
             'storedrequest': {

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -33,7 +33,7 @@ describe('nextMillenniumBidAdapterTests', function() {
 
   it('Check if refresh_count param is incremented', function() {
     const request = spec.buildRequests(bidRequestData);
-    expect(JSON.parse(request[0].data).refresh_count).to.equal(1);
+    expect(JSON.parse(request[0].data).refresh_count).to.equal(2);
   });
 
   it('validate_response_params', function() {

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { spec } from 'modules/nextMillenniumBidAdapter.js';
 describe('nextMillenniumBidAdapterTests', function() {
   const bidRequestData = [
     {
+      adUnitCode: 'test-div',
       bidId: 'bid1234',
       auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
       bidder: 'nextMillennium',
@@ -28,6 +29,11 @@ describe('nextMillenniumBidAdapterTests', function() {
     const request = spec.buildRequests(bidRequestData);
     expect(request[0].bidId).to.equal('bid1234');
     expect(JSON.parse(request[0].data).id).to.equal('b06c5141-fe8f-4cdf-9d7d-54415490a917');
+  });
+
+  it('Check if refresh_count param is incremented', function() {
+    const request = spec.buildRequests(bidRequestData);
+    expect(JSON.parse(request[0].data).refresh_count).to.equal(1);
   });
 
   it('validate_response_params', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add refresh counter for adUnitCode