### PR TITLE
Spotx Bid Adapter: Fix gvlid undefined + Update Magnite adapters to use proper GVLID's (Slimcut & Telaria)

### DIFF
--- a/modules/slimcutBidAdapter.js
+++ b/modules/slimcutBidAdapter.js
@@ -9,7 +9,8 @@ const BIDDER_CODE = 'slimcut';
 const ENDPOINT_URL = 'https://sb.freeskreen.com/pbr';
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['scm'],
+  gvlid: 52,
+  aliases: [{ code: 'scm', gvlid: 52 }],
   supportedMediaTypes: ['video', 'banner'],
   /**
      * Determines whether or not the given bid request is valid.

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -11,8 +11,7 @@ export const GOOGLE_CONSENT = { consented_providers: ['3', '7', '11', '12', '15'
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 165,
-  aliases: ['spotx'],
+  gvlid: 52,
   supportedMediaTypes: [VIDEO],
 
   /**

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -9,7 +9,11 @@ const EVENTS_ENDPOINT = `events.${DOMAIN}/diag`;
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: ['tremor', 'tremorvideo'],
+  gvlid: 52,
+  aliases: [
+    { code: 'tremor', gvlid: 52 },
+    { code: 'tremorvideo', gvlid: 52 }
+  ],
   supportedMediaTypes: [VIDEO],
   /**
    * Determines if the request is valid


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [X] Other

## Description of change
Addresses #8165 

### SpotX gvldid undefined

This was happening because spotx bid adapter declared it's own bidder code as an alias.

And the code in [bidderFactory.js](https://github.com/prebid/Prebid.js/blob/master/src/adapters/bidderFactory.js#L163) loops through the alias array and expects it to have gvlId, and if not, then sets it to undefined.

Because spotx used same bidder code in the alias array, it was overwriting the main spec! Which may have caused other weird issues as well.

Instead of declaring spotx, we now just do not declare it and the GVL shows up!

### Magnite Adapters now use Magnite gvlid
Magnites other adapters now will use the MAgnite gvlid `52` instead of the older ones.