### PR TITLE
PBS adapter: fix bug with priceFloors sometimes not being set in request

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -757,7 +757,7 @@ Object.assign(ORTB2.prototype, {
       }
 
       const floor = (() => {
-        // we have to pick a floor for the imp - here we attempt to find the minimimum floor
+        // we have to pick a floor for the imp - here we attempt to find the minimum floor
         // across all bids for this adUnit
 
         const convertCurrency = typeof getGlobal().convertCurrency !== 'function'

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -38,6 +38,7 @@ import {find, includes} from '../../src/polyfill.js';
 import { S2S_VENDORS } from './config.js';
 import { ajax } from '../../src/ajax.js';
 import {hook} from '../../src/hook.js';
+import {getGlobal} from '../../src/prebidGlobal.js';
 
 const getConfig = config.getConfig;
 
@@ -755,21 +756,58 @@ Object.assign(ORTB2.prototype, {
         deepSetValue(imp, 'ext.prebid.storedauctionresponse.id', storedAuctionResponseBid.storedAuctionResponse.toString());
       }
 
-      const getFloorBid = find(firstBidRequest.bids, bid => bid.adUnitCode === adUnit.code && typeof bid.getFloor === 'function');
+      const floor = (() => {
+        // we have to pick a floor for the imp - here we attempt to find the minimimum floor
+        // across all bids for this adUnit
 
-      if (getFloorBid) {
-        let floorInfo;
-        try {
-          floorInfo = getFloorBid.getFloor({
-            currency: config.getConfig('currency.adServerCurrency') || DEFAULT_S2S_CURRENCY,
-          });
-        } catch (e) {
-          logError('PBS: getFloor threw an error: ', e);
-        }
-        if (floorInfo && floorInfo.currency && !isNaN(parseFloat(floorInfo.floor))) {
-          imp.bidfloor = parseFloat(floorInfo.floor);
-          imp.bidfloorcur = floorInfo.currency
-        }
+        const convertCurrency = typeof getGlobal().convertCurrency !== 'function'
+          ? (amount) => amount
+          : (amount, from, to) => {
+            if (from === to) return amount;
+            let result;
+            try {
+              result = getGlobal().convertCurrency(amount, from, to);
+            } catch (e) {
+              result = amount;
+            }
+            return result == null ? amount : result;
+          }
+        const s2sCurrency = config.getConfig('currency.adServerCurrency') || DEFAULT_S2S_CURRENCY;
+
+        return adUnit.bids
+          .map((bid) => this.getBidRequest(imp.id, bid.bidder))
+          .filter((bid) => bid && typeof bid.getFloor === 'function')
+          .map((bid) => {
+            try {
+              const {currency, floor} = bid.getFloor({
+                currency: s2sCurrency
+              });
+              return {
+                currency,
+                floor: parseFloat(floor)
+              }
+            } catch (e) {
+              logError('PBS: getFloor threw an error: ', e);
+            }
+          })
+          .filter((floor) => floor && floor.currency != null && floor.floor != null && !isNaN(floor.floor))
+          .reduce((min, floor) => {
+            if (min.ref == null) {
+              min.ref = min.min = floor;
+            } else {
+              const value = convertCurrency(floor.floor, floor.currency, min.ref.currency);
+              if (value < min.ref.floor) {
+                min.ref.floor = value;
+                min.min = floor;
+              }
+            }
+            return min;
+          }, {}).min
+      })();
+
+      if (floor) {
+        imp.bidfloor = floor.floor;
+        imp.bidfloorcur = floor.currency
       }
 
       if (imp.banner || imp.video || imp.native) {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -18,6 +18,7 @@ import { decorateAdUnitsWithNativeParams } from '../../../src/native.js';
 import { auctionManager } from '../../../src/auctionManager.js';
 import { stubAuctionIndex } from '../../helpers/indexStub.js';
 import { registerBidder } from 'src/adapters/bidderFactory.js';
+import {getGlobal} from '../../../src/prebidGlobal.js';
 
 let CONFIG = {
   accountId: '1',
@@ -530,7 +531,7 @@ describe('S2S Adapter', function () {
     });
 
     it('should set id to auction ID and source.tid to tid', function () {
-      config.setConfig({ s2sConfig: CONFIG });
+      config.setConfig({s2sConfig: CONFIG});
 
       adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
 
@@ -542,8 +543,8 @@ describe('S2S Adapter', function () {
 
     it('should block request if config did not define p1Consent URL in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
-      badConfig.endpoint = { noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
-      config.setConfig({ s2sConfig: badConfig });
+      badConfig.endpoint = {noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'};
+      config.setConfig({s2sConfig: badConfig});
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -555,8 +556,8 @@ describe('S2S Adapter', function () {
 
     it('should block request if config did not define noP1Consent URL in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
-      badConfig.endpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
-      config.setConfig({ s2sConfig: badConfig });
+      badConfig.endpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'};
+      config.setConfig({s2sConfig: badConfig});
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -584,7 +585,7 @@ describe('S2S Adapter', function () {
     it('should block request if config did not define any URLs in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
       badConfig.endpoint = {};
-      config.setConfig({ s2sConfig: badConfig });
+      config.setConfig({s2sConfig: badConfig});
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -595,7 +596,7 @@ describe('S2S Adapter', function () {
     });
 
     it('should add outstream bc renderer exists on mediatype', function () {
-      config.setConfig({ s2sConfig: CONFIG });
+      config.setConfig({s2sConfig: CONFIG});
 
       adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
 
@@ -608,7 +609,7 @@ describe('S2S Adapter', function () {
       let ortb2Config = utils.deepClone(CONFIG);
       ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({ s2sConfig: ortb2Config });
+      config.setConfig({s2sConfig: ortb2Config});
 
       let videoBid = utils.deepClone(VIDEO_REQUEST);
       videoBid.ad_units[0].mediaTypes.video.context = 'instream';
@@ -624,7 +625,7 @@ describe('S2S Adapter', function () {
       let ortb2Config = utils.deepClone(CONFIG);
       ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({ s2sConfig: ortb2Config });
+      config.setConfig({s2sConfig: ortb2Config});
 
       let videoBid = utils.deepClone(VIDEO_REQUEST);
       videoBid.ad_units[0].mediaTypes.video.context = 'instream';
@@ -650,7 +651,7 @@ describe('S2S Adapter', function () {
       });
 
       it('adds gdpr consent information to ortb2 request depending on presence of module', function () {
-        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: CONFIG };
+        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: CONFIG};
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -666,7 +667,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.consent).is.equal('abc123');
 
         config.resetConfig();
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -676,7 +677,7 @@ describe('S2S Adapter', function () {
       });
 
       it('adds additional consent information to ortb2 request depending on presence of module', function () {
-        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: CONFIG };
+        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: CONFIG};
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -694,7 +695,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.ConsentedProvidersSettings.consented_providers).is.equal('superduperconsent');
 
         config.resetConfig();
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -705,9 +706,9 @@ describe('S2S Adapter', function () {
 
       it('check gdpr info gets added into cookie_sync request: have consent data', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
+        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
 
-        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -731,9 +732,9 @@ describe('S2S Adapter', function () {
 
       it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
+        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
 
-        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
         config.setConfig(consentConfig);
 
         const s2sBidRequest = utils.deepClone(REQUEST);
@@ -754,9 +755,9 @@ describe('S2S Adapter', function () {
 
       it('checks gdpr info gets added to cookie_sync request: applies is false', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
+        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
 
-        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
+        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -782,7 +783,7 @@ describe('S2S Adapter', function () {
       });
 
       it('is added to ortb2 request when in bidRequest', function () {
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         let uspBidRequest = utils.deepClone(BID_REQUESTS);
         uspBidRequest[0].uspConsent = '1NYN';
@@ -793,7 +794,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.regs.ext.us_privacy).is.equal('1NYN');
 
         config.resetConfig();
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -803,8 +804,8 @@ describe('S2S Adapter', function () {
 
       it('is added to cookie_sync request when in bidRequest', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
-        config.setConfig({ s2sConfig: cookieSyncConfig });
+        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
+        config.setConfig({s2sConfig: cookieSyncConfig});
 
         let uspBidRequest = utils.deepClone(BID_REQUESTS);
         uspBidRequest[0].uspConsent = '1YNN';
@@ -827,7 +828,7 @@ describe('S2S Adapter', function () {
       });
 
       it('is added to ortb2 request when in bidRequest', function () {
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         let consentBidRequest = utils.deepClone(BID_REQUESTS);
         consentBidRequest[0].uspConsent = '1NYN';
@@ -844,7 +845,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.consent).is.equal('abc123');
 
         config.resetConfig();
-        config.setConfig({ s2sConfig: CONFIG });
+        config.setConfig({s2sConfig: CONFIG});
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -855,8 +856,8 @@ describe('S2S Adapter', function () {
 
       it('is added to cookie_sync request when in bidRequest', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
-        config.setConfig({ s2sConfig: cookieSyncConfig });
+        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
+        config.setConfig({s2sConfig: cookieSyncConfig});
 
         let consentBidRequest = utils.deepClone(BID_REQUESTS);
         consentBidRequest[0].uspConsent = '1YNN';
@@ -882,8 +883,8 @@ describe('S2S Adapter', function () {
     it('adds device and app objects to request', function () {
       const _config = {
         s2sConfig: CONFIG,
-        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
-        app: { bundle: 'com.test.app' },
+        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
+        app: {bundle: 'com.test.app'},
       };
 
       config.setConfig(_config);
@@ -896,7 +897,7 @@ describe('S2S Adapter', function () {
       });
       expect(requestBid.app).to.deep.equal({
         bundle: 'com.test.app',
-        publisher: { 'id': '1' }
+        publisher: {'id': '1'}
       });
     });
 
@@ -909,8 +910,8 @@ describe('S2S Adapter', function () {
 
       const _config = {
         s2sConfig: s2sConfig,
-        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
-        app: { bundle: 'com.test.app' },
+        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
+        app: {bundle: 'com.test.app'},
       };
 
       config.setConfig(_config);
@@ -923,15 +924,15 @@ describe('S2S Adapter', function () {
       });
       expect(requestBid.app).to.deep.equal({
         bundle: 'com.test.app',
-        publisher: { 'id': '1' }
+        publisher: {'id': '1'}
       });
     });
 
     it('adds debugging value from storedAuctionResponse to OpenRTB', function () {
       const _config = {
         s2sConfig: CONFIG,
-        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
-        app: { bundle: 'com.test.app' }
+        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
+        app: {bundle: 'com.test.app'}
       };
 
       config.setConfig(_config);
@@ -983,11 +984,11 @@ describe('S2S Adapter', function () {
         ).to.be.true;
 
         // if getFloor does not return number
-        getFloorResponse = { currency: 'EUR', floor: 'not a number' };
+        getFloorResponse = {currency: 'EUR', floor: 'not a number'};
         runTest(undefined, undefined);
 
         // if getFloor does not return currency
-        getFloorResponse = { floor: 1.1 };
+        getFloorResponse = {floor: 1.1};
         runTest(undefined, undefined);
       });
 
@@ -1002,7 +1003,7 @@ describe('S2S Adapter', function () {
         sinon.spy(BID_REQUESTS[0].bids[0], 'getFloor');
 
         // returns USD and string floor
-        getFloorResponse = { currency: 'USD', floor: '1.23' };
+        getFloorResponse = {currency: 'USD', floor: '1.23'};
         runTest(1.23, 'USD');
         // make sure getFloor was called
         expect(
@@ -1012,14 +1013,14 @@ describe('S2S Adapter', function () {
         ).to.be.true;
 
         // returns non USD and number floor
-        getFloorResponse = { currency: 'EUR', floor: 0.85 };
+        getFloorResponse = {currency: 'EUR', floor: 0.85};
         runTest(0.85, 'EUR');
       });
 
       it('should correctly pass adServerCurrency when set to getFloor not default', function () {
         config.setConfig({
           s2sConfig: CONFIG,
-          currency: { adServerCurrency: 'JPY' },
+          currency: {adServerCurrency: 'JPY'},
         });
 
         // we have to start requestCount at 1 because a conversion rates fetch occurs when adServerCur is not USD!
@@ -1029,7 +1030,7 @@ describe('S2S Adapter', function () {
         sinon.spy(BID_REQUESTS[0].bids[0], 'getFloor');
 
         // returns USD and string floor
-        getFloorResponse = { currency: 'JPY', floor: 97.2 };
+        getFloorResponse = {currency: 'JPY', floor: 97.2};
         runTest(97.2, 'JPY');
         // make sure getFloor was called with JPY
         expect(
@@ -1037,6 +1038,167 @@ describe('S2S Adapter', function () {
             currency: 'JPY',
           })
         ).to.be.true;
+      });
+
+      it('should find the floor when not all bidderRequests contain it', () => {
+        config.setConfig({
+          s2sConfig: {
+            ...CONFIG,
+            bidders: ['b1', 'b2']
+          },
+        });
+        const bidderRequests = [
+          {
+            ...BID_REQUESTS[0],
+            bidderCode: 'b1',
+            bids: [{
+              bidder: 'b1',
+              bidId: 1,
+            }]
+          },
+          {
+            ...BID_REQUESTS[0],
+            bidderCode: 'b2',
+            bids: [{
+              bidder: 'b2',
+              bidId: 2,
+              getFloor: () => ({
+                currency: 'CUR',
+                floor: 123
+              })
+            }],
+          }
+        ];
+        const adUnits = [
+          {
+            code: 'au1',
+            transactionId: 't1',
+            mediaTypes: {
+              banner: {sizes: [1, 1]}
+            },
+            bids: [{bidder: 'b1', bid_id: 1}]
+          },
+          {
+            code: 'au2',
+            transactionId: 't2',
+            bids: [{bidder: 'b2', bid_id: 2}],
+            mediaTypes: {
+              banner: {sizes: [1, 1]}
+            }
+          }
+        ];
+        const s2sReq = {
+          ...REQUEST,
+          ad_units: adUnits
+        }
+
+        adapter.callBids(s2sReq, bidderRequests, addBidResponse, done, ajax);
+
+        const pbsReq = JSON.parse(server.requests[server.requests.length - 1].requestBody);
+        const [imp1, imp2] = pbsReq.imp;
+
+        expect(imp1.bidfloor).to.be.undefined;
+        expect(imp1.bidfloorcur).to.be.undefined;
+
+        expect(imp2.bidfloor).to.eql(123);
+        expect(imp2.bidfloorcur).to.eql('CUR');
+      });
+
+      Object.entries({
+        'is available': [true, 10, '0.1'],
+        'is not available': [false, 1, '10']
+      }).forEach(([t, [enableCurrency, expectedFloor, expectedCur]]) => {
+        describe(`when different bids have different floors - and currency conversion ${t}`, () => {
+          let s2sReq, mockConvertCurrency;
+          const origConvertCurrency = getGlobal().convertCurrency;
+          beforeEach(() => {
+            if (enableCurrency) {
+              getGlobal().convertCurrency = mockConvertCurrency = sinon.stub().callsFake((amount, from, to) => {
+                from = parseFloat(from);
+                to = parseFloat(to);
+                return amount * from / to;
+              })
+            } else {
+              delete getGlobal().convertCurrency;
+            }
+            config.setConfig({
+              s2sConfig: {
+                ...CONFIG,
+                bidders: ['b1', 'b2', 'b3']
+              },
+            });
+            BID_REQUESTS = [
+              {
+                ...BID_REQUESTS[0],
+                bidderCode: 'b2',
+                bids: [{
+                  bidder: 'b2',
+                  bidId: 2,
+                  getFloor: () => ({
+                    currency: '1',
+                    floor: 2
+                  })
+                }],
+              },
+              {
+                ...BID_REQUESTS[0],
+                bidderCode: 'b1',
+                bids: [{
+                  bidder: 'b1',
+                  bidId: 1,
+                  getFloor: () => ({
+                    floor: 10,
+                    currency: '0.1'
+                  })
+                }]
+              },
+              {
+                ...BID_REQUESTS[0],
+                bidderCode: 'b3',
+                bids: [{
+                  bidder: 'b3',
+                  bidId: 3,
+                  getFloor: () => ({
+                    currency: '10',
+                    floor: 1
+                  })
+                }],
+              }
+            ];
+            s2sReq = {
+              ...REQUEST,
+              ad_units: [
+                {
+                  code: 'au1',
+                  transactionId: 't1',
+                  mediaTypes: {
+                    banner: {sizes: [1, 1]}
+                  },
+                  bids: [
+                    {bidder: 'b3', bid_id: 3},
+                    {bidder: 'b1', bid_id: 1},
+                    {bidder: 'b2', bid_id: 2},
+                  ]
+                }
+              ]
+            };
+          });
+
+          afterEach(() => {
+            if (origConvertCurrency != null) {
+              getGlobal().convertCurrency = origConvertCurrency;
+            } else {
+              delete getGlobal().convertCurrency;
+            }
+          })
+
+          it('should pick the minimum', () => {
+            adapter.callBids(s2sReq, BID_REQUESTS, addBidResponse, done, ajax);
+            const pbsReq = JSON.parse(server.requests[server.requests.length - 1].requestBody);
+            expect(pbsReq.imp[0].bidfloor).to.eql(expectedFloor);
+            expect(pbsReq.imp[0].bidfloorcur).to.eql(expectedCur);
+          });
+        });
       });
     });
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -531,7 +531,7 @@ describe('S2S Adapter', function () {
     });
 
     it('should set id to auction ID and source.tid to tid', function () {
-      config.setConfig({s2sConfig: CONFIG});
+      config.setConfig({ s2sConfig: CONFIG });
 
       adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
 
@@ -543,8 +543,8 @@ describe('S2S Adapter', function () {
 
     it('should block request if config did not define p1Consent URL in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
-      badConfig.endpoint = {noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'};
-      config.setConfig({s2sConfig: badConfig});
+      badConfig.endpoint = { noP1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
+      config.setConfig({ s2sConfig: badConfig });
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -556,8 +556,8 @@ describe('S2S Adapter', function () {
 
     it('should block request if config did not define noP1Consent URL in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
-      badConfig.endpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction'};
-      config.setConfig({s2sConfig: badConfig});
+      badConfig.endpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction' };
+      config.setConfig({ s2sConfig: badConfig });
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -585,7 +585,7 @@ describe('S2S Adapter', function () {
     it('should block request if config did not define any URLs in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);
       badConfig.endpoint = {};
-      config.setConfig({s2sConfig: badConfig});
+      config.setConfig({ s2sConfig: badConfig });
 
       let badCfgRequest = utils.deepClone(REQUEST);
       badCfgRequest.s2sConfig = badConfig;
@@ -596,7 +596,7 @@ describe('S2S Adapter', function () {
     });
 
     it('should add outstream bc renderer exists on mediatype', function () {
-      config.setConfig({s2sConfig: CONFIG});
+      config.setConfig({ s2sConfig: CONFIG });
 
       adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
 
@@ -609,7 +609,7 @@ describe('S2S Adapter', function () {
       let ortb2Config = utils.deepClone(CONFIG);
       ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({s2sConfig: ortb2Config});
+      config.setConfig({ s2sConfig: ortb2Config });
 
       let videoBid = utils.deepClone(VIDEO_REQUEST);
       videoBid.ad_units[0].mediaTypes.video.context = 'instream';
@@ -625,7 +625,7 @@ describe('S2S Adapter', function () {
       let ortb2Config = utils.deepClone(CONFIG);
       ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({s2sConfig: ortb2Config});
+      config.setConfig({ s2sConfig: ortb2Config });
 
       let videoBid = utils.deepClone(VIDEO_REQUEST);
       videoBid.ad_units[0].mediaTypes.video.context = 'instream';
@@ -651,7 +651,7 @@ describe('S2S Adapter', function () {
       });
 
       it('adds gdpr consent information to ortb2 request depending on presence of module', function () {
-        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: CONFIG};
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: CONFIG };
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -667,7 +667,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.consent).is.equal('abc123');
 
         config.resetConfig();
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -677,7 +677,7 @@ describe('S2S Adapter', function () {
       });
 
       it('adds additional consent information to ortb2 request depending on presence of module', function () {
-        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: CONFIG};
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: CONFIG };
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -695,7 +695,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.ConsentedProvidersSettings.consented_providers).is.equal('superduperconsent');
 
         config.resetConfig();
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -706,9 +706,9 @@ describe('S2S Adapter', function () {
 
       it('check gdpr info gets added into cookie_sync request: have consent data', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
+        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
 
-        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -732,9 +732,9 @@ describe('S2S Adapter', function () {
 
       it('check gdpr info gets added into cookie_sync request: have consent data but gdprApplies is false', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
+        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
 
-        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
         config.setConfig(consentConfig);
 
         const s2sBidRequest = utils.deepClone(REQUEST);
@@ -755,9 +755,9 @@ describe('S2S Adapter', function () {
 
       it('checks gdpr info gets added to cookie_sync request: applies is false', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
+        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
 
-        let consentConfig = {consentManagement: {cmpApi: 'iab'}, s2sConfig: cookieSyncConfig};
+        let consentConfig = { consentManagement: { cmpApi: 'iab' }, s2sConfig: cookieSyncConfig };
         config.setConfig(consentConfig);
 
         let gdprBidRequest = utils.deepClone(BID_REQUESTS);
@@ -783,7 +783,7 @@ describe('S2S Adapter', function () {
       });
 
       it('is added to ortb2 request when in bidRequest', function () {
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         let uspBidRequest = utils.deepClone(BID_REQUESTS);
         uspBidRequest[0].uspConsent = '1NYN';
@@ -794,7 +794,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.regs.ext.us_privacy).is.equal('1NYN');
 
         config.resetConfig();
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -804,8 +804,8 @@ describe('S2S Adapter', function () {
 
       it('is added to cookie_sync request when in bidRequest', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
-        config.setConfig({s2sConfig: cookieSyncConfig});
+        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
+        config.setConfig({ s2sConfig: cookieSyncConfig });
 
         let uspBidRequest = utils.deepClone(BID_REQUESTS);
         uspBidRequest[0].uspConsent = '1YNN';
@@ -828,7 +828,7 @@ describe('S2S Adapter', function () {
       });
 
       it('is added to ortb2 request when in bidRequest', function () {
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         let consentBidRequest = utils.deepClone(BID_REQUESTS);
         consentBidRequest[0].uspConsent = '1NYN';
@@ -845,7 +845,7 @@ describe('S2S Adapter', function () {
         expect(requestBid.user.ext.consent).is.equal('abc123');
 
         config.resetConfig();
-        config.setConfig({s2sConfig: CONFIG});
+        config.setConfig({ s2sConfig: CONFIG });
 
         adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
         requestBid = JSON.parse(server.requests[1].requestBody);
@@ -856,8 +856,8 @@ describe('S2S Adapter', function () {
 
       it('is added to cookie_sync request when in bidRequest', function () {
         let cookieSyncConfig = utils.deepClone(CONFIG);
-        cookieSyncConfig.syncEndpoint = {p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'};
-        config.setConfig({s2sConfig: cookieSyncConfig});
+        cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
+        config.setConfig({ s2sConfig: cookieSyncConfig });
 
         let consentBidRequest = utils.deepClone(BID_REQUESTS);
         consentBidRequest[0].uspConsent = '1YNN';
@@ -883,8 +883,8 @@ describe('S2S Adapter', function () {
     it('adds device and app objects to request', function () {
       const _config = {
         s2sConfig: CONFIG,
-        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
-        app: {bundle: 'com.test.app'},
+        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
+        app: { bundle: 'com.test.app' },
       };
 
       config.setConfig(_config);
@@ -897,7 +897,7 @@ describe('S2S Adapter', function () {
       });
       expect(requestBid.app).to.deep.equal({
         bundle: 'com.test.app',
-        publisher: {'id': '1'}
+        publisher: { 'id': '1' }
       });
     });
 
@@ -910,8 +910,8 @@ describe('S2S Adapter', function () {
 
       const _config = {
         s2sConfig: s2sConfig,
-        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
-        app: {bundle: 'com.test.app'},
+        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
+        app: { bundle: 'com.test.app' },
       };
 
       config.setConfig(_config);
@@ -924,15 +924,15 @@ describe('S2S Adapter', function () {
       });
       expect(requestBid.app).to.deep.equal({
         bundle: 'com.test.app',
-        publisher: {'id': '1'}
+        publisher: { 'id': '1' }
       });
     });
 
     it('adds debugging value from storedAuctionResponse to OpenRTB', function () {
       const _config = {
         s2sConfig: CONFIG,
-        device: {ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC'},
-        app: {bundle: 'com.test.app'}
+        device: { ifa: '6D92078A-8246-4BA4-AE5B-76104861E7DC' },
+        app: { bundle: 'com.test.app' }
       };
 
       config.setConfig(_config);
@@ -984,11 +984,11 @@ describe('S2S Adapter', function () {
         ).to.be.true;
 
         // if getFloor does not return number
-        getFloorResponse = {currency: 'EUR', floor: 'not a number'};
+        getFloorResponse = { currency: 'EUR', floor: 'not a number' };
         runTest(undefined, undefined);
 
         // if getFloor does not return currency
-        getFloorResponse = {floor: 1.1};
+        getFloorResponse = { floor: 1.1 };
         runTest(undefined, undefined);
       });
 
@@ -1003,7 +1003,7 @@ describe('S2S Adapter', function () {
         sinon.spy(BID_REQUESTS[0].bids[0], 'getFloor');
 
         // returns USD and string floor
-        getFloorResponse = {currency: 'USD', floor: '1.23'};
+        getFloorResponse = { currency: 'USD', floor: '1.23' };
         runTest(1.23, 'USD');
         // make sure getFloor was called
         expect(
@@ -1013,14 +1013,14 @@ describe('S2S Adapter', function () {
         ).to.be.true;
 
         // returns non USD and number floor
-        getFloorResponse = {currency: 'EUR', floor: 0.85};
+        getFloorResponse = { currency: 'EUR', floor: 0.85 };
         runTest(0.85, 'EUR');
       });
 
       it('should correctly pass adServerCurrency when set to getFloor not default', function () {
         config.setConfig({
           s2sConfig: CONFIG,
-          currency: {adServerCurrency: 'JPY'},
+          currency: { adServerCurrency: 'JPY' },
         });
 
         // we have to start requestCount at 1 because a conversion rates fetch occurs when adServerCur is not USD!
@@ -1030,7 +1030,7 @@ describe('S2S Adapter', function () {
         sinon.spy(BID_REQUESTS[0].bids[0], 'getFloor');
 
         // returns USD and string floor
-        getFloorResponse = {currency: 'JPY', floor: 97.2};
+        getFloorResponse = { currency: 'JPY', floor: 97.2 };
         runTest(97.2, 'JPY');
         // make sure getFloor was called with JPY
         expect(


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

﻿This addresses https://github.com/prebid/Prebid.js/issues/8307 by picking what's likely to be the minimum floor for an adUnit (instead of just looking at the floor defined by the first request it finds, which may not be there)

