### PR TITLE
Build system: use local identifiers for browserstack tunnels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,18 @@ aliases:
       command: gulp e2e-test
 
   # Download and run BrowserStack local
-  - &setup_browserstack
-      name : Download BrowserStack Local binary and start it.
+  - &download_browserstack
+      name : Download BrowserStackLocal binary
       command : |
         # Download the browserstack binary file
         wget "https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip"
         # Unzip it
         unzip BrowserStackLocal-linux-x64.zip
-        # Run the file with user's access key
-        ./BrowserStackLocal ${BROWSERSTACK_ACCESS_KEY} &
+
+  - &start_browserstack
+    name: Start BrowserStackLocal
+    command: ./BrowserStackLocal --key ${BROWSERSTACK_ACCESS_KEY} --automate-only
+    background: true
 
   - &unit_test_steps
     - checkout
@@ -55,7 +58,8 @@ aliases:
     - run: npm ci
     - save_cache: *save_dep_cache
     - run: *install
-    - run: *setup_browserstack
+    - run: *download_browserstack
+    - run: *start_browserstack
     - run: *run_unit_test
 
   - &endtoend_test_steps
@@ -64,7 +68,8 @@ aliases:
     - run: npm install
     - save_cache: *save_dep_cache
     - run: *install
-    - run: *setup_browserstack
+    - run: *download_browserstack
+    - run: *start_browserstack
     - run: *run_endtoend_test
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ aliases:
 
   - &start_browserstack
     name: Start BrowserStackLocal
-    command: ./BrowserStackLocal --key ${BROWSERSTACK_ACCESS_KEY} --automate-only
+    command: ./BrowserStackLocal --key ${BROWSERSTACK_ACCESS_KEY} --automate-only --local-identifier ${CIRCLE_WORKFLOW_JOB_ID}
     background: true
 
   - &unit_test_steps

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -93,7 +93,8 @@ function setBrowsers(karmaConf, browserstack) {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
       build: 'Prebidjs Unit Tests ' + new Date().toLocaleString(),
-      startTunnel: false
+      startTunnel: false,
+      localIdentifier: process.env.CIRCLE_WORKFLOW_JOB_ID
     }
     if (process.env.TRAVIS) {
       karmaConf.browserStack.startTunnel = false;

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -92,7 +92,8 @@ function setBrowsers(karmaConf, browserstack) {
     karmaConf.browserStack = {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
-      build: 'Prebidjs Unit Tests ' + new Date().toLocaleString()
+      build: 'Prebidjs Unit Tests ' + new Date().toLocaleString(),
+      startTunnel: false
     }
     if (process.env.TRAVIS) {
       karmaConf.browserStack.startTunnel = false;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

A followup to https://github.com/prebid/Prebid.js/pull/8632 ; use a local identifier for BrowserStackLocal to avoid [interference between multiple tunnels](https://app.circleci.com/pipelines/github/prebid/Prebid.js/12092/workflows/4a973346-37ea-44d9-9c59-dffd85c63665/jobs/22981):

> Thu Jun 30 2022 21:56:43:992 GMT+0000 (UTC) -- Multiple binaries spawned with same configuration. Closing older one.
