### PR TITLE
Hadron analytics adapter: fix cross-origin exception on init

### DIFF
--- a/modules/hadronAnalyticsAdapter.js
+++ b/modules/hadronAnalyticsAdapter.js
@@ -4,6 +4,7 @@ import adapterManager from '../src/adapterManager.js';
 import * as utils from '../src/utils.js';
 import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
+import {getRefererInfo} from '../src/refererDetection.js';
 
 /**
  * hadronAnalyticsAdapter.js - Audigent Hadron Analytics Adapter
@@ -35,7 +36,10 @@ var pageView = {
   timezoneOffset: new Date().getTimezoneOffset(),
   language: window.navigator.language,
   vendor: window.navigator.vendor,
-  pageUrl: window.top.location.href,
+  pageUrl: (() => {
+    const ri = getRefererInfo();
+    return ri.canonicalUrl || ri.referer;
+  })(),
   screenWidth: x,
   screenHeight: y
 };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Remove access to window.top, which is causing prebid to throw an exception on load when cross-frame

## Other information

Tested in the cross-origin scenario through locally remapped hosts resolution - this seems to be the only offender of this type in 6.26.0

