### PR TITLE
Consent management: fix bug with adUnits without a size causing exception in GPDR processing

### DIFF
--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -335,8 +335,8 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
       let height = 1;
       if (Array.isArray(adUnits) && adUnits.length > 0) {
         let sizes = getAdUnitSizes(adUnits[0]);
-        width = sizes[0][0];
-        height = sizes[0][1];
+        width = sizes?.[0]?.[0] || 1;
+        height = sizes?.[0]?.[1] || 1;
       }
 
       return function (cb) {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -299,6 +299,14 @@ describe('consentManagement', function () {
       allowAuctionWithoutConsent: true
     };
 
+    const staticConfig = {
+      cmpApi: 'static',
+      timeout: 7500,
+      consentData: {
+        getTCData: {}
+      }
+    }
+
     let didHookReturn;
 
     afterEach(function () {
@@ -357,6 +365,17 @@ describe('consentManagement', function () {
         expect(consent).to.be.null;
         expect(gdprDataHandler.ready).to.be.true;
       });
+
+      it('should not trip when adUnits have no size', () => {
+        setConsentConfig(staticConfig);
+        let ran = false;
+        requestBidsHook(() => {
+          ran = true;
+        }, {adUnits: [{code: 'test', mediaTypes: {video: {}}}]});
+        return gdprDataHandler.promise.then(() => {
+          expect(ran).to.be.true;
+        });
+      })
     });
 
     describe('already known consentData:', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

https://github.com/prebid/Prebid.js/pull/8185 introduced a bug where non-banner adUnits cause an exception in GPDR processing (https://github.com/prebid/Prebid.js/issues/8300) - this addresses it.

## Other information

Fix https://github.com/prebid/Prebid.js/issues/8300

