### PR TITLE
Automatad Bid Adapter: changes to ajax request options for bid requests

### DIFF
--- a/modules/automatadBidAdapter.js
+++ b/modules/automatadBidAdapter.js
@@ -141,6 +141,9 @@ export const spec = {
   },
 
   ajaxCall: function(endpoint, callback, data, options = {}) {
+    if (data) {
+      options.contentType = 'application/json'
+    }
     ajax(endpoint, callback, data, options)
   },
 

--- a/modules/automatadBidAdapter.js
+++ b/modules/automatadBidAdapter.js
@@ -74,7 +74,7 @@ export const spec = {
       data: payloadString,
       options: {
         contentType: 'application/json',
-        withCredentials: false,
+        withCredentials: true,
         crossOrigin: true,
       },
     }
@@ -114,7 +114,7 @@ export const spec = {
   },
   onTimeout: function(timeoutData) {
     const timeoutUrl = ENDPOINT_URL + '/timeout'
-    ajax(timeoutUrl, null, JSON.stringify(timeoutData))
+    spec.ajaxCall(timeoutUrl, null, JSON.stringify(timeoutData), {method: 'POST', withCredentials: true})
   },
   onBidWon: function(bid) {
     if (!bid.nurl) { return }
@@ -136,11 +136,12 @@ export const spec = {
       /\$\{AUCTION_ID\}/,
       bid.auctionId
     )
-    spec.ajaxCall(winUrl, null)
+    spec.ajaxCall(winUrl, null, null, {method: 'GET', withCredentials: true})
     return true
   },
-  ajaxCall: function(endpoint, data) {
-    ajax(endpoint, data)
+
+  ajaxCall: function(endpoint, callback, data, options = {}) {
+    ajax(endpoint, callback, data, options)
   },
 
 }

--- a/test/spec/modules/automatadBidAdapter_spec.js
+++ b/test/spec/modules/automatadBidAdapter_spec.js
@@ -96,6 +96,10 @@ describe('automatadBidAdapter', function () {
     let req = spec.buildRequests([ bidRequestRequiredParams ], { refererInfo: { } })
     let rdata
 
+    it('should have withCredentials option as true', function() {
+      expect(req.options.withCredentials).to.equal(true)
+    })
+
     it('should return request object', function () {
       expect(req).to.not.be.null
     })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Have added `withCredentials:true` in options for bid requests from Automatad adapter

- contact email of the adapter’s maintainer: tech@automatad.com
