### PR TITLE
Rubicon Bid Adapter: remove fpd warning

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1026,6 +1026,8 @@ function applyFPD(bidRequest, mediaType, data) {
         }, []);
         if (segments.length > 0) return segments.toString();
       }).toString();
+    } else if (typeof prop === 'object' && !Array.isArray(prop)) {
+      return undefined;
     } else if (typeof prop !== 'undefined') {
       return (Array.isArray(prop)) ? prop.filter(value => {
         if (typeof value !== 'object' && typeof value !== 'undefined') return value.toString();

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1026,8 +1026,6 @@ function applyFPD(bidRequest, mediaType, data) {
         }, []);
         if (segments.length > 0) return segments.toString();
       }).toString();
-    } else if (typeof prop === 'object' && !Array.isArray(prop)) {
-      logWarn('Rubicon: Filtered FPD key: ', key, ': Expected value to be string, integer, or an array of strings/ints');
     } else if (typeof prop !== 'undefined') {
       return (Array.isArray(prop)) ? prop.filter(value => {
         if (typeof value !== 'object' && typeof value !== 'undefined') return value.toString();


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Remove an unuseful logging.

- contact email of the adapter’s maintainer: mnasti@magnite.com 