### PR TITLE
Criteo Bid Adapter: read mediaTypes.banner.sizes instead of bidRequest.Sizes

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -312,9 +312,9 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
         if (!checkNativeSendId(bidRequest)) {
           logWarn(LOG_PREFIX + 'all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)');
         }
-        slot.sizes = parseSizes(retrieveBannerSizes(bidRequest), parseNativeSize);
+        slot.sizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'), parseNativeSize);
       } else {
-        slot.sizes = parseSizes(retrieveBannerSizes(bidRequest), parseSize);
+        slot.sizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'), parseSize);
       }
       if (hasVideoMediaType(bidRequest)) {
         const video = {
@@ -375,11 +375,10 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   return request;
 }
 
-function retrieveBannerSizes(bidRequest) {
-  return deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
-}
-
 function parseSizes(sizes, parser) {
+  if (sizes == undefined) {
+    return [];
+  }
   if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])
     return sizes.map(size => parser(size));
   }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -430,7 +430,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {}
         },
       ];
@@ -445,7 +449,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
             publisherSubId: '123',
@@ -473,7 +481,11 @@ describe('The Criteo bidding adapter', function () {
     it('should keep undefined sizes for non native banner', function () {
       const bidRequests = [
         {
-          sizes: [[undefined, undefined]],
+          mediaTypes: {
+            banner: {
+              sizes: [[undefined, undefined]]
+            }
+          },
           params: {},
         },
       ];
@@ -486,7 +498,11 @@ describe('The Criteo bidding adapter', function () {
     it('should keep undefined size for non native banner', function () {
       const bidRequests = [
         {
-          sizes: [undefined, undefined],
+          mediaTypes: {
+            banner: {
+              sizes: [undefined, undefined]
+            }
+          },
           params: {},
         },
       ];
@@ -499,7 +515,11 @@ describe('The Criteo bidding adapter', function () {
     it('should properly detect and get sizes of native sizeless banner', function () {
       const bidRequests = [
         {
-          sizes: [[undefined, undefined]],
+          mediaTypes: {
+            banner: {
+              sizes: [[undefined, undefined]]
+            }
+          },
           params: {
             nativeCallback: function() {}
           },
@@ -514,7 +534,11 @@ describe('The Criteo bidding adapter', function () {
     it('should properly detect and get size of native sizeless banner', function () {
       const bidRequests = [
         {
-          sizes: [undefined, undefined],
+          mediaTypes: {
+            banner: {
+              sizes: [undefined, undefined]
+            }
+          },
           params: {
             nativeCallback: function() {}
           },
@@ -585,7 +609,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -594,7 +622,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-234',
           transactionId: 'transaction-234',
-          sizes: [[300, 250], [728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [728, 90]]
+            }
+          },
           params: {
             networkId: 456,
           },
@@ -625,7 +657,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -647,7 +683,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -673,7 +713,11 @@ describe('The Criteo bidding adapter', function () {
           schain: expectedSchain,
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -690,7 +734,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -711,7 +759,7 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          sizes: [[640, 480]],
           mediaTypes: {
             video: {
               playerSize: [640, 480],
@@ -738,6 +786,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
       expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
       expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
@@ -755,7 +804,7 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          sizes: [[640, 480], [800, 600]],
           mediaTypes: {
             video: {
               playerSize: [[640, 480], [800, 600]],
@@ -781,6 +830,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
       expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480', '800x600']);
       expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
@@ -799,7 +849,7 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          sizes: [[300, 250]],
           mediaTypes: {
             video: {
               playerSize: [ [300, 250] ],
@@ -821,6 +871,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
+      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
       expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['300x250']);
       expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg']);
       expect(ortbRequest.slots[0].video.minduration).to.equal(1);
@@ -837,7 +888,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
           },
@@ -859,7 +914,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123
           }
@@ -884,7 +943,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
             ext: {
@@ -928,7 +991,11 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
           transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
           params: {
             zoneId: 123,
             ext: {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Stop fallbacking to bidRequest.sizes and read banner sizes only from mediaTypes.banner.sizes.