### PR TITLE
Prebid Core: add documentResolver callback and allow the user to supply a different document object to render

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1125,7 +1125,7 @@ function buildNativeRequest(params) {
  */
 function hidedfpContainer(elementId) {
   try {
-    var el = document.getElementById(elementId).querySelectorAll("div[id^='google_ads']");
+    const el = document.getElementById(elementId).querySelectorAll("div[id^='google_ads']");
     if (el[0]) {
       el[0].style.setProperty('display', 'none');
     }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1146,12 +1146,12 @@ function hideSASIframe(elementId) {
   }
 }
 
-function outstreamRender(bid, context) {
+function outstreamRender(bid, doc) {
   hidedfpContainer(bid.adUnitCode);
   hideSASIframe(bid.adUnitCode);
   // push to render queue because ANOutstreamVideo may not be loaded yet
   bid.renderer.push(() => {
-    const win = getWindowFromDocument(context) || window;
+    const win = getWindowFromDocument(doc) || window;
     win.ANOutstreamVideo.renderAd({
       tagId: bid.adResponse.tag_id,
       sizes: [bid.getSize().split('x')],

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -591,7 +591,6 @@ function formatRequest(payload, bidderRequest) {
 }
 
 function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
-  debugger;
   const renderer = Renderer.install({
     id: rtbBid.renderer_id,
     url: rtbBid.renderer_url,

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -53,7 +53,7 @@ export function Renderer(options) {
     if (!isRendererPreferredFromAdUnit(adUnitCode)) {
       // we expect to load a renderer url once only so cache the request to load script
       this.cmd.unshift(runRender) // should render run first ?
-      loadExternalScript(url, moduleCode, this.callback);
+      loadExternalScript(url, moduleCode, this.callback, this.context);
     } else {
       logWarn(`External Js not loaded by Renderer since renderer url and callback is already defined on adUnit ${adUnitCode}`);
       runRender()
@@ -112,9 +112,18 @@ export function isRendererRequired(renderer) {
  * Render the bid returned by the adapter
  * @param {Object} renderer Renderer object installed by adapter
  * @param {Object} bid Bid response
+ * @param {Document} doc context document of bid
  */
-export function executeRenderer(renderer, bid) {
-  renderer.render(bid);
+export function executeRenderer(renderer, bid, doc) {
+  let context = null;
+  if (renderer.config && renderer.config.contextResolver) {
+    context = renderer.config.contextResolver(bid, document, doc);// a user provided callback, which should return a Document, and expect the parameters; bid, sourceDocument, renderDocument
+  }
+  if (!context) {
+    context = document;
+  }
+  renderer.context = context;
+  renderer.render(bid, renderer.context);
 }
 
 function isRendererPreferredFromAdUnit(adUnitCode) {

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -53,7 +53,7 @@ export function Renderer(options) {
     if (!isRendererPreferredFromAdUnit(adUnitCode)) {
       // we expect to load a renderer url once only so cache the request to load script
       this.cmd.unshift(runRender) // should render run first ?
-      loadExternalScript(url, moduleCode, this.callback, this.context);
+      loadExternalScript(url, moduleCode, this.callback, this.documentContext);
     } else {
       logWarn(`External Js not loaded by Renderer since renderer url and callback is already defined on adUnit ${adUnitCode}`);
       runRender()
@@ -115,15 +115,15 @@ export function isRendererRequired(renderer) {
  * @param {Document} doc context document of bid
  */
 export function executeRenderer(renderer, bid, doc) {
-  let context = null;
-  if (renderer.config && renderer.config.contextResolver) {
-    context = renderer.config.contextResolver(bid, document, doc);// a user provided callback, which should return a Document, and expect the parameters; bid, sourceDocument, renderDocument
+  let docContext = null;
+  if (renderer.config && renderer.config.documentResolver) {
+    docContext = renderer.config.documentResolver(bid, document, doc);// a user provided callback, which should return a Document, and expect the parameters; bid, sourceDocument, renderDocument
   }
-  if (!context) {
-    context = document;
+  if (!docContext) {
+    docContext = document;
   }
-  renderer.context = context;
-  renderer.render(bid, renderer.context);
+  renderer.documentContext = docContext;
+  renderer.render(bid, renderer.documentContext);
 }
 
 function isRendererPreferredFromAdUnit(adUnitCode) {

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -1,4 +1,4 @@
-import includes from 'core-js-pure/features/array/includes.js';
+import {includes} from './polyfill.js';
 import { logError, logWarn, insertElement, isArray } from './utils.js';
 
 const _requestCache = {};
@@ -8,7 +8,9 @@ const _approvedLoadExternalJSList = [
   'criteo',
   'outstream',
   'adagio',
-  'browsi'
+  'browsi',
+  'brandmetrics',
+  'justtag'
 ]
 
 /**

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -19,7 +19,7 @@ const _approvedLoadExternalJSList = [
  * @param {string} url the url to load
  * @param {string} moduleCode bidderCode or module code of the module requesting this resource
  * @param {function} [callback] callback function to be called after the script is loaded
- * @param {Document} doc the context document, in which the script will be loaded
+ * @param {Document} [doc] the context document, in which the script will be loaded, defaults to loaded document
  */
 export function loadExternalScript(url, moduleCode, callback, doc) {
   if (!moduleCode || !url) {

--- a/src/auction.js
+++ b/src/auction.js
@@ -572,7 +572,8 @@ function getPreparedBidForAuction({adUnitCode, bid, auctionId}, {index = auction
   }
 
   if (renderer) {
-    bidObject.renderer = Renderer.install({ url: renderer.url });
+    // be aware, an adapter could already have installed the bidder, in which case this overwrite's the existing adapter
+    bidObject.renderer = Renderer.install({ url: renderer.url, config: renderer.options });// rename options to config, to make it consistent?
     bidObject.renderer.setRender(renderer.render);
   }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -486,7 +486,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
           insertElement(creativeComment, doc, 'html');
 
           if (isRendererRequired(renderer)) {
-            executeRenderer(renderer, bid);
+            executeRenderer(renderer, bid, doc);
             reinjectNodeIfRemoved(creativeComment, doc, 'html');
             emitAdRenderSucceeded({ doc, bid, id });
           } else if ((doc === document && !inIframe()) || mediaType === 'video') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1362,8 +1362,5 @@ export function cyrb53Hash(str, seed = 0) {
  * @returns {Window}
  */
 export function getWindowFromDocument(doc) {
-  if (!doc) {
-    return null;
-  }
-  return doc.defaultView || doc.parentWindow;
+  return (doc) ? doc.defaultView : null;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1355,3 +1355,16 @@ export function cyrb53Hash(str, seed = 0) {
   h2 = imul(h2 ^ (h2 >>> 16), 2246822507) ^ imul(h1 ^ (h1 >>> 13), 3266489909);
   return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString();
 }
+}
+
+/**
+ * returns a window object, which holds the provided document or null
+ * @param {Document} doc
+ * @returns {Window}
+ */
+export function getWindowFromDocument(doc) {
+  if (!doc) {
+    return null;
+  }
+  return doc.defaultView || doc.parentWindow;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1355,7 +1355,6 @@ export function cyrb53Hash(str, seed = 0) {
   h2 = imul(h2 ^ (h2 >>> 16), 2246822507) ^ imul(h1 ^ (h1 >>> 13), 3266489909);
   return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString();
 }
-}
 
 /**
  * returns a window object, which holds the provided document or null

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -63,6 +63,7 @@ describe('adLoader', function () {
       const doc2 = getDocSpec();
       adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
       adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
       adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
       adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
       expect(utilsinsertElementStub.callCount).to.equal(2);

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -38,5 +38,34 @@ describe('adLoader', function () {
       adLoader.loadExternalScript('someURL1', 'criteo', callback);
       expect(utilsinsertElementStub.called).to.be.true;
     });
+
+    it('requires a url to be included once per document', function () {
+      function getDocSpec() {
+        return {
+          createElement: function() {
+            return {
+
+            }
+          },
+          getElementsByTagName: function() {
+            return {
+              firstChild: {
+                insertBefore: function() {
+
+                }
+              }
+            }
+          }
+
+        }
+      }
+      const doc1 = getDocSpec();
+      const doc2 = getDocSpec();
+      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
+      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
+      expect(utilsinsertElementStub.callCount).to.equal(2);
+    });
   });
 });

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Renderer } from 'src/Renderer.js';
+import { Renderer, executeRenderer } from 'src/Renderer.js';
 import * as utils from 'src/utils.js';
 import { loadExternalScript } from 'src/adloader.js';
 require('test/mocks/adloaderStub.js');
@@ -211,6 +211,21 @@ describe('Renderer', function () {
 
       testRenderer.render()
       expect(loadExternalScript.called).to.be.true;
+    });
+
+    it('call\'s documentResolver when configured', function () {
+      const documentResolver = sinon.spy(function(bid, sDoc, tDoc) {
+        return document;
+      });
+
+      let testRenderer = Renderer.install({
+        url: 'https://httpbin.org/post',
+        config: { documentResolver: documentResolver }
+      });
+
+      executeRenderer(testRenderer, {}, {});
+
+      expect(documentResolver.called).to.be.true;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR, allows the user to supply a different document object to render the ad/outstream video in. This can be usefull if the prebid instance is loaded in a different document/iframe, while the ad/video should be rendered in another iframe/document.
This implements this optional change also in the Appnexus bid adapter, and allows the Appnexus bid adapter to fail silently when certain elements don't exist.
The feature add's an optional ```contextResolver``` callback method to the config of the ```Renderer```, which receives the current Bid, the document where prebid is loaded, and the document object which is passed to the renderAd method. And should return the document object in which it should render the ad

Configuration can be on the adunit or mediaType level. 
For example;
```js
mediaTypes: {
    video: {
        context: 'outstream',
        playerSize: [640, 480],
        mimes: ['video/mp4'],
        protocols: [1, 2, 3, 4, 5, 6, 7, 8],
        playbackmethod: [2],
        skip: 1,
        playback_method: ['auto_play_sound_off'],
        renderer:{                                        
            options:{                                            
                contextResolver:function(bid, ownDoc, renderDoc){                                                
                    return renderDoc;                                                
                }
            }                                        
        }
    }
}
```


