### PR TITLE
appnexus bid adapter - fix in psp keywords conversion logic

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -394,11 +394,22 @@ export const spec = {
     }
   },
 
-  transformBidParams: function (params, isOpenRtb) {
+  transformBidParams: function (params, isOpenRtb, adUnit, bidRequests) {
     let conversionFn = transformBidderParamKeywords;
     if (isOpenRtb === true) {
+      let s2sEndpointUrl = null;
       let s2sConfig = config.getConfig('s2sConfig');
-      let s2sEndpointUrl = deepAccess(s2sConfig, 'endpoint.p1Consent');
+
+      if (isPlainObject(s2sConfig)) {
+        s2sEndpointUrl = deepAccess(s2sConfig, 'endpoint.p1Consent');
+      } else if (isArray(s2sConfig)) {
+        s2sConfig.forEach(s2sCfg => {
+          if (includes(s2sCfg.bidders, adUnit.bids[0].bidder)) {
+            s2sEndpointUrl = deepAccess(s2sCfg, 'endpoint.p1Consent');
+          }
+        })
+      }
+
       if (s2sEndpointUrl && s2sEndpointUrl.match('/openrtb2/prebid')) {
         conversionFn = convertKeywordsToString;
       }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1549,14 +1549,24 @@ describe('AppNexusAdapter', function () {
   });
 
   describe('transformBidParams', function () {
-    it('convert keywords param differently for psp endpoint', function () {
-      sinon.stub(config, 'getConfig')
-        .withArgs('s2sConfig')
-        .returns({
-          endpoint: {
-            p1Consent: 'https://ib.adnxs.com/openrtb2/prebid'
-          }
-        });
+    let gcStub;
+    let adUnit = { bids: [{ bidder: 'appnexus' }] }; ;
+
+    before(function() {
+      gcStub = sinon.stub(config, 'getConfig');
+    });
+
+    after(function() {
+      gcStub.restore();
+    });
+
+    it('convert keywords param differently for psp endpoint with single s2sConfig', function () {
+      gcStub.withArgs('s2sConfig').returns({
+        bidders: ['appnexus'],
+        endpoint: {
+          p1Consent: 'https://ib.adnxs.com/openrtb2/prebid'
+        }
+      });
 
       const oldParams = {
         keywords: {
@@ -1565,10 +1575,27 @@ describe('AppNexusAdapter', function () {
         }
       };
 
-      const newParams = spec.transformBidParams(oldParams, true);
+      const newParams = spec.transformBidParams(oldParams, true, adUnit);
       expect(newParams.keywords).to.equal('genre=rock,genre=pop,pets=dog');
+    });
 
-      config.getConfig.restore();
+    it('convert keywords param differently for psp endpoint with array s2sConfig', function () {
+      gcStub.withArgs('s2sConfig').returns([{
+        bidders: ['appnexus'],
+        endpoint: {
+          p1Consent: 'https://ib.adnxs.com/openrtb2/prebid'
+        }
+      }]);
+
+      const oldParams = {
+        keywords: {
+          genre: ['rock', 'pop'],
+          pets: 'dog'
+        }
+      };
+
+      const newParams = spec.transformBidParams(oldParams, true, adUnit);
+      expect(newParams.keywords).to.equal('genre=rock,genre=pop,pets=dog');
     });
   });
 });


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Corrects a small issue with the logic that converts the `bid.param.keywords` differently when using the appnexuspsp PrebidServer endpoint.  

The previous logic only assumed the s2sConfig would be defined as a single Object.  Instead it can be set as an Array of configs.  

The new logic handles both the Object and Array.  Further it will check the bids to ensure it does the PSP keyword conversion for the properly marked bidder(s) part of the appnexuspsp config.