### PR TITLE
Rubicon Analytics: handle bad auction case

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -866,7 +866,12 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         break;
       case AUCTION_END:
         // see how long it takes for the payload to come fire
-        cache.auctions[args.auctionId].endTs = Date.now();
+        let auctionCache = cache.auctions[args.auctionId];
+        // if for some reason the auction did not do its normal thing, this could be undefied so bail
+        if (!auctionCache) {
+          break;
+        }
+        auctionCache.endTs = Date.now();
 
         const isOnlyInstreamAuction = args.adUnits && args.adUnits.every(adUnit => adUnitIsOnlyInstream(adUnit));
         // If only instream, do not wait around, just send payload

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -866,12 +866,12 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         break;
       case AUCTION_END:
         // see how long it takes for the payload to come fire
-        let auctionCache = cache.auctions[args.auctionId];
+        let auctionData = cache.auctions[args.auctionId];
         // if for some reason the auction did not do its normal thing, this could be undefied so bail
-        if (!auctionCache) {
+        if (!auctionData) {
           break;
         }
-        auctionCache.endTs = Date.now();
+        auctionData.endTs = Date.now();
 
         const isOnlyInstreamAuction = args.adUnits && args.adUnits.every(adUnit => adUnitIsOnlyInstream(adUnit));
         // If only instream, do not wait around, just send payload


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Noticed cases where the auction cancels halfway through, no bids are created or something that the adapter throws an error accessing this object which does not exist. So added a check and break.