### PR TITLE
Revert "Gdpr Enforcement module and sharedId/pubCommonId modules: vendor consent should not be enforced for first-party-id modules (#8448)"

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -30,7 +30,6 @@ import {Renderer} from '../src/Renderer.js';
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
 const GLOBAL_VENDOR_ID = 10;
-const MODULE_TYPE = 'bid-adapter';
 const SECURE_BID_URL = 'https://htlb.casalemedia.com/openrtb/pbjs';
 const SUPPORTED_AD_TYPES = [BANNER, VIDEO, NATIVE];
 const BANNER_ENDPOINT_VERSION = 7.2;
@@ -1425,7 +1424,7 @@ function localStorageHandler(data) {
       hasEnforcementHook: false,
       valid: hasDeviceAccess()
     };
-    validateStorageEnforcement(GLOBAL_VENDOR_ID, BIDDER_CODE, MODULE_TYPE, DEFAULT_ENFORCEMENT_SETTINGS, (permissions) => {
+    validateStorageEnforcement(GLOBAL_VENDOR_ID, BIDDER_CODE, DEFAULT_ENFORCEMENT_SETTINGS, (permissions) => {
       if (permissions.valid) {
         storeErrorEventData(data);
       }

--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -9,8 +9,7 @@ import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
 
-const MODULE_TYPE = 'fpid-module';
-const storage = getStorageManager({moduleType: MODULE_TYPE});
+const storage = getStorageManager({moduleName: 'pubCommonId'});
 
 const ID_NAME = '_pubcid';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -5,13 +5,12 @@
  * @requires module:modules/userId
  */
 
-import {buildUrl, generateUUID, hasDeviceAccess, logInfo, parseUrl, triggerPixel} from '../src/utils.js';
+import { parseUrl, buildUrl, triggerPixel, logInfo, hasDeviceAccess, generateUUID } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
-import {coppaDataHandler} from '../src/adapterManager.js';
+import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
-const MODULE_TYPE = 'fpid-module';
-export const storage = getStorageManager({moduleName: 'pubCommonId', moduleType: MODULE_TYPE});
+export const storage = getStorageManager({moduleName: 'pubCommonId'});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';
@@ -88,7 +87,8 @@ export const sharedIdSystemSubmodule = {
       return undefined;
     }
     logInfo(' Decoded value PubCommonId ' + value);
-    return {'pubcid': value};
+    const idObj = {'pubcid': value};
+    return idObj;
   },
   /**
    * performs action to obtain id

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -48,7 +48,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
       let hookDetails = {
         hasEnforcementHook: false
       }
-      validateStorageEnforcement(gvlid, bidderCode || moduleName, moduleType, hookDetails, function(result) {
+      validateStorageEnforcement(gvlid, bidderCode || moduleName, hookDetails, function(result) {
         if (result && result.hasEnforcementHook) {
           value = cb(result);
         } else {
@@ -303,7 +303,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
 /**
  * This hook validates the storage enforcement if gdprEnforcement module is included
  */
-export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, moduleType, hookDetails, callback) {
+export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, hookDetails, callback) {
   callback(hookDetails);
 }, 'validateStorageEnforcement');
 
@@ -322,13 +322,12 @@ export function getCoreStorageManager(moduleName) {
  * @param {Number=} gvlid? Vendor id - required for proper GDPR integration
  * @param {string=} bidderCode? - required for bid adapters
  * @param {string=} moduleName? module name
- * @param {string=} moduleType? module type
  */
-export function getStorageManager({gvlid, moduleName, bidderCode, moduleType} = {}) {
+export function getStorageManager({gvlid, moduleName, bidderCode} = {}) {
   if (arguments.length > 1 || (arguments.length > 0 && !isPlainObject(arguments[0]))) {
     throw new Error('Invalid invocation for getStorageManager')
   }
-  return newStorageManager({gvlid, moduleName, bidderCode, moduleType});
+  return newStorageManager({gvlid, moduleName, bidderCode});
 }
 
 export function resetData() {

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -1,21 +1,21 @@
 import {
   deviceAccessHook,
-  enableAnalyticsHook,
-  enforcementRules,
-  getGvlid,
-  internal,
+  setEnforcementConfig,
+  userSyncHook,
+  userIdHook,
   makeBidRequestsHook,
+  validateRules,
+  enforcementRules,
   purpose1Rule,
   purpose2Rule,
-  setEnforcementConfig,
-  userIdHook,
-  userSyncHook,
-  validateRules
+  enableAnalyticsHook,
+  getGvlid,
+  internal
 } from 'modules/gdprEnforcement.js';
-import {config} from 'src/config.js';
-import adapterManager, {gdprDataHandler} from 'src/adapterManager.js';
+import { config } from 'src/config.js';
+import adapterManager, { gdprDataHandler } from 'src/adapterManager.js';
 import * as utils from 'src/utils.js';
-import {validateStorageEnforcement} from 'src/storageManager.js';
+import { validateStorageEnforcement } from 'src/storageManager.js';
 import * as events from 'src/events.js';
 
 describe('gdpr enforcement', function () {
@@ -98,9 +98,9 @@ describe('gdpr enforcement', function () {
   };
 
   after(function () {
-    validateStorageEnforcement.getHooks({hook: deviceAccessHook}).remove();
+    validateStorageEnforcement.getHooks({ hook: deviceAccessHook }).remove();
     $$PREBID_GLOBAL$$.requestBids.getHooks().remove();
-    adapterManager.makeBidRequests.getHooks({hook: makeBidRequestsHook}).remove();
+    adapterManager.makeBidRequests.getHooks({ hook: makeBidRequestsHook }).remove();
   })
 
   describe('deviceAccessHook', function () {
@@ -149,7 +149,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: false
       }
-      sinon.assert.calledWith(nextFnSpy, undefined, undefined, undefined, result);
+      sinon.assert.calledWith(nextFnSpy, undefined, undefined, result);
     });
 
     it('should only check for consent for vendor exceptions when enforcePurpose and enforceVendor are false', function () {
@@ -199,53 +199,6 @@ describe('gdpr enforcement', function () {
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
-    it('should allow device access when enforce vendor but module is vendorless ', function () {
-      adapterManagerStub.withArgs('pubCommonId').returns(getBidderSpec(1));
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-          }]
-        }
-      });
-      let consentData = {}
-      consentData.vendorData = staticConfig.consentData.getTCData;
-      consentData.gdprApplies = true;
-      consentData.apiVersion = 2;
-      gdprDataHandlerStub.returns(consentData);
-
-      deviceAccessHook(nextFnSpy, 1, 'pubCommonId', 'fpid-module');
-      expect(logWarnSpy.callCount).to.equal(0);
-    });
-
-    it('should not allow device access if enforce vendor, module is vendorless, but there is no consent for purpose 1', function () {
-      adapterManagerStub.withArgs('pubCommonId').returns(getBidderSpec(1));
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-          }]
-        }
-      });
-
-      let consentData = {}
-      // set consent for purpose 1 to false
-      const newConsentData = utils.deepClone(staticConfig);
-      newConsentData.consentData.getTCData.purpose.consents['1'] = false;
-      consentData.vendorData = newConsentData.consentData.getTCData;
-      consentData.apiVersion = 2;
-      consentData.gdprApplies = true;
-
-      gdprDataHandlerStub.returns(consentData);
-
-      deviceAccessHook(nextFnSpy, 1, 'pubCommonId', 'fpid-module');
-      expect(logWarnSpy.callCount).to.equal(1);
-    });
-
     it('should allow device access when gdprApplies is false and hasDeviceAccess flag is true', function () {
       adapterManagerStub.withArgs('appnexus').returns(getBidderSpec(1));
       setEnforcementConfig({
@@ -270,10 +223,10 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 1, 'appnexus', undefined, result);
+      sinon.assert.calledWith(nextFnSpy, 1, 'appnexus', result);
     });
 
-    it('should use gvlMapping set by publisher', function () {
+    it('should use gvlMapping set by publisher', function() {
       config.setConfig({
         'gvlMapping': {
           'appnexus': 4
@@ -301,11 +254,11 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', undefined, result);
+      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', result);
       config.resetConfig();
     });
 
-    it('should use gvl id of alias and not of parent', function () {
+    it('should use gvl id of alias and not of parent', function() {
       let curBidderStub = sinon.stub(config, 'getCurrentBidder');
       curBidderStub.returns('appnexus-alias');
       adapterManager.aliasBidAdapter('appnexus', 'appnexus-alias');
@@ -336,7 +289,7 @@ describe('gdpr enforcement', function () {
         hasEnforcementHook: true,
         valid: true
       }
-      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', undefined, result);
+      sinon.assert.calledWith(nextFnSpy, 4, 'appnexus', result);
       config.resetConfig();
       curBidderStub.restore();
     });
@@ -517,7 +470,7 @@ describe('gdpr enforcement', function () {
       const args = nextFnSpy.getCalls()[0].args;
       expect(args[1].hasValidated).to.be.true;
       expect(nextFnSpy.calledOnce).to.equal(true);
-      sinon.assert.calledWith(nextFnSpy, submodules, {...consentData, hasValidated: true});
+      sinon.assert.calledWith(nextFnSpy, submodules, { ...consentData, hasValidated: true });
     });
 
     it('should allow userId module if gdpr not in scope', function () {
@@ -571,7 +524,7 @@ describe('gdpr enforcement', function () {
           name: 'sampleUserId'
         }
       }]
-      sinon.assert.calledWith(nextFnSpy, expectedSubmodules, {...consentData, hasValidated: true});
+      sinon.assert.calledWith(nextFnSpy, expectedSubmodules, { ...consentData, hasValidated: true });
     });
   });
 
@@ -630,17 +583,17 @@ describe('gdpr enforcement', function () {
       gdprDataHandlerStub.returns(consentData);
       adapterManagerStub.withArgs('bidder_1').returns({
         getSpec: function () {
-          return {'gvlid': 4}
+          return { 'gvlid': 4 }
         }
       });
       adapterManagerStub.withArgs('bidder_2').returns({
         getSpec: function () {
-          return {'gvlid': 5}
+          return { 'gvlid': 5 }
         }
       });
       adapterManagerStub.withArgs('bidder_3').returns({
         getSpec: function () {
-          return {'gvlid': undefined}
+          return { 'gvlid': undefined }
         }
       });
       makeBidRequestsHook(nextFnSpy, MOCK_AD_UNITS, []);
@@ -651,20 +604,20 @@ describe('gdpr enforcement', function () {
         code: 'ad-unit-1',
         mediaTypes: {},
         bids: [
-          sinon.match({bidder: 'bidder_1'}),
-          sinon.match({bidder: 'bidder_2'})
+          sinon.match({ bidder: 'bidder_1' }),
+          sinon.match({ bidder: 'bidder_2' })
         ]
       }, {
         code: 'ad-unit-2',
         mediaTypes: {},
         bids: [
-          sinon.match({bidder: 'bidder_2'}),
-          sinon.match({bidder: 'bidder_3'}) // should be allowed even though it's doesn't have a gvlId because liTransparency is established.
+          sinon.match({ bidder: 'bidder_2' }),
+          sinon.match({ bidder: 'bidder_3' }) // should be allowed even though it's doesn't have a gvlId because liTransparency is established.
         ]
       }], []);
     });
 
-    it('should block bidder which does not have consent and allow bidder which has consent (liTransparency is NOT established)', function () {
+    it('should block bidder which does not have consent and allow bidder which has consent (liTransparency is NOT established)', function() {
       setEnforcementConfig({
         gdpr: {
           rules: [{
@@ -688,17 +641,17 @@ describe('gdpr enforcement', function () {
       gdprDataHandlerStub.returns(consentData);
       adapterManagerStub.withArgs('bidder_1').returns({
         getSpec: function () {
-          return {'gvlid': 4}
+          return { 'gvlid': 4 }
         }
       });
       adapterManagerStub.withArgs('bidder_2').returns({
         getSpec: function () {
-          return {'gvlid': 5}
+          return { 'gvlid': 5 }
         }
       });
       adapterManagerStub.withArgs('bidder_3').returns({
         getSpec: function () {
-          return {'gvlid': undefined}
+          return { 'gvlid': undefined }
         }
       });
 
@@ -710,13 +663,13 @@ describe('gdpr enforcement', function () {
         code: 'ad-unit-1',
         mediaTypes: {},
         bids: [
-          sinon.match({bidder: 'bidder_1'}), // 'bidder_2' is not present because it doesn't have vendorConsent
+          sinon.match({ bidder: 'bidder_1' }), // 'bidder_2' is not present because it doesn't have vendorConsent
         ]
       }, {
         code: 'ad-unit-2',
         mediaTypes: {},
         bids: [
-          sinon.match({bidder: 'bidder_3'}), // 'bidder_3' is allowed despite gvlId being undefined because it's part of vendorExceptions
+          sinon.match({ bidder: 'bidder_3' }), // 'bidder_3' is allowed despite gvlId being undefined because it's part of vendorExceptions
         ]
       }], []);
 
@@ -774,12 +727,12 @@ describe('gdpr enforcement', function () {
       nextFnSpy = sandbox.spy();
     });
 
-    afterEach(function () {
+    afterEach(function() {
       config.resetConfig();
       sandbox.restore();
     });
 
-    it('should block analytics adapter which does not have consent and allow the one(s) which have consent', function () {
+    it('should block analytics adapter which does not have consent and allow the one(s) which have consent', function() {
       setEnforcementConfig({
         gdpr: {
           rules: [{
@@ -797,9 +750,9 @@ describe('gdpr enforcement', function () {
       consentData.gdprApplies = true;
 
       gdprDataHandlerStub.returns(consentData);
-      adapterManagerStub.withArgs('analyticsAdapter_A').returns({gvlid: 3});
-      adapterManagerStub.withArgs('analyticsAdapter_B').returns({gvlid: 5});
-      adapterManagerStub.withArgs('analyticsAdapter_C').returns({gvlid: 1});
+      adapterManagerStub.withArgs('analyticsAdapter_A').returns({ gvlid: 3 });
+      adapterManagerStub.withArgs('analyticsAdapter_B').returns({ gvlid: 5 });
+      adapterManagerStub.withArgs('analyticsAdapter_C').returns({ gvlid: 1 });
 
       enableAnalyticsHook(nextFnSpy, MOCK_ANALYTICS_ADAPTER_CONFIG);
 
@@ -1072,7 +1025,7 @@ describe('gdpr enforcement', function () {
       expect(purpose2Rule).to.deep.equal(purpose2RuleDefinedInConfig);
     });
 
-    it('should use the "rules" defined in config if a definition found', function () {
+    it('should use the "rules" defined in config if a definition found', function() {
       const rules = [{
         purpose: 'storage',
         enforcePurpose: false,
@@ -1082,23 +1035,23 @@ describe('gdpr enforcement', function () {
         enforcePurpose: false,
         enforceVendor: false
       }]
-      setEnforcementConfig({gdpr: {rules}});
+      setEnforcementConfig({gdpr: { rules }});
 
       expect(enforcementRules).to.deep.equal(rules);
     });
   });
 
-  describe('TCF2FinalResults', function () {
+  describe('TCF2FinalResults', function() {
     let sandbox;
-    beforeEach(function () {
+    beforeEach(function() {
       sandbox = sinon.createSandbox();
       sandbox.spy(events, 'emit');
     });
-    afterEach(function () {
+    afterEach(function() {
       config.resetConfig();
       sandbox.restore();
     });
-    it('should emit TCF2 enforcement data on auction end', function () {
+    it('should emit TCF2 enforcement data on auction end', function() {
       const rules = [{
         purpose: 'storage',
         enforcePurpose: false,
@@ -1108,7 +1061,7 @@ describe('gdpr enforcement', function () {
         enforcePurpose: false,
         enforceVendor: false
       }]
-      setEnforcementConfig({gdpr: {rules}});
+      setEnforcementConfig({gdpr: { rules }});
 
       events.emit('auctionEnd', {})
 
@@ -1117,28 +1070,28 @@ describe('gdpr enforcement', function () {
     })
   });
 
-  describe('getGvlid', function () {
+  describe('getGvlid', function() {
     let sandbox;
     let getGvlidForBidAdapterStub;
     let getGvlidForUserIdModuleStub;
     let getGvlidForAnalyticsAdapterStub;
-    beforeEach(function () {
+    beforeEach(function() {
       sandbox = sinon.createSandbox();
       getGvlidForBidAdapterStub = sandbox.stub(internal, 'getGvlidForBidAdapter');
       getGvlidForUserIdModuleStub = sandbox.stub(internal, 'getGvlidForUserIdModule');
       getGvlidForAnalyticsAdapterStub = sandbox.stub(internal, 'getGvlidForAnalyticsAdapter');
     });
-    afterEach(function () {
+    afterEach(function() {
       sandbox.restore();
       config.resetConfig();
     });
 
-    it('should return "null" if called without passing any argument', function () {
+    it('should return "null" if called without passing any argument', function() {
       const gvlid = getGvlid();
       expect(gvlid).to.equal(null);
     });
 
-    it('should return "null" if GVL ID is not defined for any of these modules: Bid adapter, UserId submodule and Analytics adapter', function () {
+    it('should return "null" if GVL ID is not defined for any of these modules: Bid adapter, UserId submodule and Analytics adapter', function() {
       getGvlidForBidAdapterStub.withArgs('moduleA').returns(null);
       getGvlidForUserIdModuleStub.withArgs('moduleA').returns(null);
       getGvlidForAnalyticsAdapterStub.withArgs('moduleA').returns(null);
@@ -1147,7 +1100,7 @@ describe('gdpr enforcement', function () {
       expect(gvlid).to.equal(null);
     });
 
-    it('should return the GVL ID from gvlMapping if it is defined in setConfig', function () {
+    it('should return the GVL ID from gvlMapping if it is defined in setConfig', function() {
       config.setConfig({
         gvlMapping: {
           moduleA: 1
@@ -1161,7 +1114,7 @@ describe('gdpr enforcement', function () {
       expect(gvlid).to.equal(1);
     });
 
-    it('should return the GVL ID by calling getGvlidForBidAdapter -> getGvlidForUserIdModule -> getGvlidForAnalyticsAdapter in sequence', function () {
+    it('should return the GVL ID by calling getGvlidForBidAdapter -> getGvlidForUserIdModule -> getGvlidForAnalyticsAdapter in sequence', function() {
       getGvlidForBidAdapterStub.withArgs('moduleA').returns(null);
       getGvlidForUserIdModuleStub.withArgs('moduleA').returns(null);
       getGvlidForAnalyticsAdapterStub.withArgs('moduleA').returns(7);


### PR DESCRIPTION
This reverts commit 5ece4bb0eeea95f09f0560cf6882af8491b30620.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

revert https://github.com/prebid/Prebid.js/pull/8448 because of https://github.com/prebid/Prebid.js/issues/8647; there are [5 different enforcement hooks](https://github.com/prebid/Prebid.js/blob/b5c9c068048269f6dcce0f1a8c3b79b50a452442/modules/gdprEnforcement.js#L363-L376) that should be bypassed for "vendorless" modules, but the original PR addresses only one. The net result is that sharedId is broken for anyone using GDPR enforcement.
