### PR TITLE
Richaudience Bid Adapter: uncaught error on non-gdpr locations

### DIFF
--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -59,9 +59,10 @@ export const spec = {
       REFERER = (typeof bidderRequest.refererInfo.referer != 'undefined' ? encodeURIComponent(bidderRequest.refererInfo.referer) : null)
 
       payload.gdpr_consent = '';
-      payload.gdpr = bidderRequest.gdprConsent.gdprApplies;
+      payload.gdpr = 0;
 
       if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.gdpr = bidderRequest.gdprConsent.gdprApplies
         payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
       }
 


### PR DESCRIPTION
## Type of change
- [ ] Bugfix

## Description of change
Richaudience causes errors on non-gdpr locations: 
```Cannot read properties of undefined (reading 'gdprApplies')```
because bidderRequest.gdprConsent is undefined
