### PR TITLE
RTD module: set targeting on onAuctionEnd event

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -203,6 +203,9 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.BID_REQUESTED]: 'onBidRequestEvent'
       }).forEach(([ev, handler]) => {
         events.on(ev, (args) => {
+          if(ev === 'auctionEnd') {
+            getAdUnitTargeting(args);
+          }
           subModules.forEach(sm => {
             try {
               sm[handler] && sm[handler](args, sm.config, _userConsent)

--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -203,7 +203,7 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.BID_REQUESTED]: 'onBidRequestEvent'
       }).forEach(([ev, handler]) => {
         events.on(ev, (args) => {
-          if(ev === 'auctionEnd') {
+          if (ev === 'auctionEnd') {
             getAdUnitTargeting(args);
           }
           subModules.forEach(sm => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Re-introduce targeting logic for RTD onAuctionEnd event

Addresses https://github.com/prebid/Prebid.js/issues/7871
Fix from https://github.com/prebid/Prebid.js/pull/7872 , this just adds a unit test

