### PR TITLE
IX Bid Adapter: prefer pageUrl to refererUrl

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -492,6 +492,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   // Get ids from Prebid User ID Modules
   let eidInfo = getEidInfo(deepAccess(validBidRequests, '0.userIdAsEids'), deepAccess(validBidRequests, '0.userId.flocId'));
   let userEids = eidInfo.toSend;
+  const pageUrl = getPageUrl() || deepAccess(bidderRequest, 'refererInfo.referer');
 
   // RTI ids will be included in the bid request if the function getIdentityInfo() is loaded
   // and if the data for the partner exist
@@ -590,8 +591,8 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
       deepSetValue(r, 'regs.ext.us_privacy', bidderRequest.uspConsent);
     }
 
-    if (bidderRequest.refererInfo) {
-      r.site.page = bidderRequest.refererInfo.referer;
+    if (pageUrl) {
+      r.site.page = pageUrl;
     }
   }
 
@@ -927,6 +928,20 @@ function createBannerImps(validBidRequest, missingBannerSizes, bannerImps) {
 
   if (ixConfig.hasOwnProperty('detectMissingSizes') && ixConfig.detectMissingSizes) {
     updateMissingSizes(validBidRequest, missingBannerSizes, imp);
+  }
+}
+
+/**
+ * Returns the `pageUrl` set by publisher on the page if it is an valid url
+ */
+function getPageUrl() {
+  const pageUrl = config.getConfig('pageUrl');
+  try {
+    const url = new URL(pageUrl);
+    return url.href;
+  } catch (_) {
+    logWarn(`IX Bid Adapter: invalid pageUrl config property value set: ${pageUrl}`);
+    return undefined;
   }
 }
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1490,6 +1490,14 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.imp).to.have.lengthOf(1);
     });
 
+    it('payload should set site.page to pageUrl when it exists in config object', function () {
+      const url = 'https://example.com/index.html';
+      config.setConfig({ pageUrl: url });
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0].data;
+      const payload = JSON.parse(request.r);
+      expect(payload.site.page).to.contains(url);
+    });
+
     it('payload should have correct format and value for r.id when bidderRequestId is a number ', function () {
       const bidWithIntId = utils.deepClone(DEFAULT_BANNER_VALID_BID);
       bidWithIntId[0].bidderRequestId = 123456;
@@ -1699,6 +1707,10 @@ describe('IndexexchangeAdapter', function () {
     });
 
     describe('first party data', () => {
+      beforeEach(() => {
+        config.resetConfig();
+      });
+
       it('should add first party data to page url in bid request if it exists in config', function () {
         config.setConfig({
           ix: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Prioritizes pageUrl set via setConfig() over default document referrer
