### PR TITLE
Ttd Bid adapter: support for transaction id, bcat, and consolidate params

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -326,6 +326,7 @@ export const spec = {
 
     const gpid = utils.deepAccess(bid, 'ortb2Imp.ext.gpid');
     if (!bid.params.placementId && !gpid) {
+      utils.logWarn(BIDDER_CODE + ': one of params.placementId or gpid (via the GPT module https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html) must be passed');
       return false;
     }
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -59,7 +59,7 @@ function getBidFloor(bid) {
 
 function getSource(validBidRequests) {
   let source = {
-    tid: utils.deepAccess(validBidRequests[0], 'ortb2Imp.ext.tid')
+    tid: validBidRequests[0].transactionId
   };
   if (validBidRequests[0].schain) {
     utils.deepSetValue(source, 'ext.schain', validBidRequests[0].schain);
@@ -146,10 +146,11 @@ function getImpression(bidRequest) {
   };
 
   const gpid = utils.deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
-  if (gpid) {
-    impression.ext = {
-      gpid: gpid
-    }
+  const tid = utils.deepAccess(bidRequest, 'ortb2Imp.ext.tid');
+  if (gpid || tid) {
+    impression.ext = {}
+    if (gpid) { impression.ext.gpid = gpid }
+    if (tid) { impression.ext.tid = tid }
   }
 
   const tagid = gpid || bidRequest.params.placementId;

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -324,6 +324,11 @@ export const spec = {
       return false;
     }
 
+    const gpid = utils.deepAccess(bid, 'ortb2Imp.ext.gpid');
+    if (!bid.params.placementId && !gpid) {
+      return false;
+    }
+
     const mediaTypesBanner = utils.deepAccess(bid, 'mediaTypes.banner');
     const mediaTypesVideo = utils.deepAccess(bid, 'mediaTypes.video');
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -59,7 +59,7 @@ function getBidFloor(bid) {
 
 function getSource(validBidRequests) {
   let source = {
-    tid: validBidRequests[0].transactionId
+    tid: utils.deepAccess(validBidRequests[0], 'ortb2Imp.ext.tid')
   };
   if (validBidRequests[0].schain) {
     utils.deepSetValue(source, 'ext.schain', validBidRequests[0].schain);
@@ -217,6 +217,12 @@ function banner(bid) {
       format: sizes,
     },
     optionalParams);
+
+  const battr = utils.deepAccess(bid, 'ortb2Imp.battr');
+  if (battr) {
+    banner.battr = battr
+  }
+
   return banner;
 }
 
@@ -282,6 +288,11 @@ function video(bid) {
   }
   if (maxbitrate && utils.isInteger(maxbitrate)) {
     video.maxbitrate = maxbitrate;
+  }
+
+  const battr = utils.deepAccess(bid, 'ortb2Imp.battr');
+  if (battr) {
+    video.battr = battr
   }
 
   return video;
@@ -384,6 +395,10 @@ export const spec = {
 
     if (firstPartyData && firstPartyData.bcat) {
       topLevel.bcat = firstPartyData.bcat;
+    }
+
+    if (firstPartyData && firstPartyData.badv) {
+      topLevel.badv = firstPartyData.badv;
     }
 
     let url = BIDDER_ENDPOINT + bidderRequest.bids[0].params.supplySourceId;

--- a/modules/ttdBidAdapter.md
+++ b/modules/ttdBidAdapter.md
@@ -29,9 +29,7 @@ The Trade Desk bid adapter supports Banner and Video.
                         bidder: 'ttd',
                         params: {
                             supplySourceId: 'supplier',
-                            publisherId: '1427ab10f2e448057ed3b422',
-                            siteId: 'site-123',
-                            placementId: 'footer1'
+                            publisherId: '1427ab10f2e448057ed3b422'
                         }
                     }
                 ]
@@ -51,8 +49,7 @@ The Trade Desk bid adapter supports Banner and Video.
                         params: {
                             supplySourceId: 'supplier',
                             publisherId: '1427ab10f2e448057ed3b422',
-                            siteId: 'site-123',
-                            placementId: 'footer1',
+                            placementId: '/1111/home#header',
                             banner: {
                                 expdir: [1, 3]
                             },
@@ -77,9 +74,7 @@ The Trade Desk bid adapter supports Banner and Video.
                         bidder: 'ttd',
                         params: {
                             supplySourceId: 'supplier',
-                            publisherId: '1427ab10f2e448057ed3b422',
-                            siteId: 'site-123',
-                            placementId: 'footer1'
+                            publisherId: '1427ab10f2e448057ed3b422'
                         }
                     }
                 ]
@@ -112,8 +107,7 @@ The Trade Desk bid adapter supports Banner and Video.
                         params: {
                             supplySourceId: 'supplier',
                             publisherId: '1427ab10f2e448057ed3b422',
-                            siteId: 'site-123',
-                            placementId: 'footer1'
+                            placementId: '/1111/home#header'
                         }
                     }
                 ]

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -17,8 +17,7 @@ describe('ttdBidAdapter', function () {
         'params': {
           'supplySourceId': 'supplier',
           'publisherId': '22222222',
-          'placementId': 'some-PlacementId_1',
-          'siteId': 'testSiteId'
+          'placementId': 'some-PlacementId_1'
         },
         'mediaTypes': {
           'banner': {
@@ -57,30 +56,6 @@ describe('ttdBidAdapter', function () {
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       });
 
-      it('should return false when siteId not passed', function () {
-        let bid = makeBid();
-        delete bid.params.siteId;
-        expect(spec.isBidRequestValid(bid)).to.equal(false);
-      });
-
-      it('should return false when siteId is longer than 50 characters', function () {
-        let bid = makeBid();
-        bid.params.siteId = '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'
-        expect(spec.isBidRequestValid(bid)).to.equal(false);
-      });
-
-      it('should return false when placementId not passed', function () {
-        let bid = makeBid();
-        delete bid.params.placementId;
-        expect(spec.isBidRequestValid(bid)).to.equal(false);
-      });
-
-      it('should return false when the placementId is longer than 128 characters', function () {
-        let bid = makeBid();
-        bid.params.placementId = '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'; // 130 characters
-        expect(spec.isBidRequestValid(bid)).to.equal(false);
-      });
-
       it('should return false if neither mediaTypes.banner nor mediaTypes.video is passed', function () {
         let bid = makeBid();
         delete bid.mediaTypes
@@ -103,7 +78,6 @@ describe('ttdBidAdapter', function () {
           'params': {
             'supplySourceId': 'supplier',
             'publisherId': '22222222',
-            'siteId': 'testSiteId123',
             'placementId': 'somePlacementId'
           },
           'mediaTypes': {
@@ -187,8 +161,7 @@ describe('ttdBidAdapter', function () {
       'params': {
         'supplySourceId': 'supplier',
         'publisherId': '13144370',
-        'placementId': '1gaa015',
-        'siteId': 'testSiteId123'
+        'placementId': '1gaa015'
       },
       'mediaTypes': {
         'banner': {
@@ -240,14 +213,47 @@ describe('ttdBidAdapter', function () {
       expect(url).to.equal('https://direct.adsrvr.org/bid/bidder/supplier');
     });
 
-    it('sends publisher id, site id, and placement id', function () {
+    it('sends publisher id', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.site).to.be.not.null;
       expect(requestBody.site.publisher).to.be.not.null;
-      expect(requestBody.imp[0].tagid).to.be.not.null;
       expect(requestBody.site.publisher.id).to.equal(baseBannerBidRequests[0].params.publisherId);
-      expect(requestBody.site.id).to.equal(baseBannerBidRequests[0].params.siteId);
+    });
+
+    it('sends placement id in tagid', function () {
+      const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.imp[0].tagid).to.equal(baseBannerBidRequests[0].params.placementId);
+    });
+
+    it('sends gpid in tagid if present', function () {
+      let clonedBannerRequests = deepClone(baseBannerBidRequests);
+      const gpid = '/1111/home#header';
+      clonedBannerRequests[0].ortb2Imp = {
+        ext: {
+          gpid: gpid
+        }
+      };
+      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
+      expect(requestBody.imp[0].tagid).to.equal(gpid);
+    });
+
+    it('sends gpid in ext.gpid if present', function () {
+      let clonedBannerRequests = deepClone(baseBannerBidRequests);
+      const gpid = '/1111/home#header';
+      clonedBannerRequests[0].ortb2Imp = {
+        ext: {
+          gpid: gpid
+        }
+      };
+      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
+      expect(requestBody.imp[0].ext).to.be.not.null;
+      expect(requestBody.imp[0].ext.gpid).to.equal(gpid);
+    });
+
+    it('sends transaction id in source.tid', function () {
+      const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
+      expect(requestBody.source).to.be.not.null;
+      expect(requestBody.source.tid).to.equal('8651474f-58b1-4368-b812-84f8c937a099');
     });
 
     it('includes the ad size in the bid request', function () {
@@ -283,16 +289,23 @@ describe('ttdBidAdapter', function () {
     });
 
     it('sets keywords properly if sent', function () {
-      let clonedBannerRequests = deepClone(baseBannerBidRequests);
-
       const ortb2 = {
         site: {
           keywords: 'highViewability, clothing, holiday shopping'
         }
       };
-      const requestBody = testBuildRequests(clonedBannerRequests, {...baseBidderRequest, ortb2}).data;
+      const requestBody = testBuildRequests(baseBannerBidRequests, {...baseBidderRequest, ortb2}).data;
       config.resetConfig();
       expect(requestBody.ext.ttdprebid.keywords).to.deep.equal(['highViewability', 'clothing', 'holiday shopping']);
+    });
+
+    it('sets bcat properly if sent', function () {
+      const ortb2 = {
+        bcat: ['IAB1-1', 'IAB2-9']
+      };
+      const requestBody = testBuildRequests(baseBannerBidRequests, {...baseBidderRequest, ortb2}).data;
+      config.resetConfig();
+      expect(requestBody.bcat).to.deep.equal(['IAB1-1', 'IAB2-9']);
     });
 
     it('sets ext properly', function () {
@@ -454,8 +467,7 @@ describe('ttdBidAdapter', function () {
       'bidder': 'ttd',
       'params': {
         'publisherId': '13144370',
-        'placementId': 'top',
-        'siteId': 'testSite123'
+        'placementId': 'top'
       },
       'mediaTypes': {
         'banner': {

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -56,6 +56,23 @@ describe('ttdBidAdapter', function () {
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       });
 
+      it('should return true if placementId is not passed and gpid is passed', function () {
+        let bid = makeBid();
+        delete bid.params.placementId;
+        bid.ortb2Imp = {
+          ext: {
+            gpid: '/1111/home#header'
+          }
+        }
+        expect(spec.isBidRequestValid(bid)).to.equal(true);
+      });
+
+      it('should return false if neither placementId nor gpid is passed', function () {
+        let bid = makeBid();
+        delete bid.params.placementId;
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
       it('should return false if neither mediaTypes.banner nor mediaTypes.video is passed', function () {
         let bid = makeBid();
         delete bid.mediaTypes

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -191,6 +191,7 @@ describe('ttdBidAdapter', function () {
         }
       },
       'sizes': [[300, 250], [300, 600]],
+      'transactionId': '1111474f-58b1-4368-b812-84f8c937a099',
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',
@@ -274,7 +275,7 @@ describe('ttdBidAdapter', function () {
     it('sends transaction id in source.tid', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.source).to.be.not.null;
-      expect(requestBody.source.tid).to.equal('8651474f-58b1-4368-b812-84f8c937a099');
+      expect(requestBody.source.tid).to.equal('1111474f-58b1-4368-b812-84f8c937a099');
     });
 
     it('includes the ad size in the bid request', function () {
@@ -501,6 +502,7 @@ describe('ttdBidAdapter', function () {
         }
       },
       'sizes': [[300, 250], [300, 600]],
+      'transactionId': '1111474f-58b1-4368-b812-84f8c937a099',
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
       'bidId': 'small',
       'bidderRequestId': '18084284054531',
@@ -524,6 +526,7 @@ describe('ttdBidAdapter', function () {
         }
       },
       'sizes': [[728, 90]],
+      'transactionId': '825c1228-ca8c-4657-b40f-2df500621527',
       'adUnitCode': 'div-gpt-ad-91515710-0',
       'bidId': 'large',
       'bidderRequestId': '18084284054531',
@@ -553,6 +556,12 @@ describe('ttdBidAdapter', function () {
     it('sends multiple impressions', function () {
       const requestBody = testBuildRequests(baseBannerMultipleBidRequests, baseBidderRequest).data;
       expect(requestBody.imp.length).to.equal(2);
+      expect(requestBody.source).to.be.not.null;
+      expect(requestBody.source.tid).to.equal('1111474f-58b1-4368-b812-84f8c937a099');
+      expect(requestBody.imp[0].ext).to.be.not.null;
+      expect(requestBody.imp[0].ext.tid).to.equal('8651474f-58b1-4368-b812-84f8c937a099');
+      expect(requestBody.imp[1].ext).to.be.not.null;
+      expect(requestBody.imp[1].ext.tid).to.equal('12345678-58b1-4368-b812-84f8c937a099');
     });
 
     it('sends the right tag ids for each ad unit', function () {
@@ -612,6 +621,7 @@ describe('ttdBidAdapter', function () {
           'tid': '8651474f-58b1-4368-b812-84f8c937a099',
         }
       },
+      'transactionId': '1111474f-58b1-4368-b812-84f8c937a099',
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',
@@ -676,6 +686,7 @@ describe('ttdBidAdapter', function () {
           'tid': '8651474f-58b1-4368-b812-84f8c937a099',
         }
       },
+      'transactionId': '1111474f-58b1-4368-b812-84f8c937a099',
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -185,9 +185,13 @@ describe('ttdBidAdapter', function () {
           'sizes': [[300, 250], [300, 600]]
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '8651474f-58b1-4368-b812-84f8c937a099',
+        }
+      },
       'sizes': [[300, 250], [300, 600]],
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
-      'transactionId': '8651474f-58b1-4368-b812-84f8c937a099',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',
       'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
@@ -323,6 +327,25 @@ describe('ttdBidAdapter', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, {...baseBidderRequest, ortb2}).data;
       config.resetConfig();
       expect(requestBody.bcat).to.deep.equal(['IAB1-1', 'IAB2-9']);
+    });
+
+    it('sets badv properly if sent', function () {
+      const ortb2 = {
+        badv: ['adv1.com', 'adv2.com']
+      };
+      const requestBody = testBuildRequests(baseBannerBidRequests, {...baseBidderRequest, ortb2}).data;
+      config.resetConfig();
+      expect(requestBody.badv).to.deep.equal(['adv1.com', 'adv2.com']);
+    });
+
+    it('sets battr properly if present', function () {
+      let clonedBannerRequests = deepClone(baseBannerBidRequests);
+      const battr = [1, 2, 3];
+      clonedBannerRequests[0].ortb2Imp = {
+        battr: battr
+      };
+      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
+      expect(requestBody.imp[0].banner.battr).to.equal(battr);
     });
 
     it('sets ext properly', function () {
@@ -472,9 +495,13 @@ describe('ttdBidAdapter', function () {
           'sizes': [[300, 250], [300, 600]]
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '8651474f-58b1-4368-b812-84f8c937a099',
+        }
+      },
       'sizes': [[300, 250], [300, 600]],
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
-      'transactionId': '8651474f-58b1-4368-b812-84f8c937a099',
       'bidId': 'small',
       'bidderRequestId': '18084284054531',
       'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
@@ -491,9 +518,13 @@ describe('ttdBidAdapter', function () {
           'sizes': [[728, 90]]
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '12345678-58b1-4368-b812-84f8c937a099',
+        }
+      },
       'sizes': [[728, 90]],
       'adUnitCode': 'div-gpt-ad-91515710-0',
-      'transactionId': '825c1228-ca8c-4657-b40f-2df500621527',
       'bidId': 'large',
       'bidderRequestId': '18084284054531',
       'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
@@ -576,8 +607,12 @@ describe('ttdBidAdapter', function () {
           'sizes': [[300, 250], [300, 600]]
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '8651474f-58b1-4368-b812-84f8c937a099',
+        }
+      },
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
-      'transactionId': '8651474f-58b1-4368-b812-84f8c937a099',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',
       'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
@@ -636,8 +671,12 @@ describe('ttdBidAdapter', function () {
           'maxduration': 30
         }
       },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '8651474f-58b1-4368-b812-84f8c937a099',
+        }
+      },
       'adUnitCode': 'div-gpt-ad-1460505748561-0',
-      'transactionId': '8651474f-58b1-4368-b812-84f8c937a099',
       'bidId': '243310435309b5',
       'bidderRequestId': '18084284054531',
       'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature
- [X ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
TTD Adapter Updates

Remove siteId parameter
Make placementId parameter optional if GPID is passed
Pass transactionId through to source.tid
Read bcat from ortb2
