### PR TITLE
AdDefend Bidder: added gdprApplies to bid request parameters

### DIFF
--- a/modules/addefendBidAdapter.js
+++ b/modules/addefendBidAdapter.js
@@ -19,6 +19,7 @@ export const spec = {
       v: $$PREBID_GLOBAL$$.version,
       auctionId: false,
       pageId: false,
+      gdpr_applies: bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies ? bidderRequest.gdprConsent.gdprApplies : 'true',
       gdpr_consent: bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString ? bidderRequest.gdprConsent.consentString : '',
       referer: bidderRequest.refererInfo.referer,
       bids: [],


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Added gdprApplies to the http bid request parameters to clarify gdpr compliant handling. 

## Other information
#7775 the server side implementation does threat all requests as gdprApplies:true anyway.
