### PR TITLE
Mediasquare bidder: remove old user sync method

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -137,8 +137,9 @@ export const spec = {
     if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
       return serverResponses[0].body.cookies;
-    } else 
+    } else {
       return [];
+    }
   },
 
   /**

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -137,14 +137,8 @@ export const spec = {
     if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
       return serverResponses[0].body.cookies;
-    } else {
-      if (gdprConsent && typeof gdprConsent.consentString === 'string') { params += typeof gdprConsent.gdprApplies === 'boolean' ? `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}` : `&gdpr_consent=${gdprConsent.consentString}`; }
-      if (uspConsent && typeof uspConsent === 'string') { params += '&uspConsent=' + uspConsent }
-      return {
-        type: 'iframe',
-        url: endpoint + BIDDER_ENDPOINT_SYNC + '?type=iframe' + params
-      };
-    }
+    } else 
+      return [];
   },
 
   /**

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -7,7 +7,6 @@ const BIDDER_CODE = 'mediasquare';
 const BIDDER_URL_PROD = 'https://pbs-front.mediasquare.fr/'
 const BIDDER_URL_TEST = 'https://bidder-test.mediasquare.fr/'
 const BIDDER_ENDPOINT_AUCTION = 'msq_prebid';
-const BIDDER_ENDPOINT_SYNC = 'cookie_sync';
 const BIDDER_ENDPOINT_WINNING = 'winning';
 
 export const spec = {
@@ -132,8 +131,6 @@ export const spec = {
      * @return {UserSync[]} The user syncs which should be dropped.
      */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
-    let params = '';
-    let endpoint = document.location.search.match(/msq_test=true/) ? BIDDER_URL_TEST : BIDDER_URL_PROD;
     if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
       return serverResponses[0].body.cookies;

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -167,7 +167,7 @@ describe('MediaSquare bid adapter tests', function () {
   });
   it('Verifies user sync without cookie in bid response', function () {
     var syncs = spec.getUserSyncs({}, [BID_RESPONSE], DEFAULT_OPTIONS.gdprConsent, DEFAULT_OPTIONS.uspConsent);
-    expect(syncs).to.have.property('type').and.to.equal('iframe');
+    expect(syncs).to.have.lengthOf(0);
   });
   it('Verifies user sync with cookies in bid response', function () {
     BID_RESPONSE.body.cookies = [{'type': 'image', 'url': 'http://www.cookie.sync.org/'}];
@@ -178,13 +178,13 @@ describe('MediaSquare bid adapter tests', function () {
   });
   it('Verifies user sync with no bid response', function() {
     var syncs = spec.getUserSyncs({}, null, DEFAULT_OPTIONS.gdprConsent, DEFAULT_OPTIONS.uspConsent);
-    expect(syncs).to.have.property('type').and.to.equal('iframe');
+    expect(syncs).to.have.lengthOf(0);
   });
   it('Verifies user sync with no bid body response', function() {
     var syncs = spec.getUserSyncs({}, [], DEFAULT_OPTIONS.gdprConsent, DEFAULT_OPTIONS.uspConsent);
-    expect(syncs).to.have.property('type').and.to.equal('iframe');
+    expect(syncs).to.have.lengthOf(0);
     var syncs = spec.getUserSyncs({}, [{}], DEFAULT_OPTIONS.gdprConsent, DEFAULT_OPTIONS.uspConsent);
-    expect(syncs).to.have.property('type').and.to.equal('iframe');
+    expect(syncs).to.have.lengthOf(0);
   });
   it('Verifies native in bid response', function () {
     const request = spec.buildRequests(NATIVE_PARAMS, DEFAULT_OPTIONS);


### PR DESCRIPTION

## Type of change
- [ ] Refactoring (no functional changes, no api changes)

## Description of change
remove an old way to make user sync calls which is no longer needed and is related to #7775 
