### PR TITLE
FTRACK UserId Submodule: adding more tests for the get ID methods in pbjs

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -372,11 +372,11 @@ export function createEidsArray(bidRequestUserId) {
         // ftrack has multiple IDs so we add each one that exists
         let eid = {
           'atype': 1,
-          'id': (bidRequestUserId[subModuleKey]['DeviceID'] || []).join('|'),
+          'id': (bidRequestUserId.ftrackId.DeviceID || []).join('|'),
           'ext': {}
         }
-        for (let id in bidRequestUserId[subModuleKey]) {
-          eid.ext[id] = (bidRequestUserId[subModuleKey][id] || []).join('|');
+        for (let id in bidRequestUserId.ftrackId) {
+          eid.ext[id] = (bidRequestUserId.ftrackId[id] || []).join('|');
         }
 
         eids.push(eid);

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -446,8 +446,8 @@ describe('eids array generation for known sub-modules', function() {
     it('should return the correct EID schema', () => {
       expect(createEidsArray({
         ftrackId: {
-          DeviceId: ['aaa', 'bbb'],
-          SingleDeviceId: ['ccc', 'ddd'],
+          DeviceID: ['aaa', 'bbb'],
+          SingleDeviceID: ['ccc', 'ddd'],
           HHID: ['eee', 'fff']
         },
         foo: {
@@ -457,12 +457,12 @@ describe('eids array generation for known sub-modules', function() {
           ipsum: ''
         }
       })).to.deep.equal([{
-        'atype': 1,
-        'id': '',
-        'ext': {
-          'DeviceId': 'aaa|bbb',
-          'SingleDeviceId': 'ccc|ddd',
-          'HHID': 'eee|fff'
+        atype: 1,
+        id: 'aaa|bbb',
+        ext: {
+          DeviceID: 'aaa|bbb',
+          SingleDeviceID: 'ccc|ddd',
+          HHID: 'eee|fff'
         }
       }]);
     });

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -302,6 +302,7 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+
   it('uid2', function() {
     const userId = {
       uid2: {'id': 'Sample_AD_Token'}
@@ -316,6 +317,7 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+
   it('kpuid', function() {
     const userId = {
       kpuid: 'Sample_Token'
@@ -330,6 +332,7 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+
   it('tncid', function() {
     const userId = {
       tncid: 'TEST_TNCID'
@@ -344,6 +347,7 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+
   it('pubProvidedId', function() {
     const userId = {
       pubProvidedId: [{
@@ -435,6 +439,32 @@ describe('eids array generation for known sub-modules', function() {
     expect(eid).to.deep.equal({
       source: 'czechadid.cz',
       uids: [{ id: 'some-random-id-value', atype: 1 }]
+    });
+  });
+
+  describe('ftrackId', () => {
+    it('should return the correct EID schema', () => {
+      expect(createEidsArray({
+        ftrackId: {
+          DeviceId: ['aaa', 'bbb'],
+          SingleDeviceId: ['ccc', 'ddd'],
+          HHID: ['eee', 'fff']
+        },
+        foo: {
+          bar: 'baz'
+        },
+        lorem: {
+          ipsum: ''
+        }
+      })).to.deep.equal([{
+        'atype': 1,
+        'id': '',
+        'ext': {
+          'DeviceId': 'aaa|bbb',
+          'SingleDeviceId': 'ccc|ddd',
+          'HHID': 'eee|fff'
+        }
+      }]);
     });
   });
 });

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -344,7 +344,7 @@ describe('FTRACK ID System', () => {
     });
 
     afterEach(() => {
-      // Reset the defaults state for expectedIds, overwrite within test if needed
+      // Reset expectedIds to the default values because some tests overwrite them
       expectedIds = {
         HHID: ['household_test_id'],
         DeviceID: ['device_test_id'],

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -366,11 +366,7 @@ describe('FTRACK ID System', () => {
 
     describe('pbjs.getUserIds()', () => {
       it('should return the IDs in the correct schema', () => {
-        console.log('userSyncConfigMock', JSON.stringify(userSyncConfigMock, null, 4));
         config.setConfig(userSyncConfigMock);
-
-        console.log('getGlobal().getUserIds()', JSON.stringify(getGlobal().getUserIds(), null, 4));
-        console.log('expected', JSON.stringify({ 'ftrackId': expectedIds }, null, 4));
 
         expect(getGlobal().getUserIds()).to.deep.equal({
           'ftrackId': expectedIds

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -308,106 +308,179 @@ describe('FTRACK ID System', () => {
     });
   });
 
-  describe('Uses ftrack getUserIdsAsEids() method', () => {
-    it('getUserIdsAsEids using the ftrack submodule and gets three ids (HHID, DeviceId, SingleDeviceId)', () => {
+  describe('pbjs.getUserIdsAsEids()', () => {
+    let ids = {
+      ftrackId: {}
+    };
+    let expectedIds;
+
+    beforeEach(() => {
       init(config);
       setSubmoduleRegistry([ftrackIdSubmodule]);
+    });
 
-      const ids = {
-        ftrackId: {
-          HHID: ['household_test_id'],
-          DeviceID: ['device_test_id'],
-          SingleDeviceID: ['single_device_test_id']
-        }
+    it('should return the correct EIDs schema', () => {
+      expectedIds = {
+        HHID: ['household_test_id'],
+        DeviceID: ['device_test_id'],
+        SingleDeviceID: ['single_device_test_id']
       };
+      ids.ftrackId = expectedIds;
+
       config.setConfig({
         userSync: {
           auctionDelay: 10,
           userIds: [{
-            name: 'ftrack', value: ids,
+            name: 'ftrack',
+            value: ids,
           }]
         }
       });
 
-      getGlobal().getUserIdsAsync().then((ids) => {
+      expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+        id: 'device_test_id',
+        atype: 1,
+        ext: {
+          HHID: expectedIds.HHID.join('|'),
+          DeviceID: expectedIds.DeviceID.join('|'),
+          SingleDeviceID: expectedIds.SingleDeviceID.join('|')
+        }
+      }]);
+    });
+
+    describe('by ID type:', () => {
+      it('- DeviceID', () => {
+        expectedIds = {
+          DeviceID: ['device_test_id']
+        };
+        ids.ftrackId = expectedIds;
+
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack',
+              value: ids,
+            }]
+          }
+        });
+
         expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
           id: 'device_test_id',
           atype: 1,
           ext: {
-            HHID: 'household_test_id',
-            DeviceID: 'device_test_id',
-            SingleDeviceID: 'single_device_test_id',
+            DeviceID: expectedIds.DeviceID.join('|')
+          }
+        }]);
+      });
+
+      it('- HHID', () => {
+        expectedIds = {
+          HHID: ['household_test_id']
+        };
+        ids.ftrackId = expectedIds;
+
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack',
+              value: ids,
+            }]
+          }
+        });
+
+        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+          id: '',
+          atype: 1,
+          ext: {
+            HHID: expectedIds.HHID.join('|')
+          }
+        }]);
+      });
+
+      it('- SingleDeviceID', () => {
+        expectedIds = {
+          SingleDeviceID: ['single_device_test_id']
+        };
+        ids.ftrackId = expectedIds;
+
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack', value: ids,
+            }]
+          }
+        });
+
+        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+          id: '',
+          atype: 1,
+          ext: {
+            SingleDeviceID: expectedIds.SingleDeviceID.join('|')
           }
         }]);
       });
     });
+  });
 
-    it('gets only the deviceId', () => {
+  describe('pbjs.getUserIdsAsync()', () => {
+    it('should return the IDs in the correct schema', () => {
       init(config);
       setSubmoduleRegistry([ftrackIdSubmodule]);
 
-      const ids = { ftrackId: { DeviceID: ['device_test_id'] } };
+      let expectedIds = {
+        HHID: ['household_test_id'],
+        DeviceID: ['device_test_id'],
+        SingleDeviceID: ['single_device_test_id']
+      };
+
       config.setConfig({
         userSync: {
           auctionDelay: 10,
           userIds: [{
-            name: 'ftrack', value: ids,
+            name: 'ftrack',
+            value: {
+              ftrackId: expectedIds
+            },
           }]
         }
       });
 
-      getGlobal().getUserIdsAsync().then((ids) => {
-        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
-          id: 'device_test_id',
-          atype: 1,
-          ext: { DeviceID: 'device_test_id' }
-        }]);
+      getGlobal().getUserIdsAsync().then(ids => {
+        expect(ids).to.deep.equal({
+          ftrackId: expectedIds
+        });
       });
     });
+  });
 
-    it('gets only the user household id', () => {
+  describe('pbjs.getUserIds()', () => {
+    it('should return the IDs in the correct schema', () => {
       init(config);
       setSubmoduleRegistry([ftrackIdSubmodule]);
 
-      const ids = { ftrackId: { HHID: ['household_test_id'], } };
+      let expectedIds = {
+        HHID: ['household_test_id'],
+        DeviceID: ['device_test_id'],
+        SingleDeviceID: ['single_device_test_id']
+      };
+
       config.setConfig({
         userSync: {
           auctionDelay: 10,
           userIds: [{
-            name: 'ftrack', value: ids,
+            name: 'ftrack',
+            value: {
+              ftrackId: expectedIds
+            },
           }]
         }
       });
 
-      getGlobal().getUserIdsAsync().then((ids) => {
-        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
-          id: '',
-          atype: 1,
-          ext: { HHID: 'household_test_id' }
-        }]);
-      });
-    });
-
-    it('gets only the deviceId', () => {
-      init(config);
-      setSubmoduleRegistry([ftrackIdSubmodule]);
-
-      const ids = { ftrackId: { SingleDeviceID: ['single_device_test_id'] } };
-      config.setConfig({
-        userSync: {
-          auctionDelay: 10,
-          userIds: [{
-            name: 'ftrack', value: ids,
-          }]
-        }
-      });
-
-      getGlobal().getUserIdsAsync().then((ids) => {
-        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
-          id: '',
-          atype: 1,
-          ext: { SingleDeviceID: 'single_device_test_id' }
-        }]);
+      expect(getGlobal().getUserIds()).to.deep.equal({
+        'ftrackId': expectedIds
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [ ] Refactoring (no functional changes, no api changes)

## Description of change
- after making changes and adding tests for `pbjs.getUserIdsAsEids()`, we realized we also lacked tests for `pbjs.getUserIdsAsync()` and `pbjs.getUserIds()`

## Other information
