### PR TITLE
TrustX Bid Adapter: added instl support

### DIFF
--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -101,12 +101,17 @@ export const spec = {
         }
       };
 
-      if (ortb2Imp && ortb2Imp.ext && ortb2Imp.ext.data) {
-        impObj.ext.data = ortb2Imp.ext.data;
-        if (impObj.ext.data.adserver && impObj.ext.data.adserver.adslot) {
-          impObj.ext.gpid = impObj.ext.data.adserver.adslot.toString();
-        } else {
-          impObj.ext.gpid = ortb2Imp.ext.data.pbadslot && ortb2Imp.ext.data.pbadslot.toString();
+      if (ortb2Imp) {
+        if (ortb2Imp.instl) {
+          impObj.instl = ortb2Imp.instl;
+        }
+        if (ortb2Imp.ext && ortb2Imp.ext.data) {
+          impObj.ext.data = ortb2Imp.ext.data;
+          if (impObj.ext.data.adserver && impObj.ext.data.adserver.adslot) {
+            impObj.ext.gpid = impObj.ext.data.adserver.adslot.toString();
+          } else {
+            impObj.ext.gpid = ortb2Imp.ext.data.pbadslot && ortb2Imp.ext.data.pbadslot.toString();
+          }
         }
       }
 

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -561,6 +561,39 @@ describe('TrustXAdapter', function () {
         divid: bidRequests[2].adUnitCode
       });
     });
+    it('should contain imp[].instl if available', function() {
+      const ortb2Imp = [{
+        instl: 1
+      }, {
+        instl: 2,
+        ext: {
+          data: {
+            adserver: {
+              name: 'ad_server_name',
+              adslot: '/222222/slot'
+            },
+            pbadslot: '/222222/slot'
+          }
+        }
+      }];
+      const bidRequestsWithOrtb2Imp = bidRequests.slice(0, 3).map((bid, ind) => {
+        return Object.assign(ortb2Imp[ind] ? { ortb2Imp: ortb2Imp[ind] } : {}, bid);
+      });
+      const request = spec.buildRequests(bidRequestsWithOrtb2Imp, bidderRequest);
+      expect(request.data).to.be.an('string');
+      const payload = parseRequest(request.data);
+      expect(payload.imp[0].instl).to.equal(1);
+      expect(payload.imp[1].ext).to.deep.equal({
+        divid: bidRequests[1].adUnitCode,
+        data: ortb2Imp[1].ext.data,
+        gpid: ortb2Imp[1].ext.data.adserver.adslot
+      });
+      expect(payload.imp[1].instl).to.equal(2);
+      expect(payload.imp[2].ext).to.deep.equal({
+        divid: bidRequests[2].adUnitCode
+      });
+      expect(payload.imp[2].instl).to.be.undefined();
+    });
     it('all id like request fields must be a string', function () {
       const bidderRequestWithNumId = Object.assign({}, bidderRequest, { bidderRequestId: 123123, auctionId: 345345543 });
 

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -592,7 +592,7 @@ describe('TrustXAdapter', function () {
       expect(payload.imp[2].ext).to.deep.equal({
         divid: bidRequests[2].adUnitCode
       });
-      expect(payload.imp[2].instl).to.be.undefined();
+      expect(payload.imp[2].instl).to.be.undefined;
     });
     it('all id like request fields must be a string', function () {
       const bidderRequestWithNumId = Object.assign({}, bidderRequest, { bidderRequestId: 123123, auctionId: 345345543 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Added support of ortb2Imp.instl parameter for TrustX Bid Adapter


- paul@trustx.org
- [x] official adapter submission
