### PR TITLE
UserID module: fix bug with userID init sometimes getting stuck in an infinite loop

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -520,6 +520,8 @@ function delayFor(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const INIT_CANCELED = {};
+
 function idSystemInitializer({delay = delayFor} = {}) {
   /**
    * @returns a {promise, resolve, reject} trio where `promise` is resolved by calling `resolve` or `reject`.
@@ -562,7 +564,7 @@ function idSystemInitializer({delay = delayFor} = {}) {
 
   function cancelAndTry(promise) {
     if (cancel != null) {
-      cancel.reject();
+      cancel.reject(INIT_CANCELED);
     }
     cancel = breakpoint();
     return Promise.race([promise, cancel.promise]);
@@ -803,8 +805,9 @@ function refreshUserIds({submoduleNames} = {}, callback) {
  * });
  * ```
  */
+
 function getUserIdsAsync() {
-  return initIdSystem().then(() => getUserIds(), () => getUserIdsAsync());
+  return initIdSystem().then(() => getUserIds(), (e) => e === INIT_CANCELED ? getUserIdsAsync() : Promise.reject(e));
 }
 
 /**

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -497,6 +497,14 @@ describe('User ID', function () {
           mockIdCallback.callArg(0, {id: {MOCKID: '1111'}});
         })
       });
+
+      it('should not get stuck when init fails', () => {
+        const err = new Error();
+        mockIdCallback.callsFake(() => { throw err; });
+        return getGlobal().getUserIdsAsync().catch((e) =>
+          expect(e).to.equal(err)
+        );
+      });
     });
 
     it('pbjs.refreshUserIds updates submodules', function(done) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

﻿In some situations userID submodules can throw exceptions (https://github.com/prebid/Prebid.js/issues/8360) which then, after https://github.com/prebid/Prebid.js/pull/8201, causes the ID system to get stuck in an infinite loop.

## Other information

Fix https://github.com/prebid/Prebid.js/issues/8360

