### PR TITLE
Synacormedia Bid Adapter: Add GPID and Prebid Ad Slot support

### DIFF
--- a/modules/slimcutBidAdapter.js
+++ b/modules/slimcutBidAdapter.js
@@ -9,8 +9,8 @@ const BIDDER_CODE = 'slimcut';
 const ENDPOINT_URL = 'https://sb.freeskreen.com/pbr';
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
-  aliases: [{ code: 'scm', gvlid: 52 }],
+  gvlid: 102,
+  aliases: [{ code: 'scm', gvlid: 102 }],
   supportedMediaTypes: ['video', 'banner'],
   /**
      * Determines whether or not the given bid request is valid.

--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -11,7 +11,7 @@ export const GOOGLE_CONSENT = { consented_providers: ['3', '7', '11', '12', '15'
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
+  gvlid: 165,
   supportedMediaTypes: [VIDEO],
 
   /**

--- a/modules/telariaBidAdapter.js
+++ b/modules/telariaBidAdapter.js
@@ -9,10 +9,10 @@ const EVENTS_ENDPOINT = `events.${DOMAIN}/diag`;
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 52,
+  gvlid: 202,
   aliases: [
-    { code: 'tremor', gvlid: 52 },
-    { code: 'tremorvideo', gvlid: 52 }
+    { code: 'tremor', gvlid: 202 },
+    { code: 'tremorvideo', gvlid: 202 }
   ],
   supportedMediaTypes: [VIDEO],
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This updates the synacormedia bid adapter to:
- pass bid ext section for GPID and Prebid Ad Slot support in request to ad server

## Other information
No documentation updates were needed for this change.