### PR TITLE
Justpremium Bid Adapter: pass additional params

### DIFF
--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -4,7 +4,7 @@ import { deepAccess } from '../src/utils.js';
 const BIDDER_CODE = 'justpremium'
 const GVLID = 62
 const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
-const JP_ADAPTER_VERSION = '1.8.1'
+const JP_ADAPTER_VERSION = '1.8.2'
 const pixels = []
 
 export const spec = {
@@ -19,6 +19,7 @@ export const spec = {
   buildRequests: (validBidRequests, bidderRequest) => {
     const c = preparePubCond(validBidRequests)
     const dim = getWebsiteDim()
+    const ggExt = getGumGumParams()
     const payload = {
       zone: validBidRequests.map(b => {
         return parseInt(b.params.zone)
@@ -32,7 +33,8 @@ export const spec = {
       wh: dim.innerHeight,
       c: c,
       id: validBidRequests[0].params.zone,
-      sizes: {}
+      sizes: {},
+      ggExt: ggExt
     }
     validBidRequests.forEach(b => {
       const zone = b.params.zone
@@ -251,6 +253,21 @@ function getWebsiteDim () {
     innerWidth: top.innerWidth,
     innerHeight: top.innerHeight
   }
+}
+
+function getGumGumParams () {
+  if (!window.top) return null
+
+  const urlParams = new URLSearchParams(window.top.location.search)
+  const ggParams = {
+    'ggAdbuyid': urlParams.get('gg_adbuyid'),
+    'ggDealid': urlParams.get('gg_dealid'),
+    'ggEadbuyid': urlParams.get('gg_eadbuyid')
+  }
+
+  const checkIfEmpty = (obj) => Object.keys(obj).length === 0 ? null : obj
+  const removeNullEntries = (obj) => Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null))
+  return checkIfEmpty(removeNullEntries(ggParams))
 }
 
 registerBidder(spec)

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -97,12 +97,13 @@ describe('justpremium adapter', function () {
       expect(jpxRequest.id).to.equal(adUnits[0].params.zone)
       expect(jpxRequest.mediaTypes && jpxRequest.mediaTypes.banner && jpxRequest.mediaTypes.banner.sizes).to.not.equal('undefined')
       expect(jpxRequest.version.prebid).to.equal('$prebid.version$')
-      expect(jpxRequest.version.jp_adapter).to.equal('1.8.1')
+      expect(jpxRequest.version.jp_adapter).to.equal('1.8.2')
       expect(jpxRequest.pubcid).to.equal('0000000')
       expect(jpxRequest.uids.tdid).to.equal('1111111')
       expect(jpxRequest.uids.id5id.uid).to.equal('2222222')
       expect(jpxRequest.uids.digitrustid.data.id).to.equal('3333333')
       expect(jpxRequest.us_privacy).to.equal('1YYN')
+      expect(jpxRequest.ggExt).to.be.null
     })
   })
 


### PR DESCRIPTION


## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This change will search for specific URL params and pass them in the request.
