### PR TITLE
Eplanning & Adapter Manager: backport test changes to 5.20.x-legacy

### DIFF
--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -328,25 +328,24 @@ describe('E-Planning Adapter', function () {
   describe('buildRequests', function () {
     let bidRequests = [validBid];
     let sandbox;
+    let getWindowSelfStub;
+    let innerWidth;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
+      getWindowSelfStub = sandbox.stub(utils, 'getWindowSelf');
+      getWindowSelfStub.returns(createWindow(800));
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    const createWindow = () => {
+    const createWindow = (innerWidth) => {
       const win = {};
       win.self = win;
-      win.innerWidth = 1025;
+      win.innerWidth = innerWidth;
       return win;
     };
-
-    function setupSingleWindow(sandBox) {
-      const win = createWindow();
-      sandBox.stub(utils, 'getWindowSelf').returns(win);
-    }
 
     it('should create the url correctly', function () {
       const url = spec.buildRequests(bidRequests, bidderRequest).url;
@@ -516,7 +515,8 @@ describe('E-Planning Adapter', function () {
 
     it('should return the e parameter with a value according to the sizes in order corresponding to the desktop priority list of the ad units', function () {
       let bidRequestsPrioritySizes = [validBidExistingSizesInPriorityListForDesktop];
-      setupSingleWindow(sandbox);
+      // overwrite default innerWdith for tests with a larger one we consider "Desktop" or NOT Mobile
+      getWindowSelfStub.returns(createWindow(1025));
       const e = spec.buildRequests(bidRequestsPrioritySizes, bidderRequest).data.e;
       expect(e).to.equal('300x250_0:300x250,300x600,970x250');
     });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1697,14 +1697,17 @@ describe('adapterManager tests', function () {
     });
 
     describe('sizeMapping', function () {
+      let sandbox;
       beforeEach(function () {
+        sandbox = sinon.sandbox.create();
         allS2SBidders.length = 0;
         clientTestAdapters.length = 0;
-        sinon.stub(window, 'matchMedia').callsFake(() => ({matches: true}));
+        // always have matchMedia return true for us
+        sandbox.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
       });
 
       afterEach(function () {
-        matchMedia.restore();
+        sandbox.restore();
         config.resetConfig();
         setSizeConfig([]);
       });


### PR DESCRIPTION
Backports testing updates originally from pr #7679 