### PR TITLE
NextMillennium Bid Adapter: refresh_count variable moved to into ext

### DIFF
--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -25,12 +25,14 @@ export const spec = {
       window.nmmRefreshCounts[bid.adUnitCode] = window.nmmRefreshCounts[bid.adUnitCode] || 0;
       const postBody = {
         'id': bid.auctionId,
-        'refresh_count': window.nmmRefreshCounts[bid.adUnitCode]++,
         'ext': {
           'prebid': {
             'storedrequest': {
               'id': getBidIdParameter('placement_id', bid.params)
             }
+          },
+          'nextMillennium':{
+            'refresh_count': window.nmmRefreshCounts[bid.adUnitCode]++,
           }
         }
       }

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -31,7 +31,7 @@ export const spec = {
               'id': getBidIdParameter('placement_id', bid.params)
             }
           },
-          'nextMillennium':{
+          'nextMillennium': {
             'refresh_count': window.nmmRefreshCounts[bid.adUnitCode]++,
           }
         }

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -40,7 +40,7 @@ describe('nextMillenniumBidAdapterTests', function() {
 
   it('Check if refresh_count param is incremented', function() {
     const request = spec.buildRequests(bidRequestData);
-    expect(JSON.parse(request[0].data).refresh_count).to.equal(3);
+    expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(3);
   });
 
   it('Test getUserSyncs function', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Updated post body - moved refresh_count into ext.nextMillennium instead of being a root variable in the body

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'nextMillennium',
  params: {
    placement_id: '7248'
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
