### PR TITLE
Floc ID Module: remove call for floc

### DIFF
--- a/modules/flocIdSystem.js
+++ b/modules/flocIdSystem.js
@@ -28,12 +28,7 @@ function enableOriginTrial(token) {
  * @param errorCallback
  */
 function getFlocData(successCallback, errorCallback) {
-  document.interestCohort()
-    .then((data) => {
-      successCallback(data);
-    }).catch((error) => {
-      errorCallback(error);
-    });
+  errorCallback(error);
 }
 
 /**
@@ -82,7 +77,7 @@ export const flocIdSubmodule = {
       return;
     }
     // Validate feature is enabled
-    const isFlocEnabled = !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime) && !!document.featurePolicy && !!document.featurePolicy.features() && document.featurePolicy.features().includes('interest-cohort');
+    const isFlocEnabled = false;
 
     if (isFlocEnabled) {
       const configParams = (config && config.params) || {};

--- a/modules/flocIdSystem.js
+++ b/modules/flocIdSystem.js
@@ -28,7 +28,7 @@ function enableOriginTrial(token) {
  * @param errorCallback
  */
 function getFlocData(successCallback, errorCallback) {
-  errorCallback(error);
+  errorCallback('The Floc has flown');
 }
 
 /**


### PR DESCRIPTION
The floc module has some code that causes some serious problems on chrome 102 if a user opts into privacy sandbox. It won't be in prebid 7. This PR is intended to break the module without breaking people's builds.