### PR TITLE
Prebid Server Adapter: add native asset id parameter

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -563,13 +563,15 @@ Object.assign(ORTB2.prototype, {
       const nativeParams = adUnit.nativeParams;
       let nativeAssets;
       if (nativeParams) {
+        let idCounter = 0;
         try {
           nativeAssets = nativeAssetCache[impressionId] = Object.keys(nativeParams).reduce((assets, type) => {
             let params = nativeParams[type];
 
             function newAsset(obj) {
               return Object.assign({
-                required: params.required ? 1 : 0
+                required: params.required ? 1 : 0,
+                id: idCounter++
               }, obj ? cleanObj(obj) : {});
             }
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -571,7 +571,7 @@ Object.assign(ORTB2.prototype, {
             function newAsset(obj) {
               return Object.assign({
                 required: params.required ? 1 : 0,
-                id: idCounter++
+                id: (isNumber(params.id)) ? params.id : idCounter++
               }, obj ? cleanObj(obj) : {});
             }
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -563,15 +563,16 @@ Object.assign(ORTB2.prototype, {
       const nativeParams = adUnit.nativeParams;
       let nativeAssets;
       if (nativeParams) {
-        let idCounter = 0;
+        let idCounter = -1;
         try {
           nativeAssets = nativeAssetCache[impressionId] = Object.keys(nativeParams).reduce((assets, type) => {
             let params = nativeParams[type];
 
             function newAsset(obj) {
+              idCounter++;
               return Object.assign({
                 required: params.required ? 1 : 0,
-                id: (isNumber(params.id)) ? params.id : idCounter++
+                id: (isNumber(params.id)) ? idCounter = params.id : idCounter
               }, obj ? cleanObj(obj) : {});
             }
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1279,12 +1279,14 @@ describe('S2S Adapter', function () {
           'assets': [
             {
               'required': 1,
+              'id': 0,
               'title': {
                 'len': 800
               }
             },
             {
               'required': 1,
+              'id': 1,
               'img': {
                 'type': 3,
                 'w': 989,
@@ -1293,6 +1295,7 @@ describe('S2S Adapter', function () {
             },
             {
               'required': 1,
+              'id': 2,
               'img': {
                 'type': 1,
                 'wmin': 10,
@@ -1304,6 +1307,7 @@ describe('S2S Adapter', function () {
             },
             {
               'required': 1,
+              'id': 3,
               'data': {
                 'type': 1
               }


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR adds in the missing `id` field(s) for the `native.request.assets` object array of a PBS request.  The ORTB native spec has this field denoted as required (see PDF link below).  

While leaving out the field did not appear to be an issue for some of the PBS endpoints, it was found to be an issue for the appnexus PSP endpoint.  


Reference -  OpenRTB Native doc:
https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf
-- section 4.2 (pg 13)