### PR TITLE
Livewrapped Analytics adapter: Pass runner-up bid from livewrapped wrapper

### DIFF
--- a/modules/livewrappedAnalyticsAdapter.js
+++ b/modules/livewrappedAnalyticsAdapter.js
@@ -114,6 +114,7 @@ let livewrappedAnalyticsAdapter = Object.assign(adapter({EMPTYURL, ANALYTICSTYPE
         let wonBid = cache.auctions[args.auctionId].bids[args.requestId];
         wonBid.won = true;
         wonBid.floorData = args.floorData;
+        wonBid.rUp = args.rUp;
         if (wonBid.sendStatus != 0) {
           livewrappedAnalyticsAdapter.sendEvents();
         }
@@ -288,7 +289,8 @@ function getWins(gdpr, auctionIds) {
           auctionId: auctionIdPos,
           auc: bid.auc,
           buc: bid.buc,
-          lw: bid.lw
+          lw: bid.lw,
+          rUp: bid.rUp
         });
       }
     });

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -552,6 +552,28 @@ describe('Livewrapped analytics adapter', function () {
       expect(message.wins[0].floor).to.equal(1.1);
       expect(message.wins[1].floor).to.equal(2.2);
     });
+
+    it('should forward runner-up data as given by Livewrapped wrapper', function () {
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BID_WON, Object.assign({},
+        MOCK.BID_WON[0],
+        {
+          'rUp': 'rUpObject'
+        }));
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+
+      clock.tick(BID_WON_TIMEOUT + 1000);
+
+      expect(server.requests.length).to.equal(1);
+      let request = server.requests[0];
+      let message = JSON.parse(request.requestBody);
+
+      expect(message.wins.length).to.equal(1);
+      expect(message.wins[0].rUp).to.equal('rUpObject');
+    });
   });
 
   describe('when given other endpoint', function () {


### PR DESCRIPTION
## Type of change
- [x ] Feature
## Description of change
Pass information about the runner-up bid to a winning bid.

Background: The runner-up bid is given by the Livewrapped wrapper and not from the analytics data as the Livewrapped wrapper can also insert information about bidders running through the Livewrapped adapter s2s that doesn't have an official Prebid integration for instance.
