### PR TITLE
Kargo Bid Adapter: Fix issue with double-array for advertiserDomains

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -74,7 +74,7 @@ export const spec = {
       if (adUnit.metadata && adUnit.metadata.landingPageDomain) {
         meta = {
           clickUrl: adUnit.metadata.landingPageDomain,
-          advertiserDomains: [adUnit.metadata.landingPageDomain]
+          advertiserDomains: adUnit.metadata.landingPageDomain
         };
       }
       bidResponses.push({

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -73,7 +73,7 @@ export const spec = {
       let meta;
       if (adUnit.metadata && adUnit.metadata.landingPageDomain) {
         meta = {
-          clickUrl: adUnit.metadata.landingPageDomain,
+          clickUrl: adUnit.metadata.landingPageDomain[0],
           advertiserDomains: adUnit.metadata.landingPageDomain
         };
       }

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -484,7 +484,7 @@ describe('kargo adapter tests', function () {
           height: 250,
           targetingCustom: 'dmpmptest1234',
           metadata: {
-            landingPageDomain: 'https://foobar.com'
+            landingPageDomain: ['https://foobar.com']
           }
         },
         3: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This removes an extra array wrapped around advertiserDomains that was affecting the value from being read by Rubicon's analytics adapter (#7909)

- contact email of the adapter’s maintainer: jeremy@kargo.com

## Other information
Resolves #7909 as reported by @robertrmartinez 