### PR TITLE
Glimpse Bid Adapter: handle consent case where GDPR doesn't apply

### DIFF
--- a/modules/glimpseBidAdapter.js
+++ b/modules/glimpseBidAdapter.js
@@ -142,11 +142,12 @@ function getGdprConsentChoice(bidderRequest) {
 
   if (hasGdprConsent) {
     const gdprConsent = bidderRequest.gdprConsent
+    const hasGdprApplies = hasBooleanValue(gdprConsent.gdprApplies)
 
     return {
       consentString: gdprConsent.consentString || '',
       vendorData: gdprConsent.vendorData || {},
-      gdprApplies: gdprConsent.gdprApplies || true,
+      gdprApplies: hasGdprApplies ? gdprConsent.gdprApplies : true,
     }
   }
 
@@ -179,6 +180,13 @@ function hasValue(value) {
   return (
     value !== undefined &&
     value !== null
+  )
+}
+
+function hasBooleanValue(value) {
+  return (
+    hasValue(value) &&
+    typeof value === 'boolean'
   )
 }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
We made a small change to handle the case where the GDPR consent block is defined, but GDPR doesn't apply.