### PR TITLE
Prebid Core: Adding support for a global return of consent metadata. 

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -182,10 +182,10 @@ export let gdprDataHandler = {
     return gdprDataHandler.consentData;
   },
   getConsentMeta: function() {
-    if (gdprDataHandler.consentData && gdprDataHandler.consentData.vendorData && gdprDataHandler.consentData.vendorData.tcString && gdprDataHandler.generatedTime) {
+    if (gdprDataHandler.consentData && gdprDataHandler.consentData.vendorData && gdprDataHandler.generatedTime) {
       return {
         gdprApplies: gdprDataHandler.consentData.gdprApplies,
-        consentStringSize: gdprDataHandler.consentData.vendorData.tcString.length,
+        consentStringSize: (isStr(gdprDataHandler.consentData.vendorData.tcString)) ? gdprDataHandler.consentData.vendorData.tcString.length : 0,
         generatedAt: gdprDataHandler.generatedTime,
         apiVersion: gdprDataHandler.consentData.apiVersion
       };

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -173,21 +173,42 @@ function getAdUnitCopyForClientAdapters(adUnits) {
 
 export let gdprDataHandler = {
   consentData: null,
-  setConsentData: function(consentInfo) {
+  generatedTime: null,
+  setConsentData: function(consentInfo, time = timestamp()) {
     gdprDataHandler.consentData = consentInfo;
+    gdprDataHandler.generatedTime = time;
   },
   getConsentData: function() {
     return gdprDataHandler.consentData;
+  },
+  getConsentMeta: function() {
+    if (gdprDataHandler.consentData && gdprDataHandler.consentData.vendorData && gdprDataHandler.generatedTime) {
+      return {
+        gdprApplies: gdprDataHandler.consentData.gdprApplies,
+        consentStringSize: gdprDataHandler.consentData.vendorData.tcString.length,
+        timestamp: gdprDataHandler.generatedTime,
+        apiVersion: gdprDataHandler.consentData.apiVersion
+      };
+    }
   }
 };
 
 export let uspDataHandler = {
   consentData: null,
-  setConsentData: function(consentInfo) {
+  generatedTime: null,
+  setConsentData: function(consentInfo, time = timestamp()) {
     uspDataHandler.consentData = consentInfo;
+    uspDataHandler.generatedTime = time;
   },
   getConsentData: function() {
     return uspDataHandler.consentData;
+  },
+  getConsentMeta: function() {
+    if (uspDataHandler.consentData && uspDataHandler.generatedTime) {
+      return {
+        usp: uspDataHandler.consentData,
+        timestamp: uspDataHandler.generatedTime}
+    }
   }
 };
 

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -19,7 +19,8 @@ import {
   logMessage,
   logWarn,
   shuffle,
-  timestamp
+  timestamp,
+  isStr
 } from './utils.js';
 import {getLabels, resolveStatus} from './sizeMapping.js';
 import {decorateAdUnitsWithNativeParams, nativeAdapters} from './native.js';

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -182,11 +182,11 @@ export let gdprDataHandler = {
     return gdprDataHandler.consentData;
   },
   getConsentMeta: function() {
-    if (gdprDataHandler.consentData && gdprDataHandler.consentData.vendorData && gdprDataHandler.generatedTime) {
+    if (gdprDataHandler.consentData && gdprDataHandler.consentData.vendorData && gdprDataHandler.consentData.vendorData.tcString && gdprDataHandler.generatedTime) {
       return {
         gdprApplies: gdprDataHandler.consentData.gdprApplies,
         consentStringSize: gdprDataHandler.consentData.vendorData.tcString.length,
-        timestamp: gdprDataHandler.generatedTime,
+        generatedAt: gdprDataHandler.generatedTime,
         apiVersion: gdprDataHandler.consentData.apiVersion
       };
     }
@@ -207,7 +207,8 @@ export let uspDataHandler = {
     if (uspDataHandler.consentData && uspDataHandler.generatedTime) {
       return {
         usp: uspDataHandler.consentData,
-        timestamp: uspDataHandler.generatedTime}
+        generatedAt: uspDataHandler.generatedTime
+      }
     }
   }
 };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -20,6 +20,7 @@ import { executeRenderer, isRendererRequired } from './Renderer.js';
 import { createBid } from './bidfactory.js';
 import { storageCallbacks } from './storageManager.js';
 import { emitAdRenderSucceeded, emitAdRenderFail } from './adRendering.js';
+import {gdprDataHandler, uspDataHandler} from './adapterManager.js'
 
 const $$PREBID_GLOBAL$$ = getGlobal();
 const CONSTANTS = require('./constants.json');
@@ -266,6 +267,24 @@ $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCode = function (adUnitCode) {
 $$PREBID_GLOBAL$$.getAdserverTargeting = function (adUnitCode) {
   logInfo('Invoking $$PREBID_GLOBAL$$.getAdserverTargeting', arguments);
   return targeting.getAllTargeting(adUnitCode);
+};
+
+/**
+ * returns all consent data
+ * @return {Object} Map of consent types and data
+ * @alias module:pbjs.getConsentData
+ */
+function getConsentMetadata() {
+  return {
+    gdpr: gdprDataHandler.getConsentMeta(),
+    usp: uspDataHandler.getConsentMeta(),
+    coppa: !!(config.getConfig('coppa'))
+  }
+}
+
+$$PREBID_GLOBAL$$.getConsentMetadata = function () {
+  logInfo('Invoking $$PREBID_GLOBAL$$.getConsentMetadata');
+  return getConsentMetadata();
 };
 
 function getBids(type) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -20,7 +20,7 @@ import { executeRenderer, isRendererRequired } from './Renderer.js';
 import { createBid } from './bidfactory.js';
 import { storageCallbacks } from './storageManager.js';
 import { emitAdRenderSucceeded, emitAdRenderFail } from './adRendering.js';
-import {gdprDataHandler, uspDataHandler} from './adapterManager.js'
+import { gdprDataHandler, uspDataHandler } from './adapterManager.js'
 
 const $$PREBID_GLOBAL$$ = getGlobal();
 const CONSTANTS = require('./constants.json');

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -58,6 +58,12 @@ describe('consentManagement', function () {
         sinon.assert.notCalled(utils.logInfo);
       });
 
+      it('should not produce any USP metadata', function() {
+        setConsentConfig({});
+        let consentMeta = uspDataHandler.getConsentMeta();
+        expect(consentMeta).to.be.undefined;
+      });
+
       it('should exit the consent manager if only config.gdpr is an object', function() {
         setConsentConfig({ gdpr: { cmpApi: 'iab' } });
         expect(consentAPI).to.be.undefined;
@@ -365,6 +371,27 @@ describe('consentManagement', function () {
 
         expect(didHookReturn).to.be.true;
         expect(consent).to.equal(testConsentData.uspString);
+      });
+
+      it('returns USP consent metadata', function () {
+        let testConsentData = {
+          uspString: '1NY'
+        };
+
+        uspapiStub = sinon.stub(window, '__uspapi').callsFake((...args) => {
+          args[2](testConsentData, true);
+        });
+
+        setConsentConfig(goodConfig);
+        requestBidsHook(() => { didHookReturn = true; }, {});
+
+        let consentMeta = uspDataHandler.getConsentMeta();
+
+        sinon.assert.notCalled(utils.logWarn);
+        sinon.assert.notCalled(utils.logError);
+
+        expect(consentMeta.usp).to.equal(testConsentData.uspString);
+        expect(consentMeta.timestamp).to.be.above(1644367751709);
       });
     });
   });

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -391,7 +391,7 @@ describe('consentManagement', function () {
         sinon.assert.notCalled(utils.logError);
 
         expect(consentMeta.usp).to.equal(testConsentData.uspString);
-        expect(consentMeta.timestamp).to.be.above(1644367751709);
+        expect(consentMeta.generatedAt).to.be.above(1644367751709);
       });
     });
   });

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -727,32 +727,6 @@ describe('consentManagement', function () {
           expect(consent.apiVersion).to.equal(2);
         });
 
-        it('performs lookup check and stores consentData for a valid existing user with additional consent', function () {
-          let testConsentData = {
-            tcString: 'abc12345234',
-            addtlConsent: 'superduperstring',
-            gdprApplies: true,
-            purposeOneTreatment: false,
-            eventStatus: 'tcloaded'
-          };
-          cmpStub = sinon.stub(window, '__tcfapi').callsFake((...args) => {
-            args[2](testConsentData, true);
-          });
-
-          setConsentConfig(goodConfigWithAllowAuction);
-
-          requestBidsHook(() => {
-            didHookReturn = true;
-          }, {});
-          let consent = gdprDataHandler.getConsentData();
-          sinon.assert.notCalled(utils.logError);
-          expect(didHookReturn).to.be.true;
-          expect(consent.consentString).to.equal(testConsentData.tcString);
-          expect(consent.addtlConsent).to.equal(testConsentData.addtlConsent);
-          expect(consent.gdprApplies).to.be.true;
-          expect(consent.apiVersion).to.equal(2);
-        });
-
         it('throws an error when processCmpData check fails + does not call requestBids callbcack even when allowAuction is true', function () {
           let testConsentData = {};
           let bidsBackHandlerReturn = false;

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -698,7 +698,7 @@ describe('consentManagement', function () {
           expect(consentMeta.consentStringSize).to.be.above(0)
           expect(consentMeta.gdprApplies).to.be.true;
           expect(consentMeta.apiVersion).to.equal(2);
-          expect(consentMeta.timestamp).to.be.above(1644367751709);
+          expect(consentMeta.generatedAt).to.be.above(1644367751709);
         });
 
         it('performs lookup check and stores consentData for a valid existing user with additional consent', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This includes two significant changes: 
- The introduction of a `getConsentMetadata` function on the Prebid global object.
- Two corresponding functions added in `adapterManager.js` for TCF and USP return. 

With this change, calling `pbjs.getConsentMetadata();` will return a response like: 

```
{
    "coppa": false,
    "gdpr": {
        "apiVersion": 2,
        "consentStringExists": true,
        "gdprApplies": true,
        "timestamp": 1644358143306
    },
    "usp": {
        "timestamp": 1644358143306,
        "usp": "1YYY"
    }
}
```

- Docs PR: https://github.com/prebid/prebid.github.io/pull/3561

## Other information
@bretg This is follow-up to our conversation regarding making consent information available outside of the auction/userId workflow. I made an effort to remove granular information like the full TCF string and instead focused on non-personal consent information that would still be helpful to understand the underlying consent status. Rather than introduce entirely new code, I chose to piggyback off of the well-known `adapterManager.js` interface as was done in other modules likes `bidViewability.js`. There is test coverage for both the USP and TCF cases. 
