### PR TITLE
Prebid core: fix native trackers for Prebid Server; simplify native ORTB logic

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -446,11 +446,6 @@ if (FEATURES.NATIVE) {
     });
   });
 }
-/*
- * Protocol spec for OpenRTB endpoint
- * e.g., https://<prebid-server-url>/v1/openrtb2/auction
- */
-let nativeAssetCache = {}; // store processed native params to preserve
 
 /**
  * map wurl to auction id and adId for use in the BID_WON event
@@ -553,11 +548,13 @@ Object.assign(ORTB2.prototype, {
       this.adUnitsByImp[impressionId] = adUnit;
 
       const nativeParams = adUnit.nativeParams;
-      let nativeAssets = nativeAssetCache[impressionId] = deepAccess(nativeParams, 'ortb.assets');
+      let nativeAssets = deepAccess(nativeParams, 'ortb.assets');
       if (FEATURES.NATIVE && nativeParams && !nativeAssets) {
+        // TODO: all of this should not be necessary, the same logic is in native.js
+        // will be refactored as part of https://github.com/prebid/Prebid.js/pull/8738
         let idCounter = -1;
         try {
-          nativeAssets = nativeAssetCache[impressionId] = Object.keys(nativeParams).reduce((assets, type) => {
+          nativeAssets = Object.keys(nativeParams).reduce((assets, type) => {
             let params = nativeParams[type];
 
             function newAsset(obj) {
@@ -691,7 +688,7 @@ Object.assign(ORTB2.prototype, {
           // privacy: int
           assets: nativeAssets
         };
-        const ortbRequest = deepAccess(nativeParams, 'ortb');
+        const ortbRequest = deepAccess(adUnit, 'nativeOrtbRequest');
         try {
           const request = ortbRequest ? Object.assign(defaultRequest, ortbRequest) : defaultRequest;
           mediaTypes[NATIVE] = {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -1084,24 +1084,6 @@ Object.assign(ORTB2.prototype, {
               ortb = bidObject.adm = bid.adm;
             }
 
-            // ortb.imptrackers and ortb.jstracker are going to be deprecated. So, when we find
-            // those properties, we're creating the equivalent eventtrackers and let prebid universal
-            //  creative deal with it
-            for (const imptracker of ortb.imptrackers || []) {
-              ortb.eventtrackers.push({
-                event: nativeEventTrackerEventMap.impression,
-                method: nativeEventTrackerMethodMap.img,
-                url: imptracker
-              })
-            }
-            if (ortb.jstracker) {
-              ortb.eventtrackers.push({
-                event: nativeEventTrackerEventMap.impression,
-                method: nativeEventTrackerMethodMap.js,
-                url: ortb.jstracker
-              })
-            }
-
             if (isPlainObject(ortb) && Array.isArray(ortb.assets)) {
               bidObject.native = {
                 ortb,

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -695,9 +695,6 @@ Object.assign(ORTB2.prototype, {
             request: JSON.stringify(request),
             ver: '1.2'
           };
-          // saving the converted ortb native request into the native mapper, so the Universal Creative
-          // can render the native ad directly.
-          adUnit.bids.forEach(bid => nativeMapper.set(bid.bid_id, request));
         } catch (e) {
           logError('error creating native request: ' + String(e));
         }

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -30,17 +30,16 @@ import {
 } from '../../src/utils.js';
 import CONSTANTS from '../../src/constants.json';
 import adapterManager from '../../src/adapterManager.js';
-import { config } from '../../src/config.js';
-import { VIDEO, NATIVE } from '../../src/mediaTypes.js';
-import { isValid } from '../../src/adapters/bidderFactory.js';
+import {config} from '../../src/config.js';
+import {NATIVE, VIDEO} from '../../src/mediaTypes.js';
+import {isValid} from '../../src/adapters/bidderFactory.js';
 import * as events from '../../src/events.js';
 import {find, includes} from '../../src/polyfill.js';
-import { S2S_VENDORS } from './config.js';
-import { ajax } from '../../src/ajax.js';
+import {S2S_VENDORS} from './config.js';
+import {ajax} from '../../src/ajax.js';
 import {hook} from '../../src/hook.js';
 import {getGlobal} from '../../src/prebidGlobal.js';
 import {hasPurpose1Consent} from '../../src/utils/gpdr.js';
-import { nativeMapper } from '../../src/native.js';
 
 const getConfig = config.getConfig;
 

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -66,6 +66,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, src}) {
       .reduce((bids, bid) => {
         bid = Object.assign({}, bid, getDefinedParams(adUnit, [
           'nativeParams',
+          'nativeOrtbRequest',
           'ortb2Imp',
           'mediaType',
           'renderer'

--- a/src/native.js
+++ b/src/native.js
@@ -480,7 +480,7 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
   };
   for (let key in legacyNativeAssets) {
     // skip conversion for non-asset keys
-    if (key in NATIVE_KEYS_THAT_ARE_NOT_ASSETS) continue;
+    if (NATIVE_KEYS_THAT_ARE_NOT_ASSETS.includes(key)) continue;
 
     const asset = legacyNativeAssets[key];
     let required = 0;

--- a/src/native.js
+++ b/src/native.js
@@ -1,9 +1,20 @@
-import { deepAccess, getKeyByValue, insertHtmlIntoIframe, isInteger, isNumber, isPlainObject, logError, triggerPixel, isBoolean, isArray, deepClone } from './utils.js';
+import {
+  deepAccess,
+  deepClone,
+  getKeyByValue,
+  insertHtmlIntoIframe,
+  isArray,
+  isBoolean,
+  isInteger,
+  isNumber,
+  isPlainObject,
+  logError,
+  triggerPixel
+} from './utils.js';
 import {includes} from './polyfill.js';
 import {auctionManager} from './auctionManager.js';
 import CONSTANTS from './constants.json';
-import { NATIVE } from './mediaTypes.js';
-import { filters } from './targeting.js';
+import {NATIVE} from './mediaTypes.js';
 
 export const nativeAdapters = [];
 
@@ -97,6 +108,9 @@ export function decorateAdUnitsWithNativeParams(adUnits) {
       adUnit.nativeParams || deepAccess(adUnit, 'mediaTypes.native');
     if (nativeParams) {
       adUnit.nativeParams = processNativeAdUnitParams(nativeParams);
+    }
+    if (adUnit.nativeParams) {
+      adUnit.nativeOrtbRequest = adUnit.nativeParams.ortb || toOrtbNativeRequest(adUnit.nativeParams);
     }
   });
 }
@@ -342,16 +356,15 @@ export function getAssetMessage(data, adObject) {
   return message;
 }
 
-export function getAllAssetsMessage(data, adObject) {
+export function getAllAssetsMessage(data, adObject, {getNativeReq = (bidResponse) => auctionManager.index.getAdUnit(bidResponse).nativeOrtbRequest} = {}) {
   const message = {
     message: 'assetResponse',
     adId: data.adId,
   };
 
   // Pass to Prebid Universal Creative all assets, the legacy ones + the ortb ones (under ortb property)
-  const ortbRequest = nativeMapper.get(adObject.requestId);
+  const ortbRequest = getNativeReq(adObject);
   let nativeReq = adObject.native;
-  nativeMapper.delete(adObject.requestId);
   const ortbResponse = adObject.native?.ortb;
   let legacyResponse = {};
   if (ortbRequest && ortbResponse) {
@@ -384,7 +397,6 @@ export function getAllAssetsMessage(data, adObject) {
       message.assets.push({ key, value });
     }
   });
-  removeExpiredBidsFromNativeMapper();
   return message;
 }
 
@@ -459,7 +471,7 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
       if (asset.aspect_ratios) {
         if (!isArray(asset.aspect_ratios)) {
           logError("image.aspect_ratios was passed, but it's not a an array:", asset.aspect_ratios);
-        } else if (asset.aspect_ratios.length != 1) {
+        } else if (!asset.aspect_ratios.length) {
           logError("image.aspect_ratios was passed, but it's empty:", asset.aspect_ratios);
         } else {
           const { min_width: minWidth, min_height: minHeight } = asset.aspect_ratios[0];
@@ -468,6 +480,14 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
           } else {
             ortbAsset.img.wmin = minWidth;
             ortbAsset.img.hmin = minHeight;
+          }
+          const aspectRatios = asset.aspect_ratios
+            .filter((ar) => ar.ratio_width && ar.ratio_height)
+            .map(ratio => `${ratio.ratio_width}:${ratio.ratio_height}`);
+          if (aspectRatios.length > 0) {
+            ortbAsset.img.ext = {
+              aspectratios: aspectRatios
+            }
           }
         }
       }
@@ -492,9 +512,7 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
       }
     // all extensions to the native bid request are passed as is
     } else if (key === 'ext') {
-      ortbAsset.ext = {
-        asset
-      };
+      ortbAsset.ext = asset;
       // in `ext` case, required field is not needed
       delete ortbAsset.required;
     }
@@ -681,38 +699,6 @@ function toLegacyResponse(ortbResponse, ortbRequest) {
 }
 
 /**
- * Converts a Legacy native request to OpenRTB.
- * The proprietary Prebid format has many limitations and will be dropped in
- * the future; adapters are encouraged to stop using it in favour of OpenRTB format.
- * @param {BidRequest[]} bidRequests an array of valid bid requests
- * @returns an array of valid bid requests where the legacy format is converted to OpenRTB.
- */
-export function convertLegacyNativeRequestToOrtb(bidRequests) {
-  if (!bidRequests || !isArray(bidRequests)) return bidRequests;
-  // convert Native ORTB definition to old-style prebid native definition
-  for (const bidRequest of bidRequests) {
-    if (bidRequest.mediaTypes && bidRequest.mediaTypes[NATIVE]) {
-      if (bidRequest.mediaTypes[NATIVE].ortb) continue;
-      // legacy case
-      const ortbRequest = toOrtbNativeRequest(bidRequest.mediaTypes[NATIVE]);
-      bidRequest.mediaTypes[NATIVE] = {
-        ...Object.entries(bidRequest.mediaTypes['native'])
-          .filter(([key, value]) => NATIVE_KEYS_THAT_ARE_NOT_ASSETS.includes(key))
-          .reduce((acc, curr) => { acc[curr[0]] = curr[1]; return acc }, {}),
-        ortb: ortbRequest
-      }
-      nativeMapper.set(bidRequest.bidId, ortbRequest);
-      // to keep other keywords like sendTargetingKeys, rendererUrl...
-      bidRequest.nativeParams = bidRequest.mediaTypes[NATIVE];
-      if (bidRequest.nativeParams) {
-        processNativeAdUnitParams(bidRequest.nativeParams);
-      }
-    }
-  }
-  return bidRequests;
-}
-
-/**
  * Inverts key-values of an object.
  */
 function inverse(obj) {
@@ -721,12 +707,4 @@ function inverse(obj) {
     retobj[obj[key]] = key;
   }
   return retobj;
-}
-
-// to avoid memory leaks, this function will try to remove expired bids from the native wrapper.
-function removeExpiredBidsFromNativeMapper() {
-  const expiredBids = auctionManager.getBidsReceived().filter((bid) => !filters.isBidNotExpired(bid));
-  for (const expiredBid of expiredBids) {
-    nativeMapper.delete(expiredBid.requestId);
-  }
 }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1316,55 +1316,54 @@ describe('S2S Adapter', function () {
           config.setConfig(_config);
           adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
           const requestBid = JSON.parse(server.requests[0].requestBody);
-
-          expect(requestBid.imp[0].native).to.deep.equal({
-            request: JSON.stringify({
-              'context': 1,
-              'plcmttype': 1,
-              'eventtrackers': [{
-                event: 1,
-                methods: [1]
-              }],
-              'assets': [
-                {
-                  'required': 1,
-                  'id': 0,
-                  'title': {
-                    'len': 800
-                  }
-                },
-                {
-                  'required': 1,
-                  'id': 1,
-                  'img': {
-                    'type': 3,
-                    'w': 989,
-                    'h': 742
-                  }
-                },
-                {
-                  'required': 1,
-                  'id': 2,
-                  'img': {
-                    'type': 1,
-                    'wmin': 10,
-                    'hmin': 10,
-                    'ext': {
-                      'aspectratios': ['1:1']
-                    }
-                  }
-                },
-                {
-                  'required': 1,
-                  'id': 3,
-                  'data': {
-                    'type': 1
+          const ortbReq = JSON.parse(requestBid.imp[0].native.request);
+          expect(ortbReq).to.deep.equal({
+            'ver': '1.2',
+            'context': 1,
+            'plcmttype': 1,
+            'eventtrackers': [{
+              event: 1,
+              methods: [1]
+            }],
+            'assets': [
+              {
+                'required': 1,
+                'id': 0,
+                'title': {
+                  'len': 800
+                }
+              },
+              {
+                'required': 1,
+                'id': 1,
+                'img': {
+                  'type': 3,
+                  'w': 989,
+                  'h': 742
+                }
+              },
+              {
+                'required': 1,
+                'id': 2,
+                'img': {
+                  'type': 1,
+                  'wmin': 10,
+                  'hmin': 10,
+                  'ext': {
+                    'aspectratios': ['1:1']
                   }
                 }
-              ]
-            }),
-            ver: '1.2'
+              },
+              {
+                'required': 1,
+                'id': 3,
+                'data': {
+                  'type': 1
+                }
+              }
+            ]
           });
+          expect(requestBid.imp[0].native.ver).to.equal('1.2');
         });
 
         it('adds native ortb request for OpenRTB', function () {
@@ -1382,11 +1381,9 @@ describe('S2S Adapter', function () {
           config.setConfig(_config);
           adapter.callBids(openRtbNativeRequest, BID_REQUESTS, addBidResponse, done, ajax);
           const requestBid = JSON.parse(server.requests[0].requestBody);
-
-          expect(requestBid.imp[0].native).to.deep.equal({
-            request: JSON.stringify(NATIVE_ORTB_MTO.ortb),
-            ver: '1.2'
-          });
+          const nativeReq = JSON.parse(requestBid.imp[0].native.request);
+          expect(nativeReq).to.deep.equal(NATIVE_ORTB_MTO.ortb);
+          expect(requestBid.imp[0].native.ver).to.equal('1.2');
         });
 
         it('should not include ext.aspectratios if adunit\'s aspect_ratios do not define radio_width and ratio_height', () => {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -332,7 +332,7 @@ describe('native.js', function () {
       adId: '123',
     };
 
-    const message = getAllAssetsMessage(messageRequest, bid);
+    const message = getAllAssetsMessage(messageRequest, bid, {getNativeReq: () => null});
 
     expect(message.assets.length).to.equal(9);
     expect(message.assets).to.deep.include({
@@ -380,7 +380,7 @@ describe('native.js', function () {
       adId: '123',
     };
 
-    const message = getAllAssetsMessage(messageRequest, bidWithUndefinedFields);
+    const message = getAllAssetsMessage(messageRequest, bidWithUndefinedFields, {getNativeReq: () => null});
 
     expect(message.assets.length).to.equal(4);
     expect(message.assets).to.deep.include({

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -8,7 +8,7 @@ import {
   decorateAdUnitsWithNativeParams,
   isOpenRTBBidRequestValid,
   isNativeOpenRTBBidValid,
-  toOrtbNativeRequest,
+  toOrtbNativeRequest, toOrtbNativeResponse, legacyPropertiesToOrtbNative, fireImpressionTrackers, fireClickTrackers,
 } from 'src/native.js';
 import CONSTANTS from 'src/constants.json';
 import { stubAuctionIndex } from '../helpers/indexStub.js';
@@ -883,3 +883,142 @@ describe('validate native', function () {
     });
   }
 });
+
+describe('legacyPropertiesToOrtbNative', () => {
+  describe('click trakckers', () => {
+    it('should convert clickUrl to link.url', () => {
+      const native = legacyPropertiesToOrtbNative({clickUrl: 'some-url'});
+      expect(native.link.url).to.eql('some-url');
+    });
+    it('should convert single clickTrackers to link.clicktrackers', () => {
+      const native = legacyPropertiesToOrtbNative({clickTrackers: 'some-url'});
+      expect(native.link.clicktrackers).to.eql([
+        'some-url'
+      ])
+    });
+    it('should convert multiple clickTrackers into link.clicktrackers', () => {
+      const native = legacyPropertiesToOrtbNative({clickTrackers: ['url1', 'url2']});
+      expect(native.link.clicktrackers).to.eql([
+        'url1',
+        'url2'
+      ])
+    })
+  });
+  describe('impressionTrackers', () => {
+    it('should convert a single tracker into an eventtracker entry', () => {
+      const native = legacyPropertiesToOrtbNative({impressionTrackers: 'some-url'});
+      expect(native.eventtrackers).to.eql([
+        {
+          event: 1,
+          method: 1,
+          url: 'some-url'
+        }
+      ]);
+    });
+
+    it('should convert an array into corresponding eventtracker entries', () => {
+      const native = legacyPropertiesToOrtbNative({impressionTrackers: ['url1', 'url2']});
+      expect(native.eventtrackers).to.eql([
+        {
+          event: 1,
+          method: 1,
+          url: 'url1'
+        },
+        {
+          event: 1,
+          method: 1,
+          url: 'url2'
+        }
+      ])
+    })
+  });
+  describe('javascriptTrackers', () => {
+    it('should convert a single value into jstracker', () => {
+      const native = legacyPropertiesToOrtbNative({javascriptTrackers: 'some-markup'});
+      expect(native.jstracker).to.eql('some-markup');
+    })
+    it('should merge multiple values into a single jstracker', () => {
+      const native = legacyPropertiesToOrtbNative({javascriptTrackers: ['some-markup', 'some-other-markup']});
+      expect(native.jstracker).to.eql('some-markupsome-other-markup');
+    })
+  });
+});
+
+describe('fireImpressionTrackers', () => {
+  let runMarkup, fetchURL;
+  beforeEach(() => {
+    runMarkup = sinon.stub();
+    fetchURL = sinon.stub();
+  })
+
+  function runTrackers(resp) {
+    fireImpressionTrackers(resp, {runMarkup, fetchURL})
+  }
+
+  it('should run markup in jstracker', () => {
+    runTrackers({
+      jstracker: 'some-markup'
+    });
+    sinon.assert.calledWith(runMarkup, 'some-markup');
+  });
+
+  it('should fetch each url in imptrackers', () => {
+    const urls = ['url1', 'url2'];
+    runTrackers({
+      imptrackers: urls
+    });
+    urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
+  });
+
+  it('should fetch each url in eventtrackers that use the image method', () => {
+    const urls = ['url1', 'url2'];
+    runTrackers({
+      eventtrackers: urls.map(url => ({event: 1, method: 1, url}))
+    });
+    urls.forEach(url => sinon.assert.calledWith(fetchURL, url))
+  });
+
+  it('should load as a script each url in eventtrackers that use the js method', () => {
+    const urls = ['url1', 'url2'];
+    runTrackers({
+      eventtrackers: urls.map(url => ({event: 1, method: 2, url}))
+    });
+    urls.forEach(url => sinon.assert.calledWith(runMarkup, sinon.match(`script async src="${url}"`)))
+  });
+
+  it('should not fire trackers that are not impression trakcers', () => {
+    runTrackers({
+      link: {
+        clicktrackers: ['click-url']
+      },
+      eventtrackers: [{
+        event: 2, // not imp
+        method: 1,
+        url: 'some-url'
+      }]
+    });
+    sinon.assert.notCalled(fetchURL);
+    sinon.assert.notCalled(runMarkup);
+  })
+})
+
+describe('fireClickTrackers', () => {
+  let fetchURL;
+  beforeEach(() => {
+    fetchURL = sinon.stub();
+  });
+
+  function runTrackers(resp) {
+    fireClickTrackers(resp, {fetchURL});
+  }
+
+  it('should load each URL in link.clicktrackers', () => {
+    const urls = ['url1', 'url2'];
+    runTrackers({
+      link: {
+        clicktrackers: urls
+      }
+    });
+    urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
+  })
+})

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -12,6 +12,7 @@ import {hook} from '../../../../src/hook.js';
 import {auctionManager} from '../../../../src/auctionManager.js';
 import {stubAuctionIndex} from '../../../helpers/indexStub.js';
 import { bidderSettings } from '../../../../src/bidderSettings.js';
+import {decorateAdUnitsWithNativeParams} from '../../../../src/native.js';
 
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
@@ -882,6 +883,7 @@ describe('validate bid response: ', function () {
           title: {'required': true},
         }
       }]
+      decorateAdUnitsWithNativeParams(adUnits);
       let bidRequest = {
         bids: [{
           bidId: '1',
@@ -923,6 +925,7 @@ describe('validate bid response: ', function () {
           title: {'required': true},
         },
       }];
+      decorateAdUnitsWithNativeParams(adUnits);
       let bidRequest = {
         bids: [{
           bidId: '1',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

A followup to https://github.com/prebid/Prebid.js/pull/8086, this:

 - fixes several things about how native trackers are handled. The original intent was to offload their processing to the PUC (https://github.com/prebid/prebid-universal-creative/pull/150); since that has not been merged, trackers do not work for adapters that reply in native ORTB (currently that is just the Prebid Server adapter). However there are other problems with that approach  - mixing of URLs and markups; as well as a long standing problem with confusing arrays and strings in the legacy `javascriptTrackers` .
 - adUnits (and bid requests derived from it) now have a `nativeOrtbRequest` property that adapters can use instead of manually converting  `bidRequest.nativeParams` (or `bidRequest.mediaTypes.native`). I think this makes more sense because all requests derived from an ad unit will result in the same ORTB native request object.
 - native rendering now retrieves the native request from the adUnit, instead of separately associating each request with the native request.

This is also in preparation of https://github.com/prebid/Prebid.js/pull/8738, where I plan to re-use this logic for all ORTB adapters (including the PBS adapter, which currently duplicates a lot of the logic).

FYI @bretg @musikele; with this, the guidance to adapters that want to deal with native in ORTB should be to pick `bidRequest.nativeOrtbRequest` (instead of `convertLegacyNativeRequestToOrtb(validBidRequests)`).


