### PR TITLE
Insticator: add schain, eids, gpid support to version 5

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -1,12 +1,8 @@
-import { config } from '../src/config.js';
-import { BANNER } from '../src/mediaTypes.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import {
-  deepAccess,
-  generateUUID,
-  logError,
-} from '../src/utils.js';
-import { getStorageManager } from '../src/storageManager.js';
+import {config} from '../src/config.js';
+import {BANNER} from '../src/mediaTypes.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {deepAccess, generateUUID, logError, isArray} from '../src/utils.js';
+import {getStorageManager} from '../src/storageManager.js';
 import find from 'core-js-pure/features/array/find.js';
 
 const BIDDER_CODE = 'insticator';
@@ -54,6 +50,12 @@ function setUserId(userId) {
 
 function buildImpression(bidRequest) {
   const format = [];
+  const ext = {
+    insticator: {
+      adUnitId: bidRequest.params.adUnitId,
+    },
+  }
+
   const sizes =
     deepAccess(bidRequest, 'mediaTypes.banner.sizes') || bidRequest.sizes;
 
@@ -64,17 +66,19 @@ function buildImpression(bidRequest) {
     });
   }
 
+  const gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
+
+  if (gpid) {
+    ext.gpid = gpid;
+  }
+
   return {
     id: bidRequest.bidId,
     tagid: bidRequest.adUnitCode,
     banner: {
       format,
     },
-    ext: {
-      insticator: {
-        adUnitId: bidRequest.params.adUnitId,
-      },
-    },
+    ext,
   };
 }
 
@@ -121,6 +125,24 @@ function buildUser() {
   };
 }
 
+function extractSchain(bids, requestId) {
+  if (!bids || bids.length === 0 || !bids[0].schain) return;
+
+  const schain = bids[0].schain;
+  if (schain && schain.nodes && schain.nodes.length && schain.nodes[0]) {
+    schain.nodes[0].rid = requestId;
+  }
+
+  return schain;
+}
+
+function extractEids(bids) {
+  if (!bids) return;
+
+  const bid = bids.find(bid => isArray(bid.userIdAsEids) && bid.userIdAsEids.length > 0);
+  return bid ? bid.userIdAsEids : bids[0].userIdAsEids;
+}
+
 function buildRequest(validBidRequests, bidderRequest) {
   const req = {
     id: bidderRequest.bidderRequestId,
@@ -138,14 +160,34 @@ function buildRequest(validBidRequests, bidderRequest) {
     regs: buildRegs(bidderRequest),
     user: buildUser(),
     imp: validBidRequests.map((bidRequest) => buildImpression(bidRequest)),
+    ext: {
+      insticator: {
+        adapter: {
+          vendor: 'prebid',
+          prebid: '$prebid.version$'
+        }
+      }
+    }
   };
 
   const params = config.getConfig('insticator.params');
 
   if (params) {
     req.ext = {
-      insticator: params,
+      insticator: {...req.ext.insticator, ...params},
     };
+  }
+
+  const schain = extractSchain(validBidRequests, bidderRequest.bidderRequestId);
+
+  if (schain) {
+    req.source.ext = { schain };
+  }
+
+  const eids = extractEids(validBidRequests);
+
+  if (eids) {
+    req.user.ext = { eids };
   }
 
   return req;
@@ -153,6 +195,15 @@ function buildRequest(validBidRequests, bidderRequest) {
 
 function buildBid(bid, bidderRequest) {
   const originalBid = find(bidderRequest.bids, (b) => b.bidId === bid.impid);
+  let meta = {}
+
+  if (bid.ext && bid.ext.meta) {
+    meta = bid.ext.meta
+  }
+
+  if (bid.adomain) {
+    meta.advertiserDomains = bid.adomain
+  }
 
   return {
     requestId: bid.impid,
@@ -166,9 +217,7 @@ function buildBid(bid, bidderRequest) {
     mediaType: 'banner',
     ad: bid.adm,
     adUnitCode: originalBid.adUnitCode,
-    meta: {
-      advertiserDomains: bid.bidADomain && bid.bidADomain.length ? bid.bidADomain : []
-    },
+    ...(Object.keys(meta).length > 0 ? {meta} : {})
   };
 }
 

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -181,13 +181,13 @@ function buildRequest(validBidRequests, bidderRequest) {
   const schain = extractSchain(validBidRequests, bidderRequest.bidderRequestId);
 
   if (schain) {
-    req.source.ext = { schain };
+    req.source.ext = {schain};
   }
 
   const eids = extractEids(validBidRequests);
 
   if (eids) {
-    req.user.ext = { eids };
+    req.user.ext = {eids};
   }
 
   return req;
@@ -195,14 +195,14 @@ function buildRequest(validBidRequests, bidderRequest) {
 
 function buildBid(bid, bidderRequest) {
   const originalBid = find(bidderRequest.bids, (b) => b.bidId === bid.impid);
-  let meta = {}
+  let meta = {};
 
   if (bid.ext && bid.ext.meta) {
-    meta = bid.ext.meta
+    meta = bid.ext.meta;
   }
 
   if (bid.adomain) {
-    meta.advertiserDomains = bid.adomain
+    meta.advertiserDomains = bid.adomain;
   }
 
   return {

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -139,7 +139,7 @@ function extractSchain(bids, requestId) {
 function extractEids(bids) {
   if (!bids) return;
 
-  const bid = bids.find(bid => isArray(bid.userIdAsEids) && bid.userIdAsEids.length > 0);
+  const bid = find(bids, bid => isArray(bid.userIdAsEids) && bid.userIdAsEids.length > 0);
   return bid ? bid.userIdAsEids : bids[0].userIdAsEids;
 }
 

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { spec, storage } from '../../../modules/insticatorBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js'
-import { userSync } from '../../../src/userSync.js';
 
 const USER_ID_KEY = 'hb_insticator_uid';
 const USER_ID_DUMMY_VALUE = '74f78609-a92d-4cf1-869f-1b244bbfb5d2';
@@ -12,11 +11,12 @@ let utils = require('src/utils.js');
 describe('InsticatorBidAdapter', function () {
   const adapter = newBidder(spec);
 
+  const bidderRequestId = '22edbae2733bf6';
   let bidRequest = {
     bidder: 'insticator',
     adUnitCode: 'adunit-code',
     params: {
-      adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+      adUnitId: '1a2b3c4d5e6f1a2b3c4d',
     },
     sizes: [[300, 250], [300, 600]],
     mediaTypes: {
@@ -25,10 +25,38 @@ describe('InsticatorBidAdapter', function () {
       }
     },
     bidId: '30b31c1838de1e',
+    ortb2Imp: {
+      ext: {
+        gpid: '1111/homepage'
+      }
+    },
+    schain: {
+      ver: '1.0',
+      complete: 1,
+      nodes: [
+        {
+          asi: 'insticator.com',
+          sid: '00001',
+          hp: 1,
+          rid: bidderRequestId
+        }
+      ]
+    },
+    userIdAsEids: [
+      {
+        source: 'criteo.com',
+        uids: [
+          {
+            id: '123',
+            atype: 1
+          }
+        ]
+      }
+    ],
   };
 
   let bidderRequest = {
-    bidderRequestId: '22edbae2733bf6',
+    bidderRequestId,
     auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
     timeout: 300,
     gdprConsent: {
@@ -144,12 +172,23 @@ describe('InsticatorBidAdapter', function () {
       const data = JSON.parse(requests[0].data);
 
       expect(data).to.be.an('object');
-      expect(data).to.have.all.keys('id', 'tmax', 'source', 'site', 'device', 'regs', 'user', 'imp');
+      expect(data).to.have.all.keys('id', 'tmax', 'source', 'site', 'device', 'regs', 'user', 'imp', 'ext');
       expect(data.id).to.equal(bidderRequest.bidderRequestId);
       expect(data.tmax).to.equal(bidderRequest.timeout);
-      expect(data.source).to.eql({
-        fd: 1,
-        tid: bidderRequest.auctionId,
+      expect(data.source).to.have.all.keys('fd', 'tid', 'ext');
+      expect(data.source.fd).to.equal(1);
+      expect(data.source.tid).to.equal(bidderRequest.auctionId);
+      expect(data.source.ext).to.have.property('schain').to.deep.equal({
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'insticator.com',
+            sid: '00001',
+            hp: 1,
+            rid: bidderRequest.bidderRequestId
+          }
+        ]
       });
       expect(data.site).to.be.an('object');
       expect(data.site.domain).not.to.be.empty;
@@ -167,6 +206,18 @@ describe('InsticatorBidAdapter', function () {
       expect(data.regs.ext.gdprConsentString).to.equal(bidderRequest.gdprConsent.consentString);
       expect(data.user).to.be.an('object');
       expect(data.user.id).to.equal(USER_ID_DUMMY_VALUE);
+      expect(data.user.ext).to.have.property('eids');
+      expect(data.user.ext.eids).to.deep.equal([
+        {
+          source: 'criteo.com',
+          uids: [
+            {
+              id: '123',
+              atype: 1
+            }
+          ]
+        }
+      ]);
       expect(data.imp).to.be.an('array').that.have.lengthOf(1);
       expect(data.imp).to.deep.equal([{
         id: bidRequest.bidId,
@@ -178,11 +229,20 @@ describe('InsticatorBidAdapter', function () {
           ]
         },
         ext: {
+          gpid: bidRequest.ortb2Imp.ext.gpid,
           insticator: {
             adUnitId: bidRequest.params.adUnitId,
           },
         }
       }]);
+      expect(data.ext).to.be.an('object');
+      expect(data.ext.insticator).to.be.an('object')
+      expect(data.ext.insticator).to.deep.equal({
+        adapter: {
+          vendor: 'prebid',
+          prebid: '$prebid.version$'
+        }
+      });
     });
 
     it('should generate new userId if not valid user is stored', function () {
@@ -281,7 +341,12 @@ describe('InsticatorBidAdapter', function () {
                 h: 200,
                 adm: 'adm1',
                 exp: 60,
-                bidADomain: ['test1.com'],
+                adomain: ['test1.com'],
+                ext: {
+                  meta: {
+                    test: 1
+                  }
+                }
               },
               {
                 impid: 'bid2',
@@ -290,7 +355,7 @@ describe('InsticatorBidAdapter', function () {
                 w: 600,
                 h: 200,
                 adm: 'adm2',
-                bidADomain: ['test2.com'],
+                adomain: ['test2.com'],
               },
               {
                 impid: 'bid3',
@@ -299,7 +364,7 @@ describe('InsticatorBidAdapter', function () {
                 w: 300,
                 h: 200,
                 adm: 'adm3',
-                bidADomain: ['test3.com'],
+                adomain: ['test3.com'],
               }
             ],
           },
@@ -318,13 +383,12 @@ describe('InsticatorBidAdapter', function () {
         width: 300,
         height: 200,
         mediaType: 'banner',
-        meta: {
-          advertiserDomains: [
-            'test1.com'
-          ]
-        },
         ad: 'adm1',
         adUnitCode: 'adunit-code-1',
+        meta: {
+          advertiserDomains: ['test1.com'],
+          test: 1
+        }
       },
       {
         requestId: 'bid2',


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Added support schain.
Added support eids.
Added support gpid.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
   bidder: 'insticator',
   params: {
       adUnitId: 'test'
   }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission
