### PR TITLE
Yahoossp Bid Adapter: enable aliasing

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -590,7 +590,7 @@ export const spec = {
         adId: deepAccess(bid, 'adId') ? bid.adId : bid.impid || bid.crid,
         adUnitCode: bidderRequest.adUnitCode,
         requestId: bid.impid,
-        bidderCode: spec.code,
+        bidderCode: bidderRequest.bidderCode,
         cpm: cpm,
         width: bid.w,
         height: bid.h,

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -590,7 +590,6 @@ export const spec = {
         adId: deepAccess(bid, 'adId') ? bid.adId : bid.impid || bid.crid,
         adUnitCode: bidderRequest.adUnitCode,
         requestId: bid.impid,
-        bidderCode: bidderRequest.bidderCode,
         cpm: cpm,
         width: bid.w,
         height: bid.h,

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -1365,5 +1365,21 @@ describe('YahooSSP Bid Adapter:', () => {
         expect(response[0].ttl).to.equal(500);
       });
     });
+
+    describe('Aliasing support', () => {
+      it('should return default bidder code value', () => {
+        const { serverResponse, bidderRequest } = generateResponseMock('banner');
+        const response = spec.interpretResponse(serverResponse, {bidderRequest});
+        expect(response[0].bidderCode).to.equal('yahoossp');
+      });
+
+      it('should return default bidder code value', () => {
+        const { serverResponse, bidderRequest } = generateResponseMock('banner');
+        const aliasedBidderName = 'foobarbaz';
+        bidderRequest.bidderCode = aliasedBidderName;
+        const response = spec.interpretResponse(serverResponse, {bidderRequest});
+        expect(response[0].bidderCode).to.equal(aliasedBidderName);
+      })
+    });
   });
 });

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -1367,19 +1367,11 @@ describe('YahooSSP Bid Adapter:', () => {
     });
 
     describe('Aliasing support', () => {
-      it('should return the default bidder code value', () => {
+      it('should return undefined as the bidder code value', () => {
         const { serverResponse, bidderRequest } = generateResponseMock('banner');
         const response = spec.interpretResponse(serverResponse, {bidderRequest});
-        expect(response[0].bidderCode).to.equal('yahoossp');
+        expect(response[0].bidderCode).to.be.undefined;
       });
-
-      it('should return the aliased bidder code value', () => {
-        const { serverResponse, bidderRequest } = generateResponseMock('banner');
-        const aliasedBidderName = 'foobarbaz';
-        bidderRequest.bidderCode = aliasedBidderName;
-        const response = spec.interpretResponse(serverResponse, {bidderRequest});
-        expect(response[0].bidderCode).to.equal(aliasedBidderName);
-      })
     });
   });
 });

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -1367,13 +1367,13 @@ describe('YahooSSP Bid Adapter:', () => {
     });
 
     describe('Aliasing support', () => {
-      it('should return default bidder code value', () => {
+      it('should return the default bidder code value', () => {
         const { serverResponse, bidderRequest } = generateResponseMock('banner');
         const response = spec.interpretResponse(serverResponse, {bidderRequest});
         expect(response[0].bidderCode).to.equal('yahoossp');
       });
 
-      it('should return default bidder code value', () => {
+      it('should return the aliased bidder code value', () => {
         const { serverResponse, bidderRequest } = generateResponseMock('banner');
         const aliasedBidderName = 'foobarbaz';
         bidderRequest.bidderCode = aliasedBidderName;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Bid adapter was hardcoding the bidderCode in the bidResponse object, preventing aliasing.

- [x] official adapter submission
