### PR TITLE
Kargo Bid Adapter: adding media type to bid response, supporting vastXml response

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -70,27 +70,42 @@ export const spec = {
     const bidResponses = [];
     for (let bidId in bids) {
       let adUnit = bids[bidId];
-      let meta;
+      let meta = {
+        mediaType: BANNER
+      };
+
       if (adUnit.metadata && adUnit.metadata.landingPageDomain) {
-        meta = {
-          clickUrl: adUnit.metadata.landingPageDomain[0],
-          advertiserDomains: adUnit.metadata.landingPageDomain
-        };
+        meta.clickUrl = adUnit.metadata.landingPageDomain[0];
+        meta.advertiserDomains = adUnit.metadata.landingPageDomain;
       }
-      bidResponses.push({
+
+      if (adUnit.mediaType && SUPPORTED_MEDIA_TYPES.includes(adUnit.mediaType)) {
+        meta.mediaType = adUnit.mediaType;
+      }
+
+      const bidResponse = {
         requestId: bidId,
         cpm: Number(adUnit.cpm),
         width: adUnit.width,
         height: adUnit.height,
-        ad: adUnit.adm,
         ttl: 300,
         creativeId: adUnit.id,
         dealId: adUnit.targetingCustom,
         netRevenue: true,
         currency: adUnit.currency || bidRequest.currency,
+        mediaType: meta.mediaType,
         meta: meta
-      });
+      };
+
+      if (meta.mediaType == VIDEO) {
+        bidResponse.vastXml = adUnit.adm;
+      } else {
+        bidResponse.ad = adUnit.adm;
+      }
+
+      bidResponses.push(bidResponse);
     }
+
     return bidResponses;
   },
   getUserSyncs: function(syncOptions, responses, gdprConsent, usPrivacy) {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -451,6 +451,17 @@ describe('kargo adapter tests', function () {
           adm: '<div id="4"></div>',
           width: 300,
           height: 250,
+          mediaType: 'banner',
+          metadata: {},
+          currency: 'EUR'
+        },
+        5: {
+          id: 'bar',
+          cpm: 2.5,
+          adm: '<VAST></VAST>',
+          width: 300,
+          height: 250,
+          mediaType: 'video',
           metadata: {},
           currency: 'EUR'
         }
@@ -476,6 +487,11 @@ describe('kargo adapter tests', function () {
           params: {
             placementId: 'bar'
           }
+        }, {
+          bidId: 5,
+          params: {
+            placementId: 'bar'
+          }
         }]
       });
       var expectation = [{
@@ -489,7 +505,10 @@ describe('kargo adapter tests', function () {
         dealId: undefined,
         netRevenue: true,
         currency: 'USD',
-        meta: undefined
+        mediaType: 'banner',
+        meta: {
+          mediaType: 'banner'
+        }
       }, {
         requestId: '2',
         cpm: 2.5,
@@ -501,7 +520,9 @@ describe('kargo adapter tests', function () {
         dealId: 'dmpmptest1234',
         netRevenue: true,
         currency: 'USD',
+        mediaType: 'banner',
         meta: {
+          mediaType: 'banner',
           clickUrl: 'https://foobar.com',
           advertiserDomains: ['https://foobar.com']
         }
@@ -516,7 +537,10 @@ describe('kargo adapter tests', function () {
         dealId: undefined,
         netRevenue: true,
         currency: 'USD',
-        meta: undefined
+        mediaType: 'banner',
+        meta: {
+          mediaType: 'banner'
+        }
       }, {
         requestId: '4',
         cpm: 2.5,
@@ -528,7 +552,25 @@ describe('kargo adapter tests', function () {
         dealId: undefined,
         netRevenue: true,
         currency: 'EUR',
-        meta: undefined
+        mediaType: 'banner',
+        meta: {
+          mediaType: 'banner'
+        }
+      }, {
+        requestId: '5',
+        cpm: 2.5,
+        width: 300,
+        height: 250,
+        vastXml: '<VAST></VAST>',
+        ttl: 300,
+        creativeId: 'bar',
+        dealId: undefined,
+        netRevenue: true,
+        currency: 'EUR',
+        mediaType: 'video',
+        meta: {
+          mediaType: 'video'
+        }
       }];
       expect(resp).to.deep.equal(expectation);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Bid Responses from Kargo will now optionally contain a media type. At the moment that media type will be either `banner` or `video`. After interpreting the Kargo response, the bid response will have a set `mediaType` and `meta.mediaType` field with a valid media type (defaulting to `banner` if media type is undefined or invalid).

The Bid Response will also set the returned ad markup under a `vastXml` field if the media type is `video`, and continuing to set the ad markup under `ad` otherwise.

- Maintainer: andy@kargo.com
