### PR TITLE
Parrable ID system: fix spurious test failures

### DIFF
--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -96,6 +96,12 @@ function decodeBase64UrlSafe(encBase64) {
 }
 
 describe('Parrable ID System', function() {
+  after(() => {
+    // reset ID system to avoid delayed callbacks in other tests
+    config.resetConfig();
+    init(config);
+  });
+
   describe('parrableIdSystem.getId()', function() {
     describe('response callback function', function() {
       let logErrorStub;


### PR DESCRIPTION

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Update the Parrable test suite to unset userId configuration at the end, so that `syncDelay` callbacks do not run during other tests.

## Other information

Sample failure: https://app.circleci.com/pipelines/github/prebid/Prebid.js/11855/workflows/5ee83e65-7569-4cfb-9983-802b3cd5f3ee/jobs/22725