### PR TITLE
IX Bid Adapter: fix for infinite loop

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1147,8 +1147,8 @@ export const spec = {
    */
   isBidRequestValid: function (bid) {
     if (!hasRegisteredHandler) {
-      events.on(CONSTANTS.EVENTS.AUCTION_DEBUG, errorEventHandler);
-      events.on(CONSTANTS.EVENTS.AD_RENDER_FAILED, errorEventHandler);
+      events.on(CONSTANTS.EVENTS.AUCTION_DEBUG, localStorageHandler);
+      events.on(CONSTANTS.EVENTS.AD_RENDER_FAILED, localStorageHandler);
       hasRegisteredHandler = true;
     }
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -40,10 +40,6 @@ export const ERROR_CODES = {
   PB_FPD_EXCEEDS_MAX_SIZE: 8,
   VIDEO_DURATION_INVALID: 9
 };
-const DEFAULT_ENFORCEMENT_SETTINGS = {
-  hasEnforcementHook: false,
-  valid: hasDeviceAccess()
-};
 const FIRST_PARTY_DATA = {
   SITE: [
     'id', 'name', 'domain', 'cat', 'sectioncat', 'pagecat', 'page', 'ref', 'search', 'mobile',
@@ -1043,6 +1039,10 @@ function storeErrorEventData(data) {
  */
 function localStorageHandler(data) {
   if (data.type === 'ERROR' && data.arguments && data.arguments[1] && data.arguments[1].bidder === BIDDER_CODE) {
+    const DEFAULT_ENFORCEMENT_SETTINGS = {
+      hasEnforcementHook: false,
+      valid: hasDeviceAccess()
+    };
     validateStorageEnforcement(GLOBAL_VENDOR_ID, BIDDER_CODE, DEFAULT_ENFORCEMENT_SETTINGS, (permissions) => {
       if (permissions.valid) {
         storeErrorEventData(data);

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { spec, storage, ERROR_CODES } from '../../../modules/ixBidAdapter.js';
 import { createEidsArray } from 'modules/userId/eids.js';
-import { gdprDataHandler } from 'src/adapterManager.js';
 
 describe('IndexexchangeAdapter', function () {
   const IX_SECURE_ENDPOINT = 'https://htlb.casalemedia.com/cygnus';
@@ -2615,7 +2614,6 @@ describe('IndexexchangeAdapter', function () {
     });
 
     afterEach(() => {
-      gdprDataHandler.setConsentData(null);
       setDataInLocalStorageStub.restore();
       getDataFromLocalStorageStub.restore();
       removeDataFromLocalStorageStub.restore();
@@ -2810,30 +2808,6 @@ describe('IndexexchangeAdapter', function () {
     });
 
     it('should not save error data into localstorage if consent is not given', () => {
-      gdprDataHandler.setConsentData({
-        'apiVersion': 2,
-        'gdprApplies': true,
-        'vendorData': {
-          'purpose': {
-            'consents': {
-              '1': true
-            }
-          },
-          'vendor': {
-            'consents': {
-              '10': false
-            }
-          }
-        }
-      });
-
-      const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
-      bid.params.size = ['400', 100];
-      expect(spec.isBidRequestValid(bid)).to.be.false;
-      expect(localStorageValues[key]).to.be.undefined;
-    });
-
-    it('should not save error data into localstorage if deviceAccess is false', () => {
       config.setConfig({ deviceAccess: false });
       const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
       bid.params.size = ['400', 100];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This MR addresses an infinite loop bug within the IX adapter. The endless loop happens when the `gdpr enforcement` module is included in the build along with the IX adapter. 

When IX is not given permission to write to local storage an `AUCTION_DEBUG` event is emitted. IX has a handler for this particular event. The handler calls the `localStorageIsEnabled` function, which also triggers an `AUCTION_DEBUG` event. The back and forth between the handler and the `AUCTION_DEBUG` event causes an endless loop to occur. 

## Other information
Issue: https://github.com/prebid/Prebid.js/issues/7707