### PR TITLE
Original ortb2 config was unintentionally modified

### DIFF
--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -67,7 +67,7 @@ export const spec = {
     var adRequests = bidRequests.map(bidToAdRequest);
 
     if (eids) {
-      ortb2 = mergeDeep(ortb2 || {}, eids);
+      ortb2 = mergeDeep(mergeDeep({}, ortb2), eids);
     }
 
     const payload = {

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -890,9 +890,10 @@ describe('Livewrapped adapter tests', function () {
     sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
 
     let origGetConfig = config.getConfig;
+    let orgOrtb2 = {user: {ext: {prop: 'value'}}};
     sandbox.stub(config, 'getConfig').callsFake(function (key) {
       if (key === 'ortb2') {
-        return {user: {ext: {prop: 'value'}}};
+        return orgOrtb2;
       }
       return origGetConfig.apply(config, arguments);
     });
@@ -914,6 +915,7 @@ describe('Livewrapped adapter tests', function () {
     var expected = {user: {ext: {prop: 'value', eids: testbidRequest.bids[0].userIdAsEids}}}
 
     expect(data.rtbData).to.deep.equal(expected);
+    expect(orgOrtb2).to.deep.equal({user: {ext: {prop: 'value'}}});
   });
 
   it('should send schain object if available', function() {


### PR DESCRIPTION
## Type of change
- [x ] Bugfix

## Description of change
When both ortb2 config and eids were present, the original ortb2 config was modified by the adapter to include the eids instead of merging into a copy.
