### PR TITLE
clean.io RTD Module: send billable events

### DIFF
--- a/modules/cleanioRtdProvider.js
+++ b/modules/cleanioRtdProvider.js
@@ -149,7 +149,11 @@ function readConfig(config) {
   }
 }
 
-function startBillableEvents() {
+/**
+ * The function to be called upon module init.
+ * Defined as a variable to be able to reset it naturally
+ */
+let startBillableEvents = function() {
   // Upon clean.io submodule initialization, every winner bid is considered to be protected
   // and therefore, subjected to billing
   events.on(CONSTANTS.EVENTS.BID_WON, winnerBidResponse => {
@@ -177,8 +181,14 @@ function beforeInit() {
     init: (config, userConsent) => {
       try {
         readConfig(config);
-        startBillableEvents();
         onModuleInit();
+
+        // Subscribing once to ensure no duplicate events
+        // in case module initialization code runs multiple times
+        // This should have been a part of submodule definition, but well...
+        // The assumption here is that in production init() will be called exactly once
+        startBillableEvents();
+        startBillableEvents = () => {};
         return true;
       } catch (err) {
         if (err instanceof ConfigError) {

--- a/test/spec/modules/cleanioRtdProvider_spec.js
+++ b/test/spec/modules/cleanioRtdProvider_spec.js
@@ -1,5 +1,7 @@
 import * as utils from '../../../src/utils.js';
 import * as hook from '../../../src/hook.js'
+import * as events from '../../../src/events.js';
+import CONSTANTS from '../../../src/constants.json';
 
 import { __TEST__ } from '../../../modules/cleanioRtdProvider.js';
 
@@ -183,6 +185,27 @@ describe('clean.io RTD module', function () {
       const fakeBidResponse3 = makeFakeBidResponse();
       onBidResponseEvent(fakeBidResponse3, {}, {});
       ensurePrependToBidResponse(fakeBidResponse3);
+    });
+
+    it('should send billable event per bid won event', function () {
+      const { init } = getModule();
+      expect(init({ params: { cdnUrl: 'https://abc1234567890.cloudfront.net/script.js', protectionMode: 'full' } }, {})).to.equal(true);
+
+      const eventCounter = { registerCleanioBillingEvent: function() {} };
+      sinon.spy(eventCounter, 'registerCleanioBillingEvent');
+
+      events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, (evt) => {
+        if (evt.vendor === 'clean.io') {
+          eventCounter.registerCleanioBillingEvent()
+        }
+      });
+
+      events.emit(CONSTANTS.EVENTS.BID_WON, {});
+      events.emit(CONSTANTS.EVENTS.BID_WON, {});
+      events.emit(CONSTANTS.EVENTS.BID_WON, {});
+      events.emit(CONSTANTS.EVENTS.BID_WON, {});
+
+      sinon.assert.callCount(eventCounter.registerCleanioBillingEvent, 4);
     });
   });
 });


### PR DESCRIPTION
Add billable events to [clean.io Real-time Anti-Malvertising Module](https://docs.prebid.org/dev-docs/modules/cleanioRtdProvider.html)

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
As described in [Vendor Billing](https://docs.prebid.org/dev-docs/vendor-billing.html), clean.io will now submit a billable event for each protected impression.

- contact email of the adapter’s maintainer

Module Name: clean.io Rtd provider
Module Type: Rtd Provider
Maintainer: [nick@clean.io](mailto:nick@clean.io)

- [x] official adapter submission

## Other information
Solution was previously merged as part of [pull request #7449](https://github.com/prebid/Prebid.js/pull/7449)
