### PR TITLE
IX Bid Adapter: make sure siteId is string type

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -194,7 +194,7 @@ function bidToImp(bid) {
   imp.id = bid.bidId;
 
   imp.ext = {};
-  imp.ext.siteID = bid.params.siteId;
+  imp.ext.siteID = bid.params.siteId.toString();
 
   if (bid.params.hasOwnProperty('id') &&
     (typeof bid.params.id === 'string' || typeof bid.params.id === 'number')) {
@@ -1168,7 +1168,12 @@ export const spec = {
     }
 
     if (typeof bid.params.siteId !== 'string' && typeof bid.params.siteId !== 'number') {
-      logError('IX Bid Adapter: siteId must be string or number value.', { bidder: BIDDER_CODE, code: ERROR_CODES.SITE_ID_INVALID_VALUE });
+      logError('IX Bid Adapter: siteId must be string or number type.', { bidder: BIDDER_CODE, code: ERROR_CODES.SITE_ID_INVALID_VALUE });
+      return false;
+    }
+
+    if (typeof bid.params.siteId !== 'string' && isNaN(Number(bid.params.siteId))) {
+      logError('IX Bid Adapter: siteId must valid value', { bidder: BIDDER_CODE, code: ERROR_CODES.SITE_ID_INVALID_VALUE });
       return false;
     }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1502,8 +1502,20 @@ describe('IndexexchangeAdapter', function () {
 
         expect(w).to.equal(size[0]);
         expect(h).to.equal(size[1]);
-        expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+        expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
         expect(ext.sid).to.equal(sidValue);
+      });
+    });
+
+    it('payload should have imp[].banner.format[].ext.siteID as string ', function () {
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid.params.siteId = 1234;
+
+      request = spec.buildRequests([bid], DEFAULT_OPTION)[0];
+
+      const payload = JSON.parse(request.data.r);
+      payload.imp[0].banner.format.forEach((imp) => {
+        expect(imp.ext.siteID).to.be.a('string');
       });
     });
 
@@ -1638,7 +1650,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
       expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
       expect(impression.banner.format[0].ext.sid).to.equal('50');
     });
 
@@ -1652,7 +1664,7 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
       expect(impression.banner.format[0].h).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[1]);
       expect(impression.banner.topframe).to.be.oneOf([0, 1]);
-      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+      expect(impression.banner.format[0].ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
       expect(impression.banner.format[0].ext.sid).to.equal('abc');
     });
 
@@ -1750,7 +1762,7 @@ describe('IndexexchangeAdapter', function () {
 
           expect(w).to.equal(size[0]);
           expect(h).to.equal(size[1]);
-          expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId.toString());
+          expect(ext.siteID).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
           expect(ext.sid).to.equal(sidValue);
         });
       });
@@ -1915,7 +1927,7 @@ describe('IndexexchangeAdapter', function () {
 
           expect(w).to.equal(size[0]);
           expect(h).to.equal(size[1]);
-          expect(ext.siteID).to.equal(bids[impressionIndex].params.siteId.toString());
+          expect(ext.siteID).to.equal(bids[impressionIndex].params.siteId);
           expect(ext.sid).to.equal(sidValue);
         });
       });
@@ -2119,7 +2131,7 @@ describe('IndexexchangeAdapter', function () {
 
             expect(w).to.equal(size[0]);
             expect(h).to.equal(size[1]);
-            expect(ext.siteID).to.equal(bid.params.siteId.toString());
+            expect(ext.siteID).to.equal(bid.params.siteId);
             expect(ext.sid).to.equal(sidValue);
           });
         });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This change is to make sure siteID being sent in `ext` object is a string. 
