### PR TITLE
Prebid Core: send all bid info within the timeout event

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -848,13 +848,7 @@ function groupByPlacement(bidsByPlacement, bid) {
 function getTimedOutBids(bidderRequests, timelyBidders) {
   const timedOutBids = bidderRequests
     .map(bid => (bid.bids || []).filter(bid => !timelyBidders.has(bid.bidder)))
-    .reduce(flatten, [])
-    .map(bid => ({
-      bidId: bid.bidId,
-      bidder: bid.bidder,
-      adUnitCode: bid.adUnitCode,
-      auctionId: bid.auctionId,
-    }));
+    .reduce(flatten, []);
 
   return timedOutBids;
 }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -941,6 +941,8 @@ describe('auctionmanager.js', function () {
           const timedOutBids = bidTimeoutCall.args[1];
           assert.equal(timedOutBids.length, 1);
           assert.equal(timedOutBids[0].bidder, BIDDER_CODE1);
+          // Check that additional properties are available
+          assert.equal(timedOutBids[0].params.placementId, 'id');
 
           const auctionEndCall = eventsEmitSpy.withArgs(CONSTANTS.EVENTS.AUCTION_END).getCalls()[0];
           const auctionProps = auctionEndCall.args[1];


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
We are using the bids and no bids events (EVENTS.BID_TIMEOUT and EVENTS.NO_BID) and we do not retrieve the same information about the bid on both. The timeout event only has a few information. This is because most fields are not sent. 

I don't know if there is a reason to keep only little information about the timeout event, but if it's ok, it would be convenient for us to have more information.

This pull request updates the timeout event and will send the original bid in the timeout event. There will be no removal or renaming of fields. This is only an addition of field.