### PR TITLE
Conversant Bid Adapter: support for first party data through ortb2

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -2,6 +2,7 @@ import { logWarn, isStr, deepAccess, isArray, getBidIdParameter, deepSetValue, i
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {getStorageManager} from '../src/storageManager.js';
+import { config } from '../src/config.js';
 
 const GVLID = 24;
 export const storage = getStorageManager(GVLID);
@@ -76,6 +77,9 @@ export const spec = {
         displaymanager: 'Prebid.js',
         displaymanagerver: '$prebid.version$'
       };
+      if (bid.ortb2Imp) {
+        mergeDeep(imp, bid.ortb2Imp);
+      }
 
       copyOptProperty(bid.params.tag_id, imp, 'tagid');
 
@@ -166,6 +170,9 @@ export const spec = {
     if (!isEmpty(userExt)) {
       payload.user = {ext: userExt};
     }
+
+    const firstPartyData = config.getConfig('ortb2') || {};
+    mergeDeep(payload, firstPartyData);
 
     return {
       method: 'POST',

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {spec, storage} from 'modules/conversantBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {createEidsArray} from 'modules/userId/eids.js';
+import { config } from '../../../src/config.js';
 
 describe('Conversant adapter tests', function() {
   const siteId = '108060';
@@ -119,7 +120,34 @@ describe('Conversant adapter tests', function() {
       bidId: 'bid005',
       bidderRequestId: '117d765b87bed38',
       auctionId: 'req000'
-    }];
+    },
+    // video with first party data
+    {
+      bidder: 'conversant',
+      params: {
+        site_id: siteId
+      },
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          mimes: ['video/mp4', 'video/x-flv']
+        }
+      },
+      ortb2Imp: {
+        instl: 1,
+        ext: {
+          data: {
+            pbadslot: 'homepage-top-rect'
+          }
+        }
+      },
+      placementCode: 'pcode006',
+      transactionId: 'tx006',
+      bidId: 'bid006',
+      bidderRequestId: '117d765b87bed38',
+      auctionId: 'req000'
+    }
+  ];
 
   const bidResponses = {
     body: {
@@ -216,7 +244,7 @@ describe('Conversant adapter tests', function() {
     expect(payload).to.have.property('id', 'req000');
     expect(payload).to.have.property('at', 1);
     expect(payload).to.have.property('imp');
-    expect(payload.imp).to.be.an('array').with.lengthOf(6);
+    expect(payload.imp).to.be.an('array').with.lengthOf(7);
 
     expect(payload.imp[0]).to.have.property('id', 'bid000');
     expect(payload.imp[0]).to.have.property('secure', 1);
@@ -306,6 +334,16 @@ describe('Conversant adapter tests', function() {
     expect(payload.imp[5].video).to.not.have.property('maxduration');
     expect(payload.imp[5]).to.not.have.property('banner');
 
+    expect(payload.imp[6]).to.have.property('id', 'bid006');
+    expect(payload.imp[6]).to.have.property('video');
+    expect(payload.imp[6].video).to.have.property('mimes');
+    expect(payload.imp[6].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+    expect(payload.imp[6]).to.not.have.property('banner');
+    expect(payload.imp[6]).to.have.property('instl');
+    expect(payload.imp[6]).to.have.property('ext');
+    expect(payload.imp[6].ext).to.have.property('data');
+    expect(payload.imp[6].ext.data).to.have.property('pbadslot');
+
     expect(payload).to.have.property('site');
     expect(payload.site).to.have.property('id', siteId);
     expect(payload.site).to.have.property('mobile').that.is.oneOf([0, 1]);
@@ -319,6 +357,20 @@ describe('Conversant adapter tests', function() {
     expect(payload.device).to.have.property('ua', navigator.userAgent);
 
     expect(payload).to.not.have.property('user'); // there should be no user by default
+  });
+
+  it('Verify first party data', () => {
+    const bidderRequest = {refererInfo: {referer: 'http://test.com?a=b&c=123'}};
+    const cfg = {ortb2: {site: {content: {series: 'MySeries', season: 'MySeason', episode: 3, title: 'MyTitle'}}}};
+    config.setConfig(cfg);
+    const request = spec.buildRequests(bidRequests, bidderRequest);
+    const payload = request.data;
+    expect(payload.site).to.have.property('content');
+    expect(payload.site.content).to.have.property('series');
+    expect(payload.site.content).to.have.property('season');
+    expect(payload.site.content).to.have.property('episode');
+    expect(payload.site.content).to.have.property('title');
+    config.resetConfig();
   });
 
   it('Verify override url', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature


## Description of change
Update the Conversant adapter to support first party data with the ortb2 and ortb2Imp configuration options


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
