### PR TITLE
Tappx Bid Adapter: fix adtypes bug

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -176,10 +176,6 @@ function validMediaType(bid) {
       logWarn(LOG_PREFIX, 'Please review the mandatory Tappx parameters for Video. Video context not supported.');
       return false;
     }
-    if (typeof video.mimes == 'undefined') {
-      logWarn(LOG_PREFIX, 'Please review the mandatory Tappx parameters for Video. Mimes param is mandatory.');
-      return false;
-    }
   }
 
   return true;

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -53,12 +53,12 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
   */
   isBidRequestValid: function(bid) {
-    //bid.params.host
-    if ((new RegExp(`^(vz.*|zz.*)\\.*$`, 'i')).test(bid.params.host)) { //New endpoint
-      if((new RegExp(`^(zz.*)\\.*$`, 'i')).test(bid.params.host)) return validBasic(bid)
+    // bid.params.host
+    if ((new RegExp(`^(vz.*|zz.*)\\.*$`, 'i')).test(bid.params.host)) { // New endpoint
+      if ((new RegExp(`^(zz.*)\\.*$`, 'i')).test(bid.params.host)) return validBasic(bid)
       else return validBasic(bid) && validMediaType(bid)
-    } else { //This is backward compatible feature. It will be remove in the future
-      if((new RegExp(`^(ZZ.*)\\.*$`, 'i')).test(bid.params.endpoint)) return validBasic(bid)
+    } else { // This is backward compatible feature. It will be remove in the future
+      if ((new RegExp(`^(ZZ.*)\\.*$`, 'i')).test(bid.params.endpoint)) return validBasic(bid)
       else return validBasic(bid) && validMediaType(bid)
     }
   },

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -53,7 +53,14 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
   */
   isBidRequestValid: function(bid) {
-    return validBasic(bid) && validMediaType(bid)
+    //bid.params.host
+    if ((new RegExp(`^(vz.*|zz.*)\\.*$`, 'i')).test(bid.params.host)) { //New endpoint
+      if((new RegExp(`^(zz.*)\\.*$`, 'i')).test(bid.params.host)) return validBasic(bid)
+      else return validBasic(bid) && validMediaType(bid)
+    } else { //This is backward compatible feature. It will be remove in the future
+      if((new RegExp(`^(ZZ.*)\\.*$`, 'i')).test(bid.params.endpoint)) return validBasic(bid)
+      else return validBasic(bid) && validMediaType(bid)
+    }
   },
 
   /**

--- a/test/spec/modules/tappxBidAdapter_spec.js
+++ b/test/spec/modules/tappxBidAdapter_spec.js
@@ -159,15 +159,6 @@ describe('Tappx bid adapter', function () {
       assert.isTrue(spec.isBidRequestValid(badBidRequestNwEp.bids[0]));
     });
 
-    it('should return false mimes param is missing', function () {
-      let badBidRequest_mimes = c_BIDDERREQUEST_V;
-      delete badBidRequest_mimes.bids.mediaTypes.video;
-      badBidRequest_mimes.bids.mediaTypes.video = {};
-      badBidRequest_mimes.bids.mediaTypes.video.context = 'instream';
-      badBidRequest_mimes.bids.mediaTypes.video.playerSize = [320, 250];
-      assert.isFalse(spec.isBidRequestValid(badBidRequest_mimes.bids), badBidRequest_mimes);
-    });
-
     it('should return false for not instream/outstream requests', function () {
       let badBidRequest_v = c_BIDDERREQUEST_V;
       delete badBidRequest_v.bids.mediaTypes.banner;

--- a/test/spec/modules/tappxBidAdapter_spec.js
+++ b/test/spec/modules/tappxBidAdapter_spec.js
@@ -164,7 +164,6 @@ describe('Tappx bid adapter', function () {
       delete badBidRequest_v.bids.mediaTypes.banner;
       badBidRequest_v.bids.mediaTypes.video = {};
       badBidRequest_v.bids.mediaTypes.video.context = '';
-      badBidRequest_v.bids.mediaTypes.video.mimes = [ 'video/mp4', 'application/javascript' ];
       badBidRequest_v.bids.mediaTypes.video.playerSize = [320, 250];
       assert.isFalse(spec.isBidRequestValid(badBidRequest_v.bids));
     });
@@ -217,7 +216,6 @@ describe('Tappx bid adapter', function () {
       validBidRequests_V[0].mediaTypes.video = {};
       validBidRequests_V[0].mediaTypes.video.playerSize = [640, 480];
       validBidRequests_V[0].mediaTypes.video.context = 'instream';
-      validBidRequests_V[0].mediaTypes.video.mimes = [ 'video/mp4', 'application/javascript' ];
 
       bidderRequest_V.bids.mediaTypes.context = 'instream';
 
@@ -237,7 +235,6 @@ describe('Tappx bid adapter', function () {
       validBidRequests_Voutstream[0].mediaTypes.video = {};
       validBidRequests_Voutstream[0].mediaTypes.video.playerSize = [640, 480];
       validBidRequests_Voutstream[0].mediaTypes.video.context = 'outstream';
-      validBidRequests_Voutstream[0].mediaTypes.video.mimes = [ 'video/mp4', 'application/javascript' ];
 
       bidderRequest_VOutstream.bids.mediaTypes.context = 'outstream';
 
@@ -258,7 +255,6 @@ describe('Tappx bid adapter', function () {
       validBidRequests_Voutstream[0].mediaTypes.video.rewarded = 1;
       validBidRequests_Voutstream[0].mediaTypes.video.playerSize = [640, 480];
       validBidRequests_Voutstream[0].mediaTypes.video.context = 'outstream';
-      validBidRequests_Voutstream[0].mediaTypes.video.mimes = [ 'video/mp4', 'application/javascript' ];
 
       bidderRequest_VOutstream.bids.mediaTypes.context = 'outstream';
 

--- a/test/spec/modules/tappxBidAdapter_spec.js
+++ b/test/spec/modules/tappxBidAdapter_spec.js
@@ -134,12 +134,6 @@ describe('Tappx bid adapter', function () {
       assert.isTrue(spec.isBidRequestValid(c_BIDREQUEST.bids[0]), JSON.stringify(c_BIDREQUEST));
     });
 
-    it('should return false when params are missing', function () {
-      let badBidRequestParam = JSON.parse(JSON.stringify(c_BIDREQUEST));
-      delete badBidRequestParam.bids[0].params;
-      assert.isFalse(spec.isBidRequestValid(badBidRequestParam.bids[0]));
-    });
-
     it('should return false when tappxkey is missing', function () {
       let badBidRequestTpxkey = JSON.parse(JSON.stringify(c_BIDREQUEST)); ;
       delete badBidRequestTpxkey.bids[0].params.tappxkey;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
We found a bug. If our publisher was using a display endpoint, but had video options in the bidder we had a Warning that stop the request to our servers.
![20220104-180553-618](https://user-images.githubusercontent.com/77485538/148197174-bb35df6b-367f-4918-b064-79465e03411b.png)
We make our solutions in this pull request:
1. Create a condition that check video params only for video endpoints 
28e5801
2. Remove in our SSP and prebid adapter the Mime as mandatory param 
927f802
