### PR TITLE
Invibes Bid Adapter: support for custom domainId

### DIFF
--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -4,7 +4,8 @@ import {getStorageManager} from '../src/storageManager.js';
 
 const CONSTANTS = {
   BIDDER_CODE: 'invibes',
-  BID_ENDPOINT: 'https://bid.videostep.com/Bid/VideoAdContent',
+  BID_ENDPOINT: '.videostep.com/Bid/VideoAdContent',
+  BID_SUBDOMAIN: 'https://bid',
   SYNC_ENDPOINT: 'https://k.r66net.com/GetUserSync',
   TIME_TO_LIVE: 300,
   DEFAULT_CURRENCY: 'EUR',
@@ -78,14 +79,14 @@ function buildRequest(bidRequests, bidderRequest) {
   bidderRequest = bidderRequest || {};
   const _placementIds = [];
   const _adUnitCodes = [];
-  let _loginId, _customEndpoint, _userId;
+  let _customEndpoint, _userId, _domainId;
   let _ivAuctionStart = bidderRequest.auctionStart || Date.now();
 
   bidRequests.forEach(function (bidRequest) {
     bidRequest.startTime = new Date().getTime();
     _placementIds.push(bidRequest.params.placementId);
     _adUnitCodes.push(bidRequest.adUnitCode);
-    _loginId = _loginId || bidRequest.params.loginId;
+    _domainId = _domainId || bidRequest.params.domainId;
     _customEndpoint = _customEndpoint || bidRequest.params.customEndpoint;
     _customUserSync = _customUserSync || bidRequest.params.customUserSync;
     _userId = _userId || bidRequest.userId;
@@ -102,7 +103,6 @@ function buildRequest(bidRequests, bidderRequest) {
   let bidParamsJson = {
     placementIds: _placementIds,
     adUnitCodes: _adUnitCodes,
-    loginId: _loginId,
     auctionStartTime: _ivAuctionStart,
     bidVersion: CONSTANTS.PREBID_VERSION
   };
@@ -146,9 +146,11 @@ function buildRequest(bidRequests, bidderRequest) {
     }
   }
 
+  let endpoint = createEndpoint(_customEndpoint, _domainId, _placementIds);
+
   return {
     method: CONSTANTS.METHOD,
-    url: _customEndpoint || CONSTANTS.BID_ENDPOINT,
+    url: endpoint,
     data: data,
     options: {withCredentials: true},
     // for POST: { contentType: 'application/json', withCredentials: true }
@@ -278,6 +280,48 @@ function createBid(bidRequest, requestPlacement, multipositionEnabled, usedPlace
     ad: renderCreative(bidModel),
     meta: addMeta(bidModel.Meta)
   };
+}
+
+function createEndpoint(customEndpoint, domainId, placementIds) {
+  if (customEndpoint != null) {
+    return customEndpoint;
+  }
+
+  if (domainId != null) {
+    return extractEndpointFromId(domainId - 1000);
+  }
+
+  if (placementIds.length > 0) {
+    for (var i = 0; i < placementIds.length; i++) {
+      const id = extractFromPlacement(placementIds[i]);
+      if (id != null) {
+        return extractEndpointFromId(id);
+      }
+    }
+  }
+
+  return extractEndpointFromId(1);
+}
+
+function extractEndpointFromId(domainId) {
+  if (domainId < 2) {
+    return CONSTANTS.BID_SUBDOMAIN + CONSTANTS.BID_ENDPOINT;
+  }
+
+  return CONSTANTS.BID_SUBDOMAIN + domainId + CONSTANTS.BID_ENDPOINT;
+}
+
+function extractFromPlacement(placementId) {
+  if (placementId == null) { return null; }
+
+  var pattern = /_ivbs([0-9]+)/g;
+
+  var match = pattern.exec(placementId);
+  if (match != null && match[1] != null) {
+    return parseInt(match[1]);
+  }
+
+  return null;
 }
 
 function addMeta(bidModelMeta) {

--- a/modules/invibesBidAdapter.md
+++ b/modules/invibesBidAdapter.md
@@ -21,7 +21,7 @@ Connect to Invibes for bids.
                        bidder: 'invibes',
                        params: {
                            placementId: '12345',
-						   networkId: 1001
+                           domainId: 1001
                        }
                    }
                ]

--- a/modules/invibesBidAdapter.md
+++ b/modules/invibesBidAdapter.md
@@ -20,7 +20,8 @@ Connect to Invibes for bids.
                    {
                        bidder: 'invibes',
                        params: {
-                           placementId: '12345'
+                           placementId: '12345',
+						   networkId: 1001
                        }
                    }
                ]

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -164,7 +164,7 @@ describe('invibesBidAdapter:', function () {
         bidder: BIDDER_CODE,
         params: {
           placementId: 'placement',
-	  	  customEndpoint: 'sub.domain.com/Bid/VideoAdContent'
+          customEndpoint: 'sub.domain.com/Bid/VideoAdContent'
         },
         adUnitCode: 'test-div1'
       }]);
@@ -189,7 +189,7 @@ describe('invibesBidAdapter:', function () {
         bidId: 'b1',
         bidder: BIDDER_CODE,
         params: {
-		  placementId: null
+          placementId: null
         },
         adUnitCode: 'test-div1'
       }]);
@@ -216,7 +216,7 @@ describe('invibesBidAdapter:', function () {
         bidder: BIDDER_CODE,
         params: {
           placementId: 'placement',
-	  	  domainId: 1001
+          domainId: 1001
         },
         adUnitCode: 'test-div1'
       }]);
@@ -230,7 +230,7 @@ describe('invibesBidAdapter:', function () {
         bidder: BIDDER_CODE,
         params: {
           placementId: 'placement',
-	  	  domainId: 1002
+          domainId: 1002
         },
         adUnitCode: 'test-div1'
       }]);

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -158,6 +158,125 @@ describe('invibesBidAdapter:', function () {
       expect(request.method).to.equal('GET');
     });
 
+    it('sends bid request to custom endpoint via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'placement',
+	  	  customEndpoint: 'sub.domain.com/Bid/VideoAdContent'
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('sub.domain.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to default endpoint when no placement', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to default endpoint when null placement', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+		  placementId: null
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to default endpoint 1 via GET', function () {
+	  const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'placement'
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to network id endpoint 1 via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'placement',
+	  	  domainId: 1001
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to network id endpoint 2 via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'placement',
+	  	  domainId: 1002
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid2.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to network id by placement 1 via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'infeed_ivbs1'
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to network id by placement 2 via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'infeed_ivbs2'
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid2.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
+    it('sends bid request to network id by placement 10 via GET', function () {
+      const request = spec.buildRequests([{
+        bidId: 'b1',
+        bidder: BIDDER_CODE,
+        params: {
+          placementId: 'infeed_ivbs10'
+        },
+        adUnitCode: 'test-div1'
+      }]);
+      expect(request.url).to.equal('https://bid10.videostep.com/Bid/VideoAdContent');
+      expect(request.method).to.equal('GET');
+    });
+
     it('sends cookies with the bid request', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.options.withCredentials).to.equal(true);


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added support for additional bid param **domainId** and also custom extensions for placement ids

- contact email of the adapter’s maintainer
system_operations@invibes.com

- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo
https://github.com/prebid/prebid.github.io/pull/3440
