### PR TITLE
Build system: Fix CircleCi tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,18 @@ aliases:
       command: gulp e2e-test
 
   # Download and run BrowserStack local
-  - &setup_browserstack
-      name : Download BrowserStack Local binary and start it.
+  - &download_browserstack
+      name : Download BrowserStackLocal binary
       command : |
         # Download the browserstack binary file
         wget "https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip"
         # Unzip it
         unzip BrowserStackLocal-linux-x64.zip
-        # Run the file with user's access key
-        ./BrowserStackLocal ${BROWSERSTACK_ACCESS_KEY} &
+
+  - &start_browserstack
+    name: Start BrowserStackLocal
+    command: ./BrowserStackLocal --key ${BROWSERSTACK_ACCESS_KEY} --automate-only
+    background: true
 
   - &unit_test_steps
     - checkout
@@ -55,7 +58,8 @@ aliases:
     - run: npm ci
     - save_cache: *save_dep_cache
     - run: *install
-    - run: *setup_browserstack
+    - run: *download_browserstack
+    - run: *start_browserstack
     - run: *run_unit_test
 
   - &endtoend_test_steps
@@ -64,7 +68,8 @@ aliases:
     - run: npm install
     - save_cache: *save_dep_cache
     - run: *install
-    - run: *setup_browserstack
+    - run: *download_browserstack
+    - run: *start_browserstack
     - run: *run_endtoend_test
 
 version: 2

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -92,7 +92,8 @@ function setBrowsers(karmaConf, browserstack) {
     karmaConf.browserStack = {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
-      build: 'Prebidjs Unit Tests ' + new Date().toLocaleString()
+      build: 'Prebidjs Unit Tests ' + new Date().toLocaleString(),
+      startTunnel: false
     }
     if (process.env.TRAVIS) {
       karmaConf.browserStack.startTunnel = false;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

Fix an issue where tests on CircleCi would hang waiting for the browserstack tunnel to be set up. I don't know what caused it - it was not any change on our end as even old commits would fail in the same way. I'm also not sure why this particular change seems to fix it; I got here by trial and error. 
