### PR TITLE
Prebid core: fix log message when enabling a missing analytics provider

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -531,12 +531,11 @@ adapterManager.enableAnalytics = function (config) {
   }
 
   _each(config, adapterConfig => {
-    var adapter = _analyticsRegistry[adapterConfig.provider].adapter;
-    if (adapter) {
-      adapter.enableAnalytics(adapterConfig);
+    const entry = _analyticsRegistry[adapterConfig.provider];
+    if (entry && entry.adapter) {
+      entry.adapter.enableAnalytics(adapterConfig);
     } else {
-      logError(`Prebid Error: no analytics adapter found in registry for
-        ${adapterConfig.provider}.`);
+      logError(`Prebid Error: no analytics adapter found in registry for '${adapterConfig.provider}'.`);
     }
   });
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Log the appropriate message when trying to enable a missing analytics provider.

Fixes https://github.com/prebid/Prebid.js/issues/8145

