### PR TITLE
Improve Digital adapter: change asset source for native ads

### DIFF
--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -304,7 +304,10 @@ const ID_REQUEST = {
     }
 
     if (deepAccess(bidRequest, 'mediaTypes.native')) {
-      imp.native = this.buildNativeRequest(bidRequest);
+      const nativeImp = this.buildNativeRequest(bidRequest);
+      if (nativeImp) {
+        imp.native = nativeImp;
+      }
     }
 
     return imp;
@@ -358,7 +361,10 @@ const ID_REQUEST = {
   },
 
   buildNativeRequest(bidRequest) {
-    const nativeParams = bidRequest.mediaTypes.native;
+    const nativeParams = bidRequest.nativeParams;
+    if (!nativeParams) {
+      return null;
+    }
     const request = {
       assets: [],
     }
@@ -391,6 +397,10 @@ const ID_REQUEST = {
         }
         request.assets.push(asset);
       }
+    }
+    if (!request.assets.length) {
+      logWarn('No native assets recognized. Ignoring native ad request');
+      return null;
     }
     return { ver: NATIVE_DATA.VERSION, request: JSON.stringify(request) };
   },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

Improve Digital adapter: change asset source for native ads. Previously the adapter didn't check the correct param to get expanded assets of the predefined Prebid native types. More details of the problem in [this issue](https://github.com/prebid/Prebid.js/issues/6389). 

