### PR TITLE
Adagio Bid Adapter: getPrintNumber fix

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -823,7 +823,7 @@ function getPrintNumber(adUnitCode, bidderRequest) {
     return 1;
   }
   const adagioBid = find(bidderRequest.bids, bid => bid.adUnitCode === adUnitCode);
-  return adagioBid.bidRequestsCount || 1;
+  return adagioBid.bidderRequestsCount || 1;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
We used `bid.bidRequestsCount` instead of `bid.bidderRequestsCount` to compute what we call "printNumber". 

- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission
