### PR TITLE
oneKey RTD module: initial release

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -58,6 +58,7 @@
     "jwplayerRtdProvider",
     "medianetRtdProvider",
     "optimeraRtdProvider",
+    "pafRtdProvider",
     "permutiveRtdProvider",
     "reconciliationRtdProvider",
     "sirdataRtdProvider",

--- a/modules/pafRtdProvider.js
+++ b/modules/pafRtdProvider.js
@@ -1,0 +1,116 @@
+
+import { submodule } from '../src/hook.js';
+import { mergeDeep, isPlainObject, logError, logMessage, deepSetValue, generateUUID } from '../src/utils.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import {config} from '../src/config.js';
+
+const SUBMODULE_NAME = 'paf';
+
+/**
+ *
+ * @param {Object} reqBidsConfigObj
+ * @param {function} callback
+ * @param {Object} rtdConfig
+ * @param {Object} userConsent
+ */
+export function getBidRequestData(reqBidsConfigObj, onDone, rtdConfig, userConsent) {
+  let idsAndPreferences;
+  const adUnits = (reqBidsConfigObj.adUnits || getGlobal().adUnits);
+
+  if (rtdConfig.params && rtdConfig.params.proxyHostName && window.PAF) {
+    idsAndPreferences = window.PAF.getIdsAndPreferences();
+    if (!idsAndPreferences) {
+      onDone();
+      logMessage(SUBMODULE_NAME, 'No id and preferences. Not creating Seed.');
+      return;
+    }
+
+    let transactionIds = [];
+    for (var i = 0; i < adUnits.length; i++) {
+      const uuid = generateUUID();
+      transactionIds.push(uuid)
+      deepSetValue(adUnits[i], `ortb2Imp.ext.data.paf.transaction_id`, uuid)
+    }
+
+    window.PAF.generateSeed({proxyHostName: rtdConfig.params.proxyHostName, callback: function (seed) { setData(seed, rtdConfig, onDone); }}, transactionIds)
+  } else {
+    onDone();
+  }
+}
+
+/**
+ * Lazy merge objects.
+ * @param {Object} target
+ * @param {Object} source
+ */
+function mergeLazy(target, source) {
+  if (!isPlainObject(target)) {
+    target = {};
+  }
+
+  if (!isPlainObject(source)) {
+    source = {};
+  }
+
+  return mergeDeep(target, source);
+}
+
+export function setData(seed, rtdConfig, onDone) {
+  if (!seed) {
+    logError(SUBMODULE_NAME, 'Could not createSeed');
+    onDone()
+    return;
+  }
+  logMessage(SUBMODULE_NAME, 'Created Seed:', seed);
+  const pafOrtb2 = {
+    ortb2: {
+      user: {
+        ext: {
+          paf: {
+            transmission: {
+              seed
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (rtdConfig.params && rtdConfig.params.bidders) {
+    let bidderConfig = config.getBidderConfig();
+    logMessage(SUBMODULE_NAME, `set ortb2 for: ${rtdConfig.params.bidders}`, pafOrtb2);
+    rtdConfig.params.bidders.forEach(bidder => {
+      let bidderOptions = {};
+      if (isPlainObject(bidderConfig[bidder])) {
+        bidderOptions = bidderConfig[bidder];
+      }
+
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: mergeLazy(bidderOptions, pafOrtb2)
+      });
+    });
+  } else {
+    let ortb2 = config.getConfig('ortb2') || {};
+    logMessage(SUBMODULE_NAME, 'set ortb2:', pafOrtb2);
+    config.setConfig({ortb2: mergeLazy(ortb2, pafOrtb2.ortb2)});
+  }
+  onDone();
+}
+
+/** @type {RtdSubmodule} */
+export const pafDataSubmodule = {
+  /**
+   * used to link submodule with realTimeData
+   * @type {string}
+   */
+  name: SUBMODULE_NAME,
+  init: () => true,
+  getBidRequestData,
+};
+
+function registerSubModule() {
+  submodule('realTimeData', pafDataSubmodule);
+}
+
+registerSubModule();

--- a/modules/pafRtdProvider.md
+++ b/modules/pafRtdProvider.md
@@ -1,0 +1,126 @@
+## Prebid Addressability Framework Real-time Data Submodule
+
+The PAF real-time data module in Prebid has been built so that publishers
+can quickly and easily setup the Prebid Addressability Framework and utilize OneKey.
+This module is used along with the pafIdSysytem to pass PAF data to your partners.
+Both modules are required. This module will pass transmission requests to your partners
+while the pafIdSystem will pass the pafData.
+
+Background information:
+- [prebid/addressability-framework](https://github.com/prebid/addressability-framework)
+- [prebid/paf-mvp-implementation](https://github.com/prebid/paf-mvp-implementation)
+
+### Publisher Usage
+
+The paf RTD module depends on paf-lib.js existing in the page.
+
+Compile the paf RTD module into your Prebid build:
+
+`gulp build --modules=userId,pafIdSystem,rtdModule,pafRtdProvider,appnexusBidAdapter`
+
+Add the PAF RTD provider to your Prebid config. In this example we will configure
+a sample proxyHostName. See the "Parameter Descriptions" below for more detailed information
+of the configuration parameters.
+
+```
+pbjs.setConfig(
+    ...
+    realTimeData: {
+        auctionDelay: 5000,
+        dataProviders: [
+            {
+                name: "paf",
+                waitForIt: true,
+                params: {
+                    proxyHostName: "cmp.pafdemopublisher.com"
+                }
+            }
+        ]
+    }
+    ...
+}
+```
+
+### Parameter Descriptions for the PAF Configuration Section
+
+| Name  |Type | Description   | Notes  |
+| :------------ | :------------ | :------------ |:------------ |
+| name | String | Real time data module name | Always 'paf' |
+| waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
+| params | Object | | |
+| params.proxyHostName | String | servername of the PAF Proxy which will generate seeds. | Required |
+| params.bidders | Array | List of bidders to restrict the data to. | Optional |
+
+### Data for bidders
+
+The data will provided to the bidders using the `ortb2` object. You can find the
+format of the data at https://github.com/prebid/addressability-framework.
+The following is an example of the format of the data:
+
+```json
+"user": {
+    "ext": {
+        "paf": {
+            "transmission": {
+                "seed": {
+                    "version": "0.1",
+                    "transaction_ids": ["06df6992-691c-4342-bbb0-66d2a005d5b1", "d2cd0aa7-8810-478c-bd15-fb5bfa8138b8"],
+                    "publisher": "cmp.pafdemopublisher.com",
+                    "source": {
+                        "domain": "cmp.pafdemopublisher.com",
+                        "timestamp": 1649712888,
+                        "signature": "turzZlXh9IqD5Rjwh4vWR78pKLrVsmwQrGr6fgw8TPgQVJSC8K3HvkypTV7lm3UaCi+Zzjl+9sd7Hrv87gdI8w=="
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+
+```json
+"ortb2Imp": {
+    "ext": {
+        "data": {
+            "paf": {
+                "transaction_id": "52d23fed-4f50-4c17-b07a-c458143e9d09"
+            }
+        }
+    }
+}
+```
+
+### Bidder Responses
+
+Bidders who are part of the Prebid Addressability Framework and receive PAF
+transmissions are required to return transmission responses as outlined in
+[prebid/addressability-framework](https://github.com/prebid/addressability-framework/blob/main/mvp-spec/ad-auction.md). Transmission responses should be appended to bids
+along with the releveant content_id using the meta.paf field. The paf-lib will
+be responsible for collecting all of the transmission responses.
+
+Below is an example of setting a transmission response:
+```javascript
+bid.meta.paf = {
+    "content_id": "90141190-26fe-497c-acee-4d2b649c2112",
+    "transmission": {
+        "version": "0.1",
+        "contents": [
+            {
+                "transaction_id": "f55a401d-e8bb-4de1-a3d2-fa95619393e8",
+                "content_id": "90141190-26fe-497c-acee-4d2b649c2112"
+            }
+        ],
+        "status": "success",
+        "details": "",
+        "receiver": "dsp1.com",
+        "source": {
+            "domain": "dsp1.com",
+            "timestamp": 1639589531,
+            "signature": "d01c6e83f14b4f057c2a2a86d320e2454fc0c60df4645518d993b5f40019d24c"
+        },
+        "children": []
+    }
+}
+```
+

--- a/test/spec/modules/pafRtdProvider_spec.js
+++ b/test/spec/modules/pafRtdProvider_spec.js
@@ -1,0 +1,213 @@
+import {config} from 'src/config.js';
+import {setData, getBidRequestData, pafDataSubmodule} from 'modules/pafRtdProvider.js';
+import {getAdUnits} from '../../fixtures/fixtures.js';
+
+describe('pafRtdProvider', function() {
+  beforeEach(function() {
+    config.resetConfig();
+  });
+
+  describe('pafDataSubmodule', function() {
+    it('successfully instantiates', function () {
+		  expect(pafDataSubmodule.init()).to.equal(true);
+    });
+  });
+
+  describe('setData', function() {
+    it('merges global ortb2 data', function() {
+      let rtdConfig = {params: {proxyHostName: 'host'}};
+      let seed = 'seed_placeholder';
+
+      const setConfigUserObj1 = {
+        name: 'www.dataprovider1.com',
+        ext: { taxonomyname: 'iab_audience_taxonomy' },
+        segment: [{
+          id: '1776'
+        }]
+      };
+
+      config.setConfig({
+        ortb2: {
+          user: {
+            data: [setConfigUserObj1],
+            ext: {other: 'data'}
+          }
+        }
+      });
+
+      setData(seed, rtdConfig, () => {});
+
+      let ortb2Config = config.getConfig().ortb2;
+
+      expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+      expect(ortb2Config.user.ext.paf.transmission.seed).to.equal(seed);
+      expect(ortb2Config.user.ext.other).to.equal('data');
+    });
+
+    it('merges bidder-specific ortb2 data', function() {
+      let rtdConfig = {params: {proxyHostName: 'host', bidders: ['openx']}};
+      let seed = 'seed_placeholder';
+
+      const setConfigUserObj1 = {
+        name: 'www.dataprovider1.com',
+        ext: { taxonomyname: 'iab_audience_taxonomy' },
+        segment: [{
+          id: '1776'
+        }]
+      };
+
+      config.setBidderConfig({
+        bidders: ['bidder1'],
+        config: {
+          ortb2: {
+            user: {
+              data: [setConfigUserObj1],
+              ext: {other: 'data'}
+            }
+          }
+        }
+      });
+
+      config.setBidderConfig({
+        bidders: ['openx'],
+        config: {
+          ortb2: {
+            user: {
+              data: [setConfigUserObj1],
+              ext: {other: 'data'}
+            }
+          }
+        }
+      });
+
+      setData(seed, rtdConfig, () => {});
+
+      let ortb2Config = config.getBidderConfig().bidder1.ortb2;
+
+      expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+      expect(ortb2Config.user.ext.paf).to.be.undefined;
+      expect(ortb2Config.user.ext.other).to.equal('data');
+
+      ortb2Config = config.getBidderConfig().openx.ortb2;
+
+      expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+      expect(ortb2Config.user.ext.paf.transmission.seed).to.equal(seed);
+      expect(ortb2Config.user.ext.other).to.equal('data');
+    });
+  });
+
+  describe('getBidRequestData', function() {
+    it('gets seed from paf-lib and sets data and transaction_ids', function() {
+      const adUnits = getAdUnits();
+      window.PAF = {
+        getIdsAndPreferences() {
+          return true;
+        },
+        generateSeed(options, ids) {
+          options.callback({
+            transaction_ids: ids
+          })
+        }
+      }
+      let bidConfig = {adUnits};
+      let rtdConfig = {params: {proxyHostName: 'host'}};
+
+      const setConfigUserObj1 = {
+        name: 'www.dataprovider1.com',
+        ext: { taxonomyname: 'iab_audience_taxonomy' },
+        segment: [{
+          id: '1776'
+        }]
+      };
+
+      config.setConfig({
+        ortb2: {
+          user: {
+            data: [setConfigUserObj1],
+            ext: {other: 'data'}
+          }
+        }
+      });
+
+      getBidRequestData(bidConfig, () => {}, rtdConfig, {});
+      let ortb2Config = config.getConfig().ortb2;
+
+      adUnits.forEach(adUnit => {
+        const transaction_id = adUnit.ortb2Imp.ext.data.paf.transaction_id;
+        expect(transaction_id).to.not.be.undefined;
+        expect(ortb2Config.user.ext.paf.transmission.seed.transaction_ids).contain(transaction_id)
+      });
+
+      expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+      expect(ortb2Config.user.ext.paf.transmission.seed).to.have.property('transaction_ids');
+      expect(ortb2Config.user.ext.other).to.equal('data');
+    });
+  });
+
+  it('does nothing if paf-lib doesnt exist', function() {
+    const adUnits = getAdUnits();
+    window.PAF = undefined;
+    let bidConfig = {adUnits};
+    let rtdConfig = {params: {proxyHostName: 'host'}};
+
+    const setConfigUserObj1 = {
+      name: 'www.dataprovider1.com',
+      ext: { taxonomyname: 'iab_audience_taxonomy' },
+      segment: [{
+        id: '1776'
+      }]
+    };
+
+    config.setConfig({
+      ortb2: {
+        user: {
+          data: [setConfigUserObj1],
+          ext: {other: 'data'}
+        }
+      }
+    });
+
+    getBidRequestData(bidConfig, () => {}, rtdConfig, {});
+    let ortb2Config = config.getConfig().ortb2;
+    expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+    expect(ortb2Config.user.ext.other).to.equal('data');
+  });
+
+  it('requires proxyHostName', function() {
+    const adUnits = getAdUnits();
+    window.PAF = {
+      getIdsAndPreferences() {
+        return true;
+      },
+      generateSeed(options, ids) {
+        options.callback({
+          transaction_ids: ids
+        })
+      }
+    }
+    let bidConfig = {adUnits};
+    let rtdConfig = {params: {}};
+
+    const setConfigUserObj1 = {
+      name: 'www.dataprovider1.com',
+      ext: { taxonomyname: 'iab_audience_taxonomy' },
+      segment: [{
+        id: '1776'
+      }]
+    };
+
+    config.setConfig({
+      ortb2: {
+        user: {
+          data: [setConfigUserObj1],
+          ext: {other: 'data'}
+        }
+      }
+    });
+
+    getBidRequestData(bidConfig, () => {}, rtdConfig, {});
+    let ortb2Config = config.getConfig().ortb2;
+    expect(ortb2Config.user.data).to.deep.include.members([setConfigUserObj1]);
+    expect(ortb2Config.user.ext.other).to.equal('data');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [x] Feature

## Description of change
This PR adds aRTD module for the prebid addressability framework MVP found at https://github.com/prebid/paf-mvp-implementation. The demo currently uses this fork: https://github.com/openx/Prebid.js/tree/paf. More information about the specifications of the ids and data can be found at https://github.com/prebid/addressability-framework.

The design uses the RTD module to generate a seed for each auction. A userId module (https://github.com/prebid/Prebid.js/pull/8366) is used to expose the actual PAF data. Although this could have been done with an RTD module only, two modules were created so that the format of the data given to the bidders would align with the OpenRTB spec found at https://github.com/prebid/addressability-framework/blob/main/mvp-spec/ad-auction.md