### PR TITLE
Adagio Bid Adapter: remove referrer. reachedTop validation

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -268,8 +268,6 @@ function getSite(bidderRequest) {
   } else if (refererInfo.stack && refererInfo.stack.length && refererInfo.stack[0]) {
     // important note check if refererInfo.stack[0] is 'thruly' because a `null` value
     // will be considered as "localhost" by the parseUrl function.
-    // As the isBidRequestValid returns false when it does not reach the referer
-    // this should never called.
     const url = parseUrl(refererInfo.stack[0]);
     domain = url.hostname;
   }
@@ -872,12 +870,6 @@ export const spec = {
     bid.params = bid.params || {};
 
     autoFillParams(bid);
-
-    if (!internal.getRefererInfo().reachedTop) {
-      logWarn(`${LOG_PREFIX} the main page url is unreachabled.`);
-      // internal.enqueue(debugData());
-      return false;
-    }
 
     if (!(bid.params.organizationId && bid.params.site && bid.params.placement)) {
       logWarn(`${LOG_PREFIX} at least one required param is missing.`);

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -18,7 +18,7 @@ Below, the list of Adagio params and where they can be set.
 | ---------- | ------------- | ------------- |
 | siteId | x |
 | organizationId (obsolete) | | x
-| site (obsolete) | | x
+| site (obsolete) | | x
 | pagetype | x | x
 | environment | x | x
 | category | x | x

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -244,16 +244,6 @@ describe('Adagio bid adapter', () => {
       expect(spec.isBidRequestValid(bid03)).to.equal(false);
       expect(spec.isBidRequestValid(bid04)).to.equal(false);
     });
-
-    it('should return false when refererInfo.reachedTop is false', function() {
-      sandbox.spy(utils, 'logWarn');
-      sandbox.stub(adagio, 'getRefererInfo').returns({ reachedTop: false });
-      const bid = new BidRequestBuilder().withParams().build();
-
-      expect(spec.isBidRequestValid(bid)).to.equal(false);
-      sinon.assert.callCount(utils.logWarn, 1);
-      sinon.assert.calledWith(utils.logWarn, 'Adagio: the main page url is unreachabled.');
-    });
   });
 
   describe('buildRequests()', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
We do not want to invalidate bid request depending on `referrer.reachTop` value.


- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission
