### PR TITLE
5.20.x legacy appnexus bid adapter - add support for brandId

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -598,6 +598,10 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     bid.meta = Object.assign({}, bid.meta, { advertiserId: rtbBid.advertiser_id });
   }
 
+  if (rtbBid.brand_id) {
+    bid.meta = Object.assign({}, bid.meta, { brandId: rtbBid.brand_id });
+  }
+
   if (rtbBid.rtb.video) {
     // shared video properties used for all 3 contexts
     Object.assign(bid, {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1335,6 +1335,20 @@ describe('AppNexusAdapter', function () {
       expect(Object.keys(result[0].meta)).to.include.members(['advertiserId']);
     });
 
+    it('should add brand id', function() {
+      let responseBrandId = deepClone(response);
+      responseBrandId.tags[0].ads[0].brand_id = 123;
+
+      let bidderRequest = {
+        bids: [{
+          bidId: '3db3773286ee59',
+          adUnitCode: 'code'
+        }]
+      }
+      let result = spec.interpretResponse({ body: responseBrandId }, {bidderRequest});
+      expect(Object.keys(result[0].meta)).to.include.members(['brandId']);
+    });
+
     it('should add advertiserDomains', function() {
       let responseAdvertiserId = deepClone(response);
       responseAdvertiserId.tags[0].ads[0].adomain = ['123'];


### PR DESCRIPTION

## Type of change
- [x] Feature

## Description of change

Parallel change from https://github.com/prebid/Prebid.js/pull/7658 for legacy.

Adding support in the appnexus bid adapter to populate the brand Id field in the bid.meta object.
