### PR TITLE
SharedId: proper revert of https://github.com/prebid/Prebid.js/commit/5ece4bb0eeea95f09f0560cf6882af8491b30620

### DIFF
--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -9,7 +9,7 @@ import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
 
-const storage = getStorageManager({moduleName: 'pubCommonId'});
+const storage = getStorageManager();
 
 const ID_NAME = '_pubcid';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -10,7 +10,8 @@ import {submodule} from '../src/hook.js';
 import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 
-export const storage = getStorageManager({moduleName: 'pubCommonId'});
+const GVLID = 887;
+export const storage = getStorageManager({gvlid: GVLID, moduleName: 'pubCommonId'});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';
@@ -73,6 +74,11 @@ export const sharedIdSystemSubmodule = {
    */
   name: 'sharedId',
   aliasName: 'pubCommonId',
+  /**
+   * Vendor id of prebid
+   * @type {Number}
+   */
+  gvlid: GVLID,
 
   /**
    * decode the stored id value for passing to bid requests


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Followup to https://github.com/prebid/Prebid.js/pull/8648; I lost some pieces when resolving conflicts in the original revert commit. 

The intent is to revert sharedId's gvlid logic to this revision: https://github.com/prebid/Prebid.js/blob/997961fe1c10ac8e647b1ba019a1b189983daf9d/modules/sharedIdSystem.js
