### PR TITLE
Prebid core & PBS adapter: better support for server-side stored impressions

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -99,6 +99,7 @@ let eidPermissions;
  * @type {S2SDefaultConfig}
  */
 const s2sDefaultConfig = {
+  bidders: Object.freeze([]),
   timeout: 1000,
   syncTimeout: 1000,
   maxBids: 1,
@@ -143,7 +144,7 @@ function updateConfigDefaultVendor(option) {
  */
 function validateConfigRequiredProps(option) {
   const keys = Object.keys(option);
-  if (['accountId', 'bidders', 'endpoint'].filter(key => {
+  if (['accountId', 'endpoint'].filter(key => {
     if (!includes(keys, key)) {
       logError(key + ' missing in server to server config');
       return true;

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -706,7 +706,7 @@ Object.assign(ORTB2.prototype, {
       // get bidder params in form { <bidder code>: {...params} }
       // initialize reduce function with the user defined `ext` properties on the ad unit
       const ext = adUnit.bids.reduce((acc, bid) => {
-        if (bid.bidder == null) return;
+        if (bid.bidder == null) return acc;
         const adapter = adapterManager.bidderRegistry[bid.bidder];
         if (adapter && adapter.getSpec().transformBidParams) {
           bid.params = adapter.getSpec().transformBidParams(bid.params, true, adUnit, bidRequests);

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -706,6 +706,7 @@ Object.assign(ORTB2.prototype, {
       // get bidder params in form { <bidder code>: {...params} }
       // initialize reduce function with the user defined `ext` properties on the ad unit
       const ext = adUnit.bids.reduce((acc, bid) => {
+        if (bid.bidder == null) return;
         const adapter = adapterManager.bidderRegistry[bid.bidder];
         if (adapter && adapter.getSpec().transformBidParams) {
           bid.params = adapter.getSpec().transformBidParams(bid.params, true, adUnit, bidRequests);
@@ -914,10 +915,15 @@ Object.assign(ORTB2.prototype, {
       // a seatbid object contains a `bid` array and a `seat` string
       response.seatbid.forEach(seatbid => {
         (seatbid.bid || []).forEach(bid => {
-          const bidRequest = this.getBidRequest(bid.impid, seatbid.seat);
-          if (bidRequest == null && !s2sConfig.allowUnknownBidderCodes) {
-            logWarn(`PBS adapter received bid from unknown bidder (${seatbid.seat}), but 's2sConfig.allowUnknownBidderCodes' is not set. Ignoring bid.`);
-            return;
+          let bidRequest = this.getBidRequest(bid.impid, seatbid.seat);
+          if (bidRequest == null) {
+            if (!s2sConfig.allowUnknownBidderCodes) {
+              logWarn(`PBS adapter received bid from unknown bidder (${seatbid.seat}), but 's2sConfig.allowUnknownBidderCodes' is not set. Ignoring bid.`);
+              return;
+            }
+            // for stored impression, a request was made with bidder code `null`. Pick it up here so that NO_BID, BID_WON, etc events
+            // can work as expected (otherwise, the original request will always result in NO_BID).
+            bidRequest = this.getBidRequest(bid.impid, null);
           }
 
           const cpm = bid.price;

--- a/modules/s2sTesting.js
+++ b/modules/s2sTesting.js
@@ -1,12 +1,12 @@
-import { setS2STestingModule } from '../src/adapterManager.js';
+import {PARTITIONS, partitionBidders, filterBidsForAdUnit, getS2SBidderSet} from '../src/adapterManager.js';
+import {find} from '../src/polyfill.js';
+import {getBidderCodes, logWarn} from '../src/utils.js';
 
-let s2sTesting = {};
-
-const SERVER = 'server';
-const CLIENT = 'client';
-
-s2sTesting.SERVER = SERVER;
-s2sTesting.CLIENT = CLIENT;
+const {CLIENT, SERVER} = PARTITIONS;
+export const s2sTesting = {
+  ...PARTITIONS,
+  clientTestBidders: new Set()
+};
 
 s2sTesting.bidSource = {}; // store bidder sources determined from s2sConfig bidderControl
 s2sTesting.globalRand = Math.random(); // if 10% of bidderA and 10% of bidderB should be server-side, make it the same 10%
@@ -40,7 +40,7 @@ s2sTesting.getSourceBidderMap = function(adUnits = [], allS2SBidders = []) {
     [SERVER]: Object.keys(sourceBidders[SERVER]),
     [CLIENT]: Object.keys(sourceBidders[CLIENT])
   };
-};
+}
 
 /**
  * @function calculateBidSources determines the source for each s2s bidder based on bidderControl weightings.  these can be overridden at the adUnit level
@@ -53,7 +53,7 @@ s2sTesting.calculateBidSources = function(s2sConfig = {}) {
   (s2sConfig.bidders || []).forEach((bidder) => {
     s2sTesting.bidSource[bidder] = s2sTesting.getSource(bidderControl[bidder] && bidderControl[bidder].bidSource) || SERVER; // default to server
   });
-};
+}
 
 /**
  * @function getSource() gets a random source based on the given sourceWeights (export just for testing)
@@ -76,10 +76,59 @@ s2sTesting.getSource = function(sourceWeights = {}, bidSources = [SERVER, CLIENT
     // choose the first source with an incremental weight > random weight
     if (rndWeight < srcIncWeight[source]) return source;
   }
-};
+}
 
-// inject the s2sTesting module into the adapterManager rather than importing it
-// importing it causes the packager to include it even when it's not explicitly included in the build
-setS2STestingModule(s2sTesting);
+function doingS2STesting(s2sConfig) {
+  return s2sConfig && s2sConfig.enabled && s2sConfig.testing;
+}
+
+function isTestingServerOnly(s2sConfig) {
+  return Boolean(doingS2STesting(s2sConfig) && s2sConfig.testServerOnly);
+}
+
+const adUnitsContainServerRequests = (adUnits, s2sConfig) => Boolean(
+  find(adUnits, adUnit => find(adUnit.bids, bid => (
+    bid.bidSource ||
+    (s2sConfig.bidderControl && s2sConfig.bidderControl[bid.bidder])
+  ) && bid.finalSource === SERVER))
+);
+
+partitionBidders.before(function (next, adUnits, s2sConfigs) {
+  const serverBidders = getS2SBidderSet(s2sConfigs);
+  let serverOnly = false;
+
+  s2sConfigs.forEach((s2sConfig) => {
+    if (doingS2STesting(s2sConfig)) {
+      s2sTesting.calculateBidSources(s2sConfig);
+      const bidderMap = s2sTesting.getSourceBidderMap(adUnits, [...serverBidders]);
+      // get all adapters doing client testing
+      bidderMap[CLIENT].forEach((bidder) => s2sTesting.clientTestBidders.add(bidder))
+    }
+    if (isTestingServerOnly(s2sConfig) && adUnitsContainServerRequests(adUnits, s2sConfig)) {
+      logWarn('testServerOnly: True.  All client requests will be suppressed.');
+      serverOnly = true;
+    }
+  });
+
+  next.bail(getBidderCodes(adUnits).reduce((memo, bidder) => {
+    if (serverBidders.has(bidder)) {
+      memo[SERVER].push(bidder);
+    }
+    if (!serverOnly && (!serverBidders.has(bidder) || s2sTesting.clientTestBidders.has(bidder))) {
+      memo[CLIENT].push(bidder);
+    }
+    return memo;
+  }, {[CLIENT]: [], [SERVER]: []}));
+});
+
+filterBidsForAdUnit.before(function(next, bids, s2sConfig) {
+  if (s2sConfig == null) {
+    next.bail(bids.filter((bid) => !s2sTesting.clientTestBidders.size || bid.finalSource !== SERVER));
+  } else {
+    const serverBidders = getS2SBidderSet(s2sConfig);
+    next.bail(bids.filter((bid) => serverBidders.has(bid.bidder) &&
+      (!doingS2STesting(s2sConfig) || bid.finalSource !== CLIENT)));
+  }
+});
 
 export default s2sTesting;

--- a/modules/sizeMappingV2.js
+++ b/modules/sizeMappingV2.js
@@ -147,19 +147,12 @@ export function checkAdUnitSetupHook(adUnits) {
   }
   const validatedAdUnits = [];
   adUnits.forEach(adUnit => {
-    const bids = adUnit.bids;
+    adUnit = adUnitSetupChecks.validateAdUnit(adUnit);
+    if (adUnit == null) return;
+
     const mediaTypes = adUnit.mediaTypes;
     let validatedBanner, validatedVideo, validatedNative;
 
-    if (!bids || !isArray(bids)) {
-      logError(`Detected adUnit.code '${adUnit.code}' did not have 'adUnit.bids' defined or 'adUnit.bids' is not an array. Removing adUnit from auction.`);
-      return;
-    }
-
-    if (!mediaTypes || Object.keys(mediaTypes).length === 0) {
-      logError(`Detected adUnit.code '${adUnit.code}' did not have a 'mediaTypes' object defined. This is a required field for the auction, so this adUnit has been removed.`);
-      return;
-    }
     if (mediaTypes.banner) {
       if (mediaTypes.banner.sizes) {
         // Ad unit is using 'mediaTypes.banner.sizes' instead of the new property 'sizeConfig'. Apply the old checks!

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -169,19 +169,19 @@ function validateAdUnit(adUnit) {
     logError(msg(`defines 'adUnit.bids' that is not an array. Removing adUnit from auction`));
     return null;
   }
-  if (bids == null && adUnit.ortb2Imp == null && adUnit.storedAuctionResponse == null) {
-    logError(msg(`has no 'adUnit.bids', 'adUnit.ortb2Imp' or 'adUnit.storedAuctionResponse'. Removing adUnit from auction`));
+  if (bids == null && adUnit.ortb2Imp == null) {
+    logError(msg(`has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction`));
     return null;
   }
-  if ((adUnit.ortb2Imp != null || adUnit.storedAuctionResponse != null) && (bids == null || bids.length === 0)) {
-    adUnit.bids = [{bidder: null}]; // the 'null' bidder is treated as an s2s-only placeholder by adapterManager
-    logMessage(msg(`defines 'adUnit.${adUnit.storedAuctionResponse == null ? 'ortb2Imp' : 'storedAuctionResponse'}' with no 'adUnit.bids'; it will be seen only by S2S adapters`));
-  }
-
   if (!mediaTypes || Object.keys(mediaTypes).length === 0) {
     logError(msg(`does not define a 'mediaTypes' object.  This is a required field for the auction, so this adUnit has been removed.`));
     return null;
   }
+  if (adUnit.ortb2Imp != null && (bids == null || bids.length === 0)) {
+    adUnit.bids = [{bidder: null}]; // the 'null' bidder is treated as an s2s-only placeholder by adapterManager
+    logMessage(msg(`defines 'adUnit.ortb2Imp' with no 'adUnit.bids'; it will be seen only by S2S adapters`));
+  }
+
   return adUnit;
 }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -159,7 +159,34 @@ function validateAdUnitPos(adUnit, mediaType) {
   return adUnit
 }
 
+function validateAdUnit(adUnit) {
+  const msg = (msg) => `adUnit.code '${adUnit.code}' ${msg}`;
+
+  const mediaTypes = adUnit.mediaTypes;
+  const bids = adUnit.bids;
+
+  if (bids != null && !isArray(bids)) {
+    logError(msg(`defines 'adUnit.bids' that is not an array. Removing adUnit from auction`));
+    return null;
+  }
+  if (bids == null && adUnit.ortb2Imp == null) {
+    logError(msg(`has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction`));
+    return null;
+  }
+  if (adUnit.ortb2Imp != null && (bids == null || bids.length === 0)) {
+    adUnit.bids = [];
+    logMessage(msg(`defines 'adUnit.ortb2Imp' with no 'adUnit.bids'; will be seen only by S2S adapters`));
+  }
+
+  if (!mediaTypes || Object.keys(mediaTypes).length === 0) {
+    logError(msg(`does not define a 'mediaTypes' object.  This is a required field for the auction, so this adUnit has been removed.`));
+    return null;
+  }
+  return adUnit;
+}
+
 export const adUnitSetupChecks = {
+  validateAdUnit,
   validateBannerMediaType,
   validateVideoMediaType,
   validateNativeMediaType,
@@ -170,19 +197,11 @@ export const checkAdUnitSetup = hook('sync', function (adUnits) {
   const validatedAdUnits = [];
 
   adUnits.forEach(adUnit => {
+    adUnit = validateAdUnit(adUnit);
+    if (adUnit == null) return;
+
     const mediaTypes = adUnit.mediaTypes;
-    const bids = adUnit.bids;
     let validatedBanner, validatedVideo, validatedNative;
-
-    if (!bids || !isArray(bids)) {
-      logError(`Detected adUnit.code '${adUnit.code}' did not have 'adUnit.bids' defined or 'adUnit.bids' is not an array. Removing adUnit from auction.`);
-      return;
-    }
-
-    if (!mediaTypes || Object.keys(mediaTypes).length === 0) {
-      logError(`Detected adUnit.code '${adUnit.code}' did not have a 'mediaTypes' object defined.  This is a required field for the auction, so this adUnit has been removed.`);
-      return;
-    }
 
     if (mediaTypes.banner) {
       validatedBanner = validateBannerMediaType(adUnit);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -169,13 +169,13 @@ function validateAdUnit(adUnit) {
     logError(msg(`defines 'adUnit.bids' that is not an array. Removing adUnit from auction`));
     return null;
   }
-  if (bids == null && adUnit.ortb2Imp == null) {
-    logError(msg(`has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction`));
+  if (bids == null && adUnit.ortb2Imp == null && adUnit.storedAuctionResponse == null) {
+    logError(msg(`has no 'adUnit.bids', 'adUnit.ortb2Imp' or 'adUnit.storedAuctionResponse'. Removing adUnit from auction`));
     return null;
   }
-  if (adUnit.ortb2Imp != null && (bids == null || bids.length === 0)) {
-    adUnit.bids = [];
-    logMessage(msg(`defines 'adUnit.ortb2Imp' with no 'adUnit.bids'; will be seen only by S2S adapters`));
+  if ((adUnit.ortb2Imp != null || adUnit.storedAuctionResponse != null) && (bids == null || bids.length === 0)) {
+    adUnit.bids = [{bidder: null}]; // the 'null' bidder is treated as an s2s-only placeholder by adapterManager
+    logMessage(msg(`defines 'adUnit.${adUnit.storedAuctionResponse == null ? 'ortb2Imp' : 'storedAuctionResponse'}' with no 'adUnit.bids'; it will be seen only by S2S adapters`));
   }
 
   if (!mediaTypes || Object.keys(mediaTypes).length === 0) {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2483,6 +2483,17 @@ describe('S2S Adapter', function () {
       sinon.assert.calledWith(addBidResponse, sinon.match.any, sinon.match({bidderCode: 'storedImpression', requestId: 'testId'}))
     });
 
+    it('copies ortb2Imp to response when there is only a null bid', () => {
+      const cfg = {...CONFIG};
+      config.setConfig({s2sConfig: cfg});
+      const ortb2Imp = {ext: {prebid: {storedrequest: 'value'}}};
+      const req = {...REQUEST, s2sConfig: cfg, ad_units: [{...REQUEST.ad_units[0], bids: [{bidder: null, bid_id: 'testId'}], ortb2Imp}]};
+      const bidReq = {...BID_REQUESTS[0], bidderCode: null, bids: [{...BID_REQUESTS[0].bids[0], bidder: null, bidId: 'testId'}]}
+      adapter.callBids(req, [bidReq], addBidResponse, done, ajax);
+      const actual = JSON.parse(server.requests[0].requestBody);
+      sinon.assert.match(actual.imp[0], sinon.match(ortb2Imp));
+    });
+
     describe('on sync requested with no cookie', () => {
       let cfg, req, csRes;
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2471,6 +2471,18 @@ describe('S2S Adapter', function () {
       expect(addBidResponse.calledWith(sinon.match.any, sinon.match({bidderCode: 'unknown'}))).to.be.true;
     });
 
+    it('uses "null" request\'s ID for all responses, when a null request is present', function () {
+      const cfg = {...CONFIG, allowUnknownBidderCodes: true};
+      config.setConfig({s2sConfig: cfg});
+      const req = {...REQUEST, s2sConfig: cfg, ad_units: [{...REQUEST.ad_units[0], bids: [{bidder: null, bid_id: 'testId'}]}]};
+      const bidReq = {...BID_REQUESTS[0], bidderCode: null, bids: [{...BID_REQUESTS[0].bids[0], bidder: null, bidId: 'testId'}]}
+      adapter.callBids(req, [bidReq], addBidResponse, done, ajax);
+      const response = deepClone(RESPONSE_OPENRTB);
+      response.seatbid[0].seat = 'storedImpression';
+      server.requests[0].respond(200, {}, JSON.stringify(response));
+      sinon.assert.calledWith(addBidResponse, sinon.match.any, sinon.match({bidderCode: 'storedImpression', requestId: 'testId'}))
+    });
+
     describe('on sync requested with no cookie', () => {
       let cfg, req, csRes;
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2646,21 +2646,6 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should log an error when bidders is missing', function () {
-      const options = {
-        accountId: '1',
-        enabled: true,
-        timeout: 1000,
-        adapter: 's2s',
-        endpoint: {
-          p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'
-        }
-      };
-
-      config.setConfig({ s2sConfig: options });
-      sinon.assert.calledOnce(logErrorSpy);
-    });
-
     it('should log an error when endpoint is missing', function () {
       const options = {
         accountId: '1',

--- a/test/spec/modules/sizeMappingV2_spec.js
+++ b/test/spec/modules/sizeMappingV2_spec.js
@@ -194,49 +194,23 @@ describe('sizeMappingV2', function () {
       utils.logError.restore();
     });
 
-    it('should filter out adUnit if it does not contain the required property mediaTypes', function () {
-      let adUnits = utils.deepClone(AD_UNITS);
-      delete adUnits[0].mediaTypes;
-      // before checkAdUnitSetupHook is called, the length of adUnits should be '2'
-      expect(adUnits.length).to.equal(2);
-      adUnits = checkAdUnitSetupHook(adUnits);
+    describe('basic validation', () => {
+      let validateAdUnit;
 
-      // after checkAdUnitSetupHook is called, the length of adUnits should be '1'
-      expect(adUnits.length).to.equal(1);
-      expect(adUnits[0].code).to.equal('div-gpt-ad-1460505748561-1');
-    });
+      beforeEach(() => {
+        validateAdUnit = sinon.stub(adUnitSetupChecks, 'validateAdUnit');
+      });
 
-    it('should filter out adUnit if it does not contain the required property "bids"', function() {
-      let adUnits = utils.deepClone(AD_UNITS);
-      delete adUnits[0].mediaTypes;
-      // before checkAdUnitSetupHook is called, the length of the adUnits should equal '2'
-      expect(adUnits.length).to.equal(2);
-      adUnits = checkAdUnitSetupHook(adUnits);
+      afterEach(() => {
+        validateAdUnit.restore();
+      });
 
-      // after checkAdUnitSetupHook is called, the length of the adUnits should be '1'
-      expect(adUnits.length).to.equal(1);
-      expect(adUnits[0].code).to.equal('div-gpt-ad-1460505748561-1');
-    });
-
-    it('should filter out adUnit if it has declared property mediaTypes with an empty object', function () {
-      let adUnits = utils.deepClone(AD_UNITS);
-      adUnits[0].mediaTypes = {};
-      // before checkAdUnitSetupHook is called, the length of adUnits should be '2'
-      expect(adUnits.length).to.equal(2);
-      adUnits = checkAdUnitSetupHook(adUnits);
-
-      // after checkAdUnitSetupHook is called, the length of adUnits should be '1'
-      expect(adUnits.length).to.equal(1);
-      expect(adUnits[0].code).to.equal('div-gpt-ad-1460505748561-1');
-    });
-
-    it('should log an error message if Ad Unit does not contain the required property "mediaTypes"', function () {
-      let adUnits = utils.deepClone(AD_UNITS);
-      delete adUnits[0].mediaTypes;
-
-      checkAdUnitSetupHook(adUnits);
-      sinon.assert.callCount(utils.logError, 1);
-      sinon.assert.calledWith(utils.logError, 'Detected adUnit.code \'div-gpt-ad-1460505748561-0\' did not have a \'mediaTypes\' object defined. This is a required field for the auction, so this adUnit has been removed.');
+      it('should filter out adUnits that do not pass adUnitSetupChecks.validateAdUnit', () => {
+        validateAdUnit.returns(null);
+        const adUnits = checkAdUnitSetupHook(utils.deepClone(AD_UNITS));
+        AD_UNITS.forEach((u) => sinon.assert.calledWith(validateAdUnit, u));
+        expect(adUnits.length).to.equal(0);
+      });
     });
 
     describe('banner mediaTypes checks', function () {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2308,10 +2308,16 @@ describe('adapterManager tests', function () {
   });
 
   describe('getS2SBidderSet', () => {
+    it('should always return the "null" bidder', () => {
+      expect([...getS2SBidderSet({bidders: []})]).to.eql([null]);
+    });
+
     it('should not consider disabled s2s adapters', () => {
       const actual = getS2SBidderSet([{enabled: false, bidders: ['A', 'B']}, {enabled: true, bidders: ['C']}]);
-      expect([...actual]).to.eql(['C']);
+      expect([...actual]).to.include.members(['C']);
+      expect([...actual]).not.to.include.members(['A', 'B']);
     });
+
     it('should accept both single config objects and an array of them', () => {
       const conf = {enabled: true, bidders: ['A', 'B']};
       expect(getS2SBidderSet(conf)).to.eql(getS2SBidderSet([conf]));

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import adapterManager, { allS2SBidders, clientTestAdapters, gdprDataHandler, coppaDataHandler } from 'src/adapterManager.js';
+import adapterManager, {
+  gdprDataHandler,
+  coppaDataHandler,
+  _partitionBidders,
+  PARTITIONS,
+  getS2SBidderSet, _filterBidsForAdUnit
+} from 'src/adapterManager.js';
 import {
   getAdUnits,
   getServerTestingConfig,
@@ -85,6 +91,10 @@ describe('adapterManager tests', function () {
     adapterManager.bidderRegistry['rubicon'] = orgRubiconAdapter;
     adapterManager.bidderRegistry['badBidder'] = orgBadBidderAdapter;
     config.setConfig({s2sConfig: { enabled: false }});
+  });
+
+  afterEach(() => {
+    s2sTesting.clientTestBidders.clear();
   });
 
   describe('callBids', function () {
@@ -701,10 +711,6 @@ describe('adapterManager tests', function () {
       prebidServerAdapterMock.callBids.reset();
     });
 
-    afterEach(function () {
-      allS2SBidders.length = 0;
-    });
-
     const bidRequests = [{
       'bidderCode': 'appnexus',
       'auctionId': '1863e370099523',
@@ -1305,9 +1311,6 @@ describe('adapterManager tests', function () {
     }
 
     beforeEach(function () {
-      allS2SBidders.length = 0;
-      clientTestAdapters.length = 0
-
       adapterManager.bidderRegistry['prebidServer'] = prebidServerAdapterMock;
       adapterManager.bidderRegistry['adequant'] = adequantAdapterMock;
       adapterManager.bidderRegistry['appnexus'] = appnexusAdapterMock;
@@ -1662,7 +1665,6 @@ describe('adapterManager tests', function () {
   describe('makeBidRequests', function () {
     let adUnits;
     beforeEach(function () {
-      allS2SBidders.length = 0
       adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
         adUnit.bids = adUnit.bids.filter(bid => includes(['appnexus', 'rubicon'], bid.bidder));
         return adUnit;
@@ -1736,8 +1738,6 @@ describe('adapterManager tests', function () {
       let sandbox;
       beforeEach(function () {
         sandbox = sinon.sandbox.create();
-        allS2SBidders.length = 0;
-        clientTestAdapters.length = 0;
         // always have matchMedia return true for us
         sandbox.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
       });
@@ -1913,7 +1913,7 @@ describe('adapterManager tests', function () {
           ['visitor-uk', 'desktop']
         );
 
-          // only one adUnit and one bid from that adUnit should make it through the applied labels above
+        // only one adUnit and one bid from that adUnit should make it through the applied labels above
         expect(bidRequests.length).to.equal(1);
         expect(bidRequests[0].bidderCode).to.equal('rubicon');
         expect(bidRequests[0].bids.length).to.equal(1);
@@ -1997,7 +1997,6 @@ describe('adapterManager tests', function () {
     describe('s2sTesting - testServerOnly', () => {
       beforeEach(() => {
         config.setConfig({ s2sConfig: getServerTestingConfig(CONFIG) });
-        allS2SBidders.length = 0
         s2sTesting.bidSource = {};
       });
 
@@ -2128,7 +2127,6 @@ describe('adapterManager tests', function () {
 
       afterEach(() => {
         config.resetConfig()
-        allS2SBidders.length = 0;
         s2sTesting.bidSource = {};
       });
 
@@ -2306,6 +2304,98 @@ describe('adapterManager tests', function () {
           expect(bidRequests[1].bids[0].finalSource).equals('server');
         }
       );
+    });
+  });
+
+  describe('getS2SBidderSet', () => {
+    it('should not consider disabled s2s adapters', () => {
+      const actual = getS2SBidderSet([{enabled: false, bidders: ['A', 'B']}, {enabled: true, bidders: ['C']}]);
+      expect([...actual]).to.eql(['C']);
+    });
+    it('should accept both single config objects and an array of them', () => {
+      const conf = {enabled: true, bidders: ['A', 'B']};
+      expect(getS2SBidderSet(conf)).to.eql(getS2SBidderSet([conf]));
+    });
+  });
+
+  describe('separation of client and server bidders', () => {
+    let s2sBidders, getS2SBidders;
+    beforeEach(() => {
+      s2sBidders = null;
+      getS2SBidders = sinon.stub();
+      getS2SBidders.callsFake(() => s2sBidders);
+    })
+
+    describe('partitionBidders', () => {
+      let adUnits;
+
+      beforeEach(() => {
+        adUnits = [{
+          bids: [{
+            bidder: 'A'
+          }, {
+            bidder: 'B'
+          }]
+        }, {
+          bids: [{
+            bidder: 'A',
+          }, {
+            bidder: 'C'
+          }]
+        }];
+      });
+
+      function partition(adUnits, s2sConfigs) {
+        return _partitionBidders(adUnits, s2sConfigs, {getS2SBidders})
+      }
+
+      Object.entries({
+        'all client': {
+          s2s: [],
+          expected: {
+            [PARTITIONS.CLIENT]: ['A', 'B', 'C'],
+            [PARTITIONS.SERVER]: []
+          }
+        },
+        'all server': {
+          s2s: ['A', 'B', 'C'],
+          expected: {
+            [PARTITIONS.CLIENT]: [],
+            [PARTITIONS.SERVER]: ['A', 'B', 'C']
+          }
+        },
+        'mixed': {
+          s2s: ['B', 'C'],
+          expected: {
+            [PARTITIONS.CLIENT]: ['A'],
+            [PARTITIONS.SERVER]: ['B', 'C']
+          }
+        }
+      }).forEach(([test, {s2s, expected}]) => {
+        it(`should partition ${test} requests`, () => {
+          s2sBidders = new Set(s2s);
+          const s2sConfig = {};
+          expect(partition(adUnits, s2sConfig)).to.eql(expected);
+          sinon.assert.calledWith(getS2SBidders, sinon.match.same(s2sConfig));
+        });
+      });
+    });
+
+    describe('filterBidsForAdUnit', () => {
+      function filterBids(bids, s2sConfig) {
+        return _filterBidsForAdUnit(bids, s2sConfig, {getS2SBidders});
+      }
+      it('should not filter any bids when s2sConfig == null', () => {
+        const bids = ['untouched', 'data'];
+        expect(filterBids(bids)).to.eql(bids);
+      });
+
+      it('should remove bids that have bidder not present in s2sConfig', () => {
+        s2sBidders = new Set('A', 'B');
+        const s2sConfig = {};
+        expect(filterBids(['A', 'C', 'D'].map((code) => ({bidder: code})), s2sConfig)).to.eql([{bidder: 'A'}]);
+        sinon.assert.calledWith(getS2SBidders, sinon.match.same(s2sConfig));
+      })
     });
   });
 });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1900,21 +1900,23 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[1].mediaTypes.banner.pos).to.equal(0);
           });
 
-          it('should allow no bids if ortb2imp is specified', () => {
-            const adUnit = {
-              code: 'test',
-              mediaTypes: {
-                banner: {
-                  sizes: [[300, 250]]
-                }
-              },
-              ortb2Imp: {}
-            };
-            $$PREBID_GLOBAL$$.requestBids({
-              adUnits: [adUnit]
+          ['ortb2Imp', 'storedAuctionResponse'].forEach((prop) => {
+            it(`should allow no bids if ${prop} is specified`, () => {
+              const adUnit = {
+                code: 'test',
+                mediaTypes: {
+                  banner: {
+                    sizes: [[300, 250]]
+                  }
+                },
+                [prop]: {}
+              };
+              $$PREBID_GLOBAL$$.requestBids({
+                adUnits: [adUnit]
+              });
+              sinon.assert.match(auctionArgs.adUnits[0], adUnit);
             });
-            sinon.assert.match(auctionArgs.adUnits[0], adUnit);
-          });
+          })
         });
 
         describe('negative tests for validating adUnits', function() {
@@ -2050,7 +2052,7 @@ describe('Unit: Prebid Module', function () {
             });
             expect(auctionArgs.adUnits.length).to.equal(1);
             expect(auctionArgs.adUnits[1]).to.not.exist;
-            assert.ok(logErrorSpy.calledWith("adUnit.code 'bad-ad-unit-2' has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction"));
+            assert.ok(logErrorSpy.calledWith("adUnit.code 'bad-ad-unit-2' has no 'adUnit.bids', 'adUnit.ortb2Imp' or 'adUnit.storedAuctionResponse'. Removing adUnit from auction"));
           });
         });
       });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1626,6 +1626,7 @@ describe('Unit: Prebid Module', function () {
       let auctionArgs;
 
       beforeEach(function () {
+        auctionArgs = null;
         adUnitsBackup = auction.getAdUnits
         auctionManagerStub = sinon.stub(auctionManager, 'createAuction').callsFake(function() {
           auctionArgs = arguments[0];
@@ -1898,6 +1899,22 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[0].mediaTypes.banner.pos).to.equal(2);
             expect(auctionArgs.adUnits[1].mediaTypes.banner.pos).to.equal(0);
           });
+
+          it('should allow no bids if ortb2imp is specified', () => {
+            const adUnit = {
+              code: 'test',
+              mediaTypes: {
+                banner: {
+                  sizes: [[300, 250]]
+                }
+              },
+              ortb2Imp: {}
+            };
+            $$PREBID_GLOBAL$$.requestBids({
+              adUnits: [adUnit]
+            });
+            sinon.assert.match(auctionArgs.adUnits[0], adUnit);
+          });
         });
 
         describe('negative tests for validating adUnits', function() {
@@ -2033,7 +2050,7 @@ describe('Unit: Prebid Module', function () {
             });
             expect(auctionArgs.adUnits.length).to.equal(1);
             expect(auctionArgs.adUnits[1]).to.not.exist;
-            assert.ok(logErrorSpy.calledWith("Detected adUnit.code 'bad-ad-unit-2' did not have 'adUnit.bids' defined or 'adUnit.bids' is not an array. Removing adUnit from auction."));
+            assert.ok(logErrorSpy.calledWith("adUnit.code 'bad-ad-unit-2' has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction"));
           });
         });
       });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1900,23 +1900,21 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[1].mediaTypes.banner.pos).to.equal(0);
           });
 
-          ['ortb2Imp', 'storedAuctionResponse'].forEach((prop) => {
-            it(`should allow no bids if ${prop} is specified`, () => {
-              const adUnit = {
-                code: 'test',
-                mediaTypes: {
-                  banner: {
-                    sizes: [[300, 250]]
-                  }
-                },
-                [prop]: {}
-              };
-              $$PREBID_GLOBAL$$.requestBids({
-                adUnits: [adUnit]
-              });
-              sinon.assert.match(auctionArgs.adUnits[0], adUnit);
+          it(`should allow no bids if 'ortb2Imp' is specified`, () => {
+            const adUnit = {
+              code: 'test',
+              mediaTypes: {
+                banner: {
+                  sizes: [[300, 250]]
+                }
+              },
+              ortb2Imp: {}
+            };
+            $$PREBID_GLOBAL$$.requestBids({
+              adUnits: [adUnit]
             });
-          })
+            sinon.assert.match(auctionArgs.adUnits[0], adUnit);
+          });
         });
 
         describe('negative tests for validating adUnits', function() {
@@ -2052,7 +2050,7 @@ describe('Unit: Prebid Module', function () {
             });
             expect(auctionArgs.adUnits.length).to.equal(1);
             expect(auctionArgs.adUnits[1]).to.not.exist;
-            assert.ok(logErrorSpy.calledWith("adUnit.code 'bad-ad-unit-2' has no 'adUnit.bids', 'adUnit.ortb2Imp' or 'adUnit.storedAuctionResponse'. Removing adUnit from auction"));
+            assert.ok(logErrorSpy.calledWith("adUnit.code 'bad-ad-unit-2' has no 'adUnit.bids' and no 'adUnit.ortb2Imp'. Removing adUnit from auction"));
           });
         });
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

This adds the option of declaring adUnits without any explicit bidders that will be interpreted as S2S-only stored impressions (or other similar constructs where the server decides who is bidding):

 - adUnits that declare `ortb2Imp` will be considered valid even if they declare no `bids`;
 - for those adUnits, core injects a placeholder "null" bidder that generates only S2S requests;
 - the PBS adapter will then accept returned bids as long as `s2sConfig.allowUnknownBidderCodes` is set.

## Other information

Resolves https://github.com/prebid/Prebid.js/issues/7027
Docs PR TBD

This is an example page / stored impression:

```
<html>
<head>
    <script>
        var PREBID_TIMEOUT = 2000;

        var adUnits = [
            {
                code: 'test-div',
                mediaTypes: {
                    banner: {
                        sizes: [[728,90]]
                    }
                },
                ortb2Imp: { ext: { prebid: { storedauctionresponse: { id: '1001-static-response-300x250' } } } },
            }
        ];

        var pbjs = pbjs || {};
        pbjs.que = pbjs.que || [];

    </script>
    <script type="text/javascript" src="../../../build/dev/prebid.js" async></script>

    <script>
        var googletag = googletag || {};
        googletag.cmd = googletag.cmd || [];
        googletag.cmd.push(function() {
            googletag.pubads().disableInitialLoad();
        });

        pbjs.que.push(function() {
            pbjs.addAdUnits(adUnits);
            pbjs.setConfig({
                debug: true,
                s2sConfig: {
                    accountId: '14062',
                    bidders: ['rubicon'],
                    timeout: 1000,
                    endpoint: 'https://pg-prebid-server-qa.rubiconproject.com/openrtb2/auction',
                    syncEndpoint: 'https://prebid-server.qa.rubiconproject.com/cookie_sync',
                    enabled: true,
                    adapter: 'prebidServer',
                    allowUnknownBidderCodes: true
                }
            });
            pbjs.requestBids({
                bidsBackHandler: sendAdserverRequest
            });
        });

        function sendAdserverRequest(bids, timedOut, auctionId) {
            if (pbjs.adserverRequestSent) return;
            pbjs.adserverRequestSent = true;
            googletag.cmd.push(function() {
                pbjs.que.push(function() {
                    pbjs.setTargetingForGPTAsync();
                    googletag.pubads().refresh();
                });
            });
        }

        setTimeout(function() {
            sendAdserverRequest();
        }, PREBID_TIMEOUT);
    </script>

    <script>
        (function () {
            var gads = document.createElement('script');
            gads.async = true;
            gads.type = 'text/javascript';
            var useSSL = 'https:' == document.location.protocol;
            gads.src = (useSSL ? 'https:' : 'http:') +
                '//www.googletagservices.com/tag/js/gpt.js';
            var node = document.getElementsByTagName('script')[0];
            node.parentNode.insertBefore(gads, node);
        })();
    </script>

    <script>
        googletag.cmd.push(function() {
            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250], [300,600], [728,90]], 'test-div').addService(googletag.pubads());
            googletag.pubads().enableSingleRequest();
            googletag.enableServices();
        });
    </script>
</head>

<body>
<h2>Hosted Prebid - 14062</h2>

<div id='test-div'>
    <script>
        googletag.cmd.push(function() { googletag.display('test-div'); });
    </script>
</div>
</body>
</html>

```
