### PR TITLE
Ogury Bid Adapter: Add device infos with size in bidrequest

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -10,7 +10,29 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '1.2.11';
+const ADAPTER_VERSION = '1.2.12';
+
+function getClientWidth() {
+  const documentElementClientWidth = window.top.document.documentElement.clientWidth
+    ? window.top.document.documentElement.clientWidth
+    : 0
+  const innerWidth = window.top.innerWidth ? window.top.innerWidth : 0
+  const outerWidth = window.top.outerWidth ? window.top.outerWidth : 0
+  const screenWidth = window.top.screen.width ? window.top.screen.width : 0
+
+  return documentElementClientWidth || innerWidth || outerWidth || screenWidth
+}
+
+function getClientHeight() {
+  const documentElementClientHeight = window.top.document.documentElement.clientHeight
+    ? window.top.document.documentElement.clientHeight
+    : 0
+  const innerHeight = window.top.innerHeight ? window.top.innerHeight : 0
+  const outerHeight = window.top.outerHeight ? window.top.outerHeight : 0
+  const screenHeight = window.top.screen.height ? window.top.screen.height : 0
+
+  return documentElementClientHeight || innerHeight || outerHeight || screenHeight
+}
 
 function isBidRequestValid(bid) {
   const adUnitSizes = getAdUnitSizes(bid);
@@ -60,6 +82,10 @@ function buildRequests(validBidRequests, bidderRequest) {
     ext: {
       adapterversion: ADAPTER_VERSION,
       prebidversion: '$prebid.version$'
+    },
+    device: {
+      w: getClientWidth(),
+      h: getClientHeight()
     }
   };
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -339,11 +339,11 @@ describe('OguryBidAdapter', function () {
 
       it('should get documentElementClientWidth by default', () => {
         testGetClientWidth({
-          docClientSize: 23,
+          docClientSize: 22,
           innerSize: 50,
           outerSize: 45,
           screenSize: 10,
-          expectedSize: 23,
+          expectedSize: 22,
         })
       })
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -226,6 +226,16 @@ describe('OguryBidAdapter', function () {
   });
 
   describe('buildRequests', function () {
+    const stubbedWidth = 200
+    const stubbedHeight = 600
+    sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
+      return stubbedWidth;
+    });
+
+    sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
+      return stubbedHeight;
+    });
+
     const defaultTimeout = 1000;
     const expectedRequestObject = {
       id: bidRequests[0].auctionId,
@@ -270,7 +280,11 @@ describe('OguryBidAdapter', function () {
       },
       ext: {
         prebidversion: '$prebid.version$',
-        adapterversion: '1.2.11'
+        adapterversion: '1.2.12'
+      },
+      device: {
+        w: stubbedWidth,
+        h: stubbedHeight
       }
     };
 
@@ -288,6 +302,156 @@ describe('OguryBidAdapter', function () {
       const request = spec.buildRequests(validBidRequests, bidderRequest);
       expect(request.data).to.deep.equal(expectedRequestObject);
       expect(request.data.regs.ext.gdpr).to.be.a('number');
+    });
+
+    describe('getClientWidth', () => {
+      function testGetClientWidth(testGetClientSizeParams) {
+        sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
+          return testGetClientSizeParams.docClientSize
+        })
+
+        sinon.stub(window.top, 'innerWidth').get(function() {
+          return testGetClientSizeParams.innerSize
+        })
+
+        sinon.stub(window.top, 'outerWidth').get(function() {
+          return testGetClientSizeParams.outerSize
+        })
+
+        sinon.stub(window.top.screen, 'width').get(function() {
+          return testGetClientSizeParams.screenSize
+        })
+
+        const validBidRequests = utils.deepClone(bidRequests)
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        expect(request.data.device.w).to.equal(testGetClientSizeParams.expectedSize);
+      }
+
+      it('should get documentElementClientWidth by default', () => {
+        testGetClientWidth({
+          docClientSize: 22,
+          innerSize: 50,
+          outerSize: 45,
+          screenSize: 10,
+          expectedSize: 22,
+        })
+      })
+
+      it('should get innerWidth as first fallback', () => {
+        testGetClientWidth({
+          docClientSize: undefined,
+          innerSize: 700,
+          outerSize: 650,
+          screenSize: 10,
+          expectedSize: 700,
+        })
+      })
+
+      it('should get outerWidth as second fallback', () => {
+        testGetClientWidth({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: 650,
+          screenSize: 10,
+          expectedSize: 650,
+        })
+      })
+
+      it('should get screenWidth as last fallback', () => {
+        testGetClientWidth({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: undefined,
+          screenSize: 10,
+          expectedSize: 10,
+        });
+      });
+
+      it('should return 0 if all window width values are undefined', () => {
+        testGetClientWidth({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: undefined,
+          screenSize: undefined,
+          expectedSize: 0,
+        });
+      });
+    });
+
+    describe('getClientHeight', () => {
+      function testGetClientHeight(testGetClientSizeParams) {
+        sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
+          return testGetClientSizeParams.docClientSize
+        })
+
+        sinon.stub(window.top, 'innerHeight').get(function() {
+          return testGetClientSizeParams.innerSize
+        })
+
+        sinon.stub(window.top, 'outerHeight').get(function() {
+          return testGetClientSizeParams.outerSize
+        })
+
+        sinon.stub(window.top.screen, 'height').get(function() {
+          return testGetClientSizeParams.screenSize
+        })
+
+        const validBidRequests = utils.deepClone(bidRequests)
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        expect(request.data.device.h).to.equal(testGetClientSizeParams.expectedSize);
+      }
+
+      it('should get documentElementClientHeight by default', () => {
+        testGetClientHeight({
+          docClientSize: 420,
+          innerSize: 500,
+          outerSize: 480,
+          screenSize: 230,
+          expectedSize: 420,
+        });
+      });
+
+      it('should get innerHeight as first fallback', () => {
+        testGetClientHeight({
+          docClientSize: undefined,
+          innerSize: 500,
+          outerSize: 480,
+          screenSize: 230,
+          expectedSize: 500,
+        });
+      });
+
+      it('should get outerHeight as second fallback', () => {
+        testGetClientHeight({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: 480,
+          screenSize: 230,
+          expectedSize: 480,
+        });
+      });
+
+      it('should get screenHeight as last fallback', () => {
+        testGetClientHeight({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: undefined,
+          screenSize: 230,
+          expectedSize: 230,
+        });
+      });
+
+      it('should return 0 if all window height values are undefined', () => {
+        testGetClientHeight({
+          docClientSize: undefined,
+          innerSize: undefined,
+          outerSize: undefined,
+          screenSize: undefined,
+          expectedSize: 0,
+        });
+      });
     });
 
     it('should not add gdpr infos if not present', () => {
@@ -481,7 +645,7 @@ describe('OguryBidAdapter', function () {
           advertiserDomains: openRtbBidResponse.body.seatbid[0].bid[0].adomain
         },
         nurl: openRtbBidResponse.body.seatbid[0].bid[0].nurl,
-        adapterVersion: '1.2.11',
+        adapterVersion: '1.2.12',
         prebidVersion: '$prebid.version$'
       }, {
         requestId: openRtbBidResponse.body.seatbid[0].bid[1].impid,
@@ -498,7 +662,7 @@ describe('OguryBidAdapter', function () {
           advertiserDomains: openRtbBidResponse.body.seatbid[0].bid[1].adomain
         },
         nurl: openRtbBidResponse.body.seatbid[0].bid[1].nurl,
-        adapterVersion: '1.2.11',
+        adapterVersion: '1.2.12',
         prebidVersion: '$prebid.version$'
       }]
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -66,6 +66,10 @@ describe('OguryBidAdapter', function () {
     gdprConsent: {consentString: 'myConsentString', vendorData: {}, gdprApplies: true},
   };
 
+  afterAll(() => {
+    sinon.restore();
+  })
+
   describe('isBidRequestValid', function () {
     it('should validate correct bid', () => {
       let validBid = utils.deepClone(bidRequests[0]);

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -330,11 +330,11 @@ describe('OguryBidAdapter', function () {
 
       it('should get documentElementClientWidth by default', () => {
         testGetClientWidth({
-          docClientSize: 22,
+          docClientSize: 23,
           innerSize: 50,
           outerSize: 45,
           screenSize: 10,
-          expectedSize: 22,
+          expectedSize: 23,
         })
       })
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -66,10 +66,6 @@ describe('OguryBidAdapter', function () {
     gdprConsent: {consentString: 'myConsentString', vendorData: {}, gdprApplies: true},
   };
 
-  afterAll(() => {
-    sinon.restore();
-  })
-
   describe('isBidRequestValid', function () {
     it('should validate correct bid', () => {
       let validBid = utils.deepClone(bidRequests[0]);
@@ -232,11 +228,10 @@ describe('OguryBidAdapter', function () {
   describe('buildRequests', function () {
     const stubbedWidth = 200
     const stubbedHeight = 600
-    sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
+    const stubbedWidthMethod = sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
       return stubbedWidth;
     });
-
-    sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
+    const stubbedHeightMethod = sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
       return stubbedHeight;
     });
 
@@ -292,6 +287,11 @@ describe('OguryBidAdapter', function () {
       }
     };
 
+    after(function() {
+      stubbedWidthMethod.restore();
+      stubbedHeightMethod.restore();
+    });
+
     it('sends bid request to ENDPOINT via POST', function () {
       const validBidRequests = utils.deepClone(bidRequests)
 
@@ -310,19 +310,19 @@ describe('OguryBidAdapter', function () {
 
     describe('getClientWidth', () => {
       function testGetClientWidth(testGetClientSizeParams) {
-        sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
+        const stubbedClientWidth = sinon.stub(window.top.document.documentElement, 'clientWidth').get(function() {
           return testGetClientSizeParams.docClientSize
         })
 
-        sinon.stub(window.top, 'innerWidth').get(function() {
+        const stubbedInnerWidth = sinon.stub(window.top, 'innerWidth').get(function() {
           return testGetClientSizeParams.innerSize
         })
 
-        sinon.stub(window.top, 'outerWidth').get(function() {
+        const stubbedOuterWidth = sinon.stub(window.top, 'outerWidth').get(function() {
           return testGetClientSizeParams.outerSize
         })
 
-        sinon.stub(window.top.screen, 'width').get(function() {
+        const stubbedWidth = sinon.stub(window.top.screen, 'width').get(function() {
           return testGetClientSizeParams.screenSize
         })
 
@@ -330,6 +330,11 @@ describe('OguryBidAdapter', function () {
 
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         expect(request.data.device.w).to.equal(testGetClientSizeParams.expectedSize);
+
+        stubbedClientWidth.restore();
+        stubbedInnerWidth.restore();
+        stubbedOuterWidth.restore();
+        stubbedWidth.restore();
       }
 
       it('should get documentElementClientWidth by default', () => {
@@ -385,19 +390,19 @@ describe('OguryBidAdapter', function () {
 
     describe('getClientHeight', () => {
       function testGetClientHeight(testGetClientSizeParams) {
-        sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
+        const stubbedClientHeight = sinon.stub(window.top.document.documentElement, 'clientHeight').get(function() {
           return testGetClientSizeParams.docClientSize
         })
 
-        sinon.stub(window.top, 'innerHeight').get(function() {
+        const stubbedInnerHeight = sinon.stub(window.top, 'innerHeight').get(function() {
           return testGetClientSizeParams.innerSize
         })
 
-        sinon.stub(window.top, 'outerHeight').get(function() {
+        const stubbedOuterHeight = sinon.stub(window.top, 'outerHeight').get(function() {
           return testGetClientSizeParams.outerSize
         })
 
-        sinon.stub(window.top.screen, 'height').get(function() {
+        const stubbedHeight = sinon.stub(window.top.screen, 'height').get(function() {
           return testGetClientSizeParams.screenSize
         })
 
@@ -405,6 +410,11 @@ describe('OguryBidAdapter', function () {
 
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         expect(request.data.device.h).to.equal(testGetClientSizeParams.expectedSize);
+
+        stubbedClientHeight.restore();
+        stubbedInnerHeight.restore();
+        stubbedOuterHeight.restore();
+        stubbedHeight.restore();
       }
 
       it('should get documentElementClientHeight by default', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
New device infos sent with height and width in bidrequest
<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
