### PR TITLE
LiveIntent Id Submodule: Update live-connect build dependency to 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "6.15.0-pre",
+      "version": "6.17.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",
@@ -19,7 +19,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "2.0.0"
+        "live-connect-js": "2.3.1"
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
@@ -15148,9 +15148,9 @@
       "dev": true
     },
     "node_modules/live-connect-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.0.0.tgz",
-      "integrity": "sha512-Xhrj1JU5LoLjJuujjTlvDfc/n3Shzk2hPlYmLdCx/lsltFFVuCFa9uM8u5mcHlmOUKP5pu9I54bAITxZBMHoXg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.3.1.tgz",
+      "integrity": "sha512-4IT8NEOOTNmoYpw5CTxdugSF2w9xqfOujrEqx6zLPdTT3xq/lLdxxvRTREDi+qYHDsCDovdiNO3uOSoemdTCdA==",
       "dependencies": {
         "tiny-hashes": "1.0.1"
       },
@@ -23325,6 +23325,7 @@
       }
     },
     "plugins/eslint": {
+      "name": "eslint-plugin-prebid",
       "version": "1.0.0",
       "dev": true,
       "license": "Apache-2.0"
@@ -35129,9 +35130,9 @@
       "dev": true
     },
     "live-connect-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.0.0.tgz",
-      "integrity": "sha512-Xhrj1JU5LoLjJuujjTlvDfc/n3Shzk2hPlYmLdCx/lsltFFVuCFa9uM8u5mcHlmOUKP5pu9I54bAITxZBMHoXg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.3.1.tgz",
+      "integrity": "sha512-4IT8NEOOTNmoYpw5CTxdugSF2w9xqfOujrEqx6zLPdTT3xq/lLdxxvRTREDi+qYHDsCDovdiNO3uOSoemdTCdA==",
       "requires": {
         "tiny-hashes": "1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "6.17.0-pre",
+      "version": "6.18.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "2.0.0"
+    "live-connect-js": "2.3.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -66,7 +66,7 @@ describe('LiveIntentId', function() {
       consentString: 'consentDataString'
     })
     liveIntentIdSubmodule.getId(defaultConfigParams);
-    expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?wpn=prebid.*us_privacy=1YNY.*&gdpr=1&gdpr_consent=consentDataString.*/);
+    expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=1&gdpr_consent=consentDataString.*/);
   });
 
   it('should fire an event when getId and a hash is provided', function() {
@@ -88,7 +88,7 @@ describe('LiveIntentId', function() {
         }
       }
     }});
-    expect(server.requests[0].url).to.match(/https:\/\/collector.liveintent.com\/j\?aid=a-0001&wpn=prebid.*/);
+    expect(server.requests[0].url).to.match(/https:\/\/collector.liveintent.com\/j\?.*aid=a-0001.*&wpn=prebid.*/);
   });
 
   it('should initialize LiveConnect and emit an event with a privacy string when decode', function() {
@@ -195,7 +195,7 @@ describe('LiveIntentId', function() {
 
   it('should include the LiveConnect identifier when calling the LiveIntent Identity Exchange endpoint', function() {
     const oldCookie = 'a-xxxx--123e4567-e89b-12d3-a456-426655440000'
-    getDataFromLocalStorageStub.withArgs('_li_duid').returns(oldCookie);
+    getCookieStub.withArgs('_lc2_fpi').returns(oldCookie)
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
@@ -211,7 +211,7 @@ describe('LiveIntentId', function() {
 
   it('should include the LiveConnect identifier and additional Identifiers to resolve', function() {
     const oldCookie = 'a-xxxx--123e4567-e89b-12d3-a456-426655440000'
-    getDataFromLocalStorageStub.withArgs('_li_duid').returns(oldCookie);
+    getCookieStub.withArgs('_lc2_fpi').returns(oldCookie);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns('third-pc');
     const configParams = { params: {
       ...defaultConfigParams.params,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change

Live Connect library update. Changes in library relevant for LiveIntent's userId module:
- remove usage (get/set) of legacy _litra_id.X cookies