### PR TITLE
Gdpr Enforcement module and sharedId/pubCommonId modules: vendor consent should not be enforced for first-party-id modules

### DIFF
--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -18,6 +18,8 @@ const TCF2 = {
   'purpose7': { id: 7, name: 'measurement' }
 }
 
+const VENDORLESS_MODULE_TYPES = ['fpid-module'];
+
 /*
   These rules would be used if `consentManagement.gdpr.rules` is undefined by the publisher.
 */
@@ -123,9 +125,10 @@ function getGvlidForAnalyticsAdapter(code) {
  * @param {Object} consentData - gdpr consent data
  * @param {string=} currentModule - Bidder code of the current module
  * @param {number=} gvlId - GVL ID for the module
+ * @param {string=} moduleType module type
  * @returns {boolean}
  */
-export function validateRules(rule, consentData, currentModule, gvlId) {
+export function validateRules(rule, consentData, currentModule, gvlId, moduleType) {
   const purposeId = TCF2[Object.keys(TCF2).filter(purposeName => TCF2[purposeName].name === rule.purpose)[0]].id;
 
   // return 'true' if vendor present in 'vendorExceptions'
@@ -138,12 +141,14 @@ export function validateRules(rule, consentData, currentModule, gvlId) {
   const vendorConsent = deepAccess(consentData, `vendorData.vendor.consents.${gvlId}`);
   const liTransparency = deepAccess(consentData, `vendorData.purpose.legitimateInterests.${purposeId}`);
 
+  const vendorlessModule = includes(VENDORLESS_MODULE_TYPES, moduleType);
+
   /*
     Since vendor exceptions have already been handled, the purpose as a whole is allowed if it's not being enforced
     or the user has consented. Similar with vendors.
   */
   const purposeAllowed = rule.enforcePurpose === false || purposeConsent === true;
-  const vendorAllowed = rule.enforceVendor === false || vendorConsent === true;
+  const vendorAllowed = rule.enforceVendor === false || vendorConsent === true || vendorlessModule === true;
 
   /*
     Few if any vendors should be declaring Legitimate Interest for Device Access (Purpose 1), but some are claiming
@@ -162,8 +167,9 @@ export function validateRules(rule, consentData, currentModule, gvlId) {
  * @param {Function} fn reference to original function (used by hook logic)
  * @param {Number=} gvlid gvlid of the module
  * @param {string=} moduleName name of the module
+ * @param {string=} moduleType module type
  */
-export function deviceAccessHook(fn, gvlid, moduleName, result) {
+export function deviceAccessHook(fn, gvlid, moduleName, moduleType, result) {
   result = Object.assign({}, {
     hasEnforcementHook: true
   });
@@ -183,7 +189,7 @@ export function deviceAccessHook(fn, gvlid, moduleName, result) {
           gvlid = getGvlid(moduleName) || gvlid;
         }
         const curModule = moduleName || curBidder;
-        let isAllowed = validateRules(purpose1Rule, consentData, curModule, gvlid);
+        let isAllowed = validateRules(purpose1Rule, consentData, curModule, gvlid, moduleType);
         if (isAllowed) {
           result.valid = true;
           fn.call(this, gvlid, moduleName, result);

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -176,7 +176,7 @@ export function deviceAccessHook(fn, gvlid, moduleName, moduleType, result) {
   if (!hasDeviceAccess()) {
     logWarn('Device access is disabled by Publisher');
     result.valid = false;
-    fn.call(this, gvlid, moduleName, result);
+    fn.call(this, gvlid, moduleName, moduleType, result);
   } else {
     const consentData = gdprDataHandler.getConsentData();
     if (consentData && consentData.gdprApplies) {
@@ -192,21 +192,21 @@ export function deviceAccessHook(fn, gvlid, moduleName, moduleType, result) {
         let isAllowed = validateRules(purpose1Rule, consentData, curModule, gvlid, moduleType);
         if (isAllowed) {
           result.valid = true;
-          fn.call(this, gvlid, moduleName, result);
+          fn.call(this, gvlid, moduleName, moduleType, result);
         } else {
           curModule && logWarn(`TCF2 denied device access for ${curModule}`);
           result.valid = false;
           storageBlocked.push(curModule);
-          fn.call(this, gvlid, moduleName, result);
+          fn.call(this, gvlid, moduleName, moduleType, result);
         }
       } else {
         // The module doesn't enforce TCF1.1 strings
         result.valid = true;
-        fn.call(this, gvlid, moduleName, result);
+        fn.call(this, gvlid, moduleName, moduleType, result);
       }
     } else {
       result.valid = true;
-      fn.call(this, gvlid, moduleName, result);
+      fn.call(this, gvlid, moduleName, moduleType, result);
     }
   }
 }

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -30,6 +30,7 @@ import {Renderer} from '../src/Renderer.js';
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
 const GLOBAL_VENDOR_ID = 10;
+const MODULE_TYPE = 'bid-adapter';
 const SECURE_BID_URL = 'https://htlb.casalemedia.com/cygnus';
 const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BANNER_ENDPOINT_VERSION = 7.2;
@@ -1086,7 +1087,7 @@ function localStorageHandler(data) {
       hasEnforcementHook: false,
       valid: hasDeviceAccess()
     };
-    validateStorageEnforcement(GLOBAL_VENDOR_ID, BIDDER_CODE, DEFAULT_ENFORCEMENT_SETTINGS, (permissions) => {
+    validateStorageEnforcement(GLOBAL_VENDOR_ID, BIDDER_CODE, MODULE_TYPE, DEFAULT_ENFORCEMENT_SETTINGS, (permissions) => {
       if (permissions.valid) {
         storeErrorEventData(data);
       }

--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -9,7 +9,8 @@ import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
 
-const storage = getStorageManager();
+const MODULE_TYPE = 'fpid-module';
+const storage = getStorageManager({moduleType: MODULE_TYPE});
 
 const ID_NAME = '_pubcid';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -5,9 +5,9 @@
  * @requires module:modules/userId
  */
 
-import { parseUrl, buildUrl, triggerPixel, logInfo, hasDeviceAccess, generateUUID } from '../src/utils.js';
+import {buildUrl, generateUUID, hasDeviceAccess, logInfo, parseUrl, triggerPixel} from '../src/utils.js';
 import {submodule} from '../src/hook.js';
-import { coppaDataHandler } from '../src/adapterManager.js';
+import {coppaDataHandler} from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
 const MODULE_TYPE = 'fpid-module';
@@ -74,11 +74,6 @@ export const sharedIdSystemSubmodule = {
    */
   name: 'sharedId',
   aliasName: 'pubCommonId',
-  /**
-   * Vendor id of prebid
-   * @type {Number}
-   */
-  gvlid: GVLID,
 
   /**
    * decode the stored id value for passing to bid requests
@@ -93,8 +88,7 @@ export const sharedIdSystemSubmodule = {
       return undefined;
     }
     logInfo(' Decoded value PubCommonId ' + value);
-    const idObj = {'pubcid': value};
-    return idObj;
+    return {'pubcid': value};
   },
   /**
    * performs action to obtain id

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -11,7 +11,8 @@ import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
 const GVLID = 887;
-export const storage = getStorageManager({gvlid: GVLID, moduleName: 'pubCommonId'});
+const MODULE_TYPE = 'fpid-module';
+export const storage = getStorageManager({gvlid: GVLID, moduleName: 'pubCommonId', moduleType: MODULE_TYPE});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -10,9 +10,8 @@ import {submodule} from '../src/hook.js';
 import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
-const GVLID = 887;
 const MODULE_TYPE = 'fpid-module';
-export const storage = getStorageManager({gvlid: GVLID, moduleName: 'pubCommonId', moduleType: MODULE_TYPE});
+export const storage = getStorageManager({moduleName: 'pubCommonId', moduleType: MODULE_TYPE});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -48,7 +48,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
       let hookDetails = {
         hasEnforcementHook: false
       }
-      validateStorageEnforcement(gvlid, bidderCode || moduleName, hookDetails, function(result) {
+      validateStorageEnforcement(gvlid, bidderCode || moduleName, moduleType, hookDetails, function(result) {
         if (result && result.hasEnforcementHook) {
           value = cb(result);
         } else {

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -303,7 +303,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
 /**
  * This hook validates the storage enforcement if gdprEnforcement module is included
  */
-export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, hookDetails, callback) {
+export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, moduleType, hookDetails, callback) {
   callback(hookDetails);
 }, 'validateStorageEnforcement');
 
@@ -322,12 +322,13 @@ export function getCoreStorageManager(moduleName) {
  * @param {Number=} gvlid? Vendor id - required for proper GDPR integration
  * @param {string=} bidderCode? - required for bid adapters
  * @param {string=} moduleName? module name
+ * @param {string=} moduleType? module type
  */
-export function getStorageManager({gvlid, moduleName, bidderCode} = {}) {
+export function getStorageManager({gvlid, moduleName, bidderCode, moduleType} = {}) {
   if (arguments.length > 1 || (arguments.length > 0 && !isPlainObject(arguments[0]))) {
     throw new Error('Invalid invocation for getStorageManager')
   }
-  return newStorageManager({gvlid, moduleName, bidderCode});
+  return newStorageManager({gvlid, moduleName, bidderCode, moduleType});
 }
 
 export function resetData() {

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -199,6 +199,27 @@ describe('gdpr enforcement', function () {
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
+    it('should not check consent for vendors when first party id module', function () {
+      adapterManagerStub.withArgs('pubCommonId').returns(getBidderSpec(1));
+      setEnforcementConfig({
+        gdpr: {
+          rules: [{
+            purpose: 'storage',
+            enforcePurpose: true,
+            enforceVendor: true,
+          }]
+        }
+      });
+      let consentData = {}
+      consentData.vendorData = staticConfig.consentData.getTCData;
+      consentData.gdprApplies = true;
+      consentData.apiVersion = 2;
+      gdprDataHandlerStub.returns(consentData);
+
+      deviceAccessHook(nextFnSpy, 1, 'pubCommonId', 'fpid-module');
+      expect(logWarnSpy.callCount).to.equal(0);
+    });
+
     it('should allow device access when gdprApplies is false and hasDeviceAccess flag is true', function () {
       adapterManagerStub.withArgs('appnexus').returns(getBidderSpec(1));
       setEnforcementConfig({

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -149,7 +149,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: false
       }
-      sinon.assert.calledWith(nextFnSpy, undefined, undefined, result);
+      sinon.assert.calledWith(nextFnSpy, undefined, undefined, undefined, result);
     });
 
     it('should only check for consent for vendor exceptions when enforcePurpose and enforceVendor are false', function () {
@@ -270,7 +270,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 1, 'appnexus', result);
+      sinon.assert.calledWith(nextFnSpy, 1, 'appnexus', undefined, result);
     });
 
     it('should use gvlMapping set by publisher', function () {
@@ -301,7 +301,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', result);
+      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', undefined, result);
       config.resetConfig();
     });
 
@@ -336,7 +336,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', result);
+      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', undefined, result);
       config.resetConfig();
       curBidderStub.restore();
     });


### PR DESCRIPTION
…

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Fix for https://github.com/prebid/Prebid.js/issues/8161 issue.
Added additional check in the gdprEnforment module: if the module type is `fpid-module`, then skip vendor allowed check 
