### PR TITLE
AdUp Technology bid adapter: add support for floor prices

### DIFF
--- a/modules/aduptechBidAdapter.js
+++ b/modules/aduptechBidAdapter.js
@@ -114,6 +114,30 @@ export const internal = {
   },
 
   /**
+   * Extracts the floor price params from given bidRequest
+   *
+   * @param {BidRequest} bidRequest
+   * @returns {undefined|float}
+   */
+  extractFloorPrice: (bidRequest) => {
+    let floorPrice;
+    if (bidRequest && bidRequest.params && bidRequest.params.floor) {
+      // if there is a manual floorPrice set
+      floorPrice = !isNaN(parseInt(bidRequest.params.floor)) ? bidRequest.params.floor : undefined;
+    }
+    if (typeof bidRequest.getFloor === 'function') {
+      // use prebid floor module
+      let floorInfo;
+      try {
+        floorInfo = bidRequest.getFloor();
+      } catch (e) {}
+      floorPrice = typeof floorInfo === 'object' && !isNaN(parseInt(floorInfo.floor)) ? floorInfo.floor : floorPrice;
+    }
+
+    return floorPrice;
+  },
+
+  /**
    * Group given array of bidRequests by params.publisher
    *
    * @param {BidRequest[]} bidRequests
@@ -246,6 +270,12 @@ export const spec = {
         const nativeConfig = internal.extractNativeConfig(bidRequest);
         if (nativeConfig) {
           bid.native = nativeConfig;
+        }
+
+        // add floor price
+        const floorPrice = internal.extractFloorPrice(bidRequest);
+        if (floorPrice) {
+          bid.floorPrice = floorPrice;
         }
 
         request.data.imp.push(bid);

--- a/test/spec/modules/aduptechBidAdapter_spec.js
+++ b/test/spec/modules/aduptechBidAdapter_spec.js
@@ -545,6 +545,71 @@ describe('AduptechBidAdapter', () => {
           }
         ]);
       });
+
+      it('should build a request with floorPrices', () => {
+        const bidderRequest = {
+          auctionId: 'auctionId123',
+          refererInfo: {
+            canonicalUrl: 'http://crazy.canonical.url',
+            referer: 'http://crazy.referer.url'
+          },
+          gdprConsent: {
+            consentString: 'consentString123',
+            gdprApplies: true
+          }
+        };
+
+        const getFloorResponse = {
+          currency: 'USD',
+          floor: '1.23'
+        };
+
+        const validBidRequests = [
+          {
+            bidId: 'bidId1',
+            adUnitCode: 'adUnitCode1',
+            transactionId: 'transactionId1',
+            mediaTypes: {
+              banner: {
+                sizes: [[100, 200], [300, 400]]
+              }
+            },
+            params: {
+              publisher: 'publisher1',
+              placement: 'placement1'
+            },
+            getFloor: () => {
+              return getFloorResponse
+            }
+          }
+        ];
+
+        expect(spec.buildRequests(validBidRequests, bidderRequest)).to.deep.equal([
+          {
+            url: internal.buildEndpointUrl(validBidRequests[0].params.publisher),
+            method: ENDPOINT_METHOD,
+            data: {
+              auctionId: bidderRequest.auctionId,
+              pageUrl: bidderRequest.refererInfo.canonicalUrl,
+              referrer: bidderRequest.refererInfo.referer,
+              gdpr: {
+                consentString: bidderRequest.gdprConsent.consentString,
+                consentRequired: bidderRequest.gdprConsent.gdprApplies
+              },
+              imp: [
+                {
+                  bidId: validBidRequests[0].bidId,
+                  transactionId: validBidRequests[0].transactionId,
+                  adUnitCode: validBidRequests[0].adUnitCode,
+                  params: validBidRequests[0].params,
+                  banner: validBidRequests[0].mediaTypes.banner,
+                  floorPrice: getFloorResponse.floor
+                }
+              ]
+            }
+          }
+        ]);
+      });
     });
 
     describe('interpretResponse', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
* added support for prebid floor module
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
var adUnits = [
   {
        code: "example1",
        mediaTypes: {
            banner: {
                sizes: [[300, 250], [300, 600]],
            }
        },
        bids: [{
            bidder: "aduptech",
            params: {
                publisher: "prebid",
                placement: "12345"
            }
        }]
   }
];
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/3816

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
