### PR TITLE
Piano DMP Analytics Adapter: add new analytics adapter

### DIFF
--- a/modules/pianoDmpAnalyticcsAdapter.md
+++ b/modules/pianoDmpAnalyticcsAdapter.md
@@ -1,0 +1,13 @@
+# Overview
+
+Module Name: Piano DMP Analytics Adapter
+
+Module Type: Analytics Adapter
+
+Maintainer: [support@piano.com](mailto:support@piano.com)
+
+# Description
+
+Analytics adapter to be used with cx.js
+
+Visit [https://piano.io/product/dmp/](https://piano.io/product/dmp/) for more information.

--- a/modules/pianoDmpAnalyticsAdapter.js
+++ b/modules/pianoDmpAnalyticsAdapter.js
@@ -1,0 +1,38 @@
+import adapter from '../src/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+
+const pianoDmpAnalytics = adapter({ analyticsType: 'bundle', handler: 'on' });
+
+const { enableAnalytics: _enableAnalytics } = pianoDmpAnalytics;
+
+Object.assign(pianoDmpAnalytics, {
+  /**
+   * Save event in the global array that will be consumed later by cx.js
+   */
+  track: ({ eventType, args: params }) => {
+    window.cX.callQueue.push([
+      'prebid',
+      { eventType, params, time: Date.now() },
+    ]);
+  },
+
+  /**
+   * Before forwarding the call to the original enableAnalytics function -
+   * create (if needed) the global array that is used to pass events to the cx.js library
+   * by the 'track' function above.
+   */
+  enableAnalytics: function (...args) {
+    window.cX = window.cX || {};
+    window.cX.callQueue = window.cX.callQueue || [];
+
+    return _enableAnalytics.call(this, ...args);
+  },
+});
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: pianoDmpAnalytics,
+  code: 'pianoDmp',
+  gvlid: 412,
+});
+
+export default pianoDmpAnalytics;

--- a/test/spec/modules/pianoDmpAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pianoDmpAnalyticsAdapter_spec.js
@@ -1,0 +1,66 @@
+import pianoDmpAnalytics from 'modules/pianoDmpAnalyticsAdapter.js';
+import adapterManager from 'src/adapterManager';
+import * as events from 'src/events';
+import constants from 'src/constants.json';
+import { expect } from 'chai';
+
+describe('Piano DMP Analytics Adapter', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    sandbox.stub(events, 'getEvents').returns([]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('track', () => {
+    beforeEach(() => {
+      adapterManager.enableAnalytics({
+        provider: 'pianoDmp',
+      });
+    });
+
+    afterEach(() => {
+      delete window.cX;
+      pianoDmpAnalytics.disableAnalytics();
+    });
+
+    it('should pass events to call queue', () => {
+      const eventsList = [
+        constants.EVENTS.AUCTION_INIT,
+        constants.EVENTS.AUCTION_END,
+        constants.EVENTS.BID_ADJUSTMENT,
+        constants.EVENTS.BID_TIMEOUT,
+        constants.EVENTS.BID_REQUESTED,
+        constants.EVENTS.BID_RESPONSE,
+        constants.EVENTS.NO_BID,
+        constants.EVENTS.BID_WON,
+      ];
+
+      // Given
+      const testEvents = eventsList.map((event) => ({
+        event,
+        args: { test: event },
+      }));
+
+      // When
+      testEvents.forEach(({ event, args }) => events.emit(event, args));
+
+      // Then
+      const callQueue = (window.cX || {}).callQueue;
+
+      expect(callQueue).to.be.an('array');
+      expect(callQueue.length).to.equal(testEvents.length);
+
+      callQueue.forEach(([method, params], index) => {
+        expect(method).to.equal('prebid');
+        expect(params.eventType).to.equal(testEvents[index].event);
+        expect(params.params).to.deep.equal(testEvents[index].args);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New analytics adapter

## Description of change
This is an analytics adapter for the [Piano DMP](https://piano.io/product/dmp/) application

The adapter stores events in a global array that is later consumed by cxjs script 

contact email of the adapter’s maintainer: [support@piano.io](mailto:support@piano.io)

- [x] official adapter submission

- A link to a PR on the docs repo [3772](https://github.com/prebid/prebid.github.io/pull/3772)
