### PR TITLE
appnexus bid adapter - add support for auction level keywords

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -201,6 +201,17 @@ export const spec = {
       payload.app = appIdObj;
     }
 
+    let auctionKeywords = config.getConfig('appnexusAuctionKeywords');
+    if (isPlainObject(auctionKeywords)) {
+      let aucKeywords = transformBidderParamKeywords(auctionKeywords);
+
+      if (aucKeywords.length > 0) {
+        aucKeywords.forEach(deleteValues);
+      }
+
+      payload.keywords = aucKeywords;
+    }
+
     if (config.getConfig('adpod.brandCategoryExclusion')) {
       payload.brand_category_uniqueness = true;
     }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -556,6 +556,33 @@ describe('AppNexusAdapter', function () {
       config.getConfig.restore();
     });
 
+    it('adds auction level keywords to request when set', function() {
+      let bidRequest = Object.assign({}, bidRequests[0]);
+      sinon
+        .stub(config, 'getConfig')
+        .withArgs('appnexusAuctionKeywords')
+        .returns({
+          gender: 'm',
+          music: ['rock', 'pop'],
+          test: ''
+        });
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.keywords).to.deep.equal([{
+        'key': 'gender',
+        'value': ['m']
+      }, {
+        'key': 'music',
+        'value': ['rock', 'pop']
+      }, {
+        'key': 'test'
+      }]);
+
+      config.getConfig.restore();
+    });
+
     it('should attach native params to the request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
This PR adds ability for a publisher to define auction level keywords for the appnexus bid adapter.  This is a separate from the bid.params.keywords and they can work together.  The auction level keywords would apply to all adslots/tags for a request, whereas the bid params keywords apply to that particular slot.

Docs PR [here](https://github.com/prebid/prebid.github.io/pull/3523)