### PR TITLE
Welect Bid Adapter: update prebid compliance and add adapter back to master

### DIFF
--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -1,0 +1,106 @@
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+
+const BIDDER_CODE = 'welect';
+const DEFAULT_DOMAIN = 'www.welect.de';
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['wlt'],
+  gvlid: 282,
+  supportedMediaTypes: ['video'],
+
+  // short code
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    return (
+      utils.deepAccess(bid, 'mediaTypes.video.context') === 'instream' &&
+      !!bid.params.placementId
+    );
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests) {
+    return validBidRequests.map((bidRequest) => {
+      let rawSizes =
+        utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') ||
+        bidRequest.sizes;
+      let size = rawSizes[0];
+
+      let domain = bidRequest.params.domain || DEFAULT_DOMAIN;
+
+      let url = `https://${domain}/api/v2/preflight/${bidRequest.params.placementId}`;
+
+      let gdprConsent = null;
+
+      if (bidRequest && bidRequest.gdprConsent) {
+        gdprConsent = {
+          gdpr_consent: {
+            gdprApplies: bidRequest.gdprConsent.gdprApplies,
+            tcString: bidRequest.gdprConsent.gdprConsent,
+          },
+        };
+      }
+
+      const data = {
+        width: size[0],
+        height: size[1],
+        bid_id: bidRequest.bidId,
+        ...gdprConsent,
+      };
+
+      return {
+        method: 'POST',
+        url: url,
+        data: data,
+        options: {
+          contentType: 'application/json',
+          withCredentials: false,
+          crossOrigin: true,
+        },
+      };
+    });
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    const responseBody = serverResponse.body;
+
+    if (typeof responseBody !== 'object' || responseBody.available !== true) {
+      return [];
+    }
+
+    const bidResponses = [];
+    const bidResponse = {
+      requestId: responseBody.bidResponse.requestId,
+      cpm: responseBody.bidResponse.cpm,
+      width: responseBody.bidResponse.width,
+      height: responseBody.bidResponse.height,
+      creativeId: responseBody.bidResponse.creativeId,
+      currency: responseBody.bidResponse.currency,
+      netRevenue: responseBody.bidResponse.netRevenue,
+      ttl: responseBody.bidResponse.ttl,
+      ad: responseBody.bidResponse.ad,
+      vastUrl: responseBody.bidResponse.vastUrl,
+      meta: {
+        advertiserDomains: responseBody.bidResponse.meta.advertiserDomains
+      }
+    };
+    bidResponses.push(bidResponse);
+    return bidResponses;
+  },
+};
+registerBidder(spec);

--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -1,4 +1,4 @@
-import * as utils from '../src/utils.js';
+import { deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'welect';
@@ -19,7 +19,7 @@ export const spec = {
    */
   isBidRequestValid: function (bid) {
     return (
-      utils.deepAccess(bid, 'mediaTypes.video.context') === 'instream' &&
+      deepAccess(bid, 'mediaTypes.video.context') === 'instream' &&
       !!bid.params.placementId
     );
   },
@@ -32,7 +32,7 @@ export const spec = {
   buildRequests: function (validBidRequests) {
     return validBidRequests.map((bidRequest) => {
       let rawSizes =
-        utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize') ||
+        deepAccess(bidRequest, 'mediaTypes.video.playerSize') ||
         bidRequest.sizes;
       let size = rawSizes[0];
 

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -1,0 +1,211 @@
+import { expect } from 'chai';
+import { spec as adapter } from 'modules/welectBidAdapter.js';
+
+describe('WelectAdapter', function () {
+  describe('Check methods existance', function () {
+    it('exists and is a function', function () {
+      expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
+    });
+    it('exists and is a function', function () {
+      expect(adapter.buildRequests).to.exist.and.to.be.a('function');
+    });
+    it('exists and is a function', function () {
+      expect(adapter.interpretResponse).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('Check method isBidRequestValid return', function () {
+    let bid = {
+      bidder: 'welect',
+      params: {
+        placementId: 'exampleAlias',
+        domain: 'www.welect.de'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+    };
+    let bid2 = {
+      bidder: 'welect',
+      params: {
+        domain: 'www.welect.de'
+      },
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [640, 360]
+        }
+      },
+    };
+
+    it('should be true', function () {
+      expect(adapter.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should be false because the placementId is missing', function () {
+      expect(adapter.isBidRequestValid(bid2)).to.be.false;
+    });
+  });
+
+  describe('Check buildRequests method', function () {
+    // Bids to be formatted
+    let bid1 = {
+      bidder: 'welect',
+      params: {
+        placementId: 'exampleAlias'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+      bidId: 'abdc'
+    };
+    let bid2 = {
+      bidder: 'welect',
+      params: {
+        placementId: 'exampleAlias',
+        domain: 'www.welect2.de'
+      },
+      sizes: [[640, 360]],
+      mediaTypes: {
+        video: {
+          context: 'instream'
+        }
+      },
+      bidId: 'abdc',
+      gdprConsent: {
+        gdprApplies: 1,
+        gdprConsent: 'some_string'
+      }
+    };
+
+    let data1 = {
+      bid_id: 'abdc',
+      width: 640,
+      height: 360
+    }
+
+    let data2 = {
+      bid_id: 'abdc',
+      width: 640,
+      height: 360,
+      gdpr_consent: {
+        gdprApplies: 1,
+        tcString: 'some_string'
+      }
+    }
+
+    // Formatted requets
+    let request1 = {
+      method: 'POST',
+      url: 'https://www.welect.de/api/v2/preflight/exampleAlias',
+      data: data1,
+      options: {
+        contentType: 'application/json',
+        withCredentials: false,
+        crossOrigin: true,
+      }
+    };
+
+    let request2 = {
+      method: 'POST',
+      url: 'https://www.welect2.de/api/v2/preflight/exampleAlias',
+      data: data2,
+      options: {
+        contentType: 'application/json',
+        withCredentials: false,
+        crossOrigin: true,
+      }
+    }
+
+    it('defaults to www.welect.de, without gdpr object', function () {
+      expect(adapter.buildRequests([bid1])).to.deep.equal([request1]);
+    })
+
+    it('must return the right formatted requests, with gdpr object', function () {
+      expect(adapter.buildRequests([bid2])).to.deep.equal([request2]);
+    });
+  });
+
+  describe('Check interpretResponse method return', function () {
+    // invalid server response
+    let unavailableResponse = {
+      body: {
+        available: false
+      }
+    };
+
+    let availableResponse = {
+      body: {
+        available: true,
+        bidResponse: {
+          ad: {
+            video: 'some vast url'
+          },
+          meta: {
+            advertiserDomains: [],
+          },
+          cpm: 17,
+          creativeId: 'svmpreview',
+          currency: 'EUR',
+          netRevenue: true,
+          requestId: 'some bid id',
+          ttl: 120,
+          vastUrl: 'some vast url',
+          height: 640,
+          width: 320
+        }
+      }
+    }
+    // bid Request
+    let bid = {
+      data: {
+        bid_id: 'some bid id',
+        width: 640,
+        height: 320,
+        gdpr_consent: {
+          gdprApplies: 1,
+          tcString: 'some_string'
+        }
+      },
+      method: 'POST',
+      url: 'https://www.welect.de/api/v2/preflight/exampleAlias',
+      options: {
+        contentType: 'application/json',
+        withCredentials: false,
+        crossOrigin: true,
+      }
+    };
+    // Formatted reponse
+    let result = {
+      ad: {
+        video: 'some vast url'
+      },
+      meta: {
+        advertiserDomains: []
+      },
+      cpm: 17,
+      creativeId: 'svmpreview',
+      currency: 'EUR',
+      height: 640,
+      netRevenue: true,
+      requestId: 'some bid id',
+      ttl: 120,
+      vastUrl: 'some vast url',
+      width: 320
+    }
+
+    it('if response reflects unavailability, should be empty', function () {
+      expect(adapter.interpretResponse(unavailableResponse, bid)).to.deep.equal([]);
+    });
+
+    it('if response reflects availability, should equal result', function () {
+      expect(adapter.interpretResponse(availableResponse, bid)).to.deep.equal([result])
+    })
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change

- [x] Re-Add bidder adapter

## Description of change
This re-adds the welectBidderAdapter.js and the according specs.
The adapter apparently got removed with the release of version 5.
412277f72b97cab72644cb4a009f58067a165899
I got notified about required changes regarding the release which I implemented in https://github.com/prebid/Prebid.js/pull/6966.
There wasn't any further notification and the PR got merged so I assumed the adapter wouldn't be removed.

If there are any additional requirements please let me know :)

All documentation regarding this adapter is still in place.
