### PR TITLE
Sovrn Bid Adapter: handle multiple seatbids in response

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -197,30 +197,30 @@ export const spec = {
 
     try {
       return seatbid
-      .filter(seat => seat)
-      .map(seat => seat.bid.map(sovrnBid => {
-        const bid = {
-          requestId: sovrnBid.impid,
-          cpm: parseFloat(sovrnBid.price),
-          width: parseInt(sovrnBid.w),
-          height: parseInt(sovrnBid.h),
-          creativeId: sovrnBid.crid || sovrnBid.id,
-          dealId: sovrnBid.dealid || null,
-          currency: 'USD',
-          netRevenue: true,
-          mediaType: sovrnBid.nurl ? BANNER : VIDEO,
-          ttl: sovrnBid.ext?.ttl || 90,
-          meta: { advertiserDomains: sovrnBid && sovrnBid.adomain ? sovrnBid.adomain : [] }
-        }
+        .filter(seat => seat)
+        .map(seat => seat.bid.map(sovrnBid => {
+          const bid = {
+            requestId: sovrnBid.impid,
+            cpm: parseFloat(sovrnBid.price),
+            width: parseInt(sovrnBid.w),
+            height: parseInt(sovrnBid.h),
+            creativeId: sovrnBid.crid || sovrnBid.id,
+            dealId: sovrnBid.dealid || null,
+            currency: 'USD',
+            netRevenue: true,
+            mediaType: sovrnBid.nurl ? BANNER : VIDEO,
+            ttl: sovrnBid.ext?.ttl || 90,
+            meta: { advertiserDomains: sovrnBid && sovrnBid.adomain ? sovrnBid.adomain : [] }
+          }
 
-        if (sovrnBid.nurl) {
-          bid.ad = decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`)
-        } else {
-          bid.vastXml = decodeURIComponent(sovrnBid.adm)
-        }
+          if (sovrnBid.nurl) {
+            bid.ad = decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`)
+          } else {
+            bid.vastXml = decodeURIComponent(sovrnBid.adm)
+          }
 
-        return bid
-      }))
+          return bid
+        }))
         .flat()
     } catch (e) {
       logError('Could not interpret bidresponse, error details:', e)

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -404,9 +404,29 @@ describe('sovrnBidAdapter', function() {
       'currency': 'USD',
       'netRevenue': true,
       'mediaType': 'banner',
-      'ad': decodeURIComponent(`<!-- Creative --><img src="<!-- NURL -->">`),
       'ttl': 90,
-      'meta': { advertiserDomains: [] }
+      'meta': { advertiserDomains: [] },
+      'ad': decodeURIComponent(`<!-- Creative --><img src="<!-- NURL -->">`),
+    }
+    const videoBid = {
+      'id': 'a_403370_332fdb9b064040ddbec05891bd13ab28',
+      'crid': 'creativelycreatedcreativecreative',
+      'impid': '263c448586f5a1',
+      'price': 0.45882675,
+      'nurl': '',
+      'adm': '<VAST version="4.2" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">key%3Dvalue</VAST>',
+      'h': 480,
+      'w': 640
+    }
+    const bannerBid = {
+      'id': 'a_403370_332fdb9b064040ddbec05891bd13ab28',
+      'crid': 'creativelycreatedcreativecreative',
+      'impid': '263c448586f5a1',
+      'price': 0.45882675,
+      'nurl': '<!-- NURL -->',
+      'adm': '<!-- Creative -->',
+      'h': 90,
+      'w': 728
     }
     beforeEach(function () {
       response = {
@@ -414,14 +434,7 @@ describe('sovrnBidAdapter', function() {
           'id': '37386aade21a71',
           'seatbid': [{
             'bid': [{
-              'id': 'a_403370_332fdb9b064040ddbec05891bd13ab28',
-              'crid': 'creativelycreatedcreativecreative',
-              'impid': '263c448586f5a1',
-              'price': 0.45882675,
-              'nurl': '<!-- NURL -->',
-              'adm': '<!-- Creative -->',
-              'h': 90,
-              'w': 728
+              ...bannerBid
             }]
           }]
         }
@@ -431,7 +444,6 @@ describe('sovrnBidAdapter', function() {
     it('should get the correct bid response', function () {
       const expectedResponse = {
         ...baseResponse,
-        'ad': decodeURIComponent(`<!-- Creative --><img src=<!-- NURL -->>`),
         'ttl': 60000,
       };
 
@@ -491,6 +503,36 @@ describe('sovrnBidAdapter', function() {
 
       expect(result.length).to.equal(0);
     });
+
+    it('should get the correct bid response with 2 different bids', function () {
+      const expectedVideoResponse = {
+        ...baseResponse,
+        'vastXml': decodeURIComponent(videoBid.adm)
+      }
+      delete expectedVideoResponse.ad
+
+      const expectedBannerResponse = {
+        ...baseResponse
+      }
+
+      response.body.seatbid = [{ bid: [bannerBid] }, { bid: [videoBid] }]
+      const result = spec.interpretResponse(response)
+
+      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedBannerResponse))
+      expect(Object.keys(result[1])).to.deep.equal(Object.keys(expectedVideoResponse))
+    })
+
+    it('should get the correct bid response with 2 seatbid items', function () {
+      const expectedResponse = {
+        ...baseResponse
+      }
+      response.body.seatbid = [response.body.seatbid[0], response.body.seatbid[0]]
+
+      const result = spec.interpretResponse(response)
+
+      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse))
+      expect(Object.keys(result[1])).to.deep.equal(Object.keys(expectedResponse))
+    })
   });
 
   describe('interpretResponse video', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Correctly handle multiple seatbids is bid response


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- cpabst@sovrn.com
- [X] official adapter submission


