### PR TITLE
Prebid 7: change default of `allowAlternateBidderCodes` from `true` to `false`

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -257,10 +257,10 @@ export function newBidder(spec) {
   });
 
   function isInvalidAlternateBidder(responseBidder, requestBidder) {
-    let allowAlternateBidderCodes = bidderSettings.get(requestBidder, 'allowAlternateBidderCodes');
+    let allowAlternateBidderCodes = bidderSettings.get(requestBidder, 'allowAlternateBidderCodes') || false;
     let alternateBiddersList = bidderSettings.get(requestBidder, 'allowedAlternateBidderCodes');
     if (!!responseBidder && !!requestBidder && requestBidder !== responseBidder) {
-      if ((allowAlternateBidderCodes !== undefined && !allowAlternateBidderCodes) || (isArray(alternateBiddersList) && (alternateBiddersList[0] !== '*' && !alternateBiddersList.includes(responseBidder)))) {
+      if (!allowAlternateBidderCodes || (isArray(alternateBiddersList) && (alternateBiddersList[0] !== '*' && !alternateBiddersList.includes(responseBidder)))) {
         return true;
       }
     }

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1073,16 +1073,14 @@ describe('validate bid response: ', function () {
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
-    it('should accept the bid, when allowAlternateBidderCodes flag is undefined (default should be true)', function () {
+    it('should reject the bid, when allowAlternateBidderCodes flag is undefined (default should be false)', function () {
       bidderSettingStub.returns(undefined);
 
       const bidder = newBidder(spec);
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(true);
-      expect(logWarnSpy.callCount).to.equal(0);
-      expect(logErrorSpy.callCount).to.equal(0);
+      expect(addBidResponseStub.calledOnce).to.equal(false);
     });
 
     it('should log warning when the particular bidder is not specified in allowedAlternateBidderCodes and allowAlternateBidderCodes flag is true', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

Change default of `bidderSettings.allowAlternateBidderCodes` to false

## Other information

Change mentioned in https://github.com/prebid/Prebid.js/issues/7796
Documentation PR: not needed, default change already mentioned in https://github.com/prebid/prebid.github.io/pull/3721/files
