### PR TITLE
appnexus bid adapter - convert keywords differently for appnexuspsp endpoint

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -360,11 +360,20 @@ export const spec = {
   },
 
   transformBidParams: function (params, isOpenRtb) {
+    let conversionFn = transformBidderParamKeywords;
+    if (isOpenRtb === true) {
+      let s2sConfig = config.getConfig('s2sConfig');
+      let s2sEndpointUrl = deepAccess(s2sConfig, 'endpoint.p1Consent');
+      if (s2sEndpointUrl && s2sEndpointUrl.match('/openrtb2/prebid')) {
+        conversionFn = convertKeywordsToString;
+      }
+    }
+
     params = convertTypes({
       'member': 'string',
       'invCode': 'string',
       'placementId': 'number',
-      'keywords': transformBidderParamKeywords,
+      'keywords': conversionFn,
       'publisherId': 'number'
     }, params);
 
@@ -1155,6 +1164,33 @@ function getBidFloor(bid) {
     return floor.floor;
   }
   return null;
+}
+
+// keywords: { 'genre': ['rock', 'pop'], 'pets': ['dog'] } goes to 'genre=rock,genre=pop,pets=dog'
+function convertKeywordsToString(keywords) {
+  let result = '';
+  Object.keys(keywords).forEach(key => {
+    // if 'text' or ''
+    if (isStr(keywords[key])) {
+      if (keywords[key] !== '') {
+        result += `${key}=${keywords[key]},`
+      } else {
+        result += `${key},`;
+      }
+    } else if (isArray(keywords[key])) {
+      if (keywords[key][0] === '') {
+        result += `${key},`
+      } else {
+        keywords[key].forEach(val => {
+          result += `${key}=${val},`
+        });
+      }
+    }
+  });
+
+  // remove last trailing comma
+  result = result.substring(0, result.length - 1);
+  return result;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1439,4 +1439,28 @@ describe('AppNexusAdapter', function () {
       expect(Object.keys(result[0].meta.advertiserDomains)).to.deep.equal([]);
     });
   });
+
+  describe('transformBidParams', function () {
+    it('convert keywords param differently for psp endpoint', function () {
+      sinon.stub(config, 'getConfig')
+        .withArgs('s2sConfig')
+        .returns({
+          endpoint: {
+            p1Consent: 'https://ib.adnxs.com/openrtb2/prebid'
+          }
+        });
+
+      const oldParams = {
+        keywords: {
+          genre: ['rock', 'pop'],
+          pets: 'dog'
+        }
+      };
+
+      const newParams = spec.transformBidParams(oldParams, true);
+      expect(newParams.keywords).to.equal('genre=rock,genre=pop,pets=dog');
+
+      config.getConfig.restore();
+    });
+  });
 });


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
When using the appnexus bid adapter in conjunction with a request to the appnexuspsp endpoint, the keywords param set in the bid params will be converted to a direct openrtb2 format instead of the custom format used by the normal PBS endpoint.