### PR TITLE
Option to send floors/adunitcode in the Google Analytics Adapter

### DIFF
--- a/modules/googleAnalyticsAdapter.js
+++ b/modules/googleAnalyticsAdapter.js
@@ -22,6 +22,7 @@ var _enableDistribution = false;
 var _cpmDistribution = null;
 var _trackerSend = null;
 var _sampled = true;
+var _sendFloors = false;
 
 let adapter = {};
 
@@ -45,6 +46,9 @@ adapter.enableAnalytics = function ({ provider, options }) {
   }
   if (options && typeof options.cpmDistribution === 'function') {
     _cpmDistribution = options.cpmDistribution;
+  }
+  if (options && typeof options.sendFloors !== 'undefined') {
+    _sendFloors = options.sendFloors;
   }
 
   var bid = null;
@@ -203,7 +207,12 @@ function sendBidRequestToGa(bid) {
   if (bid && bid.bidderCode) {
     _analyticsQueue.push(function () {
       _eventCount++;
-      window[_gaGlobal](_trackerSend, 'event', _category, 'Requests', bid.bidderCode, 1, _disableInteraction);
+      if (_sendFloors) {
+        var floor = (bid.floorMin) ? bid.floorMin : 'No Floor';
+        window[_gaGlobal](_trackerSend, 'event', _category, 'Requests by Floor=' + floor, 'Ad Unit=' + bid.adUnitCode + ',' + bid.bidderCode, 1, _disableInteraction);
+      } else {
+        window[_gaGlobal](_trackerSend, 'event', _category, 'Requests', bid.bidderCode, 1, _disableInteraction);
+      }
     });
   }
 
@@ -229,8 +238,12 @@ function sendBidResponseToGa(bid) {
           _eventCount++;
           window[_gaGlobal](_trackerSend, 'event', 'Prebid.js CPM Distribution', cpmDis, bidder, 1, _disableInteraction);
         }
-
-        window[_gaGlobal](_trackerSend, 'event', _category, 'Bids', bidder, cpmCents, _disableInteraction);
+        if (_sendFloors) {
+          var floor = (bid.floorMin) ? bid.floorMin : 'No Floor';
+          window[_gaGlobal](_trackerSend, 'event', _category, 'Bids by Floor=' + floor, 'Ad Unit=' + bid.adUnitCode + ',' + bidder, cpmCents, _disableInteraction);
+        } else {
+          window[_gaGlobal](_trackerSend, 'event', _category, 'Bids', bidder, cpmCents, _disableInteraction);
+        }
         window[_gaGlobal](_trackerSend, 'event', _category, 'Bid Load Time', bidder, bid.timeToRespond, _disableInteraction);
       }
     });
@@ -256,7 +269,12 @@ function sendBidWonToGa(bid) {
   var cpmCents = convertToCents(bid.cpm);
   _analyticsQueue.push(function () {
     _eventCount++;
-    window[_gaGlobal](_trackerSend, 'event', _category, 'Wins', bid.bidderCode, cpmCents, _disableInteraction);
+    if (_sendFloors) {
+      var floor = (bid.floorMin) ? bid.floorMin : 'No Floor';
+      window[_gaGlobal](_trackerSend, 'event', _category, 'Wins by Floor=' + floor, 'Ad Unit=' + bid.adUnitCode + ',' + bid.bidderCode, cpmCents, _disableInteraction);
+    } else {
+      window[_gaGlobal](_trackerSend, 'event', _category, 'Wins', bid.bidderCode, cpmCents, _disableInteraction);
+    }
   });
 
   checkAnalytics();

--- a/modules/googleAnalyticsAdapter.md
+++ b/modules/googleAnalyticsAdapter.md
@@ -30,6 +30,7 @@ Here is a full list of settings available
 - `enableDistribution` (boolean) - enables additional events that track load time and cpm distribution
   by creating buckets for load time and cpm
 - `cpmDistribution` (cpm: number => string) - customize the cpm buckets for the cpm distribution
+- `sendFloors` (boolean) - if set, will include floor data in the eventCategory field and include ad unit code in eventAction field
 
 
 ## Additional resources


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
`sendFloors` option to include floor data in the eventCategory field and include ad unit code in eventAction field

## Other information

- https://github.com/prebid/Prebid.js/issues/8053
- I can test this on a page with a publisher to verify that the changes populate GA with the additional information before this is reviewed/merged. Lmk
- If anyone that knows Google Analytics has a better solution for sending additional data please tell. Maybe something that can then be layered on top of the events report?
- This adapter doesn't really have existing test coverage for these event send functions...