### PR TITLE
talkads Bid Adapter: update params access in case of different ad servers

### DIFF
--- a/modules/talkadsBidAdapter.js
+++ b/modules/talkadsBidAdapter.js
@@ -11,7 +11,6 @@ export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
   supportedMediaTypes: [ NATIVE, BANNER ],
-  params: null,
 
   /**
    * Determines whether or not the given bid request is valid.
@@ -33,7 +32,7 @@ export const spec = {
       utils.logError('VALIDATION FAILED : the parameter "bidder_url" must be defined');
       return false;
     }
-    this.params = poBid.params;
+
     return !!(poBid.nativeParams || poBid.sizes);
   }, // isBidRequestValid
 
@@ -56,7 +55,7 @@ export const spec = {
       }
       return loOne;
     });
-    let laParams = this.params ? this.params : paValidBidRequests[0].params;
+    let laParams = paValidBidRequests[0].params;
     const loServerRequest = {
       cur: CURRENCY,
       timeout: poBidderRequest.timeout,
@@ -123,7 +122,7 @@ export const spec = {
    */
   onBidWon: function (poBid) {
     utils.logInfo('onBidWon : ', poBid);
-    let laParams = this.params ? this.params : poBid.params[0];
+    let laParams = poBid.params[0];
     if (poBid.pbid) {
       ajax(laParams.bidder_url + 'won/' + poBid.pbid);
     }

--- a/modules/talkadsBidAdapter.js
+++ b/modules/talkadsBidAdapter.js
@@ -5,9 +5,11 @@ import {ajax} from '../src/ajax.js';
 
 const CURRENCY = 'EUR';
 const BIDDER_CODE = 'talkads';
+const GVLID = 1074;
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [ NATIVE, BANNER ],
   params: null,
 
@@ -17,7 +19,7 @@ export const spec = {
    * @param poBid  The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
-  isBidRequestValid: function (poBid) {
+  isBidRequestValid: (poBid) => {
     utils.logInfo('isBidRequestValid : ', poBid);
     if (poBid.params === undefined) {
       utils.logError('VALIDATION FAILED : the parameters must be defined');
@@ -42,7 +44,7 @@ export const spec = {
    * @param poBidderRequest
    * @return ServerRequest Info describing the request to the server.
    */
-  buildRequests: function (paValidBidRequests, poBidderRequest) {
+  buildRequests: (paValidBidRequests, poBidderRequest) => {
     utils.logInfo('buildRequests : ', paValidBidRequests, poBidderRequest);
     const laBids = paValidBidRequests.map((poBid, piId) => {
       const loOne = { id: piId, ad_unit: poBid.adUnitCode, bid_id: poBid.bidId, type: '', size: [] };
@@ -54,6 +56,7 @@ export const spec = {
       }
       return loOne;
     });
+    let laParams = this.params ? this.params : paValidBidRequests[0].params;
     const loServerRequest = {
       cur: CURRENCY,
       timeout: poBidderRequest.timeout,
@@ -71,7 +74,7 @@ export const spec = {
         loServerRequest.gdpr.consent = poBidderRequest.gdprConsent.consentString;
       }
     }
-    const lsUrl = this.params.bidder_url + '/' + this.params.tag_id;
+    const lsUrl = laParams.bidder_url + '/' + laParams.tag_id;
     return {
       method: 'POST',
       url: lsUrl,
@@ -118,10 +121,11 @@ export const spec = {
    *
    * @param poBid The bid that won the auction
    */
-  onBidWon: function (poBid) {
+  onBidWon: (poBid) => {
     utils.logInfo('onBidWon : ', poBid);
+    let laParams = this.params ? this.params : poBid.params[0];
     if (poBid.pbid) {
-      ajax(this.params.bidder_url + 'won/' + poBid.pbid);
+      ajax(laParams.bidder_url + 'won/' + poBid.pbid);
     }
   }, // onBidWon
 };

--- a/modules/talkadsBidAdapter.js
+++ b/modules/talkadsBidAdapter.js
@@ -19,7 +19,7 @@ export const spec = {
    * @param poBid  The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
-  isBidRequestValid: (poBid) => {
+  isBidRequestValid: function (poBid) {
     utils.logInfo('isBidRequestValid : ', poBid);
     if (poBid.params === undefined) {
       utils.logError('VALIDATION FAILED : the parameters must be defined');
@@ -44,7 +44,7 @@ export const spec = {
    * @param poBidderRequest
    * @return ServerRequest Info describing the request to the server.
    */
-  buildRequests: (paValidBidRequests, poBidderRequest) => {
+  buildRequests: function (paValidBidRequests, poBidderRequest) {
     utils.logInfo('buildRequests : ', paValidBidRequests, poBidderRequest);
     const laBids = paValidBidRequests.map((poBid, piId) => {
       const loOne = { id: piId, ad_unit: poBid.adUnitCode, bid_id: poBid.bidId, type: '', size: [] };
@@ -89,7 +89,7 @@ export const spec = {
    * @param poPidRequest Request original server request
    * @return An array of bids which were nested inside the server.
    */
-  interpretResponse: (poServerResponse, poPidRequest) => {
+  interpretResponse: function (poServerResponse, poPidRequest) {
     utils.logInfo('interpretResponse : ', poServerResponse);
     if (!poServerResponse.body) {
       return [];
@@ -121,7 +121,7 @@ export const spec = {
    *
    * @param poBid The bid that won the auction
    */
-  onBidWon: (poBid) => {
+  onBidWon: function (poBid) {
     utils.logInfo('onBidWon : ', poBid);
     let laParams = this.params ? this.params : poBid.params[0];
     if (poBid.pbid) {

--- a/test/spec/modules/talkadsBidAdapter_spec.js
+++ b/test/spec/modules/talkadsBidAdapter_spec.js
@@ -207,6 +207,7 @@ describe('TalkAds adapter', function () {
         ttl: 60,
         creativeId: 'c123a456',
         netRevenue: false,
+        params: [Object.assign({}, commonBidRequest.params)],
       }
       spec.onBidWon(loBid)
       expect(server.requests.length).to.equals(0);
@@ -222,7 +223,8 @@ describe('TalkAds adapter', function () {
         ttl: 60,
         creativeId: 'c123a456',
         netRevenue: false,
-        pbid: '6147833a65749742875ace47'
+        pbid: '6147833a65749742875ace47',
+        params: [Object.assign({}, commonBidRequest.params)],
       }
       spec.onBidWon(loBid)
       expect(server.requests[0].url).to.equals('https://test.natexo-programmatic.com/tad/tag/prebidwon/6147833a65749742875ace47');


### PR DESCRIPTION
Update params access in case of different ad servers.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
