### PR TITLE
Adkernel Bid Adapter: add Sonic Twist alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -92,7 +92,8 @@ export const spec = {
     {code: 'ergadx'},
     {code: 'turktelekom'},
     {code: 'felixads'},
-    {code: 'motionspots'}
+    {code: 'motionspots'},
+    {code: 'sonic_twist'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Adaptor alias for SonicTwist network

- prebid-dev@adkernel.com
- [x] official adapter submission