### PR TITLE
 Media.net RTD module: use internal prebid method for loading external script

### DIFF
--- a/modules/medianetRtdProvider.js
+++ b/modules/medianetRtdProvider.js
@@ -1,4 +1,5 @@
-import {insertElement, isEmptyStr, isFn, isStr, logError, mergeDeep} from '../src/utils.js';
+import {isEmptyStr, isFn, isStr, logError, mergeDeep} from '../src/utils.js';
+import {loadExternalScript} from '../src/adloader.js';
 import {submodule} from '../src/hook.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 import {includes} from '../src/polyfill.js';
@@ -82,11 +83,8 @@ function executeCommand(command) {
 }
 
 function loadRtdScript(customerId) {
-  const script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.async = true;
-  script.src = getClientUrl(customerId, window.location.hostname);
-  insertElement(script, window.document, 'head');
+  const url = getClientUrl(customerId, window.location.hostname);
+  loadExternalScript(url, MODULE_NAME)
 }
 
 function getAdUnits(adUnits, adUnitCodes) {

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -14,7 +14,8 @@ const _approvedLoadExternalJSList = [
   'akamaidap',
   'ftrackId',
   'inskin',
-  'hadron'
+  'hadron',
+  'medianet'
 ]
 
 /**

--- a/test/spec/modules/medianetRtdProvider_spec.js
+++ b/test/spec/modules/medianetRtdProvider_spec.js
@@ -1,7 +1,6 @@
 import * as medianetRTD from '../../../modules/medianetRtdProvider.js';
 import * as sinon from 'sinon';
 import { assert } from 'chai';
-import * as utils from '../../../src/utils.js';
 
 let sandbox;
 let setDataSpy;
@@ -20,9 +19,6 @@ const conf = {
 describe('medianet realtime module', function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    const insertStub = sandbox.stub(utils, 'insertElement')
-    insertStub.withArgs(sinon.match.any, sinon.match.any, 'head')
-      .returns(() => void 0)
     window.mnjs = window.mnjs || {};
     window.mnjs.que = window.mnjs.que || [];
     window.mnjs.setData = setDataSpy = sandbox.spy();


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
using internal methods for loading external scripts in medianetRtdProvider as per #8421


---

- [x] official adapter submission
- contact email of the adapter’s maintainer: prebid-support@media.net