### PR TITLE
Build system: do not use `require.resolve` for resolving library file paths

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -91,7 +91,7 @@ module.exports = {
   },
   getLibraryFiles(name) {
     const library = libraries[name];
-    const files = library.files.map(file => require.resolve(file, {paths: ['./libraries/' + name + '/']}));
+    const files = library.files.map((file) => path.resolve('./libraries/', name, file))
     return files;
   },
   isLibrary(name) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

Use `path.resolve` instead of `require.resolve` when resolving library file paths. `require.resolve` seems to behave unexpectedly in certain situations (https://github.com/prebid/Prebid.js/issues/8588)

## Other information

Closes https://github.com/prebid/Prebid.js/issues/8588
