### PR TITLE
OTM bid adapter: use top origin as default domain

### DIFF
--- a/modules/otmBidAdapter.js
+++ b/modules/otmBidAdapter.js
@@ -1,10 +1,21 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import {logInfo, logError, getBidIdParameter, _each, getValue, isFn, isPlainObject} from '../src/utils.js';
+import {
+  logInfo,
+  logError,
+  getBidIdParameter,
+  _each,
+  getValue,
+  isFn,
+  isPlainObject,
+  isArray,
+  isStr,
+  isNumber,
+} from '../src/utils.js';
 import { BANNER } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'otm';
 const OTM_BID_URL = 'https://ssp.otm-r.com/adjson';
-const DEF_CUR = 'RUB'
+const DEFAULT_CURRENCY = 'RUB'
 
 export const spec = {
 
@@ -19,7 +30,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return !!bid.params.tid;
+    return Boolean(bid.params.tid);
   },
 
   /**
@@ -33,43 +44,41 @@ export const spec = {
     logInfo('validBidRequests', validBidRequests);
 
     const bidRequests = [];
-    let tz = new Date().getTimezoneOffset()
-    let referrer = '';
-    if (bidderRequest && bidderRequest.refererInfo) {
-      referrer = bidderRequest.refererInfo.referer;
-    }
+    const tz = new Date().getTimezoneOffset()
+    const referrer = bidderRequest && bidderRequest.refererInfo ? bidderRequest.refererInfo.referer : '';
 
     _each(validBidRequests, (bid) => {
-      let domain = getValue(bid.params, 'domain') || ''
-      let tid = getValue(bid.params, 'tid')
-      let cur = getValue(bid.params, 'currency') || DEF_CUR
-      let bidid = getBidIdParameter('bidId', bid)
-      let transactionid = getBidIdParameter('transactionId', bid)
-      let auctionid = getBidIdParameter('auctionId', bid)
-      let bidfloor = _getBidFloor(bid)
+      let topOrigin = ''
+      try {
+        if (isStr(referrer)) topOrigin = new URL(referrer).host
+      } catch (e) { /* do nothing */ }
+      const domain = isStr(bid.params.domain) ? bid.params.domain : topOrigin
+      const cur = getValue(bid.params, 'currency') || DEFAULT_CURRENCY
+      const bidid = getBidIdParameter('bidId', bid)
+      const transactionid = getBidIdParameter('transactionId', bid)
+      const auctionid = getBidIdParameter('auctionId', bid)
+      const bidfloor = _getBidFloor(bid)
 
       _each(bid.sizes, size => {
-        let width = 0;
-        let height = 0;
-        if (size.length && typeof size[0] === 'number' && typeof size[1] === 'number') {
-          width = size[0];
-          height = size[1];
-        }
+        const hasSizes = isArray(size) && isNumber(size[0]) && isNumber(size[1])
+        const width = hasSizes ? size[0] : 0;
+        const height = hasSizes ? size[1] : 0;
+
         bidRequests.push({
           method: 'GET',
           url: OTM_BID_URL,
           data: {
-            tz: tz,
+            tz,
             w: width,
             h: height,
-            domain: domain,
+            domain,
             l: referrer,
-            s: tid,
-            cur: cur,
-            bidid: bidid,
-            transactionid: transactionid,
-            auctionid: auctionid,
-            bidfloor: bidfloor,
+            s: bid.params.tid,
+            cur,
+            bidid,
+            transactionid,
+            auctionid,
+            bidfloor,
           },
         })
       })
@@ -81,10 +90,9 @@ export const spec = {
    * Generate response.
    *
    * @param serverResponse
-   * @param request
    * @returns {[]|*[]}
    */
-  interpretResponse: function (serverResponse, request) {
+  interpretResponse: function (serverResponse) {
     logInfo('serverResponse', serverResponse.body);
 
     const responsesBody = serverResponse ? serverResponse.body : {};
@@ -102,7 +110,7 @@ export const spec = {
             width: bid.w,
             height: bid.h,
             creativeId: bid.creativeid,
-            currency: bid.currency || 'RUB',
+            currency: bid.currency || DEFAULT_CURRENCY,
             netRevenue: true,
             ad: bid.ad,
             ttl: bid.ttl,
@@ -132,12 +140,12 @@ function _getBidFloor(bid) {
     return bid.params.bidfloor ? bid.params.bidfloor : 0;
   }
 
-  let floor = bid.getFloor({
-    currency: DEF_CUR,
+  const floor = bid.getFloor({
+    currency: DEFAULT_CURRENCY,
     mediaType: '*',
     size: '*'
   });
-  if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEF_CUR) {
+  if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEFAULT_CURRENCY) {
     return floor.floor;
   }
   return 0;

--- a/test/spec/modules/otmBidAdapter_spec.js
+++ b/test/spec/modules/otmBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/otmBidAdapter';
 
 describe('otmBidAdapter', function () {
-  it('validate_pub_params', function () {
+  it('pub_params', function () {
     expect(spec.isBidRequestValid({
       bidder: 'otm',
       params: {
@@ -12,8 +12,27 @@ describe('otmBidAdapter', function () {
     })).to.equal(true);
   });
 
-  it('validate_generated_params', function () {
-    let bidRequestData = [{
+  it('generated_params common case', function () {
+    const bidRequestData = [{
+      bidId: 'bid1234',
+      bidder: 'otm',
+      params: {
+        tid: '123',
+        bidfloor: 20,
+        domain: 'github.com'
+      },
+      sizes: [[240, 400]]
+    }];
+
+    const request = spec.buildRequests(bidRequestData);
+    const req_data = request[0].data;
+
+    expect(req_data.bidid).to.equal('bid1234');
+    expect(req_data.domain).to.equal('github.com');
+  });
+
+  it('generated_params should return top level origin as domain if not defined', function () {
+    const bidRequestData = [{
       bidId: 'bid1234',
       bidder: 'otm',
       params: {
@@ -23,20 +42,22 @@ describe('otmBidAdapter', function () {
       sizes: [[240, 400]]
     }];
 
-    let request = spec.buildRequests(bidRequestData);
-    let req_data = request[0].data;
+    const bidderRequest = {refererInfo: {referer: `https://github.com:3000/`}}
 
-    expect(req_data.bidid).to.equal('bid1234');
+    const request = spec.buildRequests(bidRequestData, bidderRequest);
+    const req_data = request[0].data;
+
+    expect(req_data.domain).to.equal(`github.com:3000`);
   });
 
-  it('validate_response_params', function () {
-    let bidRequestData = {
+  it('response_params common case', function () {
+    const bidRequestData = {
       data: {
         bidId: 'bid1234'
       }
     };
 
-    let serverResponse = {
+    const serverResponse = {
       body: [
         {
           'auctionid': '3c6f8e22-541b-485c-9214-e974d9fb1b6f',
@@ -53,9 +74,9 @@ describe('otmBidAdapter', function () {
       ]
     };
 
-    let bids = spec.interpretResponse(serverResponse, bidRequestData);
+    const bids = spec.interpretResponse(serverResponse, bidRequestData);
     expect(bids).to.have.lengthOf(1);
-    let bid = bids[0];
+    const bid = bids[0];
     expect(bid.cpm).to.equal(847.097);
     expect(bid.currency).to.equal('RUB');
     expect(bid.width).to.equal(240);


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
use top level origin as a default 'domain' argument for bid request

## Other information
Need @krecu review as the OTM module maintainer
Need @ChrisHuie review