### PR TITLE
Prebid core: accept MessageChannel communication from cross-origin creatives

### DIFF
--- a/integrationExamples/gpt/x-domain/creative.html
+++ b/integrationExamples/gpt/x-domain/creative.html
@@ -8,6 +8,13 @@ urlParser.href = '%%PATTERN:url%%';
 const publisherDomain = urlParser.protocol + '//' + urlParser.hostname;
 const adId = '%%PATTERN:hb_adid%%';
 
+function receiveMessage(ev) {
+  const origin = ev.origin || ev.originalEvent.origin;
+  if (origin === publisherDomain) {
+      renderAd(ev);
+  }
+}
+
 function renderAd(ev) {
   const key = ev.message ? 'message' : 'data';
   let adObject = {};
@@ -17,9 +24,7 @@ function renderAd(ev) {
     return;
   }
 
-  const origin = ev.origin || ev.originalEvent.origin;
   if (adObject.message && adObject.message === 'Prebid Response' &&
-    publisherDomain === origin &&
     adObject.adId === adId) {
     try {
       const body = window.document.body;
@@ -75,22 +80,24 @@ function renderAd(ev) {
     if (!success) {
       payload.info = {reason, message};
     }
-    ev.source.postMessage(JSON.stringify(payload), publisherDomain);
+    window.parent.postMessage(JSON.stringify(payload), publisherDomain);
   }
 
 }
 
 
 function requestAdFromPrebid() {
-  var message = JSON.stringify({
+  const message = JSON.stringify({
     message: 'Prebid Request',
     adId
   });
-  window.parent.postMessage(message, publisherDomain);
+  const channel = new MessageChannel();
+  channel.port1.onmessage = renderAd;
+  window.parent.postMessage(message, publisherDomain, [channel.port2]);
 }
 
 function listenAdFromPrebid() {
-  window.addEventListener('message', renderAd, false);
+  window.addEventListener('message', receiveMessage, false);
 }
 
 listenAdFromPrebid();

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -27,6 +27,24 @@ export function listenMessagesFromCreative() {
   window.addEventListener('message', receiveMessage, false);
 }
 
+export function getReplier(ev) {
+  if (ev.origin == null && ev.ports.length === 0) {
+    return function () {
+      const msg = 'Cannot post message to a frame with null origin. Please update creatives to use MessageChannel, see https://github.com/prebid/Prebid.js/issues/7870'
+      logError(msg)
+      throw new Error(msg);
+    }
+  } else if (ev.ports.length > 0) {
+    return function (message) {
+      ev.ports[0].postMessage(JSON.stringify(message));
+    }
+  } else {
+    return function (message) {
+      ev.source.postMessage(JSON.stringify(message), ev.origin);
+    }
+  }
+}
+
 export function receiveMessage(ev) {
   var key = ev.message ? 'message' : 'data';
   var data = {};
@@ -41,12 +59,12 @@ export function receiveMessage(ev) {
       return bid.adId === data.adId;
     });
     if (HANDLER_MAP.hasOwnProperty(data.message)) {
-      HANDLER_MAP[data.message](ev, data, adObject);
+      HANDLER_MAP[data.message](getReplier(ev), data, adObject);
     }
   }
 }
 
-function handleRenderRequest(ev, data, adObject) {
+function handleRenderRequest(reply, data, adObject) {
   if (adObject == null) {
     emitAdRenderFail({
       reason: constants.AD_RENDER_FAILED_REASON.CANNOT_FIND_AD,
@@ -64,7 +82,7 @@ function handleRenderRequest(ev, data, adObject) {
   }
 
   try {
-    _sendAdToCreative(adObject, ev);
+    _sendAdToCreative(adObject, reply);
   } catch (e) {
     emitAdRenderFail({
       reason: constants.AD_RENDER_FAILED_REASON.EXCEPTION,
@@ -81,7 +99,7 @@ function handleRenderRequest(ev, data, adObject) {
   events.emit(BID_WON, adObject);
 }
 
-function handleNativeRequest(ev, data, adObject) {
+function handleNativeRequest(reply, data, adObject) {
   // handle this script from native template in an ad server
   // window.parent.postMessage(JSON.stringify({
   //   message: 'Prebid Native',
@@ -111,13 +129,9 @@ function handleNativeRequest(ev, data, adObject) {
       auctionManager.addWinningBid(adObject);
       events.emit(BID_WON, adObject);
   }
-
-  function reply(message) {
-    ev.source.postMessage(JSON.stringify(message), ev.origin);
-  }
 }
 
-function handleEventRequest(ev, data, adObject) {
+function handleEventRequest(reply, data, adObject) {
   if (adObject == null) {
     logError(`Cannot find ad '${data.adId}' for x-origin event request`);
     return;
@@ -147,21 +161,21 @@ function handleEventRequest(ev, data, adObject) {
   }
 }
 
-export function _sendAdToCreative(adObject, ev) {
+export function _sendAdToCreative(adObject, reply) {
   const { adId, ad, adUrl, width, height, renderer, cpm } = adObject;
   // rendering for outstream safeframe
   if (isRendererRequired(renderer)) {
     executeRenderer(renderer, adObject);
   } else if (adId) {
     resizeRemoteCreative(adObject);
-    ev.source.postMessage(JSON.stringify({
+    reply({
       message: 'Prebid Response',
       ad: replaceAuctionPrice(ad, cpm),
       adUrl: replaceAuctionPrice(adUrl, cpm),
       adId,
       width,
       height
-    }), ev.origin);
+    });
   }
 }
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1006,12 +1006,7 @@ describe('Unit: Prebid Module', function () {
         adUnitCode: config.adUnitCodes[0],
       };
 
-      const event = {
-        source: { postMessage: sinon.stub() },
-        origin: 'origin.sf.com'
-      };
-
-      _sendAdToCreative(mockAdObject, event);
+      _sendAdToCreative(mockAdObject, sinon.stub());
 
       expect(slots[0].spyGetSlotElementId.called).to.equal(false);
       expect(slots[1].spyGetSlotElementId.called).to.equal(true);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
﻿Accept MessageChannel ports from cross-origin creatives to allow communication with frames behind opaque origins

Addresses https://github.com/prebid/Prebid.js/issues/7870

## Notes

PUC changes pending

Test pages:

PBJS and creative both support MessageChannel: https://s3.us-east-1.amazonaws.com/files.prebid.org/test/dgirardi/x-domain/3/custom_safeframe_messagechannel.html
PBJS supports MessageChannel, creative does not: https://s3.us-east-1.amazonaws.com/files.prebid.org/test/dgirardi/x-domain/3/custom_safeframe_messagechannel_old_creative.html
PBJS does not support MessageChannel, creative does: https://s3.us-east-1.amazonaws.com/files.prebid.org/test/dgirardi/x-domain/2/custom_safeframe_messagechannel.html
