### PR TITLE
Floor price : allow having a 0$ floor

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -138,7 +138,7 @@ export function getFirstMatchingFloor(floorData, bidObject, responseObject = {})
 
   let matchingData = {
     floorMin: floorData.floorMin || 0,
-    floorRuleValue: floorData.values[matchingRule] || floorData.default,
+    floorRuleValue: isNaN(floorData.values[matchingRule]) ? floorData.default : floorData.values[matchingRule],
     matchingData: allPossibleMatches[0], // the first possible match is an "exact" so contains all data relevant for anlaytics adapters
     matchingRule
   };

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -230,6 +230,44 @@ describe('the price floors module', function () {
   });
 
   describe('getFirstMatchingFloor', function () {
+    it('uses a 0 floor as overrite', function () {
+      let inputFloorData = {
+        currency: 'USD',
+        schema: {
+          delimiter: '|',
+          fields: ['adUnitCode']
+        },
+        values: {
+          'test_div_1': 0,
+          'test_div_2': 2
+        },
+        default: 0.5
+      };
+
+      expect(getFirstMatchingFloor(inputFloorData, basicBidRequest, {mediaType: 'banner', size: '*'})).to.deep.equal({
+        floorMin: 0,
+        floorRuleValue: 0,
+        matchingFloor: 0,
+        matchingData: 'test_div_1',
+        matchingRule: 'test_div_1'
+      });
+
+      expect(getFirstMatchingFloor(inputFloorData, {...basicBidRequest, adUnitCode: 'test_div_2'}, {mediaType: 'banner', size: '*'})).to.deep.equal({
+        floorMin: 0,
+        floorRuleValue: 2,
+        matchingFloor: 2,
+        matchingData: 'test_div_2',
+        matchingRule: 'test_div_2'
+      });
+
+      expect(getFirstMatchingFloor(inputFloorData, {...basicBidRequest, adUnitCode: 'test_div_3'}, {mediaType: 'banner', size: '*'})).to.deep.equal({
+        floorMin: 0,
+        floorRuleValue: 0.5,
+        matchingFloor: 0.5,
+        matchingData: 'test_div_3',
+        matchingRule: undefined
+      });
+    });
     it('selects the right floor for different mediaTypes', function () {
       // banner with * size (not in rule file so does not do anything)
       expect(getFirstMatchingFloor({...basicFloorData}, basicBidRequest, {mediaType: 'banner', size: '*'})).to.deep.equal({


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
While using priceFloors, I had an issue where I needed a default floor, but needed to disable it on one condition. 
By adding a floor at 0, it will be ignored and replaced by the defaultFloor, which doesn't seem to me like the expected behavior.

I made a change to check that the floor is a Number, therefore, a 0 floor will be accepted and would not be overwritten by the defaultFloor
