### PR TITLE
Prebid core: fix adUnits for auction at the time requestBids is called

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -48,3 +48,14 @@ export function submodule(name, ...args) {
     next(modules);
   });
 }
+
+/**
+ * Copy hook methods (.before, .after, etc) from a given hook to a given wrapper object.
+ */
+export function wrapHook(hook, wrapper) {
+  Object.defineProperties(
+    wrapper,
+    Object.fromEntries(['before', 'after', 'getHooks', 'removeAll'].map((m) => [m, {get: () => hook[m]}]))
+  );
+  return wrapper;
+}

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -222,6 +222,51 @@ describe('Unit: Prebid Module', function () {
     auctionManager.clearAllAuctions();
   });
 
+  describe('and global adUnits', () => {
+    const startingAdUnits = [
+      {
+        code: 'one',
+      },
+      {
+        code: 'two',
+      }
+    ];
+    let actualAdUnits, hookRan, done;
+
+    function deferringHook(next, req) {
+      setTimeout(() => {
+        actualAdUnits = req.adUnits || $$PREBID_GLOBAL$$.adUnits;
+        done();
+      });
+    }
+
+    beforeEach(() => {
+      $$PREBID_GLOBAL$$.requestBids.before(deferringHook, 99);
+      $$PREBID_GLOBAL$$.adUnits.splice(0, $$PREBID_GLOBAL$$.adUnits.length, ...startingAdUnits);
+      hookRan = new Promise((resolve) => {
+        done = resolve;
+      });
+    });
+
+    afterEach(() => {
+      $$PREBID_GLOBAL$$.requestBids.getHooks({hook: deferringHook}).remove();
+      $$PREBID_GLOBAL$$.adUnits.splice(0, $$PREBID_GLOBAL$$.adUnits.length);
+    })
+
+    Object.entries({
+      'addAdUnits': (g) => g.addAdUnits({code: 'three'}),
+      'removeAdUnit': (g) => g.removeAdUnit('one')
+    }).forEach(([method, op]) => {
+      it(`once called, should not be affected by ${method}`, () => {
+        $$PREBID_GLOBAL$$.requestBids({});
+        op($$PREBID_GLOBAL$$);
+        return hookRan.then(() => {
+          expect(actualAdUnits).to.eql(startingAdUnits);
+        })
+      });
+    });
+  });
+
   describe('getAdserverTargetingForAdUnitCodeStr', function () {
     beforeEach(function () {
       resetAuction();


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

If a publisher calls `pbjs.addAdUnits` or `pbjs.removeAdUnit` _after_ calling `requestBids`, those calls might have an effect on ongoing auctions - depending on whether any module needs to defer the start of the auction (for example, if `consentManagement` needs to look up consent data).

This changes `requestBids` to always use the adUnits that were defined at the moment it's called.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/8628
