### PR TITLE
Prebid core: isolate global and bidder-specific configuration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -305,7 +305,7 @@ export function newConfig() {
           memo[topic] = currBidderConfig[topic];
         } else {
           if (isPlainObject(currBidderConfig[topic])) {
-            memo[topic] = mergeDeep({}, config[topic], currBidderConfig[topic]);
+            memo[topic] = mergeDeep(deepClone(config[topic]), currBidderConfig[topic]);
           } else {
             memo[topic] = currBidderConfig[topic];
           }

--- a/src/config.js
+++ b/src/config.js
@@ -305,7 +305,7 @@ export function newConfig() {
           memo[topic] = currBidderConfig[topic];
         } else {
           if (isPlainObject(currBidderConfig[topic])) {
-            memo[topic] = mergeDeep(deepClone(config[topic]), currBidderConfig[topic]);
+            memo[topic] = mergeDeep({}, config[topic], currBidderConfig[topic]);
           } else {
             memo[topic] = currBidderConfig[topic];
           }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1279,7 +1279,7 @@ export function mergeDeep(target, ...sources) {
         mergeDeep(target[key], source[key]);
       } else if (isArray(source[key])) {
         if (!target[key]) {
-          Object.assign(target, { [key]: source[key] });
+          Object.assign(target, { [key]: [...source[key]] });
         } else if (isArray(target[key])) {
           source[key].forEach(obj => {
             let addItFlag = 1;

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -16,8 +16,10 @@ let setDefaults;
 describe('config API', function () {
   let logErrorSpy;
   let logWarnSpy;
+  let config;
+
   beforeEach(function () {
-    const config = newConfig();
+    config = newConfig();
     getConfig = config.getConfig;
     setConfig = config.setConfig;
     readConfig = config.readConfig;
@@ -623,5 +625,26 @@ describe('config API', function () {
     expect(ortb2Config.site.content.data).to.deep.include.members([siteObj1]);
     expect(ortb2Config.user.data).to.have.lengthOf(2);
     expect(ortb2Config.site.content.data).to.have.lengthOf(1);
+  });
+
+  it('should not corrupt global configuration with bidder configuration', () => {
+    // https://github.com/prebid/Prebid.js/issues/7956
+    config.setConfig({
+      outer: {
+        inner: ['global']
+      }
+    });
+    config.setBidderConfig({
+      bidders: ['bidder'],
+      config: {
+        outer: {
+          inner: ['bidder']
+        }
+      }
+    });
+    config.runWithBidder('bidder', () => config.getConfig())
+    expect(config.getConfig('outer')).to.eql({
+      inner: ['global']
+    });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where `getConfig` called from within a bidder "context" will sometimes merge bidder configuration into the global config.

Addresses https://github.com/prebid/Prebid.js/issues/7956

