### PR TITLE
Criteo Adapter: remove bid.adId

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, getUniqueIdentifierStr, isArray, logError, logInfo, logWarn, parseUrl } from '../src/utils.js';
+import { deepAccess, isArray, logError, logInfo, logWarn, parseUrl } from '../src/utils.js';
 import { loadExternalScript } from '../src/adloader.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
@@ -235,7 +235,6 @@ export const spec = {
         const bidId = bidRequest.bidId;
         const bid = {
           requestId: bidId,
-          adId: slot.bidId || getUniqueIdentifierStr(),
           cpm: slot.cpm,
           currency: slot.currency,
           netRevenue: true,

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1310,7 +1310,6 @@ describe('The Criteo bidding adapter', function () {
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
       expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].adId).to.equal('abc123');
       expect(bids[0].cpm).to.equal(1.23);
       expect(bids[0].ad).to.equal('test-ad');
       expect(bids[0].width).to.equal(728);
@@ -1344,7 +1343,6 @@ describe('The Criteo bidding adapter', function () {
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
       expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].adId).to.equal('abc123');
       expect(bids[0].cpm).to.equal(1.23);
       expect(bids[0].vastUrl).to.equal('http://test-ad');
       expect(bids[0].mediaType).to.equal(VIDEO);
@@ -1401,7 +1399,6 @@ describe('The Criteo bidding adapter', function () {
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
       expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].adId).to.equal('abc123');
       expect(bids[0].cpm).to.equal(1.23);
       expect(bids[0].mediaType).to.equal(NATIVE);
     });
@@ -1518,40 +1515,6 @@ describe('The Criteo bidding adapter', function () {
       expect(bids[0].ad).to.equal('test-ad');
       expect(bids[0].width).to.equal(728);
       expect(bids[0].height).to.equal(90);
-    });
-
-    it('should generate unique adIds if none are returned by the endpoint', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            width: 300,
-            height: 250,
-          }, {
-            impid: 'test-requestId',
-            cpm: 4.56,
-            creative: 'test-ad',
-            width: 728,
-            height: 90,
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          sizes: [[300, 250], [728, 90]],
-          params: {
-            networkId: 456,
-          }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(2);
-      const prebidBids = bids.map(bid => Object.assign(createBid(CONSTANTS.STATUS.GOOD, request.bidRequests[0]), bid));
-      expect(prebidBids[0].adId).to.not.equal(prebidBids[1].adId);
     });
 
     [{


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Removed bid.adId parameter as asked (see #6381)