### PR TITLE
Prebid Core: Implement transaction id on imp.ext.tid

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -5,7 +5,7 @@ import {
   adUnitsFilter, flatten, getHighestCpm, isArrayOfNums, isGptPubadsDefined, uniques, logInfo,
   contains, logError, isArray, deepClone, deepAccess, isNumber, logWarn, logMessage, isFn,
   transformAdServerTargetingObj, bind, replaceAuctionPrice, replaceClickThrough, insertElement,
-  inIframe, callBurl, createInvisibleIframe, generateUUID, unsupportedBidderMessage, isEmpty, mergeDeep
+  inIframe, callBurl, createInvisibleIframe, generateUUID, unsupportedBidderMessage, isEmpty, mergeDeep, deepSetValue
 } from './utils.js';
 import { listenMessagesFromCreative } from './secureCreatives.js';
 import { userSync } from './userSync.js';
@@ -617,25 +617,7 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
     adUnit.transactionId = generateUUID();
 
     // Populate ortb2Imp.ext.tid with transactionId. Specifying a transaction ID per item in the ortb impression array, lets multiple transaction IDs be transmitted in a single bid request.
-    if (adUnit.hasOwnProperty('ortb2Imp')) {
-      if (adUnit.ortb2Imp.hasOwnProperty('ext')) {
-        adUnit.ortb2Imp.ext.tid = adUnit.transactionId;
-      }
-    } else if ((adUnit.hasOwnProperty('ortb2Imp')) && !(adUnit.ortb2Imp.hasOwnProperty('ext'))) {
-      Object.assign(adUnit.ortb2Imp, {
-        ext: {
-          tid: adUnit.transactionId
-        }
-      })
-    } else if (!adUnit.hasOwnProperty('ortb2Imp')) {
-      Object.assign(adUnit, {
-        ortb2Imp: {
-          ext: {
-            tid: adUnit.transactionId
-          }
-        }
-      })
-    }
+    deepSetValue(adUnit, 'ortb2Imp.ext.tid', adUnit.transactionId)
 
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -616,6 +616,27 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
 
     adUnit.transactionId = generateUUID();
 
+    // Populate ortb2Imp.ext.tid with transactionId. Specifying a transaction ID per item in the ortb impression array, lets multiple transaction IDs be transmitted in a single bid request.
+    if (adUnit.hasOwnProperty('ortb2Imp')) {
+      if (adUnit.ortb2Imp.hasOwnProperty('ext')) {
+        adUnit.ortb2Imp.ext.tid = adUnit.transactionId;
+      }
+    } else if ((adUnit.hasOwnProperty('ortb2Imp')) && !(adUnit.ortb2Imp.hasOwnProperty('ext'))) {
+      Object.assign(adUnit.ortb2Imp, {
+        ext: {
+          tid: adUnit.transactionId
+        }
+      })
+    } else if (!adUnit.hasOwnProperty('ortb2Imp')) {
+      Object.assign(adUnit, {
+        ortb2Imp: {
+          ext: {
+            tid: adUnit.transactionId
+          }
+        }
+      })
+    }
+
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
       const spec = adapter && adapter.getSpec && adapter.getSpec();

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2200,7 +2200,7 @@ describe('IndexexchangeAdapter', function () {
         expect(diagObj.mfu).to.equal(2);
         expect(diagObj.allu).to.equal(2);
         expect(diagObj.version).to.equal('$prebid.version$');
-        expect(diagObj.url).to.equal('http://localhost:9876/context.html')
+        expect(diagObj.url).to.exist
       });
     });
   });

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2200,7 +2200,7 @@ describe('IndexexchangeAdapter', function () {
         expect(diagObj.mfu).to.equal(2);
         expect(diagObj.allu).to.equal(2);
         expect(diagObj.version).to.equal('$prebid.version$');
-        expect(diagObj.url).to.exist
+        expect(diagObj.url).to.equal('http://localhost:9876/context.html')
       });
     });
   });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1800,6 +1800,29 @@ describe('Unit: Prebid Module', function () {
           .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
+      it('should always set ortb2.ext.tid same as transactionId in adUnits', function () {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'test1',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }, {
+              code: 'test2',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }
+          ]
+        });
+
+        expect(auctionArgs.adUnits[0]).to.have.property('transactionId');
+        expect(auctionArgs.adUnits[0]).to.have.property('ortb2Imp');
+        expect(auctionArgs.adUnits[0].transactionId).to.equal(auctionArgs.adUnits[0].ortb2Imp.ext.tid);
+        expect(auctionArgs.adUnits[1]).to.have.property('transactionId');
+        expect(auctionArgs.adUnits[1]).to.have.property('ortb2Imp');
+        expect(auctionArgs.adUnits[1].transactionId).to.equal(auctionArgs.adUnits[1].ortb2Imp.ext.tid);
+      });
+
       it('should notify targeting of the latest auction for each adUnit', function () {
         let latestStub = sinon.stub(targeting, 'setLatestAuctionForAdUnit');
         let getAuctionStub = sinon.stub(auction, 'getAuctionId').returns(2);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Addresses #8543 (add imp[].ext.tid to openrtb2Imp object).

Tested locally and added unit tests.

- contact email of the adapter’s maintainer: shahin.rahbariasl@indexexchange.com

## Other information
https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/per-imp-tids.md
