### PR TITLE
Add AudienceOne ID support and the parameters language, screen_size to yieldoneBidAdapter

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -68,6 +68,12 @@ export const spec = {
         payload.imuid = imuid;
       }
 
+      // DACID
+      const dacId = deepAccess(bidRequest, 'userId.dacId.id');
+      if (isStr(dacId) && !isEmpty(dacId)) {
+        payload.dac_id = dacId;
+      }
+
       return {
         method: 'GET',
         url: ENDPOINT_URL,

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -30,6 +30,8 @@ export const spec = {
       const transactionId = bidRequest.transactionId;
       const unitCode = bidRequest.adUnitCode;
       const timeout = config.getConfig('bidderTimeout');
+      const language = window.navigator.language;
+      const screenSize = window.screen.width + 'x' + window.screen.height;
       const payload = {
         v: 'hb1',
         p: placementId,
@@ -39,7 +41,9 @@ export const spec = {
         tid: transactionId,
         uc: unitCode,
         tmax: timeout,
-        t: 'i'
+        t: 'i',
+        language: language,
+        screen_size: screenSize
       };
 
       const mediaType = getMediaType(bidRequest);
@@ -72,6 +76,7 @@ export const spec = {
       const dacId = deepAccess(bidRequest, 'userId.dacId.id');
       if (isStr(dacId) && !isEmpty(dacId)) {
         payload.dac_id = dacId;
+        payload.fuuid = dacId;
       }
 
       return {

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -399,6 +399,39 @@ describe('yieldoneBidAdapter', function() {
         expect(request[0].data.imuid).to.equal('imuid_sample');
       });
     });
+
+    describe('DAC ID', function () {
+      it('dont send DAC ID if undefined', function () {
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+          },
+          {
+            params: {placementId: '1'},
+            userId: {},
+          },
+          {
+            params: {placementId: '2'},
+            userId: undefined,
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        expect(request[0].data).to.not.have.property('dac_id');
+        expect(request[1].data).to.not.have.property('dac_id');
+        expect(request[2].data).to.not.have.property('dac_id');
+      });
+
+      it('should send DAC ID if available', function () {
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+            userId: {dacId: {id: 'dacId_sample'}},
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        expect(request[0].data.dac_id).to.equal('dacId_sample');
+      });
+    });
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -419,6 +419,9 @@ describe('yieldoneBidAdapter', function() {
         expect(request[0].data).to.not.have.property('dac_id');
         expect(request[1].data).to.not.have.property('dac_id');
         expect(request[2].data).to.not.have.property('dac_id');
+        expect(request[0].data).to.not.have.property('fuuid');
+        expect(request[1].data).to.not.have.property('fuuid');
+        expect(request[2].data).to.not.have.property('fuuid');
       });
 
       it('should send DAC ID if available', function () {
@@ -430,6 +433,7 @@ describe('yieldoneBidAdapter', function() {
         ];
         const request = spec.buildRequests(bidRequests, bidderRequest);
         expect(request[0].data.dac_id).to.equal('dacId_sample');
+        expect(request[0].data.fuuid).to.equal('dacId_sample');
       });
     });
   });
@@ -446,7 +450,9 @@ describe('yieldoneBidAdapter', function() {
           'cb': 12892917383,
           'r': 'http%3A%2F%2Flocalhost%3A9876%2F%3Fid%3D74552836',
           'uid': '23beaa6af6cdde',
-          't': 'i'
+          't': 'i',
+          'language': 'ja',
+          'screen_size': '1440x900'
         }
       }
     ];
@@ -519,7 +525,9 @@ describe('yieldoneBidAdapter', function() {
           'cb': 12892917383,
           'r': 'http%3A%2F%2Flocalhost%3A9876%2F%3Fid%3D74552836',
           'uid': '23beaa6af6cdde',
-          't': 'i'
+          't': 'i',
+          'language': 'ja',
+          'screen_size': '1440x900'
         }
       }
     ];


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
YieldOne Bid Adapter: add AudienceOne ID support and the parameters language, screen_size

- contact email of the adapter’s maintainer
- [x] official adapter submission
- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
https://github.com/prebid/prebid.github.io/pull/3819

## Other information