### PR TITLE
openxOrtb Bid Adapter: avoid error logging when response body is null

### DIFF
--- a/modules/openxOrtbBidAdapter.js
+++ b/modules/openxOrtbBidAdapter.js
@@ -263,7 +263,7 @@ function interpretResponse(resp, req) {
   }
 
   const respBody = resp.body;
-  if ('nbr' in respBody) {
+  if (!respBody || 'nbr' in respBody) {
     return [];
   }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
avoid error logging when response body is null

```
prebid.js:5 Prebid openx ERROR: Bidder openx failed to interpret the server's response. Continuing without bids null TypeError: Cannot use 'in' operator to search for 'nbr' in at prebid.js:12:4571
```
Thanks for reporting the issue @piotrj-rtbh
