### PR TITLE
MediaKeys Bid Adapter: fix for first party data `geo` usage

### DIFF
--- a/modules/mediakeysBidAdapter.js
+++ b/modules/mediakeysBidAdapter.js
@@ -653,11 +653,6 @@ export const spec = {
     if (fpd.user) {
       mergeDeep(payload, { user: fpd.user });
     }
-    // Here we can handle device.geo prop
-    const deviceGeo = deepAccess(fpd, 'device.geo');
-    if (deviceGeo) {
-      mergeDeep(payload.device, { geo: deviceGeo });
-    }
 
     const request = {
       method: 'POST',

--- a/test/spec/modules/mediakeysBidAdapter_spec.js
+++ b/test/spec/modules/mediakeysBidAdapter_spec.js
@@ -575,12 +575,15 @@ describe('mediakeysBidAdapter', function () {
               },
               user: {
                 yob: 1985,
-                gender: 'm'
-              },
-              device: {
+                gender: 'm',
                 geo: {
                   country: 'FR',
                   city: 'Marseille'
+                },
+                ext: {
+                  data: {
+                    registered: true
+                  }
                 }
               }
             }
@@ -596,8 +599,9 @@ describe('mediakeysBidAdapter', function () {
         expect(data.site.ext.data.category).to.equal('sport');
         expect(data.user.yob).to.equal(1985);
         expect(data.user.gender).to.equal('m');
-        expect(data.device.geo.country).to.equal('FR');
-        expect(data.device.geo.city).to.equal('Marseille');
+        expect(data.user.geo.country).to.equal('FR');
+        expect(data.user.geo.city).to.equal('Marseille');
+        expect(data.user.ext.data.registered).to.be.true;
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Fix `geo` first party data that should not be attached to `device` but to `user` literal.

- contact email of the adapter’s maintainer: prebidjs@mediakeys.com
- doc updated: https://github.com/prebid/prebid.github.io/pull/3549
