### PR TITLE
Multiple modules: automatically fill in PPID for DFP video URLs

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -11,6 +11,7 @@ import { auctionManager } from '../src/auctionManager.js';
 import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
+import {getPPID} from '../src/adserver.js';
 
 /**
  * @typedef {Object} DfpVideoParams
@@ -117,6 +118,13 @@ export function buildDfpVideoUrl(options) {
 
   const uspConsent = uspDataHandler.getConsentData();
   if (uspConsent) { queryParams.us_privacy = uspConsent; }
+
+  if (!queryParams.ppid) {
+    const ppid = getPPID();
+    if (ppid != null) {
+      queryParams.ppid = ppid;
+    }
+  }
 
   return buildUrl(Object.assign({
     protocol: 'https',

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -151,6 +151,7 @@ import {
   timestamp,
   isEmpty
 } from '../../src/utils.js';
+import {getPPID as coreGetPPID} from '../../src/adserver.js';
 
 const MODULE_NAME = 'User ID';
 const COOKIE = 'cookie';
@@ -643,6 +644,19 @@ function idSystemInitializer({delay = delayFor} = {}) {
 
 let initIdSystem;
 
+function getPPID() {
+  // userSync.ppid should be one of the 'source' values in getUserIdsAsEids() eg pubcid.org or id5-sync.com
+  const matchingUserId = ppidSource && (getUserIdsAsEids() || []).find(userID => userID.source === ppidSource);
+  if (matchingUserId && typeof deepAccess(matchingUserId, 'uids.0.id') === 'string') {
+    const ppidValue = matchingUserId.uids[0].id.replace(/[\W_]/g, '');
+    if (ppidValue.length >= 32 && ppidValue.length <= 150) {
+      return ppidValue;
+    } else {
+      logWarn(`User ID - Googletag Publisher Provided ID for ${ppidSource} is not between 32 and 150 characters - ${ppidValue}`);
+    }
+  }
+}
+
 /**
  * Hook is executed before adapters, but after consentManagement. Consent data is requied because
  * this module requires GDPR consent with Purpose #1 to save data locally.
@@ -659,23 +673,16 @@ export function requestBidsHook(fn, reqBidsConfigObj, {delay = delayFor} = {}) {
   ]).then(() => {
     // pass available user id data to bid adapters
     addIdDataToAdUnitBids(reqBidsConfigObj.adUnits || getGlobal().adUnits, initializedSubmodules);
-
-    // userSync.ppid should be one of the 'source' values in getUserIdsAsEids() eg pubcid.org or id5-sync.com
-    const matchingUserId = ppidSource && (getUserIdsAsEids() || []).find(userID => userID.source === ppidSource);
-    if (matchingUserId && typeof deepAccess(matchingUserId, 'uids.0.id') === 'string') {
-      const ppidValue = matchingUserId.uids[0].id.replace(/[\W_]/g, '');
-      if (ppidValue.length >= 32 && ppidValue.length <= 150) {
-        if (isGptPubadsDefined()) {
-          window.googletag.pubads().setPublisherProvidedId(ppidValue);
-        } else {
-          window.googletag = window.googletag || {};
-          window.googletag.cmd = window.googletag.cmd || [];
-          window.googletag.cmd.push(function() {
-            window.googletag.pubads().setPublisherProvidedId(ppidValue);
-          });
-        }
+    const ppid = getPPID();
+    if (ppid) {
+      if (isGptPubadsDefined()) {
+        window.googletag.pubads().setPublisherProvidedId(ppid);
       } else {
-        logWarn(`User ID - Googletag Publisher Provided ID for ${ppidSource} is not between 32 and 150 characters - ${ppidValue}`);
+        window.googletag = window.googletag || {};
+        window.googletag.cmd = window.googletag.cmd || [];
+        window.googletag.cmd.push(function() {
+          window.googletag.pubads().setPublisherProvidedId(ppid);
+        });
       }
     }
 
@@ -968,6 +975,7 @@ function updateSubmodules() {
   if (!addedUserIdHook && submodules.length) {
     // priority value 40 will load after consentManagement with a priority of 50
     getGlobal().requestBids.before(requestBidsHook, 40);
+    coreGetPPID.after((next) => next(getPPID()));
     logInfo(`${MODULE_NAME} - usersync config updated for ${submodules.length} submodules: `, submodules.map(a => a.submodule.name));
     addedUserIdHook = true;
   }

--- a/src/adserver.js
+++ b/src/adserver.js
@@ -1,5 +1,6 @@
 import { formatQS } from './utils.js';
 import { targeting } from './targeting.js';
+import {hook} from './hook.js';
 
 // Adserver parent class
 const AdServer = function(attr) {
@@ -11,6 +12,7 @@ const AdServer = function(attr) {
 };
 
 // DFP ad server
+// TODO: this seems to be unused?
 export function dfpAdserver(options, urlComponents) {
   var adserver = new AdServer(options);
   adserver.urlComponents = urlComponents;
@@ -53,3 +55,8 @@ export function dfpAdserver(options, urlComponents) {
 
   return adserver;
 };
+
+/**
+ * return the GAM PPID, if available (eid for the userID configured with `userSync.ppidSource`)
+ */
+export const getPPID = hook('sync', () => undefined);

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -52,6 +52,7 @@ import * as mockGpt from '../integration/faker/googletag.js';
 import 'src/prebid.js';
 import {hook} from '../../../src/hook.js';
 import {mockGdprConsent} from '../../helpers/consentData.js';
+import {getPPID} from '../../../src/adserver.js';
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
@@ -443,6 +444,23 @@ describe('User ID', function () {
         // a warning should have been emmited
         expect(utils.logWarn.args[0][0]).to.exist.and.to.contain('User ID - Googletag Publisher Provided ID for pubcid.org is not between 32 and 150 characters - pubcommonIdValue');
       });
+    });
+
+    it('should make PPID available to core', () => {
+      init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+      const id = 'thishastobelongerthan32characters';
+      config.setConfig({
+        userSync: {
+          ppid: 'pubcid.org',
+          userIds: [
+            { name: 'pubCommonId', value: {'pubcid': id} },
+          ]
+        }
+      });
+      return getGlobal().refreshUserIds().then(() => {
+        expect(getPPID()).to.eql(id);
+      })
     });
 
     describe('refreshing before init is complete', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This updates the `dfpAdServerVideo` module to automatically include PPID in video URLs if a ppid source was provided to `userSync` configuration.

**NOTE**: the `buildDfpVideoUrl` does not include GDPR information if called with `url` but no `params`. I followed the same logic for PPID, but I'm not sure it's correct (@msm0504 can you comment? from #6143)

## Other information
Closes ﻿https://github.com/prebid/Prebid.js/issues/8151

