### PR TITLE
Release Drafter: change default tagging to maintenance

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,7 +10,8 @@ categories:
     labels:
       - 'fix'
       - 'bugfix'
-      - 'bug'      
+      - 'bug'
+    default: maintenance
 change-template: '- $TITLE (#$NUMBER)'
 version-resolver:
   major:


### PR DESCRIPTION
Update the release drafter so that if a pr is not tagged it defaults to maintenance