### PR TITLE
CircleCI : change to npm ci 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ aliases:
   - &unit_test_steps
     - checkout
     - restore_cache: *restore_dep_cache
-    - run: npm install
+    - run: npm ci
     - save_cache: *save_dep_cache
     - run: *install
     - run: *setup_browserstack


### PR DESCRIPTION
Legacy is currently failing in circle ci. Update to npm ci instead of install to fix cacheing