### PR TITLE
JwPlayer RTD Module: Support cids

### DIFF
--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -155,8 +155,10 @@ export function enrichAdUnits(adUnits) {
       if (!vat) {
         return;
       }
-      const contentId = getContentId(vat.mediaID);
-      const contentData = getContentData(vat.segments);
+      const mediaId = vat.mediaID;
+      const contentId = getContentId(mediaId);
+      const contentSegments = getContentSegments(vat.segments);
+      const contentData = getContentData(mediaId, contentSegments);
       const targeting = formatTargetingResponse(vat);
       enrichBids(adUnit.bids, targeting, contentId, contentData);
     };
@@ -263,7 +265,7 @@ export function getContentId(mediaID) {
   return 'jw_' + mediaID;
 }
 
-export function getContentData(segments) {
+export function getContentSegments(segments) {
   if (!segments || !segments.length) {
     return;
   }
@@ -276,13 +278,29 @@ export function getContentData(segments) {
     return convertedSegments;
   }, []);
 
-  return {
-    name: 'jwplayer',
-    ext: {
-      segtax: 502
-    },
-    segment: formattedSegments
+  return formattedSegments;
+}
+
+export function getContentData(mediaId, segments) {
+  if (!mediaId && !segments) {
+    return;
+  }
+
+  const contentData = {
+    name: 'jwplayer.com',
+    ext: {}
   };
+
+  if (mediaId) {
+    contentData.ext.cids = [mediaId];
+  }
+
+  if (segments) {
+    contentData.segment = segments;
+    contentData.ext.segtax = 502;
+  }
+
+  return contentData;
 }
 
 export function addOrtbSiteContent(bid, contentId, contentData) {

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -95,9 +95,10 @@ Example:
             content: {
                 id: 'jw_abc123',
                 data: [{
-                    name: 'jwplayer',
+                    name: 'jwplayer.com',
                     ext: {
-                        segtax: 502
+                        segtax: 502,
+                        cids: ['abc123']
                     },
                     segment: [{ 
                         id: '123'
@@ -117,8 +118,9 @@ where:
     - `content` is an object containing metadata for the media. It may contain the following information: 
       - `id` is a unique identifier for the specific media asset
       - `data` is an array containing segment taxonomy objects that have the following parameters:
-        - `name` is the `jwplayer` string indicating the provider name
+        - `name` is the `jwplayer.com` string indicating the provider name
         - `ext.segtax` whose `502` value is the unique identifier for JW Player's proprietary taxonomy
+        - `ext.cids` is an array containing the list of extended content ids as defined in [oRTB's community extensions](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/extended-content-ids.md#example---content-id-and-seller-defined-context). 
         - `segment` is an array containing the segment taxonomy values as an object where:
           - `id` is the string representation of the data segment value. 
   


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
- Adds `cids` to to `ortb2.site.content.data[index].ext` in compliance with the [extended content ids spec](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/extended-content-ids.md#example---content-id-and-seller-defined-context)
- Updates the `name` to `jwplayer.com` in compliance with the [extended content ids spec](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/extended-content-ids.md#example---content-id-and-seller-defined-context)


For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/3744
