### PR TITLE
IX Bid Adapter: added trustpid.com support and removed a few user providers

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -59,21 +59,17 @@ const SOURCE_RTI_MAPPING = {
   'epsilon.com': '', // Publisher Link, publinkId
   'audigent.com': '', // Halo ID from Audigent, haloId
   'pubcid.org': '' // SharedID, pubcid
+  'trustpid.com': '' // Trustpid
 };
 const PROVIDERS = [
   'britepoolid',
-  'id5id',
   'lipbid',
-  'haloId',
   'criteoId',
-  'lotamePanoramaId',
   'merkleId',
   'parrableId',
   'connectid',
   'tapadId',
   'quantcastId',
-  'pubcid',
-  'TDID',
   'flocId',
   'pubProvidedId'
 ];

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -58,7 +58,7 @@ const SOURCE_RTI_MAPPING = {
   'crwdcntrl.net': '', // Lotame Panorama ID, lotamePanoramaId
   'epsilon.com': '', // Publisher Link, publinkId
   'audigent.com': '', // Halo ID from Audigent, haloId
-  'pubcid.org': '' // SharedID, pubcid
+  'pubcid.org': '', // SharedID, pubcid
   'trustpid.com': '' // Trustpid
 };
 const PROVIDERS = [

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1230,7 +1230,7 @@ describe('IndexexchangeAdapter', function () {
       const r = JSON.parse(request.data.r);
 
       expect(r.ext.ixdiag.userIds).to.be.an('array');
-      expect(r.ext.ixdiag.userIds.should.include('lotamePanoramaId'));
+      expect(r.ext.ixdiag.userIds.should.not.include('lotamePanoramaId'));
       expect(r.ext.ixdiag.userIds.should.not.include('merkleId'));
       expect(r.ext.ixdiag.userIds.should.not.include('parrableId'));
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- Feature

## Description of change
Added trustpid.com adapter support to ixBidAdapter
Removed unused userID modules in ixBidAdapter diagnostics

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.
