### PR TITLE
UserID module: do not start initialization until `pbjs.processQueue()` has been called

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -5,6 +5,7 @@ import CONSTANTS from '../src/constants.json';
 import { ajax } from '../src/ajax.js';
 import { config } from '../src/config.js';
 import { getHook } from '../src/hook.js';
+import {promiseControls} from '../src/utils/promise.js';
 
 const DEFAULT_CURRENCY_RATE_URL = 'https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json?date=$$TODAY$$';
 const CURRENCY_RATE_PRECISION = 4;
@@ -21,22 +22,12 @@ var bidderCurrencyDefault = {};
 var defaultRates;
 
 export const ready = (() => {
-  let isDone, resolver, promise;
+  let ctl;
   function reset() {
-    isDone = false;
-    resolver = null;
-    promise = new Promise((resolve) => {
-      resolver = resolve;
-      if (isDone) resolve();
-    })
-  }
-  function done() {
-    isDone = true;
-    if (resolver != null) { resolver() }
+    ctl = promiseControls();
   }
   reset();
-
-  return {done, reset, promise: () => promise}
+  return {done: () => ctl.resolve(), reset, promise: () => ctl.promise}
 })();
 
 /**

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -131,7 +131,7 @@ import * as events from '../../src/events.js';
 import {getGlobal} from '../../src/prebidGlobal.js';
 import {gdprDataHandler} from '../../src/adapterManager.js';
 import CONSTANTS from '../../src/constants.json';
-import {hook, module} from '../../src/hook.js';
+import {hook, module, ready as hooksReady} from '../../src/hook.js';
 import {buildEidPermissions, createEidsArray, USER_IDS_CONFIG} from './eids.js';
 import {getCoreStorageManager} from '../../src/storageManager.js';
 import {
@@ -529,7 +529,6 @@ function delayFor(ms) {
 const INIT_CANCELED = {};
 
 function idSystemInitializer({delay = delayFor} = {}) {
-
   const startInit = promiseControls();
   const startCallbacks = promiseControls();
   let cancel;
@@ -559,7 +558,7 @@ function idSystemInitializer({delay = delayFor} = {}) {
   }
 
   let done = cancelAndTry(
-    startInit.promise
+    Promise.all([hooksReady, startInit.promise])
       .then(() => gdprDataHandler.promise)
       .then(checkRefs((consentData) => {
         initSubmodules(initModules, allModules, consentData);

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,9 +1,27 @@
-
 import funHooks from 'fun-hooks/no-eval/index.js';
+import {promiseControls} from './utils/promise.js';
 
 export let hook = funHooks({
   ready: funHooks.SYNC | funHooks.ASYNC | funHooks.QUEUE
 });
+
+const readyCtl = promiseControls();
+hook.ready = (() => {
+  const ready = hook.ready;
+  return function () {
+    try {
+      return ready.apply(hook, arguments);
+    } finally {
+      readyCtl.resolve();
+    }
+  }
+})();
+
+/**
+ * A promise that resolves when hooks are ready.
+ * @type {Promise}
+ */
+export const ready = readyCtl.promise;
 
 export const getHook = hook.get;
 

--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -5,14 +5,14 @@ const RESULT = 2;
 /**
  * @returns a {promise, resolve, reject} trio where `promise` is resolved by calling `resolve` or `reject`.
  */
-export function promiseControls() {
+export function promiseControls({promiseFactory = (resolver) => new Promise(resolver)} = {}) {
   const status = {};
 
   function finisher(slot) {
     return function (val) {
-      if (status[slot] != null) {
+      if (typeof status[slot] === 'function') {
         status[slot](val);
-      } else {
+      } else if (!status[slot]) {
         status[slot] = true;
         status[RESULT] = val;
       }
@@ -20,7 +20,7 @@ export function promiseControls() {
   }
 
   return {
-    promise: new Promise((resolve, reject) => {
+    promise: promiseFactory((resolve, reject) => {
       if (status[SUCCESS] != null) {
         resolve(status[RESULT]);
       } else if (status[FAIL] != null) {

--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -1,0 +1,36 @@
+const SUCCESS = 0;
+const FAIL = 1;
+const RESULT = 2;
+
+/**
+ * @returns a {promise, resolve, reject} trio where `promise` is resolved by calling `resolve` or `reject`.
+ */
+export function promiseControls() {
+  const status = {};
+
+  function finisher(slot) {
+    return function (val) {
+      if (status[slot] != null) {
+        status[slot](val);
+      } else {
+        status[slot] = true;
+        status[RESULT] = val;
+      }
+    }
+  }
+
+  return {
+    promise: new Promise((resolve, reject) => {
+      if (status[SUCCESS] != null) {
+        resolve(status[RESULT]);
+      } else if (status[FAIL] != null) {
+        reject(status[RESULT]);
+      } else {
+        status[SUCCESS] = resolve;
+        status[FAIL] = reject;
+      }
+    }),
+    resolve: finisher(SUCCESS),
+    reject: finisher(FAIL)
+  }
+}

--- a/test/spec/unit/utils/promise_spec.js
+++ b/test/spec/unit/utils/promise_spec.js
@@ -1,29 +1,49 @@
 import {promiseControls} from '../../../../src/utils/promise.js';
 
 describe('promiseControls', () => {
+  function lazyControls() {
+    // NOTE: here we are testing that calling resolve / reject works correctly regardless of whether the
+    // browser runs promise resolvers before / after returning control to the code; e.g. with the following:
+    //
+    // new Promise(() => console.log('1')); console.log('2')
+    //
+    // it seems that the browser will output '1', then '2' - but is it always guaranteed to do so?
+    // it's not clear from MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise)
+    // so here we make sure it works in both cases.
+
+    return promiseControls({
+      promiseFactory: (r) => ({
+        then: function () {
+          const p = new Promise(r);
+          return p.then.apply(p, arguments);
+        }
+      })
+    })
+  }
   Object.entries({
     'resolve': (p) => p,
-    'reject': (p) => p.then(() => 'incorrect', (v) => v)
+    'reject': (p) => p.then(() => 'wrong', (v) => v)
   }).forEach(([method, transform]) => {
     describe(method, () => {
-      it(`should ${method} the promise when called after its resolver runs`, (done) => {
-        const ctl = promiseControls();
-        setTimeout(() => {
-          ctl[method]('result');
-          transform(ctl.promise).then((result) => {
-            expect(result).to.equal('result');
-            done();
+      Object.entries({
+        'before the resolver': lazyControls,
+        'after the resolver': promiseControls,
+      }).forEach(([t, controls]) => {
+        describe(`when called ${t}`, () => {
+          it(`should ${method} the promise`, () => {
+            const ctl = controls();
+            ctl[method]('result');
+            return transform(ctl.promise).then((res) => expect(res).to.equal('result'));
           });
-        });
-      });
 
-      it(`should ${method} the promise when called before its resolver runs`, () => {
-        const ctl = promiseControls();
-        ctl[method]('result');
-        return transform(ctl.promise).then((result) => {
-          expect(result).to.equal('result');
-        });
-      });
-    });
+          it('should ignore calls after the first', () => {
+            const ctl = controls();
+            ctl[method]('result');
+            ctl[method]('other');
+            return transform(ctl.promise).then((res) => expect(res).to.equal('result'));
+          });
+        })
+      })
+    })
   });
 });

--- a/test/spec/unit/utils/promise_spec.js
+++ b/test/spec/unit/utils/promise_spec.js
@@ -1,0 +1,29 @@
+import {promiseControls} from '../../../../src/utils/promise.js';
+
+describe('promiseControls', () => {
+  Object.entries({
+    'resolve': (p) => p,
+    'reject': (p) => p.then(() => 'incorrect', (v) => v)
+  }).forEach(([method, transform]) => {
+    describe(method, () => {
+      it(`should ${method} the promise when called after its resolver runs`, (done) => {
+        const ctl = promiseControls();
+        setTimeout(() => {
+          ctl[method]('result');
+          transform(ctl.promise).then((result) => {
+            expect(result).to.equal('result');
+            done();
+          });
+        });
+      });
+
+      it(`should ${method} the promise when called before its resolver runs`, () => {
+        const ctl = promiseControls();
+        ctl[method]('result');
+        return transform(ctl.promise).then((result) => {
+          expect(result).to.equal('result');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

After https://github.com/prebid/Prebid.js/pull/8201, the userID module will start initialization as soon as it gets configured with `setConfig`. If that happens before `pbjs.processQueue` is called (currenly only possible with a custom build), it throws an exception when it tries to use hooks that are not ready.
