### PR TITLE
Cwire Bid Adapter: fix cwcreative parameter conversion

### DIFF
--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -11,6 +11,7 @@ import {
   getValue,
   isArray,
   isNumber,
+  isStr,
   logError,
   logWarn,
   parseSizesInput,
@@ -130,6 +131,11 @@ export const spec = {
   isBidRequestValid: function(bid) {
     bid.params = bid.params || {};
 
+    if (bid.params.cwcreative && !isStr(bid.params.cwcreative)) {
+      logError('cwcreative must be of type string!');
+      return false;
+    }
+
     if (!bid.params.placementId || !isNumber(bid.params.placementId)) {
       logError('placementId not provided or invalid');
       return false;
@@ -178,8 +184,8 @@ export const spec = {
 
     let refgroups = [];
 
-    const cwCreative = parseInt(getQueryVariable(CW_CREATIVE_QUERY), 10) || null;
-    const cwCreativeFromConfig = this.getFirstValueOrNull(slots, 'cwcreative');
+    const cwCreative = getQueryVariable(CW_CREATIVE_QUERY) || null;
+    const cwCreativeIdFromConfig = this.getFirstValueOrNull(slots, 'cwcreative');
     const refGroupsFromConfig = this.getFirstValueOrNull(slots, 'refgroups');
     const cwApiKeyFromConfig = this.getFirstValueOrNull(slots, 'cwapikey');
     const rgQuery = getQueryVariable(CW_GROUPS_QUERY);
@@ -199,7 +205,7 @@ export const spec = {
     const payload = {
       cwid: localStorageCWID,
       refgroups,
-      cwcreative: cwCreative || cwCreativeFromConfig,
+      cwcreative: cwCreative || cwCreativeIdFromConfig,
       slots: slots,
       cwapikey: cwApiKeyFromConfig,
       httpRef: referer || '',

--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -178,8 +178,8 @@ export const spec = {
 
     let refgroups = [];
 
-    const cwCreativeId = parseInt(getQueryVariable(CW_CREATIVE_QUERY), 10) || null;
-    const cwCreativeIdFromConfig = this.getFirstValueOrNull(slots, 'cwcreative');
+    const cwCreative = parseInt(getQueryVariable(CW_CREATIVE_QUERY), 10) || null;
+    const cwCreativeFromConfig = this.getFirstValueOrNull(slots, 'cwcreative');
     const refGroupsFromConfig = this.getFirstValueOrNull(slots, 'refgroups');
     const cwApiKeyFromConfig = this.getFirstValueOrNull(slots, 'cwapikey');
     const rgQuery = getQueryVariable(CW_GROUPS_QUERY);
@@ -199,7 +199,7 @@ export const spec = {
     const payload = {
       cwid: localStorageCWID,
       refgroups,
-      cwcreative: cwCreativeId || cwCreativeIdFromConfig,
+      cwcreative: cwCreative || cwCreativeFromConfig,
       slots: slots,
       cwapikey: cwApiKeyFromConfig,
       httpRef: referer || '',

--- a/modules/cwireBidAdapter.md
+++ b/modules/cwireBidAdapter.md
@@ -13,12 +13,12 @@ Connects to C-WIRE demand source to fetch bids.
 
 Below, the list of C-WIRE params and where they can be set.
 
-| Param name | Global config | AdUnit config | Type | Required |
-| ---------- | ------------- | ------------- | ---- | ---------|
+| Param name | Global config | AdUnit config | Type   | Required |
+| ---------- | ------------- | ------------- |--------| ---------|
 | pageId |  | x | number | YES |
 | placementId |  | x | number | YES |
 | refgroups | | x | string | NO |
-| cwcreative |  | x | integer | NO |
+| cwcreative |  | x | string | NO |
 | cwapikey | | x | string | NO |
 
 

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -131,7 +131,7 @@ describe('C-WIRE bid adapter', () => {
           }
         }
       }).withParams({
-        cwcreative: 54321,
+        cwcreative: '54321',
         cwapikey: 'xxx-xxx-yyy-zzz-uuid',
         refgroups: 'group_1',
       }).build();
@@ -144,7 +144,7 @@ describe('C-WIRE bid adapter', () => {
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.slots[0].sizes[0]).to.equal('1x1');
-      expect(requests.data.cwcreative).to.equal(54321);
+      expect(requests.data.cwcreative).to.equal('54321');
       expect(requests.data.cwapikey).to.equal('xxx-xxx-yyy-zzz-uuid');
       expect(requests.data.refgroups[0]).to.equal('group_1');
     });
@@ -159,7 +159,7 @@ describe('C-WIRE bid adapter', () => {
           }
         }
       }).withParams({
-        cwcreative: 1234,
+        cwcreative: '1234',
         cwapikey: 'api_key_5',
         refgroups: 'group_5',
       }).build();
@@ -171,7 +171,7 @@ describe('C-WIRE bid adapter', () => {
       expect(requests.data.slots.length).to.equal(2);
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.cwid).to.be.null;
-      expect(requests.data.cwcreative).to.equal(1234);
+      expect(requests.data.cwcreative).to.equal('1234');
       expect(requests.data.cwapikey).to.equal('api_key_5');
       expect(requests.data.refgroups[0]).to.equal('group_5');
     });
@@ -179,14 +179,14 @@ describe('C-WIRE bid adapter', () => {
     it('creates a valid request - read debug params from first bid, ignore second', function () {
       const bid01 = new BidRequestBuilder()
         .withParams({
-          cwcreative: 33,
+          cwcreative: '33',
           cwapikey: 'api_key_33',
           refgroups: 'group_33',
         }).build();
 
       const bid02 = new BidRequestBuilder()
         .withParams({
-          cwcreative: 1234,
+          cwcreative: '1234',
           cwapikey: 'api_key_5',
           refgroups: 'group_5',
         }).build();
@@ -198,7 +198,7 @@ describe('C-WIRE bid adapter', () => {
       expect(requests.data.slots.length).to.equal(2);
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.cwid).to.be.null;
-      expect(requests.data.cwcreative).to.equal(33);
+      expect(requests.data.cwcreative).to.equal('33');
       expect(requests.data.cwapikey).to.equal('api_key_33');
       expect(requests.data.refgroups[0]).to.equal('group_33');
     });
@@ -206,7 +206,7 @@ describe('C-WIRE bid adapter', () => {
     it('creates a valid request - read debug params from 3 different slots', function () {
       const bid01 = new BidRequestBuilder()
         .withParams({
-          cwcreative: 33,
+          cwcreative: '33',
         }).build();
 
       const bid02 = new BidRequestBuilder()
@@ -225,7 +225,7 @@ describe('C-WIRE bid adapter', () => {
       expect(requests.data.slots.length).to.equal(3);
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.cwid).to.be.null;
-      expect(requests.data.cwcreative).to.equal(33);
+      expect(requests.data.cwcreative).to.equal('33');
       expect(requests.data.cwapikey).to.equal('api_key_5');
       expect(requests.data.refgroups[0]).to.equal('group_5');
     });
@@ -244,7 +244,7 @@ describe('C-WIRE bid adapter', () => {
           }
         }
       }).withParams({
-        cwcreative: 54321,
+        cwcreative: '54321',
         cwapikey: 'xxx-xxx-yyy-zzz',
         refgroups: 'group_1',
       }).build();
@@ -257,7 +257,7 @@ describe('C-WIRE bid adapter', () => {
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.cwid).to.be.null;
       expect(requests.data.slots[0].sizes[0]).to.equal('1x1');
-      expect(requests.data.cwcreative).to.equal(654321);
+      expect(requests.data.cwcreative).to.equal('654321');
       expect(requests.data.cwapikey).to.equal('xxx-xxx-yyy-zzz');
       expect(requests.data.refgroups[0]).to.equal('group_2');
     });

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -120,6 +120,19 @@ describe('C-WIRE bid adapter', () => {
       bid01.params.pageId = '3320';
       expect(spec.isBidRequestValid(bid01)).to.equal(false);
     });
+
+    it('should fail if cwcreative of type number', function () {
+      const bid01 = new BidRequestBuilder().withParams().build();
+      delete bid01.params.cwcreative;
+      bid01.params.cwcreative = 3320;
+      expect(spec.isBidRequestValid(bid01)).to.equal(false);
+    });
+
+    it('should pass with valid cwcreative of type string', function () {
+      const bid01 = new BidRequestBuilder().withParams().build();
+      bid01.params.cwcreative = 'i-am-a-string';
+      expect(spec.isBidRequestValid(bid01)).to.equal(true);
+    });
   });
 
   describe('C-WIRE - buildRequests()', function () {


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
..

## Description of change
When passing `cwcreative` as a query parameter the adapter wrongly converts it to a number, whereas our endpoint expects a string.

Added unit tests to cover the change.
