### PR TITLE
Appnexus Bid Adapter : add support for setConfig pageUrl

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -271,6 +271,10 @@ export const spec = {
         rd_ifs: bidderRequest.refererInfo.numIframes,
         rd_stk: bidderRequest.refererInfo.stack.map((url) => encodeURIComponent(url)).join(',')
       }
+      let pubPageUrl = config.getConfig('pageUrl');
+      if (isStr(pubPageUrl) && pubPageUrl !== '') {
+        refererinfo.rd_can = pubPageUrl;
+      }
       payload.referrer_detection = refererinfo;
     }
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR updates the appnexus Bid adapter to support reading from the `pbjs.setConfig('pageUrl')` field. 