### PR TITLE
Prebid Core: add filename to pbjsGlobals module append

### DIFF
--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -39,7 +39,7 @@ module.exports = function(api, options) {
         const modName = getModuleName(state.filename);
         if (modName != null) {
           // append "registration" of module file to $$PREBID_GLOBAL$$.installedModules
-          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`, {filename: modName}).program.body);
+          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`, {filename: state.filename}).program.body);
         }
       },
       StringLiteral(path) {

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -39,7 +39,7 @@ module.exports = function(api, options) {
         const modName = getModuleName(state.filename);
         if (modName != null) {
           // append "registration" of module file to $$PREBID_GLOBAL$$.installedModules
-          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`).program.body);
+          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`,{filename:modName}).program.body);
         }
       },
       StringLiteral(path) {

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -39,7 +39,7 @@ module.exports = function(api, options) {
         const modName = getModuleName(state.filename);
         if (modName != null) {
           // append "registration" of module file to $$PREBID_GLOBAL$$.installedModules
-          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`,{filename:modName}).program.body);
+          path.node.body.push(...api.parse(`window.${pbGlobal}.installedModules.push('${modName}');`, {filename: modName}).program.body);
         }
       },
       StringLiteral(path) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

There is a conflict while building modules if `@babel/preset-typescript` is configured through a root `babel.config.js` file. From my understanding of babel configs, adding `configFile: false` to the module rule configuration should be able to resolve, but it doesn't.

The solution I encountered was adding the `filename` property to the `api.parse()` config. This resolves the build without regression or conflicts with `@babel/preset-typescript` requirements.

This demo repository allows you to test the error, note the config inside `babel.config.js` and the `configFile: false` at `webpack.config.js`: https://github.com/miguelpeixe/prebid-config-test

Confirm the error by running `npm ci && webpack`:

```
[BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
See https://babeljs.io/docs/en/options#filename for more information.
```