### PR TITLE
StroeerCore Bid Adapter: use page & ref from refererInfo, support schain

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -13,14 +13,6 @@ const USER_SYNC_IFRAME_URL = 'https://js.adscale.de/pbsync.html';
 const isSecureWindow = () => getWindowSelf().location.protocol === 'https:';
 const isMainPageAccessible = () => getMostAccessibleTopWindow() === getWindowTop();
 
-function getTopWindowReferrer() {
-  try {
-    return getWindowTop().document.referrer;
-  } catch (e) {
-    return '';
-  }
-}
-
 function getMostAccessibleTopWindow() {
   let res = getWindowSelf();
 
@@ -124,11 +116,12 @@ export const spec = {
     const payload = {
       id: bidderRequest.auctionId,
       bids: [],
-      ref: getTopWindowReferrer(),
+      ref: refererInfo.ref,
       ssl: isSecureWindow(),
       mpa: isMainPageAccessible(),
       timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart),
-      url: refererInfo && (refererInfo.canonicalUrl || refererInfo.referer)
+      url: refererInfo.page,
+      schain: anyBid.schain
     };
 
     const userIds = anyBid.userId;

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -59,7 +59,8 @@ describe('stroeerCore bid adapter', function () {
     timeout: 5000,
     auctionStart: 10000,
     refererInfo: {
-      referer: 'https://www.example.com/index.html'
+      page: 'https://www.example.com/monkey/index.html',
+      ref: 'https://www.example.com/?search=monkey'
     },
     bids: [{
       bidId: 'bid1',
@@ -109,7 +110,7 @@ describe('stroeerCore bid adapter', function () {
   });
 
   const createWindow = (href, params = {}) => {
-    let {parent, referrer, top, frameElement, placementElements = []} = params;
+    let {parent, top, frameElement, placementElements = []} = params;
 
     const protocol = (href.indexOf('https') === 0) ? 'https:' : 'http:';
     const win = {
@@ -126,7 +127,6 @@ describe('stroeerCore bid adapter', function () {
             }
           }
         },
-        referrer,
         getElementById: id => find(placementElements, el => el.id === id)
       }
     };
@@ -169,7 +169,7 @@ describe('stroeerCore bid adapter', function () {
   }
 
   function setupNestedWindows(sandBox, placementElements = [createElement('div-1', 17), createElement('div-2', 54)]) {
-    const topWin = createWindow('http://www.abc.org/', {referrer: 'http://www.google.com/?query=monkey'});
+    const topWin = createWindow('http://www.abc.org/');
     topWin.innerHeight = 800;
 
     const midWin = createWindow('http://www.abc.org/', {parent: topWin, top: topWin, frameElement: createElement()});
@@ -310,10 +310,10 @@ describe('stroeerCore bid adapter', function () {
         const expectedJsonPayload = {
           'id': AUCTION_ID,
           'timeout': expectedTimeout,
-          'ref': topWin.document.referrer,
+          'ref': 'https://www.example.com/?search=monkey',
           'mpa': true,
           'ssl': false,
-          'url': 'https://www.example.com/index.html',
+          'url': 'https://www.example.com/monkey/index.html',
           'bids': [{
             'sid': 'NDA=', 'bid': 'bid1', 'siz': [[300, 600], [160, 60]], 'viz': true
           }, {
@@ -402,6 +402,30 @@ describe('stroeerCore bid adapter', function () {
           const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
           assert.lengthOf(serverRequestInfo.data.bids, 2);
           assert.notProperty(serverRequestInfo, 'uids');
+        });
+
+        it('should add schain if available', () => {
+          const schain = Object.freeze({
+            ver: '1.0',
+            complete: 1,
+            'nodes': [
+              {
+                asi: 'exchange1.com',
+                sid: 'ABC',
+                hp: 1,
+                rid: 'bid-request-1',
+                name: 'publisher',
+                domain: 'publisher.com'
+              }
+            ]
+          });
+
+          const bidReq = buildBidderRequest();
+          bidReq.bids.forEach(bid => bid.schain = schain);
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
+
+          assert.deepEqual(serverRequestInfo.data.schain, schain);
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
* Use new refererInfo fields introduced in v7: ref and page
* Support supply chain object (schain)

