### PR TITLE
Topics FPD module: initial release

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -69,7 +69,8 @@
     ],
     "fpdModule": [
       "enrichmentFpdModule",
-      "validationFpdModule"
+      "validationFpdModule",
+      "topicsFpdModule"
     ]
   },
   "libraries": {

--- a/modules/fpdModule/index.js
+++ b/modules/fpdModule/index.js
@@ -4,6 +4,7 @@
  */
 import { config } from '../../src/config.js';
 import { module, getHook } from '../../src/hook.js';
+import {logError} from '../../src/utils.js';
 
 let submodules = [];
 
@@ -17,19 +18,28 @@ export function reset() {
 
 export function processFpd({global = {}, bidder = {}} = {}) {
   let modConf = config.getConfig('firstPartyData') || {};
-
+  // TODO: convert this to GreedyPromise once #8626 gets merged
+  let result = Promise.resolve({global, bidder});
   submodules.sort((a, b) => {
     return ((a.queue || 1) - (b.queue || 1));
   }).forEach(submodule => {
-    ({global = global, bidder = bidder} = submodule.processFpd(modConf, {global, bidder}));
+    result = result.then(
+      ({global, bidder}) => Promise.resolve(submodule.processFpd(modConf, {global, bidder}))
+        .catch((err) => {
+          logError(`Error in FPD module ${submodule.name}`, err);
+          return {};
+        })
+        .then((result) => ({global: result.global || global, bidder: result.bidder || bidder}))
+    );
   });
-
-  return {global, bidder};
+  return result;
 }
 
 export function startAuctionHook(fn, req) {
-  Object.assign(req.ortb2Fragments, processFpd(req.ortb2Fragments));
-  fn.call(this, req);
+  processFpd(req.ortb2Fragments).then((ortb2Fragments) => {
+    Object.assign(req.ortb2Fragments, ortb2Fragments);
+    fn.call(this, req);
+  })
 }
 
 function setupHook() {

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -2,27 +2,29 @@ import {logError, mergeDeep} from '../src/utils.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {submodule} from '../src/hook.js';
 
+export const TOPICS_TAXONOMY = 600;
+
 export function getTopicsData(name, topics) {
-  const data = Object.entries(
+  return Object.entries(
     topics.reduce((byTaxVersion, topic) => {
       const taxv = topic.taxonomyVersion;
       if (!byTaxVersion.hasOwnProperty(taxv)) byTaxVersion[taxv] = [];
       byTaxVersion[taxv].push(topic.topic);
       return byTaxVersion;
     }, {})
-  ).map(([taxv, topics]) => ({
-    ext: {
-      segtax: 600,
-      segclass: taxv
-    },
-    segment: topics.map((topic) => ({id: topic.toString()}))
-  }));
-  if (name != null) {
-    data.forEach((datum) => {
+  ).map(([taxv, topics]) => {
+    const datum = {
+      ext: {
+        segtax: TOPICS_TAXONOMY,
+        segclass: taxv
+      },
+      segment: topics.map((topic) => ({id: topic.toString()}))
+    };
+    if (name != null) {
       datum.name = name;
-    });
-  }
-  return data;
+    }
+    return datum;
+  });
 }
 
 export function getTopics(doc = document) {

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -1,0 +1,63 @@
+import {logError, mergeDeep} from '../src/utils.js';
+import {getRefererInfo} from '../src/refererDetection.js';
+import {submodule} from '../src/hook.js';
+
+export function getTopicsData(name, topics) {
+  const data = Object.entries(
+    topics.reduce((byTaxVersion, topic) => {
+      const taxv = topic.taxonomyVersion;
+      if (!byTaxVersion.hasOwnProperty(taxv)) byTaxVersion[taxv] = [];
+      byTaxVersion[taxv].push(topic.topic);
+      return byTaxVersion;
+    }, {})
+  ).map(([taxv, topics]) => ({
+    ext: {
+      segtax: 600,
+      segclass: taxv
+    },
+    segment: topics.map((topic) => ({id: topic.toString()}))
+  }));
+  if (name != null) {
+    data.forEach((datum) => {
+      datum.name = name;
+    });
+  }
+  return data;
+}
+
+export function getTopics(doc = document) {
+  let topics = null;
+  try {
+    if ('browsingTopics' in doc && doc.featurePolicy.allowsFeature('browsing-topics')) {
+      topics = doc.browsingTopics();
+    }
+  } catch (e) {
+    logError('Could not call topics API', e);
+  }
+  if (topics == null) {
+    // TODO: convert this to GreedyPromise once #8626 gets merged
+    topics = Promise.resolve([]);
+  }
+  return topics;
+}
+
+const topicsData = getTopics().then((topics) => getTopicsData(getRefererInfo().domain, topics));
+
+export function processFpd(config, {global}, {data = topicsData} = {}) {
+  return data.then((data) => {
+    if (data.length) {
+      mergeDeep(global, {
+        user: {
+          data
+        }
+      });
+    }
+    return {global};
+  });
+}
+
+submodule('firstPartyData', {
+  name: 'topics',
+  queue: 1,
+  processFpd
+});

--- a/test/spec/modules/fpdModule_spec.js
+++ b/test/spec/modules/fpdModule_spec.js
@@ -5,9 +5,6 @@ import {processFpd, registerSubmodules, startAuctionHook, reset} from 'modules/f
 import * as enrichmentModule from 'modules/enrichmentFpdModule.js';
 import * as validationModule from 'modules/validationFpdModule/index.js';
 
-let enrichments = {...enrichmentModule};
-let validations = {...validationModule};
-
 describe('the first party data module', function () {
   afterEach(function () {
     config.resetConfig();
@@ -18,21 +15,37 @@ describe('the first party data module', function () {
       global: {key: 'value'},
       bidder: {A: {bkey: 'bvalue'}}
     }
-    before(() => {
+    beforeEach(() => {
       reset();
+    });
+
+    it('should run ortb2Fragments through fpd submodules', () => {
       registerSubmodules({
         name: 'test',
-        queue: 2,
         processFpd: function () {
           return mockFpd;
         }
       });
-    })
-
-    it('should run ortb2Fragments through fpd submodules', () => {
       const req = {ortb2Fragments: {}};
-      startAuctionHook(() => null, req);
-      expect(req.ortb2Fragments).to.eql(mockFpd);
+      return new Promise((resolve) => startAuctionHook(resolve, req))
+        .then(() => {
+          expect(req.ortb2Fragments).to.eql(mockFpd);
+        })
+    });
+
+    it('should work with fpd submodules that return promises', () => {
+      registerSubmodules({
+        name: 'test',
+        processFpd: function () {
+          return Promise.resolve(mockFpd);
+        }
+      });
+      const req = {ortb2Fragments: {}};
+      return new Promise((resolve) => {
+        startAuctionHook(resolve, req);
+      }).then(() => {
+        expect(req.ortb2Fragments).to.eql(mockFpd);
+      });
     });
   });
 
@@ -79,7 +92,6 @@ describe('the first party data module', function () {
     });
 
     it('filters ortb2 data that is set', function () {
-      let validated;
       const global = {
         user: {
           data: {},
@@ -113,42 +125,42 @@ describe('the first party data module', function () {
       width = 1120;
       height = 750;
 
-      ({global: validated} = processFpd({global}));
-      expect(validated.site.ref).to.equal(getRefererInfo().ref || undefined);
-      expect(validated.site.page).to.equal('https://www.domain.com/path?query=12345');
-      expect(validated.site.domain).to.equal('domain.com');
-      expect(validated.site.content.data).to.deep.equal([{segment: [{id: 'test'}], name: 'bar'}]);
-      expect(validated.user.data).to.be.undefined;
-      expect(validated.device).to.deep.to.equal({w: 1, h: 1});
-      expect(validated.site.keywords).to.be.undefined;
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.site.ref).to.equal(getRefererInfo().ref || undefined);
+        expect(validated.site.page).to.equal('https://www.domain.com/path?query=12345');
+        expect(validated.site.domain).to.equal('domain.com');
+        expect(validated.site.content.data).to.deep.equal([{segment: [{id: 'test'}], name: 'bar'}]);
+        expect(validated.user.data).to.be.undefined;
+        expect(validated.device).to.deep.to.equal({w: 1, h: 1});
+        expect(validated.site.keywords).to.be.undefined;
+      });
     });
 
     it('should not overwrite existing data with default settings', function () {
-      let validated;
       const global = {
         site: {
           ref: 'https://referer.com'
         }
       };
 
-      ({global: validated} = processFpd({global}));
-      expect(validated.site.ref).to.equal('https://referer.com');
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.site.ref).to.equal('https://referer.com');
+      });
     });
 
     it('should allow overwrite default data with setConfig', function () {
-      let validated;
       const global = {
         site: {
           ref: 'https://referer.com'
         }
       };
 
-      ({global: validated} = processFpd({global}));
-      expect(validated.site.ref).to.equal('https://referer.com');
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.site.ref).to.equal('https://referer.com');
+      });
     });
 
     it('should filter all data', function () {
-      let validated;
       let global = {
         imp: [],
         site: {
@@ -179,15 +191,13 @@ describe('the first party data module', function () {
           adServerCurrency: 'USD'
         }
       };
-
       config.setConfig({'firstPartyData': {skipEnrichments: true}});
-
-      ({global: validated} = processFpd({global}));
-      expect(validated).to.deep.equal({});
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated).to.deep.equal({});
+      });
     });
 
     it('should add enrichments but not alter any arbitrary ortb2 data', function () {
-      let validated;
       let global = {
         site: {
           ext: {
@@ -205,12 +215,12 @@ describe('the first party data module', function () {
         },
         cur: ['USD']
       };
-
-      ({global: validated} = processFpd({global}));
-      expect(validated.site.ref).to.equal(getRefererInfo().referer);
-      expect(validated.site.ext.data).to.deep.equal({inventory: ['value1']});
-      expect(validated.user.ext.data).to.deep.equal({visitor: ['value2']});
-      expect(validated.cur).to.deep.equal(['USD']);
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.site.ref).to.equal(getRefererInfo().referer);
+        expect(validated.site.ext.data).to.deep.equal({inventory: ['value1']});
+        expect(validated.user.ext.data).to.deep.equal({visitor: ['value2']});
+        expect(validated.cur).to.deep.equal(['USD']);
+      })
     });
 
     it('should filter bidderConfig data', function () {
@@ -230,12 +240,13 @@ describe('the first party data module', function () {
         }
       };
 
-      const {bidder: validated} = processFpd({bidder});
-      expect(validated.bidderA).to.not.be.undefined;
-      expect(validated.bidderA.user.data).to.be.undefined;
-      expect(validated.bidderA.user.keywords).to.equal('test');
-      expect(validated.bidderA.site.keywords).to.equal('other');
-      expect(validated.bidderA.site.ref).to.equal('https://domain.com');
+      return processFpd({bidder}).then(({bidder: validated}) => {
+        expect(validated.bidderA).to.not.be.undefined;
+        expect(validated.bidderA.user.data).to.be.undefined;
+        expect(validated.bidderA.user.keywords).to.equal('test');
+        expect(validated.bidderA.site.keywords).to.equal('other');
+        expect(validated.bidderA.site.ref).to.equal('https://domain.com');
+      })
     });
 
     it('should not filter bidderConfig data as it is valid', function () {
@@ -255,17 +266,16 @@ describe('the first party data module', function () {
         }
       };
 
-      const {bidder: validated} = processFpd({bidder});
-
-      expect(validated.bidderA).to.not.be.undefined;
-      expect(validated.bidderA.user.data).to.deep.equal([{segment: [{id: 'data1_id'}], name: 'data1'}]);
-      expect(validated.bidderA.user.keywords).to.equal('test');
-      expect(validated.bidderA.site.keywords).to.equal('other');
-      expect(validated.bidderA.site.ref).to.equal('https://domain.com');
+      return processFpd({bidder}).then(({bidder: validated}) => {
+        expect(validated.bidderA).to.not.be.undefined;
+        expect(validated.bidderA.user.data).to.deep.equal([{segment: [{id: 'data1_id'}], name: 'data1'}]);
+        expect(validated.bidderA.user.keywords).to.equal('test');
+        expect(validated.bidderA.site.keywords).to.equal('other');
+        expect(validated.bidderA.site.ref).to.equal('https://domain.com');
+      });
     });
 
     it('should not set default values if skipEnrichments is turned on', function () {
-      let validated;
       config.setConfig({'firstPartyData': {skipEnrichments: true}});
 
       let global = {
@@ -281,15 +291,15 @@ describe('the first party data module', function () {
         }
       };
 
-      ({global: validated} = processFpd({global}));
-      expect(validated.device).to.be.undefined;
-      expect(validated.site.ref).to.be.undefined;
-      expect(validated.site.page).to.be.undefined;
-      expect(validated.site.domain).to.be.undefined;
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.device).to.be.undefined;
+        expect(validated.site.ref).to.be.undefined;
+        expect(validated.site.page).to.be.undefined;
+        expect(validated.site.domain).to.be.undefined;
+      });
     });
 
     it('should not validate ortb2 data if skipValidations is turned on', function () {
-      let validated;
       config.setConfig({'firstPartyData': {skipValidations: true}});
 
       let global = {
@@ -304,8 +314,9 @@ describe('the first party data module', function () {
         }
       };
 
-      ({global: validated} = processFpd({global}));
-      expect(validated.user.data).to.deep.equal([{segment: [{id: 'nonfiltered'}]}]);
+      return processFpd({global}).then(({global: validated}) => {
+        expect(validated.user.data).to.deep.equal([{segment: [{id: 'nonfiltered'}]}]);
+      });
     });
   });
 });

--- a/test/spec/modules/topicsFpdModule_spec.js
+++ b/test/spec/modules/topicsFpdModule_spec.js
@@ -1,0 +1,168 @@
+import {getTopics, getTopicsData, processFpd} from '../../../modules/topicsFpdModule.js';
+import {deepClone} from '../../../src/utils.js';
+
+describe('getTopicsData', () => {
+  function makeTopic(topic, taxv) {
+    return {
+      topic,
+      taxonomyVersion: taxv
+    }
+  }
+
+  [
+    {
+      t: 'no topics',
+      topics: [],
+      expected: []
+    },
+    {
+      t: 'single topic',
+      topics: [makeTopic(123, 'v1')],
+      expected: [
+        {
+          ext: {
+            segclass: 'v1'
+          },
+          segment: [
+            {id: '123'}
+          ]
+        }
+      ]
+    },
+    {
+      t: 'multiple topics with the same taxonomy version',
+      topics: [makeTopic(123, 'v1'), makeTopic(321, 'v1')],
+      expected: [
+        {
+          ext: {
+            segclass: 'v1'
+          },
+          segment: [
+            {id: '123'},
+            {id: '321'}
+          ]
+        }
+      ]
+    },
+    {
+      t: 'multiple topics with different taxonomy versions',
+      topics: [makeTopic(1, 'v1'), makeTopic(2, 'v1'), makeTopic(3, 'v2')],
+      expected: [
+        {
+          ext: {
+            segclass: 'v1'
+          },
+          segment: [
+            {id: '1'},
+            {id: '2'}
+          ]
+        },
+        {
+          ext: {
+            segclass: 'v2'
+          },
+          segment: [
+            {id: '3'}
+          ]
+        }
+      ]
+    }
+  ].forEach(({t, topics, expected}) => {
+    it(`on ${t}`, () => {
+      const actual = getTopicsData('mockName', topics);
+      actual.forEach((data, i) => {
+        sinon.assert.match(data, expected[i]);
+        expect(data.name).to.equal('mockName');
+        expect(data.ext.segtax).to.eql(600);
+      })
+    });
+
+    it('should not set name if null', () => {
+      getTopicsData(null, topics).forEach((data) => {
+        expect(data.hasOwnProperty('name')).to.be.false;
+      })
+    })
+  })
+});
+
+describe('getTopics', () => {
+  Object.entries({
+    'document with no browsingTopics': {},
+    'document that disallows topics': {
+      featurePolicy: {
+        allowsFeature: sinon.stub().returns(false)
+      }
+    },
+    'document that throws on featurePolicy': {
+      browsingTopics: sinon.stub(),
+      get featurePolicy() {
+        throw new Error()
+      }
+    },
+    'document that throws on browsingTopics': {
+      browsingTopics: sinon.stub().callsFake(() => { throw new Error(); }),
+      featurePolicy: {
+        allowsFeature: sinon.stub().returns(true)
+      }
+    },
+  }).forEach(([t, doc]) => {
+    it(`should resolve to an empty list on ${t}`, () => {
+      return getTopics(doc).then((topics) => {
+        expect(topics).to.eql([]);
+      });
+    })
+  });
+
+  it('should call `document.browsingTopics` when allowed', () => {
+    const topics = ['t1', 't2']
+    return getTopics({
+      browsingTopics: sinon.stub().returns(Promise.resolve(topics)),
+      featurePolicy: {
+        allowsFeature: sinon.stub().returns(true)
+      }
+    }).then((actual) => {
+      expect(actual).to.eql(topics);
+    })
+  })
+})
+
+describe('processFpd', () => {
+  const mockData = [
+    {
+      name: 'domain',
+      segment: [{id: 123}]
+    },
+    {
+      name: 'domain',
+      segment: [{id: 321}]
+    }
+  ];
+
+  it('should add topics data', () => {
+    return processFpd({}, {global: {}}, {data: Promise.resolve(mockData)})
+      .then(({global}) => {
+        expect(global.user.data).to.eql(mockData);
+      });
+  });
+
+  it('should apppend to existing user.data', () => {
+    const global = {
+      user: {
+        data: [
+          {name: 'preexisting'},
+        ]
+      }
+    };
+    return processFpd({}, {global: deepClone(global)}, {data: Promise.resolve(mockData)})
+      .then((data) => {
+        expect(data.global.user.data).to.eql(global.user.data.concat(mockData));
+      });
+  });
+
+  it('should not modify fpd when there is no data', () => {
+    return processFpd({}, {global: {}}, {data: Promise.resolve([])})
+      .then((data) => {
+        expect(data.global).to.eql({});
+      });
+  });
+});

--- a/test/spec/modules/topicsFpdModule_spec.js
+++ b/test/spec/modules/topicsFpdModule_spec.js
@@ -1,4 +1,4 @@
-import {getTopics, getTopicsData, processFpd} from '../../../modules/topicsFpdModule.js';
+import {getTopics, getTopicsData, processFpd, TOPICS_TAXONOMY} from '../../../modules/topicsFpdModule.js';
 import {deepClone} from '../../../src/utils.js';
 
 describe('getTopicsData', () => {
@@ -70,10 +70,11 @@ describe('getTopicsData', () => {
   ].forEach(({t, topics, expected}) => {
     it(`on ${t}`, () => {
       const actual = getTopicsData('mockName', topics);
+      expect(actual.length).to.eql(expected.length);
       actual.forEach((data, i) => {
         sinon.assert.match(data, expected[i]);
         expect(data.name).to.equal('mockName');
-        expect(data.ext.segtax).to.eql(600);
+        expect(data.ext.segtax).to.eql(TOPICS_TAXONOMY);
       })
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This adds a new `topicsFpdModule` that queries the [topics api](https://developer.chrome.com/docs/privacy-sandbox/topics/) to populate `user.data`.

Since `document.browsingTopics()` always returns an empty list for me, I need volunteers to test this in the real world.


## Other information

Closes https://github.com/prebid/Prebid.js/issues/7968
Depends on https://github.com/prebid/Prebid.js/pull/8626
Documentation TBD

