### PR TITLE
Prebid Server Adapter: use bidRequest.auctionid as source.tid

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -341,7 +341,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
   let counter = 0;
 
   // $.source.tid MUST be a unique UUID and also THE SAME between all PBS Requests for a given Auction
-  const sourceTid = bidRequests[0].transactionId;
+  const sourceTid = bidRequests.auctionId;
   _s2sConfigs.forEach((s2sConfig) => {
     if (s2sConfig && uniqueServerBidRequests[counter] && getS2SBidderSet(s2sConfig).has(uniqueServerBidRequests[counter].bidderCode)) {
       // s2s should get the same client side timeout as other client side requests.

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -341,7 +341,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
   let counter = 0;
 
   // $.source.tid MUST be a unique UUID and also THE SAME between all PBS Requests for a given Auction
-  const sourceTid = generateUUID();
+  const sourceTid = bidRequests[0].transactionId;
   _s2sConfigs.forEach((s2sConfig) => {
     if (s2sConfig && uniqueServerBidRequests[counter] && getS2SBidderSet(s2sConfig).has(uniqueServerBidRequests[counter].bidderCode)) {
       // s2s should get the same client side timeout as other client side requests.


### PR DESCRIPTION
Related:

https://github.com/prebid/Prebid.js/pull/7585
https://github.com/prebid/Prebid.js/issues/8573
https://github.com/prebid/Prebid.js/pull/3190

7585 Made a new uuid for source.tid for prebid server because auction id was flawed. The first transaction id seems more appropriate, as other adapters can refer to it for source.tid as well. imp.ext.tid will be preferred by buyers in the long term, but source.tid has remaining interim utility and we want to unite their definitions