### PR TITLE
33accross Bid Adapter: add 33across_mgni alias

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -71,7 +71,7 @@ function isBidRequestValid(bid) {
 }
 
 function _validateBasic(bid) {
-  if (!bid.params) {
+  if ((bid.bidder !== BIDDER_CODE && BIDDER_ALIASES.includes(bid.bidder) === false) || !bid.params) {
     return false;
   }
 

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -16,6 +16,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 // **************************** UTILS *************************** //
 const BIDDER_CODE = '33across';
+const BIDDER_ALIASES = ['33across_mgni']; //short code
 const END_POINT = 'https://ssc.33across.com/api/v1/hb';
 const SYNC_ENDPOINT = 'https://ssc-cms.33across.com/ps/?m=xch&rt=html&ru=deb';
 
@@ -70,7 +71,7 @@ function isBidRequestValid(bid) {
 }
 
 function _validateBasic(bid) {
-  if (bid.bidder !== BIDDER_CODE || typeof bid.params === 'undefined') {
+  if (!bid.params) {
     return false;
   }
 
@@ -735,6 +736,7 @@ export const spec = {
   NON_MEASURABLE,
 
   code: BIDDER_CODE,
+  aliases: BIDDER_ALIASES,
   supportedMediaTypes: [ BANNER, VIDEO ],
   gvlid: GVLID,
   isBidRequestValid,

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -16,7 +16,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 // **************************** UTILS *************************** //
 const BIDDER_CODE = '33across';
-const BIDDER_ALIASES = ['33across_mgni']; //short code
+const BIDDER_ALIASES = ['33across_mgni'];
 const END_POINT = 'https://ssc.33across.com/api/v1/hb';
 const SYNC_ENDPOINT = 'https://ssc-cms.33across.com/ps/?m=xch&rt=html&ru=deb';
 

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -71,7 +71,9 @@ function isBidRequestValid(bid) {
 }
 
 function _validateBasic(bid) {
-  if ((bid.bidder !== BIDDER_CODE && BIDDER_ALIASES.includes(bid.bidder) === false) || !bid.params) {
+  const invalidBidderName = bid.bidder !== BIDDER_CODE && !BIDDER_ALIASES.includes(bid.bidder);
+
+  if (invalidBidderName || !bid.params) {
     return false;
   }
 

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -387,6 +387,46 @@ describe('33acrossBidAdapter:', function () {
 
   describe('isBidRequestValid:', function() {
     context('basic validation', function() {
+      it('returns true for valid bidder name values', function() {
+        const validBidderName = [
+          '33across',
+          '33across_mgni'
+        ];
+
+        validBidderName.forEach((bidderName) => {
+          const bid = {
+            bidder: bidderName,
+            params: {
+              siteId: 'sample33xGUID123456789'
+            }
+          };
+
+          expect(spec.isBidRequestValid(bid)).to.be.true;
+        });
+      });
+
+      it('returns false for invalid bidder name values', function() {
+        const invalidBidderName = [
+          undefined,
+          '33',
+          '33x',
+          'thirtythree',
+          ''
+        ];
+
+        invalidBidderName.forEach((bidderName) => {
+          const bid = {
+            bidder: bidderName,
+            params: {
+              siteId: 'sample33xGUID123456789'
+            }
+          };
+
+          expect(spec.isBidRequestValid(bid)).to.be.false;
+        });
+      });
+
+
       it('returns true for valid guid values', function() {
         // NOTE: We ignore whitespace at the start and end since
         // in our experience these are common typos

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -426,7 +426,6 @@ describe('33acrossBidAdapter:', function () {
         });
       });
 
-
       it('returns true for valid guid values', function() {
         // NOTE: We ignore whitespace at the start and end since
         // in our experience these are common typos


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
-Added alias '33across_mgni'
-Added validation for alias '33across_mgni'
-Updated tests for biddername validation

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
headerbidding@33across.com

- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
