### PR TITLE
appnexus bid adapter - add support for pubProvidedId userId

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -270,6 +270,13 @@ export const spec = {
       addUserId(eids, deepAccess(bidRequests[0], `userId.idl_env`), 'liveramp.com', null);
       addUserId(eids, deepAccess(bidRequests[0], `userId.tdid`), 'adserver.org', 'TDID');
       addUserId(eids, deepAccess(bidRequests[0], `userId.uid2.id`), 'uidapi.com', 'UID2');
+      if (bidRequests[0].userId.pubProvidedId) {
+        bidRequests[0].userId.pubProvidedId.forEach(ppId => {
+          ppId.uids.forEach(uid => {
+            eids.push({ source: ppId.source, id: uid.id });
+          });
+        });
+      }
 
       if (eids.length) {
         payload.eids = eids;

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -943,7 +943,22 @@ describe('AppNexusAdapter', function () {
           flocId: {
             id: 'sample-flocid-value',
             version: 'chrome.1.0'
-          }
+          },
+          pubProvidedId: [{
+            source: 'puburl.com',
+            uids: [{
+              id: 'pubid1',
+              atype: 1,
+              ext: {
+                stype: 'ppuid'
+              }
+            }]
+          }, {
+            source: 'puburl2.com',
+            uids: [{
+              id: 'pubid2'
+            }]
+          }]
         }
       });
 
@@ -979,6 +994,16 @@ describe('AppNexusAdapter', function () {
         source: 'uidapi.com',
         id: 'sample-uid2-value',
         rti_partner: 'UID2'
+      });
+
+      expect(payload.eids).to.deep.include({
+        source: 'puburl.com',
+        id: 'pubid1'
+      });
+
+      expect(payload.eids).to.deep.include({
+        source: 'puburl2.com',
+        id: 'pubid2'
       });
     });
 


### PR DESCRIPTION
**Please hold from merging for now.**

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
This PR adds support for the `pubProvidedId` userId for the `appnexusBidAdapter`.