### PR TITLE
AdxPremium analytics adapter: do not generate network activity after tests have completed

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -164,6 +164,12 @@ module.exports = function(codeCoverage, browserstack, watchMode, file) {
 
     reporters: ['mocha'],
 
+    client: {
+      mocha: {
+        timeout: 3000
+      }
+    },
+
     mochaReporter: {
       showDiff: true,
       output: 'minimal'

--- a/modules/adxpremiumAnalyticsAdapter.js
+++ b/modules/adxpremiumAnalyticsAdapter.js
@@ -232,6 +232,7 @@ function sendEventFallback() {
 }
 
 function sendEvent(completeObject) {
+  if (!adxpremiumAnalyticsAdapter.enabled) return;
   requestDelivered = true;
   try {
     let responseEvents = btoa(JSON.stringify(completeObject));

--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -34,16 +34,17 @@ const BUNDLE = 'bundle';
 var _sampled = true;
 
 export default function AnalyticsAdapter({ url, analyticsType, global, handler }) {
-  var _queue = [];
-  var _eventCount = 0;
-  var _enableCheck = true;
-  var _handlers;
+  const _queue = [];
+  let _eventCount = 0;
+  let _enableCheck = true;
+  let _handlers;
+  let _enabled = false;
 
   if (analyticsType === ENDPOINT || BUNDLE) {
     _emptyQueue();
   }
 
-  return {
+  return Object.defineProperties({
     track: _track,
     enqueue: _enqueue,
     enableAnalytics: _enable,
@@ -52,7 +53,11 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
     getGlobal: () => global,
     getHandler: () => handler,
     getUrl: () => url
-  };
+  }, {
+    enabled: {
+      get: () => _enabled
+    }
+  });
 
   function _track({ eventType, args }) {
     if (this.getAdapterType() === BUNDLE) {
@@ -140,6 +145,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
     this.enableAnalytics = function _enable() {
       return logMessage(`Analytics adapter for "${global}" already enabled, unnecessary call to \`enableAnalytics\`.`);
     };
+    _enabled = true;
   }
 
   function _disable() {
@@ -147,6 +153,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
       events.off(event, handler);
     });
     this.enableAnalytics = this._oldEnable ? this._oldEnable : _enable;
+    _enabled = false;
   }
 
   function _emptyQueue() {

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -37,6 +37,14 @@ FEATURE: Analytics Adapters API
     adapter.disableAnalytics();
   });
 
+  it('should track enable status in `enabled`', () => {
+    expect(adapter.enabled).to.equal(false);
+    adapter.enableAnalytics();
+    expect(adapter.enabled).to.equal(true);
+    adapter.disableAnalytics();
+    expect(adapter.enabled).to.equal(false);
+  })
+
   it(`SHOULD call the endpoint WHEN an event occurs that is to be tracked`, function () {
     const eventType = BID_REQUESTED;
     const args = { some: 'data' };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Update the adxpremium analytics adapter to not send queued events over the network if the adapter has been disabled by the time the queue is being processed. This should fix some spurious test failures like:

https://app.circleci.com/pipelines/github/prebid/Prebid.js/11695/workflows/73a3b5e6-a331-4246-b364-49a00552224e/jobs/22531
