### PR TITLE
OneKey Id Submodule: initial release

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -29,6 +29,7 @@
       "naveggIdSystem",
       "netIdSystem",
       "novatiqIdSystem",
+      "oneKeyIdSystem",
       "parrableIdSystem",
       "pubProvidedIdSystem",
       "publinkIdSystem",

--- a/modules/oneKeyIdSystem.js
+++ b/modules/oneKeyIdSystem.js
@@ -58,7 +58,7 @@ export const oneKeyIdSubmodule = {
     * @returns {(Object|undefined)}
     */
   decode(data) {
-    return { pafData: data };
+    return { oneKeyData: data };
   },
   /**
     * performs action to obtain id and return a value in the callback's response argument

--- a/modules/oneKeyIdSystem.js
+++ b/modules/oneKeyIdSystem.js
@@ -1,0 +1,78 @@
+/**
+ * This module adds Onekey data to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/oneKeyIdSystem
+ * @requires module:modules/userId
+ */
+
+import {submodule} from '../src/hook.js';
+import { logError, logMessage } from '../src/utils.js';
+
+// Pre-init OneKey if it has not load yet.
+window.OneKey = window.OneKey || {};
+window.OneKey.queue = window.OneKey.queue || [];
+
+const logPrefix = 'OneKey.Id-Module';
+
+/**
+ * Generate callback that deserializes the result of getIdsAndPreferences.
+ */
+const onIdsAndPreferencesResult = (callback) => {
+  return (result) => {
+    logMessage(logPrefix, `Has got Ids and Prefs with status: `, result);
+    callback(result.data);
+  };
+};
+
+/**
+ * Call OneKey once it is loaded for retrieving
+ * the ids and the preferences.
+ */
+const getIdsAndPreferences = (callback) => {
+  logMessage(logPrefix, 'Queue getIdsAndPreferences call');
+  // Call OneKey in a queue so that we are sure
+  // it will be called when fully load and configured
+  // within the page.
+  window.OneKey.queue.push(() => {
+    logMessage(logPrefix, 'Get Ids and Prefs');
+    window.OneKey.getIdsAndPreferences()
+      .then(onIdsAndPreferencesResult(callback))
+      .catch(() => {
+        logError(logPrefix, 'Cannot retrieve the ids and preferences from OneKey.');
+        callback(undefined);
+      });
+  });
+};
+
+/** @type {Submodule} */
+export const oneKeyIdSubmodule = {
+  /**
+    * used to link submodule with config
+    * @type {string}
+    */
+  name: 'oneKeyData',
+  /**
+    * decode the stored data value for passing to bid requests
+    * @function decode
+    * @param {(Object|string)} value
+    * @returns {(Object|undefined)}
+    */
+  decode(data) {
+    return { pafData: data };
+  },
+  /**
+    * performs action to obtain id and return a value in the callback's response argument
+    * @function
+    * @param {SubmoduleConfig} [config]
+    * @param {ConsentData} [consentData]
+    * @param {(Object|undefined)} cacheIdObj
+    * @returns {IdResponse|undefined}
+    */
+  getId(config) {
+    return {
+      callback: getIdsAndPreferences
+    };
+  }
+};
+
+submodule('userId', oneKeyIdSubmodule);

--- a/modules/oneKeyIdSystem.md
+++ b/modules/oneKeyIdSystem.md
@@ -7,8 +7,8 @@ Both modules are required. This module will pass oneKeyData to your partners
 while the oneKeyRtdProvider will pass the transmission requests.
 
 Background information:
-- [prebid/addressability-framework](https://github.com/prebid/addressability-framework)
-- [prebid/paf-mvp-implementation](https://github.com/prebid/paf-mvp-implementation)
+- [OneKey-Network/addressability-framework](https://github.com/OneKey-Network/addressability-framework)
+- [OneKey-Network/OneKey-implementation](https://github.com/OneKey-Network/OneKey-implementation)
 
 It can be added to you Prebid.js package with:
 

--- a/modules/oneKeyIdSystem.md
+++ b/modules/oneKeyIdSystem.md
@@ -1,0 +1,104 @@
+# OneKey
+
+The OneKey real-time data module in Prebid has been built so that publishers
+can quickly and easily setup the OneKey Addressability Framework.
+This module is used along with the oneKeyRtdProvider to pass OneKey data to your partners.
+Both modules are required. This module will pass oneKeyData to your partners
+while the oneKeyRtdProvider will pass the transmission requests.
+
+Background information:
+- [prebid/addressability-framework](https://github.com/prebid/addressability-framework)
+- [prebid/paf-mvp-implementation](https://github.com/prebid/paf-mvp-implementation)
+
+## OneKey Configuration
+
+The oneKeyData module depends on paf-lib.js existing in the page.
+
+Compile the oneKeyData module into your Prebid build.
+You will also want to add the oneKeyRtdProvider module as well.
+
+`gulp build --modules=userId,oneKeyIdSystem,rtdModule,oneKeyRtdProvider,appnexusBidAdapter`
+
+There are no custom configuration parameters for OneKey. The module
+will retrieve the OneKey data from the page if available and pass the 
+information to bidders. Here is a configuration example:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+      userIds: [{
+          name: "oneKeyData",
+          params: {}
+      }]
+    }],
+    auctionDelay: 50    // example auction delay, applies to all userId modules
+  }
+});
+```
+
+Bidders will receive the data in the following format:
+
+```json
+{
+    "identifiers": [{
+        "version": "0.1",
+        "type": "paf_browser_id",
+        "value": "da135b3a-7d04-44bf-a0af-c4709f10420b",
+        "source": {
+            "domain": "crto-poc-1.onekey.network",
+            "timestamp": 1648836556881,
+            "signature": "+NF27bBvPM54z103YPExXuS834+ggAQe6JV0jPeGo764vRYiiBl5OmEXlnB7UZgxNe3KBU7rN2jk0SkI4uL0bg=="
+        }
+    }],
+    "preferences": {
+        "version": "0.1",
+        "data": {
+            "use_browsing_for_personalization": true
+        },
+        "source": {
+            "domain": "cmp.pafdemopublisher.com",
+            "timestamp": 1648836566468,
+            "signature": "ipbYhU8IbSFm2tCqAVYI2d5w4DnGF7Xa2AaiZScx2nmBPLfMmIT/FkBYGitR8Mi791DHtcy5MXr4+bs1aeZFqw=="
+        }
+    }
+}
+```
+
+
+If the bidder elects to use pbjs.getUserIdsAsEids() then the format will be:
+
+```json
+"user": {
+    "ext": {
+        "eids": [{
+            "source": "paf",
+            "uids": [{
+                "id": "da135b3a-7d04-44bf-a0af-c4709f10420b",
+                "atype": 1,
+                "ext": {
+                    "version": "0.1",
+                    "type": "paf_browser_id",
+                    "source": {
+                        "domain": "crto-poc-1.onekey.network",
+                        "timestamp": 1648836556881,
+                        "signature": "+NF27bBvPM54z103YPExXuS834+ggAQe6JV0jPeGo764vRYiiBl5OmEXlnB7UZgxNe3KBU7rN2jk0SkI4uL0bg=="
+                    }
+                }
+            }],
+            "ext": {
+                "preferences": {
+                    "version": "0.1",
+                    "data": {
+                        "use_browsing_for_personalization": true
+                    },
+                    "source": {
+                        "domain": "cmp.pafdemopublisher.com",
+                        "timestamp": 1648836566468,
+                        "signature": "ipbYhU8IbSFm2tCqAVYI2d5w4DnGF7Xa2AaiZScx2nmBPLfMmIT/FkBYGitR8Mi791DHtcy5MXr4+bs1aeZFqw=="
+                    }
+                }
+            }
+        }]
+    }
+}
+```

--- a/modules/oneKeyIdSystem.md
+++ b/modules/oneKeyIdSystem.md
@@ -10,29 +10,35 @@ Background information:
 - [prebid/addressability-framework](https://github.com/prebid/addressability-framework)
 - [prebid/paf-mvp-implementation](https://github.com/prebid/paf-mvp-implementation)
 
-## OneKey Configuration
+It can be added to you Prebid.js package with:
 
-The oneKeyData module depends on paf-lib.js existing in the page.
+{: .alert.alert-info :}
+gulp build –modules=userId,oneKeyIdSystem
 
-Compile the oneKeyData module into your Prebid build.
-You will also want to add the oneKeyRtdProvider module as well.
+⚠️ This module works in association with a RTD module. See [oneKeyRtdProvider](oneKeyRtdProvider.md).
 
-`gulp build --modules=userId,oneKeyIdSystem,rtdModule,oneKeyRtdProvider,appnexusBidAdapter`
+#### OneKey Registration
 
-There are no custom configuration parameters for OneKey. The module
-will retrieve the OneKey data from the page if available and pass the 
-information to bidders. Here is a configuration example:
+OneKey is a community based Framework with a decentralized approach.
+Go to [onekey.community](https://onekey.community/) for more details.
+
+#### OneKey Configuration
+
+{: .table .table-bordered .table-striped }
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | The name of this module | `"oneKeyData"` |
+
+
+#### OneKey Exemple
 
 ```javascript
 pbjs.setConfig({
-  userSync: {
-      userIds: [{
-          name: "oneKeyData",
-          params: {}
-      }]
-    }],
-    auctionDelay: 50    // example auction delay, applies to all userId modules
-  }
+    userSync: {
+        userIds: [{
+            name: 'oneKeyData'
+        }]
+    }
 });
 ```
 
@@ -63,7 +69,6 @@ Bidders will receive the data in the following format:
     }
 }
 ```
-
 
 If the bidder elects to use pbjs.getUserIdsAsEids() then the format will be:
 

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -330,6 +330,32 @@ export const USER_IDS_CONFIG = {
   'cpexId': {
     source: 'czechadid.cz',
     atype: 1
+  },
+
+  // OneKey Data
+  'oneKeyData': {
+    getValue: function(data) {
+      if (data && Array.isArray(data.identifiers) && data.identifiers[0]) {
+        return data.identifiers[0].value;
+      }
+    },
+    source: 'paf',
+    atype: 1,
+    getEidExt: function(data) {
+      if (data && data.preferences) {
+        return {preferences: data.preferences};
+      }
+    },
+    getUidExt: function(data) {
+      if (data && Array.isArray(data.identifiers) && data.identifiers[0]) {
+        const id = data.identifiers[0];
+        return {
+          version: id.version,
+          type: id.type,
+          source: id.source
+        };
+      }
+    }
   }
 };
 

--- a/test/spec/modules/oneKeyIdSystem_spec.js
+++ b/test/spec/modules/oneKeyIdSystem_spec.js
@@ -1,0 +1,107 @@
+import { oneKeyIdSubmodule } from 'modules/oneKeyIdSystem'
+
+const defaultConf = {
+  params: {
+    proxyHostName: 'proxy.com'
+  }
+};
+
+const defaultIdsAndPreferences = {
+  identifiers: [
+    {
+      version: '0.1',
+      type: 'paf_browser_id',
+      value: 'df0a5664-987d-4074-bbd9-e9b12ebae6ef',
+      source: {
+        domain: 'crto-poc-1.onekey.network',
+        timestamp: 1657100291,
+        signature: 'ikjV6WwpcroNB5XyLOr3MgYHLpS6UjICEOuv/jEr00uVrjZm0zluDSWh11OeGDZrMhxMBPeTabtQ4U2rNk3IzQ=='
+      }
+    }
+  ],
+  preferences: {
+    version: '0.1',
+    data: {
+      use_browsing_for_personalization: true
+    },
+    source: {
+      domain: 'cmp.pafdemopublisher.com',
+      timestamp: 1657100294,
+      signature: 'aAbMThxyeKpe/EgT5ARI1xecjCwwh0uRagsTuPXNY2fzh7foeW31qljDZf6h8UwOd9M2bAN7XNtM2LYBbJzskQ=='
+    }
+  }
+};
+
+const defaultIdsAndPreferencesResult = {
+  status: 'PARTICIPATING',
+  data: defaultIdsAndPreferences
+};
+
+describe('oneKeyData module', () => {
+  describe('getId function', () => {
+    beforeEach(() => {
+      setUpOneKey();
+    });
+
+    it('return a callback for handling asynchron results', () => {
+      const moduleIdResponse = oneKeyIdSubmodule.getId(defaultConf);
+
+      expect(moduleIdResponse.callback).to.be.an('function');
+    });
+
+    it(`return a callback that waits for OneKey to be loaded`, () => {
+      const moduleIdResponse = oneKeyIdSubmodule.getId(defaultConf);
+
+      moduleIdResponse.callback(function() {})
+
+      expect(window.OneKey.queue.length).to.equal(1);
+    });
+
+    it('return a callback that gets ids and prefs', () => {
+      const moduleIdResponse = oneKeyIdSubmodule.getId(defaultConf);
+
+      // Act
+      return new Promise((resolve) => {
+        moduleIdResponse.callback(resolve);
+        executeOneKeyQueue();
+      })
+
+      // Assert
+        .then((idsAndPrefs) => {
+          expect(idsAndPrefs).to.equal(defaultIdsAndPreferences);
+        });
+    });
+
+    it('return a callback with undefined if impossible to get ids and prefs', () => {
+      window.OneKey.getIdsAndPreferences = () => {
+        return Promise.reject(new Error(`Impossible to get ids and prefs`));
+      };
+      const moduleIdResponse = oneKeyIdSubmodule.getId(defaultConf);
+
+      // Act
+      return new Promise((resolve) => {
+        moduleIdResponse.callback(resolve);
+        executeOneKeyQueue();
+      })
+
+      // Assert
+        .then((idsAndPrefs) => {
+          expect(idsAndPrefs).to.be.undefined;
+        });
+    });
+  });
+});
+
+const setUpOneKey = () => {
+  window.OneKey.queue = [];
+  window.OneKey.getIdsAndPreferences = () => {
+    return Promise.resolve(defaultIdsAndPreferencesResult);
+  };
+}
+
+const executeOneKeyQueue = () => {
+  while (window.OneKey.queue.length > 0) {
+    window.OneKey.queue[0]();
+    window.OneKey.queue.shift();
+  }
+}


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

This PR adds a userId module for OneKey at https://github.com/prebid/paf-mvp-implementation. The demo currently uses [changes that are a superset of this PR](https://github.com/criteo-forks/Prebid.js/pull/9). More information about the specifications of the ids and data can be found at https://github.com/prebid/addressability-framework.

## Other information

It doesn't appear in the history due to reworks, squashes, and splits of branches but a significant contribution has been done by @bwschmidt on those changes. The current proposal basically renames PAF to OneKey, uses Prebid V7 API and asynchronous API on top of https://github.com/prebid/Prebid.js/pull/8366 

Pull Request for the documentation: https://github.com/prebid/prebid.github.io/pull/3948