### PR TITLE
Prebid Core: Consent management allow auction to continue when CMP doesn't respond

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -371,7 +371,13 @@ function processCmpData(consentObject, hookConfig) {
  * General timeout callback when interacting with CMP takes too long.
  */
 function cmpTimedOut(hookConfig) {
-  cmpFailed('CMP workflow exceeded timeout threshold.', hookConfig);
+  if (cmpVersion === 2) {
+    logWarn(`No response from CMP, continuing auction...`)
+    storeConsentData(undefined);
+    exitModule(null, hookConfig)
+  } else {
+    cmpFailed('CMP workflow exceeded timeout threshold.', hookConfig);
+  }
 }
 
 /**

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -715,6 +715,26 @@ describe('consentManagement', function () {
           expect(consent).to.be.null;
         });
 
+        it('allows the auction when CMP is unresponsive', (done) => {
+          setConsentConfig({
+            cmpApi: 'iab',
+            timeout: 10,
+            defaultGdprScope: true
+          });
+
+          requestBidsHook(() => {
+            didHookReturn = true;
+          }, {});
+
+          setTimeout(() => {
+            expect(didHookReturn).to.be.true;
+            const consent = gdprDataHandler.getConsentData();
+            expect(consent.gdprApplies).to.be.true;
+            expect(consent.consentString).to.be.undefined;
+            done();
+          }, 20);
+        });
+
         it('It still considers it a valid cmp response if gdprApplies is not a boolean', function () {
           // gdprApplies is undefined, should just still store consent response but use whatever defaultGdprScope was
           let testConsentData = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
﻿This reproduces the behavior of `allowAuctionWithoutConsent` when a TCFv2 CMP times out.
https://github.com/prebid/Prebid.js/issues/7156

**NOTE**: With this change, the auction will start with `consentData: {gdprApplies: true, consentData: undefined, consentString: undefined}`. There is a substantial number of modules that in my estimation will **not** work correctly with this configuration, see https://github.com/prebid/Prebid.js/issues/7156#issuecomment-978354248. I understand this to be an existing problem if one uses TCFv1 and `allowAuctionWithoutConsent`; the difference there is that one has to explicitly 'opt-in' to the broken behavior by setting that config flag; this would automatically start it after `consentManagement.gdpr.timeout` expires.
