### PR TITLE
VidoomyAdapter: add schain and bidfloor to vidoomy adapter

### DIFF
--- a/modules/vidoomyBidAdapter.js
+++ b/modules/vidoomyBidAdapter.js
@@ -77,6 +77,7 @@ const buildRequests = (validBidRequests, bidderRequest) => {
     const hostname = aElement.hostname
 
     const videoContext = deepAccess(bid, 'mediaTypes.video.context');
+    const bidfloor = deepAccess(bid, `params.bidfloor`, 0);
 
     const queryParams = {
       id: bid.params.id,
@@ -90,6 +91,8 @@ const buildRequests = (validBidRequests, bidderRequest) => {
       dt: /Mobi/.test(navigator.userAgent) ? 2 : 1,
       pid: bid.params.pid,
       requestId: bid.bidId,
+      schain: bid.schain || '',
+      bidfloor,
       d: getDomainWithoutSubdomain(hostname), // 'vidoomy.com',
       sp: encodeURIComponent(aElement.href),
       usp: bidderRequest.uspConsent || '',

--- a/modules/vidoomyBidAdapter.js
+++ b/modules/vidoomyBidAdapter.js
@@ -42,6 +42,11 @@ const isBidRequestValid = bid => {
     return false;
   }
 
+  if (bid.params.bidfloor && (isNaN(bid.params.bidfloor) || bid.params.bidfloor < 0)) {
+    logError(BIDDER_CODE + ': bid.params.bidfloor should be a number equal or greater than zero');
+    return false;
+  }
+
   return true;
 };
 

--- a/modules/vidoomyBidAdapter.md
+++ b/modules/vidoomyBidAdapter.md
@@ -26,7 +26,8 @@ var adUnits = [
         bidder: 'vidoomy',
         params: {
           id: '123123',
-          pid: '123123'
+          pid: '123123',
+          bidfloor: 0.5
         }
       }
     ]
@@ -50,7 +51,8 @@ var adUnits = [
         bidder: 'vidoomy',
         params: {
           id: '123123',
-          pid: '123123'
+          pid: '123123',
+          bidfloor: 0.5
         }
       }
     ]

--- a/modules/vidoomyBidAdapter.md
+++ b/modules/vidoomyBidAdapter.md
@@ -27,7 +27,7 @@ var adUnits = [
         params: {
           id: '123123',
           pid: '123123',
-          bidfloor: 0.5
+          bidfloor: 0.5 // This is optional
         }
       }
     ]
@@ -52,7 +52,7 @@ var adUnits = [
         params: {
           id: '123123',
           pid: '123123',
-          bidfloor: 0.5
+          bidfloor: 0.5 // This is optional
         }
       }
     ]

--- a/test/spec/modules/vidoomyBidAdapter_spec.js
+++ b/test/spec/modules/vidoomyBidAdapter_spec.js
@@ -16,7 +16,8 @@ describe('vidoomyBidAdapter', function() {
         'bidder': 'vidoomy',
         'params': {
           pid: '123123',
-          id: '123123'
+          id: '123123',
+          bidfloor: 0.5
         },
         'adUnitCode': 'code',
         'sizes': [[300, 250]]
@@ -29,6 +30,11 @@ describe('vidoomyBidAdapter', function() {
 
     it('should return false when pid is empty', function () {
       bid.params.pid = '';
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when bidfloor is invalid', function () {
+      bid.params.bidfloor = 'not a number';
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adds support for `schain` in Vidoomy adapter.
Adds bidfloor parameter to params.