### PR TITLE
Vidazoo bid adapter: fix spurious test failure

### DIFF
--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -322,7 +322,9 @@ describe('VidazooBidAdapter', function () {
   describe('unique deal id', function () {
     const key = 'myKey';
     let uniqueDealId;
-    uniqueDealId = getUniqueDealId(key);
+    beforeEach(() => {
+      uniqueDealId = getUniqueDealId(key, 0);
+    })
 
     it('should get current unique deal id', function (done) {
       // waiting some time so `now` will become past
@@ -333,9 +335,12 @@ describe('VidazooBidAdapter', function () {
       }, 200);
     });
 
-    it('should get new unique deal id on expiration', function () {
-      const current = getUniqueDealId(key, 100);
-      expect(current).to.not.be.equal(uniqueDealId);
+    it('should get new unique deal id on expiration', function (done) {
+      setTimeout(() => {
+        const current = getUniqueDealId(key, 100);
+        expect(current).to.not.be.equal(uniqueDealId);
+        done();
+      }, 200)
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a test that would fail when it happened to run 15 seconds or more after its `describe` block:

https://app.circleci.com/pipelines/github/prebid/Prebid.js/11680/workflows/59aa141d-5c2b-487f-b965-3bff6029b3c6/jobs/22515
