### PR TITLE
Prebid Core: async submodule loading

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -13,14 +13,18 @@ export function setupBeforeHookFnOnce(baseFn, hookFn, priority = 15) {
     baseFn.before(hookFn, priority);
   }
 }
+const submoduleInstallMap = {};
 
 export function module(name, install) {
   hook('async', function (submodules) {
     submodules.forEach(args => install(...args));
+    submoduleInstallMap[name] = install;
   }, name)([]); // will be queued until hook.ready() called in pbjs.processQueue();
 }
 
 export function submodule(name, ...args) {
+  const install = submoduleInstallMap[name];
+  if (install) return install(...args);
   getHook(name).before((next, modules) => {
     modules.push(args);
     next(modules);

--- a/src/hook.js
+++ b/src/hook.js
@@ -15,10 +15,10 @@ export function setupBeforeHookFnOnce(baseFn, hookFn, priority = 15) {
 }
 const submoduleInstallMap = {};
 
-export function module(name, install) {
+export function module(name, install, {postInstallAllowed = false} = {}) {
   hook('async', function (submodules) {
     submodules.forEach(args => install(...args));
-    submoduleInstallMap[name] = install;
+    if (postInstallAllowed) submoduleInstallMap[name] = install;
   }, name)([]); // will be queued until hook.ready() called in pbjs.processQueue();
 }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
if submodule loaded asynchronously (after hook ready) it will never be installed in module. 

we store install method and call it immediately if it exist.