### PR TITLE
PubCommonID module: use topmost domain for cookie storage

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -11,7 +11,7 @@ import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
 const GVLID = 887;
-const storage = getStorageManager(GVLID, 'pubCommonId');
+export const storage = getStorageManager(GVLID, 'pubCommonId');
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';
@@ -171,7 +171,33 @@ export const sharedIdSystemSubmodule = {
         return {id: storedId};
       }
     }
+  },
+
+  domainOverride: function () {
+    const domainElements = document.domain.split('.');
+    const cookieName = `_gd${Date.now()}`;
+    for (let i = 0, topDomain, testCookie; i < domainElements.length; i++) {
+      const nextDomain = domainElements.slice(i).join('.');
+
+      // write test cookie
+      storage.setCookie(cookieName, '1', undefined, undefined, nextDomain);
+
+      // read test cookie to verify domain was valid
+      testCookie = storage.getCookie(cookieName);
+
+      // delete test cookie
+      storage.setCookie(cookieName, '', 'Thu, 01 Jan 1970 00:00:01 GMT', undefined, nextDomain);
+
+      if (testCookie === '1') {
+        // cookie was written successfully using test domain so the topDomain is updated
+        topDomain = nextDomain;
+      } else {
+        // cookie failed to write using test domain so exit by returning the topDomain
+        return topDomain;
+      }
+    }
   }
+
 };
 
 submodule('userId', sharedIdSystemSubmodule);

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -91,4 +91,50 @@ describe('SharedId System', function () {
       expect(result).to.be.undefined;
     });
   });
+
+  describe('SharedID System domainOverride', () => {
+    let sandbox, domain, cookies, rejectCookiesFor;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(document, 'domain').get(() => domain);
+      cookies = {};
+      sandbox.stub(storage, 'getCookie').callsFake((key) => cookies[key]);
+      rejectCookiesFor = null;
+      sandbox.stub(storage, 'setCookie').callsFake((key, value, expires, sameSite, domain) => {
+        if (domain !== rejectCookiesFor) {
+          if (expires != null) {
+            expires = new Date(expires);
+          }
+          if (expires == null || expires > Date.now()) {
+            cookies[key] = value;
+          } else {
+            delete cookies[key];
+          }
+        }
+      });
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should return TLD if cookies can be set there', () => {
+      domain = 'sub.domain.com';
+      rejectCookiesFor = 'com';
+      expect(sharedIdSystemSubmodule.domainOverride()).to.equal('domain.com');
+    });
+
+    it('should return undefined when cookies cannot be set', () => {
+      domain = 'sub.domain.com';
+      rejectCookiesFor = 'sub.domain.com';
+      expect(sharedIdSystemSubmodule.domainOverride()).to.be.undefined;
+    });
+
+    it('should return half-way domain if parent domain rejects cookies', () => {
+      domain = 'inner.outer.domain.com';
+      rejectCookiesFor = 'domain.com';
+      expect(sharedIdSystemSubmodule.domainOverride()).to.equal('outer.domain.com');
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
﻿This reintroduces logic to have sharedIdSystem/pubCommonID use the TLD for cookie storage
https://github.com/prebid/Prebid.js/issues/7663

**NOTE**: changing the domain will likely not work properly for people that have that cookie already under a different domain. I am not sure the behavior is well-defined; I get duplicate cookies in Chrome. This would apply to people with a `pubcid` cookie that saw the update in https://github.com/prebid/Prebid.js/pull/7149 as well as this one.

