### PR TITLE
Adds cpexIdSystem

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -7,6 +7,7 @@
     "amxIdSystem",
     "britepoolIdSystem",
     "connectIdSystem",
+    "cpexIdSystem",
     "criteoIdSystem",
     "dacIdSystem",
     "deepintentDpesIdSystem",

--- a/modules/cpexIdSystem.js
+++ b/modules/cpexIdSystem.js
@@ -1,0 +1,49 @@
+/**
+ * This module adds 'caid' to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/cpexIdSystem
+ * @requires module:modules/userId
+ */
+
+import { submodule } from '../src/hook.js'
+import { getStorageManager } from '../src/storageManager.js'
+
+window.top.cpexIdVersion = '0.0.3'
+
+// Returns StorageManager
+export const storage = getStorageManager({ gvlid: 570, moduleName: 'cpexId' })
+
+// Returns the id string from either cookie or localstorage
+const getId = () => { return storage.getCookie('caid') || storage.getDataFromLocalStorage('caid') }
+
+/** @type {Submodule} */
+export const cpexIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: 'cpexId',
+  /**
+   * Vendor ID of Czech Publisher Exchange
+   * @type {Number}
+   */
+  gvlid: 570,
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function decode
+   * @param {(Object|string)} value
+   * @returns {(Object|undefined)}
+   */
+  decode (value) { return { cpexId: getId() } },
+  /**
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
+   * @param {(Object|undefined)} cacheIdObj
+   * @returns {IdResponse|undefined}
+   */
+  getId (config, consentData) { return { cpexId: getId() } }
+}
+
+submodule('userId', cpexIdSubmodule)

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -112,6 +112,12 @@ pbjs.setConfig({
                  expires: 1
               }
         }, {
+            name: "cpexId",
+            storage: {
+                type: "cookie",
+                name: "caid"
+            }
+        }, {
             name: 'mwOpenLinkId',
             params: {
                 accountId: 0000,

--- a/test/spec/modules/cpexIdSystem_spec.js
+++ b/test/spec/modules/cpexIdSystem_spec.js
@@ -1,0 +1,38 @@
+import { cpexIdSubmodule, storage } from 'modules/cpexIdSystem.js';
+
+describe('cpexId module', function () {
+  let getCookieStub;
+
+  beforeEach(function (done) {
+    getCookieStub = sinon.stub(storage, 'getCookie');
+    done();
+  });
+
+  afterEach(function () {
+    getCookieStub.restore();
+  });
+
+  const cookieTestCasesForEmpty = [undefined, null, '']
+
+  describe('getId()', function () {
+    it('should return the uid when it exists in cookie', function () {
+      getCookieStub.withArgs('caid').returns('cpexIdTest');
+      const id = cpexIdSubmodule.getId();
+      expect(id).to.be.deep.equal({ id: { cpexId: 'cpexIdTest' } });
+    });
+
+    cookieTestCasesForEmpty.forEach(testCase => it('should not return the uid when it doesnt exist in cookie', function () {
+      getCookieStub.withArgs('caid').returns(testCase);
+      const id = cpexIdSubmodule.getId();
+      expect(id).to.be.deep.equal({ id: { cpexId: null } });
+    }));
+  });
+
+  describe('decode()', function () {
+    it('should return the uid when it exists in cookie', function () {
+      getCookieStub.withArgs('caid').returns('cpexIdTest');
+      const decoded = cpexIdSubmodule.decode();
+      expect(decoded).to.be.deep.equal({ cpexId: 'cpexIdTest' });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
New User Sync submodule (User ID), called CPExID or Czech Ad ID (caid).
It's use is intended for selected partners in direct communication with our company (cpex.cz).

Covered with basic tests. Not sure if it needs docs, it's use is the same as all the other id submodules.