### PR TITLE
Permutive RTD module: support IAB Audience taxonomy

### DIFF
--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -201,6 +201,7 @@
                       data: [
                         {
                           name: 'permutive.com',
+                          ext: { segtax: 6 },
                           segment: [{ id: '1' }]
                         }
                       ]

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -153,8 +153,9 @@
                         maxSegs: 500,
                         transformations: [
                           {
-                            id: 'iabAudienceTaxonomy11',
+                            id: 'iab',
                             config: {
+                              segtax: 4,
                               iabIds: {
                                 1000001: '777777',
                                 1000002: '888888'

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -46,6 +46,12 @@
                 },
                 bids: [
                   {
+                    bidder: 'ix',
+                    params: {
+                      siteId: '123456',
+                    }
+                  },
+                  {
                     bidder: 'appnexus',
                     params: {
                       placementId: 13144370,
@@ -135,6 +141,7 @@
             pbjs.que.push(function() {
               pbjs.setConfig({
                 debug: true,
+                pageUrl: 'http://www.test.com/test.html',
                 realTimeData: {
                   auctionDelay: 80, // maximum time for RTD modules to respond
                   dataProviders: [
@@ -142,8 +149,19 @@
                       name: 'permutive',
                       waitForIt: true,
                       params: {
-                        acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx'],
+                        acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx', 'ix'],
                         maxSegs: 500,
+                        transformations: [
+                          {
+                            id: 'iabAudienceTaxonomy11',
+                            config: {
+                              iabIds: {
+                                1000001: '777777',
+                                1000002: '888888'
+                              }
+                            }
+                          }
+                        ],
                         overwrites: {
                           rubicon: function (bid, data, acEnabled, utils, defaultFn) {
                             if (defaultFn){
@@ -160,7 +178,7 @@
                 }
               });
               pbjs.setBidderConfig({
-                bidders: ['appnexus', 'rubicon'],
+                bidders: ['appnexus', 'rubicon', 'ix'],
                 config: {
                   ortb2: {
                     site: {

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -199,11 +199,6 @@
                       keywords: 'a,b',
                       data: [
                         {
-                          name: 'www.dataprovider1.com',
-                          ext: { taxonomyname: 'iab_audience_taxonomy' },
-                          segment: [{ id: '687' }, { id: '123' }]
-                        },
-                        {
                           name: 'permutive.com',
                           segment: [{ id: '1' }]
                         }

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -312,7 +312,7 @@ export const permutiveSubmodule = {
   onAuctionInitEvent: function (auctionDetails, customModuleConfig) {
     makeSafe(function () {
       // Route for bidders supporting ORTB2
-      setBidderRtb(auctionDetails, customModuleConfig, ortb2UserDataTransformations)
+      setBidderRtb(auctionDetails, customModuleConfig)
     })
   },
   init: init

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -75,7 +75,7 @@ export function setBidderRtb (auctionDetails, customModuleConfig) {
 
   acBidders.forEach(function (bidder) {
     const currConfig = bidderConfig[bidder] || {}
-    const nextConfig = mergeOrtbConfig(currConfig, segmentData.ac, transformationConfigs) // ORTB2 uses the `ac` segment IDs
+    const nextConfig = updateOrtbConfig(currConfig, segmentData.ac, transformationConfigs) // ORTB2 uses the `ac` segment IDs
 
     config.setBidderConfig({
       bidders: [bidder],
@@ -85,15 +85,14 @@ export function setBidderRtb (auctionDetails, customModuleConfig) {
 }
 
 /**
- * Merges segment data into existing bidder config
- * Segments are retrieved from the `ac` property of `segmentData`
+ * Updates `user.data` object in existing bidder config with Permutive segments
  * @param {Object} currConfig - Current bidder config
  * @param {Object[]} transformationConfigs - array of objects with `id` and `config` properties, used to determine
  *                                           the transformations on user data to include the ORTB2 object
  * @param {string[]} segmentIDs - Permutive segment IDs
  * @return {Object} Merged ortb2 object
  */
-function mergeOrtbConfig (currConfig, segmentIDs, transformationConfigs) {
+function updateOrtbConfig (currConfig, segmentIDs, transformationConfigs) {
   const name = 'permutive.com'
 
   const permutiveUserData = {

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -281,9 +281,9 @@ const unknownIabSegmentId = '_unknown_'
  * under `user.data` in the bid request.
  */
 const ortb2UserDataTransformations = {
-  iabAudienceTaxonomy11: (userData, config) => ({
+  iab: (userData, config) => ({
     name: userData.name,
-    ext: { segtax: '4' },
+    ext: { segtax: config.segtax },
     segment: (userData.segment || [])
       .map(segment => ({ id: iabSegmentId(segment.id, config.iabIds) }))
       .filter(segment => segment.id !== unknownIabSegmentId)

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -1,8 +1,11 @@
 # Permutive Real-time Data Submodule
+
 This submodule reads cohorts from Permutive and attaches them as targeting keys to bid requests. Using this module will deliver best targeting results, leveraging Permutive's real-time segmentation and modelling capabilities.
 
 ## Usage
+
 Compile the Permutive RTD module into your Prebid build:
+
 ```
 gulp build --modules=rtdModule,permutiveRtdProvider
 ```
@@ -29,25 +32,32 @@ pbjs.setConfig({
 ```
 
 ## Supported Bidders
+
 The Permutive RTD module sets Audience Connector cohorts as bidder-specific `ortb2.user.data` first-party data, following the Prebid `ortb2` convention, for any bidder included in `acBidders`. The module also supports bidder-specific data locations per ad unit (custom parameters) for the below bidders:
 
-| Bidder      | ID         | Custom Cohorts       | Audience Connector |
-| ----------- | ---------- | -------------------- | ------------------ |
-| Xandr       | `appnexus` | Yes                  | Yes                |
-| Magnite     | `rubicon`  | Yes                  | No                 |
-| Ozone       | `ozone`    | No                   | Yes                |
+| Bidder  | ID         | Custom Cohorts | Audience Connector |
+| ------- | ---------- | -------------- | ------------------ |
+| Xandr   | `appnexus` | Yes            | Yes                |
+| Magnite | `rubicon`  | Yes            | No                 |
+| Ozone   | `ozone`    | No             | Yes                |
 
 Key-values details for custom parameters:
-* **Custom Cohorts:** When enabling the respective Activation for a cohort in Permutive, this module will automatically attach that cohort ID to the bid request. There is no need to enable individual bidders in the module configuration, it will automatically reflect which SSP integrations you have enabled in your Permutive dashboard. Permutive cohorts will be sent in the `permutive` key-value.
 
-* **Audience Connector:** You'll need to define which bidders should receive Audience Connector cohorts. You need to include the `ID` of any bidder in the `acBidders` array. Audience Connector cohorts will be sent in the `p_standard` key-value.
+- **Custom Cohorts:** When enabling the respective Activation for a cohort in Permutive, this module will automatically attach that cohort ID to the bid request. There is no need to enable individual bidders in the module configuration, it will automatically reflect which SSP integrations you have enabled in your Permutive dashboard. Permutive cohorts will be sent in the `permutive` key-value.
 
+- **Audience Connector:** You'll need to define which bidders should receive Audience Connector cohorts. You need to include the `ID` of any bidder in the `acBidders` array. Audience Connector cohorts will be sent in the `p_standard` key-value.
 
 ## Parameters
-| Name              | Type                 | Description        | Default        |
-| ----------------- | -------------------- | ------------------ | ------------------ |
-| name              | String               | This should always be `permutive` | - |
-| waitForIt         | Boolean              | Should be `true` if there's an `auctionDelay` defined (optional) | `false` |
-| params            | Object               |                 | - |
-| params.acBidders  | String[]             | An array of bidders which should receive AC cohorts. | `[]` |
-| params.maxSegs    | Integer              | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500` |
+
+| Name                   | Type     | Description                                                                                   | Default |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------- | ------- |
+| name                   | String   | This should always be `permutive`                                                             | -       |
+| waitForIt              | Boolean  | Should be `true` if there's an `auctionDelay` defined (optional)                              | `false` |
+| params                 | Object   |                                                                                               | -       |
+| params.acBidders       | String[] | An array of bidders which should receive AC cohorts.                                          | `[]`    |
+| params.maxSegs         | Integer  | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`   |
+| params.transformations | Object[] | An array of configurations for ORTB2 user data transformations                                |
+
+### The `transformations` parameter
+
+This array contains configurations for transformations we'll apply to the Permutive object in the ORTB2 `user.data` array. The results of these transformations will be appended to the `user.data` array that's attached to ORTB2 bid requests.

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -56,8 +56,14 @@ Key-values details for custom parameters:
 | params                 | Object   |                                                                                               | -       |
 | params.acBidders       | String[] | An array of bidders which should receive AC cohorts.                                          | `[]`    |
 | params.maxSegs         | Integer  | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`   |
-| params.transformations | Object[] | An array of configurations for ORTB2 user data transformations                                |
+| params.transformations | Object[] | An array of configurations for ORTB2 user data transformations                                |         |
 
 ### The `transformations` parameter
 
 This array contains configurations for transformations we'll apply to the Permutive object in the ORTB2 `user.data` array. The results of these transformations will be appended to the `user.data` array that's attached to ORTB2 bid requests.
+
+#### Supported transformations
+
+| Name           | ID  | Config structure                                  | Description                                                                          |
+| -------------- | --- | ------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| IAB taxonomies | iab | { segtax: number, iabIds: Object<number, number>} | Transform segment IDs from Permutive to IAB (note: alpha version, subject to change) |

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -51,6 +51,45 @@ describe('permutiveRtdProvider', function () {
         }])
       })
     })
+    it('should include ortb2 user data transformation for IAB audience taxonomy', function() {
+      const moduleConfig = getConfig()
+      const bidderConfig = config.getBidderConfig()
+      const acBidders = moduleConfig.params.acBidders
+      const expectedTargetingData = transformedTargeting().ac.map(seg => {
+        return { id: seg }
+      })
+
+      Object.assign(
+        moduleConfig.params,
+        {
+          transformations: [{
+            id: 'iabAudienceTaxonomy11',
+            config: {
+              iabIds: {
+                1000001: '9000009',
+                1000002: '9000008'
+              }
+            }
+          }]
+        }
+      )
+
+      setBidderRtb({}, moduleConfig)
+
+      acBidders.forEach(bidder => {
+        expect(bidderConfig[bidder].ortb2.user.data).to.deep.include.members([
+          {
+            name: 'permutive.com',
+            segment: expectedTargetingData
+          },
+          {
+            name: 'permutive.com',
+            ext: { segtax: '4' },
+            segment: [{ id: '9000009' }, { id: '9000008' }]
+          }
+        ])
+      })
+    })
     it('should not overwrite ortb2 config', function () {
       const moduleConfig = getConfig()
       const bidderConfig = config.getBidderConfig()
@@ -78,7 +117,15 @@ describe('permutiveRtdProvider', function () {
         config: sampleOrtbConfig
       })
 
-      setBidderRtb({}, moduleConfig)
+      const transformedUserData = {
+        name: 'transformation',
+        ext: { test: true },
+        segment: [1, 2, 3]
+      }
+
+      setBidderRtb({}, moduleConfig, {
+        testTransformation: userData => transformedUserData
+      })
 
       acBidders.forEach(bidder => {
         expect(bidderConfig[bidder].ortb2.site.name).to.equal(sampleOrtbConfig.ortb2.site.name)
@@ -293,6 +340,10 @@ describe('permutiveRtdProvider', function () {
       expect(isAcEnabled({ params: { acBidders: ['ozone'] } }, 'ozone')).to.equal(true)
       expect(isAcEnabled({ params: { acBidders: ['kjdvb'] } }, 'ozone')).to.equal(false)
     })
+    it('checks if AC is enabled for Index', function () {
+      expect(isAcEnabled({ params: { acBidders: ['ix'] } }, 'ix')).to.equal(true)
+      expect(isAcEnabled({ params: { acBidders: ['kjdvb'] } }, 'ix')).to.equal(false)
+    })
   })
 })
 
@@ -313,7 +364,7 @@ function getConfig () {
     name: 'permutive',
     waitForIt: true,
     params: {
-      acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx'],
+      acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx', 'ix'],
       maxSegs: 500
     }
   }
@@ -326,7 +377,7 @@ function transformedTargeting () {
     ac: [...data._pcrprs, ...data._ppam, ...data._psegs.filter(seg => seg >= 1000000)],
     appnexus: data._papns,
     rubicon: data._prubicons,
-    gam: data._pdfps
+    gam: data._pdfps,
   }
 }
 

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -63,8 +63,9 @@ describe('permutiveRtdProvider', function () {
         moduleConfig.params,
         {
           transformations: [{
-            id: 'iabAudienceTaxonomy11',
+            id: 'iab',
             config: {
+              segtax: 4,
               iabIds: {
                 1000001: '9000009',
                 1000002: '9000008'
@@ -84,7 +85,7 @@ describe('permutiveRtdProvider', function () {
           },
           {
             name: 'permutive.com',
-            ext: { segtax: '4' },
+            ext: { segtax: 4 },
             segment: [{ id: '9000009' }, { id: '9000008' }]
           }
         ])


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Updates the Permutive RTD module to facilitate for segmentation by
the new IAB Audience taxonomy.

To achieve this, this change introduces the concept of "transformations"
on the ORT2B `user.data` object. There are two components to these
transformations: a new `transformations` property on the Prebid config,
to be set by the publisher, and logic in the module for the actual
behaviour of the transformation.

We plan to use the transformation logic in this PR, combined with
configuration we'll share with publishers, to send IAB Audience
taxonomy cohort IDs to bidders.