### PR TITLE
Inskin bid adapter: use loadExternalScript utility instead of appendC…

### DIFF
--- a/modules/inskinBidAdapter.js
+++ b/modules/inskinBidAdapter.js
@@ -1,4 +1,5 @@
 import { createTrackPixelHtml } from '../src/utils.js';
+import { loadExternalScript } from '../src/adloader.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'inskin';
@@ -211,9 +212,9 @@ export const spec = {
           bidPrice: bidsMap[e.data.bidId].price,
           serverResponse
         };
-        const script = document.createElement('script');
-        script.src = 'https://cdn.inskinad.com/isfe/publishercode/' + bidsMap[e.data.bidId].params.siteId + '/default.js?autoload&id=' + id;
-        document.getElementsByTagName('head')[0].appendChild(script);
+
+        const url = 'https://cdn.inskinad.com/isfe/publishercode/' + bidsMap[e.data.bidId].params.siteId + '/default.js?autoload&id=' + id;
+        loadExternalScript(url, BIDDER_CODE);
       });
     }
 

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -12,7 +12,8 @@ const _approvedLoadExternalJSList = [
   'brandmetrics',
   'justtag',
   'akamaidap',
-  'ftrackId'
+  'ftrackId',
+  'inskin'
 ]
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Use loadExternalScript utility instead of appendChild() to insert the ad tag. Fixes issue #8421 