### PR TITLE
fix: Add back in correct logic for purpose 1 consent check

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -57,7 +57,7 @@ const SUPPORTED_USER_ID_SOURCES = [
 function hasPurpose1Consent(bidderRequest) {
   if (bidderRequest && bidderRequest.gdprConsent) {
     if (bidderRequest.gdprConsent.gdprApplies && bidderRequest.gdprConsent.apiVersion === 2) {
-      return !!false;
+      return !!(deepAccess(bidderRequest.gdprConsent, 'vendorData.purpose.consents.1') === true);
     }
   }
   return true;

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -57,7 +57,7 @@ const SUPPORTED_USER_ID_SOURCES = [
 function hasPurpose1Consent(bidderRequest) {
   if (bidderRequest && bidderRequest.gdprConsent) {
     if (bidderRequest.gdprConsent.gdprApplies && bidderRequest.gdprConsent.apiVersion === 2) {
-      return !!(deepAccess(bidderRequest.gdprConsent, 'vendorData.purpose.consents.1') === true);
+      return deepAccess(bidderRequest.gdprConsent, 'vendorData.purpose.consents.1') === true;
     }
   }
   return true;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Seems that the check for purpose 1 consent was replaced during a test and not put back. This is causing users in EU to not have cookies sent up with bid requests.

- [x] official adapter submission

## Other information
This change was pretty quick to spot once the issue was identified. I will run a validation test on a publisher's site using something like Switcharoo as soon as I open this PR, but I just want to get this PR out and reviewed quickly. 
