### PR TITLE
1plusX RTD submodule: New RTD Module

### DIFF
--- a/integrationExamples/gpt/1plusXRtdProviderExample.html
+++ b/integrationExamples/gpt/1plusXRtdProviderExample.html
@@ -1,0 +1,111 @@
+<html>
+
+<head>
+
+  <script>
+    var FAILSAFE_TIMEOUT = 2000;
+
+    var adUnits = [
+      {
+        code: 'test-div',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 600], [728, 90]]
+          }
+        },
+        bids: [
+          {
+            bidder: 'appnexus',
+            params: {
+              placementId: 13144370
+            }
+          }
+        ]
+      }
+    ];
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+  </script>
+  <script src="../../build/dev/prebid.js" async></script>
+
+  <script>
+    var googletag = googletag || {};
+    var testAuctionDelay = 2000;
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () {
+      googletag.pubads().disableInitialLoad();
+    });
+
+    pbjs.que.push(function () {
+      pbjs.setConfig({
+        debug: true,
+        realTimeData: {
+          auctionDelay: testAuctionDelay, // lower in real scenario to meet publisher spec
+          dataProviders: [
+            {
+              name: "1plusX",
+              waitForIt: true,
+              params: {
+                customerId: 'acme',
+                timeout: 1000
+              }
+
+            }
+          ]
+        }
+      });
+      pbjs.addAdUnits(adUnits);
+      pbjs.requestBids({ bidsBackHandler: sendAdserverRequest });
+    });
+
+    function sendAdserverRequest() {
+      if (pbjs.adserverRequestSent) return;
+      pbjs.adserverRequestSent = true;
+
+      googletag.cmd.push(function () {
+        pbjs.que.push(function () {
+          pbjs.setTargetingForGPTAsync();
+          googletag.pubads().refresh();
+        });
+      });
+    }
+
+    setTimeout(function () {
+      sendAdserverRequest();
+    }, FAILSAFE_TIMEOUT);
+  </script>
+
+  <script>
+    (function () {
+      var gads = document.createElement('script');
+      gads.async = true;
+      gads.type = 'text/javascript';
+      var useSSL = 'https:' == document.location.protocol;
+      gads.src = (useSSL ? 'https:' : 'http:') +
+        '//www.googletagservices.com/tag/js/gpt.js';
+      var node = document.getElementsByTagName('script')[0];
+      node.parentNode.insertBefore(gads, node);
+    })();
+  </script>
+
+  <script>
+    googletag.cmd.push(function () {
+      googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250], [300, 600]], 'test-div').addService(googletag.pubads());
+      googletag.pubads().enableSingleRequest();
+      googletag.enableServices();
+    });
+  </script>
+</head>
+
+<body>
+  <h2>1plusX RTD Module for Prebid</h2>
+
+  <div id='test-div'>
+    <script>
+      googletag.cmd.push(function () { googletag.display('test-div'); });
+    </script>
+  </div>
+</body>
+
+</html>

--- a/integrationExamples/gpt/1plusXRtdProviderExample.html
+++ b/integrationExamples/gpt/1plusXRtdProviderExample.html
@@ -48,6 +48,7 @@
               waitForIt: true,
               params: {
                 customerId: 'acme',
+                bidders: ['appnexus'],
                 timeout: 1000
               }
 

--- a/integrationExamples/gpt/1plusXRtdProviderExample.html
+++ b/integrationExamples/gpt/1plusXRtdProviderExample.html
@@ -84,7 +84,7 @@
       gads.type = 'text/javascript';
       var useSSL = 'https:' == document.location.protocol;
       gads.src = (useSSL ? 'https:' : 'http:') +
-        '//www.googletagservices.com/tag/js/gpt.js';
+        '//securepubads.g.doubleclick.net/tag/js/gpt.js';
       var node = document.getElementsByTagName('script')[0];
       node.parentNode.insertBefore(gads, node);
     })();

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -49,6 +49,7 @@
       "dfpAdServerVideo"
     ],
     "rtdModule": [
+      "1plusXRtdProvider",
       "airgridRtdProvider",
       "akamaiDapRtdProvider",
       "blueconicRtdProvider",

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,22 +1,25 @@
-import { submodule } from "../src/hook"
+import { submodule } from '../src/hook.js'
+import { logMessage } from '../src/utils.js';
+
 // Constants
 const REAL_TIME_MODULE = 'realTimeData'
 const MODULE_NAME = '1plusX'
 
 // Functions
-const getBidRequestDataAsync = async (reqBidsConfigObj, config, userConsent) => {
+const getBidRequestDataAsync = (reqBidsConfigObj, config, userConsent) => {
+  // We don't
   // Maybe treat the case where we already have the audiences & segments in local storage
   // Get the required config
   // Call PAPI
   // -- Then :
   // ---- extract relevant data
   // ---- set the data to the bid
-  // -- Catch : print err & do nothing 
+  // -- Catch : print err & do nothing
 }
 
 // Functions exported in submodule object
 const init = (config, userConsent) => {
-  // We prolly get the config again in getBidRequestData 
+  // We prolly get the config again in getBidRequestData
   return true;
 }
 
@@ -24,7 +27,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
   getBidRequestDataAsync(reqBidsConfigObj, config, userConsent)
     .then(() => callback())
     .catch((err) => {
-      console.error(err);
+      logMessage(err);
       callback();
     })
 }

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,26 +1,64 @@
-import { submodule } from '../src/hook.js'
-import { ajax } from '../src/ajax.js'
-import { logMessage, logError, deepAccess, isNumber } from '../src/utils.js';
+import { submodule } from '../src/hook.js';
+import { config } from '../src/config.js';
+import { ajax } from '../src/ajax.js';
+import {
+  logMessage, logError,
+  deepAccess, mergeDeep,
+  isNumber, isArray, deepSetValue
+} from '../src/utils.js';
 
 // Constants
 const REAL_TIME_MODULE = 'realTimeData';
 const MODULE_NAME = '1plusX';
 const PAPI_VERSION = 'v1.0';
+const SUPPORTED_BIDDERS = ['appnexus', 'rubicon']
 
 // Functions
-const extractConfig = (config) => {
+/**
+ * Extracts the parameters for 1plusX RTD module from the config object passed at instanciation
+ * @param {Object} moduleConfig Config object passed to the module
+ * @param {Object} reqBidsConfigObj Config object for the bidders; each adapter has its own entry
+ * @returns
+ */
+const extractConfig = (moduleConfig, reqBidsConfigObj) => {
   // CustomerId
-  const customerId = deepAccess(config, 'params.customerId');
+  const customerId = deepAccess(moduleConfig, 'params.customerId');
   if (!customerId) {
     throw new Error('REQUIRED CUSTOMER ID');
   }
   // Timeout
-  const tempTimeout = deepAccess(config, 'params.timeout');
+  const tempTimeout = deepAccess(moduleConfig, 'params.timeout');
   const timeout = isNumber(tempTimeout) && tempTimeout > 300 ? tempTimeout : 1000;
 
-  return { customerId, timeout };
+  // Bidders
+  const biddersTemp = deepAccess(moduleConfig, 'params.bidders');
+  if (!isArray(biddersTemp) || !biddersTemp.length) {
+    throw new Error('REQUIRED BIDDERS IN SUBMODULE CONFIG');
+  }
+
+  const adUnitBidders = reqBidsConfigObj.adUnits
+    .flatMap(({ bids }) => bids.map(({ bidder }) => bidder))
+    .filter((e, i, a) => a.indexOf(e) === i);
+  if (!isArray(adUnitBidders) || !adUnitBidders.length) {
+    throw new Error('REQUIRED BIDDERS IN BID REQUEST CONFIG');
+  }
+
+  const bidders = biddersTemp.filter(
+    bidder =>
+      SUPPORTED_BIDDERS.includes(bidder) && adUnitBidders.includes(bidder)
+  );
+  if (!bidders.length) {
+    throw new Error('NO SUPPORTED BIDDER FOUND IN SUBMODULE/ BID REQUEST CONFIG');
+  }
+
+  return { customerId, timeout, bidders };
 }
 
+/**
+ * Gets the URL of Profile Api from which targeting data will be fetched 
+ * @param {*} param0
+ * @returns
+ */
 const getPapiUrl = ({ customerId }) => {
   logMessage('GET PAPI URL');
   // https://[yourClientId].profiles.tagger.opecloud.com/[VERSION]/targeting?url=
@@ -29,6 +67,11 @@ const getPapiUrl = ({ customerId }) => {
   return papiUrl;
 }
 
+/**
+ * Fetches targeting data. It contains the audience segments & the contextual topics
+ * @param {string} papiUrl URL of profile API
+ * @returns
+ */
 const getTargetingDataFromPapi = (papiUrl) => {
   return new Promise((resolve, reject) => {
     const requestOptions = {
@@ -38,7 +81,7 @@ const getTargetingDataFromPapi = (papiUrl) => {
     }
     const callbacks = {
       success(responseText, response) {
-        logMessage("Say it has been successful");
+        logMessage('Say it has been successful');
         resolve(JSON.parse(response.response));
       },
       error(errorText, error) {
@@ -51,26 +94,102 @@ const getTargetingDataFromPapi = (papiUrl) => {
   })
 }
 
+/**
+ * Prepares the update for the ORTB2 object
+ * @param {*} param0
+ * @returns
+ */
+export const buildOrtb2Updates = ({ segments = [], topics = [] }) => {
+  const userData = {
+    name: '1plusX.com',
+    segment: segments.map((segmentId) => ({ id: segmentId }))
+  };
+  const site = {
+    keywords: topics.join(',')
+  };
+  return { userData, site };
+}
+
+/**
+ * Merges the targeting data with the existing config for bidder and updates
+ * @param {string} bidder Bidder for which to set config
+ * @param {Object} ortb2
+ * @param {Object} bidderConfigs
+ * @returns
+ */
+export const updateBidderConfig = (bidder, ortb2Updates, bidderConfigs) => {
+  if (!SUPPORTED_BIDDERS.includes(bidder)) {
+    return null;
+  }
+  const { site, userData } = ortb2Updates;
+  const bidderConfigCopy = mergeDeep({}, bidderConfigs[bidder]);
+
+  const currentSite = deepAccess(bidderConfigCopy, 'ortb2.site')
+  const updatedSite = mergeDeep(currentSite, site);
+
+  const currentUserData = deepAccess(bidderConfigCopy, 'ortb2.user.data') || [];
+  const updatedUserData = [
+    ...currentUserData.filter(({ name }) => name != userData.name),
+    userData
+  ];
+
+  deepSetValue(bidderConfigCopy, 'ortb2.site', updatedSite);
+  deepSetValue(bidderConfigCopy, 'ortb2.user.data', updatedUserData);
+
+  return bidderConfigCopy
+};
+
+/**
+ * Updates bidder configs with the targeting data retreived from Profile API
+ * @param {*} papiResponse
+ * @param {*} param1
+ */
+export const setTargetingDataToConfig = (papiResponse, { bidders }) => {
+  const bidderConfigs = config.getBidderConfig();
+  const { s: segments, t: topics } = papiResponse;
+  const ortb2Updates = buildOrtb2Updates({ segments, topics });
+
+  for (const bidder of bidders) {
+    const updatedBidderConfig = updateBidderConfig(bidder, ortb2Updates, bidderConfigs);
+    if (updatedBidderConfig) {
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: updatedBidderConfig
+      });
+    }
+  }
+}
+
 // Functions exported in submodule object
+/**
+ * Init
+ * @param {*} config
+ * @param {*} userConsent
+ * @returns
+ */
 const init = (config, userConsent) => {
   // We prolly get the config again in getBidRequestData
   return true;
 }
 
-const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
+/**
+ *
+ * @param {*} reqBidsConfigObj
+ * @param {*} callback
+ * @param {*} moduleConfig
+ * @param {*} userConsent
+ */
+const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent) => {
   try {
     // Get the required config
-    const { customerId } = extractConfig(config);
+    const { customerId, bidders } = extractConfig(moduleConfig, reqBidsConfigObj);
     // Get PAPI URL
     const papiUrl = getPapiUrl({ customerId })
     // Call PAPI
     getTargetingDataFromPapi(papiUrl)
-      .then((response) => {
-        // -- Then :
-        // ---- extract relevant data
-        // ---- set the data to the bid
+      .then((papiResponse) => {
         logMessage('REQUEST TO PAPI SUCCESS');
-        const { s: segments, t: targeting } = response;
+        setTargetingDataToConfig(papiResponse, { bidders });
         callback();
       })
       .catch((error) => {

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,20 +1,48 @@
 import { submodule } from '../src/hook.js'
-import { logMessage } from '../src/utils.js';
+import { ajax } from '../src/ajax.js'
+import { logMessage, logError, deepAccess, isNumber } from '../src/utils.js';
 
 // Constants
-const REAL_TIME_MODULE = 'realTimeData'
-const MODULE_NAME = '1plusX'
+const REAL_TIME_MODULE = 'realTimeData';
+const MODULE_NAME = '1plusX';
+const PAPI_VERSION = 'v1.0';
 
 // Functions
-const getBidRequestDataAsync = (reqBidsConfigObj, config, userConsent) => {
-  // We don't
-  // Maybe treat the case where we already have the audiences & segments in local storage
-  // Get the required config
-  // Call PAPI
-  // -- Then :
-  // ---- extract relevant data
-  // ---- set the data to the bid
-  // -- Catch : print err & do nothing
+const extractConfig = (config) => {
+  // CustomerId
+  const customerId = deepAccess(config, 'params.customerId');
+  if (!customerId) {
+    throw new Error('REQUIRED CUSTOMER ID');
+  }
+  // Timeout
+  const tempTimeout = deepAccess(config, 'params.timeout');
+  const timeout = isNumber(tempTimeout) && tempTimeout > 300 ? tempTimeout : 1000;
+
+  return { customerId, timeout };
+}
+
+const getPapiUrl = ({ customerId }) => {
+  logMessage('GET PAPI URL');
+  // https://[yourClientId].profiles.tagger.opecloud.com/[VERSION]/targeting?url=
+  const currentUrl = encodeURIComponent(window.location.href);
+  const papiUrl = `https://${customerId}.profiles.tagger.opecloud.com/${PAPI_VERSION}/targeting?url=${currentUrl}`;
+  return papiUrl;
+}
+
+const getTargetingDataFromPapi = (papiUrl) => {
+  return new Promise((resolve, reject) => {
+    ajax(papiUrl, {
+      success(responseText, response) {
+        logMessage(responseText);
+        resolve(response.response);
+      },
+      error(errorText, error) {
+        console.log(errorText)
+        console.log(JSON.stringify(error, null, 2))
+        reject(error);
+      }
+    })
+  })
 }
 
 // Functions exported in submodule object
@@ -24,12 +52,30 @@ const init = (config, userConsent) => {
 }
 
 const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
-  getBidRequestDataAsync(reqBidsConfigObj, config, userConsent)
-    .then(() => callback())
-    .catch((err) => {
-      logMessage(err);
-      callback();
-    })
+  try {
+    // Get the required config
+    const { customerId } = extractConfig(config);
+    // Get PAPI URL
+    const papiUrl = getPapiUrl({ customerId })
+    // Call PAPI
+    getTargetingDataFromPapi(papiUrl)
+      .then((response) => {
+        // -- Then :
+        // ---- extract relevant data
+        // ---- set the data to the bid
+        console.log('REQUEST TO PAPI SUCCESS');
+        callback();
+      })
+      .catch((error) => {
+        // -- Catch : print err & do nothing
+        console.log('REQUEST TO PAPI ERROR');
+        // logError(error);
+        callback();
+      })
+  } catch (error) {
+    logError(error);
+    callback();
+  }
 }
 
 // The RTD submodule object to be exported

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,0 +1,14 @@
+// Constants 
+const MODULE_NAME = ''
+
+// Functions
+
+// Functions exported in submodule object
+const init = () => { }
+const getBidRequestData = () => { }
+// The RTD submodule object to be exported
+export const onePlusXSubmodule = {
+  name: MODULE_NAME,
+  init,
+  getBidRequestData
+}

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -31,17 +31,23 @@ const getPapiUrl = ({ customerId }) => {
 
 const getTargetingDataFromPapi = (papiUrl) => {
   return new Promise((resolve, reject) => {
-    ajax(papiUrl, {
+    const requestOptions = {
+      customHeaders: {
+        'Accept': 'application/json'
+      }
+    }
+    const callbacks = {
       success(responseText, response) {
-        logMessage(responseText);
-        resolve(response.response);
+        logMessage("Say it has been successful");
+        resolve(JSON.parse(response.response));
       },
       error(errorText, error) {
-        console.log(errorText)
-        console.log(JSON.stringify(error, null, 2))
+        logMessage(errorText)
+        logMessage(JSON.stringify(error, null, 2))
         reject(error);
       }
-    })
+    };
+    ajax(papiUrl, callbacks, null, requestOptions)
   })
 }
 
@@ -63,14 +69,13 @@ const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
         // -- Then :
         // ---- extract relevant data
         // ---- set the data to the bid
-        console.log('REQUEST TO PAPI SUCCESS');
+        logMessage('REQUEST TO PAPI SUCCESS');
+        const { s: segments, t: targeting } = response;
         callback();
       })
       .catch((error) => {
         // -- Catch : print err & do nothing
-        console.log('REQUEST TO PAPI ERROR');
-        // logError(error);
-        callback();
+        throw error;
       })
   } catch (error) {
     logError(error);
@@ -86,4 +91,4 @@ export const onePlusXSubmodule = {
 }
 
 // Register the onePlusXSubmodule as submodule of realTimeData
-submodule(REAL_TIME_MODULE, MODULE_NAME);
+submodule(REAL_TIME_MODULE, onePlusXSubmodule);

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,14 +1,40 @@
-// Constants 
-const MODULE_NAME = ''
+import { submodule } from "../src/hook"
+// Constants
+const REAL_TIME_MODULE = 'realTimeData'
+const MODULE_NAME = '1plusX'
 
 // Functions
+const getBidRequestDataAsync = async (reqBidsConfigObj, config, userConsent) => {
+  // Maybe treat the case where we already have the audiences & segments in local storage
+  // Get the required config
+  // Call PAPI
+  // -- Then :
+  // ---- extract relevant data
+  // ---- set the data to the bid
+  // -- Catch : print err & do nothing 
+}
 
 // Functions exported in submodule object
-const init = () => { }
-const getBidRequestData = () => { }
+const init = (config, userConsent) => {
+  // We prolly get the config again in getBidRequestData 
+  return true;
+}
+
+const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
+  getBidRequestDataAsync(reqBidsConfigObj, config, userConsent)
+    .then(() => callback())
+    .catch((err) => {
+      console.error(err);
+      callback();
+    })
+}
+
 // The RTD submodule object to be exported
 export const onePlusXSubmodule = {
   name: MODULE_NAME,
   init,
   getBidRequestData
 }
+
+// Register the onePlusXSubmodule as submodule of realTimeData
+submodule(REAL_TIME_MODULE, MODULE_NAME);

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -20,7 +20,7 @@ const LOG_PREFIX = '[1plusX RTD Module]: ';
  * @param {Object} reqBidsConfigObj Config object for the bidders; each adapter has its own entry
  * @returns {Object} Extracted configuration parameters for the module
  */
-const extractConfig = (moduleConfig, reqBidsConfigObj) => {
+export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
   // CustomerId
   const customerId = deepAccess(moduleConfig, 'params.customerId');
   if (!customerId) {

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -11,7 +11,6 @@ import {
 const REAL_TIME_MODULE = 'realTimeData';
 const MODULE_NAME = '1plusX';
 const PAPI_VERSION = 'v1.0';
-const SUPPORTED_BIDDERS = ['appnexus', 'rubicon'];
 const LOG_PREFIX = '[1plusX RTD Module]: ';
 // Functions
 /**
@@ -43,12 +42,9 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
     throw new Error('Missing parameter bidders in bidRequestConfig');
   }
 
-  const bidders = biddersTemp.filter(
-    bidder =>
-      SUPPORTED_BIDDERS.includes(bidder) && adUnitBidders.includes(bidder)
-  );
+  const bidders = biddersTemp.filter(bidder => adUnitBidders.includes(bidder));
   if (!bidders.length) {
-    throw new Error('No supported bidder found in config parameter bidders');
+    throw new Error('No bidRequestConfig bidder found in moduleConfig bidders');
   }
 
   return { customerId, timeout, bidders };
@@ -117,9 +113,6 @@ export const buildOrtb2Updates = ({ segments = [], topics = [] }) => {
  * @returns {Object} Updated bidder config
  */
 export const updateBidderConfig = (bidder, ortb2Updates, bidderConfigs) => {
-  if (!SUPPORTED_BIDDERS.includes(bidder)) {
-    return null;
-  }
   const { site, userData } = ortb2Updates;
   const bidderConfigCopy = mergeDeep({}, bidderConfigs[bidder]);
 

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -14,6 +14,11 @@ const ORTB2_NAME = '1plusX.com'
 const PAPI_VERSION = 'v1.0';
 const LOG_PREFIX = '[1plusX RTD Module]: ';
 const LEGACY_SITE_KEYWORDS_BIDDERS = ['appnexus'];
+export const segtaxes = {
+  // cf. https://github.com/InteractiveAdvertisingBureau/openrtb/pull/108
+  AUDIENCE: 526,
+  CONTENT: 527,
+};
 // Functions
 /**
  * Extracts the parameters for 1plusX RTD module from the config object passed at instanciation
@@ -115,7 +120,8 @@ export const buildOrtb2Updates = ({ segments = [], topics = [] }, bidder) => {
   } else {
     const siteContentData = {
       name: ORTB2_NAME,
-      segment: topics.map((topicId) => ({ id: topicId }))
+      segment: topics.map((topicId) => ({ id: topicId })),
+      ext: { segtax: segtaxes.CONTENT }
     }
     return { userData, siteContentData };
   }
@@ -140,7 +146,7 @@ export const updateBidderConfig = (bidder, ortb2Updates, bidderConfigs) => {
   }
 
   if (siteContentData) {
-    const siteDataPath = 'ortb2.site.content.data'
+    const siteDataPath = 'ortb2.site.content.data';
     const currentSiteContentData = deepAccess(bidderConfigCopy, siteDataPath) || [];
     const updatedSiteContentData = [
       ...currentSiteContentData.filter(({ name }) => name != siteContentData.name),

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -1,0 +1,76 @@
+# 1plusX Real-time Data Submodule
+
+## Overview
+
+    Module Name: 1plusX Rtd Provider
+    Module Type: Rtd Provider
+    Maintainer: dev@1plusx.com 
+
+## Description
+
+RTD provider for 1plusX. 
+Enriches the bidding object with Audience & Targeting data
+Contact dev@1plusx.com for information.
+
+## Usage
+
+### Build
+```
+gulp build --modules="rtdModule,1plusXRtdProvider,appnexusBidAdapter,..."  
+```
+
+> Note that the global RTD module, `rtdModule`, is a prerequisite of the 1plusX RTD module.
+
+### Configuration
+
+Use `setConfig` to instruct Prebid.js to initilize the 1plusX RTD module, as specified below. 
+
+This module is configured as part of the `realTimeData.dataProviders`
+
+```javascript
+var TIMEOUT = 1000;
+pbjs.setConfig({
+    realTimeData: {
+        auctionDelay: TIMEOUT,
+        dataProviders: [{
+            name: '1plusX',
+            waitForIt: true,
+            params: {
+                customerId: 'acme',
+                bidders: ['appnexus', 'rubicon'],
+                timeout: TIMEOUT
+            }
+        }]
+    }
+});
+```
+
+### Parameters 
+
+| Name  |Type | Description   | Notes  |
+| :------------ | :------------ | :------------ |:------------ |
+| name  | String | Real time data module name | Always '1plusX' |
+| waitForIt | Boolean | Should be `true` if there's an `auctionDelay` defined (optional) | `false` |
+| params  | Object |   |   |
+| params.customerId  | Integer | Your 1plusX customer id  |  |
+| params.biders  | Array<string> | List of bidders for which you would like data to be set | To this date only `appnexus` and `rubicon` are supported |
+| params.timeout  | Integer | timeout (ms) | 1000 |
+
+## Supported Bidders
+At the moment only Appnexus (`appnexus`) and Magnite (`rubicon`) are supported
+
+
+| Bidder  | ID (for `bidders` parameter) | Module name (for `gulp build`) |
+| ------- | ---------------------------- | ------------------------------ |
+| Xandr   | `appnexus`                   | `appnexusBidAdapter`           |
+| Magnite | `rubicon`                    | `rubiconBidAdapter`            |
+
+## Testing 
+
+To view an example of how the 1plusX RTD module works :
+
+`gulp serve --modules=rtdModule,1plusXRtdProvider,appnexusBidAdapter,rubiconBidAdapter`
+
+and then point your browser at:
+
+`http://localhost:9999/integrationExamples/gpt/1plusXRtdProvider_example.html`

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -4,13 +4,13 @@
 
     Module Name: 1plusX Rtd Provider
     Module Type: Rtd Provider
-    Maintainer: dev@1plusx.com 
+    Maintainer: dc-team-1px@triplelift.com
 
 ## Description
 
 RTD provider for 1plusX. 
 Enriches the bidding object with Audience & Targeting data
-Contact dev@1plusx.com for information.
+Contact dc-team-1px@triplelift.com for information.
 
 ## Usage
 
@@ -47,14 +47,14 @@ pbjs.setConfig({
 
 ### Parameters 
 
-| Name  |Type | Description   | Notes  |
-| :------------ | :------------ | :------------ |:------------ |
-| name  | String | Real time data module name | Always '1plusX' |
-| waitForIt | Boolean | Should be `true` if there's an `auctionDelay` defined (optional) | `false` |
-| params  | Object |   |   |
-| params.customerId  | Integer | Your 1plusX customer id  |  |
-| params.biders  | Array<string> | List of bidders for which you would like data to be set | To this date only `appnexus` and `rubicon` are supported |
-| params.timeout  | Integer | timeout (ms) | 1000 |
+| Name              | Type          | Description                                                      | Notes                                                    |
+| :---------------- | :------------ | :--------------------------------------------------------------- |:-------------------------------------------------------- |
+| name              | String        | Real time data module name                                       | Always '1plusX'                                          |
+| waitForIt         | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`                                                  |
+| params            | Object        |                                                                  |                                                          |
+| params.customerId | Integer       | Your 1plusX customer id                                          |                                                          |
+| params.bidders    | Array<string> | List of bidders for which you would like data to be set          | To this date only `appnexus` and `rubicon` are supported |
+| params.timeout    | Integer       | timeout (ms)                                                     | 1000ms                                                   |
 
 ## Supported Bidders
 At the moment only Appnexus (`appnexus`) and Magnite (`rubicon`) are supported

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -52,7 +52,7 @@ pbjs.setConfig({
 | name              | String        | Real time data module name                                       | Always '1plusX'                                          |
 | waitForIt         | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`                                                  |
 | params            | Object        |                                                                  |                                                          |
-| params.customerId | Integer       | Your 1plusX customer id                                          |                                                          |
+| params.customerId | String        | Your 1plusX customer id                                          |                                                          |
 | params.bidders    | Array<string> | List of bidders for which you would like data to be set          | To this date only `appnexus` and `rubicon` are supported |
 | params.timeout    | Integer       | timeout (ms)                                                     | 1000ms                                                   |
 

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -53,17 +53,8 @@ pbjs.setConfig({
 | waitForIt         | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`                                                  |
 | params            | Object        |                                                                  |                                                          |
 | params.customerId | String        | Your 1plusX customer id                                          |                                                          |
-| params.bidders    | Array<string> | List of bidders for which you would like data to be set          | To this date only `appnexus` and `rubicon` are supported |
+| params.bidders    | Array<string> | List of bidders for which you would like data to be set          |                                                          |
 | params.timeout    | Integer       | timeout (ms)                                                     | 1000ms                                                   |
-
-## Supported Bidders
-At the moment only Appnexus (`appnexus`) and Magnite (`rubicon`) are supported
-
-
-| Bidder  | ID (for `bidders` parameter) | Module name (for `gulp build`) |
-| ------- | ---------------------------- | ------------------------------ |
-| Xandr   | `appnexus`                   | `appnexusBidAdapter`           |
-| Magnite | `rubicon`                    | `rubiconBidAdapter`            |
 
 ## Testing 
 

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -1,0 +1,17 @@
+import { config } from 'src/config';
+import { onePlusXSubmodule } from 'modules/1plusXRtdProvider';
+
+describe('1plusXRtdProvider', () => {
+  before(() => {
+    config.resetConfig();
+  })
+
+  after(() => { })
+
+  describe('onePlusXSubmodule', () => {
+    it('init is successfull', () => {
+      const initResult = onePlusXSubmodule.init();
+      expect(initResult).to.be.true;
+    })
+  })
+})

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -15,7 +15,7 @@ describe('1plusXRtdProvider', () => {
 
   beforeEach(() => {
     fakeServer = sinon.createFakeServer();
-    fakeServer.respondWith("GET", "*", [200, {}, '']);
+    fakeServer.respondWith('GET', '*', [200, {}, '']);
     fakeServer.respondImmediately = true;
     fakeServer.autoRespond = true;
   })
@@ -27,7 +27,6 @@ describe('1plusXRtdProvider', () => {
     })
 
     it('callback is called after getBidRequestData', () => {
-
       // Nice case; everything runs as expected
       {
         const callbackSpy = sinon.spy();
@@ -35,7 +34,6 @@ describe('1plusXRtdProvider', () => {
         onePlusXSubmodule.getBidRequestData(reqBidsConfigObj, callbackSpy, config);
         setTimeout(() => {
           expect(callbackSpy.calledOnce).to.be.true
-
         }, 100)
       }
       // No customer id in config => error but still callback called
@@ -45,7 +43,6 @@ describe('1plusXRtdProvider', () => {
         onePlusXSubmodule.getBidRequestData(reqBidsConfigObj, callbackSpy, config);
         setTimeout(() => {
           expect(callbackSpy.calledOnce).to.be.true
-
         }, 100);
       }
     })

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -1,11 +1,47 @@
 import { config } from 'src/config';
 import { logMessage } from 'src/utils';
 import { server } from 'test/mocks/xhr.js';
-import { onePlusXSubmodule } from 'modules/1plusXRtdProvider';
+import {
+  onePlusXSubmodule,
+  buildOrtb2Updates,
+  updateBidderConfig,
+  setTargetingDataToConfig
+} from 'modules/1plusXRtdProvider';
 
 describe('1plusXRtdProvider', () => {
   const reqBidsConfigObj = {};
   let fakeServer;
+  const fakeResponseHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*'
+  };
+  const fakeResponse = {
+    s: ['segment1', 'segment2', 'segment3'],
+    t: ['targeting1', 'targeting2', 'targeting3']
+  };
+
+  const bidderConfigInitial = {
+    ortb2: {
+      user: { keywords: '' },
+      site: { content: { data: [] } }
+    }
+  }
+  const bidderConfigInitialWith1plusXEntry = {
+    ortb2: {
+      user: {
+        data: [{ name: '1plusX.com', segment: [{ id: 'initial' }] }]
+      },
+      site: { content: { data: [] } }
+    }
+  }
+  const bidderConfigInitialWithUserData = {
+    ortb2: {
+      user: {
+        data: [{ name: 'hello.world', segment: [{ id: 'initial' }] }]
+      },
+      site: { content: { data: [] } }
+    }
+  }
 
   before(() => {
     config.resetConfig();
@@ -15,7 +51,7 @@ describe('1plusXRtdProvider', () => {
 
   beforeEach(() => {
     fakeServer = sinon.createFakeServer();
-    fakeServer.respondWith('GET', '*', [200, {}, '']);
+    fakeServer.respondWith('GET', '*', [200, fakeResponseHeaders, JSON.stringify(fakeResponse)]);
     fakeServer.respondImmediately = true;
     fakeServer.autoRespond = true;
   })
@@ -45,6 +81,230 @@ describe('1plusXRtdProvider', () => {
           expect(callbackSpy.calledOnce).to.be.true
         }, 100);
       }
+    })
+  })
+
+  describe('buildOrtb2Updates', () => {
+    it('fills site.keywords & user.data in the ortb2 config', () => {
+      const rtdData = { segments: fakeResponse.s, topics: fakeResponse.t };
+      const ortb2Updates = buildOrtb2Updates(rtdData);
+
+      const expectedOutput = {
+        site: {
+          keywords: rtdData.topics.join(','),
+        },
+        userData: {
+          name: '1plusX.com',
+          segment: rtdData.segments.map((segmentId) => ({ id: segmentId }))
+        }
+      }
+      expect([ortb2Updates]).to.deep.include.members([expectedOutput]);
+    });
+
+    it('defaults to empty array if no segment is given', () => {
+      const rtdData = { topics: fakeResponse.t };
+      const ortb2Updates = buildOrtb2Updates(rtdData);
+
+      const expectedOutput = {
+        site: {
+          keywords: rtdData.topics.join(','),
+        },
+        userData: {
+          name: '1plusX.com',
+          segment: []
+        }
+      }
+      expect(ortb2Updates).to.deep.include(expectedOutput);
+    })
+
+    it('defaults to empty string if no topic is given', () => {
+      const rtdData = { segments: fakeResponse.s };
+      const ortb2Updates = buildOrtb2Updates(rtdData);
+
+      const expectedOutput = {
+        site: {
+          keywords: '',
+        },
+        userData: {
+          name: '1plusX.com',
+          segment: rtdData.segments.map((segmentId) => ({ id: segmentId }))
+        }
+      }
+      expect(ortb2Updates).to.deep.include(expectedOutput);
+    })
+  })
+
+  describe('updateBidderConfig', () => {
+    const ortb2Updates = {
+      site: {
+        keywords: fakeResponse.t.join(','),
+      },
+      userData: {
+        name: '1plusX.com',
+        segment: fakeResponse.s.map((segmentId) => ({ id: segmentId }))
+      }
+    }
+
+
+    it("doesn't write in config of unsupported bidder", () => {
+      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
+      // Set initial config for this bidder
+      config.setBidderConfig({
+        bidders: [unsupportedBidder],
+        config: bidderConfigInitial
+      })
+      // Call my own setBidderConfig with targeting data
+      const newBidderConfig = updateBidderConfig(unsupportedBidder, ortb2Updates, config.getBidderConfig());
+      // Check that the config has not been changed for unsupported bidder
+      expect(newBidderConfig).to.be.null;
+    })
+
+    it('merges config for supported bidders (appnexus)', () => {
+      const bidder = 'appnexus';
+      // Set initial config
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: bidderConfigInitial
+      });
+      // Call submodule's setBidderConfig
+      const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
+
+      // Check that the targeting data has been set in the config
+      expect(newBidderConfig).not.to.be.null;
+      expect(newBidderConfig.ortb2.site).to.deep.include(ortb2Updates.site);
+      expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2Updates.userData);
+      // Check that existing config didn't get erased
+      expect(newBidderConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
+      expect(newBidderConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
+    })
+
+    it('merges config for supported bidders (rubicon)', () => {
+      const bidder = 'rubicon';
+      // Set initial config
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: bidderConfigInitial
+      });
+      // Call submodule's setBidderConfig
+      const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
+      // Check that the targeting data has been set in the config
+      expect(newBidderConfig).not.to.be.null;
+      expect(newBidderConfig.ortb2.site).to.deep.include(ortb2Updates.site);
+      expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2Updates.userData);
+      // Check that existing config didn't get erased
+      expect(newBidderConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
+      expect(newBidderConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
+    })
+
+    it('overwrites an existing 1plus.com entry in ortb2.user.data', () => {
+      const bidder = 'appnexus';
+      // Set initial config
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: bidderConfigInitialWith1plusXEntry
+      });
+      // Save previous user.data entry
+      const previousUserData = bidderConfigInitialWithUserData.ortb2.user.data[0]
+      // Call submodule's setBidderConfig
+      const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
+      // Check that the targeting data has been set in the config
+      expect(newBidderConfig).not.to.be.null;
+      expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2Updates.userData);
+      expect(newBidderConfig.ortb2.user.data).not.to.include(previousUserData);
+    })
+
+    it("doesn't overwrite entries in ortb2.user.data that aren't 1plusx.com", () => {
+      const bidder = 'appnexus';
+      // Set initial config
+      config.setBidderConfig({
+        bidders: [bidder],
+        config: bidderConfigInitialWithUserData
+      });
+      // Save previous user.data entry
+      const previousUserData = bidderConfigInitialWithUserData.ortb2.user.data[0]
+      // Call submodule's setBidderConfig
+      const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
+      // Check that the targeting data has been set in the config
+      expect(newBidderConfig).not.to.be.null;
+      expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2Updates.userData);
+      expect(newBidderConfig.ortb2.user.data).to.deep.include(previousUserData);
+    })
+
+  })
+
+  describe('setTargetingDataToConfig', () => {
+    const expectedOrtb2 = {
+      site: {
+        keywords: fakeResponse.t.join(',')
+      },
+      user: {
+        data: [{
+          name: '1plusX.com',
+          segment: fakeResponse.s.map((segmentId) => ({ id: segmentId }))
+        }]
+      }
+    }
+
+    it("doesn't set config for unsupported bidders", () => {
+      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
+      // setting initial config for this bidder
+      config.setBidderConfig({
+        bidders: [unsupportedBidder],
+        config: bidderConfigInitial
+      })
+      // call setTargetingDataToConfig
+      setTargetingDataToConfig(fakeResponse, { bidders: [unsupportedBidder] });
+      // Check that the config has not been changed for unsupported bidder
+      const newConfig = config.getBidderConfig()[unsupportedBidder];
+      expect(newConfig.ortb2.user.data).to.be.undefined;
+      expect(newConfig.ortb2.site).to.not.have.any.keys('keywords')
+      expect(newConfig).to.deep.include(bidderConfigInitial);
+    })
+
+    it('sets the config for the selected bidders', () => {
+      const bidders = ['appnexus', 'rubicon'];
+      // setting initial config for those bidders
+      config.setBidderConfig({
+        bidders,
+        config: bidderConfigInitial
+      })
+      // call setTargetingDataToConfig
+      setTargetingDataToConfig(fakeResponse, { bidders });
+
+      // Check that the targeting data has been set in both configs
+      for (const bidder of bidders) {
+        const newConfig = config.getBidderConfig()[bidder];
+        expect(newConfig.ortb2.site).to.deep.include(expectedOrtb2.site);
+        expect(newConfig.ortb2.user).to.deep.include(expectedOrtb2.user);
+        // Check that existing config didn't get erased
+        expect(newConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
+        expect(newConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
+      }
+    })
+    it('ignores unsupported bidders', () => {
+      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
+      const bidders = ['appnexus', unsupportedBidder];
+      // setting initial config for those bidders
+      config.setBidderConfig({
+        bidders,
+        config: bidderConfigInitial
+      })
+      // call setTargetingDataToConfig
+      setTargetingDataToConfig(fakeResponse, { bidders });
+
+      // Check that the targeting data has been set for supported bidder
+      const appnexusConfig = config.getBidderConfig()['appnexus'];
+      expect(appnexusConfig.ortb2.site).to.deep.include(expectedOrtb2.site);
+      expect(appnexusConfig.ortb2.user).to.deep.include(expectedOrtb2.user);
+      // Check that existing config didn't get erased
+      expect(appnexusConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
+      expect(appnexusConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
+
+      // Check that config for unsupported bidder remained unchanged
+      const newConfig = config.getBidderConfig()[unsupportedBidder];
+      expect(newConfig.ortb2.user.data).to.be.undefined;
+      expect(newConfig.ortb2.site).to.not.have.any.keys('keywords')
+      expect(newConfig).to.deep.include(bidderConfigInitial);
     })
   })
 })

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -1,17 +1,53 @@
 import { config } from 'src/config';
+import { logMessage } from 'src/utils';
+import { server } from 'test/mocks/xhr.js';
 import { onePlusXSubmodule } from 'modules/1plusXRtdProvider';
 
 describe('1plusXRtdProvider', () => {
+  const reqBidsConfigObj = {};
+  let fakeServer;
+
   before(() => {
     config.resetConfig();
   })
 
   after(() => { })
 
+  beforeEach(() => {
+    fakeServer = sinon.createFakeServer();
+    fakeServer.respondWith("GET", "*", [200, {}, '']);
+    fakeServer.respondImmediately = true;
+    fakeServer.autoRespond = true;
+  })
+
   describe('onePlusXSubmodule', () => {
     it('init is successfull', () => {
       const initResult = onePlusXSubmodule.init();
       expect(initResult).to.be.true;
+    })
+
+    it('callback is called after getBidRequestData', () => {
+
+      // Nice case; everything runs as expected
+      {
+        const callbackSpy = sinon.spy();
+        const config = { params: { customerId: 'test' } };
+        onePlusXSubmodule.getBidRequestData(reqBidsConfigObj, callbackSpy, config);
+        setTimeout(() => {
+          expect(callbackSpy.calledOnce).to.be.true
+
+        }, 100)
+      }
+      // No customer id in config => error but still callback called
+      {
+        const callbackSpy = sinon.spy();
+        const config = {}
+        onePlusXSubmodule.getBidRequestData(reqBidsConfigObj, callbackSpy, config);
+        setTimeout(() => {
+          expect(callbackSpy.calledOnce).to.be.true
+
+        }, 100);
+      }
     })
   })
 })

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -1,6 +1,4 @@
 import { config } from 'src/config';
-import { logMessage } from 'src/utils';
-import { server } from 'test/mocks/xhr.js';
 import {
   onePlusXSubmodule,
   buildOrtb2Updates,
@@ -145,7 +143,6 @@ describe('1plusXRtdProvider', () => {
       }
     }
 
-
     it("doesn't write in config of unsupported bidder", () => {
       const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
       // Set initial config for this bidder
@@ -229,7 +226,6 @@ describe('1plusXRtdProvider', () => {
       expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2Updates.userData);
       expect(newBidderConfig.ortb2.user.data).to.deep.include(previousUserData);
     })
-
   })
 
   describe('setTargetingDataToConfig', () => {

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -128,7 +128,7 @@ describe('1plusXRtdProvider', () => {
     /* 1plusX RTD module may only use bidders that are both specified in :
         - the bid request configuration
         - AND in the 1plusX RTD module configuration
-      Below 2 tests are enforcing those rules 
+      Below 2 tests are enforcing those rules
     */
     it('Returns the intersection of bidders found in bid request config & module config', () => {
       const bidders = ['appnexus', 'rubicon'];
@@ -205,21 +205,8 @@ describe('1plusXRtdProvider', () => {
       }
     }
 
-    it("doesn't write in config of unsupported bidder", () => {
-      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
-      // Set initial config for this bidder
-      config.setBidderConfig({
-        bidders: [unsupportedBidder],
-        config: bidderConfigInitial
-      })
-      // Call my own setBidderConfig with targeting data
-      const newBidderConfig = updateBidderConfig(unsupportedBidder, ortb2Updates, config.getBidderConfig());
-      // Check that the config has not been changed for unsupported bidder
-      expect(newBidderConfig).to.be.null;
-    })
-
-    it('merges config for supported bidders (appnexus)', () => {
-      const bidder = 'appnexus';
+    it('merges fetched data in bidderConfig for configured bidders', () => {
+      const bidder = 'rubicon';
       // Set initial config
       config.setBidderConfig({
         bidders: [bidder],
@@ -227,7 +214,6 @@ describe('1plusXRtdProvider', () => {
       });
       // Call submodule's setBidderConfig
       const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
-
       // Check that the targeting data has been set in the config
       expect(newBidderConfig).not.to.be.null;
       expect(newBidderConfig.ortb2.site).to.deep.include(ortb2Updates.site);
@@ -237,8 +223,8 @@ describe('1plusXRtdProvider', () => {
       expect(newBidderConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
     })
 
-    it('merges config for supported bidders (rubicon)', () => {
-      const bidder = 'rubicon';
+    it('merges fetched data in bidderConfig for configured bidders (appnexus specific)', () => {
+      const bidder = 'appnexus';
       // Set initial config
       config.setBidderConfig({
         bidders: [bidder],
@@ -246,6 +232,7 @@ describe('1plusXRtdProvider', () => {
       });
       // Call submodule's setBidderConfig
       const newBidderConfig = updateBidderConfig(bidder, ortb2Updates, config.getBidderConfig());
+
       // Check that the targeting data has been set in the config
       expect(newBidderConfig).not.to.be.null;
       expect(newBidderConfig.ortb2.site).to.deep.include(ortb2Updates.site);
@@ -303,22 +290,6 @@ describe('1plusXRtdProvider', () => {
       }
     }
 
-    it("doesn't set config for unsupported bidders", () => {
-      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
-      // setting initial config for this bidder
-      config.setBidderConfig({
-        bidders: [unsupportedBidder],
-        config: bidderConfigInitial
-      })
-      // call setTargetingDataToConfig
-      setTargetingDataToConfig(fakeResponse, { bidders: [unsupportedBidder] });
-      // Check that the config has not been changed for unsupported bidder
-      const newConfig = config.getBidderConfig()[unsupportedBidder];
-      expect(newConfig.ortb2.user.data).to.be.undefined;
-      expect(newConfig.ortb2.site).to.not.have.any.keys('keywords')
-      expect(newConfig).to.deep.include(bidderConfigInitial);
-    })
-
     it('sets the config for the selected bidders', () => {
       const bidders = ['appnexus', 'rubicon'];
       // setting initial config for those bidders
@@ -338,31 +309,6 @@ describe('1plusXRtdProvider', () => {
         expect(newConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
         expect(newConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
       }
-    })
-    it('ignores unsupported bidders', () => {
-      const unsupportedBidder = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 5);
-      const bidders = ['appnexus', unsupportedBidder];
-      // setting initial config for those bidders
-      config.setBidderConfig({
-        bidders,
-        config: bidderConfigInitial
-      })
-      // call setTargetingDataToConfig
-      setTargetingDataToConfig(fakeResponse, { bidders });
-
-      // Check that the targeting data has been set for supported bidder
-      const appnexusConfig = config.getBidderConfig()['appnexus'];
-      expect(appnexusConfig.ortb2.site).to.deep.include(expectedOrtb2.site);
-      expect(appnexusConfig.ortb2.user).to.deep.include(expectedOrtb2.user);
-      // Check that existing config didn't get erased
-      expect(appnexusConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
-      expect(appnexusConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
-
-      // Check that config for unsupported bidder remained unchanged
-      const newConfig = config.getBidderConfig()[unsupportedBidder];
-      expect(newConfig.ortb2.user.data).to.be.undefined;
-      expect(newConfig.ortb2.site).to.not.have.any.keys('keywords')
-      expect(newConfig).to.deep.include(bidderConfigInitial);
     })
   })
 })

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -1,6 +1,7 @@
 import { config } from 'src/config';
 import {
   onePlusXSubmodule,
+  segtaxes,
   extractConfig,
   buildOrtb2Updates,
   updateBidderConfig,
@@ -56,7 +57,9 @@ describe('1plusXRtdProvider', () => {
       user: { data: [] },
       site: {
         content: {
-          data: [{ name: '1plusX.com', segment: [{ id: 'initial' }] }]
+          data: [{
+            name: '1plusX.com', segment: [{ id: 'initial' }], ext: { segtax: 525 }
+          }]
         }
       },
     }
@@ -178,7 +181,8 @@ describe('1plusXRtdProvider', () => {
       const expectedOutput = {
         siteContentData: {
           name: '1plusX.com',
-          segment: rtdData.topics.map((topicId) => ({ id: topicId }))
+          segment: rtdData.topics.map((topicId) => ({ id: topicId })),
+          ext: { segtax: segtaxes.CONTENT }
         },
         userData: {
           name: '1plusX.com',
@@ -210,7 +214,8 @@ describe('1plusXRtdProvider', () => {
       const expectedOutput = {
         siteContentData: {
           name: '1plusX.com',
-          segment: rtdData.topics.map((topicId) => ({ id: topicId }))
+          segment: rtdData.topics.map((topicId) => ({ id: topicId })),
+          ext: { segtax: segtaxes.CONTENT }
         },
         userData: {
           name: '1plusX.com',
@@ -242,7 +247,8 @@ describe('1plusXRtdProvider', () => {
       const expectedOutput = {
         siteContentData: {
           name: '1plusX.com',
-          segment: []
+          segment: [],
+          ext: { segtax: segtaxes.CONTENT }
         },
         userData: {
           name: '1plusX.com',
@@ -281,7 +287,8 @@ describe('1plusXRtdProvider', () => {
     const ortb2Updates = {
       siteContentData: {
         name: '1plusX.com',
-        segment: fakeResponse.t.map((topicId) => ({ id: topicId }))
+        segment: fakeResponse.t.map((topicId) => ({ id: topicId })),
+        ext: { segtax: segtaxes.CONTENT }
       },
       userData: {
         name: '1plusX.com',
@@ -398,7 +405,8 @@ describe('1plusXRtdProvider', () => {
     const expectedSiteContentObj = {
       data: [{
         name: '1plusX.com',
-        segment: fakeResponse.t.map((topicId) => ({ id: topicId }))
+        segment: fakeResponse.t.map((topicId) => ({ id: topicId })),
+        ext: { segtax: segtaxes.CONTENT }
       }]
     }
     const expectedUserObj = {

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -191,17 +191,13 @@ describe('1plusXRtdProvider', () => {
       }
       expect([ortb2Updates]).to.deep.include.members([expectedOutput]);
     });
-    it('fills site.keywords & user.data in the ortb2 config (appnexus specific)', () => {
+    it('fills site.keywords in the ortb2 config (appnexus specific)', () => {
       const rtdData = { segments: fakeResponse.s, topics: fakeResponse.t };
       const ortb2Updates = buildOrtb2Updates(rtdData, 'appnexus');
 
       const expectedOutput = {
         site: {
           keywords: rtdData.topics.join(','),
-        },
-        userData: {
-          name: '1plusX.com',
-          segment: rtdData.segments.map((segmentId) => ({ id: segmentId }))
         }
       }
       expect([ortb2Updates]).to.deep.include.members([expectedOutput]);
@@ -216,21 +212,6 @@ describe('1plusXRtdProvider', () => {
           name: '1plusX.com',
           segment: rtdData.topics.map((topicId) => ({ id: topicId })),
           ext: { segtax: segtaxes.CONTENT }
-        },
-        userData: {
-          name: '1plusX.com',
-          segment: []
-        }
-      }
-      expect(ortb2Updates).to.deep.include(expectedOutput);
-    })
-    it('defaults to empty array if no segment is given (appnexus specific)', () => {
-      const rtdData = { topics: fakeResponse.t };
-      const ortb2Updates = buildOrtb2Updates(rtdData, 'appnexus');
-
-      const expectedOutput = {
-        site: {
-          keywords: rtdData.topics.join(','),
         },
         userData: {
           name: '1plusX.com',
@@ -264,10 +245,6 @@ describe('1plusXRtdProvider', () => {
       const expectedOutput = {
         site: {
           keywords: '',
-        },
-        userData: {
-          name: '1plusX.com',
-          segment: rtdData.segments.map((segmentId) => ({ id: segmentId }))
         }
       }
       expect(ortb2Updates).to.deep.include(expectedOutput);
@@ -327,7 +304,6 @@ describe('1plusXRtdProvider', () => {
       // Check that the targeting data has been set in the config
       expect(newBidderConfig).not.to.be.null;
       expect(newBidderConfig.ortb2.site).to.deep.include(ortb2UpdatesAppNexus.site);
-      expect(newBidderConfig.ortb2.user.data).to.deep.include(ortb2UpdatesAppNexus.userData);
       // Check that existing config didn't get erased
       expect(newBidderConfig.ortb2.site).to.deep.include(bidderConfigInitial.ortb2.site);
       expect(newBidderConfig.ortb2.user).to.deep.include(bidderConfigInitial.ortb2.user);
@@ -417,8 +393,7 @@ describe('1plusXRtdProvider', () => {
     }
     const expectedOrtb2 = {
       appnexus: {
-        site: { keywords: expectedKeywords },
-        user: expectedUserObj
+        site: { keywords: expectedKeywords }
       },
       rubicon: {
         site: { content: expectedSiteContentObj },
@@ -442,7 +417,9 @@ describe('1plusXRtdProvider', () => {
         // Check that we got what we expect
         const expectedConfErr = (prop) => `New config for ${bidder} doesn't comply with expected at ${prop}`;
         expect(newConfig.ortb2.site, expectedConfErr('site')).to.deep.include(expectedOrtb2[bidder].site);
-        expect(newConfig.ortb2.user, expectedConfErr('user')).to.deep.include(expectedOrtb2[bidder].user);
+        if (expectedOrtb2[bidder].user) {
+          expect(newConfig.ortb2.user, expectedConfErr('user')).to.deep.include(expectedOrtb2[bidder].user);
+        }
         // Check that existing config didn't get erased
         const existingConfErr = (prop) => `Existing config for ${bidder} got unlawfully overwritten at ${prop}`;
         expect(newConfig.ortb2.site, existingConfErr('site')).to.deep.include(bidderConfigInitial.ortb2.site);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature (New RTD submodule)
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR adds a RTD submodule for 1plusX 
This module will fetch first party data from 1plusX's Profile API consisting of : 
  - the audiences the user is part of 
  - the topics related to the page
 
Then it will transmit this data to the supported & selected bid adapters through `setBidderConfig`

Contents of the PR : 
    - 1plusX RTD module: `modules/1plusXRtdProvider.js`
    - Unit tests for 1plusX RTD module: `test/spec/modules/1plusXRtdProvider_spec.js`
    - Integration example for 1plusX RTD module: `integrationExamples/gpt/1plusXRtdProviderExample.html`
    - Documentation for 1plusX RTD module: `modules/1plusXRtdProvider.md`

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- PR adding the documentation : prebid/prebid.github.io#3873

## Other information
I am not 100% sure about where to write the data in the ORTB2 format when updating the bid adapter configs.

The data I am fetching from 1plusX's Profile API consists of lists of custom-defined Ids that don't follow the standard taxonomy. 
While I found info about where to write audience segments & topics in ORTB2; it seemed that it concerned only those following the standard taxonomy. 

I reached a solution by combining the [ORTB2 specs](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) (pages 31 & 25) AND some examples from other RTD Providers : 
   - audience segments will be written in an element of `ortb2.user.data` array
   - topics will be written in `ortb2.site.keywords`

I will add comments to the related parts of the code, please review these parts with special care.
