### PR TITLE
Multiple Modules: fix constants JSON imports for webpack

### DIFF
--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -9,7 +9,7 @@
 import { registerVideoSupport } from '../src/adServerManager.js';
 import { command as analyticsCommand, COMMAND } from './adlooxAnalyticsAdapter.js';
 import { ajax } from '../src/ajax.js';
-import { EVENTS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 import { targeting } from '../src/targeting.js';
 import { logInfo, isFn, logError, isPlainObject, isStr, isBoolean, deepSetValue, deepClone, timestamp, logWarn } from '../src/utils.js';
 
@@ -74,7 +74,7 @@ function track(options, callback) {
   bid.ext.adloox.video.adserver = false;
 
   analyticsCommand(COMMAND.TRACK, {
-    eventType: EVENTS.BID_WON,
+    eventType: CONSTANTS.EVENTS.BID_WON,
     args: bid
   });
 }

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -49,7 +49,7 @@ export function buildVideoUrl(options, callback) {
     return false;
   }
 
-  // same logic used in modules/dfpAdServerVideo.js
+  // same logic used in modules/dfpAdServerVideo.js 
   options.bid = options.bid || targeting.getWinningBids(options.adUnit.code)[0];
 
   deepSetValue(options.bid, 'ext.adloox.video.adserver', true);

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -49,7 +49,7 @@ export function buildVideoUrl(options, callback) {
     return false;
   }
 
-  // same logic used in modules/dfpAdServerVideo.js 
+  // same logic used in modules/dfpAdServerVideo.js
   options.bid = options.bid || targeting.getWinningBids(options.adUnit.code)[0];
 
   deepSetValue(options.bid, 'ext.adloox.video.adserver', true);

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -9,7 +9,7 @@ import adapter from '../src/AnalyticsAdapter.js';
 import { loadExternalScript } from '../src/adloader.js';
 import { auctionManager } from '../src/auctionManager.js';
 import { AUCTION_COMPLETED } from '../src/auction.js';
-import { EVENTS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 import find from 'core-js-pure/features/array/find.js';
 import {
   deepAccess, logInfo, isPlainObject, logError, isStr, isNumber, getGptSlotInfoForAdUnitCode,
@@ -199,9 +199,9 @@ analyticsAdapter.url = function(url, args, bid) {
   return url + a2qs(args);
 }
 
-analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
+analyticsAdapter[`handle_${CONSTANTS.EVENTS.AUCTION_END}`] = function(auctionDetails) {
   if (!(auctionDetails.auctionStatus == AUCTION_COMPLETED && auctionDetails.bidsReceived.length > 0)) return;
-  analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = NOOP;
+  analyticsAdapter[`handle_${CONSTANTS.EVENTS.AUCTION_END}`] = NOOP;
 
   logMessage(MODULE, 'preloading verification JS');
 
@@ -214,7 +214,7 @@ analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
   insertElement(link);
 }
 
-analyticsAdapter[`handle_${EVENTS.BID_WON}`] = function(bid) {
+analyticsAdapter[`handle_${CONSTANTS.EVENTS.BID_WON}`] = function(bid) {
   if (deepAccess(bid, 'ext.adloox.video.adserver')) {
     logMessage(MODULE, `measuring '${bid.mediaType}' ad unit code '${bid.adUnitCode}' via Ad Server module`);
     return;

--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -4,7 +4,7 @@
 
 import { config } from '../src/config.js';
 import * as events from '../src/events.js';
-import { EVENTS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 import { logWarn, isFn, triggerPixel } from '../src/utils.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 import adapterManager, { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
@@ -70,12 +70,12 @@ export let impressionViewableHandler = (globalModuleConfig, slot, event) => {
     // trigger respective bidder's onBidViewable handler
     adapterManager.callBidViewableBidder(respectiveBid.bidder, respectiveBid);
     // emit the BID_VIEWABLE event with bid details, this event can be consumed by bidders and analytics pixels
-    events.emit(EVENTS.BID_VIEWABLE, respectiveBid);
+    events.emit(CONSTANTS.EVENTS.BID_VIEWABLE, respectiveBid);
   }
 };
 
 export let init = () => {
-  events.on(EVENTS.AUCTION_INIT, () => {
+  events.on(CONSTANTS.EVENTS.AUCTION_INIT, () => {
     // read the config for the module
     const globalModuleConfig = config.getConfig(MODULE_NAME) || {};
     // do nothing if module-config.enabled is not set to true

--- a/modules/bidViewabilityIO.js
+++ b/modules/bidViewabilityIO.js
@@ -1,7 +1,7 @@
 import { logMessage } from '../src/utils.js';
 import { config } from '../src/config.js';
 import * as events from '../src/events.js';
-import { EVENTS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 
 const MODULE_NAME = 'bidViewabilityIO';
 const CONFIG_ENABLED = 'enabled';
@@ -42,7 +42,7 @@ export let getViewableOptions = (bid) => {
 export let markViewed = (bid, entry, observer) => {
   return () => {
     observer.unobserve(entry.target);
-    events.emit(EVENTS.BID_VIEWABLE, bid);
+    events.emit(CONSTANTS.EVENTS.BID_VIEWABLE, bid);
     _logMessage(`id: ${entry.target.getAttribute('id')} code: ${bid.adUnitCode} was viewed`);
   }
 }
@@ -77,7 +77,7 @@ export let init = () => {
     if (conf[MODULE_NAME][CONFIG_ENABLED] && CLIENT_SUPPORTS_IO) {
       // if the module is enabled and the browser supports Intersection Observer,
       // then listen to AD_RENDER_SUCCEEDED to setup IO's for supported mediaTypes
-      events.on(EVENTS.AD_RENDER_SUCCEEDED, ({doc, bid, id}) => {
+      events.on(CONSTANTS.EVENTS.AD_RENDER_SUCCEEDED, ({doc, bid, id}) => {
         if (isSupportedMediaType(bid)) {
           let viewable = new IntersectionObserver(viewCallbackFactory(bid), getViewableOptions(bid));
           let element = document.getElementById(bid.adUnitCode);

--- a/modules/currency.js
+++ b/modules/currency.js
@@ -1,7 +1,7 @@
 import { logInfo, logWarn, logError, logMessage } from '../src/utils.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 import { createBid } from '../src/bidfactory.js';
-import { STATUS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 import { ajax } from '../src/ajax.js';
 import { config } from '../src/config.js';
 import { getHook } from '../src/hook.js';
@@ -219,7 +219,7 @@ function wrapFunction(fn, context, params) {
         }
       } catch (e) {
         logWarn('Returning NO_BID, getCurrencyConversion threw error: ', e);
-        params[1] = createBid(STATUS.NO_BID, {
+        params[1] = createBid(CONSTANTS.STATUS.NO_BID, {
           bidder: bid.bidderCode || bid.bidder,
           bidId: bid.requestId
         });

--- a/modules/instreamTracking.js
+++ b/modules/instreamTracking.js
@@ -3,11 +3,11 @@ import { config } from '../src/config.js';
 import { auctionManager } from '../src/auctionManager.js';
 import { INSTREAM } from '../src/video.js';
 import * as events from '../src/events.js';
-import { BID_STATUS, EVENTS, TARGETING_KEYS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json'
 
-const {CACHE_ID, UUID} = TARGETING_KEYS;
-const {BID_WON, AUCTION_END} = EVENTS;
-const {RENDERED} = BID_STATUS;
+const {CACHE_ID, UUID} = CONSTANTS.TARGETING_KEYS;
+const {BID_WON, AUCTION_END} = CONSTANTS.EVENTS;
+const {RENDERED} = CONSTANTS.BID_STATUS;
 
 const INSTREAM_TRACKING_DEFAULT_CONFIG = {
   enabled: false,

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1,7 +1,7 @@
 import { deepAccess, parseGPTSingleSizeArray, inIframe, deepClone, logError, logWarn, isFn, contains, isInteger, isArray, deepSetValue, parseQueryStringParameters, isEmpty, mergeDeep, convertTypes } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
-import { EVENTS } from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
 import events from '../src/events.js';
 import find from 'core-js-pure/features/array/find.js';
@@ -1129,8 +1129,8 @@ export const spec = {
    */
   isBidRequestValid: function (bid) {
     if (!hasRegisteredHandler) {
-      events.on(EVENTS.AUCTION_DEBUG, errorEventHandler);
-      events.on(EVENTS.AD_RENDER_FAILED, errorEventHandler);
+      events.on(CONSTANTS.EVENTS.AUCTION_DEBUG, errorEventHandler);
+      events.on(CONSTANTS.EVENTS.AD_RENDER_FAILED, errorEventHandler);
       hasRegisteredHandler = true;
     }
 

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -2,7 +2,7 @@ import { logError, isEmpty, deepAccess, triggerPixel, logWarn, isArray } from '.
 import {createBid as createBidFactory} from '../src/bidfactory.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {VIDEO} from '../src/mediaTypes.js';
-import {STATUS} from '../src/constants.json';
+import CONSTANTS from '../src/constants.json';
 
 const BIDDER_CODE = 'telaria';
 const DOMAIN = 'tremorhub.com';
@@ -86,7 +86,7 @@ export const spec = {
       logError(errorMessage);
     } else if (!isEmpty(bidResult.seatbid)) {
       bidResult.seatbid[0].bid.forEach(tag => {
-        bids.push(createBid(STATUS.GOOD, bidderRequest, tag, width, height, BIDDER_CODE));
+        bids.push(createBid(CONSTANTS.STATUS.GOOD, bidderRequest, tag, width, height, BIDDER_CODE));
       });
     }
 

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -3,7 +3,7 @@ import analyticsAdapter, { command as analyticsCommand, COMMAND } from 'modules/
 import { AUCTION_COMPLETED } from 'src/auction.js';
 import { expect } from 'chai';
 import events from 'src/events.js';
-import { EVENTS } from 'src/constants.json';
+import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils.js';
 import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
@@ -143,10 +143,10 @@ describe('Adloox Analytics Adapter', function () {
           return arg.tagName === 'LINK' && arg.getAttribute('rel') === 'preload' && arg.getAttribute('as') === 'script' && href_uri.href === uri.href;
         };
 
-        events.emit(EVENTS.AUCTION_END, auctionDetails);
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, auctionDetails);
         expect(insertElementStub.calledWith(sinon.match(isLinkPreloadAsScript))).to.true;
 
-        events.emit(EVENTS.AUCTION_END, auctionDetails);
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, auctionDetails);
         expect(insertElementStub.callCount).to.equal(1);
 
         done();
@@ -167,7 +167,7 @@ describe('Adloox Analytics Adapter', function () {
         const querySelectorStub = sandbox.stub(document, 'querySelector');
         querySelectorStub.withArgs(`#${bid.adUnitCode}`).returns(slot);
 
-        events.emit(EVENTS.BID_WON, bid);
+        events.emit(CONSTANTS.EVENTS.BID_WON, bid);
 
         const [urlInserted, moduleCode] = loadExternalScriptStub.getCall(0).args;
 
@@ -196,7 +196,7 @@ describe('Adloox Analytics Adapter', function () {
         const querySelectorStub = sandbox.stub(document, 'querySelector');
         querySelectorStub.withArgs(`#${bid.adUnitCode}`).returns(slot);
 
-        events.emit(EVENTS.BID_WON, bidIgnore);
+        events.emit(CONSTANTS.EVENTS.BID_WON, bidIgnore);
 
         expect(parent.querySelector('script')).is.null;
 
@@ -238,7 +238,7 @@ describe('Adloox Analytics Adapter', function () {
 
       it('should inject tracking event', function (done) {
         const data = {
-          eventType: EVENTS.BID_WON,
+          eventType: CONSTANTS.EVENTS.BID_WON,
           args: bid
         };
 

--- a/test/spec/modules/bidViewabilityIO_spec.js
+++ b/test/spec/modules/bidViewabilityIO_spec.js
@@ -3,7 +3,7 @@ import * as events from 'src/events.js';
 import * as utils from 'src/utils.js';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { EVENTS } from 'src/constants.json';
+import CONSTANTS from 'src/constants.json';
 
 describe('#bidViewabilityIO', function() {
   const makeElement = (id) => {
@@ -97,7 +97,7 @@ describe('#bidViewabilityIO', function() {
       expect(mockObserver.unobserve.calledOnce).to.be.true;
       expect(emitSpy.calledOnce).to.be.true;
       // expect(emitSpy.firstCall.args).to.be.false;
-      expect(emitSpy.firstCall.args[0]).to.eq(EVENTS.BID_VIEWABLE);
+      expect(emitSpy.firstCall.args[0]).to.eq(CONSTANTS.EVENTS.BID_VIEWABLE);
     });
   })
 

--- a/test/spec/modules/bidViewability_spec.js
+++ b/test/spec/modules/bidViewability_spec.js
@@ -5,7 +5,7 @@ import * as utils from 'src/utils.js';
 import * as sinon from 'sinon';
 import {expect, spy} from 'chai';
 import * as prebidGlobal from 'src/prebidGlobal.js';
-import { EVENTS } from 'src/constants.json';
+import CONSTANTS from 'src/constants.json';
 import adapterManager, { gdprDataHandler, uspDataHandler } from 'src/adapterManager.js';
 import parse from 'url-parse';
 
@@ -279,9 +279,9 @@ describe('#bidViewability', function() {
       let call = callBidViewableBidderSpy.getCall(0);
       expect(call.args[0]).to.equal(PBJS_WINNING_BID.bidder);
       expect(call.args[1]).to.deep.equal(PBJS_WINNING_BID);
-      // EVENTS.BID_VIEWABLE is triggered
+      // CONSTANTS.EVENTS.BID_VIEWABLE is triggered
       call = eventsEmitSpy.getCall(0);
-      expect(call.args[0]).to.equal(EVENTS.BID_VIEWABLE);
+      expect(call.args[0]).to.equal(CONSTANTS.EVENTS.BID_VIEWABLE);
       expect(call.args[1]).to.deep.equal(PBJS_WINNING_BID);
     });
 
@@ -290,7 +290,7 @@ describe('#bidViewability', function() {
       expect(triggerPixelSpy.callCount).to.equal(0);
       // adapterManager.callBidViewableBidder is NOT called
       expect(callBidViewableBidderSpy.callCount).to.equal(0);
-      // EVENTS.BID_VIEWABLE is NOT triggered
+      // CONSTANTS.EVENTS.BID_VIEWABLE is NOT triggered
       expect(eventsEmitSpy.callCount).to.equal(0);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Webpack is unable to build prebid because it can't import named fields from a JSON file.

```
ModuleDependencyError: Should not import the named export 'EVENTS'.'AD_RENDER_FAILED' (imported as 'EVENTS') from default-exporting module (only default export is available soon)
```

This issue has cropped up a few times. I replaced all occurrences with the proper default import.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

Previous issues:
#5909
#6677
