### PR TITLE
Prebid Server Bid Adapter: add support for all imp parameters

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -745,7 +745,7 @@ Object.assign(ORTB2.prototype, {
         }
       });
 
-      Object.assign(imp, mediaTypes);
+      mergeDeep(imp, mediaTypes);
 
       // if storedAuctionResponse has been set, pass SRID
       const storedAuctionResponseBid = find(firstBidRequest.bids, bid => (bid.adUnitCode === adUnit.code && bid.storedAuctionResponse));

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -714,7 +714,7 @@ Object.assign(ORTB2.prototype, {
         return acc;
       }, {...deepAccess(adUnit, 'ortb2Imp.ext')});
 
-      const imp = { id: impressionId, ext, secure: s2sConfig.secure };
+      const imp = {...adUnit.ortb2Imp, id: impressionId, ext, secure: s2sConfig.secure };
 
       const ortb2 = {...deepAccess(adUnit, 'ortb2Imp.ext.data')};
       Object.keys(ortb2).forEach(prop => {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -714,7 +714,7 @@ Object.assign(ORTB2.prototype, {
         return acc;
       }, {...deepAccess(adUnit, 'ortb2Imp.ext')});
 
-      const imp = {...adUnit.ortb2Imp, id: impressionId, ext, secure: s2sConfig.secure };
+      const imp = { ...adUnit.ortb2Imp, id: impressionId, ext, secure: s2sConfig.secure };
 
       const ortb2 = {...deepAccess(adUnit, 'ortb2Imp.ext.data')};
       Object.keys(ortb2).forEach(prop => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2910,6 +2910,25 @@ describe('S2S Adapter', function () {
       expect(requestBid.coopSync).to.be.undefined;
     });
 
+    it('should set imp banner if ortb2Imp.banner is present', function() {
+      const consentConfig = { s2sConfig: CONFIG };
+      config.setConfig(consentConfig);
+      const bidRequest = utils.deepClone(REQUEST);
+      bidRequest.ad_units[0].ortb2Imp = {
+        banner: {
+          api: 7
+        }
+      };
+
+      adapter.callBids(bidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+      const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
+
+      expect(parsedRequestBody.imp).to.be.a('array');
+      expect(parsedRequestBody.imp[0]).to.be.a('object');
+      expect(parsedRequestBody.imp[0]).to.have.property('banner');
+      expect(parsedRequestBody.imp[0].banner.api).to.equal(7);
+    });
+
     it('adds debug flag', function () {
       config.setConfig({debug: true});
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2917,7 +2917,8 @@ describe('S2S Adapter', function () {
       bidRequest.ad_units[0].ortb2Imp = {
         banner: {
           api: 7
-        }
+        },
+        instl: 1
       };
 
       adapter.callBids(bidRequest, BID_REQUESTS, addBidResponse, done, ajax);
@@ -2927,6 +2928,8 @@ describe('S2S Adapter', function () {
       expect(parsedRequestBody.imp[0]).to.be.a('object');
       expect(parsedRequestBody.imp[0]).to.have.property('banner');
       expect(parsedRequestBody.imp[0].banner.api).to.equal(7);
+      expect(parsedRequestBody.imp[0]).to.have.property('instl');
+      expect(parsedRequestBody.imp[0].instl).to.equal(1);
     });
 
     it('adds debug flag', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2924,11 +2924,7 @@ describe('S2S Adapter', function () {
       adapter.callBids(bidRequest, BID_REQUESTS, addBidResponse, done, ajax);
       const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
 
-      expect(parsedRequestBody.imp).to.be.a('array');
-      expect(parsedRequestBody.imp[0]).to.be.a('object');
-      expect(parsedRequestBody.imp[0]).to.have.property('banner');
       expect(parsedRequestBody.imp[0].banner.api).to.equal(7);
-      expect(parsedRequestBody.imp[0]).to.have.property('instl');
       expect(parsedRequestBody.imp[0].instl).to.equal(1);
     });
 


### PR DESCRIPTION
Fix for issue #7831 . Add support for all Imp object properties instead of just 'ext.data'

Also, added testing from pr #8040 to cover instl