### PR TITLE
justPremium Bid Adapter : support for user sync pixels

### DIFF
--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -4,8 +4,7 @@ import { deepAccess } from '../src/utils.js';
 const BIDDER_CODE = 'justpremium'
 const GVLID = 62
 const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
-const JP_ADAPTER_VERSION = '1.8.2'
-const pixels = []
+const JP_ADAPTER_VERSION = '1.8.3'
 
 export const spec = {
   code: BIDDER_CODE,
@@ -114,8 +113,10 @@ export const spec = {
     return bidResponses
   },
 
-  getUserSyncs: function getUserSyncs(syncOptions, responses, gdprConsent, uspConsent) {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
     let url = 'https://pre.ads.justpremium.com/v/1.0/t/sync' + '?_c=' + 'a' + Math.random().toString(36).substring(7) + Date.now();
+    let pixels = []
+
     if (gdprConsent && (typeof gdprConsent.gdprApplies === 'boolean') && gdprConsent.gdprApplies && gdprConsent.consentString) {
       url = url + '&consentString=' + encodeURIComponent(gdprConsent.consentString)
     }
@@ -127,6 +128,10 @@ export const spec = {
         type: 'iframe',
         url: url
       })
+    }
+    if (syncOptions.pixelEnabled && serverResponses.length !== 0) {
+      const pxsFromResponse = serverResponses.map(res => res?.body?.pxs).reduce((acc, cur) => acc.concat(cur), []);
+      pixels = [...pixels, ...pxsFromResponse];
     }
     return pixels
   },

--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -130,7 +130,7 @@ export const spec = {
       })
     }
     if (syncOptions.pixelEnabled && serverResponses.length !== 0) {
-      const pxsFromResponse = serverResponses.map(res => res?.body?.pxs).reduce((acc, cur) => acc.concat(cur), []);
+      const pxsFromResponse = serverResponses.map(res => res?.body?.pxs).reduce((acc, cur) => acc.concat(cur), []).filter((obj) => obj !== undefined);
       pixels = [...pixels, ...pxsFromResponse];
     }
     return pixels

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -65,6 +65,24 @@ describe('justpremium adapter', function () {
     }
   }
 
+  const serverResponses = [
+    {
+      'body': {
+        'bid': {},
+        'pass': {
+          '141952': true
+        },
+        'deals': {},
+        'pxs': [
+          {
+            'url': 'https://url.com',
+            'type': 'image'
+          }
+        ]
+      }
+    }
+  ]
+
   describe('isBidRequestValid', function () {
     it('Verifies bidder code', function () {
       expect(spec.code).to.equal('justpremium')
@@ -97,7 +115,7 @@ describe('justpremium adapter', function () {
       expect(jpxRequest.id).to.equal(adUnits[0].params.zone)
       expect(jpxRequest.mediaTypes && jpxRequest.mediaTypes.banner && jpxRequest.mediaTypes.banner.sizes).to.not.equal('undefined')
       expect(jpxRequest.version.prebid).to.equal('$prebid.version$')
-      expect(jpxRequest.version.jp_adapter).to.equal('1.8.2')
+      expect(jpxRequest.version.jp_adapter).to.equal('1.8.3')
       expect(jpxRequest.pubcid).to.equal('0000000')
       expect(jpxRequest.uids.tdid).to.equal('1111111')
       expect(jpxRequest.uids.id5id.uid).to.equal('2222222')
@@ -185,13 +203,19 @@ describe('justpremium adapter', function () {
   })
 
   describe('getUserSyncs', function () {
-    it('Verifies sync options', function () {
+    it('Verifies sync options for iframe', function () {
       const options = spec.getUserSyncs({iframeEnabled: true}, {}, {gdprApplies: true, consentString: 'BOOgjO9OOgjO9APABAENAi-AAAAWd'}, '1YYN')
       expect(options).to.not.be.undefined
       expect(options[0].type).to.equal('iframe')
       expect(options[0].url).to.match(/\/\/pre.ads.justpremium.com\/v\/1.0\/t\/sync/)
       expect(options[0].url).to.match(/&consentString=BOOgjO9OOgjO9APABAENAi-AAAAWd/)
       expect(options[0].url).to.match(/&usPrivacy=1YYN/)
+    })
+    it('Returns array of user sync pixels', function () {
+      const options = spec.getUserSyncs({pixelEnabled: true}, serverResponses)
+      expect(options).to.not.be.undefined
+      expect(Array.isArray(options)).to.be.true
+      expect(options[0].type).to.equal('image')
     })
   })
 })


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This change will allow justpremium bid adapter to parse user sync pixels.
