### PR TITLE
Medianet Bidder Adpater: Sending no decode whole url options to true

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -27,10 +27,10 @@ window.mnet = window.mnet || {};
 window.mnet.queue = window.mnet.queue || [];
 
 mnData.urlData = {
-  domain: parseUrl(refererInfo.referer).hostname,
+  domain: parseUrl(refererInfo.referer, {noDecodeWholeURL: true}).hostname,
   page: refererInfo.referer,
   isTop: refererInfo.reachedTop
-}
+};
 
 $$PREBID_GLOBAL$$.medianetGlobals = $$PREBID_GLOBAL$$.medianetGlobals || {};
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

  Sending no decode whole url options to true, to avoid errors while decoding publisher url

--- 
- contact email of the adapter’s maintainer prebid-support@media.net
- [x] official adapter submission
