### PR TITLE
PBjs Core Price Floors Module: improve logging on bid rejections to clarify which CPM is being compared with which floor

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -751,14 +751,7 @@ export function addBidResponseHook(fn, adUnitCode, bid) {
     flooredBid.status = CONSTANTS.BID_STATUS.BID_REJECTED;
     // if floor not met update bid with 0 cpm so it is not included downstream and marked as no-bid
     flooredBid.cpm = 0;
-    const floorMsg = (() => {
-      try {
-        return ` (adjusted cpm: ${bid.floorData.cpmAfterAdjustments.toFixed(2)}, floor: ${floorInfo.matchingFloor.toFixed(2)})`
-      } catch (e) {
-        return ''
-      }
-    })();
-    logWarn(`${MODULE_NAME}: ${flooredBid.bidderCode}'s Bid Response for ${adUnitCode} was rejected due to floor not met${floorMsg}`, bid);
+    logWarn(`${MODULE_NAME}: ${flooredBid.bidderCode}'s Bid Response for ${adUnitCode} was rejected due to floor not met (adjusted cpm: ${bid?.floorData?.cpmAfterAdjustments}, floor: ${floorInfo?.matchingFloor})`, bid);
     return fn.call(this, adUnitCode, flooredBid);
   }
   return fn.call(this, adUnitCode, bid);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

When a bid is rejected because below its price floor, the logged bid object shows a `cpm` _before_ `bidCpmAdjustment`, but the comparison to the floor may have taken adjustment into account. This can appear as if a valid bid is being rejected (see https://github.com/prebid/Prebid.js/issues/8565)

This modifies the log message to explicitly show which cpm was found to be below the floor, which should help avoid confusion.
