### PR TITLE
Kargo Bid Adapter: fixing adm for legacy vast support

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -88,6 +88,7 @@ export const spec = {
       }
 
       const bidResponse = {
+        ad: adUnit.adm,
         requestId: bidId,
         cpm: Number(adUnit.cpm),
         width: adUnit.width,
@@ -103,8 +104,6 @@ export const spec = {
 
       if (meta.mediaType == VIDEO) {
         bidResponse.vastXml = adUnit.adm;
-      } else {
-        bidResponse.ad = adUnit.adm;
       }
 
       bidResponses.push(bidResponse);

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -572,6 +572,7 @@ describe('kargo adapter tests', function () {
         cpm: 2.5,
         width: 300,
         height: 250,
+        ad: '<VAST></VAST>',
         vastXml: '<VAST></VAST>',
         ttl: 300,
         creativeId: 'bar',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Some publishers had previously made changes to accept Vast XML through the `bid.ad` field before the Kargo Bid Adapter was populating the `bid.vastXml` field and setting the correct `mediaType` (changed with #8426).

This change will set the `bid.ad` field like it did previously while still correctly setting the `bid.vastXml` field for vast ads.