### PR TITLE
Prebid core: do not use `document.write` for rendering HTML

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -23,6 +23,7 @@ import { emitAdRenderSucceeded, emitAdRenderFail } from './adRendering.js';
 import {gdprDataHandler, getS2SBidderSet, uspDataHandler, default as adapterManager} from './adapterManager.js';
 import CONSTANTS from './constants.json';
 import * as events from './events.js'
+import {appendHTML} from './utils/writeHTML.js';
 
 const $$PREBID_GLOBAL$$ = getGlobal();
 const { triggerUserSyncs } = userSync;
@@ -495,8 +496,7 @@ $$PREBID_GLOBAL$$.renderAd = hook('async', function (doc, id, options) {
             const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
             emitAdRenderFail({reason: PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid, id});
           } else if (ad) {
-            doc.write(ad);
-            doc.close();
+            appendHTML(doc.body, ad);
             setRenderSize(doc, width, height);
             reinjectNodeIfRemoved(creativeComment, doc, 'html');
             callBurl(bid);

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import { config } from './config.js';
 import clone from 'just-clone';
 import {find, includes} from './polyfill.js';
 import CONSTANTS from './constants.json';
+import {replaceHTML} from './utils/writeHTML.js';
 export { default as deepAccess } from 'dlv/index.js';
 export { default as deepSetValue } from 'dset';
 
@@ -581,9 +582,7 @@ export function insertHtmlIntoIframe(htmlCode) {
 
   internal.insertElement(iframe, document, 'body');
 
-  iframe.contentWindow.document.open();
-  iframe.contentWindow.document.write(htmlCode);
-  iframe.contentWindow.document.close();
+  replaceHTML(iframe.contentDocument.body, htmlCode);
 }
 
 /**

--- a/src/utils/writeHTML.js
+++ b/src/utils/writeHTML.js
@@ -1,0 +1,44 @@
+/**
+ * Replace the contents of `element` with the given `html` string, running all scripts contained within it.
+ *
+ * @param element the container element. Must be in the DOM.
+ * @param html HTML string
+ */
+export function replaceHTML(element, html) {
+  element.innerHTML = html;
+  rebuildScriptsIn(element);
+}
+
+/**
+ * Append some html to the contents of `element`, running all scripts contained within it.
+ *
+ * @param element the container element to append to. Must be in the DOM.
+ * @param html HTML string
+ */
+export function appendHTML(element, html) {
+  const container = element.ownerDocument.createElement('template');
+  container.innerHTML = html;
+
+  Array.from(container.content.childNodes).forEach((node) => {
+    if (node?.tagName === 'SCRIPT') {
+      node = cloneScript(node);
+    }
+    if (typeof node?.querySelectorAll === 'function') {
+      rebuildScriptsIn(node);
+    }
+    element.appendChild(node);
+  });
+}
+
+function cloneScript(node) {
+  const repl = node.ownerDocument.createElement('script');
+  Array.from(node.attributes).forEach((attr) => repl.setAttribute(attr.name, attr.value));
+  repl.appendChild(node.ownerDocument.createTextNode(node.innerHTML));
+  return repl;
+}
+
+function rebuildScriptsIn(container) {
+  container.querySelectorAll('script').forEach((node) => {
+    node.parentNode.replaceChild(cloneScript(node), node);
+  });
+}

--- a/test/spec/unit/utils/writeHTML_spec.js
+++ b/test/spec/unit/utils/writeHTML_spec.js
@@ -1,0 +1,79 @@
+import {replaceHTML, appendHTML} from '../../../../src/utils/writeHTML.js';
+
+describe('HTML write utils', () => {
+  let iframe, elem, doc;
+  beforeEach(() => {
+    iframe = document.createElement('iframe');
+    document.documentElement.appendChild(iframe);
+    doc = iframe.contentDocument;
+    elem = doc.body;
+  });
+
+  afterEach(() => {
+    iframe.remove();
+  });
+
+  Object.entries({
+    'replaceHTML': replaceHTML,
+    'appendHTML': appendHTML
+  }).forEach(([t, manipulator]) => {
+    describe(t, () => {
+      Object.entries({
+        'script content': '<script>window.__scriptRan = true</script>',
+        'script source': '<script src="data:application/javascript;charset=utf-8;base64,d2luZG93Ll9fc2NyaXB0UmFuID0gdHJ1ZTs="></script>' // same script as above, encoded in a data uri
+      }).forEach(([typ, script]) => {
+        Object.entries({
+          'at top-level': script,
+          'when nested': `<div><p>${script}</p></div>`,
+          'in head': `<html><head>${script}</head></html>`,
+        }).forEach(([t, html]) => {
+          it(`should run ${typ} ${t}`, (done) => {
+            manipulator(elem, html);
+            setTimeout(() => {
+              expect(iframe.contentWindow.__scriptRan).to.be.true;
+              done();
+            });
+          });
+        });
+      })
+
+      it('should not fail on malformed html', () => {
+        manipulator(elem, '<div id="t">test</p>');
+        expect(doc.querySelector('#t').childNodes[0].textContent).to.eql('test');
+      });
+
+      it('should accept a complete html page', () => {
+        manipulator(elem, `<!DOCTYPE html>
+        <html>
+            <head>
+                <meta name="keywords" data-value="test" />
+            </head>
+            <body>
+                <p id="content">content</p>
+            </body>
+        </html>`);
+        expect(doc.querySelector('meta').dataset.value).to.equal('test');
+        expect(doc.querySelector('#content').innerHTML).to.equal('content');
+      });
+    })
+  });
+
+  [
+    {
+      t: 'appendHTML should not touch',
+      manipulator: appendHTML,
+      expected: ['preexisting', 'added']
+    },
+    {
+      t: 'replaceHTML should replace',
+      manipulator: replaceHTML,
+      expected: ['added']
+    }
+  ].forEach(({t, manipulator, expected}) => {
+    it(`${t} existing contents`, () => {
+      elem.innerHTML = '<p id="preexisting"></p>';
+      manipulator(elem, '<p id="added"></p>');
+      expect(Array.from(doc.querySelectorAll('p')).map((n) => n.id)).to.eql(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change

Replace core's usage of `document.write` with `Element.innerHTML`, with some additional logic to run scripts.

According to:

https://www.w3.org/TR/2008/WD-html5-20080610/dom.html#innerhtml0
https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML

'script' is the only major difference called out between  `document.write` and `innerHTML`, with the rest being about state of the browser's internal parsers - which should hopefully not matter for us.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/8337
