### PR TITLE
Prebid Core: Remove ancient Firefox handling

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -474,16 +474,6 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
             const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
             emitAdRenderFail({reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id});
           } else if (ad) {
-            // will check if browser is firefox and below version 67, if so execute special doc.open()
-            // for details see: https://github.com/prebid/Prebid.js/pull/3524
-            // TODO remove this browser specific code at later date (when Firefox < 67 usage is mostly gone)
-            if (navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox/') > -1) {
-              const firefoxVerRegx = /firefox\/([\d\.]+)/;
-              let firefoxVer = navigator.userAgent.toLowerCase().match(firefoxVerRegx)[1]; // grabs the text in the 1st matching group
-              if (firefoxVer && parseInt(firefoxVer, 10) < 67) {
-                doc.open('text/html', 'replace');
-              }
-            }
             doc.write(ad);
             doc.close();
             setRenderSize(doc, width, height);


### PR DESCRIPTION
With Prebid 6 we stopped supporting Fox < 67