### PR TITLE
fluct Bid Adapter: Add user data support

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -7,6 +7,16 @@ const VERSION = '1.2';
 const NET_REVENUE = true;
 const TTL = 300;
 
+/**
+ * See modules/userId/eids.js for supported sources
+ */
+const SUPPORTED_USER_ID_SOURCES = [
+  'adserver.org',
+  'criteo.com',
+  'intimatemerger.com',
+  'liveramp.com',
+];
+
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['adingo'],
@@ -38,6 +48,9 @@ export const spec = {
       data.adUnitCode = request.adUnitCode;
       data.bidId = request.bidId;
       data.transactionId = request.transactionId;
+      data.user = {
+        eids: (request.userIdAsEids || []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
+      };
 
       data.sizes = [];
       _each(request.sizes, (size) => {
@@ -48,7 +61,11 @@ export const spec = {
       });
 
       data.params = request.params;
-      const searchParams = new URLSearchParams(request.params);
+      const searchParams = new URLSearchParams({
+        dfpUnitCode: request.params.dfpUnitCode,
+        tagId: request.params.tagId,
+        groupId: request.params.groupId,
+      });
 
       serverRequests.push({
         method: 'POST',

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -83,6 +83,98 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.url).to.equal('https://hb.adingo.jp/prebid?dfpUnitCode=%2F100000%2Funit_code&tagId=10000%3A100000001&groupId=1000000002');
     });
+
+    it('includes data.user.eids = [] by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.user.eids).to.eql([]);
+    });
+
+    it('includes no data.params.kv by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.params.kv).to.eql(undefined);
+    });
+
+    it('includes filtered user.eids if any exists', function () {
+      const bidRequests2 = bidRequests.map(
+        (bidReq) => Object.assign(bidReq, {
+          userIdAsEids: [
+            {
+              source: 'foobar.com',
+              uids: [
+                { id: 'foobar-id' }
+              ],
+            },
+            {
+              source: 'adserver.org',
+              uids: [
+                { id: 'tdid' }
+              ],
+            },
+            {
+              source: 'criteo.com',
+              uids: [
+                { id: 'criteo-id' }
+              ],
+            },
+            {
+              source: 'intimatemerger.com',
+              uids: [
+                { id: 'imuid' }
+              ],
+            },
+            {
+              source: 'liveramp.com',
+              uids: [
+                { id: 'idl-env' }
+              ],
+            },
+          ],
+        })
+      );
+      const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
+      expect(request.data.user.eids).to.eql([
+        {
+          source: 'adserver.org',
+          uids: [
+            { id: 'tdid' }
+          ],
+        },
+        {
+          source: 'criteo.com',
+          uids: [
+            { id: 'criteo-id' }
+          ],
+        },
+        {
+          source: 'intimatemerger.com',
+          uids: [
+            { id: 'imuid' }
+          ],
+        },
+        {
+          source: 'liveramp.com',
+          uids: [
+            { id: 'idl-env' }
+          ],
+        },
+      ]);
+    });
+
+    it('includes data.params.kv if any exists', function () {
+      const bidRequests2 = bidRequests.map(
+        (bidReq) => Object.assign(bidReq, {
+          params: {
+            kv: {
+              imsids: ['imsid1', 'imsid2']
+            }
+          }
+        })
+      );
+      const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
+      expect(request.data.params.kv).to.eql({
+        imsids: ['imsid1', 'imsid2']
+      });
+    });
   });
 
   describe('interpretResponse', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

* add a capability to send user EIDs from the known user ID systems
* add test cases on sending injected user data

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'fluct',
    params: {
        tagId: '25405:1000192893',
        groupId: '1000105712',
        dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940', // Optional
    }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

* Relates to #8016