### PR TITLE
Vibrant Media Bid Adapter: onBidWon pixel trigger

### DIFF
--- a/modules/vibrantmediaBidAdapter.js
+++ b/modules/vibrantmediaBidAdapter.js
@@ -13,6 +13,7 @@ import {OUTSTREAM} from '../src/video.js';
 
 const BIDDER_CODE = 'vibrantmedia';
 const VIBRANT_MEDIA_PREBID_URL = 'https://prebid.intellitxt.com/prebid';
+const VALID_PIXEL_URL_REGEX = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)+([/?].*)?$/;
 const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
 
 /**
@@ -49,6 +50,10 @@ const isBaseUrl = function(url) {
   const urlMinusScheme = url.substring(url.indexOf('://') + 3);
   const endOfDomain = urlMinusScheme.indexOf('/');
   return (endOfDomain === -1) || (endOfDomain === (urlMinusScheme.length - 1));
+};
+
+const isValidPixelUrl = function (candidateUrl) {
+  return VALID_PIXEL_URL_REGEX.test(candidateUrl);
 };
 
 /**
@@ -213,7 +218,7 @@ export const spec = {
    * @param {*} bidData the data associated with the won bid. See example above for data format.
    */
   onBidWon: function(bidData) {
-    if (bidData && bidData.meta && bidData.meta.wp) {
+    if (bidData && bidData.meta && isValidPixelUrl(bidData.meta.wp)) {
       triggerPixel(`${bidData.meta.wp}${bidData.status}`);
     }
   }

--- a/modules/vibrantmediaBidAdapter.js
+++ b/modules/vibrantmediaBidAdapter.js
@@ -13,7 +13,7 @@ import {OUTSTREAM} from '../src/video.js';
 
 const BIDDER_CODE = 'vibrantmedia';
 const VIBRANT_MEDIA_PREBID_URL = 'https://prebid.intellitxt.com/prebid';
-const VALID_PIXEL_URL_REGEX = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)+([/?].*)?$/;
+const VALID_PIXEL_URL_REGEX = /^https?:\/\/[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+([/?].*)?$/;
 const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
 
 /**

--- a/modules/vibrantmediaBidAdapter.js
+++ b/modules/vibrantmediaBidAdapter.js
@@ -6,7 +6,7 @@
  * Note: Only BANNER and VIDEO are currently supported by the prebid server.
  */
 
-import {logError, logInfo} from '../src/utils.js';
+import {logError, triggerPixel} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {OUTSTREAM} from '../src/video.js';
@@ -213,7 +213,9 @@ export const spec = {
    * @param {*} bidData the data associated with the won bid. See example above for data format.
    */
   onBidWon: function(bidData) {
-    logInfo('Bid won: ' + JSON.stringify(bidData));
+    if (bidData && bidData.meta && bidData.meta.wp) {
+      triggerPixel(`${bidData.meta.wp}${bidData.status}`);
+    }
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Triggered Vibrant internal pixel endpoint on bidWon event handler


- contact email of the adapter’s maintainer: [kormorant@vibrantmedia.com](mailto:kormorant@vibrantmedia.com)

- [x] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
