### PR TITLE
Criteo Id System: add support for user sync pixels

### DIFF
--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -13,17 +13,18 @@ import { getStorageManager } from '../src/storageManager.js';
 
 const gvlid = 91;
 const bidderCode = 'criteo';
-export const storage = getStorageManager({gvlid: gvlid, moduleName: bidderCode});
+export const storage = getStorageManager({ gvlid: gvlid, moduleName: bidderCode });
 
 const bididStorageKey = 'cto_bidid';
 const bundleStorageKey = 'cto_bundle';
+const dnaBundleStorageKey = 'cto_dna_bundle';
 const cookiesMaxAge = 13 * 30 * 24 * 60 * 60 * 1000;
 
 const pastDateString = new Date(0).toString();
 const expirationString = new Date(timestamp() + cookiesMaxAge).toString();
 
-function extractProtocolHost (url, returnOnlyHost = false) {
-  const parsedUrl = parseUrl(url, {noDecodeWholeURL: true})
+function extractProtocolHost(url, returnOnlyHost = false) {
+  const parsedUrl = parseUrl(url, { noDecodeWholeURL: true })
   return returnOnlyHost
     ? `${parsedUrl.hostname}`
     : `${parsedUrl.protocol}://${parsedUrl.hostname}${parsedUrl.port ? ':' + parsedUrl.port : ''}/`;
@@ -70,15 +71,17 @@ function deleteFromAllStorages(key, hostname) {
 function getCriteoDataFromAllStorages() {
   return {
     bundle: getFromAllStorages(bundleStorageKey),
+    dnaBundle: getFromAllStorages(dnaBundleStorageKey),
     bidId: getFromAllStorages(bididStorageKey),
   }
 }
 
-function buildCriteoUsersyncUrl(topUrl, domain, bundle, areCookiesWriteable, isLocalStorageWritable, isPublishertagPresent, gdprString) {
+function buildCriteoUsersyncUrl(topUrl, domain, bundle, dnaBundle, areCookiesWriteable, isLocalStorageWritable, isPublishertagPresent, gdprString) {
   const url = 'https://gum.criteo.com/sid/json?origin=prebid' +
     `${topUrl ? '&topUrl=' + encodeURIComponent(topUrl) : ''}` +
     `${domain ? '&domain=' + encodeURIComponent(domain) : ''}` +
     `${bundle ? '&bundle=' + encodeURIComponent(bundle) : ''}` +
+    `${dnaBundle ? '&info=' + encodeURIComponent(dnaBundle) : ''}` +
     `${gdprString ? '&gdprString=' + encodeURIComponent(gdprString) : ''}` +
     `${areCookiesWriteable ? '&cw=1' : ''}` +
     `${isPublishertagPresent ? '&pbt=1' : ''}` +
@@ -98,6 +101,7 @@ function callCriteoUserSync(parsedCriteoData, gdprString, callback) {
     topUrl,
     domain,
     parsedCriteoData.bundle,
+    parsedCriteoData.dnaBundle,
     cw,
     lsw,
     isPublishertagPresent,

--- a/test/spec/modules/criteoIdSystem_spec.js
+++ b/test/spec/modules/criteoIdSystem_spec.js
@@ -1,6 +1,6 @@
 import { criteoIdSubmodule, storage } from 'modules/criteoIdSystem.js';
 import * as utils from 'src/utils.js';
-import {server} from '../../mocks/xhr';
+import { server } from '../../mocks/xhr';
 
 const pastDateString = new Date(0).toString()
 
@@ -25,7 +25,7 @@ describe('CriteoId module', function () {
     setLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
     removeFromLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage');
     timeStampStub = sinon.stub(utils, 'timestamp').returns(nowTimestamp);
-    parseUrlStub = sinon.stub(utils, 'parseUrl').returns({protocol: 'https', hostname: 'testdev.com'})
+    parseUrlStub = sinon.stub(utils, 'parseUrl').returns({ protocol: 'https', hostname: 'testdev.com' })
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
     done();
   });
@@ -64,20 +64,21 @@ describe('CriteoId module', function () {
 
   it('should call user sync url with the right params', function () {
     getCookieStub.withArgs('cto_bundle').returns('bundle');
+    getCookieStub.withArgs('cto_dna_bundle').returns('info');
     window.criteo_pubtag = {}
 
     let callBackSpy = sinon.spy();
     let result = criteoIdSubmodule.getId();
     result.callback(callBackSpy);
 
-    const expectedUrl = `https://gum.criteo.com/sid/json?origin=prebid&topUrl=https%3A%2F%2Ftestdev.com%2F&domain=testdev.com&bundle=bundle&cw=1&pbt=1&lsw=1`;
+    const expectedUrl = `https://gum.criteo.com/sid/json?origin=prebid&topUrl=https%3A%2F%2Ftestdev.com%2F&domain=testdev.com&bundle=bundle&info=info&cw=1&pbt=1&lsw=1`;
 
     let request = server.requests[0];
     expect(request.url).to.be.eq(expectedUrl);
 
     request.respond(
       200,
-      {'Content-Type': 'application/json'},
+      { 'Content-Type': 'application/json' },
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
@@ -107,7 +108,7 @@ describe('CriteoId module', function () {
       let request = server.requests[0];
       request.respond(
         200,
-        {'Content-Type': 'application/json'},
+        { 'Content-Type': 'application/json' },
         JSON.stringify(response)
       );
 
@@ -156,7 +157,7 @@ describe('CriteoId module', function () {
 
     request.respond(
       200,
-      {'Content-Type': 'application/json'},
+      { 'Content-Type': 'application/json' },
       JSON.stringify({})
     );
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Changes in the CriteoIdSystem:
- Parse pixel list from user sync response
- Trigger user sync pixels
- Save pixels' response if necessary

## Contacts
- Tachfine El Belky (t.elbelky@criteo.com)
