### PR TITLE
DFP Ad Server Video: respect original url

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -95,11 +95,7 @@ export function buildDfpVideoUrl(options) {
     derivedParams.sz = urlSzParam + '|' + derivedParams.sz;
   }
 
-  let encodedCustomParams = getCustParams(bid, options);
-  const urlCustParams = urlSearchComponent.cust_params;
-  if (urlCustParams) {
-    encodedCustomParams = urlCustParams + '%26' + encodedCustomParams;
-  }
+  let encodedCustomParams = getCustParams(bid, options, urlSearchComponent && urlSearchComponent.cust_params);
 
   const queryParams = Object.assign({},
     defaultParamConstants,
@@ -237,8 +233,7 @@ function buildUrlFromAdserverUrlComponents(components, bid, options) {
   const descriptionUrl = getDescriptionUrl(bid, components, 'search');
   if (descriptionUrl) { components.search.description_url = descriptionUrl; }
 
-  const encodedCustomParams = getCustParams(bid, options);
-  components.search.cust_params = (components.search.cust_params) ? components.search.cust_params + '%26' + encodedCustomParams : encodedCustomParams;
+  components.search.cust_params = getCustParams(bid, options, components.search.cust_params);
   return buildUrl(components);
 }
 
@@ -267,7 +262,7 @@ function getDescriptionUrl(bid, components, prop) {
  * @param {Object} options this is the options passed in from the `buildDfpVideoUrl` function
  * @return {Object} Encoded key value pairs for cust_params
  */
-function getCustParams(bid, options) {
+function getCustParams(bid, options, urlCustParams) {
   const adserverTargeting = (bid && bid.adserverTargeting) || {};
 
   let allTargetingData = {};
@@ -290,7 +285,12 @@ function getCustParams(bid, options) {
   // merge the prebid + publisher targeting sets
   const publisherTargetingSet = deepAccess(options, 'params.cust_params');
   const targetingSet = Object.assign({}, prebidTargetingSet, publisherTargetingSet);
-  return encodeURIComponent(formatQS(targetingSet));
+  let encodedParams = encodeURIComponent(formatQS(targetingSet));
+  if (urlCustParams) {
+    encodedParams = urlCustParams + '%26' + encodedParams;
+  }
+
+  return encodedParams;
 }
 
 registerVideoSupport('dfp', {

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -88,7 +88,18 @@ export function buildDfpVideoUrl(options) {
     sz: parseSizesInput(deepAccess(adUnit, 'mediaTypes.video.playerSize')).join('|'),
     url: encodeURIComponent(location.href),
   };
-  const encodedCustomParams = getCustParams(bid, options);
+
+  const urlSearchComponent = urlComponents.search;
+  const urlSzParam = urlSearchComponent && urlSearchComponent.sz
+  if (urlSzParam) {
+    derivedParams.sz = urlSzParam + '|' + derivedParams.sz;
+  }
+
+  let encodedCustomParams = getCustParams(bid, options);
+  const urlCustParams = urlSearchComponent.cust_params;
+  if (urlCustParams) {
+    encodedCustomParams = urlCustParams + '%26' + encodedCustomParams;
+  }
 
   const queryParams = Object.assign({},
     defaultParamConstants,
@@ -228,7 +239,6 @@ function buildUrlFromAdserverUrlComponents(components, bid, options) {
 
   const encodedCustomParams = getCustParams(bid, options);
   components.search.cust_params = (components.search.cust_params) ? components.search.cust_params + '%26' + encodedCustomParams : encodedCustomParams;
-
   return buildUrl(components);
 }
 

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -111,12 +111,11 @@ export function buildDfpVideoUrl(options) {
   const uspConsent = uspDataHandler.getConsentData();
   if (uspConsent) { queryParams.us_privacy = uspConsent; }
 
-  return buildUrl({
+  return buildUrl(Object.assign({
     protocol: 'https',
     host: 'securepubads.g.doubleclick.net',
-    pathname: '/gampad/ads',
-    search: queryParams
-  });
+    pathname: '/gampad/ads'
+  }, urlComponents, { search: queryParams }));
 }
 
 export function notifyTranslationModule(fn) {

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -427,6 +427,42 @@ describe('The DFP video support module', function () {
     expect(url.pathname).to.equal('/ads');
   });
 
+  it('should append to the url size param', () => {
+    const url = parse(buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bid,
+      url: 'http://video.adserver.example/ads?sz=360x240&iu=/123/aduniturl&impl=s',
+      params: {
+        cust_params: {
+          hb_rand: 'random'
+        }
+      }
+    }));
+
+    const queryObject = utils.parseQS(url.query);
+    expect(queryObject.sz).to.equal('360x240|640x480');
+  });
+
+  it('should append to the existing url cust params', () => {
+    const url = parse(buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bid,
+      url: 'http://video.adserver.example/ads?sz=360x240&iu=/123/aduniturl&impl=s&cust_params=existing_key%3Dexisting_value%26other_key%3Dother_value',
+      params: {
+        cust_params: {
+          hb_rand: 'random'
+        }
+      }
+    }));
+
+    const queryObject = utils.parseQS(url.query);
+    const customParams = utils.parseQS('?' + decodeURIComponent(queryObject.cust_params));
+
+    expect(customParams).to.have.property('existing_key', 'existing_value');
+    expect(customParams).to.have.property('other_key', 'other_value');
+    expect(customParams).to.have.property('hb_rand', 'random');
+  });
+
   describe('adpod unit tests', function () {
     let amStub;
     let amGetAdUnitsStub;

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -410,6 +410,23 @@ describe('The DFP video support module', function () {
     expect(customParams).to.have.property('hb_cache_id', 'def');
   });
 
+  it('should keep the url protocol, host, and pathname when using url and params', function () {
+    const url = parse(buildDfpVideoUrl({
+      adUnit: adUnit,
+      bid: bid,
+      url: 'http://video.adserver.example/ads?sz=640x480&iu=/123/aduniturl&impl=s',
+      params: {
+        cust_params: {
+          hb_rand: 'random'
+        }
+      }
+    }));
+
+    expect(url.protocol).to.equal('http:');
+    expect(url.host).to.equal('video.adserver.example');
+    expect(url.pathname).to.equal('/ads');
+  });
+
   describe('adpod unit tests', function () {
     let amStub;
     let amGetAdUnitsStub;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Fixes a bug where when `buildDfpVideoUrl` is called with both a url and params, the original url is modified extensively:

- the url's host, protocol and pathname are overriden. 
- if a size param is included in the url, it is overriden.
- cust_params in the url are discarded.

For example, if my ad tag url's host is `pubads.g.doubleclick.net`, it gets replaced with  `'securepubads.g.doubleclick.net'`. Instead, `'securepubads.g.doubleclick.net'` should be used as a fallback. 

With this change, the original host, protocol and pathname are kept. Additionally, sizes and cust_params are appended to any existing values in the URL.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
