### PR TITLE
YieldOne Bid Adapter: add ID5 support

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -80,6 +80,12 @@ export const spec = {
         payload.fuuid = dacId;
       }
 
+      // ID5
+      const id5id = deepAccess(bidRequest, 'userId.id5id.uid');
+      if (isStr(id5id) && !isEmpty(id5id)) {
+        payload.id5Id = id5id;
+      }
+
       return {
         method: 'GET',
         url: ENDPOINT_URL,

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -436,6 +436,39 @@ describe('yieldoneBidAdapter', function() {
         expect(request[0].data.fuuid).to.equal('dacId_sample');
       });
     });
+
+    describe('ID5', function () {
+      it('dont send ID5 if undefined', function () {
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+          },
+          {
+            params: {placementId: '1'},
+            userId: {},
+          },
+          {
+            params: {placementId: '2'},
+            userId: undefined,
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        expect(request[0].data).to.not.have.property('id5Id');
+        expect(request[1].data).to.not.have.property('id5Id');
+        expect(request[2].data).to.not.have.property('id5Id');
+      });
+
+      it('should send ID5 if available', function () {
+        const bidRequests = [
+          {
+            params: {placementId: '0'},
+            userId: {id5id: {uid: 'id5id_sample'}},
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        expect(request[0].data.id5Id).to.equal('id5id_sample');
+      });
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
YieldOne Bid Adapter: add ID5 support.

- contact email of the adapter’s maintainer
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information