### PR TITLE
UserID module: graceful handling of exceptions from ID submodules

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -5,7 +5,16 @@
  * @requires module:modules/userId
  */
 
-import { deepAccess, logInfo, deepSetValue, logError, isEmpty, isEmptyStr, logWarn } from '../src/utils.js';
+import {
+  deepAccess,
+  logInfo,
+  deepSetValue,
+  logError,
+  isEmpty,
+  isEmptyStr,
+  logWarn,
+  safeJSONParse
+} from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { getRefererInfo } from '../src/refererDetection.js';
@@ -24,7 +33,7 @@ const LOG_PREFIX = 'User ID - ID5 submodule: ';
 // cookie in the array is the most preferred to use
 const LEGACY_COOKIE_NAMES = [ 'pbjs-id5id', 'id5id.1st', 'id5id' ];
 
-const storage = getStorageManager({gvlid: GVLID, moduleName: MODULE_NAME});
+export const storage = getStorageManager({gvlid: GVLID, moduleName: MODULE_NAME});
 
 /** @type {Submodule} */
 export const id5IdSubmodule = {
@@ -253,7 +262,7 @@ function getLegacyCookieSignature() {
   let legacyStoredValue;
   LEGACY_COOKIE_NAMES.forEach(function(cookie) {
     if (storage.getCookie(cookie)) {
-      legacyStoredValue = JSON.parse(storage.getCookie(cookie)) || legacyStoredValue;
+      legacyStoredValue = safeJSONParse(storage.getCookie(cookie)) || legacyStoredValue;
     }
   });
   return (legacyStoredValue && legacyStoredValue.signature) || '';

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -423,7 +423,7 @@ function processSubmoduleCallbacks(submodules, cb) {
     }, submodules.length);
   }
   submodules.forEach(function (submodule) {
-    submodule.callback(function callbackCompleted(idObj) {
+    function callbackCompleted(idObj) {
       // if valid, id data should be saved to cookie/html storage
       if (idObj) {
         if (submodule.config.storage) {
@@ -435,8 +435,13 @@ function processSubmoduleCallbacks(submodules, cb) {
         logInfo(`${MODULE_NAME}: ${submodule.submodule.name} - request id responded with an empty value`);
       }
       done();
-    });
-
+    }
+    try {
+      submodule.callback(callbackCompleted);
+    } catch (e) {
+      logError(`Error in userID module '${submodule.submodule.name}':`, e);
+      done();
+    }
     // clear callback, this prop is used to test if all submodule callbacks are complete below
     submodule.callback = undefined;
   });
@@ -881,8 +886,12 @@ function initSubmodules(dest, submodules, consentData, forceRefresh = false) {
   setStoredConsentData(consentData);
 
   const initialized = userIdModules.reduce((carry, submodule) => {
-    populateSubmoduleId(submodule, consentData, storedConsentData, forceRefresh);
-    carry.push(submodule);
+    try {
+      populateSubmoduleId(submodule, consentData, storedConsentData, forceRefresh);
+      carry.push(submodule);
+    } catch (e) {
+      logError(`Error in userID module '${submodule.submodule.name}':`, e);
+    }
     return carry;
   }, []);
   if (initialized.length) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1364,3 +1364,14 @@ export function cyrb53Hash(str, seed = 0) {
 export function getWindowFromDocument(doc) {
   return (doc) ? doc.defaultView : null;
 }
+
+/**
+ * returns the result of `JSON.parse(data)`, or undefined if that throws an error.
+ * @param data
+ * @returns {any}
+ */
+export function safeJSONParse(data) {
+  try {
+    return JSON.parse(data);
+  } catch (e) {}
+}

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -5,7 +5,7 @@ import {
   ID5_PRIVACY_STORAGE_NAME,
   ID5_STORAGE_NAME,
   id5IdSubmodule,
-  nbCacheName,
+  nbCacheName, storage,
   storeInLocalStorage,
   storeNbInCache,
 } from 'modules/id5IdSystem.js';
@@ -310,6 +310,21 @@ describe('ID5 ID System', function() {
       request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
       expect(getFromLocalStorage(ID5_PRIVACY_STORAGE_NAME)).to.be.null;
     });
+
+    describe('when legacy cookies are set', () => {
+      let sandbox;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(storage, 'getCookie');
+      });
+      afterEach(() => {
+        sandbox.restore();
+      });
+      it('should not throw if malformed JSON is forced into cookies', () => {
+        storage.getCookie.callsFake(() => ' Not JSON ');
+        id5IdSubmodule.getId(getId5FetchConfig());
+      });
+    })
   });
 
   describe('Request Bids Hook', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This changes the behavior of userID when ID submodules throw exceptions - instead of failing, log an error and continue with other submodules.

## Other information

Fix https://github.com/prebid/Prebid.js/issues/8360

