### PR TITLE
consumable Bid Adapter : add bidResponse fields

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -122,9 +122,29 @@ export const spec = {
           bid.currency = 'USD';
           bid.creativeId = decision.adId;
           bid.ttl = 30;
-          bid.meta = { advertiserDomains: decision.adomain ? decision.adomain : [] }
           bid.netRevenue = true;
           bid.referrer = bidRequest.bidderRequest.refererInfo.referer;
+
+          bid.meta = {
+            advertiserDomains: decision.adomain || []
+          };
+
+          if (decision.cats) {
+            if (decision.cats.length > 0) {
+              bid.meta.primaryCatId = decision.cats[0];
+              if (decision.cats.length > 1) {
+                bid.meta.secondaryCatIds = decision.cats.slice(1);
+              }
+            }
+          }
+
+          if (decision.networkId) {
+            bid.meta.networkId = decision.networkId;
+          }
+
+          if (decision.mediaType) {
+            bid.meta.mediaType = decision.mediaType;
+          }
 
           bidResponses.push(bid);
         }
@@ -136,13 +156,15 @@ export const spec = {
 
   getUserSyncs: function(syncOptions, serverResponses) {
     if (syncOptions.iframeEnabled) {
-      return [{
-        type: 'iframe',
-        url: 'https://sync.serverbid.com/ss/' + siteId + '.html'
-      }];
+      if (!serverResponses || serverResponses.length === 0 || !serverResponses[0].body.bdr || serverResponses[0].body.bdr !== 'cx') {
+        return [{
+          type: 'iframe',
+          url: 'https://sync.serverbid.com/ss/' + siteId + '.html'
+        }];
+      }
     }
 
-    if (syncOptions.pixelEnabled && serverResponses.length > 0) {
+    if (syncOptions.pixelEnabled && serverResponses && serverResponses.length > 0) {
       return serverResponses[0].body.pixels;
     } else {
       logWarn(bidder + ': Please enable iframe based user syncing.');

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -177,6 +177,69 @@ const AD_SERVER_RESPONSE = {
   }
 };
 
+const AD_SERVER_RESPONSE_2 = {
+  'headers': null,
+  'body': {
+    'user': { 'key': 'ue1-2d33e91b71e74929b4aeecc23f4376f1' },
+    'pixels': [{ 'type': 'image', 'url': '//sync.serverbid.com/ss/' }],
+    'bdr': 'notcx',
+    'decisions': {
+      '2b0f82502298c9': {
+        'adId': 2364764,
+        'creativeId': 1950991,
+        'flightId': 2788300,
+        'campaignId': 542982,
+        'clickUrl': 'https://e.serverbid.com/r',
+        'impressionUrl': 'https://e.serverbid.com/i.gif',
+        'contents': [{
+          'type': 'html',
+          'body': '<html></html>',
+          'data': {
+            'height': 90,
+            'width': 728,
+            'imageUrl': 'https://static.adzerk.net/Advertisers/b0ab77db8a7848c8b78931aed022a5ef.gif',
+            'fileName': 'b0ab77db8a7848c8b78931aed022a5ef.gif'
+          },
+          'template': 'image'
+        }],
+        'height': 90,
+        'width': 728,
+        'events': [],
+        'pricing': {'price': 0.5, 'clearPrice': 0.5, 'revenue': 0.0005, 'rateType': 2, 'eCPM': 0.5},
+        'mediaType': 'banner',
+        'cats': ['IAB1', 'IAB2', 'IAB3'],
+        'networkId': 1234567,
+      },
+      '123': {
+        'adId': 2364764,
+        'creativeId': 1950991,
+        'flightId': 2788300,
+        'campaignId': 542982,
+        'clickUrl': 'https://e.serverbid.com/r',
+        'impressionUrl': 'https://e.serverbid.com/i.gif',
+        'contents': [{
+          'type': 'html',
+          'body': '<html></html>',
+          'data': {
+            'height': 90,
+            'width': 728,
+            'imageUrl': 'https://static.adzerk.net/Advertisers/b0ab77db8a7848c8b78931aed022a5ef.gif',
+            'fileName': 'b0ab77db8a7848c8b78931aed022a5ef.gif'
+          },
+          'template': 'image'
+        }],
+        'height': 90,
+        'width': 728,
+        'events': [],
+        'pricing': {'price': 0.5, 'clearPrice': 0.5, 'revenue': 0.0005, 'rateType': 2, 'eCPM': 0.5},
+        'mediaType': 'banner',
+        'cats': ['IAB1', 'IAB2'],
+        'networkId': 2345678,
+      }
+    }
+  }
+};
+
 const BUILD_REQUESTS_OUTPUT = {
   method: 'POST',
   url: 'https://e.serverbid.com/api/v2',
@@ -285,7 +348,7 @@ describe('Consumable BidAdapter', function () {
     });
 
     it('registers bids', function () {
-      let bids = spec.interpretResponse(AD_SERVER_RESPONSE, BUILD_REQUESTS_OUTPUT);
+      let bids = spec.interpretResponse(AD_SERVER_RESPONSE_2, BUILD_REQUESTS_OUTPUT);
       bids.forEach(b => {
         expect(b).to.have.property('cpm');
         expect(b.cpm).to.be.above(0);
@@ -299,9 +362,13 @@ describe('Consumable BidAdapter', function () {
         expect(b).to.have.property('currency', 'USD');
         expect(b).to.have.property('creativeId');
         expect(b).to.have.property('ttl', 30);
-        expect(b.meta).to.have.property('advertiserDomains');
         expect(b).to.have.property('netRevenue', true);
         expect(b).to.have.property('referrer');
+        expect(b.meta).to.have.property('advertiserDomains');
+        expect(b.meta).to.have.property('primaryCatId');
+        expect(b.meta).to.have.property('secondaryCatIds');
+        expect(b.meta).to.have.property('networkId');
+        expect(b.meta).to.have.property('mediaType');
       });
     });
 
@@ -329,6 +396,24 @@ describe('Consumable BidAdapter', function () {
 
     it('should return a sync url if iframe syncs are enabled', function () {
       let opts = spec.getUserSyncs(syncOptions);
+
+      expect(opts.length).to.equal(1);
+    });
+
+    it('should return a sync url if iframe syncs are enabled and server response is empty', function () {
+      let opts = spec.getUserSyncs(syncOptions, []);
+
+      expect(opts.length).to.equal(1);
+    });
+
+    it('should return a sync url if iframe syncs are enabled and server response does not contain a bdr attribute', function () {
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE]);
+
+      expect(opts.length).to.equal(1);
+    });
+
+    it('should return a sync url if iframe syncs are enabled and server response contains a bdr attribute that is not cx', function () {
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE_2]);
 
       expect(opts.length).to.equal(1);
     });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This change adds additional fields to the bidResponse.meta object and adds an additional conditional check for iframe based user syncing.
