### PR TITLE
UserID module: better initialization logic

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -125,12 +125,6 @@
  * @property {(function|undefined)} callback - function that will return an id
  */
 
-/**
-  * @typedef {Object} RefreshUserIdsOptions
-  * @property {(string[]|undefined)} submoduleNames - submodules to refresh
- *  @property {Boolean?} refresh - if false, nothing is refreshed - useful if you need a promise to ID resolution
-  */
-
 import {find, includes} from '../../src/polyfill.js';
 import {config} from '../../src/config.js';
 import * as events from '../../src/events.js';

--- a/test/helpers/consentData.js
+++ b/test/helpers/consentData.js
@@ -1,0 +1,6 @@
+import {gdprDataHandler} from 'src/adapterManager.js';
+
+export function mockGdprConsent(sandbox, getConsentData = () => null) {
+  sandbox.stub(gdprDataHandler, 'promise').get(() => Promise.resolve(getConsentData()));
+  sandbox.stub(gdprDataHandler, 'getConsentData').callsFake(getConsentData)
+}

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -1,21 +1,23 @@
 import {
-  id5IdSubmodule,
-  ID5_STORAGE_NAME,
-  ID5_PRIVACY_STORAGE_NAME,
-  getFromLocalStorage,
-  storeInLocalStorage,
   expDaysStr,
-  nbCacheName,
+  getFromLocalStorage,
   getNbFromCache,
+  ID5_PRIVACY_STORAGE_NAME,
+  ID5_STORAGE_NAME,
+  id5IdSubmodule,
+  nbCacheName,
+  storeInLocalStorage,
   storeNbInCache,
-  isInControlGroup
 } from 'modules/id5IdSystem.js';
-import { init, requestBidsHook, setSubmoduleRegistry, coreStorage } from 'modules/userId/index.js';
-import { config } from 'src/config.js';
-import { server } from 'test/mocks/xhr.js';
+import {coreStorage, init, requestBidsHook, setSubmoduleRegistry} from 'modules/userId/index.js';
+import {config} from 'src/config.js';
+import {server} from 'test/mocks/xhr.js';
 import * as events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils.js';
+import 'src/prebid.js';
+import {hook} from '../../../src/hook.js';
+import {mockGdprConsent} from '../../helpers/consentData.js';
 
 let expect = require('chai').expect;
 
@@ -88,6 +90,10 @@ describe('ID5 ID System', function() {
       bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}]
     };
   }
+
+  before(() => {
+    hook.ready();
+  });
 
   describe('Check for valid publisher config', function() {
     it('should fail with invalid config', function() {
@@ -308,8 +314,11 @@ describe('ID5 ID System', function() {
 
   describe('Request Bids Hook', function() {
     let adUnits;
+    let sandbox;
 
     beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      mockGdprConsent(sandbox);
       sinon.stub(events, 'getEvents').returns([]);
       coreStorage.removeDataFromLocalStorage(ID5_STORAGE_NAME);
       coreStorage.removeDataFromLocalStorage(`${ID5_STORAGE_NAME}_last`);
@@ -321,13 +330,14 @@ describe('ID5 ID System', function() {
       coreStorage.removeDataFromLocalStorage(ID5_STORAGE_NAME);
       coreStorage.removeDataFromLocalStorage(`${ID5_STORAGE_NAME}_last`);
       coreStorage.removeDataFromLocalStorage(ID5_NB_STORAGE_NAME);
+      sandbox.restore();
     });
 
     it('should add stored ID from cache to bids', function (done) {
       storeInLocalStorage(ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
 
-      setSubmoduleRegistry([id5IdSubmodule]);
       init(config);
+      setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(getFetchLocalStorageConfig());
 
       requestBidsHook(function () {
@@ -352,8 +362,8 @@ describe('ID5 ID System', function() {
     });
 
     it('should add config value ID to bids', function (done) {
-      setSubmoduleRegistry([id5IdSubmodule]);
       init(config);
+      setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(getValueConfig(ID5_STORED_ID));
 
       requestBidsHook(function () {
@@ -371,32 +381,32 @@ describe('ID5 ID System', function() {
       }, { adUnits });
     });
 
-    it('should set nb=1 in cache when no stored nb value exists and cached ID', function () {
+    it('should set nb=1 in cache when no stored nb value exists and cached ID', function (done) {
       storeInLocalStorage(ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
       coreStorage.removeDataFromLocalStorage(ID5_NB_STORAGE_NAME);
 
-      setSubmoduleRegistry([id5IdSubmodule]);
       init(config);
+      setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(getFetchLocalStorageConfig());
 
-      let innerAdUnits;
-      requestBidsHook((adUnitConfig) => { innerAdUnits = adUnitConfig.adUnits }, {adUnits});
-
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(1);
+      requestBidsHook((adUnitConfig) => {
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(1);
+        done()
+      }, {adUnits});
     });
 
-    it('should increment nb in cache when stored nb value exists and cached ID', function () {
+    it('should increment nb in cache when stored nb value exists and cached ID', function (done) {
       storeInLocalStorage(ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
       storeNbInCache(ID5_TEST_PARTNER_ID, 1);
 
-      setSubmoduleRegistry([id5IdSubmodule]);
       init(config);
+      setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(getFetchLocalStorageConfig());
 
-      let innerAdUnits;
-      requestBidsHook((adUnitConfig) => { innerAdUnits = adUnitConfig.adUnits }, {adUnits});
-
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
+      requestBidsHook(() => {
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
+        done()
+      }, {adUnits});
     });
 
     it('should call ID5 servers with signature and incremented nb post auction if refresh needed', function () {
@@ -407,29 +417,32 @@ describe('ID5 ID System', function() {
       let id5Config = getFetchLocalStorageConfig();
       id5Config.userSync.userIds[0].storage.refreshInSeconds = 2;
 
-      setSubmoduleRegistry([id5IdSubmodule]);
       init(config);
+      setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(id5Config);
 
-      let innerAdUnits;
-      requestBidsHook((adUnitConfig) => { innerAdUnits = adUnitConfig.adUnits }, {adUnits});
+      return new Promise((resolve) => {
+        requestBidsHook(() => {
+          resolve()
+        }, {adUnits});
+      }).then(() => {
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
+        expect(server.requests).to.be.empty;
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
+        return new Promise((resolve) => setTimeout(resolve))
+      }).then(() => {
+        let request = server.requests[0];
+        let requestBody = JSON.parse(request.requestBody);
+        expect(request.url).to.contain(ID5_ENDPOINT);
+        expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
+        expect(requestBody.nbPage).to.eq(2);
 
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
+        const responseHeader = { 'Content-Type': 'application/json' };
+        request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
 
-      expect(server.requests).to.be.empty;
-      events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
-
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(request.url).to.contain(ID5_ENDPOINT);
-      expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
-      expect(requestBody.nbPage).to.eq(2);
-
-      const responseHeader = { 'Content-Type': 'application/json' };
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-
-      expect(decodeURIComponent(getFromLocalStorage(ID5_STORAGE_NAME))).to.be.eq(JSON.stringify(ID5_JSON_RESPONSE));
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
+        expect(decodeURIComponent(getFromLocalStorage(ID5_STORAGE_NAME))).to.be.eq(JSON.stringify(ID5_JSON_RESPONSE));
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
+      })
     });
   });
 

--- a/test/spec/modules/idImportLibrary_spec.js
+++ b/test/spec/modules/idImportLibrary_spec.js
@@ -1,6 +1,9 @@
+import {init} from 'modules/userId/index.js';
 import * as utils from 'src/utils.js';
 import * as idImportlibrary from 'modules/idImportLibrary.js';
-
+import {getGlobal} from '../../../src/prebidGlobal.js';
+import {config} from 'src/config.js';
+import {hook} from '../../../src/hook.js';
 var expect = require('chai').expect;
 
 const mockMutationObserver = {
@@ -14,6 +17,11 @@ describe('IdImportLibrary Tests', function () {
   let sandbox;
   let clock;
   let fn = sinon.spy();
+
+  before(() => {
+    hook.ready();
+    init(config);
+  });
 
   beforeEach(function () {
     fakeServer = sinon.fakeServer.create();
@@ -85,10 +93,10 @@ describe('IdImportLibrary Tests', function () {
     let refreshUserIdSpy;
     beforeEach(function() {
       let sandbox = sinon.createSandbox();
-      refreshUserIdSpy = sinon.spy(window.$$PREBID_GLOBAL$$, 'refreshUserIds');
+      refreshUserIdSpy = sinon.stub(getGlobal(), 'refreshUserIds');
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
       mutationObserverStub = sinon.stub(window, 'MutationObserver').returns(mockMutationObserver);
-      userId = sandbox.stub(window.$$PREBID_GLOBAL$$, 'getUserIds').returns({id: {'MOCKID': '1111'}});
+      userId = sandbox.stub(getGlobal(), 'getUserIds').returns({id: {'MOCKID': '1111'}});
       fakeServer.respondWith('POST', 'URL', [200,
         {
           'Content-Type': 'application/json',
@@ -230,14 +238,14 @@ describe('IdImportLibrary Tests', function () {
       jsonSpy.restore();
       mutationObserverStub.restore();
     });
-    it('results with config inputscan without listner with no user ids ', function () {
+    it('results with config inputscan without listner with no user ids #1', function () {
       let config = { 'url': 'testUrl', 'inputscan': true, 'debounce': 0 }
       document.body.innerHTML = '<body><input  id="userid" value="test@test.com"></body>';
       idImportlibrary.setConfig(config);
       expect(config.inputscan).to.be.equal(true);
       expect(jsonSpy.calledOnce).to.equal(false);
     });
-    it('results with config inputscan without listner with no user ids ', function () {
+    it('results with config inputscan without listner with no user ids #2', function () {
       let config = { 'url': 'testUrl', 'inputscan': true, 'debounce': 0 }
       document.body.innerHTML = '<body><input  id="userid"></body>';
       idImportlibrary.setConfig(config);

--- a/test/spec/modules/idxIdSystem_spec.js
+++ b/test/spec/modules/idxIdSystem_spec.js
@@ -3,6 +3,7 @@ import {find} from 'src/polyfill.js';
 import { config } from 'src/config.js';
 import { init, requestBidsHook, setSubmoduleRegistry } from 'modules/userId/index.js';
 import { storage, idxIdSubmodule } from 'modules/idxIdSystem.js';
+import {mockGdprConsent} from '../../helpers/consentData.js';
 
 const IDX_COOKIE_NAME = '_idx';
 const IDX_DUMMY_VALUE = 'idx value for testing';
@@ -85,14 +86,21 @@ describe('IDx ID System', () => {
 
   describe('requestBids hook', () => {
     let adUnits;
+    let sandbox;
 
     beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      mockGdprConsent(sandbox);
       adUnits = [getAdUnitMock()];
-      setSubmoduleRegistry([idxIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([idxIdSubmodule]);
       config.setConfig(getConfigMock());
       getCookieStub.withArgs(IDX_COOKIE_NAME).returns(IDX_COOKIE_STORED);
     });
+
+    afterEach(() => {
+      sandbox.restore();
+    })
 
     it('when a stored IDx exists it is added to bids', (done) => {
       requestBidsHook(() => {

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -8,6 +8,7 @@ import { uspDataHandler } from 'src/adapterManager.js';
 import { init, requestBidsHook, setSubmoduleRegistry } from 'modules/userId/index.js';
 import { parrableIdSubmodule } from 'modules/parrableIdSystem.js';
 import { server } from 'test/mocks/xhr.js';
+import {mockGdprConsent} from '../../helpers/consentData.js';
 
 const storage = newStorageManager();
 
@@ -639,18 +640,22 @@ describe('Parrable ID System', function() {
 
   describe('userId requestBids hook', function() {
     let adUnits;
+    let sandbox;
 
     beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      mockGdprConsent(sandbox);
       adUnits = [getAdUnitMock()];
       writeParrableCookie({ eid: P_COOKIE_EID, ibaOptout: true });
-      setSubmoduleRegistry([parrableIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([parrableIdSubmodule]);
       config.setConfig(getConfigMock());
     });
 
     afterEach(function() {
       removeParrableCookie();
       storage.setCookie(P_COOKIE_NAME, '', EXPIRED_COOKIE_DATE);
+      sandbox.restore();
     });
 
     it('when a stored Parrable ID exists it is added to bids', function(done) {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -18,9 +18,7 @@ import * as events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
 import {getGlobal} from 'src/prebidGlobal.js';
 import {
-  requestBidsHook as consentManagementRequestBidsHook,
   resetConsentData,
-  setConsentConfig
 } from 'modules/consentManagement.js';
 import {server} from 'test/mocks/xhr.js';
 import {find} from 'src/polyfill.js';
@@ -51,6 +49,9 @@ import {akamaiDAPIdSubmodule} from 'modules/akamaiDAPIdSystem.js'
 import {kinessoIdSubmodule} from 'modules/kinessoIdSystem.js'
 import {adqueryIdSubmodule} from 'modules/adqueryIdSystem.js';
 import * as mockGpt from '../integration/faker/googletag.js';
+import 'src/prebid.js';
+import {hook} from '../../../src/hook.js';
+import {mockGdprConsent} from '../../helpers/consentData.js';
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
@@ -106,12 +107,55 @@ describe('User ID', function () {
     });
   }
 
+  let sandbox, consentData, startDelay, callbackDelay;
+
+  function clearStack() {
+    return new Promise((resolve) => setTimeout(resolve));
+  }
+
+  function delay() {
+    const stub = sinon.stub().callsFake(() => new Promise((resolve) => {
+      stub.resolve = () => {
+        resolve();
+        return clearStack();
+      };
+    }));
+    return stub;
+  }
+
+  function runBidsHook(...args) {
+    startDelay = delay();
+
+    const result = requestBidsHook(...args, {delay: startDelay});
+    return new Promise((resolve) => setTimeout(() => resolve(result)));
+  }
+
+  function expectImmediateBidHook(...args) {
+    return runBidsHook(...args).then(() => {
+      startDelay.calledWith(0);
+      return startDelay.resolve();
+    })
+  }
+
+  function initModule(config) {
+    callbackDelay = delay();
+    return init(config, {delay: callbackDelay});
+  }
+
   before(function () {
+    hook.ready();
     localStorage.removeItem(PBJS_USER_ID_OPTOUT_NAME);
   });
 
   beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    consentData = null;
+    mockGdprConsent(sandbox, () => consentData);
     coreStorage.setCookie(CONSENT_LOCAL_STORAGE_NAME, '', EXPIRED_COOKIE_DATE);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   describe('Decorate Ad Units', function () {
@@ -121,6 +165,7 @@ describe('User ID', function () {
       mockGpt.enable();
       coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
       coreStorage.setCookie('pubcid_alt', 'altpubcid200000', (new Date(Date.now() + 5000).toUTCString()));
+      let origSK = coreStorage.setCookie.bind(coreStorage);
       sinon.spy(coreStorage, 'setCookie');
       sinon.stub(utils, 'logWarn');
     });
@@ -147,30 +192,33 @@ describe('User ID', function () {
       let pubcid = coreStorage.getCookie('pubcid');
       expect(pubcid).to.be.null; // there should be no cookie initially
 
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
 
-      requestBidsHook(config => {
+      return expectImmediateBidHook(config => {
         innerAdUnits1 = config.adUnits
-      }, {adUnits: adUnits1});
-      pubcid = coreStorage.getCookie('pubcid'); // cookies is created after requestbidHook
+      }, {adUnits: adUnits1}).then(() => {
+        pubcid = coreStorage.getCookie('pubcid'); // cookies is created after requestbidHook
 
-      innerAdUnits1.forEach(unit => {
-        unit.bids.forEach(bid => {
-          expect(bid).to.have.deep.nested.property('userId.pubcid');
-          expect(bid.userId.pubcid).to.equal(pubcid);
-          expect(bid.userIdAsEids[0]).to.deep.equal({
-            source: 'pubcid.org',
-            uids: [{id: pubcid, atype: 1}]
+        innerAdUnits1.forEach(unit => {
+          unit.bids.forEach(bid => {
+            expect(bid).to.have.deep.nested.property('userId.pubcid');
+            expect(bid.userId.pubcid).to.equal(pubcid);
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: 'pubcid.org',
+              uids: [{id: pubcid, atype: 1}]
+            });
           });
         });
-      });
 
-      requestBidsHook(config => {
-        innerAdUnits2 = config.adUnits
-      }, {adUnits: adUnits2});
-      assert.deepEqual(innerAdUnits1, innerAdUnits2);
+        return expectImmediateBidHook(config => {
+          innerAdUnits2 = config.adUnits
+        }, {adUnits: adUnits2}).then(() => {
+          assert.deepEqual(innerAdUnits1, innerAdUnits2);
+        });
+      });
     });
 
     it('Check different cookies', function () {
@@ -181,73 +229,78 @@ describe('User ID', function () {
       let pubcid1;
       let pubcid2;
 
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-      requestBidsHook((config) => {
+      return expectImmediateBidHook((config) => {
         innerAdUnits1 = config.adUnits
-      }, {adUnits: adUnits1});
-      pubcid1 = coreStorage.getCookie('pubcid'); // get first cookie
-      coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE); // erase cookie
+      }, {adUnits: adUnits1}).then(() => {
+        pubcid1 = coreStorage.getCookie('pubcid'); // get first cookie
+        coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE); // erase cookie
 
-      innerAdUnits1.forEach((unit) => {
-        unit.bids.forEach((bid) => {
-          expect(bid).to.have.deep.nested.property('userId.pubcid');
-          expect(bid.userId.pubcid).to.equal(pubcid1);
-          expect(bid.userIdAsEids[0]).to.deep.equal({
-            source: 'pubcid.org',
-            uids: [{id: pubcid1, atype: 1}]
+        innerAdUnits1.forEach((unit) => {
+          unit.bids.forEach((bid) => {
+            expect(bid).to.have.deep.nested.property('userId.pubcid');
+            expect(bid.userId.pubcid).to.equal(pubcid1);
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: 'pubcid.org',
+              uids: [{id: pubcid1, atype: 1}]
+            });
           });
         });
-      });
 
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
-      init(config);
-      config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-      requestBidsHook((config) => {
-        innerAdUnits2 = config.adUnits
-      }, {adUnits: adUnits2});
+        init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
-      pubcid2 = coreStorage.getCookie('pubcid'); // get second cookie
+        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
+        return expectImmediateBidHook((config) => {
+          innerAdUnits2 = config.adUnits
+        }, {adUnits: adUnits2}).then(() => {
+          pubcid2 = coreStorage.getCookie('pubcid'); // get second cookie
 
-      innerAdUnits2.forEach((unit) => {
-        unit.bids.forEach((bid) => {
-          expect(bid).to.have.deep.nested.property('userId.pubcid');
-          expect(bid.userId.pubcid).to.equal(pubcid2);
-          expect(bid.userIdAsEids[0]).to.deep.equal({
-            source: 'pubcid.org',
-            uids: [{id: pubcid2, atype: 1}]
+          innerAdUnits2.forEach((unit) => {
+            unit.bids.forEach((bid) => {
+              expect(bid).to.have.deep.nested.property('userId.pubcid');
+              expect(bid.userId.pubcid).to.equal(pubcid2);
+              expect(bid.userIdAsEids[0]).to.deep.equal({
+                source: 'pubcid.org',
+                uids: [{id: pubcid2, atype: 1}]
+              });
+            });
           });
+
+          expect(pubcid1).to.not.equal(pubcid2);
         });
       });
-
-      expect(pubcid1).to.not.equal(pubcid2);
     });
 
     it('Use existing cookie', function () {
       let adUnits = [getAdUnitMock()];
       let innerAdUnits;
 
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid_alt', 'cookie']));
-      requestBidsHook((config) => {
+      return expectImmediateBidHook((config) => {
         innerAdUnits = config.adUnits
-      }, {adUnits});
-      innerAdUnits.forEach((unit) => {
-        unit.bids.forEach((bid) => {
-          expect(bid).to.have.deep.nested.property('userId.pubcid');
-          expect(bid.userId.pubcid).to.equal('altpubcid200000');
-          expect(bid.userIdAsEids[0]).to.deep.equal({
-            source: 'pubcid.org',
-            uids: [{id: 'altpubcid200000', atype: 1}]
+      }, {adUnits}).then(() => {
+        innerAdUnits.forEach((unit) => {
+          unit.bids.forEach((bid) => {
+            expect(bid).to.have.deep.nested.property('userId.pubcid');
+            expect(bid.userId.pubcid).to.equal('altpubcid200000');
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: 'pubcid.org',
+              uids: [{id: 'altpubcid200000', atype: 1}]
+            });
           });
         });
+        // Because the consent cookie doesn't exist yet, we'll have 2 setCookie calls:
+        // 1) for the consent cookie
+        // 2) from the getId() call that results in a new call to store the results
+        expect(coreStorage.setCookie.callCount).to.equal(2);
       });
-      // Because the consent cookie doesn't exist yet, we'll have two setCookie calls:
-      // 1) for the consent cookie
-      // 2) from the getId() call that results in a new call to store the results
-      expect(coreStorage.setCookie.callCount).to.equal(2);
     });
 
     it('Extend cookie', function () {
@@ -256,25 +309,25 @@ describe('User ID', function () {
       let customConfig = getConfigMock(['pubCommonId', 'pubcid_alt', 'cookie']);
       customConfig = addConfig(customConfig, 'params', {extend: true});
 
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
+
       config.setConfig(customConfig);
-      requestBidsHook((config) => {
+      return expectImmediateBidHook((config) => {
         innerAdUnits = config.adUnits
-      }, {adUnits});
-      innerAdUnits.forEach((unit) => {
-        unit.bids.forEach((bid) => {
-          expect(bid).to.have.deep.nested.property('userId.pubcid');
-          expect(bid.userId.pubcid).to.equal('altpubcid200000');
-          expect(bid.userIdAsEids[0]).to.deep.equal({
-            source: 'pubcid.org',
-            uids: [{id: 'altpubcid200000', atype: 1}]
+      }, {adUnits}).then(() => {
+        innerAdUnits.forEach((unit) => {
+          unit.bids.forEach((bid) => {
+            expect(bid).to.have.deep.nested.property('userId.pubcid');
+            expect(bid.userId.pubcid).to.equal('altpubcid200000');
+            expect(bid.userIdAsEids[0]).to.deep.equal({
+              source: 'pubcid.org',
+              uids: [{id: 'altpubcid200000', atype: 1}]
+            });
           });
         });
+        expect(coreStorage.setCookie.callCount).to.equal(2);
       });
-      // Because extend is true, the cookie will be updated even if it exists already. The second setCookie call
-      // is for storing consentData
-      expect(coreStorage.setCookie.callCount).to.equal(2);
     });
 
     it('Disable auto create', function () {
@@ -283,56 +336,68 @@ describe('User ID', function () {
       let customConfig = getConfigMock(['pubCommonId', 'pubcid', 'cookie']);
       customConfig = addConfig(customConfig, 'params', {create: false});
 
+      init(config);
       setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
-      init(config);
+
       config.setConfig(customConfig);
-      requestBidsHook((config) => {
+      return expectImmediateBidHook((config) => {
         innerAdUnits = config.adUnits
-      }, {adUnits});
-      innerAdUnits.forEach((unit) => {
-        unit.bids.forEach((bid) => {
-          expect(bid).to.not.have.deep.nested.property('userId.pubcid');
-          expect(bid).to.not.have.deep.nested.property('userIdAsEids');
+      }, {adUnits}).then(() => {
+        innerAdUnits.forEach((unit) => {
+          unit.bids.forEach((bid) => {
+            expect(bid).to.not.have.deep.nested.property('userId.pubcid');
+            expect(bid).to.not.have.deep.nested.property('userIdAsEids');
+          });
         });
+        // setCookie is called once in order to store consentData
+        expect(coreStorage.setCookie.callCount).to.equal(1);
       });
-      // setCookie is called once in order to store consentData
-      expect(coreStorage.setCookie.callCount).to.equal(1);
     });
 
-    it('pbjs.getUserIds', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+    it('pbjs.getUserIds', function (done) {
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
+      const ids = {pubcid: '11111'};
       config.setConfig({
         userSync: {
-          syncDelay: 0,
+          auctionDelay: 10, // with auctionDelay > 0, no auction is needed to complete init
           userIds: [{
-            name: 'pubCommonId', value: {'pubcid': '11111'}
+            name: 'pubCommonId', value: ids
           }]
         }
       });
-      expect(typeof (getGlobal()).getUserIds).to.equal('function');
-      expect((getGlobal()).getUserIds()).to.deep.equal({pubcid: '11111'});
+      getGlobal().getUserIds((uids) => {
+        expect(uids).to.deep.equal(ids);
+        expect(getGlobal().getUserIds()).to.deep.equal(ids);
+        done();
+      })
     });
 
-    it('pbjs.getUserIdsAsEids', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+    it('pbjs.getUserIdsAsEids', function (done) {
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
+      const ids = {'pubcid': '11111'};
       config.setConfig({
         userSync: {
-          syncDelay: 0,
+          auctionDelay: 10,
           userIds: [{
-            name: 'pubCommonId', value: {'pubcid': '11111'}
+            name: 'pubCommonId', value: ids
           }]
         }
       });
-      expect(typeof (getGlobal()).getUserIdsAsEids).to.equal('function');
-      expect((getGlobal()).getUserIdsAsEids()).to.deep.equal(createEidsArray((getGlobal()).getUserIds()));
+      getGlobal().getUserIdsAsEids((eids) => {
+        expect(eids).to.deep.equal(createEidsArray(ids));
+        expect(getGlobal().getUserIdsAsEids()).to.deep.equal(eids);
+        done();
+      });
     });
 
     it('should set googletag ppid correctly', function () {
       let adUnits = [getAdUnitMock()];
-      setSubmoduleRegistry([amxIdSubmodule, sharedIdSystemSubmodule, identityLinkSubmodule]);
       init(config);
+      setSubmoduleRegistry([amxIdSubmodule, sharedIdSystemSubmodule, identityLinkSubmodule]);
 
       config.setConfig({
         userSync: {
@@ -346,15 +411,17 @@ describe('User ID', function () {
       });
       // before ppid should not be set
       expect(window.googletag._ppid).to.equal(undefined);
-      requestBidsHook(() => {}, {adUnits});
-      // ppid should have been set without dashes and stuff
-      expect(window.googletag._ppid).to.equal('pubCommonidvaluepubCommonidvalue');
+      return expectImmediateBidHook(() => {}, {adUnits}).then(() => {
+        // ppid should have been set without dashes and stuff
+        expect(window.googletag._ppid).to.equal('pubCommonidvaluepubCommonidvalue');
+      });
     });
 
     it('should log a warning if PPID too big or small', function () {
       let adUnits = [getAdUnitMock()];
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig({
         userSync: {
@@ -366,18 +433,63 @@ describe('User ID', function () {
       });
       // before ppid should not be set
       expect(window.googletag._ppid).to.equal(undefined);
-      requestBidsHook(() => {}, {adUnits});
-      // ppid should NOT have been set
-      expect(window.googletag._ppid).to.equal(undefined);
-      // a warning should have been emmited
-      expect(utils.logWarn.args[0][0]).to.exist.and.to.contain('User ID - Googletag Publisher Provided ID for pubcid.org is not between 32 and 150 characters - pubcommonIdValue');
+      return expectImmediateBidHook(() => {}, {adUnits}).then(() => {
+        // ppid should NOT have been set
+        expect(window.googletag._ppid).to.equal(undefined);
+        // a warning should have been emmited
+        expect(utils.logWarn.args[0][0]).to.exist.and.to.contain('User ID - Googletag Publisher Provided ID for pubcid.org is not between 32 and 150 characters - pubcommonIdValue');
+      });
     });
 
-    it('pbjs.refreshUserIds refreshes', function() {
+    describe('refreshing before init is complete', () => {
+      const MOCK_ID = {'MOCKID': '1111'};
+      let mockIdCallback;
+
+      beforeEach(() => {
+        mockIdCallback = sinon.stub();
+        let mockIdSystem = {
+          name: 'mockId',
+          decode: function(value) {
+            return {
+              'mid': value['MOCKID']
+            };
+          },
+          getId: sinon.stub().returns({callback: mockIdCallback})
+        };
+        init(config);
+        setSubmoduleRegistry([mockIdSystem]);
+        config.setConfig({
+          userSync: {
+            syncDelay: 10,
+            userIds: [{
+              name: 'mockId',
+              storage: {name: 'MOCKID', type: 'cookie'}
+            }]
+          }
+        });
+      });
+
+      Object.entries({
+        'getUserIds': (cb) => getGlobal().getUserIds(cb),
+        'getUserIdsAsEids': (cb) => getGlobal().getUserIdsAsEids(cb),
+      }).forEach(([fname, attachCallback]) => {
+        it(`should force init - regardless of auction state - and propagate to ${fname} callbacks`, () => {
+          let result = null;
+          attachCallback((val) => { result = val });
+          return new Promise((resolve) => setTimeout(resolve)).then(() => {
+            expect(result).to.equal(null); // auction has not ended, callback should not have been called
+            mockIdCallback.callsFake((cb) => cb(MOCK_ID));
+            return getGlobal().refreshUserIds();
+          }).then(() => {
+            expect(result).not.to.equal(null); // auction still not over, but refresh was explicitly forced
+          })
+        });
+      });
+    });
+
+    it('pbjs.refreshUserIds updates submodules', function(done) {
       let sandbox = sinon.createSandbox();
-
       let mockIdCallback = sandbox.stub().returns({id: {'MOCKID': '1111'}});
-
       let mockIdSystem = {
         name: 'mockId',
         decode: function(value) {
@@ -387,54 +499,12 @@ describe('User ID', function () {
         },
         getId: mockIdCallback
       };
-
-      setSubmoduleRegistry([mockIdSystem]);
       init(config);
-      config.setConfig({
-        userSync: {
-          syncDelay: 0,
-          userIds: [{
-            name: 'mockId',
-            value: {id: {mockId: '1111'}}
-          }]
-        }
-      });
-      expect(typeof (getGlobal()).refreshUserIds).to.equal('function');
-
-      getGlobal().getUserIds(); // force initialization
-
-      // update config so that getId will be called
-      config.setConfig({
-        userSync: {
-          syncDelay: 0,
-          userIds: [{
-            name: 'mockId',
-            storage: {name: 'mockid', type: 'cookie'},
-          }]
-        }
-      });
-
-      getGlobal().refreshUserIds();
-      expect(mockIdCallback.callCount).to.equal(1);
-    });
-
-    it('pbjs.refreshUserIds updates submodules', function() {
-      let sandbox = sinon.createSandbox();
-      let mockIdCallback = sandbox.stub().returns({id: {'MOCKID': '1111'}});
-      let mockIdSystem = {
-        name: 'mockId',
-        decode: function(value) {
-          return {
-            'mid': value['MOCKID']
-          };
-        },
-        getId: mockIdCallback
-      };
       setSubmoduleRegistry([mockIdSystem]);
-      init(config);
+
       config.setConfig({
         userSync: {
-          syncDelay: 0,
+          auctionDelay: 10,
           userIds: [{
             name: 'mockId',
             value: {id: {mockId: '1111'}}
@@ -442,20 +512,23 @@ describe('User ID', function () {
         }
       });
 
-      expect(getGlobal().getUserIds().id.mockId).to.equal('1111');
-
-      // update to new config value
-      config.setConfig({
-        userSync: {
-          syncDelay: 0,
-          userIds: [{
-            name: 'mockId',
-            value: {id: {mockId: '1212'}}
-          }]
-        }
+      getGlobal().getUserIds((uids) => {
+        expect(uids.id.mockId).to.equal('1111');
+        // update to new config value
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'mockId',
+              value: {id: {mockId: '1212'}}
+            }]
+          }
+        });
+        getGlobal().refreshUserIds({ submoduleNames: ['mockId'] }).then(() => {
+          expect(getGlobal().getUserIds().id.mockId).to.equal('1212');
+          done();
+        });
       });
-      getGlobal().refreshUserIds({ submoduleNames: ['mockId'] });
-      expect(getGlobal().getUserIds().id.mockId).to.equal('1212');
     });
 
     it('pbjs.refreshUserIds refreshes single', function() {
@@ -488,11 +561,12 @@ describe('User ID', function () {
         getId: refreshedIdCallback
       };
 
-      setSubmoduleRegistry([refreshedIdSystem, mockIdSystem]);
       init(config);
+      setSubmoduleRegistry([refreshedIdSystem, mockIdSystem]);
+
       config.setConfig({
         userSync: {
-          syncDelay: 0,
+          auctionDelay: 10,
           userIds: [
             {
               name: 'mockId',
@@ -506,13 +580,11 @@ describe('User ID', function () {
         }
       });
 
-      getGlobal().getUserIds(); // force initialization
-
-      getGlobal().refreshUserIds({submoduleNames: 'refreshedId'}, refreshUserIdsCallback);
-
-      expect(refreshedIdCallback.callCount).to.equal(2);
-      expect(mockIdCallback.callCount).to.equal(1);
-      expect(refreshUserIdsCallback.callCount).to.equal(1);
+      return getGlobal().refreshUserIds({submoduleNames: 'refreshedId'}, refreshUserIdsCallback).then(() => {
+        expect(refreshedIdCallback.callCount).to.equal(2);
+        expect(mockIdCallback.callCount).to.equal(1);
+        expect(refreshUserIdsCallback.callCount).to.equal(1);
+      });
     });
   });
 
@@ -534,15 +606,15 @@ describe('User ID', function () {
     });
 
     it('fails initialization if opt out cookie exists', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('User ID - opt-out cookie found, exit module');
     });
 
     it('initializes if no opt out cookie exists', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
       expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 1 submodules');
     });
@@ -560,23 +632,23 @@ describe('User ID', function () {
     });
 
     it('handles config with no usersync object', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({});
       // usersync is undefined, and no logInfo message for 'User ID - usersync config updated'
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
     });
 
     it('handles config with empty usersync object', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({userSync: {}});
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
     });
 
     it('handles config with usersync and userIds that are empty objs', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           userIds: [{}]
@@ -586,8 +658,8 @@ describe('User ID', function () {
     });
 
     it('handles config with usersync and userIds with empty names or that dont match a submodule.name', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           userIds: [{
@@ -603,16 +675,16 @@ describe('User ID', function () {
     });
 
     it('config with 1 configurations should create 1 submodules', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig(getConfigMock(['unifiedId', 'unifiedid', 'cookie']));
 
       expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 1 submodules');
     });
 
     it('handles config with name in different case', function () {
-      setSubmoduleRegistry([criteoIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([criteoIdSubmodule]);
       config.setConfig({
         userSync: {
           userIds: [{
@@ -625,8 +697,8 @@ describe('User ID', function () {
     });
 
     it('config with 24 configurations should result in 24 submodules add', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, liveIntentIdSubmodule, britepoolIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, liveIntentIdSubmodule, britepoolIdSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           syncDelay: 0,
@@ -700,9 +772,8 @@ describe('User ID', function () {
     });
 
     it('config syncDelay updates module correctly', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
-
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           syncDelay: 99,
@@ -716,8 +787,8 @@ describe('User ID', function () {
     });
 
     it('config auctionDelay updates module correctly', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           auctionDelay: 100,
@@ -731,8 +802,8 @@ describe('User ID', function () {
     });
 
     it('config auctionDelay defaults to 0 if not a number', function () {
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, nextrollIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, flocIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           auctionDelay: '',
@@ -753,8 +824,6 @@ describe('User ID', function () {
 
       beforeEach(function () {
         sandbox = sinon.createSandbox();
-        sandbox.stub(global, 'setTimeout').returns(2);
-        sandbox.stub(global, 'clearTimeout');
         sandbox.stub(events, 'on');
         sandbox.stub(coreStorage, 'getCookie');
 
@@ -780,9 +849,7 @@ describe('User ID', function () {
             return {callback: mockIdCallback};
           }
         };
-
-        init(config);
-
+        initModule(config);
         attachIdSystem(mockIdSystem, true);
       });
 
@@ -803,30 +870,29 @@ describe('User ID', function () {
           }
         });
 
-        requestBidsHook(auctionSpy, {adUnits});
+        return runBidsHook(auctionSpy, {adUnits}).then(() => {
+          // check auction was delayed
+          startDelay.calledWith(33);
+          auctionSpy.calledOnce.should.equal(false);
 
-        // check auction was delayed
-        global.clearTimeout.calledOnce.should.equal(false);
-        global.setTimeout.calledOnce.should.equal(true);
-        global.setTimeout.calledWith(sinon.match.func, 33);
-        auctionSpy.calledOnce.should.equal(false);
+          // check ids were fetched
+          mockIdCallback.calledOnce.should.equal(true);
 
-        // check ids were fetched
-        mockIdCallback.calledOnce.should.equal(true);
+          // mock timeout
+          return startDelay.resolve();
+        }).then(() => {
+          auctionSpy.calledOnce.should.equal(true);
 
-        // callback to continue auction if timed out
-        global.setTimeout.callArg(0);
-        auctionSpy.calledOnce.should.equal(true);
+          // does not call auction again once ids are synced
+          mockIdCallback.callArgWith(0, {'MOCKID': '1234'});
+          auctionSpy.calledOnce.should.equal(true);
 
-        // does not call auction again once ids are synced
-        mockIdCallback.callArgWith(0, {'MOCKID': '1234'});
-        auctionSpy.calledOnce.should.equal(true);
-
-        // no sync after auction ends
-        events.on.called.should.equal(false);
+          // no sync after auction ends
+          events.on.called.should.equal(false);
+        });
       });
 
-      it('delays auction if auctionDelay is set, continuing auction if ids are fetched before timing out', function (done) {
+      it('delays auction if auctionDelay is set, continuing auction if ids are fetched before timing out', function () {
         config.setConfig({
           userSync: {
             auctionDelay: 33,
@@ -837,33 +903,32 @@ describe('User ID', function () {
           }
         });
 
-        requestBidsHook(auctionSpy, {adUnits});
+        return runBidsHook(auctionSpy, {adUnits}).then(() => {
+          // check auction was delayed
+          startDelay.calledWith(33);
+          auctionSpy.calledOnce.should.equal(false);
 
-        // check auction was delayed
-        // global.setTimeout.calledOnce.should.equal(true);
-        global.clearTimeout.calledOnce.should.equal(false);
-        global.setTimeout.calledWith(sinon.match.func, 33);
-        auctionSpy.calledOnce.should.equal(false);
+          // check ids were fetched
+          mockIdCallback.calledOnce.should.equal(true);
 
-        // check ids were fetched
-        mockIdCallback.calledOnce.should.equal(true);
+          // if ids returned, should continue auction
+          mockIdCallback.callArgWith(0, {'MOCKID': '1234'});
+          return clearStack();
+        }).then(() => {
+          auctionSpy.calledOnce.should.equal(true);
 
-        // if ids returned, should continue auction
-        mockIdCallback.callArgWith(0, {'MOCKID': '1234'});
-        auctionSpy.calledOnce.should.equal(true);
-
-        // check ids were copied to bids
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.mid');
-            expect(bid.userId.mid).to.equal('1234');
-            expect(bid.userIdAsEids.length).to.equal(0);// "mid" is an un-known submodule for USER_IDS_CONFIG in eids.js
+          // check ids were copied to bids
+          adUnits.forEach(unit => {
+            unit.bids.forEach(bid => {
+              expect(bid).to.have.deep.nested.property('userId.mid');
+              expect(bid.userId.mid).to.equal('1234');
+              expect(bid.userIdAsEids.length).to.equal(0);// "mid" is an un-known submodule for USER_IDS_CONFIG in eids.js
+            });
           });
-          done();
-        });
 
-        // no sync after auction ends
-        events.on.called.should.equal(false);
+          // no sync after auction ends
+          events.on.called.should.equal(false);
+        });
       });
 
       it('does not delay auction if not set, delays id fetch after auction ends with syncDelay', function () {
@@ -880,26 +945,26 @@ describe('User ID', function () {
         expect(auctionDelay).to.equal(0);
         expect(syncDelay).to.equal(77);
 
-        requestBidsHook(auctionSpy, {adUnits});
+        return expectImmediateBidHook(auctionSpy, {adUnits})
+          .then(() => {
+            // should not delay auction
+            auctionSpy.calledOnce.should.equal(true);
 
-        // should not delay auction
-        global.setTimeout.calledOnce.should.equal(false);
-        auctionSpy.calledOnce.should.equal(true);
+            // check user sync is delayed after auction is ended
+            mockIdCallback.calledOnce.should.equal(false);
+            events.on.calledOnce.should.equal(true);
+            events.on.calledWith(CONSTANTS.EVENTS.AUCTION_END, sinon.match.func);
 
-        // check user sync is delayed after auction is ended
-        mockIdCallback.calledOnce.should.equal(false);
-        events.on.calledOnce.should.equal(true);
-        events.on.calledWith(CONSTANTS.EVENTS.AUCTION_END, sinon.match.func);
+            // once auction is ended, sync user ids after delay
+            events.on.callArg(1);
+            callbackDelay.calledWith(77);
+            mockIdCallback.calledOnce.should.equal(false);
 
-        // once auction is ended, sync user ids after delay
-        events.on.callArg(1);
-        global.setTimeout.calledOnce.should.equal(true);
-        global.setTimeout.calledWith(sinon.match.func, 77);
-        mockIdCallback.calledOnce.should.equal(false);
-
-        // once sync delay is over, ids should be fetched
-        global.setTimeout.callArg(0);
-        mockIdCallback.calledOnce.should.equal(true);
+            return callbackDelay.resolve();
+          }).then(() => {
+            // once sync delay is over, ids should be fetched
+            mockIdCallback.calledOnce.should.equal(true);
+          });
       });
 
       it('does not delay user id sync after auction ends if set to 0', function () {
@@ -914,21 +979,23 @@ describe('User ID', function () {
 
         expect(syncDelay).to.equal(0);
 
-        requestBidsHook(auctionSpy, {adUnits});
+        return expectImmediateBidHook(auctionSpy, {adUnits})
+          .then(() => {
+            // auction should not be delayed
+            auctionSpy.calledOnce.should.equal(true);
 
-        // auction should not be delayed
-        global.setTimeout.calledOnce.should.equal(false);
-        auctionSpy.calledOnce.should.equal(true);
+            // sync delay after auction is ended
+            mockIdCallback.calledOnce.should.equal(false);
+            events.on.calledOnce.should.equal(true);
+            events.on.calledWith(CONSTANTS.EVENTS.AUCTION_END, sinon.match.func);
 
-        // sync delay after auction is ended
-        mockIdCallback.calledOnce.should.equal(false);
-        events.on.calledOnce.should.equal(true);
-        events.on.calledWith(CONSTANTS.EVENTS.AUCTION_END, sinon.match.func);
-
-        // once auction is ended, if no sync delay, fetch ids
-        events.on.callArg(1);
-        global.setTimeout.calledOnce.should.equal(false);
-        mockIdCallback.calledOnce.should.equal(true);
+            // once auction is ended, if no sync delay, fetch ids
+            events.on.callArg(1);
+            callbackDelay.calledWith(0);
+            return callbackDelay.resolve();
+          }).then(() => {
+            mockIdCallback.calledOnce.should.equal(true);
+          });
       });
 
       it('does not delay auction if there are no ids to fetch', function () {
@@ -943,14 +1010,13 @@ describe('User ID', function () {
           }
         });
 
-        requestBidsHook(auctionSpy, {adUnits});
+        return runBidsHook(auctionSpy, {adUnits}).then(() => {
+          auctionSpy.calledOnce.should.equal(true);
+          mockIdCallback.calledOnce.should.equal(false);
 
-        global.setTimeout.calledOnce.should.equal(false);
-        auctionSpy.calledOnce.should.equal(true);
-        mockIdCallback.calledOnce.should.equal(false);
-
-        // no sync after auction ends
-        events.on.called.should.equal(false);
+          // no sync after auction ends
+          events.on.called.should.equal(false);
+        });
       });
     });
 
@@ -964,8 +1030,8 @@ describe('User ID', function () {
       it('test hook from pubcommonid cookie', function (done) {
         coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
 
         requestBidsHook(function () {
@@ -989,8 +1055,8 @@ describe('User ID', function () {
         localStorage.setItem('pubcid', 'testpubcid');
         localStorage.setItem('pubcid_exp', new Date(Date.now() + 100000).toUTCString());
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'html5']));
 
         requestBidsHook(function () {
@@ -1011,8 +1077,8 @@ describe('User ID', function () {
       });
 
       it('test hook from pubcommonid config value object', function (done) {
-        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigValueMock('pubCommonId', {'pubcidvalue': 'testpubcidvalue'}));
 
         requestBidsHook(function () {
@@ -1032,8 +1098,8 @@ describe('User ID', function () {
         localStorage.setItem('unifiedid_alt', JSON.stringify({'TDID': 'testunifiedid_alt'}));
         localStorage.setItem('unifiedid_alt_exp', '');
 
-        setSubmoduleRegistry([unifiedIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([unifiedIdSubmodule]);
         config.setConfig(getConfigMock(['unifiedId', 'unifiedid_alt', 'html5']));
 
         requestBidsHook(function () {
@@ -1058,8 +1124,8 @@ describe('User ID', function () {
         localStorage.setItem('amxId', 'test_amxid_id');
         localStorage.setItem('amxId_exp', '');
 
-        setSubmoduleRegistry([amxIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([amxIdSubmodule]);
         config.setConfig(getConfigMock(['amxId', 'amxId', 'html5']));
 
         requestBidsHook(() => {
@@ -1089,8 +1155,8 @@ describe('User ID', function () {
         localStorage.setItem('idl_env', 'AiGNC8Z5ONyZKSpIPf');
         localStorage.setItem('idl_env_exp', '');
 
-        setSubmoduleRegistry([identityLinkSubmodule]);
         init(config);
+        setSubmoduleRegistry([identityLinkSubmodule]);
         config.setConfig(getConfigMock(['identityLink', 'idl_env', 'html5']));
         requestBidsHook(function () {
           adUnits.forEach(unit => {
@@ -1112,8 +1178,8 @@ describe('User ID', function () {
       it('test hook from identityLink cookie', function (done) {
         coreStorage.setCookie('idl_env', 'AiGNC8Z5ONyZKSpIPf', (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([identityLinkSubmodule]);
         init(config);
+        setSubmoduleRegistry([identityLinkSubmodule]);
         config.setConfig(getConfigMock(['identityLink', 'idl_env', 'cookie']));
 
         requestBidsHook(function () {
@@ -1135,8 +1201,8 @@ describe('User ID', function () {
       it('test hook from criteoIdModule cookie', function (done) {
         coreStorage.setCookie('storage_bidid', JSON.stringify({'criteoId': 'test_bidid'}), (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([criteoIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([criteoIdSubmodule]);
         config.setConfig(getConfigMock(['criteo', 'storage_bidid', 'cookie']));
 
         requestBidsHook(function () {
@@ -1158,8 +1224,8 @@ describe('User ID', function () {
       it('test hook from tapadIdModule cookie', function (done) {
         coreStorage.setCookie('tapad_id', 'test-tapad-id', (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([tapadIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([tapadIdSubmodule]);
         config.setConfig(getConfigMock(['tapadId', 'tapad_id', 'cookie']));
 
         requestBidsHook(function () {
@@ -1183,9 +1249,10 @@ describe('User ID', function () {
         localStorage.setItem('_li_pbid', JSON.stringify({'unifiedId': 'random-ls-identifier'}));
         localStorage.setItem('_li_pbid_exp', '');
 
-        setSubmoduleRegistry([liveIntentIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([liveIntentIdSubmodule]);
         config.setConfig(getConfigMock(['liveIntentId', '_li_pbid', 'html5']));
+
         requestBidsHook(function () {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
@@ -1207,8 +1274,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('kpuid', 'KINESSO_ID', (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([kinessoIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([kinessoIdSubmodule]);
         config.setConfig(getConfigMock(['kpuid', 'kpuid', 'cookie']));
 
         requestBidsHook(function () {
@@ -1232,8 +1299,8 @@ describe('User ID', function () {
         localStorage.setItem('kpuid', 'KINESSO_ID');
         localStorage.setItem('kpuid_exp', '');
 
-        setSubmoduleRegistry([kinessoIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([kinessoIdSubmodule]);
         config.setConfig(getConfigMock(['kpuid', 'kpuid', 'html5']));
 
         requestBidsHook(function () {
@@ -1256,8 +1323,8 @@ describe('User ID', function () {
       it('test hook from liveIntentId cookie', function (done) {
         coreStorage.setCookie('_li_pbid', JSON.stringify({'unifiedId': 'random-cookie-identifier'}), (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([liveIntentIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([liveIntentIdSubmodule]);
         config.setConfig(getConfigMock(['liveIntentId', '_li_pbid', 'cookie']));
 
         requestBidsHook(function () {
@@ -1279,12 +1346,12 @@ describe('User ID', function () {
       it('eidPermissions fun with bidders', function (done) {
         coreStorage.setCookie('pubcid', 'test222', (new Date(Date.now() + 5000).toUTCString()));
 
+        init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         let eidPermissions;
         getPrebidInternal().setEidPermissions = function (newEidPermissions) {
           eidPermissions = newEidPermissions;
         }
-        init(config);
         config.setConfig({
           userSync: {
             syncDelay: 0,
@@ -1345,12 +1412,12 @@ describe('User ID', function () {
       it('eidPermissions fun without bidders', function (done) {
         coreStorage.setCookie('pubcid', 'test222', new Date(Date.now() + 5000).toUTCString());
 
+        init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         let eidPermissions;
         getPrebidInternal().setEidPermissions = function (newEidPermissions) {
           eidPermissions = newEidPermissions;
         }
-        init(config);
         config.setConfig({
           userSync: {
             syncDelay: 0,
@@ -1392,8 +1459,8 @@ describe('User ID', function () {
       });
 
       it('test hook from pubProvidedId config params', function (done) {
-        setSubmoduleRegistry([pubProvidedIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([pubProvidedIdSubmodule]);
         config.setConfig({
           userSync: {
             syncDelay: 0,
@@ -1493,8 +1560,8 @@ describe('User ID', function () {
         localStorage.setItem('_li_pbid', JSON.stringify({'unifiedId': 'random-ls-identifier', 'segments': ['123']}));
         localStorage.setItem('_li_pbid_exp', '');
 
-        setSubmoduleRegistry([liveIntentIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([liveIntentIdSubmodule]);
         config.setConfig(getConfigMock(['liveIntentId', '_li_pbid', 'html5']));
         requestBidsHook(function () {
           adUnits.forEach(unit => {
@@ -1521,8 +1588,8 @@ describe('User ID', function () {
           'segments': ['123']
         }), (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([liveIntentIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([liveIntentIdSubmodule]);
         config.setConfig(getConfigMock(['liveIntentId', '_li_pbid', 'cookie']));
 
         requestBidsHook(function () {
@@ -1547,8 +1614,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('britepoolid', JSON.stringify({'primaryBPID': '279c0161-5152-487f-809e-05d7f7e653fd'}), (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([britepoolIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([britepoolIdSubmodule]);
         config.setConfig(getConfigMock(['britepoolId', 'britepoolid', 'cookie']));
 
         requestBidsHook(function () {
@@ -1571,8 +1638,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('dmdId', 'testdmdId', (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([dmdIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([dmdIdSubmodule]);
         config.setConfig(getConfigMock(['dmdId', 'dmdId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1595,8 +1662,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('netId', JSON.stringify({'netId': 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg'}), (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([netIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([netIdSubmodule]);
         config.setConfig(getConfigMock(['netId', 'netId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1619,8 +1686,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('intentIqId', 'abcdefghijk', (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([intentIqIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([intentIqIdSubmodule]);
         config.setConfig(getConfigMock(['intentIqId', 'intentIqId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1644,8 +1711,8 @@ describe('User ID', function () {
         localStorage.setItem('hadronId', JSON.stringify({'hadronId': 'random-ls-identifier'}));
         localStorage.setItem('hadronId_exp', '');
 
-        setSubmoduleRegistry([hadronIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([hadronIdSubmodule]);
         config.setConfig(getConfigMock(['hadronId', 'hadronId', 'html5']));
 
         requestBidsHook(function () {
@@ -1669,8 +1736,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('merkleId', JSON.stringify({'pam_id': {'id': 'testmerkleId', 'keyID': 1}}), (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([merkleIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([merkleIdSubmodule]);
         config.setConfig(getConfigMock(['merkleId', 'merkleId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1693,8 +1760,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('IDP', btoa(JSON.stringify('abcdefghijk')), (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([zeotapIdPlusSubmodule]);
         init(config);
+        setSubmoduleRegistry([zeotapIdPlusSubmodule]);
         config.setConfig(getConfigMock(['zeotapIdPlus', 'IDP', 'cookie']));
 
         requestBidsHook(function () {
@@ -1717,8 +1784,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('mwol', JSON.stringify({eid: 'XX-YY-ZZ-123'}), (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([mwOpenLinkIdSubModule]);
         init(config);
+        setSubmoduleRegistry([mwOpenLinkIdSubModule]);
         config.setConfig(getConfigMock(['mwOpenLinkId', 'mwol', 'cookie']));
 
         requestBidsHook(function () {
@@ -1738,8 +1805,8 @@ describe('User ID', function () {
         localStorage.setItem('admixerId', 'testadmixerId');
         localStorage.setItem('admixerId_exp', '');
 
-        setSubmoduleRegistry([admixerIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([admixerIdSubmodule]);
         config.setConfig(getConfigMock(['admixerId', 'admixerId', 'html5']));
         requestBidsHook(function () {
           adUnits.forEach(unit => {
@@ -1760,8 +1827,8 @@ describe('User ID', function () {
       it('test hook from admixerId cookie', function (done) {
         coreStorage.setCookie('admixerId', 'testadmixerId', (new Date(Date.now() + 100000).toUTCString()));
 
-        setSubmoduleRegistry([admixerIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([admixerIdSubmodule]);
         config.setConfig(getConfigMock(['admixerId', 'admixerId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1784,8 +1851,8 @@ describe('User ID', function () {
         // simulate existing browser local storage values
         coreStorage.setCookie('deepintentId', 'testdeepintentId', (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([deepintentDpesSubmodule]);
         init(config);
+        setSubmoduleRegistry([deepintentDpesSubmodule]);
         config.setConfig(getConfigMock(['deepintentId', 'deepintentId', 'cookie']));
 
         requestBidsHook(function () {
@@ -1809,8 +1876,8 @@ describe('User ID', function () {
         localStorage.setItem('deepintentId', 'testdeepintentId');
         localStorage.setItem('deepintentId_exp', '');
 
-        setSubmoduleRegistry([deepintentDpesSubmodule]);
         init(config);
+        setSubmoduleRegistry([deepintentDpesSubmodule]);
         config.setConfig(getConfigMock(['deepintentId', 'deepintentId', 'html5']));
         requestBidsHook(function () {
           adUnits.forEach(unit => {
@@ -1832,8 +1899,8 @@ describe('User ID', function () {
         localStorage.setItem('qid', 'testqid');
         localStorage.setItem('qid_exp', '');
 
-        setSubmoduleRegistry([adqueryIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([adqueryIdSubmodule]);
         config.setConfig(getConfigMock(['qid', 'qid', 'html5']));
 
         requestBidsHook(() => {
@@ -1881,8 +1948,8 @@ describe('User ID', function () {
         // qid only supports localStorage
         localStorage.setItem('qid', 'testqid');
         localStorage.setItem('qid_exp', (new Date(Date.now() + 5000)).toUTCString());
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie'],
           ['unifiedId', 'unifiedid', 'cookie'],
           ['id5Id', 'id5id', 'cookie'],
@@ -1989,150 +2056,11 @@ describe('User ID', function () {
         }, {adUnits});
       });
 
-      it('test hook when pubCommonId, unifiedId, id5Id, britepoolId, dmdId, intentIqId, zeotapIdPlus, criteo, netId, hadronId, UID 2.0, admixerId, kpuid and mwOpenLinkId have their modules added before and after init', function (done) {
-        coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('unifiedid', JSON.stringify({'TDID': 'cookie-value-add-module-variations'}), new Date(Date.now() + 5000).toUTCString());
-        coreStorage.setCookie('id5id', JSON.stringify({'universal_uid': 'testid5id'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('idl_env', 'AiGNC8Z5ONyZKSpIPf', new Date(Date.now() + 5000).toUTCString());
-        coreStorage.setCookie('britepoolid', JSON.stringify({'primaryBPID': 'testbritepoolid'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('netId', JSON.stringify({'netId': 'testnetId'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('intentIqId', 'testintentIqId', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('IDP', btoa(JSON.stringify('zeotapId')), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('hadronId', JSON.stringify({'hadronId': 'testHadronId'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('dmdId', 'testdmdId', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('storage_criteo', JSON.stringify({'criteoId': 'test_bidid'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('mwol', JSON.stringify({eid: 'XX-YY-ZZ-123'}), (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('uid2id', 'Sample_AD_Token', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('admixerId', 'testadmixerId', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('deepintentId', 'testdeepintentId', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('kpuid', 'KINESSO_ID', (new Date(Date.now() + 5000).toUTCString()));
-
-        setSubmoduleRegistry([]);
-
-        // attaching before init
-        attachIdSystem(sharedIdSystemSubmodule);
-
-        init(config);
-
-        // attaching after init
-        attachIdSystem(unifiedIdSubmodule);
-        attachIdSystem(id5IdSubmodule);
-        attachIdSystem(identityLinkSubmodule);
-        attachIdSystem(britepoolIdSubmodule);
-        attachIdSystem(netIdSubmodule);
-        attachIdSystem(intentIqIdSubmodule);
-        attachIdSystem(zeotapIdPlusSubmodule);
-        attachIdSystem(hadronIdSubmodule);
-        attachIdSystem(dmdIdSubmodule);
-        attachIdSystem(criteoIdSubmodule);
-        attachIdSystem(mwOpenLinkIdSubModule);
-        attachIdSystem(tapadIdSubmodule);
-        attachIdSystem(uid2IdSubmodule);
-        attachIdSystem(admixerIdSubmodule);
-        attachIdSystem(deepintentDpesSubmodule);
-        attachIdSystem(kinessoIdSubmodule);
-
-        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie'],
-          ['unifiedId', 'unifiedid', 'cookie'],
-          ['id5Id', 'id5id', 'cookie'],
-          ['identityLink', 'idl_env', 'cookie'],
-          ['britepoolId', 'britepoolid', 'cookie'],
-          ['netId', 'netId', 'cookie'],
-          ['intentIqId', 'intentIqId', 'cookie'],
-          ['zeotapIdPlus', 'IDP', 'cookie'],
-          ['hadronId', 'hadronId', 'cookie'],
-          ['dmdId', 'dmdId', 'cookie'],
-          ['criteo', 'storage_criteo', 'cookie'],
-          ['mwOpenLinkId', 'mwol', 'cookie'],
-          ['tapadId', 'tapad_id', 'cookie'],
-          ['uid2', 'uid2id', 'cookie'],
-          ['admixerId', 'admixerId', 'cookie'],
-          ['deepintentId', 'deepintentId', 'cookie'],
-          ['kpuid', 'kpuid', 'cookie']));
-
-        requestBidsHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              // verify that the PubCommonId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.pubcid');
-              expect(bid.userId.pubcid).to.equal('testpubcid');
-              // also check that UnifiedId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.tdid');
-              expect(bid.userId.tdid).to.equal('cookie-value-add-module-variations');
-              // also check that Id5Id id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.id5id.uid');
-              expect(bid.userId.id5id.uid).to.equal('testid5id');
-              // also check that identityLink id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.idl_env');
-              expect(bid.userId.idl_env).to.equal('AiGNC8Z5ONyZKSpIPf');
-              // also check that britepoolId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.britepoolid');
-              expect(bid.userId.britepoolid).to.equal('testbritepoolid');
-              // also check that britepoolId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.netId');
-              expect(bid.userId.netId).to.equal('testnetId');
-              // also check that intentIqId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.intentIqId');
-              expect(bid.userId.intentIqId).to.equal('testintentIqId');
-
-              // also check that zeotapIdPlus id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.IDP');
-              expect(bid.userId.IDP).to.equal('zeotapId');
-              // also check that hadronId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.hadronId');
-              expect(bid.userId.hadronId).to.equal('testHadronId');
-              // also check that dmdId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.dmdId');
-              expect(bid.userId.dmdId).to.equal('testdmdId');
-
-              // also check that criteo id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.criteoId');
-              expect(bid.userId.criteoId).to.equal('test_bidid');
-
-              // also check that mwOpenLink id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.mwOpenLinkId');
-              expect(bid.userId.mwOpenLinkId).to.equal('XX-YY-ZZ-123')
-              expect(bid.userId.uid2).to.deep.equal({
-                id: 'Sample_AD_Token'
-              });
-
-              // also check that admixerId id data was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.admixerId');
-              expect(bid.userId.admixerId).to.equal('testadmixerId');
-              // also check that deepintentId was copied to bid
-              expect(bid).to.have.deep.nested.property('userId.deepintentId');
-              expect(bid.userId.deepintentId).to.equal('testdeepintentId');
-              expect(bid).to.have.deep.nested.property('userId.kpuid');
-              expect(bid.userId.kpuid).to.equal('KINESSO_ID');
-
-              expect(bid.userIdAsEids.length).to.equal(16);
-            });
-          });
-          coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('unifiedid', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('id5id', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('idl_env', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('britepoolid', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('netId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('intentIqId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('IDP', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('hadronId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('dmdId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('storage_criteo', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('mwol', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('uid2id', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('admixerId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('deepintentId', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('kpuid', EXPIRED_COOKIE_DATE);
-          done();
-        }, {adUnits});
-      });
-
       it('test hook from UID2 cookie', function (done) {
         coreStorage.setCookie('uid2id', 'Sample_AD_Token', (new Date(Date.now() + 5000).toUTCString()));
 
-        setSubmoduleRegistry([uid2IdSubmodule]);
         init(config);
+        setSubmoduleRegistry([uid2IdSubmodule]);
         config.setConfig(getConfigMock(['uid2', 'uid2id', 'cookie']));
 
         requestBidsHook(function () {
@@ -2177,8 +2105,8 @@ describe('User ID', function () {
         localStorage.setItem('qid', 'testqid');
         localStorage.setItem('qid_exp', new Date(Date.now() + 5000).toUTCString())
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, akamaiDAPIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
 
         config.setConfig({
           userSync: {
@@ -2335,22 +2263,28 @@ describe('User ID', function () {
         delete window.__tcfapi;
       });
 
+      function endAuction() {
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
+        return new Promise((resolve) => setTimeout(resolve));
+      }
+
       it('pubcid callback with url', function () {
         let adUnits = [getAdUnitMock()];
         let innerAdUnits;
         let customCfg = getConfigMock(['pubCommonId', 'pubcid', 'cookie']);
         customCfg = addConfig(customCfg, 'params', {pixelUrl: '/any/pubcid/url'});
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         config.setConfig(customCfg);
-        requestBidsHook((config) => {
+        return runBidsHook((config) => {
           innerAdUnits = config.adUnits
-        }, {adUnits});
-
-        expect(utils.triggerPixel.called).to.be.false;
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
-        expect(utils.triggerPixel.getCall(0).args[0]).to.include('/any/pubcid/url');
+        }, {adUnits}).then(() => {
+          expect(utils.triggerPixel.called).to.be.false;
+          return endAuction();
+        }).then(() => {
+          expect(utils.triggerPixel.getCall(0).args[0]).to.include('/any/pubcid/url');
+        });
       });
 
       it('unifiedid callback with url', function () {
@@ -2359,16 +2293,17 @@ describe('User ID', function () {
         let customCfg = getConfigMock(['unifiedId', 'unifiedid', 'cookie']);
         addConfig(customCfg, 'params', {url: '/any/unifiedid/url'});
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         config.setConfig(customCfg);
-        requestBidsHook((config) => {
+        return runBidsHook((config) => {
           innerAdUnits = config.adUnits
-        }, {adUnits});
-
-        expect(server.requests).to.be.empty;
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
-        expect(server.requests[0].url).to.equal('/any/unifiedid/url');
+        }, {adUnits}).then(() => {
+          expect(server.requests).to.be.empty;
+          return endAuction();
+        }).then(() => {
+          expect(server.requests[0].url).to.equal('/any/unifiedid/url');
+        });
       });
 
       it('unifiedid callback with partner', function () {
@@ -2377,16 +2312,17 @@ describe('User ID', function () {
         let customCfg = getConfigMock(['unifiedId', 'unifiedid', 'cookie']);
         addConfig(customCfg, 'params', {partner: 'rubicon'});
 
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule]);
         config.setConfig(customCfg);
-        requestBidsHook((config) => {
+        return runBidsHook((config) => {
           innerAdUnits = config.adUnits
-        }, {adUnits});
-
-        expect(server.requests).to.be.empty;
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
-        expect(server.requests[0].url).to.equal('https://match.adsrvr.org/track/rid?ttd_pid=rubicon&fmt=json');
+        }, {adUnits}).then(() => {
+          expect(server.requests).to.be.empty;
+          return endAuction();
+        }).then(() => {
+          expect(server.requests[0].url).to.equal('https://match.adsrvr.org/track/rid?ttd_pid=rubicon&fmt=json');
+        });
       });
     });
 
@@ -2434,40 +2370,44 @@ describe('User ID', function () {
     describe('Consent changes determine getId refreshes', function () {
       let expStr;
       let adUnits;
+      let mockGetId;
+      let mockDecode;
+      let mockExtendId;
+      let mockIdSystem;
+      let userIdConfig;
 
       const mockIdCookieName = 'MOCKID';
-      let mockGetId = sinon.stub();
-      let mockDecode = sinon.stub();
-      let mockExtendId = sinon.stub();
-      const mockIdSystem = {
-        name: 'mockId',
-        getId: mockGetId,
-        decode: mockDecode,
-        extendId: mockExtendId
-      };
-      const userIdConfig = {
-        userSync: {
-          userIds: [{
-            name: 'mockId',
-            storage: {
-              name: 'MOCKID',
-              type: 'cookie',
-              refreshInSeconds: 30
-            }
-          }],
-          auctionDelay: 5
+
+      beforeEach(function () {
+        mockGetId = sinon.stub();
+        mockDecode = sinon.stub();
+        mockExtendId = sinon.stub();
+        mockIdSystem = {
+          name: 'mockId',
+          getId: mockGetId,
+          decode: mockDecode,
+          extendId: mockExtendId
+        };
+        userIdConfig = {
+          userSync: {
+            userIds: [{
+              name: 'mockId',
+              storage: {
+                name: 'MOCKID',
+                type: 'cookie',
+                refreshInSeconds: 30
+              }
+            }],
+            auctionDelay: 5
+          }
+        };
+
+        consentData = {
+          gdprApplies: true,
+          consentString: 'mockString',
+          apiVersion: 1,
+          hasValidated: true // mock presence of GPDR enforcement module
         }
-      };
-
-      let cmpStub;
-      let testConsentData;
-      const consentConfig = {
-        cmpApi: 'iab',
-        timeout: 7500,
-        allowAuctionWithoutConsent: false
-      };
-
-      const sharedBeforeFunction = function () {
         // clear cookies
         expStr = (new Date(Date.now() + 25000).toUTCString());
         coreStorage.setCookie(mockIdCookieName, '', EXPIRED_COOKIE_DATE);
@@ -2481,177 +2421,128 @@ describe('User ID', function () {
         // init id system
         attachIdSystem(mockIdSystem);
         config.setConfig(userIdConfig);
-      }
-      const sharedAfterFunction = function () {
+      });
+
+      afterEach(function () {
         config.resetConfig();
-        mockGetId.reset();
-        mockDecode.reset();
-        mockExtendId.reset();
-        cmpStub.restore();
-        resetConsentData();
-        delete window.__cmp;
-        delete window.__tcfapi;
-      };
+      });
 
-      describe('TCF v1', function () {
-        testConsentData = {
-          gdprApplies: true,
-          consentData: 'xyz',
-          apiVersion: 1
-        };
+      it('calls getId if no stored consent data and refresh is not needed', function () {
+        coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+        coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
 
-        beforeEach(function () {
-          sharedBeforeFunction();
-
-          // init v1 consent management
-          window.__cmp = function () {
-          };
-          delete window.__tcfapi;
-          cmpStub = sinon.stub(window, '__cmp').callsFake((...args) => {
-            args[2](testConsentData);
-          });
-          setConsentConfig(consentConfig);
-        });
-
-        afterEach(function () {
-          sharedAfterFunction();
-        });
-
-        it('calls getId if no stored consent data and refresh is not needed', function () {
-          coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
-          coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
-
-          let innerAdUnits;
-          consentManagementRequestBidsHook(() => {
-          }, {});
-          requestBidsHook((config) => {
-            innerAdUnits = config.adUnits
-          }, {adUnits});
-
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
           sinon.assert.calledOnce(mockGetId);
           sinon.assert.calledOnce(mockDecode);
           sinon.assert.notCalled(mockExtendId);
         });
+      });
 
-        it('calls getId if no stored consent data but refresh is needed', function () {
-          coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
-          coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 60 * 1000).toUTCString()), expStr);
+      it('calls getId if no stored consent data but refresh is needed', function () {
+        coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+        coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 60 * 1000).toUTCString()), expStr);
 
-          let innerAdUnits;
-          consentManagementRequestBidsHook(() => {
-          }, {});
-          requestBidsHook((config) => {
-            innerAdUnits = config.adUnits
-          }, {adUnits});
-
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
           sinon.assert.calledOnce(mockGetId);
           sinon.assert.calledOnce(mockDecode);
           sinon.assert.notCalled(mockExtendId);
         });
+      });
 
-        it('calls getId if empty stored consent and refresh not needed', function () {
-          coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
-          coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+      it('calls getId if empty stored consent and refresh not needed', function () {
+        coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+        coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
 
-          setStoredConsentData();
+        setStoredConsentData();
 
-          let innerAdUnits;
-          consentManagementRequestBidsHook(() => {
-          }, {});
-          requestBidsHook((config) => {
-            innerAdUnits = config.adUnits
-          }, {adUnits});
-
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
           sinon.assert.calledOnce(mockGetId);
           sinon.assert.calledOnce(mockDecode);
           sinon.assert.notCalled(mockExtendId);
         });
+      });
 
-        it('calls getId if stored consent does not match current consent and refresh not needed', function () {
-          coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
-          coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+      it('calls getId if stored consent does not match current consent and refresh not needed', function () {
+        coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+        coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
 
-          setStoredConsentData({
-            gdprApplies: testConsentData.gdprApplies,
-            consentString: 'abc',
-            apiVersion: testConsentData.apiVersion
-          });
+        setStoredConsentData({...consentData, consentString: 'different'});
 
-          let innerAdUnits;
-          consentManagementRequestBidsHook(() => {
-          }, {});
-          requestBidsHook((config) => {
-            innerAdUnits = config.adUnits
-          }, {adUnits});
-
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
           sinon.assert.calledOnce(mockGetId);
           sinon.assert.calledOnce(mockDecode);
           sinon.assert.notCalled(mockExtendId);
         });
+      });
 
-        it('does not call getId if stored consent matches current consent and refresh not needed', function () {
-          coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
-          coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
+      it('does not call getId if stored consent matches current consent and refresh not needed', function () {
+        coreStorage.setCookie(mockIdCookieName, JSON.stringify({id: '1234'}), expStr);
+        coreStorage.setCookie(`${mockIdCookieName}_last`, (new Date(Date.now() - 1 * 1000).toUTCString()), expStr);
 
-          setStoredConsentData({
-            gdprApplies: testConsentData.gdprApplies,
-            consentString: testConsentData.consentData,
-            apiVersion: testConsentData.apiVersion
-          });
+        setStoredConsentData({...consentData});
 
-          let innerAdUnits;
-          consentManagementRequestBidsHook(() => {
-          }, {});
-          requestBidsHook((config) => {
-            innerAdUnits = config.adUnits
-          }, {adUnits});
-
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
           sinon.assert.notCalled(mockGetId);
           sinon.assert.calledOnce(mockDecode);
           sinon.assert.calledOnce(mockExtendId);
         });
       });
+    });
 
-      describe('findRootDomain', function () {
-        let sandbox;
+    describe('findRootDomain', function () {
+      let sandbox;
 
-        beforeEach(function () {
-          setSubmoduleRegistry([sharedIdSystemSubmodule]);
-          init(config);
-          config.setConfig({
-            userSync: {
-              syncDelay: 0,
-              userIds: [
-                {
-                  name: 'pubCommonId',
-                  value: { pubcid: '11111' },
-                },
-              ],
-            },
-          });
-          sandbox = sinon.createSandbox();
-          sandbox
-            .stub(coreStorage, 'getCookie')
-            .onFirstCall()
-            .returns(null) // .co.uk
-            .onSecondCall()
-            .returns('writeable'); // realdomain.co.uk;
+      beforeEach(function () {
+        init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
+        config.setConfig({
+          userSync: {
+            syncDelay: 0,
+            userIds: [
+              {
+                name: 'pubCommonId',
+                value: { pubcid: '11111' },
+              },
+            ],
+          },
         });
+        sandbox = sinon.createSandbox();
+        sandbox
+          .stub(coreStorage, 'getCookie')
+          .onFirstCall()
+          .returns(null) // .co.uk
+          .onSecondCall()
+          .returns('writeable'); // realdomain.co.uk;
+      });
 
-        afterEach(function () {
-          sandbox.restore();
-        });
+      afterEach(function () {
+        sandbox.restore();
+      });
 
-        it('should just find the root domain', function () {
-          var domain = findRootDomain('sub.realdomain.co.uk');
-          expect(domain).to.be.eq('realdomain.co.uk');
-        });
+      it('should just find the root domain', function () {
+        var domain = findRootDomain('sub.realdomain.co.uk');
+        expect(domain).to.be.eq('realdomain.co.uk');
+      });
 
-        it('should find the full domain when no subdomain is present', function () {
-          var domain = findRootDomain('realdomain.co.uk');
-          expect(domain).to.be.eq('realdomain.co.uk');
-        });
+      it('should find the full domain when no subdomain is present', function () {
+        var domain = findRootDomain('realdomain.co.uk');
+        expect(domain).to.be.eq('realdomain.co.uk');
       });
     });
-  })
+  });
 });

--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -162,8 +162,8 @@ describe('Zeotap ID System', function() {
         ZEOTAP_COOKIE_NAME,
         ENCODED_ZEOTAP_COOKIE
       );
-      setSubmoduleRegistry([zeotapIdPlusSubmodule]);
       init(config);
+      setSubmoduleRegistry([zeotapIdPlusSubmodule]);
       config.setConfig(getConfigMock());
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -197,6 +197,7 @@ describe('Unit: Prebid Module', function () {
 
   before(() => {
     hook.ready();
+    $$PREBID_GLOBAL$$.requestBids.getHooks().remove();
   });
 
   beforeEach(function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

﻿This updates the userID module to avoid premature initialization (https://github.com/prebid/Prebid.js/issues/5447):

 - `pbjs.getUserIds` and `pbjs.getUserIdsAsEids` no longer force initialization of the ID system
 - ID submodules are now initialized after after GDPR consent has been resolved *and* `userSync` configuration has been set
 - added `pbjs.getUserIdsAsync()`, which returns a promise to user IDs, completing only once all ID submodules have completed init
 - `pbjs.refreshUserIds` now forces an immediate refresh regardless of `userSync` config and returns a promise that completes when all ID submodules have filled in their data. `pbjs.refreshUserIds({refresh: false})` will just return the promise without refreshing.

Note that until https://github.com/prebid/Prebid.js/pull/8185 gets merged, GDPR data cannot be resolved without an auction, so this will prevent any ID from being resolved if the consentManagement module is installed and no auction is started. No additional action should be required to fix this besides the merge.

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/5447
Documentation PR: https://github.com/prebid/prebid.github.io/pull/3698

