### PR TITLE
Ftrack Id Module: remove configured url validation

### DIFF
--- a/modules/ftrackIdSystem.js
+++ b/modules/ftrackIdSystem.js
@@ -17,7 +17,6 @@ const VENDOR_ID = null;
 const LOCAL_STORAGE = 'html5';
 const FTRACK_STORAGE_NAME = 'ftrackId';
 const FTRACK_PRIVACY_STORAGE_NAME = `${FTRACK_STORAGE_NAME}_privacy`;
-const FTRACK_URL = 'https://d9.flashtalking.com/d9core';
 const storage = getStorageManager({gvlid: VENDOR_ID, moduleName: MODULE_NAME});
 
 let consentInfo = {
@@ -102,7 +101,7 @@ export const ftrackIdSubmodule = {
           }
         }
 
-        if (config.params && config.params.url && config.params.url === FTRACK_URL) {
+        if (config.params && config.params.url) {
           var ftrackScript = document.createElement('script');
           ftrackScript.setAttribute('src', config.params.url);
           window.document.body.appendChild(ftrackScript);
@@ -146,8 +145,8 @@ export const ftrackIdSubmodule = {
       utils.logWarn(LOG_PREFIX + 'config.storage.name recommended to be "' + FTRACK_STORAGE_NAME + '".');
     }
 
-    if (!config.hasOwnProperty('params') || !config.params.hasOwnProperty('url') || config.params.url !== FTRACK_URL) {
-      utils.logWarn(LOG_PREFIX + 'config.params.url is required for ftrack to run. Url should be "' + FTRACK_URL + '".');
+    if (!config.hasOwnProperty('params') || !config.params.hasOwnProperty('url')) {
+      utils.logWarn(LOG_PREFIX + 'config.params.url is required for ftrack to run.');
       return false;
     }
 

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -95,15 +95,7 @@ describe('FTRACK ID System', () => {
       delete configMock1.params.url;
 
       ftrackIdSubmodule.isConfigOk(configMock1);
-      expect(logWarnStub.args[0][0]).to.equal(`FTRACK - config.params.url is required for ftrack to run. Url should be "https://d9.flashtalking.com/d9core".`);
-    });
-
-    it(`should be rejected if 'storage.param.url' does not exist or is not 'https://d9.flashtalking.com/d9core'`, () => {
-      let configMock1 = JSON.parse(JSON.stringify(configMock));
-      configMock1.params.url = 'https://d9.NOT.flashtalking.com/d9core';
-
-      ftrackIdSubmodule.isConfigOk(configMock1);
-      expect(logWarnStub.args[0][0]).to.equal(`FTRACK - config.params.url is required for ftrack to run. Url should be "https://d9.flashtalking.com/d9core".`);
+      expect(logWarnStub.args[0][0]).to.equal(`FTRACK - config.params.url is required for ftrack to run.`);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Removing a check of a url string that in effect made the url not configurable

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:
- this change does not require a documentation change