### PR TITLE
RTD Module: add getAdUnitTargeting to the auctionEnd event

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -203,6 +203,9 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.BID_REQUESTED]: 'onBidRequestEvent'
       }).forEach(([ev, handler]) => {
         events.on(ev, (args) => {
+          if(ev === 'auctionEnd') {
+            getAdUnitTargeting(args);
+          }
           subModules.forEach(sm => {
             try {
               sm[handler] && sm[handler](args, sm.config, _userConsent)


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Adding in the getAdUnitTargeting() call inside the setEventsListeners() method.

## Other information
I noticed this function call was removed in: https://github.com/prebid/Prebid.js/commit/59895632226ed89dc1b78b1e89f5b50f8cd3c61f#diff-6243b20988efe8c84d52352b6115dd25be399540b466384651a51a8eeb937b30L222

If this correct, is there another way setting targeting should be called now? 

If not, I am providing this patch in the event this function needs to be added back in here.