### PR TITLE
Debugging module: multiple bugfixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ function makeDevpackPkg() {
     mode: 'development'
   })
 
-  const babelConfig = require('./babelConfig.js')({prebidDistUrlBase: '/build/dev/'});
+  const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures(), prebidDistUrlBase: argv.distUrlBase || '/build/dev/'});
 
   // update babel config to set local dist url
   cloned.module.rules

--- a/modules/debugging/bidInterceptor.js
+++ b/modules/debugging/bidInterceptor.js
@@ -122,7 +122,7 @@ Object.assign(BidInterceptor.prototype, {
       replFn = () => ({});
     } else {
       replFn = ({args, ref = replDef}) => {
-        const result = {};
+        const result = Array.isArray(ref) ? [] : {};
         Object.entries(ref).forEach(([key, val]) => {
           if (typeof val === 'function') {
             result[key] = val(...args);

--- a/modules/debugging/index.js
+++ b/modules/debugging/index.js
@@ -3,5 +3,6 @@ import {hook} from '../../src/hook.js';
 import {install} from './debugging.js';
 import {prefixLog} from '../../src/utils.js';
 import {createBid} from '../../src/bidfactory.js';
+import {DEBUG_KEY} from '../../src/debugging.js';
 
-install({config, hook, createBid, logger: prefixLog('DEBUG:')});
+install({DEBUG_KEY, config, hook, createBid, logger: prefixLog('DEBUG:')});

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -19,7 +19,8 @@ function featureMap(disable = []) {
 
 function getNpmVersion(version) {
   try {
-    return /^(.*?)(-pre)?$/.exec(version)[1];
+    // only use "real" versions (that is, not the -pre ones, they won't be on jsDelivr)
+    return /^([\d.]+)$/.exec(version)[1];
   } catch (e) {
     return 'latest';
   }

--- a/test/spec/modules/debugging_mod_spec.js
+++ b/test/spec/modules/debugging_mod_spec.js
@@ -134,6 +134,13 @@ describe('bid interceptor', () => {
             expect(result).to.include.keys(REQUIRED_KEYS);
             expect(result.outer.inner).to.eql({key: 'value'});
           });
+
+          it('should respect array vs object definitions', () => {
+            const result = matchingRule({replace: {item: [replDef]}}).replace({});
+            expect(result.item).to.be.an('array');
+            expect(result.item.length).to.equal(1);
+            expect(result.item[0]).to.eql({key: 'value'});
+          });
         });
       });
 

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -5,7 +5,7 @@ var webpack = require('webpack');
 var helpers = require('./gulpHelpers.js');
 var { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 var argv = require('yargs').argv;
-const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures()});
+const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures(), prebidDistUrlBase: argv.distUrlBase});
 
 var plugins = [
   new webpack.EnvironmentPlugin({'LiveConnectMode': null}),


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

- Fix a bug where debugging configuration would only be retrieved from session storage if the debugging module was _not_ included in the build
- Fix a bug where building a "-pre" version of Prebid would cause it to fetch a version of 'debugging-standalone.js' that does not exist yet
- Fix a bug where arrays in the `then` portion of a rule  would be converted to objects 
- Add a `--dist-url-base` CLI option to allow overriding of the debugging-standalone URL

