### PR TITLE
Prebid core: fix logic detecting if prebid is already loaded

### DIFF
--- a/bundle-template.txt
+++ b/bundle-template.txt
@@ -2,14 +2,14 @@
 Updated: <%= (new Date()).toISOString().substring(0, 10) %>
 Modules: <%= modules %> */
 
-if (!<%= prebid.globalVarName %> || !<%= prebid.globalVarName %>.libLoaded) {
+if (!window.<%= prebid.globalVarName %> || !window.<%= prebid.globalVarName %>.libLoaded) {
  $$PREBID_SOURCE$$
  <% if(enable) {%>
    <%= prebid.globalVarName %>.processQueue();
  <% } %>
 } else {
  try {
-  if(<%= prebid.globalVarName %>.getConfig('debug')) {
+  if(window.<%= prebid.globalVarName %>.getConfig('debug')) {
     console.warn('Attempted to load a copy of Prebid.js that clashes with the existing \'<%= prebid.globalVarName %>\' instance. Load aborted.');
   }
  } catch (e) {}


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug introduced by https://github.com/prebid/Prebid.js/pull/8508#event-6769477833 - exceptinos when  `pbjs` is not defined by the time prebid is loaded.

