### PR TITLE
Adf adapter: avoid preflight request

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -232,9 +232,6 @@ export const spec = {
       method: 'POST',
       url: 'https://' + adxDomain + '/adx/openrtb',
       data: JSON.stringify(request),
-      options: {
-        contentType: 'application/json'
-      },
       bids: validBidRequests
     };
   },

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -75,7 +75,7 @@ describe('Adf adapter', function () {
 
       assert.equal(request.method, 'POST');
       assert.equal(request.url, 'https://10.8.57.207/adx/openrtb');
-      assert.deepEqual(request.options, {contentType: 'application/json'});
+      assert.equal(request.options, undefined);
       assert.ok(request.data);
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
Content-type `application/json` causes preflight requests, this adds additional latency.

- contact email of the adapter’s maintainer Scope.FL.Scripts@adform.com
- [x] official adapter submission

