### PR TITLE
BeOp Bid Adapter: prefer canonical URL when present & prepend protocol

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -180,7 +180,7 @@ function getPageUrl(refererInfo, window) {
   let pageUrl = refererInfo.canonicalUrl || safeDeepAccess(window, 'top.location.href') || deepAccess(window, 'location.href');
   // Ensure the protocol is present (looks like sometimes the extracted pageUrl misses it)
   if (pageUrl != null) {
-    const defaultProtocol = deepAccess(window, 'top.location.protocol') || deepAccess(window, 'location.protocol');
+    const defaultProtocol = safeDeepAccess(window, 'top.location.protocol') || deepAccess(window, 'location.protocol');
     pageUrl = ensureProtocolInUrl(pageUrl, defaultProtocol);
   }
   return pageUrl;

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -162,10 +162,23 @@ function ensureProtocolInUrl(url, defaultProtocol) {
   return url;
 }
 
+/**
+ * sometimes trying to access a field (protected?) triggers an exception
+ * Ex deepAccess(window, 'top.location.href') might throw if it crosses origins
+ * so here is a lenient version
+ */
+function safeDeepAccess(obj, path) {
+  try {
+    return deepAccess(obj, path)
+  } catch (_e) {
+    return null;
+  }
+}
+
 function getPageUrl(refererInfo, window) {
   refererInfo = refererInfo || getRefererInfo();
-  let pageUrl = refererInfo.canonicalUrl || refererInfo.referer || deepAccess(window, 'top.location.href') || deepAccess(window, 'location.href');
-  // Ensure the protocol is present (looks like sometimes canonicalUrl misses it)
+  let pageUrl = refererInfo.canonicalUrl || safeDeepAccess(window, 'top.location.href') || deepAccess(window, 'location.href');
+  // Ensure the protocol is present (looks like sometimes the extracted pageUrl misses it)
   if (pageUrl != null) {
     const defaultProtocol = deepAccess(window, 'top.location.protocol') || deepAccess(window, 'location.protocol');
     pageUrl = ensureProtocolInUrl(pageUrl, defaultProtocol);

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -115,7 +115,7 @@ describe('BeOp Bid Adapter tests', () => {
         },
         'refererInfo':
         {
-          'canonicalUrl': 'http://test.te'
+          'canonicalUrl': 'test.te'
         }
       };
 
@@ -124,7 +124,20 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.tc_string).to.exist;
       expect(payload.tc_string).to.equal('BOJ8RZsOJ8RZsABAB8AAAAAZ+A==');
       expect(payload.url).to.exist;
-      expect(payload.url).to.equal('http://localhost:9876/context.html');
+      // check that the protocol is added correctly
+      expect(payload.url).to.equal('http://test.te');
+    });
+
+    it('should not prepend the protocol in page url if already present', function () {
+      const bidderRequest = {
+        'refererInfo': {
+          'canonicalUrl': 'https://test.te'
+        }
+      };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.url).to.exist;
+      expect(payload.url).to.equal('https://test.te');
     });
   });
 


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Prefer the canonical url when present when setting the payload url for the BeOp adapter.

We've noticed at least sometimes the protocol is missing (not sure where the problem is) so we prepend it when needed.