### PR TITLE
YahooSSP Bid Adapter: Extend banner mimes to include image/gif for display inventory (6.29.x)

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -239,7 +239,7 @@ function generateOpenRtbObject(bidderRequest, bid) {
       cur: [getFloorModuleData(bidderRequest).currency || deepAccess(bid, 'params.bidOverride.cur') || DEFAULT_CURRENCY],
       imp: [],
       site: {
-        page: deepAccess(bidderRequest, 'refererInfo.page'),
+        page: deepAccess(bidderRequest, 'refererInfo.canonicalUrl') || deepAccess(bidderRequest, 'refererInfo.referer')
       },
       device: {
         dnt: 0,
@@ -541,7 +541,7 @@ export const spec = {
     };
 
     const requestOptions = {
-      contentType: 'application/json',
+      contentType: 'text/plain',
       customHeaders: {
         'x-openrtb-version': '2.5'
       }

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -239,7 +239,7 @@ function generateOpenRtbObject(bidderRequest, bid) {
       cur: [getFloorModuleData(bidderRequest).currency || deepAccess(bid, 'params.bidOverride.cur') || DEFAULT_CURRENCY],
       imp: [],
       site: {
-        page: deepAccess(bidderRequest, 'refererInfo.referer'),
+        page: deepAccess(bidderRequest, 'refererInfo.page'),
       },
       device: {
         dnt: 0,
@@ -309,7 +309,7 @@ function appendImpObject(bid, openRtbObject) {
 
     if (bid.mediaTypes.banner && (typeof mediaTypeMode === 'undefined' || mediaTypeMode === BANNER || mediaTypeMode === '*')) {
       impObject.banner = {
-        mimes: bid.mediaTypes.banner.mimes || ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+        mimes: bid.mediaTypes.banner.mimes || ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
         format: transformSizes(bid.sizes)
       };
       if (bid.mediaTypes.banner.pos) {

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -80,7 +80,8 @@ let generateBidderRequest = (bidRequestArray, adUnitCode) => {
     bidderRequestId: '112f1c7c5d399a',
     bids: bidRequestArray,
     refererInfo: {
-      referer: 'https://serach-engine.com',
+      canonicalUrl: 'https://publisher-test.com',
+      referer: 'https://search-engine.com',
       page: 'https://publisher-test.com',
       reachedTop: true,
       isAmp: false,
@@ -827,7 +828,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const options = spec.buildRequests(validBidRequests, bidderRequest).options;
       expect(options).to.deep.equal(
         {
-          contentType: 'application/json',
+          contentType: 'text/plain',
           customHeaders: {
             'x-openrtb-version': '2.5'
           },

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -843,7 +843,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest).data;
       expect(data.site).to.deep.equal({
         id: bidderRequest.bids[0].params.dcn,
-        page: bidderRequest.refererInfo.page
+        page: bidderRequest.refererInfo.referer
       });
 
       expect(data.device).to.deep.equal({

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -843,7 +843,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest).data;
       expect(data.site).to.deep.equal({
         id: bidderRequest.bids[0].params.dcn,
-        page: bidderRequest.refererInfo.referer
+        page: bidderRequest.refererInfo.canonicalUrl
       });
 
       expect(data.device).to.deep.equal({

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -80,7 +80,8 @@ let generateBidderRequest = (bidRequestArray, adUnitCode) => {
     bidderRequestId: '112f1c7c5d399a',
     bids: bidRequestArray,
     refererInfo: {
-      referer: 'https://publisher-test.com',
+      referer: 'https://serach-engine.com',
+      page: 'https://publisher-test.com',
       reachedTop: true,
       isAmp: false,
       numIframes: 0,
@@ -841,7 +842,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest).data;
       expect(data.site).to.deep.equal({
         id: bidderRequest.bids[0].params.dcn,
-        page: bidderRequest.refererInfo.referer
+        page: bidderRequest.refererInfo.page
       });
 
       expect(data.device).to.deep.equal({
@@ -915,7 +916,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
       expect(data.imp[0].video).to.not.exist;
       expect(data.imp[0].banner).to.deep.equal({
-        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
         format: [{w: 300, h: 250}, {w: 300, h: 600}]
       });
     });
@@ -929,7 +930,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
       expect(data.imp[0].video).to.not.exist;
       expect(data.imp[0].banner).to.deep.equal({
-        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
         format: [{w: 300, h: 250}, {w: 300, h: 600}]
       });
     });
@@ -969,7 +970,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const { validBidRequests, bidderRequest } = generateBuildRequestMock({adUnitType: 'multi-format'});
       const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
       expect(data.imp[0].banner).to.deep.equal({
-        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
         format: [{w: 300, h: 250}, {w: 300, h: 600}]
       });
       expect(data.imp[0].video).to.deep.equal({
@@ -1042,7 +1043,7 @@ describe('YahooSSP Bid Adapter:', () => {
       response.forEach((obj) => {
         expect(obj.data.imp[0].video).to.not.exist
         expect(obj.data.imp[0].banner).to.deep.equal({
-          mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+          mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
           format: [{w: 300, h: 250}, {w: 300, h: 600}]
         });
       });
@@ -1118,7 +1119,7 @@ describe('YahooSSP Bid Adapter:', () => {
       const data1 = response[0].data;
       expect(data1.imp[0].video).to.not.exist;
       expect(data1.imp[0].banner).to.deep.equal({
-        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg'],
+        mimes: ['text/html', 'text/javascript', 'application/javascript', 'image/jpg', 'image/gif'],
         format: [{w: 300, h: 250}, {w: 300, h: 600}]
       });
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
- Extended banner mimes to include `image/gif` for display inventory
- Set XHR content type to text.plain to prevent preflight requests

- [x] official adapter submission
