### PR TITLE
Datablocks bid adapter: do not send metrics during tests

### DIFF
--- a/test/spec/modules/datablocksBidAdapter_spec.js
+++ b/test/spec/modules/datablocksBidAdapter_spec.js
@@ -305,6 +305,15 @@ let bid_request = {
 }
 
 describe('DatablocksAdapter', function() {
+  before(() => {
+    // stub out queue metric to avoid it polluting the global xhr mock during other tests
+    sinon.stub(spec, 'queue_metric').callsFake(() => null);
+  });
+
+  after(() => {
+    spec.queue_metric.restore();
+  });
+
   describe('All needed functions are available', function() {
     it(`isBidRequestValid is present and type function`, function () {
       expect(spec.isBidRequestValid).to.exist.and.to.be.a('function')
@@ -374,14 +383,6 @@ describe('DatablocksAdapter', function() {
     it('Should return true / array', function() {
       expect(spec.store_syncs([{id: 1, uid: 'test'}])).to.be.true;
       expect(spec.get_syncs()).to.be.a('object');
-    });
-  })
-
-  describe('queue / send metrics', function() {
-    it('Should return true', function() {
-      expect(spec.queue_metric({type: 'test'})).to.be.true;
-      expect(spec.queue_metric('string')).to.be.false;
-      expect(spec.send_metrics()).to.be.true;
     });
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
