### PR TITLE
Rubicon Bid Adapter: Pass along prebid bidId to exchange

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -407,6 +407,7 @@ export const spec = {
       .concat([
         'tk_flint',
         'x_source.tid',
+        'l_pb_bid_id',
         'x_source.pchain',
         'p_screen_res',
         'rp_floor',
@@ -480,6 +481,7 @@ export const spec = {
       'rp_secure': '1',
       'tk_flint': `${rubiConf.int_type || DEFAULT_INTEGRATION}_v$prebid.version$`,
       'x_source.tid': bidRequest.transactionId,
+      'l_pb_bid_id': bidRequest.bidId,
       'x_source.pchain': params.pchain,
       'p_screen_res': _getScreenResolution(),
       'tk_user_key': params.userId,

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {expect} from 'chai';
 import {
   spec,
@@ -597,9 +598,10 @@ describe('the rubicon adapter', function () {
           sandbox.stub(Math, 'random').callsFake(() => 0.1);
           let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
 
-          const referenceOrdering = ['account_id', 'site_id', 'zone_id', 'size_id', 'alt_size_ids', 'p_pos', 'rf', 'p_geo.latitude', 'p_geo.longitude', 'kw', 'tg_v.ucat', 'tg_v.lastsearch', 'tg_v.likes', 'tg_i.rating', 'tg_i.prodtype', 'tk_flint', 'x_source.tid', 'x_source.pchain', 'p_screen_res', 'rp_secure', 'tk_user_key', 'tg_fl.eid', 'rp_maxbids', 'slots', 'rand'];
+          const referenceOrdering = ['account_id', 'site_id', 'zone_id', 'size_id', 'alt_size_ids', 'p_pos', 'rf', 'p_geo.latitude', 'p_geo.longitude', 'kw', 'tg_v.ucat', 'tg_v.lastsearch', 'tg_v.likes', 'tg_i.rating', 'tg_i.prodtype', 'tk_flint', 'x_source.tid', 'l_pb_bid_id', 'x_source.pchain', 'p_screen_res', 'rp_secure', 'tk_user_key', 'tg_fl.eid', 'rp_maxbids', 'slots', 'rand'];
 
           request.data.split('&').forEach((item, i) => {
+            console.log(item.split('=')[0]);
             expect(item.split('=')[0]).to.equal(referenceOrdering[i]);
           });
         });

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {expect} from 'chai';
 import {
   spec,
@@ -601,7 +600,6 @@ describe('the rubicon adapter', function () {
           const referenceOrdering = ['account_id', 'site_id', 'zone_id', 'size_id', 'alt_size_ids', 'p_pos', 'rf', 'p_geo.latitude', 'p_geo.longitude', 'kw', 'tg_v.ucat', 'tg_v.lastsearch', 'tg_v.likes', 'tg_i.rating', 'tg_i.prodtype', 'tk_flint', 'x_source.tid', 'l_pb_bid_id', 'x_source.pchain', 'p_screen_res', 'rp_secure', 'tk_user_key', 'tg_fl.eid', 'rp_maxbids', 'slots', 'rand'];
 
           request.data.split('&').forEach((item, i) => {
-            console.log(item.split('=')[0]);
             expect(item.split('=')[0]).to.equal(referenceOrdering[i]);
           });
         });


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Rubicon Bid Adapter now passes along prebid.js's bidId to the magnite exchange.