### PR TITLE
Glimpse Bid Adapter: Capture publisher-supplied first party data

### DIFF
--- a/modules/glimpseBidAdapter.js
+++ b/modules/glimpseBidAdapter.js
@@ -40,28 +40,21 @@ export const spec = {
    * @returns {ServerRequest}
    */
   buildRequests: (validBidRequests, bidderRequest) => {
-    const demo = config.getConfig('glimpse.demo') || false
-    const account = config.getConfig('glimpse.account') || -1
-    const demand = config.getConfig('glimpse.demand') || 'glimpse'
-    const keywords = config.getConfig('glimpse.keywords') || {}
-
     const auth = getVaultJwt()
     const referer = getReferer(bidderRequest)
     const gdprConsent = getGdprConsentChoice(bidderRequest)
-    const bids = validBidRequests.map((bidRequest) => {
-      return processBidRequest(bidRequest, keywords)
-    })
+    const bidRequests = validBidRequests.map(processBidRequest)
+    const firstPartyData = getFirstPartyData()
 
     const data = {
       auth,
       data: {
-        bidderCode: spec.code,
-        demo,
-        account,
-        demand,
         referer,
         gdprConsent,
-        bids,
+        bidRequests,
+        site: firstPartyData.site,
+        user: firstPartyData.user,
+        bidderCode: spec.code,
       }
     }
 
@@ -91,35 +84,12 @@ export const spec = {
   },
 }
 
-function processBidRequest(bidRequest, globalKeywords) {
-  const sizes = normalizeSizes(bidRequest.sizes)
-  const bidKeywords = bidRequest.params.keywords || {}
-  const keywords = {
-    ...globalKeywords,
-    ...bidKeywords,
-  }
-
-  return {
-    unitCode: bidRequest.adUnitCode,
-    bidId: bidRequest.bidId,
-    placementId: bidRequest.params.placementId,
-    keywords,
-    sizes,
-  }
+function setVaultJwt(auth) {
+  storageManager.setDataInLocalStorage(LOCAL_STORAGE_KEY.vault.jwt, auth)
 }
 
-function normalizeSizes(sizes) {
-  const isSingleSize =
-    isArray(sizes) &&
-    sizes.length === 2 &&
-    !isArray(sizes[0]) &&
-    !isArray(sizes[1])
-
-  if (isSingleSize) {
-    return [sizes]
-  }
-
-  return sizes
+function getVaultJwt() {
+  return storageManager.getDataFromLocalStorage(LOCAL_STORAGE_KEY.vault.jwt) || ''
 }
 
 function getReferer(bidderRequest) {
@@ -158,12 +128,64 @@ function getGdprConsentChoice(bidderRequest) {
   }
 }
 
-function setVaultJwt(auth) {
-  storageManager.setDataInLocalStorage(LOCAL_STORAGE_KEY.vault.jwt, auth)
+function processBidRequest(bidRequest) {
+  const demand = bidRequest.params.demand || 'glimpse'
+  const sizes = normalizeSizes(bidRequest.sizes)
+  const keywords = bidRequest.params.keywords || {}
+
+  return {
+    demand,
+    sizes,
+    keywords,
+    bidId: bidRequest.bidId,
+    placementId: bidRequest.params.placementId,
+    unitCode: bidRequest.adUnitCode,
+  }
 }
 
-function getVaultJwt() {
-  return storageManager.getDataFromLocalStorage(LOCAL_STORAGE_KEY.vault.jwt) || ''
+function normalizeSizes(sizes) {
+  const isSingleSize =
+    isArray(sizes) &&
+    sizes.length === 2 &&
+    !isArray(sizes[0]) &&
+    !isArray(sizes[1])
+
+  if (isSingleSize) {
+    return [sizes]
+  }
+
+  return sizes
+}
+
+function getFirstPartyData() {
+  const siteKeywords = parseGlobalKeywords('site')
+  const userKeywords = parseGlobalKeywords('user')
+
+  const siteAttributes = getConfig('ortb2.site.ext.data', {})
+  const userAttributes = getConfig('ortb2.user.ext.data', {})
+
+  return {
+    site: {
+      keywords: siteKeywords,
+      attributes: siteAttributes,
+    },
+    user: {
+      keywords: userKeywords,
+      attributes: userAttributes,
+    },
+  }
+}
+
+function parseGlobalKeywords(scope) {
+  const keywords = getConfig(`ortb2.${scope}.keywords`, '')
+
+  return keywords
+    .split(', ')
+    .filter((keyword) => keyword !== '')
+}
+
+function getConfig(path, defaultValue) {
+  return config.getConfig(path) || defaultValue
 }
 
 function isValidBidResponse(bidResponse) {

--- a/test/spec/modules/glimpseBidAdapter_spec.js
+++ b/test/spec/modules/glimpseBidAdapter_spec.js
@@ -178,24 +178,6 @@ describe('GlimpseProtocolAdapter', () => {
     const bidRequests = [getBidRequest()]
     const bidderRequest = getBidderRequest()
 
-    it('Adds a demo flag', () => {
-      const request = spec.buildRequests(bidRequests, bidderRequest)
-      const payload = JSON.parse(request.data)
-      expect(payload.data.demo).to.be.false
-    })
-
-    it('Adds an account id', () => {
-      const request = spec.buildRequests(bidRequests, bidderRequest)
-      const payload = JSON.parse(request.data)
-      expect(payload.data.account).to.equal(-1)
-    })
-
-    it('Adds a demand provider', () => {
-      const request = spec.buildRequests(bidRequests, bidderRequest)
-      const payload = JSON.parse(request.data)
-      expect(payload.data.demand).to.equal('glimpse')
-    })
-
     it('Adds GDPR consent', () => {
       const request = spec.buildRequests(bidRequests, bidderRequest)
       const payload = JSON.parse(request.data)


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- Capture site and user level first party data
- Move bidder config params to unit-level to follow convention
- Remove account id (now captured within the placement id path)
- Remove demo flag (now enabled by setting demand source to 'demo')

## Other information

Discussion that led to these changes: https://github.com/prebid/prebid.github.io/pull/3397
