### PR TITLE
Rubicon Analytics: Handle bad advertiserDomain scenarios

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -384,8 +384,9 @@ export function parseBidResponse(bid, previousBidResponse, auctionFloorData) {
     'floorRuleValue', () => deepAccess(bid, 'floorData.floorRuleValue'),
     'floorRule', () => debugTurnedOn() ? deepAccess(bid, 'floorData.floorRule') : undefined,
     'adomains', () => {
-      let adomains = deepAccess(bid, 'meta.advertiserDomains');
-      return Array.isArray(adomains) && adomains.length > 0 ? adomains.slice(0, 10) : undefined
+      const adomains = deepAccess(bid, 'meta.advertiserDomains');
+      const validAdomains = Array.isArray(adomains) && adomains.filter(domain => typeof domain === 'string');
+      return validAdomains && validAdomains.length > 0 ? validAdomains.slice(0, 10) : undefined
     }
   ]);
 }


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
We are seeing scenarios where bid adapters are setting invalid `meta.advertiserDomains`

This field should be an array of strings

We noticed at least one adapter sending it as an double array with one string in it like so:

![image](https://user-images.githubusercontent.com/13972794/148279832-05124439-20af-4e44-8e1c-cf65e9a71e43.png)

```
[['nytimes.com']]
```

This change simply filters out any elements in the `advertiserDomain` array that are not strings.