### PR TITLE
Criteo Bid Adapteer: add schain support

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -281,6 +281,7 @@ function checkNativeSendId(bidRequest) {
  */
 function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
+  let schain;
   const request = {
     publisher: {
       url: context.url,
@@ -288,6 +289,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
     },
     slots: bidRequests.map(bidRequest => {
       networkId = bidRequest.params.networkId || networkId;
+      schain = bidRequest.schain || schain;
       const slot = {
         impid: bidRequest.adUnitCode,
         transactionid: bidRequest.transactionId,
@@ -344,6 +346,13 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   if (networkId) {
     request.publisher.networkid = networkId;
   }
+  if (schain) {
+    request.source = {
+      ext: {
+        schain: schain
+      }
+    }
+  };
   request.user = {
     ext: bidderRequest.userExt
   };

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -663,6 +663,27 @@ describe('The Criteo bidding adapter', function () {
       expect(request.data.user.uspIab).to.equal('1YNY');
     });
 
+    it('should properly build a request with schain object', function () {
+      const expectedSchain = {
+        someProperty: 'someValue'
+      };
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          schain: expectedSchain,
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          sizes: [[728, 90]],
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.source.ext.schain).to.equal(expectedSchain);
+    });
+
     it('should properly build a request with if ccpa consent field is not provided', function () {
       const bidRequests = [
         {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Added schain support to Criteo adapter.

Doc update : https://github.com/prebid/prebid.github.io/pull/3511