### PR TITLE
Build CircleCI: disable e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ workflows:
   commit:
     jobs:
       - build
-      - e2etest
 
 experimental:
   pipelines: true


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change
﻿Our BrowserStack plan is too small to run e2e tests on commit - with rate limits causing test failures. This disables running the tests until we solve that.
