### PR TITLE
Fix imports of `events` in browsiRtdProvider to work with webpack 5

### DIFF
--- a/modules/browsiRtdProvider.js
+++ b/modules/browsiRtdProvider.js
@@ -22,7 +22,7 @@ import {loadExternalScript} from '../src/adloader.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {find, includes} from '../src/polyfill.js';
 import {getGlobal} from '../src/prebidGlobal.js';
-import events from '../src/events.js';
+import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 
 const storage = getStorageManager();

--- a/test/spec/modules/browsiRtdProvider_spec.js
+++ b/test/spec/modules/browsiRtdProvider_spec.js
@@ -1,7 +1,7 @@
 import * as browsiRTD from '../../../modules/browsiRtdProvider.js';
 import {makeSlot} from '../integration/faker/googletag.js';
 import * as utils from '../../../src/utils'
-import {default as events} from '../../../src/events';
+import * as events from '../../../src/events';
 import * as sinon from 'sinon';
 
 describe('browsi Real time  data sub module', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

With https://github.com/prebid/Prebid.js/pull/7935, `events` no longer exports a default symbol. This updates the browsi RTD module accordingly.
