### PR TITLE
RTB House Bid Adapter: add channel as an optional param

### DIFF
--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -165,16 +165,26 @@ function mapBanner(slot) {
  * @returns {object} Site by OpenRTB 2.5 §3.2.13
  */
 function mapSite(slot, bidderRequest) {
-  const pubId = slot && slot.length > 0
-    ? slot[0].params.publisherId
-    : 'unknown';
-  return {
+  let pubId = 'unknown';
+  let channel = null;
+  if (slot && slot.length > 0) {
+    pubId = slot[0].params.publisherId;
+    channel = slot[0].params.channel &&
+    slot[0].params.channel
+      .toString()
+      .slice(0, 50);
+  }
+  let siteData = {
     publisher: {
       id: pubId.toString(),
     },
     page: bidderRequest.refererInfo.referer,
     name: getOrigin()
+  };
+  if (channel) {
+    siteData.channel = channel;
   }
+  return siteData;
 }
 
 /**

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -68,6 +68,7 @@ describe('RTBHouseAdapter', () => {
           'params': {
             'publisherId': 'PREBID_TEST',
             'region': 'prebid-eu',
+            'channel': 'Partner_Site - news',
             'test': 1
           },
           'adUnitCode': 'adunit-code',
@@ -100,6 +101,25 @@ describe('RTBHouseAdapter', () => {
       let builtTestRequest = spec.buildRequests(bidRequests, bidderRequest).data;
       expect(JSON.parse(builtTestRequest).test).to.equal(1);
     });
+
+    it('should build channel param into request.site', () => {
+      let builtTestRequest = spec.buildRequests(bidRequests, bidderRequest).data;
+      expect(JSON.parse(builtTestRequest).site.channel).to.equal('Partner_Site - news');
+    })
+
+    it('should not build channel param into request.site if no value is passed', () => {
+      let bidRequest = Object.assign([], bidRequests);
+      bidRequest[0].params.channel = undefined;
+      let builtTestRequest = spec.buildRequests(bidRequest, bidderRequest).data;
+      expect(JSON.parse(builtTestRequest).site.channel).to.be.undefined
+    })
+
+    it('should cap the request.site.channel length to 50', () => {
+      let bidRequest = Object.assign([], bidRequests);
+      bidRequest[0].params.channel = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent scelerisque ipsum eu purus lobortis iaculis.';
+      let builtTestRequest = spec.buildRequests(bidRequest, bidderRequest).data;
+      expect(JSON.parse(builtTestRequest).site.channel.length).to.equal(50)
+    })
 
     it('should build valid OpenRTB banner object', () => {
       const request = JSON.parse(spec.buildRequests(bidRequests, bidderRequest).data);


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change

- Includes support to optional param "channel", a string-only field limited to 50 characters.


## Contact

Please reach us at inventory_support@rtbhouse.com with leandro.otani@rtbhouse.com and filip.witkowski@rtbhouse.com on cc.
