### PR TITLE
Gumgum Bid Adapter: support multiple GG params

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -17,32 +17,48 @@ const TIME_TO_LIVE = 60
 const DELAY_REQUEST_TIME = 1800000; // setting to 30 mins
 
 let invalidRequestIds = {};
-let browserParams = {};
 let pageViewId = null;
 
 // TODO: potential 0 values for browserParams sent to ad server
 function _getBrowserParams(topWindowUrl) {
-  let topWindow
-  let topScreen
-  let topUrl
-  let ggad
-  let ns
-  function getNetworkSpeed() {
-    const connection = window.navigator && (window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection)
-    const Mbps = connection && (connection.downlink || connection.bandwidth)
-    return Mbps ? Math.round(Mbps * 1024) : null
+  const paramRegex = paramName => new RegExp(`[?#&](${paramName}=(.*?))($|&)`, 'i');
+
+  let browserParams = {};
+  let topWindow;
+  let topScreen;
+  let topUrl;
+  let ggad;
+  let ggdeal;
+  let ns;
+
+  function getNetworkSpeed () {
+    const connection = window.navigator && (window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection);
+    const Mbps = connection && (connection.downlink || connection.bandwidth);
+    return Mbps ? Math.round(Mbps * 1024) : null;
   }
-  function getOgURL() {
-    let ogURL = ''
-    const ogURLSelector = "meta[property='og:url']"
-    const head = document && document.getElementsByTagName('head')[0]
-    const ogURLElement = head.querySelector(ogURLSelector)
-    ogURL = ogURLElement ? ogURLElement.content : null
-    return ogURL
+
+  function getOgURL () {
+    let ogURL = '';
+    const ogURLSelector = "meta[property='og:url']";
+    const head = document && document.getElementsByTagName('head')[0];
+    const ogURLElement = head.querySelector(ogURLSelector);
+    ogURL = ogURLElement ? ogURLElement.content : null;
+    return ogURL;
   }
-  if (browserParams.vw) {
-    // we've already initialized browserParams, just return it.
-    return browserParams
+
+  function stripGGParams (url) {
+    const params = [
+      'ggad',
+      'ggdeal'
+    ];
+
+    return params.reduce((result, param) => {
+      const matches = url.match(paramRegex(param));
+      if (!matches) return result;
+      matches[1] && (result = result.replace(matches[1], ''));
+      matches[3] && (result = result.replace(matches[3], ''));
+      return result;
+    }, url);
   }
 
   try {
@@ -51,7 +67,7 @@ function _getBrowserParams(topWindowUrl) {
     topUrl = topWindowUrl || '';
   } catch (error) {
     logError(error);
-    return browserParams
+    return browserParams;
   }
 
   browserParams = {
@@ -59,23 +75,25 @@ function _getBrowserParams(topWindowUrl) {
     vh: topWindow.innerHeight,
     sw: topScreen.width,
     sh: topScreen.height,
-    pu: topUrl,
+    pu: stripGGParams(topUrl),
     ce: storage.cookiesAreEnabled(),
     dpr: topWindow.devicePixelRatio || 1,
     jcsi: JSON.stringify(JCSI),
     ogu: getOgURL()
-  }
+  };
 
-  ns = getNetworkSpeed()
+  ns = getNetworkSpeed();
   if (ns) {
-    browserParams.ns = ns
+    browserParams.ns = ns;
   }
 
-  ggad = (topUrl.match(/#ggad=(\w+)$/) || [0, 0])[1]
-  if (ggad) {
-    browserParams[isNaN(ggad) ? 'eAdBuyId' : 'adBuyId'] = ggad
-  }
-  return browserParams
+  ggad = (topUrl.match(paramRegex('ggad')) || [0, 0, 0])[2];
+  if (ggad) browserParams[isNaN(ggad) ? 'eAdBuyId' : 'adBuyId'] = ggad;
+
+  ggdeal = (topUrl.match(paramRegex('ggdeal')) || [0, 0, 0])[2];
+  if (ggdeal) browserParams.ggdeal = ggdeal;
+
+  return browserParams;
 }
 
 function getWrapperCode(wrapper, data) {
@@ -291,9 +309,9 @@ function buildRequests(validBidRequests, bidderRequest) {
     } = bidRequest;
     const { currency, floor } = _getFloor(mediaTypes, params.bidfloor, bidRequest);
     const eids = getEids(userId);
+    const gpid = deepAccess(ortb2Imp, 'ext.data.pbadslot') || deepAccess(ortb2Imp, 'ext.data.adserver.adslot');
     let sizes = [1, 1];
     let data = {};
-    let gpid = '';
 
     const date = new Date();
     const lt = date.getTime();
@@ -309,12 +327,8 @@ function buildRequests(validBidRequests, bidderRequest) {
     // ADTS-134 Retrieve ID envelopes
     for (const eid in eids) data[eid] = eids[eid];
 
-    // ADJS-1024 & ADSS-1297
-    if (deepAccess(ortb2Imp, 'ext.data.pbadslot')) {
-      gpid = deepAccess(ortb2Imp, 'ext.data.pbadslot')
-    } else if (deepAccess(ortb2Imp, 'ext.data.adserver.name')) {
-      gpid = ortb2Imp.ext.data.adserver.adslot
-    }
+    // ADJS-1024 & ADSS-1297 & ADTS-175
+    gpid && (data.gpid = gpid);
 
     if (mediaTypes.banner) {
       sizes = mediaTypes.banner.sizes;
@@ -384,7 +398,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       sizes,
       url: BID_ENDPOINT,
       method: 'GET',
-      data: Object.assign(data, _getBrowserParams(topWindowUrl), _getDigiTrustQueryParams(userId), { gpid })
+      data: Object.assign(data, _getBrowserParams(topWindowUrl), _getDigiTrustQueryParams(userId))
     })
   });
   return bids;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -544,6 +544,52 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       expect(!!bidRequest.data.lt).to.be.true;
     });
+
+    it('should handle no gg params', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&param2=bar&param3=baz' } })[0];
+
+      // no params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+    });
+
+    it('should handle encrypted ad buy id', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&ggad=bar&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+    });
+
+    it('should handle unencrypted ad buy id', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&ggad=123&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+    });
+
+    it('should handle multiple gg params', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?ggdeal=foo&ggad=bar&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.true;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+      expect(bidRequest.data.pu.includes('ggdeal')).to.be.false;
+    });
   })
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Modified how we detect GG params in the top window's URL in order to allow passing additional params (currently supporting ggad and ggdeal).

Also, did some structure and syntax cleanup.