### PR TITLE
Prebid Core: creative comment injection spot reverted

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -404,9 +404,22 @@ function emitAdRenderSucceeded({ doc, bid, id }) {
 }
 
 /**
+ * This function will check for presence of given node in given parent. If not present - will inject it.
+ * @param {Node} node node, whose existance is in question
+ * @param {Document} doc document element do look in
+ * @param {string} tagName tag name to look in
+ */
+function reinjectNodeIfRemoved(node, doc, tagName) {
+  const injectionNode = doc.querySelector(tagName);
+  if (!node.parentNode || node.parentNode !== injectionNode) {
+    insertElement(node, doc, tagName);
+  }
+}
+
+/**
  * This function will render the ad (based on params) in the given iframe document passed through.
  * Note that doc SHOULD NOT be the parent document page as we can't doc.write() asynchronously
- * @param  {HTMLDocument} doc document
+ * @param  {Document} doc document
  * @param  {string} id bid id to locate the ad
  * @alias module:pbjs.renderAd
  */
@@ -450,10 +463,13 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
           const {height, width, ad, mediaType, adUrl, renderer} = bid;
 
           const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
+          // It is important that the comment with metadata is injected before the ad is actually rendered,
+          // so the creativeId can be used by e.g. ad quality scanners to check against blocking rules
+          insertElement(creativeComment, doc, 'html');
 
           if (isRendererRequired(renderer)) {
             executeRenderer(renderer, bid);
-            insertElement(creativeComment, doc, 'html');
+            reinjectNodeIfRemoved(creativeComment, doc, 'html');
             emitAdRenderSucceeded({ doc, bid, id });
           } else if ((doc === document && !inIframe()) || mediaType === 'video') {
             const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
@@ -472,7 +488,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
             doc.write(ad);
             doc.close();
             setRenderSize(doc, width, height);
-            insertElement(creativeComment, doc, 'html');
+            reinjectNodeIfRemoved(creativeComment, doc, 'html');
             callBurl(bid);
             emitAdRenderSucceeded({ doc, bid, id });
           } else if (adUrl) {
@@ -485,7 +501,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
 
             insertElement(iframe, doc, 'body');
             setRenderSize(doc, width, height);
-            insertElement(creativeComment, doc, 'html');
+            reinjectNodeIfRemoved(creativeComment, doc, 'html');
             callBurl(bid);
             emitAdRenderSucceeded({ doc, bid, id });
           } else {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1135,13 +1135,15 @@ describe('Unit: Prebid Module', function () {
             height: 0
           }
         },
-        getElementsByTagName: sinon.stub()
+        getElementsByTagName: sinon.stub(),
+        querySelector: sinon.stub()
       };
 
       elStub = {
         insertBefore: sinon.stub()
       };
       doc.getElementsByTagName.returns([elStub]);
+      doc.querySelector.returns(elStub);
 
       spyLogError = sinon.spy(utils, 'logError');
       spyLogMessage = sinon.spy(utils, 'logMessage');


### PR DESCRIPTION
This PR is mirroring the changes in #7874 to the v5.x release, which a lot of our clients still use.
So, the original PR's comments below:

- reverted injection point of creative comment to pre-PR #6860
- added code to reinject comment in case it was removed upon rendering

## Type of change
- [x] Bugfix

## Description of change
This is an adjustment to the code previously pushed (#6860) to address the issue of disappearing bid detail comments in the document. We (Confiant) as a provider of ad quality and security need to have access to the bid detail comment before rendering starts, to match it against our data. The previous push broke our logic. We would like to put the injection of the comment back to the pre-rendering stage and only re-inject it again if it was in fact removed by the adaptor rendering as noticed by the previous developer (@jsut).