### PR TITLE
Add DistroScale Bid Adapter

### DIFF
--- a/modules/distroscaleBidAdapter.js
+++ b/modules/distroscaleBidAdapter.js
@@ -1,4 +1,4 @@
-import { logWarn, _each, isBoolean, isStr, isArray, isFn, inIframe, mergeDeep, deepAccess, isNumber, deepSetValue, logInfo, logError, deepClone, convertTypes } from '../src/utils.js';
+import { logWarn, isPlainObject, isStr, isArray, isFn, inIframe, mergeDeep, deepSetValue, logError, deepClone } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
@@ -14,249 +14,249 @@ const UNDEF = undefined;
 const SUPPORTED_MEDIATYPES = [ BANNER ];
 
 function _getHost(url) {
-	let a = document.createElement('a');
-	a.href = url;
-	return a.hostname;
+  let a = document.createElement('a');
+  a.href = url;
+  return a.hostname;
 }
 
 function _getBidFloor(bid, mType, sz) {
-	if (isFn(bid.getFloor)) {
-		let floor = bid.getFloor({
-			currency: DEFAULT_CURRENCY,
-			mediaType: mType || '*',
-			size: sz || '*'
-		});
-		if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEFAULT_CURRENCY) {
-			return floor.floor;
-		}
-	}
-	return null;
+  if (isFn(bid.getFloor)) {
+    let floor = bid.getFloor({
+      currency: DEFAULT_CURRENCY,
+      mediaType: mType || '*',
+      size: sz || '*'
+    });
+    if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEFAULT_CURRENCY) {
+      return floor.floor;
+    }
+  }
+  return null;
 }
 
 function _createImpressionObject(bid) {
-	var impObj = UNDEF;
+  var impObj = UNDEF;
+  var i;
+  var sizes = {};
+  var sizesCount = 0;
 
-	var sizes = {};
-	var sizesCount = 0;
+  function addSize(arr) {
+    var w, h;
+    if (arr && arr.length > 1) {
+      w = parseInt(arr[0]);
+      h = parseInt(arr[1]);
+    }
+    sizes[w + 'x' + h] = {
+      w: w,
+      h: h,
+      area: w * h,
+      idx:
+        ({
+          '970x250': 1,
+          '300x250': 2
+        })[w + 'x' + h] || Math.max(w * h, 200)
+    };
+    sizesCount++;
+  }
 
-	function addSize(arr) {
-		var w, h;
-		if (arr && arr.length > 1) {
-			w = parseInt(arr[0]);
-			h = parseInt(arr[1]);
-		}
-		sizes[w + 'x' + h] = {
-			w: w,
-			h: h,
-			area: w * h,
-			idx:
-				({
-					'970x250': 1,
-					'300x250': 2
-				})[w + 'x' + h] || Math.max(w * h, 200)
-		};
-		sizesCount++;
-	}
+  // Gather all sizes
+  if (isArray(bid.sizes)) {
+    for (i = 0; i < bid.sizes.length; i++) {
+      addSize(bid.sizes[i]);
+    }
+  }
+  if (bid.params && bid.params.width && bid.params.height) {
+    addSize([bid.params.width, bid.params.height]);
+  }
+  if (bid.mediaTypes && BANNER in bid.mediaTypes && bid.mediaTypes[BANNER] && bid.mediaTypes[BANNER].sizes) {
+    for (i = 0; i < bid.mediaTypes[BANNER].sizes.length; i++) {
+      addSize(bid.mediaTypes[BANNER].sizes[i]);
+    }
+  }
+  if (sizesCount == 0) {
+    logWarn(LOG_WARN_PREFIX + 'Error: missing sizes: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
+  } else {
+    // Use the first preferred size
+    var keys = Object.keys(sizes);
+    keys.sort(function(a, b) {
+      return sizes[a].idx - sizes[b].idx
+    });
+    var bannerObj = {
+      pos: 0,
+      w: sizes[keys[0]].w,
+      h: sizes[keys[0]].h,
+      topframe: inIframe() ? 0 : 1,
+      format: [{
+        'w': sizes[keys[0]].w,
+        'h': sizes[keys[0]].h
+      }]
+    };
 
-	// Gather all sizes
-	if (isArray(bid.sizes)) {
-		for (var i=0; i<bid.sizes.length; i++) {
-			addSize(bid.sizes[i]);
-		}
-	}
-	if (bid.params && bid.params.width && bid.params.height) {
-		addSize([bid.params.width, bid.params.height]);
-	}
-	if (bid.mediaTypes && BANNER in bid.mediaTypes && bid.mediaTypes[BANNER] && bid.mediaTypes[BANNER].sizes) {
-		for (var i=0; i<bid.mediaTypes[BANNER].sizes.length; i++) {
-			addSize(bid.mediaTypes[BANNER].sizes[i]);
-		}
-	}
-	if (sizesCount == 0) {
-		logWarn(LOG_WARN_PREFIX + 'Error: missing sizes: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
-	} else {
-		// Use the first preferred size
-		var keys = Object.keys(sizes);
-		keys.sort(function(a, b) {
-			return sizes[a].idx - sizes[b].idx
-		});
-		var bannerObj = {
-			pos: 0,
-			w: sizes[keys[0]].w,
-			h: sizes[keys[0]].h,
-			topframe: inIframe() ? 0 : 1,
-			format: [{
-				"w": sizes[keys[0]].w,
-				"h": sizes[keys[0]].h
-			}]
-		};
+    impObj = {
+      id: bid.bidId,
+      tagid: bid.params.zoneid || '',
+      secure: 1,
+      ext: {
+        pubid: bid.params.pubid || '',
+        zoneid: bid.params.zoneid || ''
+      }
+    };
 
-		impObj = {
-			id: bid.bidId,
-			tagid: bid.params.zoneid || '',
-			secure: 1,
-			ext: {
-				pubid: bid.params.pubid || '',
-				zoneid: bid.params.zoneid || ''
-			}
-		};
+    var floor = _getBidFloor(bid, BANNER, [sizes[keys[0]].w, sizes[keys[0]].h]);
+    if (floor > 0) {
+      impObj.bidfloor = floor;
+      impObj.bidfloorcur = DEFAULT_CURRENCY;
+    }
 
-		var floor = _getBidFloor(bid, BANNER, [sizes[keys[0]].w, sizes[keys[0]].h]);
-		if (floor > 0) {
-			impObj.bidfloor = floor;
-			impObj.bidfloorcur = DEFAULT_CURRENCY;
-		}
+    impObj[BANNER] = bannerObj;
+  }
 
-		impObj[BANNER] = bannerObj;
-	}
-
-	return impObj;
+  return impObj;
 }
 
 export const spec = {
-	code: BIDDER_CODE,
-	gvlid: GVLID,
-	supportedMediaTypes: SUPPORTED_MEDIATYPES,
-	aliases: [SHORT_CODE],
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: SUPPORTED_MEDIATYPES,
+  aliases: [SHORT_CODE],
 
-	isBidRequestValid: bid => {
-		if (bid && bid.params && bid.params.pubid && isStr(bid.params.pubid)) {
-			return true;
-		} else {
-			logWarn(LOG_WARN_PREFIX + 'Error: pubid is mandatory and cannot be numeric');
-		}
-		return false;
-	},
+  isBidRequestValid: bid => {
+    if (bid && bid.params && bid.params.pubid && isStr(bid.params.pubid)) {
+      return true;
+    } else {
+      logWarn(LOG_WARN_PREFIX + 'Error: pubid is mandatory and cannot be numeric');
+    }
+    return false;
+  },
 
-	buildRequests: (validBidRequests, bidderRequest) => {
-		var pageUrl = bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer || window.location.href;
+  buildRequests: (validBidRequests, bidderRequest) => {
+    var pageUrl = (bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer) || window.location.href;
 
-		var payload = {
-			id: '' + (new Date()).getTime(),
-			at: AUCTION_TYPE,
-			cur: [DEFAULT_CURRENCY],
-			site: {
-				page: pageUrl
-			},
-			device: {
-				ua: navigator.userAgent
-				,js: 1
-				,h: screen.height
-				,w: screen.width
-				,language: navigator.language && navigator.language.replace(/-.*/,'') || 'en'
-				,dnt: (navigator.doNotTrack=='1' || navigator.msDoNotTrack=='1' || navigator.doNotTrack=='yes') ? 1 : 0
-			},
-			imp: [],
-			user: {},
-			ext: {}
-		};
+    var payload = {
+      id: '' + (new Date()).getTime(),
+      at: AUCTION_TYPE,
+      cur: [DEFAULT_CURRENCY],
+      site: {
+        page: pageUrl
+      },
+      device: {
+        ua: navigator.userAgent,
+        js: 1,
+        h: screen.height,
+        w: screen.width,
+        language: (navigator.language && navigator.language.replace(/-.*/, '')) || 'en',
+        dnt: (navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1' || navigator.doNotTrack == 'yes') ? 1 : 0
+      },
+      imp: [],
+      user: {},
+      ext: {}
+    };
 
-		validBidRequests.forEach(b => {
-			var bid = deepClone(b);
-			var impObj = _createImpressionObject(bid);
-			if (impObj) {
-				payload.imp.push(impObj);
-			}
-		});
+    validBidRequests.forEach(b => {
+      var bid = deepClone(b);
+      var impObj = _createImpressionObject(bid);
+      if (impObj) {
+        payload.imp.push(impObj);
+      }
+    });
 
-		if (payload.imp.length == 0) {
-			return;
-		}
+    if (payload.imp.length == 0) {
+      return;
+    }
 
-		payload.site.domain = _getHost(payload.site.page);
+    payload.site.domain = _getHost(payload.site.page);
 
-		// add the content object from config in request
-		if (typeof config.getConfig('content') === 'object') {
-			payload.site.content = config.getConfig('content');
-		}
+    // add the content object from config in request
+    if (typeof config.getConfig('content') === 'object') {
+      payload.site.content = config.getConfig('content');
+    }
 
-		// merge the device from config.getConfig('device')
-		if (typeof config.getConfig('device') === 'object') {
-			payload.device = Object.assign(payload.device, config.getConfig('device'));
-		}
+    // merge the device from config.getConfig('device')
+    if (typeof config.getConfig('device') === 'object') {
+      payload.device = Object.assign(payload.device, config.getConfig('device'));
+    }
 
-		// adding schain object
-		if (validBidRequests[0].schain) {
-			deepSetValue(payload, 'source.schain', validBidRequests[0].schain);
-		}
+    // adding schain object
+    if (validBidRequests[0].schain) {
+      deepSetValue(payload, 'source.schain', validBidRequests[0].schain);
+    }
 
-		// Attaching GDPR Consent Params
-		if (bidderRequest && bidderRequest.gdprConsent) {
-			deepSetValue(payload, 'user.consent', bidderRequest.gdprConsent.consentString);
-			deepSetValue(payload, 'regs.gdpr', (bidderRequest.gdprConsent.gdprApplies ? 1 : 0));
-		}
+    // Attaching GDPR Consent Params
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      deepSetValue(payload, 'user.consent', bidderRequest.gdprConsent.consentString);
+      deepSetValue(payload, 'regs.gdpr', (bidderRequest.gdprConsent.gdprApplies ? 1 : 0));
+    }
 
-		// CCPA
-		if (bidderRequest && bidderRequest.uspConsent) {
-			deepSetValue(payload, 'regs.us_privacy', bidderRequest.uspConsent);
-		}
+    // CCPA
+    if (bidderRequest && bidderRequest.uspConsent) {
+      deepSetValue(payload, 'regs.us_privacy', bidderRequest.uspConsent);
+    }
 
-		// coppa compliance
-		if (config.getConfig('coppa') === true) {
-			deepSetValue(payload, 'regs.coppa', 1);
-		}
+    // coppa compliance
+    if (config.getConfig('coppa') === true) {
+      deepSetValue(payload, 'regs.coppa', 1);
+    }
 
-		// First Party Data
-		const commonFpd = config.getConfig('ortb2') || {};
-		if (commonFpd.site) {
-			mergeDeep(payload, {site: commonFpd.site});
-		}
-		if (commonFpd.user) {
-			mergeDeep(payload, {user: commonFpd.user});
-		}
+    // First Party Data
+    const commonFpd = config.getConfig('ortb2') || {};
+    if (commonFpd.site) {
+      mergeDeep(payload, {site: commonFpd.site});
+    }
+    if (commonFpd.user) {
+      mergeDeep(payload, {user: commonFpd.user});
+    }
 
-		// User IDs
-		if (validBidRequests[0].userIdAsEids && validBidRequests[0].userIdAsEids.length > 0) {
-			// Standard ORTB structure
-			deepSetValue(payload, 'user.eids', validBidRequests[0].userIdAsEids);
-		} else if (validBidRequests[0].userId && Object.keys(validBidRequests[0].userId).length > 0) {
-			// Fallback to non-ortb structure
-			deepSetValue(payload, 'user.ext.userId', validBidRequests[0].userId);
-		}
+    // User IDs
+    if (validBidRequests[0].userIdAsEids && validBidRequests[0].userIdAsEids.length > 0) {
+      // Standard ORTB structure
+      deepSetValue(payload, 'user.eids', validBidRequests[0].userIdAsEids);
+    } else if (validBidRequests[0].userId && Object.keys(validBidRequests[0].userId).length > 0) {
+      // Fallback to non-ortb structure
+      deepSetValue(payload, 'user.ext.userId', validBidRequests[0].userId);
+    }
 
-		return {
-			method: 'POST',
-			url: ENDPOINT,
-			data: payload,
-			bidderRequest: bidderRequest
-		};
-	},
+    return {
+      method: 'POST',
+      url: ENDPOINT,
+      data: payload,
+      bidderRequest: bidderRequest
+    };
+  },
 
-	interpretResponse: (response, request) => {
-		const bidResponses = [];
-		try {
-			if (response.body && response.body.seatbid && isArray(response.body.seatbid)) {
-				// Supporting multiple bid responses for same adSize
-				response.body.seatbid.forEach(seatbidder => {
-					seatbidder.bid &&
-						isArray(seatbidder.bid) &&
-						seatbidder.bid.forEach(bid => {
-							let newBid = {
-								requestId: bid.impid,
-								cpm: (parseFloat(bid.price) || 0),
-								currency: DEFAULT_CURRENCY,
-								width: parseInt(bid.w),
-								height: parseInt(bid.h),
-								creativeId: bid.crid || bid.id,
-								netRevenue: true,
-								ttl: 300,
-								ad: bid.adm,
-								meta: {
-									advertiserDomains: []
-								}
-							};
-							if (isArray(bid.adomain) && bid.adomain.length > 0) {
-								newBid.meta.advertiserDomains = bid.adomain;
-							}
-							bidResponses.push(newBid);
-						});
-				});
-			}
-		} catch (error) {
-			logError(error);
-		}
-		return bidResponses;
-	}
+  interpretResponse: (response, request) => {
+    const bidResponses = [];
+    try {
+      if (response.body && response.body.seatbid && isArray(response.body.seatbid)) {
+        // Supporting multiple bid responses for same adSize
+        response.body.seatbid.forEach(seatbidder => {
+          seatbidder.bid &&
+            isArray(seatbidder.bid) &&
+            seatbidder.bid.forEach(bid => {
+              let newBid = {
+                requestId: bid.impid,
+                cpm: (parseFloat(bid.price) || 0),
+                currency: DEFAULT_CURRENCY,
+                width: parseInt(bid.w),
+                height: parseInt(bid.h),
+                creativeId: bid.crid || bid.id,
+                netRevenue: true,
+                ttl: 300,
+                ad: bid.adm,
+                meta: {
+                  advertiserDomains: []
+                }
+              };
+              if (isArray(bid.adomain) && bid.adomain.length > 0) {
+                newBid.meta.advertiserDomains = bid.adomain;
+              }
+              bidResponses.push(newBid);
+            });
+        });
+      }
+    } catch (error) {
+      logError(error);
+    }
+    return bidResponses;
+  }
 };
 
 registerBidder(spec);

--- a/modules/distroscaleBidAdapter.js
+++ b/modules/distroscaleBidAdapter.js
@@ -1,0 +1,262 @@
+import { logWarn, _each, isBoolean, isStr, isArray, isFn, inIframe, mergeDeep, deepAccess, isNumber, deepSetValue, logInfo, logError, deepClone, convertTypes } from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
+import { BANNER } from '../src/mediaTypes.js';
+const BIDDER_CODE = 'distroscale';
+const SHORT_CODE = 'ds';
+const LOG_WARN_PREFIX = 'DistroScale: ';
+const ENDPOINT = 'https://hb.jsrdn.com/hb?from=pbjs';
+const DEFAULT_CURRENCY = 'USD';
+const AUCTION_TYPE = 1;
+const GVLID = 754;
+const UNDEF = undefined;
+
+const SUPPORTED_MEDIATYPES = [ BANNER ];
+
+function _getHost(url) {
+	let a = document.createElement('a');
+	a.href = url;
+	return a.hostname;
+}
+
+function _getBidFloor(bid, mType, sz) {
+	if (isFn(bid.getFloor)) {
+		let floor = bid.getFloor({
+			currency: DEFAULT_CURRENCY,
+			mediaType: mType || '*',
+			size: sz || '*'
+		});
+		if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEFAULT_CURRENCY) {
+			return floor.floor;
+		}
+	}
+	return null;
+}
+
+function _createImpressionObject(bid) {
+	var impObj = UNDEF;
+
+	var sizes = {};
+	var sizesCount = 0;
+
+	function addSize(arr) {
+		var w, h;
+		if (arr && arr.length > 1) {
+			w = parseInt(arr[0]);
+			h = parseInt(arr[1]);
+		}
+		sizes[w + 'x' + h] = {
+			w: w,
+			h: h,
+			area: w * h,
+			idx:
+				({
+					'970x250': 1,
+					'300x250': 2
+				})[w + 'x' + h] || Math.max(w * h, 200)
+		};
+		sizesCount++;
+	}
+
+	// Gather all sizes
+	if (isArray(bid.sizes)) {
+		for (var i=0; i<bid.sizes.length; i++) {
+			addSize(bid.sizes[i]);
+		}
+	}
+	if (bid.params && bid.params.width && bid.params.height) {
+		addSize([bid.params.width, bid.params.height]);
+	}
+	if (bid.mediaTypes && BANNER in bid.mediaTypes && bid.mediaTypes[BANNER] && bid.mediaTypes[BANNER].sizes) {
+		for (var i=0; i<bid.mediaTypes[BANNER].sizes.length; i++) {
+			addSize(bid.mediaTypes[BANNER].sizes[i]);
+		}
+	}
+	if (sizesCount == 0) {
+		logWarn(LOG_WARN_PREFIX + 'Error: missing sizes: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
+	} else {
+		// Use the first preferred size
+		var keys = Object.keys(sizes);
+		keys.sort(function(a, b) {
+			return sizes[a].idx - sizes[b].idx
+		});
+		var bannerObj = {
+			pos: 0,
+			w: sizes[keys[0]].w,
+			h: sizes[keys[0]].h,
+			topframe: inIframe() ? 0 : 1,
+			format: [{
+				"w": sizes[keys[0]].w,
+				"h": sizes[keys[0]].h
+			}]
+		};
+
+		impObj = {
+			id: bid.bidId,
+			tagid: bid.params.zoneid || '',
+			secure: 1,
+			ext: {
+				pubid: bid.params.pubid || '',
+				zoneid: bid.params.zoneid || ''
+			}
+		};
+
+		var floor = _getBidFloor(bid, BANNER, [sizes[keys[0]].w, sizes[keys[0]].h]);
+		if (floor > 0) {
+			impObj.bidfloor = floor;
+			impObj.bidfloorcur = DEFAULT_CURRENCY;
+		}
+
+		impObj[BANNER] = bannerObj;
+	}
+
+	return impObj;
+}
+
+export const spec = {
+	code: BIDDER_CODE,
+	gvlid: GVLID,
+	supportedMediaTypes: SUPPORTED_MEDIATYPES,
+	aliases: [SHORT_CODE],
+
+	isBidRequestValid: bid => {
+		if (bid && bid.params && bid.params.pubid && isStr(bid.params.pubid)) {
+			return true;
+		} else {
+			logWarn(LOG_WARN_PREFIX + 'Error: pubid is mandatory and cannot be numeric');
+		}
+		return false;
+	},
+
+	buildRequests: (validBidRequests, bidderRequest) => {
+		var pageUrl = bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer || window.location.href;
+
+		var payload = {
+			id: '' + (new Date()).getTime(),
+			at: AUCTION_TYPE,
+			cur: [DEFAULT_CURRENCY],
+			site: {
+				page: pageUrl
+			},
+			device: {
+				ua: navigator.userAgent
+				,js: 1
+				,h: screen.height
+				,w: screen.width
+				,language: navigator.language && navigator.language.replace(/-.*/,'') || 'en'
+				,dnt: (navigator.doNotTrack=='1' || navigator.msDoNotTrack=='1' || navigator.doNotTrack=='yes') ? 1 : 0
+			},
+			imp: [],
+			user: {},
+			ext: {}
+		};
+
+		validBidRequests.forEach(b => {
+			var bid = deepClone(b);
+			var impObj = _createImpressionObject(bid);
+			if (impObj) {
+				payload.imp.push(impObj);
+			}
+		});
+
+		if (payload.imp.length == 0) {
+			return;
+		}
+
+		payload.site.domain = _getHost(payload.site.page);
+
+		// add the content object from config in request
+		if (typeof config.getConfig('content') === 'object') {
+			payload.site.content = config.getConfig('content');
+		}
+
+		// merge the device from config.getConfig('device')
+		if (typeof config.getConfig('device') === 'object') {
+			payload.device = Object.assign(payload.device, config.getConfig('device'));
+		}
+
+		// adding schain object
+		if (validBidRequests[0].schain) {
+			deepSetValue(payload, 'source.schain', validBidRequests[0].schain);
+		}
+
+		// Attaching GDPR Consent Params
+		if (bidderRequest && bidderRequest.gdprConsent) {
+			deepSetValue(payload, 'user.consent', bidderRequest.gdprConsent.consentString);
+			deepSetValue(payload, 'regs.gdpr', (bidderRequest.gdprConsent.gdprApplies ? 1 : 0));
+		}
+
+		// CCPA
+		if (bidderRequest && bidderRequest.uspConsent) {
+			deepSetValue(payload, 'regs.us_privacy', bidderRequest.uspConsent);
+		}
+
+		// coppa compliance
+		if (config.getConfig('coppa') === true) {
+			deepSetValue(payload, 'regs.coppa', 1);
+		}
+
+		// First Party Data
+		const commonFpd = config.getConfig('ortb2') || {};
+		if (commonFpd.site) {
+			mergeDeep(payload, {site: commonFpd.site});
+		}
+		if (commonFpd.user) {
+			mergeDeep(payload, {user: commonFpd.user});
+		}
+
+		// User IDs
+		if (validBidRequests[0].userIdAsEids && validBidRequests[0].userIdAsEids.length > 0) {
+			// Standard ORTB structure
+			deepSetValue(payload, 'user.eids', validBidRequests[0].userIdAsEids);
+		} else if (validBidRequests[0].userId && Object.keys(validBidRequests[0].userId).length > 0) {
+			// Fallback to non-ortb structure
+			deepSetValue(payload, 'user.ext.userId', validBidRequests[0].userId);
+		}
+
+		return {
+			method: 'POST',
+			url: ENDPOINT,
+			data: payload,
+			bidderRequest: bidderRequest
+		};
+	},
+
+	interpretResponse: (response, request) => {
+		const bidResponses = [];
+		try {
+			if (response.body && response.body.seatbid && isArray(response.body.seatbid)) {
+				// Supporting multiple bid responses for same adSize
+				response.body.seatbid.forEach(seatbidder => {
+					seatbidder.bid &&
+						isArray(seatbidder.bid) &&
+						seatbidder.bid.forEach(bid => {
+							let newBid = {
+								requestId: bid.impid,
+								cpm: (parseFloat(bid.price) || 0),
+								currency: DEFAULT_CURRENCY,
+								width: parseInt(bid.w),
+								height: parseInt(bid.h),
+								creativeId: bid.crid || bid.id,
+								netRevenue: true,
+								ttl: 300,
+								ad: bid.adm,
+								meta: {
+									advertiserDomains: []
+								}
+							};
+							if (isArray(bid.adomain) && bid.adomain.length > 0) {
+								newBid.meta.advertiserDomains = bid.adomain;
+							}
+							bidResponses.push(newBid);
+						});
+				});
+			}
+		} catch (error) {
+			logError(error);
+		}
+		return bidResponses;
+	}
+};
+
+registerBidder(spec);

--- a/modules/distroscaleBidAdapter.md
+++ b/modules/distroscaleBidAdapter.md
@@ -1,0 +1,30 @@
+# Overview
+
+```
+Module Name:  DistroScale Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer:   prebid@distroscale.com
+```
+
+# Description
+
+Connects to DistroScale exchange for bids.  DistroScale bid adapter supports Banner currently.
+
+# Test Parameters
+```
+var adUnits = [{
+	code: 'banner-1',
+	mediaTypes: {
+		banner: {
+			sizes: [[970, 250]],
+		}
+	},
+	bids: [{
+		bidder: 'distroscale',
+		params: {
+			pubid: '12345'   // required, must be a string
+			,zoneid: '67890' // optional, must be a string
+		}
+	}]
+}];
+```

--- a/test/spec/modules/distroscaleBidAdapter_spec.js
+++ b/test/spec/modules/distroscaleBidAdapter_spec.js
@@ -3,215 +3,211 @@ import { spec } from 'modules/distroscaleBidAdapter.js';
 import * as utils from 'src/utils.js';
 
 describe('distroscaleBidAdapter', function() {
+  const DSNAME = 'distroscale';
 
-	const DSNAME = 'distroscale';
+  describe('isBidRequestValid', function() {
+    it('with no param', function() {
+      expect(spec.isBidRequestValid({
+        bidder: DSNAME,
+        params: {}
+      })).to.equal(false);
+    });
 
-	describe('isBidRequestValid', function() {
-		it('with no param', function() {
-			expect(spec.isBidRequestValid({
-				bidder: DSNAME,
-				params: {}
-			})).to.equal(false);
-		});
+    it('with pubid param', function() {
+      expect(spec.isBidRequestValid({
+        bidder: DSNAME,
+        params: {
+          pubid: '12345'
+        }
+      })).to.equal(true);
+    });
 
-		it('with pubid param', function() {
-			expect(spec.isBidRequestValid({
-				bidder: DSNAME,
-				params: {
-					pubid: "12345"
-				}
-			})).to.equal(true);
-		});
+    it('with pubid and zoneid params', function() {
+      expect(spec.isBidRequestValid({
+        bidder: DSNAME,
+        params: {
+          pubid: '12345',
+          zoneid: '67890'
+        }
+      })).to.equal(true);
+    });
+  });
 
-		it('with pubid and zoneid params', function() {
-			expect(spec.isBidRequestValid({
-				bidder: DSNAME,
-				params: {
-					pubid: "12345",
-					zoneid: "67890"
-				}
-			})).to.equal(true);
-		});
-	});
+  describe('buildRequests', function() {
+    const CONSENT_STRING = 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw';
+    const BID_REQUESTS = [{
+      'bidder': DSNAME,
+      'params': {
+        'pubid': '12345',
+        'zoneid': '67890'
+      },
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[970, 250], [300, 250]]
+        }
+      },
+      'adUnitCode': 'div-gpt-ad-1460505748561-0',
+      'transactionId': 'ca59932f-90f4-4dff-bed2-b90ffa2c2b6a',
+      'sizes': [[970, 250], [300, 250]],
+      'bidId': '20b96f0310083c',
+      'bidderRequestId': '1dd684edba2006',
+      'auctionId': '22ed3053-f76f-476c-a08e-dcda5862443d'
+    }];
+    const BIDDER_REQUEST = {
+      'bidderCode': DSNAME,
+      'auctionId': '22ed3053-f76f-476c-a08e-dcda5862443d',
+      'bidderRequestId': '1dd684edba2006',
+      'refererInfo': {
+        'referer': 'https://publisher.com/homepage.html',
+        'reachedTop': true,
+        'isAmp': false,
+        'numIframes': 0,
+        'stack': [
+          'https://publisher.com/homepage.html'
+        ],
+        'canonicalUrl': null
+      },
+      'gdprConsent': {
+        'consentString': CONSENT_STRING,
+        'gdprApplies': true
+      }
+    };
 
-	describe('buildRequests', function() {
-		const CONSENT_STRING = 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw';
-		const BID_REQUESTS = [{
-			"bidder": DSNAME,
-			"params": {
-				"pubid": "12345",
-				"zoneid": "67890"
-			},
-			"mediaTypes": {
-				"banner": {
-					"sizes": [[970, 250], [300, 250]]
-				}
-			},
-			"adUnitCode": "div-gpt-ad-1460505748561-0",
-			"transactionId": "ca59932f-90f4-4dff-bed2-b90ffa2c2b6a",
-			"sizes": [[970, 250], [300, 250]],
-			"bidId": "20b96f0310083c",
-			"bidderRequestId": "1dd684edba2006",
-			"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d"
-		}];
-		const BIDDER_REQUEST = {
-			"bidderCode": DSNAME,
-			"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d",
-			"bidderRequestId": "1dd684edba2006",
-			"refererInfo": {
-				"referer": "https://publisher.com/homepage.html",
-				"reachedTop": true,
-				"isAmp": false,
-				"numIframes": 0,
-				"stack": [
-					"https://publisher.com/homepage.html"
-				],
-				"canonicalUrl": null
-			},
-			"gdprConsent": {
-				"consentString": CONSENT_STRING,
-				"gdprApplies": true
-			}
-		};
+    it('basic', function() {
+      const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.have.string('https://hb.jsrdn.com/hb?from=pbjs');
+      expect(request.bidderRequest).to.deep.equal(BIDDER_REQUEST);
+      expect(request.data).to.exist;
+      expect(request.data.id).to.be.a('string').that.is.not.empty;
+      expect(request.data.at).to.equal(1);
+      expect(request.data.cur).to.deep.equal(['USD']);
+      expect(request.data.device).to.exist;
+      expect(request.data.site).to.exist;
+      expect(request.data.user).to.exist;
+      expect(request.data.imp).to.be.an('array').that.is.not.empty;
+      expect(request.data.imp[0]).to.exist;
+      expect(request.data.imp[0].id).to.equal(BID_REQUESTS[0].bidId);
+      expect(request.data.imp[0].tagid).to.equal(BID_REQUESTS[0].params.zoneid || '');
+      expect(request.data.imp[0].secure).to.equal(1);
+      expect(request.data.imp[0].banner).to.exist;
+      expect(request.data.imp[0].banner.format).to.be.an('array').that.is.not.empty;
+      expect(request.data.imp[0].banner.format[0]).to.exist;
+      expect(request.data.imp[0].banner.format[0].w).to.equal(970);
+      expect(request.data.imp[0].banner.format[0].h).to.equal(250);
+      expect(request.data.imp[0].banner.w).to.equal(970);
+      expect(request.data.imp[0].banner.h).to.equal(250);
+      expect(request.data.imp[0].banner.pos).to.equal(0);
+      expect(request.data.imp[0].banner.topframe).to.be.oneOf([0, 1]);
+      expect(request.data.imp[0].ext).to.exist;
+      expect(request.data.imp[0].ext.pubid).to.equal(BID_REQUESTS[0].params.pubid);
+      expect(request.data.imp[0].ext.zoneid).to.equal(BID_REQUESTS[0].params.zoneid || '');
+    });
 
-		it('basic', function() {
-			const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
-			expect(request.method).to.equal('POST');
-			expect(request.url).to.have.string('https://hb.jsrdn.com/hb?from=pbjs');
-			expect(request.bidderRequest).to.deep.equal(BIDDER_REQUEST);
-			expect(request.data).to.exist;
-			expect(request.data.id).to.be.a('string').that.is.not.empty;
-			expect(request.data.at).to.equal(1);
-			expect(request.data.cur).to.deep.equal(['USD']);
-			expect(request.data.device).to.exist;
-			expect(request.data.site).to.exist;
-			expect(request.data.user).to.exist;
-			expect(request.data.imp).to.be.an('array').that.is.not.empty;
-			expect(request.data.imp[0]).to.exist;
-			expect(request.data.imp[0].id).to.equal(BID_REQUESTS[0].bidId);
-			expect(request.data.imp[0].tagid).to.equal(BID_REQUESTS[0].params.zoneid || '');
-			expect(request.data.imp[0].secure).to.equal(1);
-			expect(request.data.imp[0].banner).to.exist;
-			expect(request.data.imp[0].banner.format).to.be.an('array').that.is.not.empty;
-			expect(request.data.imp[0].banner.format[0]).to.exist;
-			expect(request.data.imp[0].banner.format[0].w).to.equal(970);
-			expect(request.data.imp[0].banner.format[0].h).to.equal(250);
-			expect(request.data.imp[0].banner.w).to.equal(970);
-			expect(request.data.imp[0].banner.h).to.equal(250);
-			expect(request.data.imp[0].banner.pos).to.equal(0);
-			expect(request.data.imp[0].banner.topframe).to.be.oneOf([0, 1]);
-			expect(request.data.imp[0].ext).to.exist;
-			expect(request.data.imp[0].ext.pubid).to.equal(BID_REQUESTS[0].params.pubid);
-			expect(request.data.imp[0].ext.zoneid).to.equal(BID_REQUESTS[0].params.zoneid || '');
-		});
+    it('gdpr', function() {
+      const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
+      expect(request.data).to.exist;
+      expect(request.data.regs).to.exist;
+      expect(request.data.regs.gdpr).to.equal(1);
+      expect(request.data.user).to.exist;
+      expect(request.data.user.consent).to.equal(CONSENT_STRING);
+    });
+  });
 
-		it('gdpr', function() {
-			const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
-			expect(request.data).to.exist;
-			expect(request.data.regs).to.exist;
-			expect(request.data.regs.gdpr).to.equal(1);
-			expect(request.data.user).to.exist;
-			expect(request.data.user.consent).to.equal(CONSENT_STRING);
-		});
+  describe('interpretResponse', function() {
+    const REQUEST = {
+      'method': 'POST',
+      'url': 'https://hb.jsrdn.com/hb?from=pbjs',
+      'data': '{"id":"1648161050749","at":1,"cur":["USD"],"site":{"page":"https://publisher.com/homepage.html","domain":"publisher.com"},"device":{"ua":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36","js":1,"h":1200,"w":1920,"language":"en","dnt":0},"imp":[{"id":"20b96f0310083c","tagid":"67890","secure":1,"ext":{"pubid":"12345","zoneid":"67890"},"banner":{"pos":0,"w":970,"h":250,"topframe":1,"format":[{"w":970,"h":250}]}}],"user":{},"ext":{}}',
+      'bidderRequest': {
+        'bidderCode': DSNAME,
+        'auctionId': '22ed3053-f76f-476c-a08e-dcda5862443d',
+        'bidderRequestId': '1dd684edba2006',
+        'bids': [{
+          'bidder': DSNAME,
+          'params': {
+            'pubid': '12345',
+            'zoneid': '67890'
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [[970, 250], [300, 250]]
+            }
+          },
+          'adUnitCode': 'div-gpt-ad-1460505748561-0',
+          'transactionId': 'ca59932f-90f4-4dff-bed2-b90ffa2c2b6a',
+          'sizes': [[970, 250], [300, 250]],
+          'bidId': '20b96f0310083c',
+          'bidderRequestId': '1dd684edba2006',
+          'auctionId': '22ed3053-f76f-476c-a08e-dcda5862443d'
+        }],
+        'refererInfo': {
+          'referer': 'https://publisher.com/homepage.html',
+          'reachedTop': true,
+          'isAmp': false,
+          'numIframes': 0,
+          'stack': [
+            'https://publisher.com/homepage.html'
+          ],
+          'canonicalUrl': null
+        }
+      }
+    };
+    const RESPONSE = {
+      'body': {
+        'id': '1648161050749',
+        'seatbid': [{
+          'bid': [{
+            'id': '212f1c7b-378b-47e4-8294-ac38658b33f6_0',
+            'impid': '20b96f0310083c',
+            'price': 0.1,
+            'w': 970,
+            'h': 250,
+            'adm': "<div class='dsunit-test' id='20b96f0310083c' style='width:970px;height:250px;background-image:url(https://advertiser.dsp.com/creatives/aaaaaaaa-fa90-46ec-a0f9-1a898452ade3/banner.jpg);background-size:cover'></div>"
+          }]
+        }],
+        'cur': 'USD'
+      },
+      'headers': {}
+    };
+    const SAMPLE_PARSED = [{
+      'requestId': '20b96f0310083c',
+      'cpm': 0.1,
+      'currency': 'USD',
+      'width': 970,
+      'height': 250,
+      'creativeId': 'bbbbbbbb-648d-4e03-a5e2-7198bcd07cfe',
+      'netRevenue': true,
+      'ttl': 300,
+      'ad': "<div class='dsunit-test' id='2f0dfc70a1c251' style='width:970px;height:250px;background-image:url(https://dummyimage.com/970x250/444444/ffffff?text=Test%20Ad);background-size:cover'></div>",
+      'meta': {
+        'advertiserDomains': []
+      }
+    }];
 
-	});
+    it('valid bid response for banner ad', function() {
+      const result = spec.interpretResponse(RESPONSE, REQUEST);
+      const bid = RESPONSE.body.seatbid[0].bid[0];
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].requestId).to.equal(bid.impid);
+      expect(result[0].cpm).to.equal(Number(bid.price));
+      expect(result[0].currency).to.equal(RESPONSE.body.cur);
+      expect(result[0].width).to.equal(Number(bid.w));
+      expect(result[0].height).to.equal(Number(bid.h));
+      expect(result[0].creativeId).to.be.a('string').that.is.not.empty;
+      expect(result[0].netRevenue).to.equal(true);
+      expect(result[0].ttl).to.equal(300);
+      expect(result[0].ad).to.equal(bid.adm);
+      expect(result[0].meta).to.exist;
+      expect(result[0].meta.advertiserDomains).to.exist;
+    });
 
-	describe('interpretResponse', function() {
-		const REQUEST = {
-			"method": "POST",
-			"url": "https://hb.jsrdn.com/hb?from=pbjs",
-			"data": "{\"id\":\"1648161050749\",\"at\":1,\"cur\":[\"USD\"],\"site\":{\"page\":\"https://publisher.com/homepage.html\",\"domain\":\"publisher.com\"},\"device\":{\"ua\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36\",\"js\":1,\"h\":1200,\"w\":1920,\"language\":\"en\",\"dnt\":0},\"imp\":[{\"id\":\"20b96f0310083c\",\"tagid\":\"67890\",\"secure\":1,\"ext\":{\"pubid\":\"12345\",\"zoneid\":\"67890\"},\"banner\":{\"pos\":0,\"w\":970,\"h\":250,\"topframe\":1,\"format\":[{\"w\":970,\"h\":250}]}}],\"user\":{},\"ext\":{}}",
-			"bidderRequest": {
-				"bidderCode": DSNAME,
-				"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d",
-				"bidderRequestId": "1dd684edba2006",
-				"bids": [{
-					"bidder": DSNAME,
-					"params": {
-						"pubid": "12345",
-						"zoneid": "67890"
-					},
-					"mediaTypes": {
-						"banner": {
-							"sizes": [[970, 250], [300, 250]]
-						}
-					},
-					"adUnitCode": "div-gpt-ad-1460505748561-0",
-					"transactionId": "ca59932f-90f4-4dff-bed2-b90ffa2c2b6a",
-					"sizes": [[970, 250], [300, 250]],
-					"bidId": "20b96f0310083c",
-					"bidderRequestId": "1dd684edba2006",
-					"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d"
-				}],
-				"refererInfo": {
-					"referer": "https://publisher.com/homepage.html",
-					"reachedTop": true,
-					"isAmp": false,
-					"numIframes": 0,
-					"stack": [
-						"https://publisher.com/homepage.html"
-					],
-					"canonicalUrl": null
-				}
-			}
-		};
-		const RESPONSE = {
-			"body": {
-				"id": "1648161050749",
-				"seatbid": [{
-					"bid": [{
-						"id": "212f1c7b-378b-47e4-8294-ac38658b33f6_0",
-						"impid": "20b96f0310083c",
-						"price": 0.1,
-						"w": 970,
-						"h": 250,
-						"adm": "<div class='dsunit-test' id='20b96f0310083c' style='width:970px;height:250px;background-image:url(https://advertiser.dsp.com/creatives/aaaaaaaa-fa90-46ec-a0f9-1a898452ade3/banner.jpg);background-size:cover'></div>"
-					}]
-				}],
-				"cur": "USD"
-			},
-			"headers": {}
-		};
-		const SAMPLE_PARSED = [{
-			"requestId": "20b96f0310083c",
-			"cpm": 0.1,
-			"currency": "USD",
-			"width": 970,
-			"height": 250,
-			"creativeId": "bbbbbbbb-648d-4e03-a5e2-7198bcd07cfe",
-			"netRevenue": true,
-			"ttl": 300,
-			"ad": "<div class='dsunit-test' id='2f0dfc70a1c251' style='width:970px;height:250px;background-image:url(https://dummyimage.com/970x250/444444/ffffff?text=Test%20Ad);background-size:cover'></div>",
-			"meta": {
-				"advertiserDomains": []
-			}
-		}];
-
-		it('valid bid response for banner ad', function() {
-			const result = spec.interpretResponse(RESPONSE, REQUEST);
-			const bid = RESPONSE.body.seatbid[0].bid[0];
-			expect(result).to.have.lengthOf(1);
-			expect(result[0].requestId).to.equal(bid.impid);
-			expect(result[0].cpm).to.equal(Number(bid.price));
-			expect(result[0].currency).to.equal(RESPONSE.body.cur);
-			expect(result[0].width).to.equal(Number(bid.w));
-			expect(result[0].height).to.equal(Number(bid.h));
-			expect(result[0].creativeId).to.be.a('string').that.is.not.empty;
-			expect(result[0].netRevenue).to.equal(true);
-			expect(result[0].ttl).to.equal(300);
-			expect(result[0].ad).to.equal(bid.adm);
-			expect(result[0].meta).to.exist;
-			expect(result[0].meta.advertiserDomains).to.exist;
-		});
-
-		it('advertiserDomains is included when sent by server', function() {
-			const ADOMAIN = ['advertiser_adomain'];
-			let RESPONSE_CLONE = utils.deepClone(RESPONSE);
-			RESPONSE_CLONE.body.seatbid[0].bid[0].adomain = utils.deepClone(ADOMAIN);;
-			let result = spec.interpretResponse(RESPONSE_CLONE, REQUEST);
-			expect(result[0].meta.advertiserDomains).to.deep.equal(ADOMAIN);
-		});
-
-	});
-
+    it('advertiserDomains is included when sent by server', function() {
+      const ADOMAIN = ['advertiser_adomain'];
+      let RESPONSE_CLONE = utils.deepClone(RESPONSE);
+      RESPONSE_CLONE.body.seatbid[0].bid[0].adomain = utils.deepClone(ADOMAIN); ;
+      let result = spec.interpretResponse(RESPONSE_CLONE, REQUEST);
+      expect(result[0].meta.advertiserDomains).to.deep.equal(ADOMAIN);
+    });
+  });
 });

--- a/test/spec/modules/distroscaleBidAdapter_spec.js
+++ b/test/spec/modules/distroscaleBidAdapter_spec.js
@@ -1,0 +1,217 @@
+import { expect } from 'chai';
+import { spec } from 'modules/distroscaleBidAdapter.js';
+import * as utils from 'src/utils.js';
+
+describe('distroscaleBidAdapter', function() {
+
+	const DSNAME = 'distroscale';
+
+	describe('isBidRequestValid', function() {
+		it('with no param', function() {
+			expect(spec.isBidRequestValid({
+				bidder: DSNAME,
+				params: {}
+			})).to.equal(false);
+		});
+
+		it('with pubid param', function() {
+			expect(spec.isBidRequestValid({
+				bidder: DSNAME,
+				params: {
+					pubid: "12345"
+				}
+			})).to.equal(true);
+		});
+
+		it('with pubid and zoneid params', function() {
+			expect(spec.isBidRequestValid({
+				bidder: DSNAME,
+				params: {
+					pubid: "12345",
+					zoneid: "67890"
+				}
+			})).to.equal(true);
+		});
+	});
+
+	describe('buildRequests', function() {
+		const CONSENT_STRING = 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw';
+		const BID_REQUESTS = [{
+			"bidder": DSNAME,
+			"params": {
+				"pubid": "12345",
+				"zoneid": "67890"
+			},
+			"mediaTypes": {
+				"banner": {
+					"sizes": [[970, 250], [300, 250]]
+				}
+			},
+			"adUnitCode": "div-gpt-ad-1460505748561-0",
+			"transactionId": "ca59932f-90f4-4dff-bed2-b90ffa2c2b6a",
+			"sizes": [[970, 250], [300, 250]],
+			"bidId": "20b96f0310083c",
+			"bidderRequestId": "1dd684edba2006",
+			"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d"
+		}];
+		const BIDDER_REQUEST = {
+			"bidderCode": DSNAME,
+			"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d",
+			"bidderRequestId": "1dd684edba2006",
+			"refererInfo": {
+				"referer": "https://publisher.com/homepage.html",
+				"reachedTop": true,
+				"isAmp": false,
+				"numIframes": 0,
+				"stack": [
+					"https://publisher.com/homepage.html"
+				],
+				"canonicalUrl": null
+			},
+			"gdprConsent": {
+				"consentString": CONSENT_STRING,
+				"gdprApplies": true
+			}
+		};
+
+		it('basic', function() {
+			const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
+			expect(request.method).to.equal('POST');
+			expect(request.url).to.have.string('https://hb.jsrdn.com/hb?from=pbjs');
+			expect(request.bidderRequest).to.deep.equal(BIDDER_REQUEST);
+			expect(request.data).to.exist;
+			expect(request.data.id).to.be.a('string').that.is.not.empty;
+			expect(request.data.at).to.equal(1);
+			expect(request.data.cur).to.deep.equal(['USD']);
+			expect(request.data.device).to.exist;
+			expect(request.data.site).to.exist;
+			expect(request.data.user).to.exist;
+			expect(request.data.imp).to.be.an('array').that.is.not.empty;
+			expect(request.data.imp[0]).to.exist;
+			expect(request.data.imp[0].id).to.equal(BID_REQUESTS[0].bidId);
+			expect(request.data.imp[0].tagid).to.equal(BID_REQUESTS[0].params.zoneid || '');
+			expect(request.data.imp[0].secure).to.equal(1);
+			expect(request.data.imp[0].banner).to.exist;
+			expect(request.data.imp[0].banner.format).to.be.an('array').that.is.not.empty;
+			expect(request.data.imp[0].banner.format[0]).to.exist;
+			expect(request.data.imp[0].banner.format[0].w).to.equal(970);
+			expect(request.data.imp[0].banner.format[0].h).to.equal(250);
+			expect(request.data.imp[0].banner.w).to.equal(970);
+			expect(request.data.imp[0].banner.h).to.equal(250);
+			expect(request.data.imp[0].banner.pos).to.equal(0);
+			expect(request.data.imp[0].banner.topframe).to.be.oneOf([0, 1]);
+			expect(request.data.imp[0].ext).to.exist;
+			expect(request.data.imp[0].ext.pubid).to.equal(BID_REQUESTS[0].params.pubid);
+			expect(request.data.imp[0].ext.zoneid).to.equal(BID_REQUESTS[0].params.zoneid || '');
+		});
+
+		it('gdpr', function() {
+			const request = spec.buildRequests(BID_REQUESTS, BIDDER_REQUEST);
+			expect(request.data).to.exist;
+			expect(request.data.regs).to.exist;
+			expect(request.data.regs.gdpr).to.equal(1);
+			expect(request.data.user).to.exist;
+			expect(request.data.user.consent).to.equal(CONSENT_STRING);
+		});
+
+	});
+
+	describe('interpretResponse', function() {
+		const REQUEST = {
+			"method": "POST",
+			"url": "https://hb.jsrdn.com/hb?from=pbjs",
+			"data": "{\"id\":\"1648161050749\",\"at\":1,\"cur\":[\"USD\"],\"site\":{\"page\":\"https://publisher.com/homepage.html\",\"domain\":\"publisher.com\"},\"device\":{\"ua\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36\",\"js\":1,\"h\":1200,\"w\":1920,\"language\":\"en\",\"dnt\":0},\"imp\":[{\"id\":\"20b96f0310083c\",\"tagid\":\"67890\",\"secure\":1,\"ext\":{\"pubid\":\"12345\",\"zoneid\":\"67890\"},\"banner\":{\"pos\":0,\"w\":970,\"h\":250,\"topframe\":1,\"format\":[{\"w\":970,\"h\":250}]}}],\"user\":{},\"ext\":{}}",
+			"bidderRequest": {
+				"bidderCode": DSNAME,
+				"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d",
+				"bidderRequestId": "1dd684edba2006",
+				"bids": [{
+					"bidder": DSNAME,
+					"params": {
+						"pubid": "12345",
+						"zoneid": "67890"
+					},
+					"mediaTypes": {
+						"banner": {
+							"sizes": [[970, 250], [300, 250]]
+						}
+					},
+					"adUnitCode": "div-gpt-ad-1460505748561-0",
+					"transactionId": "ca59932f-90f4-4dff-bed2-b90ffa2c2b6a",
+					"sizes": [[970, 250], [300, 250]],
+					"bidId": "20b96f0310083c",
+					"bidderRequestId": "1dd684edba2006",
+					"auctionId": "22ed3053-f76f-476c-a08e-dcda5862443d"
+				}],
+				"refererInfo": {
+					"referer": "https://publisher.com/homepage.html",
+					"reachedTop": true,
+					"isAmp": false,
+					"numIframes": 0,
+					"stack": [
+						"https://publisher.com/homepage.html"
+					],
+					"canonicalUrl": null
+				}
+			}
+		};
+		const RESPONSE = {
+			"body": {
+				"id": "1648161050749",
+				"seatbid": [{
+					"bid": [{
+						"id": "212f1c7b-378b-47e4-8294-ac38658b33f6_0",
+						"impid": "20b96f0310083c",
+						"price": 0.1,
+						"w": 970,
+						"h": 250,
+						"adm": "<div class='dsunit-test' id='20b96f0310083c' style='width:970px;height:250px;background-image:url(https://advertiser.dsp.com/creatives/aaaaaaaa-fa90-46ec-a0f9-1a898452ade3/banner.jpg);background-size:cover'></div>"
+					}]
+				}],
+				"cur": "USD"
+			},
+			"headers": {}
+		};
+		const SAMPLE_PARSED = [{
+			"requestId": "20b96f0310083c",
+			"cpm": 0.1,
+			"currency": "USD",
+			"width": 970,
+			"height": 250,
+			"creativeId": "bbbbbbbb-648d-4e03-a5e2-7198bcd07cfe",
+			"netRevenue": true,
+			"ttl": 300,
+			"ad": "<div class='dsunit-test' id='2f0dfc70a1c251' style='width:970px;height:250px;background-image:url(https://dummyimage.com/970x250/444444/ffffff?text=Test%20Ad);background-size:cover'></div>",
+			"meta": {
+				"advertiserDomains": []
+			}
+		}];
+
+		it('valid bid response for banner ad', function() {
+			const result = spec.interpretResponse(RESPONSE, REQUEST);
+			const bid = RESPONSE.body.seatbid[0].bid[0];
+			expect(result).to.have.lengthOf(1);
+			expect(result[0].requestId).to.equal(bid.impid);
+			expect(result[0].cpm).to.equal(Number(bid.price));
+			expect(result[0].currency).to.equal(RESPONSE.body.cur);
+			expect(result[0].width).to.equal(Number(bid.w));
+			expect(result[0].height).to.equal(Number(bid.h));
+			expect(result[0].creativeId).to.be.a('string').that.is.not.empty;
+			expect(result[0].netRevenue).to.equal(true);
+			expect(result[0].ttl).to.equal(300);
+			expect(result[0].ad).to.equal(bid.adm);
+			expect(result[0].meta).to.exist;
+			expect(result[0].meta.advertiserDomains).to.exist;
+		});
+
+		it('advertiserDomains is included when sent by server', function() {
+			const ADOMAIN = ['advertiser_adomain'];
+			let RESPONSE_CLONE = utils.deepClone(RESPONSE);
+			RESPONSE_CLONE.body.seatbid[0].bid[0].adomain = utils.deepClone(ADOMAIN);;
+			let result = spec.interpretResponse(RESPONSE_CLONE, REQUEST);
+			expect(result[0].meta.advertiserDomains).to.deep.equal(ADOMAIN);
+		});
+
+	});
+
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
Adding a new DistroScale Bid Adapter.

- test parameters for validating bids
```
[{
    code: 'div-gpt-ad-1460505748561-0',
    mediaTypes: {
        banner: {
            sizes: [[300, 250]],
        }
    },
    bids: [{
        bidder: 'distroscale',
        params: {
            pubid: '12345',
            zoneid: '67890'
        }
    }]
}]
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer: prebid@distroscale.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
This change does not change any API nor documentation other than the one dedicated to DistroScale Bid Adapter.

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/3665

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
