### PR TITLE
Sharethrough Bid Adapter: getUserSyncs URL clean up

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -4,7 +4,7 @@ import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { createEidsArray } from './userId/eids.js';
 
-const VERSION = '4.1.0';
+const VERSION = '4.1.1';
 const BIDDER_CODE = 'sharethrough';
 const SUPPLY_ID = 'WYu2BXv1';
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -34,9 +34,8 @@ export const sharethroughAdapterSpec = {
       cur: ['USD'],
       tmax: timeout,
       site: {
-        // TODO: do the fallbacks make sense here?
-        domain: deepAccess(bidderRequest, 'refererInfo.domain') || window.location.hostname,
-        page: deepAccess(bidderRequest, 'refererInfo.page') || window.location.href,
+        domain: deepAccess(bidderRequest, 'refererInfo.domain', window.location.hostname),
+        page: deepAccess(bidderRequest, 'refererInfo.page', window.location.href),
         ref: deepAccess(bidderRequest, 'refererInfo.ref'),
         ...firstPartyData.site,
       },
@@ -66,7 +65,7 @@ export const sharethroughAdapterSpec = {
 
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
-    req.user.ext.eids = userIdAsEids(bidRequests[0]);
+    req.user.ext.eids = createEidsArray(deepAccess(bidRequests[0], 'userId')) || [];
 
     if (bidderRequest.gdprConsent) {
       const gdprApplies = bidderRequest.gdprConsent.gdprApplies === true;
@@ -181,21 +180,12 @@ export const sharethroughAdapterSpec = {
     });
   },
 
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
-    const syncParams = uspConsent ? `&us_privacy=${uspConsent}` : '';
-    const syncs = [];
-    const shouldCookieSync = syncOptions.pixelEnabled &&
-      serverResponses.length > 0 &&
-      serverResponses[0].body &&
-      serverResponses[0].body.cookieSyncUrls;
+  getUserSyncs: (syncOptions, serverResponses) => {
+    const shouldCookieSync = syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    if (shouldCookieSync) {
-      serverResponses[0].body.cookieSyncUrls.forEach(url => {
-        syncs.push({ type: 'image', url: url + syncParams });
-      });
-    }
-
-    return syncs;
+    return shouldCookieSync
+      ? serverResponses[0].body.cookieSyncUrls.map(url => ({ type: 'image', url: url }))
+      : [];
   },
 
   // Empty implementation for prebid core to be able to find it
@@ -242,11 +232,6 @@ function getBidRequestFloor(bid) {
     }
   }
   return floor !== null ? floor : bid.params.floor;
-}
-
-function userIdAsEids(bidRequest) {
-  const eids = createEidsArray(deepAccess(bidRequest, 'userId')) || [];
-  return eids;
 }
 
 function getProtocol() {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -601,11 +601,11 @@ describe('sharethrough adapter spec', function () {
       const serverResponses = [{ body: { cookieSyncUrls: cookieSyncs } }];
 
       it('returns an array of correctly formatted user syncs', function () {
-        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, null, 'fake-privacy-signal');
+        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses);
         expect(syncArray).to.deep.equal([
-          { type: 'image', url: 'cookieUrl1&us_privacy=fake-privacy-signal' },
-          { type: 'image', url: 'cookieUrl2&us_privacy=fake-privacy-signal' },
-          { type: 'image', url: 'cookieUrl3&us_privacy=fake-privacy-signal' }],
+          { type: 'image', url: 'cookieUrl1' },
+          { type: 'image', url: 'cookieUrl2' },
+          { type: 'image', url: 'cookieUrl3' }],
         );
       });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Code style update (formatting, local variables)

## Description of change
1. we've removed an extra query param from the URLs in `getUserSyncs` as it was redundant with the URL itself
2. following the clean up done on the adapter for Prebid 7 compatibility, we've done a little bit of clean up/polish (no functional change there)

Contact: pubgrowth.engineering@sharethrough.com
