### PR TITLE
Rubicon Bid Adapter: Do not send storedrequests

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -320,6 +320,10 @@ export const spec = {
       // set ext.prebid.auctiontimestamp using auction time
       deepSetValue(data.imp[0], 'ext.prebid.auctiontimestamp', bidderRequest.auctionStart);
 
+      // delete stored requests - top level and imp level both 'ext.prebid' objects are set above so no exception thrown here
+      delete data.ext.prebid.storedrequest;
+      delete data.imp[0].ext.prebid.storedrequest;
+
       return {
         method: 'POST',
         url: `https://${rubiConf.videoHost || 'prebid-server'}.rubiconproject.com/openrtb2/auction`,

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -320,9 +320,10 @@ export const spec = {
       // set ext.prebid.auctiontimestamp using auction time
       deepSetValue(data.imp[0], 'ext.prebid.auctiontimestamp', bidderRequest.auctionStart);
 
-      // delete stored requests - top level and imp level both 'ext.prebid' objects are set above so no exception thrown here
-      delete data.ext.prebid.storedrequest;
-      delete data.imp[0].ext.prebid.storedrequest;
+      // set storedrequests to undefined so not sent to PBS
+      // top level and imp level both 'ext.prebid' objects are set above so no exception thrown here
+      data.ext.prebid.storedrequest = undefined;
+      data.imp[0].ext.prebid.storedrequest = undefined;
 
       return {
         method: 'POST',

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2139,6 +2139,33 @@ describe('the rubicon adapter', function () {
           expect(request.data.imp[0].ext.data.pbadslot).to.equal('1234567890');
         });
 
+        it('should NOT include storedrequests in pbs payload', function () {
+          createVideoBidderRequest();
+          bidderRequest.bids[0].ortb2 = {
+            ext: {
+              prebid: {
+                storedrequest: 'no-send-top-level-sr'
+              }
+            }
+          }
+
+          bidderRequest.bids[0].ortb2Imp = {
+            ext: {
+              prebid: {
+                storedrequest: 'no-send-imp-sr'
+              }
+            }
+          }
+
+          sandbox.stub(Date, 'now').callsFake(() =>
+            bidderRequest.auctionStart + 100
+          );
+
+          const [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
+          expect(request.data.ext.prebid.storedrequest).to.be.undefined;
+          expect(request.data.imp[0].ext.prebid.storedrequest).to.be.undefined;
+        });
+
         it('should include GAM ad unit in bid request', function () {
           createVideoBidderRequest();
           bidderRequest.bids[0].ortb2Imp = {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
With prebid moving towards ortb2 stuff, we need to make sure that when a publisher sets a storedrequest for their PBS integration, that we do not mistakingly forward the same one into the rubicon video endpoint (which is a PBS instance in itself). Otherwise, that would be bad!