### PR TITLE
Rubicon Analytics: Only map one slot render to one adunit

### DIFF
--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -578,21 +578,21 @@ const ANALYTICS_MESSAGE = {
   }
 };
 
-function performStandardAuction(gptEvents) {
-  events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
-  events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
-  events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
-  events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
-  events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
-  events.emit(AUCTION_END, MOCK.AUCTION_END);
+function performStandardAuction(gptEvents, auctionId = MOCK.AUCTION_INIT.auctionId) {
+  events.emit(AUCTION_INIT, { ...MOCK.AUCTION_INIT, auctionId });
+  events.emit(BID_REQUESTED, { ...MOCK.BID_REQUESTED, auctionId });
+  events.emit(BID_RESPONSE, { ...MOCK.BID_RESPONSE[0], auctionId });
+  events.emit(BID_RESPONSE, { ...MOCK.BID_RESPONSE[1], auctionId });
+  events.emit(BIDDER_DONE, { ...MOCK.BIDDER_DONE, auctionId });
+  events.emit(AUCTION_END, { ...MOCK.AUCTION_END, auctionId });
 
   if (gptEvents && gptEvents.length) {
     gptEvents.forEach(gptEvent => mockGpt.emitEvent(gptEvent.eventName, gptEvent.params));
   }
 
-  events.emit(SET_TARGETING, MOCK.SET_TARGETING);
-  events.emit(BID_WON, MOCK.BID_WON[0]);
-  events.emit(BID_WON, MOCK.BID_WON[1]);
+  events.emit(SET_TARGETING, { ...MOCK.SET_TARGETING, auctionId });
+  events.emit(BID_WON, { ...MOCK.BID_WON[0], auctionId });
+  events.emit(BID_WON, { ...MOCK.BID_WON[1], auctionId });
 }
 
 describe('rubicon analytics adapter', function () {
@@ -1777,6 +1777,50 @@ describe('rubicon analytics adapter', function () {
           adSlot: '/19968336/header-bid-tag1'
         };
         expect(message).to.deep.equal(expectedMessage);
+      });
+
+      it('should only mark the first gam data not all matches', function () {
+        config.setConfig({
+          rubicon: {
+            waitForGamSlots: true
+          }
+        });
+        performStandardAuction();
+        performStandardAuction([gptSlotRenderEnded0, gptSlotRenderEnded1], '32d332de-123a-32dg-2345-cefef3423324');
+
+        // tick the clock and both should fire
+        clock.tick(3000);
+
+        expect(server.requests.length).to.equal(2);
+
+        // first one should have GAM data
+        let request = server.requests[0];
+        let message = JSON.parse(request.requestBody);
+
+        // trigger should be gam since all adunits had associated gam render
+        expect(message.trigger).to.be.equal('gam');
+        expect(message.auctions[0].adUnits[0].gam).to.deep.equal({
+          advertiserId: 1111,
+          creativeId: 2222,
+          lineItemId: 3333,
+          adSlot: '/19968336/header-bid-tag-0'
+        });
+        expect(message.auctions[0].adUnits[1].gam).to.deep.equal({
+          advertiserId: 4444,
+          creativeId: 5555,
+          lineItemId: 6666,
+          adSlot: '/19968336/header-bid-tag1'
+        });
+
+        // second one should NOT have gam data
+        request = server.requests[1];
+        message = JSON.parse(request.requestBody);
+        validate(message);
+
+        // trigger should be auctionEnd
+        expect(message.trigger).to.be.equal('auctionEnd');
+        expect(message.auctions[0].adUnits[0].gam).to.be.undefined;
+        expect(message.auctions[0].adUnits[1].gam).to.be.undefined;
       });
 
       it('should send request when waitForGamSlots is present but no bidWons are sent', function () {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Previously, if there was multiple auctions pending with same adunits mapping to same GPT Slot, we would mark one gpt render to each adunit which matched.

This change now only marks the first auctions adunits, so we do not double count.

And if a gpt refresh happens later, then it will mark the second one.