### PR TITLE
Magnite GVL ID update (7.0 branch)

### DIFF
--- a/modules/slimcutBidAdapter.js
+++ b/modules/slimcutBidAdapter.js
@@ -9,8 +9,8 @@ const BIDDER_CODE = 'slimcut';
 const ENDPOINT_URL = 'https://sb.freeskreen.com/pbr';
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
-  aliases: [{ code: 'scm', gvlid: 52 }],
+  gvlid: 102,
+  aliases: [{ code: 'scm', gvlid: 102 }],
   supportedMediaTypes: ['video', 'banner'],
   /**
      * Determines whether or not the given bid request is valid.

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -11,7 +11,7 @@ export const GOOGLE_CONSENT = { consented_providers: ['3', '7', '11', '12', '15'
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
+  gvlid: 165,
   supportedMediaTypes: [VIDEO],
 
   /**

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -9,10 +9,10 @@ const EVENTS_ENDPOINT = `events.${DOMAIN}/diag`;
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 102,
+  gvlid: 202,
   aliases: [
-    { code: 'tremor', gvlid: 102 },
-    { code: 'tremorvideo', gvlid: 102 }
+    { code: 'tremor', gvlid: 202 },
+    { code: 'tremorvideo', gvlid: 202 }
   ],
   supportedMediaTypes: [VIDEO],
   /**

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -9,10 +9,10 @@ const EVENTS_ENDPOINT = `events.${DOMAIN}/diag`;
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
+  gvlid: 102,
   aliases: [
-    { code: 'tremor', gvlid: 52 },
-    { code: 'tremorvideo', gvlid: 52 }
+    { code: 'tremor', gvlid: 102 },
+    { code: 'tremorvideo', gvlid: 102 }
   ],
   supportedMediaTypes: [VIDEO],
   /**


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
At this point, the various Magnite exchanges are not in fact able to use the same GVL ID. 

## Other information
See the [IAB GVL vendors](https://vendor-list.consensu.org/v2/vendor-list.json) 52, 102, 165, and 202.
