### PR TITLE
Adriver ID system: fix spurious test failure

### DIFF
--- a/test/spec/modules/adriverIdSystem_spec.js
+++ b/test/spec/modules/adriverIdSystem_spec.js
@@ -67,12 +67,16 @@ describe('AdriverIdSystem', function () {
         let request = server.requests[0];
         request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ adrcid: response.adrcid }));
 
-        let now = new Date();
-        now.setTime(now.getTime() + 86400 * 1825 * 1000);
+        let expectedExpiration = new Date();
+        expectedExpiration.setTime(expectedExpiration.getTime() + 86400 * 1825 * 1000);
         const minimalDate = new Date(0).toString();
 
+        function dateStringFor(date, maxDeltaMs = 2000) {
+          return sinon.match((val) => Math.abs(date.getTime() - new Date(val).getTime()) <= maxDeltaMs)
+        }
+
         if (response.adrcid) {
-          expect(setCookieStub.calledWith('adrcid', response.adrcid, now.toUTCString())).to.be.true;
+          expect(setCookieStub.calledWith('adrcid', response.adrcid, dateStringFor(expectedExpiration))).to.be.true;
           expect(setLocalStorageStub.calledWith('adrcid', response.adrcid)).to.be.true;
         } else {
           expect(setCookieStub.calledWith('adrcid', '', minimalDate)).to.be.false;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a test case that would sometimes fail (when the expectation happened to run in the next millisecond compared to the SOT).

## Other information

Sample failure: https://app.circleci.com/pipelines/github/prebid/Prebid.js/11631/workflows/173e7d4f-bb0a-4d2a-b5c9-11e844073dcd/jobs/22462
